### PR TITLE
Fixes #366: Remove pipeline stage pills from session banner header

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -37,10 +37,10 @@ function AppContent() {
   const {
     connected, orchestratorStatus, workers, prs,
     mergedCount, sessionTriaged, sessionPlanned,
-    sessionImplemented, sessionReviewed, config, events,
+    sessionImplemented, sessionReviewed, events,
     hitlItems, humanInputRequests, submitHumanInput, refreshHitl,
     backgroundWorkers, metrics, systemAlert, intents,
-    lifetimeStats, githubMetrics, metricsHistory, phase, toggleBgWorker,
+    lifetimeStats, githubMetrics, metricsHistory, toggleBgWorker,
   } = useHydra()
   const [selectedWorker, setSelectedWorker] = useState(null)
   const [activeTab, setActiveTab] = useState('issues')
@@ -93,7 +93,6 @@ function AppContent() {
         orchestratorStatus={orchestratorStatus}
         onStart={handleStart}
         onStop={handleStop}
-        phase={phase}
         workers={workers}
       />
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -4,7 +4,7 @@ import { ACTIVE_STATUSES } from '../constants'
 
 export function Header({
   connected, orchestratorStatus,
-  onStart, onStop, phase, workers,
+  onStart, onStop, workers,
 }) {
   const workerList = Object.values(workers || {})
   const hasActiveWorkers = workerList.some(w => ACTIVE_STATUSES.includes(w.status))

--- a/ui/src/components/__tests__/Header.test.jsx
+++ b/ui/src/components/__tests__/Header.test.jsx
@@ -46,7 +46,6 @@ describe('Header component', () => {
     orchestratorStatus: 'idle',
     onStart: () => {},
     onStop: () => {},
-    phase: 'idle',
     workers: {},
   }
 


### PR DESCRIPTION
## Summary

Closes #366.

## Issue

Remove pipeline stage pills from session banner header

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra