### PR TITLE
Validate issue bodies, bump reviewers, fix gh-issue skill

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ REVIEW_BUDGET ?= 0
 PLANNER_LABEL ?= hydra-plan
 PLANNER_MODEL ?= opus
 PLANNER_BUDGET ?= 0
+REVIEWERS ?= 2
 PORT ?= 5555
 
 # Colors
@@ -82,6 +83,7 @@ run:
 		--planner-label $(PLANNER_LABEL) \
 		--planner-model $(PLANNER_MODEL) \
 		--planner-budget-usd $(PLANNER_BUDGET) \
+		--max-reviewers $(REVIEWERS) \
 		--dashboard-port $(PORT) & \
 	wait
 

--- a/config.py
+++ b/config.py
@@ -28,7 +28,7 @@ class HydraConfig(BaseModel):
         default=1, ge=1, le=10, description="Concurrent planning agents"
     )
     max_reviewers: int = Field(
-        default=1, ge=1, le=10, description="Concurrent review agents"
+        default=2, ge=1, le=10, description="Concurrent review agents"
     )
     max_budget_usd: float = Field(
         default=0, ge=0, description="USD cap per implementation agent (0 = unlimited)"

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -324,6 +324,14 @@ class HydraOrchestrator:
 
                     # File new issues discovered during planning
                     for new_issue in result.new_issues:
+                        if len(new_issue.body) < 50:
+                            logger.warning(
+                                "Skipping discovered issue %r — body too short "
+                                "(%d chars, need ≥50)",
+                                new_issue.title,
+                                len(new_issue.body),
+                            )
+                            continue
                         labels = new_issue.labels or (
                             [self._config.planner_label[0]]
                             if self._config.planner_label

--- a/planner.py
+++ b/planner.py
@@ -225,14 +225,18 @@ you can file them as new GitHub issues using these markers:
 
 NEW_ISSUES_START
 - title: Short issue title
-  body: Description of the issue
+  body: Detailed description of the issue (at least 2-3 sentences). Include what the
+    problem is, where in the codebase it occurs, and what the expected behavior should be.
   labels: {find_label}
 - title: Another issue
-  body: Another description
+  body: Another detailed description with enough context for someone to understand
+    and act on it without additional research.
   labels: {find_label}
 NEW_ISSUES_END
 
 Only include this section if you actually discover issues worth filing.
+**IMPORTANT:** Each issue body MUST be detailed (at least 50 characters). One-word
+or one-line bodies will be rejected. Include file paths, function names, and context.
 
 **IMPORTANT:** You MUST only use the following label for new issues: `{find_label}`
 Do NOT invent labels. All discovered issues enter the pipeline via the find label.
@@ -332,6 +336,7 @@ Do NOT invent labels. All discovered issues enter the pipeline via the find labe
         issues: list[NewIssueSpec] = []
         current: dict[str, str] = {}
 
+        last_key = ""
         for line in block.splitlines():
             stripped = line.strip()
             if stripped.startswith("- title:"):
@@ -348,10 +353,16 @@ Do NOT invent labels. All discovered issues enter the pipeline via the find labe
                         )
                     )
                 current = {"title": stripped[len("- title:") :].strip()}
+                last_key = "title"
             elif stripped.startswith("body:"):
                 current["body"] = stripped[len("body:") :].strip()
+                last_key = "body"
             elif stripped.startswith("labels:"):
                 current["labels"] = stripped[len("labels:") :].strip()
+                last_key = "labels"
+            elif stripped and last_key == "body":
+                # Continuation line for multi-line body
+                current["body"] = current.get("body", "") + " " + stripped
 
         # Don't forget the last entry
         if current.get("title"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,7 +110,7 @@ class TestBuildConfig:
         assert cfg.batch_size == 15
         assert cfg.max_workers == 2
         assert cfg.max_planners == 1
-        assert cfg.max_reviewers == 1
+        assert cfg.max_reviewers == 2
         assert cfg.max_budget_usd == pytest.approx(0)
         assert cfg.model == "sonnet"
         assert cfg.review_model == "opus"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -328,7 +328,7 @@ class TestHydraConfigDefaults:
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.max_reviewers == 1
+        assert cfg.max_reviewers == 2
 
     def test_max_budget_usd_default(self, tmp_path: Path) -> None:
         cfg = HydraConfig(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -868,8 +868,18 @@ class TestPlanPhase:
             plan="The plan",
             summary="Done",
             new_issues=[
-                NewIssueSpec(title="Issue A", body="Body A", labels=["bug"]),
-                NewIssueSpec(title="Issue B", body="Body B", labels=["bug"]),
+                NewIssueSpec(
+                    title="Issue A",
+                    body="Issue A has a bug in the authentication flow "
+                    "that causes login failures on retry.",
+                    labels=["bug"],
+                ),
+                NewIssueSpec(
+                    title="Issue B",
+                    body="Issue B has a race condition in the websocket "
+                    "handler that drops messages under load.",
+                    labels=["bug"],
+                ),
             ],
         )
 
@@ -902,7 +912,10 @@ class TestPlanPhase:
             summary="Done",
             new_issues=[
                 NewIssueSpec(
-                    title="Tech debt", body="Cleanup needed", labels=["tech-debt"]
+                    title="Tech debt",
+                    body="The auth module has accumulated significant tech debt "
+                    "that needs cleanup and refactoring.",
+                    labels=["tech-debt"],
                 ),
             ],
         )
