### PR TITLE
Detect GitHub auth failures — auto-pause with system alert

### DIFF
--- a/events.py
+++ b/events.py
@@ -42,6 +42,7 @@ class EventType(StrEnum):
     METRICS_UPDATE = "metrics_update"
     REVIEW_INSIGHT = "review_insight"
     BACKGROUND_WORKER_STATUS = "background_worker_status"
+    SYSTEM_ALERT = "system_alert"
 
 
 class HydraEvent(BaseModel):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -37,6 +37,7 @@ class TestEventTypeEnum:
             "METRICS_UPDATE",
             "REVIEW_INSIGHT",
             "BACKGROUND_WORKER_STATUS",
+            "SYSTEM_ALERT",
         }
         actual = {member.name for member in EventType}
         assert expected == actual

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -27,6 +27,7 @@ from models import (
     WorkerResult,
 )
 from orchestrator import HydraOrchestrator
+from subprocess_util import AuthenticationError
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -2854,3 +2855,116 @@ class TestHITLLoop:
         await orch._process_one_hitl(42, "Fix it", semaphore)
 
         mock_wt.destroy.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Auth failure detection
+# ---------------------------------------------------------------------------
+
+
+class TestAuthFailure:
+    """Tests for AuthenticationError handling in the orchestrator."""
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_stops_all_loops(self, config: HydraConfig) -> None:
+        """An AuthenticationError in any loop should stop the orchestrator."""
+        orch = HydraOrchestrator(config)
+        orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+
+        async def auth_failing_triage() -> None:
+            raise AuthenticationError("401 Unauthorized")
+
+        orch._triage_find_issues = auth_failing_triage  # type: ignore[method-assign]
+        orch._plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        orch._implementer.run_batch = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+        orch._fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+
+        async def instant_sleep(seconds: int) -> None:
+            await asyncio.sleep(0)
+
+        orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
+
+        await orch.run()
+
+        assert not orch.running
+        assert orch._stop_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_publishes_system_alert_event(
+        self, config: HydraConfig
+    ) -> None:
+        """Auth failure should publish a SYSTEM_ALERT event."""
+        bus = EventBus()
+        orch = HydraOrchestrator(config, event_bus=bus)
+        orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+
+        async def auth_failing_plan() -> list[PlanResult]:
+            raise AuthenticationError("401 Unauthorized")
+
+        orch._triage_find_issues = AsyncMock()  # type: ignore[method-assign]
+        orch._plan_issues = auth_failing_plan  # type: ignore[method-assign]
+        orch._implementer.run_batch = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+        orch._fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+
+        async def instant_sleep(seconds: int) -> None:
+            await asyncio.sleep(0)
+
+        orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
+
+        await orch.run()
+
+        alert_events = [
+            e for e in bus.get_history() if e.type == EventType.SYSTEM_ALERT
+        ]
+        assert len(alert_events) == 1
+        assert "authentication" in alert_events[0].data["message"].lower()
+        assert alert_events[0].data["source"] == "plan"
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_sets_auth_failed_flag(
+        self, config: HydraConfig
+    ) -> None:
+        """Auth failure should set the _auth_failed flag."""
+        orch = HydraOrchestrator(config)
+        orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+
+        async def auth_failing_implement() -> tuple[
+            list[WorkerResult], list[GitHubIssue]
+        ]:
+            raise AuthenticationError("401 Unauthorized")
+
+        orch._triage_find_issues = AsyncMock()  # type: ignore[method-assign]
+        orch._plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        orch._implementer.run_batch = auth_failing_implement  # type: ignore[method-assign]
+        orch._fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+
+        async def instant_sleep(seconds: int) -> None:
+            await asyncio.sleep(0)
+
+        orch._sleep_or_stop = instant_sleep  # type: ignore[method-assign]
+
+        await orch.run()
+
+        assert orch._auth_failed is True
+
+    def test_run_status_returns_auth_failed(self, config: HydraConfig) -> None:
+        """run_status should return 'auth_failed' when the flag is set."""
+        orch = HydraOrchestrator(config)
+        orch._auth_failed = True
+        assert orch.run_status == "auth_failed"
+
+    def test_run_status_auth_failed_takes_precedence(self, config: HydraConfig) -> None:
+        """auth_failed should take precedence over other statuses."""
+        orch = HydraOrchestrator(config)
+        orch._auth_failed = True
+        orch._running = True
+        assert orch.run_status == "auth_failed"
+
+    def test_reset_clears_auth_failed(self, config: HydraConfig) -> None:
+        """reset() should clear the _auth_failed flag."""
+        orch = HydraOrchestrator(config)
+        orch._auth_failed = True
+        orch._stop_event.set()
+        orch.reset()
+        assert orch._auth_failed is False
+        assert not orch._stop_event.is_set()

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -15,13 +15,24 @@ import { ACTIVE_STATUSES } from './constants'
 
 const TABS = ['transcript', 'prs', 'hitl', 'timeline', 'livestream', 'system', 'metrics']
 
