### PR TITLE
Fixes #158: Tee Vite and Python output to log files for Loki ingestion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ PLANNER_BUDGET ?= 0
 REVIEWERS ?= 2
 HITL_WORKERS ?= 1
 PORT ?= 5555
+LOG_DIR ?= $(PROJECT_ROOT)/.hydra/logs
 
 # Colors
 RED := \033[0;31m
@@ -68,12 +69,14 @@ help:
 	@echo "  PLANNER_BUDGET   USD per planner agent (default: 0 = unlimited)"
 	@echo "  HITL_WORKERS     Max concurrent HITL agents (default: 1)"
 	@echo "  PORT             Dashboard port (default: 5555)"
+	@echo "  LOG_DIR          Log directory (default: .hydra/logs)"
 
 run:
+	@mkdir -p $(LOG_DIR)
 	@echo "$(BLUE)Starting Hydra — backend :$(PORT) + frontend :5556$(RESET)"
 	@echo "$(GREEN)Open http://localhost:5556 to use the dashboard$(RESET)"
 	@trap 'kill 0' EXIT; \
-	cd $(HYDRA_DIR)ui && npm install --silent 2>/dev/null && npm run dev & \
+	cd $(HYDRA_DIR)ui && npm install --silent 2>/dev/null && npm run dev 2>&1 | tee $(LOG_DIR)/vite.log & \
 	cd $(HYDRA_DIR) && $(UV) python cli.py \
 		--ready-label $(READY_LABEL) \
 		--max-workers $(WORKERS) \

--- a/cli.py
+++ b/cli.py
@@ -184,6 +184,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Enable debug-level logging",
     )
     parser.add_argument(
+        "--log-file",
+        default=".hydra/logs/hydra.log",
+        help="Path to log file for structured JSON logging (default: .hydra/logs/hydra.log)",
+    )
+    parser.add_argument(
         "--clean",
         action="store_true",
         help="Remove all worktrees and state, then exit",
@@ -341,7 +346,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
 
     level = logging.DEBUG if args.verbose else logging.INFO
-    setup_logging(level=level, json_output=not args.verbose)
+    setup_logging(level=level, json_output=not args.verbose, log_file=args.log_file)
 
     config = build_config(args)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,16 @@ class TestParseArgs:
         assert args.verbose is False
         assert args.clean is False
 
+    def test_log_file_default(self) -> None:
+        """--log-file should default to .hydra/logs/hydra.log."""
+        args = parse_args([])
+        assert args.log_file == ".hydra/logs/hydra.log"
+
+    def test_log_file_explicit_value(self) -> None:
+        """An explicit --log-file value should be preserved."""
+        args = parse_args(["--log-file", "/tmp/custom.log"])
+        assert args.log_file == "/tmp/custom.log"
+
     def test_explicit_int_arg_preserved(self) -> None:
         args = parse_args(["--batch-size", "10"])
         assert args.batch_size == 10

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -6,6 +6,8 @@ import inspect
 import json
 import logging
 from collections.abc import Generator
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +24,8 @@ def _clean_hydra_logger() -> Generator[None, None, None]:
     logger = logging.getLogger("hydra")
     logger.handlers.clear()
     yield
+    for handler in logger.handlers[:]:
+        handler.close()
     logger.handlers.clear()
 
 
@@ -136,3 +140,80 @@ class TestSetupLogging:
         """Regression guard: log_dir must not be a parameter."""
         sig = inspect.signature(setup_logging)
         assert "log_dir" not in sig.parameters
+
+
+# ---------------------------------------------------------------------------
+# setup_logging — log_file (RotatingFileHandler)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupLoggingWithFile:
+    """Tests for setup_logging() with the log_file parameter."""
+
+    def test_log_file_adds_file_handler(self, tmp_path: Path) -> None:
+        """When log_file is provided, a second handler should be added."""
+        logger = setup_logging(log_file=tmp_path / "test.log")
+        assert len(logger.handlers) == 2
+
+    def test_log_file_handler_is_rotating(self, tmp_path: Path) -> None:
+        """The file handler should be a RotatingFileHandler."""
+        logger = setup_logging(log_file=tmp_path / "test.log")
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+        ]
+        assert len(file_handlers) == 1
+
+    def test_log_file_handler_uses_json_formatter(self, tmp_path: Path) -> None:
+        """The file handler should always use JSONFormatter."""
+        logger = setup_logging(log_file=tmp_path / "test.log")
+        file_handler = next(
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+        )
+        assert isinstance(file_handler.formatter, JSONFormatter)
+
+    def test_log_file_handler_uses_json_even_with_plain_console(
+        self, tmp_path: Path
+    ) -> None:
+        """File handler uses JSON even when console is plain text."""
+        logger = setup_logging(json_output=False, log_file=tmp_path / "test.log")
+        file_handler = next(
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+        )
+        assert isinstance(file_handler.formatter, JSONFormatter)
+
+    def test_log_file_creates_parent_directories(self, tmp_path: Path) -> None:
+        """Parent directories should be created if they don't exist."""
+        log_file = tmp_path / "nested" / "dir" / "test.log"
+        setup_logging(log_file=log_file)
+        assert log_file.parent.exists()
+
+    def test_log_file_rotation_config(self, tmp_path: Path) -> None:
+        """Rotation should be configured for 10 MB max, 5 backups."""
+        logger = setup_logging(log_file=tmp_path / "test.log")
+        file_handler = next(
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+        )
+        assert file_handler.maxBytes == 10 * 1024 * 1024
+        assert file_handler.backupCount == 5
+
+    def test_log_file_none_skips_file_handler(self) -> None:
+        """When log_file is None, only the console handler is added."""
+        logger = setup_logging(log_file=None)
+        assert len(logger.handlers) == 1
+
+    def test_log_file_writes_json(self, tmp_path: Path) -> None:
+        """The file handler should write valid JSON log lines."""
+        log_file = tmp_path / "test.log"
+        logger = setup_logging(log_file=log_file)
+        logger.info("test message")
+        for handler in logger.handlers:
+            handler.flush()
+        content = log_file.read_text().strip()
+        parsed = json.loads(content)
+        assert parsed["msg"] == "test message"
+        assert parsed["level"] == "INFO"
+
+    def test_log_file_accepts_string_path(self, tmp_path: Path) -> None:
+        """log_file should accept a string path in addition to Path."""
+        logger = setup_logging(log_file=str(tmp_path / "test.log"))
+        assert len(logger.handlers) == 2


### PR DESCRIPTION
## Summary
- Add `log_file` parameter to `setup_logging()` with `RotatingFileHandler` (10MB max, 5 backups, always JSON-formatted for Loki/Grafana ingestion)
- Add `--log-file` CLI arg with default `.hydra/logs/hydra.log` so Python logs are always written to a structured file alongside console output
- Add `LOG_DIR` overridable Makefile variable and pipe Vite dev server through `tee` to `.hydra/logs/vite.log`
- Ensure `.hydra/logs/` directory is created via `mkdir -p` before startup

## Test plan
- [x] `make quality` passes (lint, typecheck, security, 1089 tests)
- [ ] Verify `make run` creates `.hydra/logs/vite.log` with Vite output
- [ ] Verify `.hydra/logs/hydra.log` contains structured JSON log lines
- [ ] Verify `--log-file /custom/path` overrides the default log file path
- [ ] Verify log rotation works (10MB cap, 5 backups)
- [ ] Verify `.gitignore` covers `.hydra/` (already does)

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)