@@ -920,7 +933,10 @@ class TestPlanPhase:
         await orch._plan_issues()
 
         mock_prs.create_issue.assert_awaited_once_with(
-            "Tech debt", "Cleanup needed", ["tech-debt"]
+            "Tech debt",
+            "The auth module has accumulated significant tech debt "
+            "that needs cleanup and refactoring.",
+            ["tech-debt"],
         )
 
     @pytest.mark.asyncio
@@ -1003,7 +1019,11 @@ class TestPlanPhase:
             plan="The plan",
             summary="Done",
             new_issues=[
-                NewIssueSpec(title="Discovered issue", body="Body"),
+                NewIssueSpec(
+                    title="Discovered issue",
+                    body="This issue was discovered during planning — the config "
+                    "parser does not handle nested environment variables.",
+                ),
             ],
         )
 
@@ -1020,8 +1040,45 @@ class TestPlanPhase:
         await orch._plan_issues()
 
         mock_prs.create_issue.assert_awaited_once_with(
-            "Discovered issue", "Body", [config.planner_label[0]]
+            "Discovered issue",
+            "This issue was discovered during planning — the config "
+            "parser does not handle nested environment variables.",
+            [config.planner_label[0]],
         )
+
+    @pytest.mark.asyncio
+    async def test_plan_issues_skips_new_issues_with_short_body(
+        self, config: HydraConfig
+    ) -> None:
+        """New issues with body < 50 chars should be skipped, not filed."""
+        from models import NewIssueSpec
+
+        orch = HydraOrchestrator(config)
+        issue = make_issue(42)
+        plan_result = PlanResult(
+            issue_number=42,
+            success=True,
+            plan="The plan",
+            summary="Done",
+            new_issues=[
+                NewIssueSpec(title="Short body issue", body="Too short"),
+            ],
+        )
+
+        orch._planners.plan = AsyncMock(return_value=plan_result)  # type: ignore[method-assign]
+        orch._fetch_plan_issues = AsyncMock(return_value=[issue])  # type: ignore[method-assign]
+
+        mock_prs = AsyncMock()
+        mock_prs.post_comment = AsyncMock()
+        mock_prs.remove_label = AsyncMock()
+        mock_prs.add_labels = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=99)
+        orch._prs = mock_prs
+
+        await orch._plan_issues()
+
+        mock_prs.create_issue.assert_not_awaited()
+        assert orch._state.get_lifetime_stats()["issues_created"] == 0
 
     @pytest.mark.asyncio
     async def test_plan_issues_stop_event_cancels_remaining(

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -447,6 +447,27 @@ def test_extract_new_issues_single_issue(config, event_bus):
     assert issues[0].title == "Add logging"
 
 
+def test_extract_new_issues_multiline_body(config, event_bus):
+    """Multi-line body continuation lines are concatenated."""
+    runner = _make_runner(config, event_bus)
+    transcript = (
+        "NEW_ISSUES_START\n"
+        "- title: Fix the widget\n"
+        "  body: The widget is broken in production. Users are seeing\n"
+        "    errors when they click the submit button because the form\n"
+        "    validation skips required fields.\n"
+        "  labels: bug\n"
+        "NEW_ISSUES_END"
+    )
+    issues = runner._extract_new_issues(transcript)
+    assert len(issues) == 1
+    assert issues[0].title == "Fix the widget"
+    assert "widget is broken" in issues[0].body
+    assert "form" in issues[0].body
+    assert "validation" in issues[0].body
+    assert len(issues[0].body) > 50
+
+
 # ---------------------------------------------------------------------------
 # plan - success path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Prevent planner-discovered issues from being created with empty/short bodies (which triggers HITL escalation)
- Bump `max_reviewers` default from 1 to 2 and wire it into the Makefile
- Fix `/gh-issue` slash command to always include labels and detailed bodies

## Changes

### Issue body validation (`orchestrator.py`, `planner.py`)
- Skip creating discovered issues with body < 50 chars (logs warning instead)
- Support multi-line body continuation in `_extract_new_issues` parser
- Updated planner prompt to require detailed bodies (50+ chars with file paths and context)

### Config (`config.py`, `Makefile`)
- `max_reviewers` default changed from 1 to 2
- Added `REVIEWERS` variable and `--max-reviewers` flag to Makefile `run` target

### Slash command (`.claude/commands/gh-issue.md`)
- Hardcode `hydra-plan` label fallback when `$HYDRA_LABEL_PLAN` is empty
- Use `--body-file` for long content to avoid shell escaping issues
- Detect epics and skip automation label on parent issues
- Require body >= 200 chars

## Test plan

- [x] All 980 tests pass
- [x] 96% coverage
- [x] Lint, typecheck, security all pass
- [x] New test: `test_extract_new_issues_multiline_body`
- [x] New test: `test_plan_issues_skips_new_issues_with_short_body`
- [x] Updated existing tests for new default and body lengths

🤖 Generated with [Claude Code](https://claude.com/claude-code)