+function SystemAlertBanner({ alert }) {
+  if (!alert) return null
+  return (
+    <div style={styles.alertBanner}>
+      <span style={styles.alertIcon}>!</span>
+      <span>{alert.message}</span>
+      {alert.source && <span style={styles.alertSource}>Source: {alert.source}</span>}
+    </div>
+  )
+}
+
 export default function App() {
   const {
     connected, batchNum, phase, orchestratorStatus, workers, prs, reviews,
     mergedCount, sessionPrsCount, sessionTriaged, sessionPlanned,
     sessionImplemented, sessionReviewed, lifetimeStats, config, events,
     hitlItems, humanInputRequests, submitHumanInput, refreshHitl,
-    backgroundWorkers, metrics,
+    backgroundWorkers, metrics, systemAlert,
   } = useHydraSocket()
   const [selectedWorker, setSelectedWorker] = useState(null)
   const [activeTab, setActiveTab] = useState('transcript')
@@ -81,6 +92,7 @@ export default function App() {
       />
 
       <div style={styles.main}>
+        <SystemAlertBanner alert={systemAlert} />
         <HumanInputBanner requests={humanInputRequests} onSubmit={submitHumanInput} />
 
         <div style={styles.tabs}>
@@ -194,6 +206,36 @@ const styles = {
     borderRadius: 10,
     padding: '1px 6px',
     marginLeft: 6,
+  },
+  alertBanner: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '8px 16px',
+    background: theme.redSubtle,
+    borderBottom: `2px solid ${theme.red}`,
+    color: theme.red,
+    fontSize: 13,
+    fontWeight: 600,
+  },
+  alertIcon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 20,
+    height: 20,
+    borderRadius: '50%',
+    background: theme.red,
+    color: theme.white,
+    fontSize: 12,
+    fontWeight: 700,
+    flexShrink: 0,
+  },
+  alertSource: {
+    marginLeft: 'auto',
+    fontSize: 11,
+    fontWeight: 400,
+    opacity: 0.8,
   },
 }
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -41,7 +41,7 @@ export function Header({
   }, [hasActiveWorkers, orchestratorStatus])
 
   const isStopping = orchestratorStatus === 'stopping' || stoppingHeld
-  const canStart = (orchestratorStatus === 'idle' || orchestratorStatus === 'done') &&
+  const canStart = (orchestratorStatus === 'idle' || orchestratorStatus === 'done' || orchestratorStatus === 'auth_failed') &&
     !stoppingHeld
   const isRunning = orchestratorStatus === 'running'
   const workload = {

--- a/ui/src/hooks/useHydraSocket.js
+++ b/ui/src/hooks/useHydraSocket.js
@@ -23,6 +23,7 @@ const initialState = {
   humanInputRequests: {},  // Record<string, string>
   backgroundWorkers: [],  // BackgroundWorkerState[]
   metrics: null,  // MetricsData | null
+  systemAlert: null,  // { message, source } | null
 }
 
 export function reducer(state, action) {
@@ -291,6 +292,9 @@ export function reducer(state, action) {
 
     case 'METRICS':
       return { ...state, metrics: action.data }
+
+    case 'system_alert':
+      return { ...addEvent(state, action), systemAlert: action.data }
 
     case 'error':
       return addEvent(state, action)


### PR DESCRIPTION
## Summary
- Adds `AuthenticationError` exception and `_is_auth_error()` detection in `subprocess_util.py` for patterns like `401`, `not logged in`, `authentication required`, `auth token`
- Adds `SYSTEM_ALERT` event type to `EventType` enum for critical system-level alerts
- Orchestrator catches `AuthenticationError` in all 5 loops, sets `_auth_failed` flag, publishes a `SYSTEM_ALERT` event, and stops all loops instead of endlessly restarting
- Dashboard displays a red alert banner when `system_alert` events arrive, and the Start button becomes available in `auth_failed` state so operators can restart after fixing their token

## Test plan
- [x] `TestAuthenticationError` — 9 tests covering error class inheritance, `_is_auth_error` detection, and `run_subprocess`/`run_subprocess_with_retry` raising `AuthenticationError`
- [x] `TestAuthFailure` — 6 tests covering loop stopping, `SYSTEM_ALERT` event publishing, `_auth_failed` flag, `run_status` property, and `reset()` clearing the flag
- [x] Updated `test_all_expected_values_exist` in `test_events.py` for the new enum member
- [ ] Manual: start Hydra with invalid/no gh token, confirm system pauses and banner appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)