### PR TITLE
feat: Multi-label support for all Hydra label fields

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,7 +22,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--ready-label",
         default="hydra-ready",
-        help="GitHub issue label to filter by (default: hydra-ready)",
+        help="GitHub issue labels to filter by, comma-separated (default: hydra-ready)",
     )
     parser.add_argument(
         "--batch-size",
@@ -79,22 +79,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--review-label",
         default="hydra-review",
-        help="Label for issues/PRs under review (default: hydra-review)",
+        help="Labels for issues/PRs under review, comma-separated (default: hydra-review)",
     )
     parser.add_argument(
         "--hitl-label",
         default="hydra-hitl",
-        help="Label for human-in-the-loop escalation (default: hydra-hitl)",
+        help="Labels for human-in-the-loop escalation, comma-separated (default: hydra-hitl)",
     )
     parser.add_argument(
         "--fixed-label",
         default="hydra-fixed",
-        help="Label applied after PR is merged (default: hydra-fixed)",
+        help="Labels applied after PR is merged, comma-separated (default: hydra-fixed)",
     )
     parser.add_argument(
         "--planner-label",
         default="hydra-plan",
-        help="Label for issues needing plans (default: hydra-plan)",
+        help="Labels for issues needing plans, comma-separated (default: hydra-plan)",
     )
     parser.add_argument(
         "--planner-model",
@@ -147,10 +147,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _parse_label_arg(value: str) -> list[str]:
+    """Split a comma-separated label string into a list."""
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
 def build_config(args: argparse.Namespace) -> HydraConfig:
     """Convert parsed CLI args into a :class:`HydraConfig`."""
     return HydraConfig(
-        ready_label=args.ready_label,
+        ready_label=_parse_label_arg(args.ready_label),
         batch_size=args.batch_size,
         max_workers=args.max_workers,
         max_budget_usd=args.max_budget_usd,
@@ -160,10 +165,10 @@ def build_config(args: argparse.Namespace) -> HydraConfig:
         ci_check_timeout=args.ci_check_timeout,
         ci_poll_interval=args.ci_poll_interval,
         max_ci_fix_attempts=args.max_ci_fix_attempts,
-        review_label=args.review_label,
-        hitl_label=args.hitl_label,
-        fixed_label=args.fixed_label,
-        planner_label=args.planner_label,
+        review_label=_parse_label_arg(args.review_label),
+        hitl_label=_parse_label_arg(args.hitl_label),
+        fixed_label=_parse_label_arg(args.fixed_label),
+        planner_label=_parse_label_arg(args.planner_label),
         planner_model=args.planner_model,
         planner_budget_usd=args.planner_budget_usd,
         repo=args.repo,

--- a/config.py
+++ b/config.py
@@ -12,8 +12,9 @@ class HydraConfig(BaseModel):
     """Configuration for the Hydra orchestrator."""
 
     # Issue selection
-    ready_label: str = Field(
-        default="hydra-ready", description="GitHub issue label to filter by"
+    ready_label: list[str] = Field(
+        default=["hydra-ready"],
+        description="GitHub issue labels to filter by (OR logic)",
     )
     batch_size: int = Field(default=15, ge=1, le=50, description="Issues per batch")
     repo: str = Field(
@@ -51,20 +52,23 @@ class HydraConfig(BaseModel):
     )
 
     # Label lifecycle
-    review_label: str = Field(
-        default="hydra-review", description="Label for issues/PRs under review"
+    review_label: list[str] = Field(
+        default=["hydra-review"],
+        description="Labels for issues/PRs under review (OR logic)",
     )
-    hitl_label: str = Field(
-        default="hydra-hitl",
-        description="Label for issues escalated to human-in-the-loop",
+    hitl_label: list[str] = Field(
+        default=["hydra-hitl"],
+        description="Labels for issues escalated to human-in-the-loop (OR logic)",
     )
-    fixed_label: str = Field(
-        default="hydra-fixed", description="Label applied after PR is merged"
+    fixed_label: list[str] = Field(
+        default=["hydra-fixed"],
+        description="Labels applied after PR is merged (OR logic)",
     )
 
     # Planner configuration
-    planner_label: str = Field(
-        default="hydra-plan", description="Label for issues needing plans"
+    planner_label: list[str] = Field(
+        default=["hydra-plan"],
+        description="Labels for issues needing plans (OR logic)",
     )
     planner_model: str = Field(default="opus", description="Model for planning agents")
     planner_budget_usd: float = Field(
@@ -129,18 +133,24 @@ class HydraConfig(BaseModel):
             )
 
         # Label env var overrides (only apply when still at the default)
-        _ENV_LABEL_MAP: dict[str, tuple[str, str]] = {
-            "HYDRA_LABEL_PLAN": ("planner_label", "hydra-plan"),
-            "HYDRA_LABEL_READY": ("ready_label", "hydra-ready"),
-            "HYDRA_LABEL_REVIEW": ("review_label", "hydra-review"),
-            "HYDRA_LABEL_HITL": ("hitl_label", "hydra-hitl"),
-            "HYDRA_LABEL_FIXED": ("fixed_label", "hydra-fixed"),
+        _ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
+            "HYDRA_LABEL_PLAN": ("planner_label", ["hydra-plan"]),
+            "HYDRA_LABEL_READY": ("ready_label", ["hydra-ready"]),
+            "HYDRA_LABEL_REVIEW": ("review_label", ["hydra-review"]),
+            "HYDRA_LABEL_HITL": ("hitl_label", ["hydra-hitl"]),
+            "HYDRA_LABEL_FIXED": ("fixed_label", ["hydra-fixed"]),
         }
         for env_key, (field_name, default_val) in _ENV_LABEL_MAP.items():
             current = getattr(self, field_name)
-            env_val = os.environ.get(env_key, "")
-            if current == default_val and env_val:
-                object.__setattr__(self, field_name, env_val)
+            env_val = os.environ.get(env_key)
+            if env_val is not None and current == default_val:
+                # Empty string → empty list (scan-all mode); otherwise split on comma
+                labels = (
+                    [part.strip() for part in env_val.split(",") if part.strip()]
+                    if env_val
+                    else []
+                )
+                object.__setattr__(self, field_name, labels)
 
         return self
 

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -146,7 +146,7 @@ class HydraOrchestrator:
         logger.info(
             "Hydra starting — repo=%s label=%s workers=%d poll=%ds",
             self._config.repo,
-            self._config.ready_label,
+            ",".join(self._config.ready_label),
             self._config.max_workers,
             self._config.poll_interval,
         )
@@ -220,45 +220,93 @@ class HydraOrchestrator:
             )
         return issues
 
-    async def _fetch_plan_issues(self) -> list[GitHubIssue]:
-        """Fetch issues labeled with the planner label (e.g. ``hydra-plan``)."""
+    async def _fetch_issues_by_labels(
+        self,
+        labels: list[str],
+        limit: int,
+        exclude_labels: list[str] | None = None,
+    ) -> list[GitHubIssue]:
+        """Fetch open issues matching *any* of *labels*, deduplicated.
+
+        If *labels* is empty but *exclude_labels* is provided, fetch all
+        open issues and filter out those carrying any of the exclude labels.
+        """
         if self._config.dry_run:
             logger.info(
-                "[dry-run] Would fetch issues with planner label %r",
-                self._config.planner_label,
+                "[dry-run] Would fetch issues with labels=%r exclude=%r",
+                labels,
+                exclude_labels,
             )
             return []
 
-        try:
-            env = {**os.environ}
-            env.pop("CLAUDECODE", None)
-            proc = await asyncio.create_subprocess_exec(
+        seen: dict[int, dict] = {}
+
+        async def _query_label(label: str | None) -> None:
+            cmd = [
                 "gh",
                 "issue",
                 "list",
                 "--repo",
                 self._config.repo,
-                "--label",
-                self._config.planner_label,
                 "--limit",
-                str(self._config.batch_size),
+                str(limit),
                 "--json",
                 "number,title,body,labels,comments,url",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            stdout, stderr = await proc.communicate()
-            if proc.returncode != 0:
-                logger.error("gh issue list (planner) failed: %s", stderr.decode())
-                return []
+            ]
+            if label is not None:
+                cmd += ["--label", label]
+            try:
+                raw = await self._gh_run(*cmd)
+                for item in json.loads(raw):
+                    seen.setdefault(item["number"], item)
+            except (RuntimeError, json.JSONDecodeError, FileNotFoundError) as exc:
+                logger.error("gh issue list failed for label=%r: %s", label, exc)
 
-            raw_issues = json.loads(stdout.decode())
-        except (json.JSONDecodeError, FileNotFoundError) as exc:
-            logger.error("Failed to fetch plan issues: %s", exc)
+        if labels:
+            await asyncio.gather(*[_query_label(lbl) for lbl in labels])
+        elif exclude_labels:
+            await _query_label(None)
+            # Remove issues that carry any of the exclude labels
+            exclude_set = set(exclude_labels)
+            to_remove = []
+            for num, raw in seen.items():
+                raw_labels = {
+                    (rl["name"] if isinstance(rl, dict) else str(rl))
+                    for rl in raw.get("labels", [])
+                }
+                if raw_labels & exclude_set:
+                    to_remove.append(num)
+            for num in to_remove:
+                del seen[num]
+        else:
             return []
 
-        issues = self._parse_raw_issues(raw_issues)
+        issues = self._parse_raw_issues(list(seen.values()))
+        return issues[:limit]
+
+    async def _fetch_plan_issues(self) -> list[GitHubIssue]:
+        """Fetch issues labeled with the planner label (e.g. ``hydra-plan``)."""
+        if not self._config.planner_label:
+            # No planner labels configured — fetch all open issues that are
+            # not already in a downstream pipeline stage.
+            exclude = list(
+                {
+                    *self._config.ready_label,
+                    *self._config.review_label,
+                    *self._config.hitl_label,
+                    *self._config.fixed_label,
+                }
+            )
+            issues = await self._fetch_issues_by_labels(
+                [],
+                self._config.batch_size,
+                exclude_labels=exclude,
+            )
+        else:
+            issues = await self._fetch_issues_by_labels(
+                self._config.planner_label,
+                self._config.batch_size,
+            )
         logger.info("Fetched %d issues for planning", len(issues))
         return issues[: self._config.batch_size]
 
@@ -293,15 +341,20 @@ class HydraOrchestrator:
                     )
                     await self._prs.post_comment(issue.number, comment_body)
 
-                    # Swap labels: remove planner label, add implementation label
-                    await self._prs.remove_label(
-                        issue.number, self._config.planner_label
+                    # Swap labels: remove planner label(s), add implementation label
+                    for lbl in self._config.planner_label:
+                        await self._prs.remove_label(issue.number, lbl)
+                    await self._prs.add_labels(
+                        issue.number, [self._config.ready_label[0]]
                     )
-                    await self._prs.add_labels(issue.number, [self._config.ready_label])
 
                     # File new issues discovered during planning
                     for new_issue in result.new_issues:
-                        labels = new_issue.labels or [self._config.planner_label]
+                        labels = new_issue.labels or (
+                            [self._config.planner_label[0]]
+                            if self._config.planner_label
+                            else []
+                        )
                         await self._prs.create_issue(
                             new_issue.title, new_issue.body, labels
                         )
@@ -340,44 +393,10 @@ class HydraOrchestrator:
         """
         queue_size = 2 * self._config.max_workers
 
-        if self._config.dry_run:
-            logger.info(
-                "[dry-run] Would fetch up to %d issues with label %r",
-                queue_size,
-                self._config.ready_label,
-            )
-            return []
-
-        try:
-            env = {**os.environ}
-            env.pop("CLAUDECODE", None)
-            proc = await asyncio.create_subprocess_exec(
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                self._config.repo,
-                "--label",
-                self._config.ready_label,
-                "--limit",
-                str(queue_size),
-                "--json",
-                "number,title,body,labels,comments,url",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            stdout, stderr = await proc.communicate()
-            if proc.returncode != 0:
-                logger.error("gh issue list failed: %s", stderr.decode())
-                return []
-
-            raw_issues = json.loads(stdout.decode())
-        except (json.JSONDecodeError, FileNotFoundError) as exc:
-            logger.error("Failed to fetch issues: %s", exc)
-            return []
-
-        all_issues = self._parse_raw_issues(raw_issues)
+        all_issues = await self._fetch_issues_by_labels(
+            self._config.ready_label,
+            queue_size,
+        )
         # Only skip issues already active in this run (GitHub labels are
         # the source of truth — if it still has hydra-ready, it needs work)
         issues = [i for i in all_issues if i.number not in self._active_issues]
@@ -395,41 +414,12 @@ class HydraOrchestrator:
 
         Returns ``(pr_infos, issues)`` so the reviewer has both.
         """
-        if self._config.dry_run:
-            return [], []
-
-        try:
-            env = {**os.environ}
-            env.pop("CLAUDECODE", None)
-            proc = await asyncio.create_subprocess_exec(
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                self._config.repo,
-                "--label",
-                self._config.review_label,
-                "--limit",
-                str(self._config.batch_size),
-                "--json",
-                "number,title,body,labels,comments,url",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-            )
-            stdout, stderr = await proc.communicate()
-            if proc.returncode != 0:
-                logger.error("gh issue list (review) failed: %s", stderr.decode())
-                return [], []
-
-            raw_issues = json.loads(stdout.decode())
-        except (json.JSONDecodeError, FileNotFoundError) as exc:
-            logger.error("Failed to fetch review issues: %s", exc)
-            return [], []
-
-        issues = self._parse_raw_issues(raw_issues)
+        all_issues = await self._fetch_issues_by_labels(
+            self._config.review_label,
+            self._config.batch_size,
+        )
         # Only skip issues already active in this run
-        issues = [i for i in issues if i.number not in self._active_issues]
+        issues = [i for i in all_issues if i.number not in self._active_issues]
         if not issues:
             return [], []
 
@@ -563,15 +553,14 @@ class HydraOrchestrator:
 
                         if result.success:
                             # Success: move to review pipeline
-                            await self._prs.remove_label(
-                                issue.number, self._config.ready_label
-                            )
+                            for lbl in self._config.ready_label:
+                                await self._prs.remove_label(issue.number, lbl)
                             await self._prs.add_labels(
-                                issue.number, [self._config.review_label]
+                                issue.number, [self._config.review_label[0]]
                             )
                             if pr and pr.number > 0:
                                 await self._prs.add_pr_labels(
-                                    pr.number, [self._config.review_label]
+                                    pr.number, [self._config.review_label[0]]
                                 )
                         # Failure: keep implementation label so issue can be retried
 
@@ -660,11 +649,10 @@ class HydraOrchestrator:
                             self._state.mark_issue(pr.issue_number, "merged")
                             self._state.record_pr_merged()
                             self._state.record_issue_completed()
-                            await self._prs.remove_label(
-                                pr.issue_number, self._config.review_label
-                            )
+                            for lbl in self._config.review_label:
+                                await self._prs.remove_label(pr.issue_number, lbl)
                             await self._prs.add_labels(
-                                pr.issue_number, [self._config.fixed_label]
+                                pr.issue_number, [self._config.fixed_label[0]]
                             )
 
                 # Cleanup worktree after review
@@ -747,8 +735,9 @@ class HydraOrchestrator:
             f"PR not merged — escalating to human review.",
         )
         # Swap to HITL label so the dashboard HITL tab picks it up
-        await self._prs.remove_label(issue.number, self._config.review_label)
-        await self._prs.add_labels(issue.number, [self._config.hitl_label])
+        for lbl in self._config.review_label:
+            await self._prs.remove_label(issue.number, lbl)
+        await self._prs.add_labels(issue.number, [self._config.hitl_label[0]])
         return False
 
     async def _set_phase(self, phase: Phase) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -45,7 +45,7 @@ class ConfigFactory:
     @staticmethod
     def create(
         *,
-        ready_label: str = "test-label",
+        ready_label: list[str] | None = None,
         batch_size: int = 3,
         max_workers: int = 2,
         max_budget_usd: float = 1.0,
@@ -55,10 +55,10 @@ class ConfigFactory:
         ci_check_timeout: int = 600,
         ci_poll_interval: int = 30,
         max_ci_fix_attempts: int = 0,
-        review_label: str = "hydra-review",
-        hitl_label: str = "hydra-hitl",
-        fixed_label: str = "hydra-fixed",
-        planner_label: str = "hydra-plan",
+        review_label: list[str] | None = None,
+        hitl_label: list[str] | None = None,
+        fixed_label: list[str] | None = None,
+        planner_label: list[str] | None = None,
         planner_model: str = "opus",
         planner_budget_usd: float = 1.0,
         repo: str = "test-org/test-repo",
@@ -74,7 +74,7 @@ class ConfigFactory:
 
         root = repo_root or Path("/tmp/hydra-test-repo")
         return HydraConfig(
-            ready_label=ready_label,
+            ready_label=ready_label if ready_label is not None else ["test-label"],
             batch_size=batch_size,
             max_workers=max_workers,
             max_budget_usd=max_budget_usd,
@@ -84,10 +84,12 @@ class ConfigFactory:
             ci_check_timeout=ci_check_timeout,
             ci_poll_interval=ci_poll_interval,
             max_ci_fix_attempts=max_ci_fix_attempts,
-            review_label=review_label,
-            hitl_label=hitl_label,
-            fixed_label=fixed_label,
-            planner_label=planner_label,
+            review_label=review_label if review_label is not None else ["hydra-review"],
+            hitl_label=hitl_label if hitl_label is not None else ["hydra-hitl"],
+            fixed_label=fixed_label if fixed_label is not None else ["hydra-fixed"],
+            planner_label=planner_label
+            if planner_label is not None
+            else ["hydra-plan"],
             planner_model=planner_model,
             planner_budget_usd=planner_budget_usd,
             repo=repo,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -122,7 +122,7 @@ class TestHydraConfigDefaults:
         )
 
         # Assert
-        assert cfg.ready_label == "hydra-ready"
+        assert cfg.ready_label == ["hydra-ready"]
 
     def test_batch_size_default(self, tmp_path: Path) -> None:
         cfg = HydraConfig(
@@ -225,14 +225,14 @@ class TestHydraConfigCustomValues:
     def test_custom_label(self, tmp_path: Path) -> None:
         # Arrange / Act
         cfg = HydraConfig(
-            ready_label="sprint",
+            ready_label=["sprint"],
             repo_root=tmp_path,
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
         # Assert
-        assert cfg.ready_label == "sprint"
+        assert cfg.ready_label == ["sprint"]
 
     def test_custom_batch_size(self, tmp_path: Path) -> None:
         cfg = HydraConfig(

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -904,7 +904,11 @@ class TestControlStatusEndpoint:
 
         body = response.json()
         assert body["config"]["repo"] == config.repo
-        assert body["config"]["label"] == config.ready_label
+        assert body["config"]["ready_label"] == config.ready_label
+        assert body["config"]["planner_label"] == config.planner_label
+        assert body["config"]["review_label"] == config.review_label
+        assert body["config"]["hitl_label"] == config.hitl_label
+        assert body["config"]["fixed_label"] == config.fixed_label
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
All 5 label fields (planner_label, ready_label, review_label, hitl_label, fixed_label) now accept list[str] instead of str. Hydra picks up issues tagged with ANY of the configured labels.

- config.py: str → list[str] with env var comma-split parsing
- cli.py: comma-separated CLI args parsed into lists
- orchestrator.py: shared _fetch_issues_by_labels helper with per-label query + dedupe; label mutations loop over all labels
- dashboard.py: multi-label queries for /api/prs and /api/hitl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple labels per category (ready, review, HITL, fixed, planner)—specify comma-separated values for flexible filtering and categorization.
  * Enhanced API responses to expose individual label fields, replacing the single-label format for clearer configuration visibility.

* **Bug Fixes**
  * Improved handling of multiple labels with automatic deduplication across queries for more accurate results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->