### PR TITLE
Fixes #6: Extract shared _execute streaming method from agent/plann...

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -3,16 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import os
 import time
 from pathlib import Path
 
 from config import HydraConfig
 from events import EventBus, EventType, HydraEvent
 from models import GitHubIssue, WorkerResult, WorkerStatus
-from stream_parser import StreamParser
+from runner_utils import stream_claude_process, terminate_processes
 
 logger = logging.getLogger("hydra.agent")
 
@@ -201,9 +199,7 @@ class AgentRunner:
 
     def terminate(self) -> None:
         """Kill all active agent subprocesses."""
-        for proc in list(self._active_procs):
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
+        terminate_processes(self._active_procs)
 
     async def _execute(
         self,
@@ -213,72 +209,15 @@ class AgentRunner:
         issue_number: int,
     ) -> str:
         """Run the claude process and stream its output."""
-        env = {**os.environ}
-        env.pop("CLAUDECODE", None)
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(worktree_path),
-            env=env,
-            limit=1024 * 1024,  # 1 MB — stream-json lines can exceed 64 KB default
+        return await stream_claude_process(
+            cmd=cmd,
+            prompt=prompt,
+            cwd=worktree_path,
+            active_procs=self._active_procs,
+            event_bus=self._bus,
+            event_data={"issue": issue_number},
+            logger=logger,
         )
