### PR TITLE
Clear dashboard state immediately on Stop button press

### DIFF
--- a/ui/src/hooks/__tests__/useHydraSocket.test.js
+++ b/ui/src/hooks/__tests__/useHydraSocket.test.js
@@ -507,15 +507,15 @@ describe('useHydraSocket reducer', () => {
       expect(next.sessionImplemented).toBe(5)
     })
 
-    it('preserves workers and session stats when status is stopping', () => {
+    it('clears workers and session stats when status is stopping', () => {
       const next = reducer(staleState, {
         type: 'orchestrator_status',
         data: { status: 'stopping' },
         timestamp: '2024-01-01T00:00:01Z',
       })
       expect(next.orchestratorStatus).toBe('stopping')
-      expect(Object.keys(next.workers)).toHaveLength(2)
-      expect(next.sessionImplemented).toBe(5)
+      expect(next.workers).toEqual({})
+      expect(next.sessionImplemented).toBe(0)
     })
   })
 })

--- a/ui/src/hooks/useHydraSocket.js
+++ b/ui/src/hooks/useHydraSocket.js
@@ -58,7 +58,7 @@ export function reducer(state, action) {
 
     case 'orchestrator_status': {
       const newStatus = action.data.status
-      const isStopped = newStatus === 'idle' || newStatus === 'done'
+      const isStopped = newStatus === 'idle' || newStatus === 'done' || newStatus === 'stopping'
       return {
         ...addEvent(state, action),
         orchestratorStatus: newStatus,


### PR DESCRIPTION
## Summary
- The previous PR (#278) cleared workers/session stats on `idle` and `done`, but not on `stopping`
- Pressing Stop now immediately clears the sidebar workers and header session counters instead of waiting for the `idle` transition
- Adds `stopping` to the `isStopped` check in the `orchestrator_status` reducer case

## Test plan
- [x] Updated reducer test to verify `stopping` clears state
- [x] All 39 useHydraSocket tests passing
- [ ] CI validates full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)