### PR TITLE
Fixes #37: Dashboard accesses private method orchestrator._publish_...

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -274,8 +274,7 @@ class HydraDashboard:
         async def stop_orchestrator() -> JSONResponse:
             if not self._orchestrator or not self._orchestrator.running:
                 return JSONResponse({"error": "not running"}, status_code=400)
-            self._orchestrator.request_stop()
-            await self._orchestrator._publish_status()
+            await self._orchestrator.request_stop()
             return JSONResponse({"status": "stopping"})
 
         @app.get("/api/control/status")

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -104,13 +104,14 @@ class HydraOrchestrator:
         self._human_input_responses[issue_number] = answer
         self._human_input_requests.pop(issue_number, None)
 
-    def stop(self) -> None:
+    async def stop(self) -> None:
         """Signal the orchestrator to stop and kill active subprocesses."""
         self._stop_event.set()
         logger.info("Stop requested — terminating active processes")
         self._planners.terminate()
         self._agents.terminate()
         self._reviewers.terminate()
+        await self._publish_status()
 
     # Alias for backward compatibility
     request_stop = stop

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -40,9 +40,8 @@ def make_orchestrator_mock(
     orch.provide_human_input = MagicMock()
     orch.running = running
     orch.run_status = run_status
-    orch.stop = MagicMock()
-    orch.request_stop = MagicMock()
-    orch._publish_status = AsyncMock()
+    orch.stop = AsyncMock()
+    orch.request_stop = AsyncMock()
     return orch
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1692,13 +1692,15 @@ class TestConstructorInjection:
 class TestStopMechanism:
     """Tests for request_stop(), reset(), run_status, and stop-at-batch-boundary."""
 
-    def test_request_stop_sets_stop_event(self, config: HydraConfig) -> None:
+    @pytest.mark.asyncio
+    async def test_request_stop_sets_stop_event(self, config: HydraConfig) -> None:
         orch = HydraOrchestrator(config)
         assert not orch._stop_event.is_set()
-        orch.request_stop()
+        await orch.request_stop()
         assert orch._stop_event.is_set()
 
-    def test_stop_terminates_all_runners(self, config: HydraConfig) -> None:
+    @pytest.mark.asyncio
+    async def test_stop_terminates_all_runners(self, config: HydraConfig) -> None:
         """stop() should call terminate() on planners, agents, and reviewers."""
         orch = HydraOrchestrator(config)
         with (
@@ -1706,11 +1708,23 @@ class TestStopMechanism:
             patch.object(orch._agents, "terminate") as mock_a,
             patch.object(orch._reviewers, "terminate") as mock_r,
         ):
-            orch.stop()
+            await orch.stop()
 
         mock_p.assert_called_once()
         mock_a.assert_called_once()
         mock_r.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_publishes_status(self, config: HydraConfig) -> None:
+        """stop() should publish ORCHESTRATOR_STATUS event."""
+        orch = HydraOrchestrator(config)
+        orch._running = True  # simulate running state
+        await orch.stop()
+
+        history = orch._bus.get_history()
+        status_events = [e for e in history if e.type == EventType.ORCHESTRATOR_STATUS]
+        assert len(status_events) == 1
+        assert status_events[0].data["status"] == "stopping"
 
     def test_reset_clears_stop_event_and_running(self, config: HydraConfig) -> None:
         orch = HydraOrchestrator(config)
@@ -1787,7 +1801,7 @@ class TestStopMechanism:
         async def counting_implement() -> tuple[list[WorkerResult], list[GitHubIssue]]:
             nonlocal call_count
             call_count += 1
-            orch.request_stop()
+            await orch.request_stop()
             return [make_worker_result(42)], [make_issue(42)]
 
         orch._plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]
@@ -1803,7 +1817,7 @@ class TestStopMechanism:
         """Calling run() again after stop should reset the stop event."""
         orch = HydraOrchestrator(config)
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch.request_stop()
+        await orch.request_stop()
         assert orch._stop_event.is_set()
 
         # run() clears the stop event at start, then loops exit immediately
@@ -1828,7 +1842,7 @@ class TestStopMechanism:
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
 
         async def stop_on_implement() -> tuple[list[WorkerResult], list[GitHubIssue]]:
-            orch.request_stop()
+            await orch.request_stop()
             return [make_worker_result(42)], [make_issue(42)]
 
         orch._plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary

Closes #37.

## Issue

Dashboard accesses private method orchestrator._publish_status()

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Orchestrator stop operation is now asynchronous, ensuring status updates are published during shutdown.

* **Tests**
  * Updated tests to verify asynchronous stop behavior and status publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->