### PR TITLE
Pull branch from remote before merging main

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -643,7 +643,7 @@ class HydraOrchestrator:
                 # Merge main into the branch before reviewing so we review
                 # up-to-date code.  Merge (not rebase) keeps the push
                 # fast-forward so no force-push is needed.
-                merged_main = await self._worktrees.merge_main(wt_path)
+                merged_main = await self._worktrees.merge_main(wt_path, pr.branch)
                 if merged_main:
                     await self._prs.push_branch(wt_path, pr.branch)
                 else:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -381,12 +381,12 @@ class TestMergeMain:
     async def test_merge_main_success_returns_true(
         self, config, tmp_path: Path
     ) -> None:
-        """merge_main should return True when both fetch and merge succeed."""
+        """merge_main should return True when fetch, ff-pull, and merge succeed."""
         manager = WorktreeManager(config)
         success_proc = _make_proc()
 
         with patch("asyncio.create_subprocess_exec", return_value=success_proc):
-            result = await manager.merge_main(tmp_path)
+            result = await manager.merge_main(tmp_path, "agent/issue-7")
 
         assert result is True
 
@@ -397,7 +397,7 @@ class TestMergeMain:
         """merge_main should abort and return False when conflicts occur."""
         manager = WorktreeManager(config)
 
-        fetch_proc = _make_proc(returncode=0)
+        success_proc = _make_proc(returncode=0)
         merge_fail_proc = _make_proc(
             returncode=1, stderr=b"CONFLICT (content): Merge conflict"
         )
@@ -408,16 +408,16 @@ class TestMergeMain:
         async def fake_exec(*args, **kwargs):
             nonlocal call_count
             call_count += 1
-            if call_count == 1:
-                return fetch_proc  # git fetch succeeds
-            if call_count == 2:
-                return merge_fail_proc  # git merge fails
+            if call_count <= 2:
+                return success_proc  # git fetch + ff-only merge succeed
+            if call_count == 3:
+                return merge_fail_proc  # git merge origin/main fails
             return abort_proc  # git merge --abort
 
         with patch(
             "asyncio.create_subprocess_exec", side_effect=fake_exec
         ) as mock_exec:
-            result = await manager.merge_main(tmp_path)
+            result = await manager.merge_main(tmp_path, "agent/issue-7")
 
         assert result is False
         # Verify abort was called
@@ -444,7 +444,7 @@ class TestMergeMain:
             return abort_proc
 
         with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
-            result = await manager.merge_main(tmp_path)
+            result = await manager.merge_main(tmp_path, "agent/issue-7")
 
         assert result is False
 

--- a/worktree.py
+++ b/worktree.py
@@ -189,11 +189,12 @@ class WorktreeManager:
                 gh_token=self._config.gh_token,
             )
 
-    async def merge_main(self, worktree_path: Path) -> bool:
-        """Merge latest main into the current branch inside *worktree_path*.
+    async def merge_main(self, worktree_path: Path, branch: str) -> bool:
+        """Merge latest main into *branch* inside *worktree_path*.
 
-        Uses merge (not rebase) so the push remains fast-forward and
-        doesn't require ``--force``.
+        First pulls the branch itself so the local copy is in sync with
+        the remote, then merges ``origin/main``.  Because this uses merge
+        the subsequent push is always fast-forward.
 
         Returns *True* on success, *False* if conflicts arise.
         """
@@ -203,6 +204,16 @@ class WorktreeManager:
                 "fetch",
                 "origin",
                 self._config.main_branch,
+                branch,
+                cwd=worktree_path,
+                gh_token=self._config.gh_token,
+            )
+            # Fast-forward local branch to match remote so push stays ff
+            await run_subprocess(
+                "git",
+                "merge",
+                "--ff-only",
+                f"origin/{branch}",
                 cwd=worktree_path,
                 gh_token=self._config.gh_token,
             )


### PR DESCRIPTION
## Summary
- Fixes `non-fast-forward` push rejections after merging main into PR branches
- `merge_main` now fetches **both** `origin/main` and `origin/<branch>` in a single fetch
- Fast-forwards the local branch to match remote (`git merge --ff-only origin/<branch>`) before merging main
- This ensures the local worktree is in sync with the remote, so the subsequent push is always fast-forward

## Root cause
When a worktree persists across Hydra runs, the local branch can fall behind `origin/<branch>` (e.g., from a previous push). Merging main adds a commit on top of the stale local state, but push fails because remote has commits local doesn't.

## Test plan
- [x] `test_merge_main_success_returns_true` — fetch + ff-pull + merge all succeed
- [x] `test_merge_main_conflict_aborts_and_returns_false` — conflict on merge main aborts cleanly
- [x] `test_merge_main_fetch_failure_returns_false` — fetch failure handled
- [x] All 933 tests pass, `make quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)