### PR TITLE
Fix HITL escalation to swap labels on both issue and PR

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -658,8 +658,12 @@ class HydraOrchestrator:
                     )
                     for lbl in self._config.review_label:
                         await self._prs.remove_label(pr.issue_number, lbl)
+                        await self._prs.remove_pr_label(pr.number, lbl)
                     await self._prs.add_labels(
                         pr.issue_number, [self._config.hitl_label[0]]
+                    )
+                    await self._prs.add_pr_labels(
+                        pr.number, [self._config.hitl_label[0]]
                     )
                     self._active_issues.discard(pr.issue_number)
                     return ReviewResult(
@@ -725,8 +729,13 @@ class HydraOrchestrator:
                             )
                             for lbl in self._config.review_label:
                                 await self._prs.remove_label(pr.issue_number, lbl)
+                                await self._prs.remove_pr_label(pr.number, lbl)
                             await self._prs.add_labels(
                                 pr.issue_number,
+                                [self._config.hitl_label[0]],
+                            )
+                            await self._prs.add_pr_labels(
+                                pr.number,
                                 [self._config.hitl_label[0]],
                             )
 
@@ -814,7 +823,9 @@ class HydraOrchestrator:
         # Swap to HITL label so the dashboard HITL tab picks it up
         for lbl in self._config.review_label:
             await self._prs.remove_label(issue.number, lbl)
+            await self._prs.remove_pr_label(pr.number, lbl)
         await self._prs.add_labels(issue.number, [self._config.hitl_label[0]])
+        await self._prs.add_pr_labels(pr.number, [self._config.hitl_label[0]])
         return False
 
     async def _set_phase(self, phase: Phase) -> None:

--- a/pr_manager.py
+++ b/pr_manager.py
@@ -404,6 +404,31 @@ class PRManager:
                 exc,
             )
 
+    async def remove_pr_label(self, pr_number: int, label: str) -> None:
+        """Remove *label* from a GitHub pull request."""
+        if self._config.dry_run:
+            return
+        try:
+            await run_subprocess(
+                "gh",
+                "pr",
+                "edit",
+                str(pr_number),
+                "--repo",
+                self._repo,
+                "--remove-label",
+                label,
+                cwd=self._config.repo_root,
+                gh_token=self._config.gh_token,
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "Could not remove label %r from PR #%d: %s",
+                label,
+                pr_number,
+                exc,
+            )
+
     async def add_pr_labels(self, pr_number: int, labels: list[str]) -> None:
         """Add *labels* to a GitHub pull request."""
         if self._config.dry_run or not labels:

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -940,6 +940,47 @@ async def test_add_pr_labels_subprocess_error_does_not_raise(config, event_bus):
 
 
 # ---------------------------------------------------------------------------
+# remove_pr_label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remove_pr_label_calls_gh_pr_edit(config, event_bus):
+    manager = _make_manager(config, event_bus)
+    mock_create = _make_subprocess_mock(returncode=0, stdout="")
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        await manager.remove_pr_label(101, "hydra-review")
+
+    args = mock_create.call_args[0]
+    assert "pr" in args
+    assert "edit" in args
+    assert "--remove-label" in args
+    assert "hydra-review" in args
+
+
+@pytest.mark.asyncio
+async def test_remove_pr_label_dry_run_skips_command(dry_config, event_bus):
+    manager = _make_manager(dry_config, event_bus)
+    mock_create = _make_subprocess_mock(returncode=0)
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        await manager.remove_pr_label(101, "hydra-review")
+
+    mock_create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_pr_label_subprocess_error_does_not_raise(config, event_bus):
+    manager = _make_manager(config, event_bus)
+    mock_create = _make_subprocess_mock(returncode=1, stderr="label error")
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        # Should not raise
+        await manager.remove_pr_label(101, "hydra-review")
+
+
+# ---------------------------------------------------------------------------
 # get_pr_diff
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `remove_pr_label` method to PRManager (uses `gh pr edit --remove-label`)
- Update all three HITL escalation paths (rebase conflict, merge failure, CI failure) to also swap labels on the PR, not just the issue
- Previously only the issue got `hydra-hitl` — the PR kept `hydra-review`

## Test plan
- [x] 915 tests pass, 94.81% coverage
- [x] `make quality` passes
- [ ] Verify PR #64 gets `hydra-hitl` label on next escalation

🤖 Generated with [Claude Code](https://claude.com/claude-code)