### PR TITLE
Fix Makefile defaults: 3 implementers, 5 reviewers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ UV := VIRTUAL_ENV=$(VENV) uv run --active
 
 # CLI argument passthrough
 READY_LABEL ?= hydra-ready
-WORKERS ?= 2
+WORKERS ?= 3
 MODEL ?= opus
 REVIEW_MODEL ?= opus
 BATCH_SIZE ?= 15
@@ -20,7 +20,7 @@ REVIEW_BUDGET ?= 0
 PLANNER_LABEL ?= hydra-plan
 PLANNER_MODEL ?= opus
 PLANNER_BUDGET ?= 0
-REVIEWERS ?= 3
+REVIEWERS ?= 5
 HITL_WORKERS ?= 1
 PORT ?= 5555
 LOG_DIR ?= $(PROJECT_ROOT)/.hydra/logs

--- a/cli.py
+++ b/cli.py
@@ -36,7 +36,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-workers",
         type=int,
         default=None,
-        help="Max concurrent implementation agents (default: 2)",
+        help="Max concurrent implementation agents (default: 3)",
     )
     parser.add_argument(
         "--max-planners",
@@ -48,7 +48,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-reviewers",
         type=int,
         default=None,
-        help="Max concurrent review agents (default: 3)",
+        help="Max concurrent review agents (default: 5)",
     )
     parser.add_argument(
         "--max-hitl-workers",


### PR DESCRIPTION
## Summary
- Makefile `WORKERS` was hardcoded to `2` and `REVIEWERS` to `3`, overriding `config.py` defaults via explicit CLI args
- Updated to `WORKERS ?= 3` and `REVIEWERS ?= 5` to match `config.py`
- Updated CLI `--help` text to reflect correct defaults

This was missed in the #281 squash merge.

## Test plan
- [ ] CI validates
- [ ] `make run` starts with 3 implementers and 5 reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)