### PR TITLE
Fixes #240: Swap Livestream and Timeline tab labels

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -90,7 +90,7 @@ export default function App() {
                 ? <>Pull Requests{prs.length > 0 && <span style={styles.tabBadge}>{prs.length}</span>}</>
                 : tab === 'hitl' ? (
                 <>HITL{hitlItems?.length > 0 && <span style={hitlBadgeStyle}>{hitlItems.length}</span>}</>
-              ) : tab === 'livestream' ? 'Livestream' : tab.charAt(0).toUpperCase() + tab.slice(1)}
+              ) : tab === 'livestream' ? 'Timeline' : tab === 'timeline' ? 'Livestream' : tab.charAt(0).toUpperCase() + tab.slice(1)}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Swap the display labels for the Livestream and Timeline tabs in the dashboard
- "Livestream" tab (which shows aggregate/formatted summaries) is now labeled "Timeline"
- "Timeline" tab (which shows raw events) is now labeled "Livestream"
- Only display text changes — no component wiring or behavior changes

## Test plan
- [ ] Open dashboard, verify "Timeline" tab shows the formatted event summaries (Livestream component)
- [ ] Verify "Livestream" tab shows the raw JSON event list
- [ ] Verify tab click behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)