-        self._active_procs.add(proc)
-
-        try:
-            # Send the prompt on stdin and close it
-            assert proc.stdin is not None
-            assert proc.stdout is not None
-            assert proc.stderr is not None
-
-            proc.stdin.write(prompt.encode())
-            await proc.stdin.drain()
-            proc.stdin.close()
-
-            # Drain stderr in background to prevent deadlock
-            stderr_task = asyncio.create_task(proc.stderr.read())
-
-            parser = StreamParser()
-            raw_lines: list[str] = []
-            result_text = ""
-            async for raw in proc.stdout:
-                line = raw.decode(errors="replace").rstrip("\n")
-                raw_lines.append(line)
-                if not line.strip():
-                    continue
-
-                display, result = parser.parse(line)
-                if result is not None:
-                    result_text = result
-
-                if display.strip():
-                    await self._bus.publish(
-                        HydraEvent(
-                            type=EventType.TRANSCRIPT_LINE,
-                            data={"issue": issue_number, "line": display},
-                        )
-                    )
-
-            stderr_bytes = await stderr_task
-            await proc.wait()
-
-            if proc.returncode != 0:
-                stderr_text = stderr_bytes.decode(errors="replace").strip()
-                logger.warning(
-                    "Agent process exited with code %d for issue #%d: %s",
-                    proc.returncode,
-                    issue_number,
-                    stderr_text[:500],
-                )
-
-            return result_text or "\n".join(raw_lines)
-        except asyncio.CancelledError:
-            proc.kill()
-            raise
-        finally:
-            self._active_procs.discard(proc)
 
     async def _verify_result(
         self, worktree_path: Path, branch: str

--- a/reviewer.py
+++ b/reviewer.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import os
 import re
 import time
 from pathlib import Path
@@ -13,7 +11,7 @@ from pathlib import Path
 from config import HydraConfig
 from events import EventBus, EventType, HydraEvent
 from models import GitHubIssue, PRInfo, ReviewResult, ReviewVerdict
-from stream_parser import StreamParser
+from runner_utils import stream_claude_process, terminate_processes
 
 logger = logging.getLogger("hydra.reviewer")
 
@@ -299,9 +297,7 @@ SUMMARY: Implementation looks good, tests are comprehensive, all checks pass.
 
     def terminate(self) -> None:
         """Kill all active reviewer subprocesses."""
-        for proc in list(self._active_procs):
-            with contextlib.suppress(ProcessLookupError):
-                proc.kill()
+        terminate_processes(self._active_procs)
 
     async def _execute(
         self,
@@ -311,65 +307,15 @@ SUMMARY: Implementation looks good, tests are comprehensive, all checks pass.
         pr_number: int,
     ) -> str:
         """Run the claude review process."""
-        env = {**os.environ}
-        env.pop("CLAUDECODE", None)
-
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(worktree_path),
-            env=env,
-            limit=1024 * 1024,  # 1 MB — stream-json lines can exceed 64 KB default
+        return await stream_claude_process(
+            cmd=cmd,
+            prompt=prompt,
+            cwd=worktree_path,
+            active_procs=self._active_procs,
+            event_bus=self._bus,
+            event_data={"pr": pr_number, "source": "reviewer"},
+            logger=logger,
         )
-        self._active_procs.add(proc)
-
-        try:
-            assert proc.stdin is not None
-            assert proc.stdout is not None
-            assert proc.stderr is not None
-
-            proc.stdin.write(prompt.encode())
-            await proc.stdin.drain()
-            proc.stdin.close()
-
-            # Drain stderr in background to prevent deadlock
-            stderr_task = asyncio.create_task(proc.stderr.read())
-
-            parser = StreamParser()
-            raw_lines: list[str] = []
-            result_text = ""
-            async for raw in proc.stdout:
-                line = raw.decode(errors="replace").rstrip("\n")
-                raw_lines.append(line)
-                if not line.strip():
-                    continue
-
-                display, result = parser.parse(line)
-                if result is not None:
-                    result_text = result
-
-                if display.strip():
-                    await self._bus.publish(
-                        HydraEvent(
-                            type=EventType.TRANSCRIPT_LINE,
-                            data={
-                                "pr": pr_number,
-                                "line": display,
-                                "source": "reviewer",
-                            },
-                        )
-                    )
-
-            await stderr_task
-            await proc.wait()
-            return result_text or "\n".join(raw_lines)
-        except asyncio.CancelledError:
-            proc.kill()
-            raise
-        finally:
-            self._active_procs.discard(proc)
 
     def _save_transcript(self, pr_number: int, transcript: str) -> None:
         """Write the review transcript to .hydra/logs/ for post-mortem review."""

--- a/runner_utils.py
+++ b/runner_utils.py
@@ -1,0 +1,140 @@
+"""Shared subprocess streaming utilities for Claude agent runners."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from events import EventBus, EventType, HydraEvent
+from stream_parser import StreamParser
+
+
+async def stream_claude_process(
+    *,
+    cmd: list[str],
+    prompt: str,
+    cwd: Path,
+    active_procs: set[asyncio.subprocess.Process],
+    event_bus: EventBus,
+    event_data: dict[str, Any],
+    logger: logging.Logger,
+    on_output: Callable[[str], bool] | None = None,
+) -> str:
+    """Run a ``claude -p`` subprocess and stream its output.
+
+    Parameters
+    ----------
+    cmd:
+        Command to execute (e.g. ``["claude", "-p", ...]``).
+    prompt:
+        Text to write to the process's stdin.
+    cwd:
+        Working directory for the subprocess.
+    active_procs:
+        Shared set for tracking active processes (for terminate).
+    event_bus:
+        For publishing ``TRANSCRIPT_LINE`` events.
+    event_data:
+        Base dict for event data (runner-specific keys like ``issue``/``pr``/``source``).
+        ``"line"`` is added automatically per output line.
+    logger:
+        Caller's logger for warnings (preserves per-runner log context).
+    on_output:
+        Optional callback receiving accumulated display text.
+        Return ``True`` to kill the process early.
+
+    Returns
+    -------
+    str
+        The transcript string, using the fallback chain:
+        result_text → accumulated_text → raw_lines.
+    """
+    env = {**os.environ}
+    env.pop("CLAUDECODE", None)
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=str(cwd),
+        env=env,
+        limit=1024 * 1024,  # 1 MB — stream-json lines can exceed 64 KB default
+    )
+    active_procs.add(proc)
+
+    try:
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+
+        proc.stdin.write(prompt.encode())
+        await proc.stdin.drain()
+        proc.stdin.close()
+
+        # Drain stderr in background to prevent deadlock
+        stderr_task = asyncio.create_task(proc.stderr.read())
+
+        parser = StreamParser()
+        raw_lines: list[str] = []
+        result_text = ""
+        accumulated_text = ""
+        early_killed = False
+
+        async for raw in proc.stdout:
+            line = raw.decode(errors="replace").rstrip("\n")
+            raw_lines.append(line)
+            if not line.strip():
+                continue
+
+            display, result = parser.parse(line)
+            if result is not None:
+                result_text = result
+
+            if display.strip():
+                accumulated_text += display + "\n"
+                await event_bus.publish(
+                    HydraEvent(
+                        type=EventType.TRANSCRIPT_LINE,
+                        data={**event_data, "line": display},
+                    )
+                )
+
+            if (
+                on_output is not None
+                and not early_killed
+                and on_output(accumulated_text)
+            ):
+                early_killed = True
+                proc.kill()
+                break
+
+        stderr_bytes = await stderr_task
+        await proc.wait()
+
+        if not early_killed and proc.returncode != 0:
+            stderr_text = stderr_bytes.decode(errors="replace").strip()
+            logger.warning(
+                "Process exited with code %d: %s",
+                proc.returncode,
+                stderr_text[:500],
+            )
+
+        return result_text or accumulated_text.rstrip("\n") or "\n".join(raw_lines)
+    except asyncio.CancelledError:
+        proc.kill()
+        raise
+    finally:
+        active_procs.discard(proc)
+
+
+def terminate_processes(active_procs: set[asyncio.subprocess.Process]) -> None:
+    """Kill all processes in *active_procs*, ignoring already-exited ones."""
+    for proc in list(active_procs):
+        with contextlib.suppress(ProcessLookupError):
+            proc.kill()


### PR DESCRIPTION
## Summary

Closes #6.

## Issue

Extract shared _execute streaming method from agent/planner/reviewer

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra