### PR TITLE
Use merge instead of rebase before review to avoid force-push

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -640,9 +640,11 @@ class HydraOrchestrator:
                     # Create a fresh worktree for review
                     wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
 
-                # Rebase onto main before reviewing so we review up-to-date code
-                rebased = await self._worktrees.rebase(wt_path, pr.branch)
-                if rebased:
+                # Merge main into the branch before reviewing so we review
+                # up-to-date code.  Merge (not rebase) keeps the push
+                # fast-forward so no force-push is needed.
+                merged_main = await self._worktrees.merge_main(wt_path)
+                if merged_main:
                     await self._prs.push_branch(wt_path, pr.branch)
                 else:
                     logger.warning(

--- a/worktree.py
+++ b/worktree.py
@@ -189,8 +189,11 @@ class WorktreeManager:
                 gh_token=self._config.gh_token,
             )
 
-    async def rebase(self, worktree_path: Path, branch: str) -> bool:
-        """Rebase *branch* onto latest main inside *worktree_path*.
+    async def merge_main(self, worktree_path: Path) -> bool:
+        """Merge latest main into the current branch inside *worktree_path*.
+
+        Uses merge (not rebase) so the push remains fast-forward and
+        doesn't require ``--force``.
 
         Returns *True* on success, *False* if conflicts arise.
         """
@@ -205,18 +208,19 @@ class WorktreeManager:
             )
             await run_subprocess(
                 "git",
-                "rebase",
+                "merge",
                 f"origin/{self._config.main_branch}",
+                "--no-edit",
                 cwd=worktree_path,
                 gh_token=self._config.gh_token,
             )
             return True
         except RuntimeError:
-            # Abort rebase on conflict
+            # Abort merge on conflict
             with contextlib.suppress(RuntimeError):
                 await run_subprocess(
                     "git",
-                    "rebase",
+                    "merge",
                     "--abort",
                     cwd=worktree_path,
                     gh_token=self._config.gh_token,


### PR DESCRIPTION
## Summary
- Replace `WorktreeManager.rebase()` with `merge_main()` — merges `origin/main` into the PR branch instead of rebasing onto it
- Pushes remain fast-forward (no `--force-with-lease` needed), so branch protection rules and git hooks are respected
- Updated orchestrator to call `merge_main` before review instead of `rebase`
- Removed the `force` parameter that was added to `push_branch` (no longer needed)

## Test plan
- [x] `test_review_merges_main_before_reviewing` — verifies merge + push happen before review
- [x] `test_review_merge_main_conflict_escalates_to_hitl` — verifies conflict escalation skips review
- [x] `test_merge_main_success_returns_true` — worktree merge success
- [x] `test_merge_main_conflict_aborts_and_returns_false` — worktree merge conflict abort
- [x] `test_merge_main_fetch_failure_returns_false` — worktree fetch failure
- [x] All 933 tests pass, `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)