### PR TITLE
Fixes #26: templates/index.html: input field missing accessible label

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -330,7 +330,7 @@
     <div class="main">
       <div class="human-input-banner" id="human-input-banner">
         <span class="question" id="human-input-question">Agent needs input:</span>
-        <input type="text" id="human-input-field" placeholder="Type your response..." />
+        <input type="text" id="human-input-field" aria-labelledby="human-input-question" placeholder="Type your response..." />
         <button onclick="submitHumanInput()">Send</button>
       </div>
       <div class="tabs">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -189,6 +189,32 @@ class TestIndexRoute:
 
 
 # ---------------------------------------------------------------------------
+# Accessibility
+# ---------------------------------------------------------------------------
+
+
+class TestAccessibility:
+    """Tests for accessibility attributes in the dashboard HTML."""
+
+    def test_human_input_field_has_aria_labelledby(
+        self, config: HydraConfig, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """The human-input field must be linked to its label for screen readers."""
+        from fastapi.testclient import TestClient
+
+        from dashboard import HydraDashboard
+
+        state = make_state(tmp_path)
+        dashboard = HydraDashboard(config, event_bus, state)
+        app = dashboard.create_app()
+
+        client = TestClient(app)
+        response = client.get("/")
+
+        assert 'aria-labelledby="human-input-question"' in response.text
+
+
+# ---------------------------------------------------------------------------
 # GET /api/state
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #26.

## Issue

templates/index.html: input field missing accessible label

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra