### PR TITLE
Add audit-code command, update audit-tests to self-submit

### DIFF
--- a/.claude/commands/audit-code.md
+++ b/.claude/commands/audit-code.md
@@ -1,0 +1,351 @@
+# Code Quality Audit
+
+Run a comprehensive code quality audit across the entire repo. Dynamically analyzes source code for dead code, complexity, duplication, error handling gaps, type safety issues, and architectural problems. Creates GitHub issues for findings so Hydra can process them.
+
+## Instructions
+
+1. **Resolve configuration** before doing anything else:
+   - Run `echo "$HYDRA_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
+   - Run `echo "$HYDRA_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
+   - Run `echo "$HYDRA_LABEL_PLAN"` — if set, use it as the label for created issues. If empty, default to `hydra-plan`.
+   - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
+
+2. **Discover project structure:**
+   - Use Glob to find all `*.py` source files, excluding `.venv/`, `venv/`, `__pycache__/`, `node_modules/`, `dist/`, `build/`.
+   - Separate into SOURCE files (production code) and TEST files (anything under `tests/` or matching `test_*.py`).
+   - Count total source files, total lines, and identify the main modules.
+
+3. **Launch agents in parallel** using `Task` with `run_in_background: true` and `subagent_type: "general-purpose"`:
+   - **Agent 1: Dead code & unused exports** — Finds unreachable code, unused functions, unused imports, and stale modules.
+   - **Agent 2: Complexity & duplication** — Finds overly complex functions, duplicated logic, and DRY violations.
+   - **Agent 3: Error handling & robustness** — Finds bare excepts, swallowed errors, missing error paths, and fragile patterns.
+   - **Agent 4: Type safety & API consistency** — Finds missing type annotations, `Any` overuse, inconsistent return types, and public API gaps.
+
+4. Wait for all agents to complete.
+5. After all finish, run `gh issue list --repo $REPO --label $LABEL --state open --search "code quality" --limit 200` to show the user a final summary of all issues created.
+
+## Agent 1: Dead Code & Unused Exports
+
+```
+You are a code quality auditor focused on dead code detection for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Map All Definitions
+1. Use Glob to find all *.py source files (exclude tests/, .venv/, __pycache__/)
+2. Read each source file and catalog every:
+   - Function/method definition (def, async def)
+   - Class definition
+   - Module-level constant
+   - Import statement
+
+### Phase 2: Cross-Reference Usage
+3. For each definition, search the codebase for references:
+   - Is the function/class actually called or imported elsewhere?
+   - Is the constant referenced outside its definition file?
+   - Are there imports that are never used?
+   - Are there entire modules that nothing imports from?
+4. Check __init__.py re-exports — are re-exported names actually used by consumers?
+5. Check for functions only called by other dead functions (transitive dead code)
+
+### Phase 3: Detect Stale Patterns
+6. Look for:
+   - **Commented-out code blocks** (> 3 lines of commented code)
+   - **TODO/FIXME/HACK comments** older than the surrounding code's last edit
+   - **Unused class methods** (defined but never called, including by tests)
+   - **Unreachable code** after unconditional return/raise/break
+   - **Empty function bodies** (just `pass` or `...`) that aren't abstract methods
+   - **Duplicate function signatures** (same name defined in multiple places)
+
+### Phase 4: Create GitHub Issues
+7. Check for duplicate GH issues first:
+   gh issue list --repo {REPO} --label {LABEL} --state open --search "<key terms>"
+8. Create GH issues for NEW findings only, grouped by theme:
+   gh issue create --repo {REPO} --assignee {ASSIGNEE} --label {LABEL} --title "Code Quality: <theme>" --body "<details>"
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on why this cleanup matters>
+
+## Dead Code Found
+| Type | File:Line | Name | Reason |
+|------|-----------|------|--------|
+| <function/class/import> | <path:line> | <name> | <never called/never imported/unreachable> |
+
+## Suggested Actions
+- [ ] Remove <item> — unused since <reason>
+- [ ] Remove <item> — only referenced by other dead code
+
+## Impact
+- Lines removable: ~<N>
+- Files affected: <N>
+- Risk: <low — dead code removal>
+```
+
+## Grouping Strategy
+Create ONE issue per theme, not one per dead function. Good themes:
+- "Code Quality: Remove unused utility functions"
+- "Code Quality: Clean up stale imports across modules"
+- "Code Quality: Remove commented-out code blocks"
+- "Code Quality: Remove empty/stub functions"
+
+Be pragmatic: exclude protocol/ABC methods, __dunder__ methods, and test helpers.
+Verify a function is truly unused before flagging — check tests too, as test-only helpers are valid.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 2: Complexity & Duplication
+
+```
+You are a code quality auditor focused on complexity and duplication for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Identify Complex Functions
+1. Use Glob to find all *.py source files (exclude tests/, .venv/, __pycache__/)
+2. Read each source file and identify functions that are overly complex:
+   - **Long functions**: > 50 lines (excluding docstring and blank lines)
+   - **Deep nesting**: > 4 levels of indentation (nested if/for/try/with)
+   - **High branch count**: > 8 if/elif/else branches in a single function
+   - **Too many parameters**: > 6 parameters (excluding self/cls)
+   - **Mixed concerns**: Function does unrelated things (e.g., I/O + business logic + formatting)
+   For each finding, note: file path, line number, function name, metric value, why it's problematic
+
+### Phase 2: Detect Code Duplication
+3. Find duplicated logic patterns:
+   - **Copy-paste blocks**: 5+ consecutive lines that appear nearly identical in 2+ locations
+   - **Similar functions**: Functions with same structure but different variable names
+   - **Repeated patterns**: Same sequence of API calls, error handling, or data transformation in 3+ places
+   - **Inline constants**: Same magic number or string literal used in 3+ places without a named constant
+4. For each duplication, identify: both locations, what differs, and how to extract a shared abstraction
+
+### Phase 3: DRY Violations & Abstraction Opportunities
+5. Look for:
+   - **Missing helper functions**: Same 3+ line pattern repeated across files
+   - **Missing base classes**: Multiple classes with identical method implementations
+   - **Missing constants**: Repeated string literals or numbers that should be named
+   - **Config duplication**: Same default values hardcoded in multiple places instead of referencing config
+   - **Parallel implementations**: Two different ways of doing the same thing (e.g., two JSON serializers)
+
+### Phase 4: Create GitHub Issues
+6. Check for duplicate GH issues first:
+   gh issue list --repo {REPO} --label {LABEL} --state open --search "<key terms>"
+7. Create GH issues for NEW findings only:
+   gh issue create --repo {REPO} --assignee {ASSIGNEE} --label {LABEL} --title "Code Quality: <theme>" --body "<details>"
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on why reducing complexity/duplication matters here>
+
+## Findings
+| Issue | File:Line | Function/Block | Metric |
+|-------|-----------|---------------|--------|
+| <long function/duplication/deep nesting> | <path:line> | <name> | <value> |
+
+## Suggested Refactoring
+- [ ] Extract <helper function> from <locations> — <what it does>
+- [ ] Split <long function> into <sub-functions>
+- [ ] Replace magic value `<value>` with named constant
+
+## Code Example (Before/After)
+<Show a concrete before/after for the highest-impact item>
+```
+
+## Grouping Strategy
+- "Code Quality: Reduce function complexity in <module>"
+- "Code Quality: Extract shared patterns into helpers"
+- "Code Quality: Replace magic constants with named values"
+- "Code Quality: Deduplicate <pattern> across modules"
+
+Focus on high-impact items: functions > 80 lines, 3+ duplicated blocks, deeply nested logic.
+Skip trivial duplication (< 3 lines) and acceptable complexity (simple long switch-like patterns).
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 3: Error Handling & Robustness
+
+```
+You are a code quality auditor focused on error handling and robustness for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Audit Exception Handling
+1. Use Glob to find all *.py source files (exclude tests/, .venv/, __pycache__/)
+2. Read each source file and find:
+   - **Bare except**: `except:` or `except Exception:` that catches too broadly
+   - **Swallowed exceptions**: `except: pass` or `except Exception: pass` — errors silently ignored
+   - **Missing error context**: `raise` without chaining (`raise X from e`)
+   - **Inconsistent error types**: Same error condition raises different exception types across modules
+   - **Missing try/except**: External calls (subprocess, HTTP, file I/O) without error handling
+   - **Overly broad try blocks**: try block wraps 20+ lines instead of just the risky operation
+
+### Phase 2: Audit Subprocess & External Calls
+3. Find all subprocess calls and external tool invocations:
+   - Do they check return codes? (`check=True` or manual returncode check)
+   - Do they have timeouts? (subprocess.run without timeout, asyncio without timeout)
+   - Do they handle stderr?
+   - Do they handle the tool not being installed? (FileNotFoundError)
+4. Find all HTTP/API client calls:
+   - Do they handle connection errors, timeouts, non-2xx responses?
+   - Do they retry on transient failures?
+   - Do they have reasonable timeouts?
+
+### Phase 3: Audit Resource Management
+5. Look for:
+   - **Missing context managers**: File open() without `with`, connections without cleanup
+   - **Missing finally blocks**: Resources acquired in try without finally/context manager
+   - **Async resource leaks**: aiohttp sessions, asyncio tasks not awaited or cancelled
+   - **Temp file cleanup**: tempfile usage without cleanup on error paths
+
+### Phase 4: Audit Edge Cases
+6. Look for:
+   - **Missing None checks**: Accessing attributes on potentially-None values without guards
+   - **Missing empty collection checks**: Indexing into lists/dicts that might be empty
+   - **Race conditions**: Shared mutable state in async code without locks
+   - **Integer overflow/underflow**: Counters that could wrap or go negative
+   - **Path traversal**: User-influenced file paths without sanitization
+
+### Phase 5: Create GitHub Issues
+7. Check for duplicate GH issues first, then create themed issues
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on the robustness risk>
+
+## Findings
+| Severity | File:Line | Issue | Risk |
+|----------|-----------|-------|------|
+| <high/medium/low> | <path:line> | <description> | <what could go wrong> |
+
+## Suggested Fixes
+- [ ] <file:line> — Add error handling for <operation>
+- [ ] <file:line> — Replace bare except with specific exception type
+- [ ] <file:line> — Add timeout to subprocess call
+
+## Impact
+- Blast radius: <what breaks if this isn't fixed>
+- Frequency: <how often this code path runs>
+```
+
+## Grouping Strategy
+- "Code Quality: Fix bare/swallowed exceptions in <module>"
+- "Code Quality: Add timeouts to subprocess calls"
+- "Code Quality: Add error handling for external API calls"
+- "Code Quality: Fix resource leaks in async code"
+
+Focus on production code paths that run frequently. Skip test code and one-off scripts.
+Prioritize by blast radius — errors in the orchestrator or review loop matter more than CLI parsing.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 4: Type Safety & API Consistency
+
+```
+You are a code quality auditor focused on type safety and API consistency for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Audit Type Annotations
+1. Use Glob to find all *.py source files (exclude tests/, .venv/, __pycache__/)
+2. Read each source file and find:
+   - **Missing return types**: Public functions/methods without `-> ReturnType`
+   - **Missing parameter types**: Public function parameters without type annotations
+   - **`Any` overuse**: Functions typed as `-> Any` or parameters as `param: Any` when a more specific type is available
+   - **Incorrect Optional**: Parameters that can be None but aren't typed `X | None`
+   - **Dict/List without generics**: `dict` instead of `dict[str, int]`, `list` instead of `list[str]`
+   - **Inconsistent None handling**: Function returns None in some paths but return type doesn't include None
+
+### Phase 2: Audit Pydantic Models
+3. Check all Pydantic models (BaseModel subclasses):
+   - **Missing validators**: Fields that should have validation (e.g., URL fields, email, ranges)
+   - **Loose types**: Fields typed as `str` that should be enums or Literal types
+   - **Missing field descriptions**: Fields without `Field(description=...)`
+   - **Inconsistent defaults**: Similar fields across models with different defaults
+   - **Missing model_config**: Models without `model_config` for JSON serialization settings
+
+### Phase 3: Audit Public API Consistency
+4. Check function signatures across modules for consistency:
+   - **Inconsistent parameter ordering**: Similar functions with parameters in different order
+   - **Inconsistent naming**: Same concept called different names across modules (e.g., `issue_num` vs `issue_number` vs `issue_id`)
+   - **Inconsistent return types**: Similar operations returning different shapes
+   - **Missing docstrings**: Public functions/classes without docstrings
+   - **Stale docstrings**: Docstrings that don't match the current signature
+
+### Phase 4: Audit Configuration Consistency
+5. Check config.py and its consumers:
+   - Are all config fields actually used somewhere?
+   - Are there hardcoded values that should come from config?
+   - Are environment variable names consistent with field names?
+   - Are CLI arguments consistent with config field names?
+
+### Phase 5: Create GitHub Issues
+6. Check for duplicate GH issues first, then create themed issues
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on why type safety/consistency matters here>
+
+## Findings
+| Issue | File:Line | Current | Suggested |
+|-------|-----------|---------|-----------|
+| <missing type/Any overuse/inconsistent name> | <path:line> | <current state> | <what it should be> |
+
+## Suggested Fixes
+- [ ] <file:line> — Add return type annotation `-> X`
+- [ ] <file:line> — Replace `Any` with `SpecificType`
+- [ ] <file:line> — Rename `issue_num` to `issue_number` for consistency
+
+## Impact
+- Type checker improvements: <N> new errors caught
+- API consistency: <description of improvement>
+```
+
+## Grouping Strategy
+- "Code Quality: Add missing type annotations in <module>"
+- "Code Quality: Replace Any with specific types"
+- "Code Quality: Standardize parameter naming across modules"
+- "Code Quality: Add Pydantic field validators for <model>"
+- "Code Quality: Remove unused config fields"
+
+Focus on public APIs and cross-module interfaces. Skip internal helper functions and test code.
+Prioritize by impact — type gaps in widely-used functions matter more than leaf functions.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Important Notes
+- Each agent should read files directly (no spawning sub-agents)
+- Each agent should check `gh issue list` before creating any issue to avoid duplicates
+- All issues should use the resolved `$REPO`, `$ASSIGNEE`, and `$LABEL`
+- Group related findings into single themed issues — don't create one issue per finding
+- Title format: "Code Quality: <theme>" for consistency
+- Be pragmatic: focus on high-impact items that meaningfully improve code quality
+- Skip nitpicks, style preferences, and issues already caught by ruff/pyright
+- Don't duplicate what linters already catch — focus on semantic issues that require understanding the code

--- a/.claude/commands/audit-tests.md
+++ b/.claude/commands/audit-tests.md
@@ -1,77 +1,297 @@
 # Test Audit
 
-Audit all test files for quality, structure, and adherence to established patterns. Launch a single agent that analyzes tests and reports findings.
+Run a comprehensive test quality audit across the entire repo. Analyzes test naming, structure, factory usage, anti-patterns, coverage gaps, and flaky patterns. Creates GitHub issues for findings so Hydra can process them.
 
 ## Instructions
 
-1. Launch the agent below using `Task` with `subagent_type: "test-audit"`.
-2. Present the findings to the user.
+1. **Resolve configuration** before doing anything else:
+   - Run `echo "$HYDRA_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
+   - Run `echo "$HYDRA_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
+   - Run `echo "$HYDRA_LABEL_PLAN"` — if set, use it as the label for created issues. If empty, default to `hydra-plan`.
+   - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
-## Agent Prompt
+2. **Discover project structure:**
+   - Use Glob to find all test files: `**/test_*.py`, `**/tests/conftest.py`, `**/tests/helpers.py`
+   - Exclude `.venv/`, `venv/`, `__pycache__/`, `node_modules/`
+   - Also find all UI test files: `ui/src/**/*.test.jsx`, `ui/src/**/*.test.js`
+   - Count total test files and identify the test helper infrastructure
+
+3. **Launch agents in parallel** using `Task` with `run_in_background: true` and `subagent_type: "general-purpose"`:
+   - **Agent 1: Test naming & structure** — Checks naming conventions, 3As structure, single responsibility, and organization.
+   - **Agent 2: Anti-patterns & flaky tests** — Detects over-mocking, weak assertions, flaky patterns, and test isolation issues.
+   - **Agent 3: Factory/fixture gaps & coverage** — Finds missing factories, repeated setup, coverage gaps, and missing edge case tests.
+
+4. Wait for all agents to complete.
+5. After all finish, run `gh issue list --repo $REPO --label $LABEL --state open --search "test quality" --limit 200` to show the user a final summary of all issues created.
+
+## Agent 1: Test Naming & Structure
 
 ```
-You are a test quality auditor for this project. Audit all test files for quality, structure, and patterns.
+You are a test quality auditor focused on naming and structure for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
 
 ## Steps
 
-1. Find all test files: `tests/test_*.py` (use Glob for `**/test_*.py`)
-2. Find all test helpers/factories: `tests/helpers.py`, `tests/conftest.py`
-3. For each test file, analyze against the checklist below
-4. Return a structured report of findings
+### Phase 1: Read All Test Files
+1. Use Glob to find all test files: tests/test_*.py, ui/src/**/*.test.jsx
+2. Read each test file
 
-## Test Naming Checklist
+### Phase 2: Audit Test Naming
+3. Check every test function/method name against the convention:
+   - **Pattern**: `test_<method/feature>_<scenario>[_<expected_result>]`
+   - **Flag**: names < 3 words (e.g., `test_init`, `test_run`)
+   - **Flag**: generic names (test_1, test_something, test_basic)
+   - **Flag**: redundant "test" in name (test_user_test)
+   - **Flag**: names that don't describe what's being tested
+   For each violation, note: file path, line number, current name, suggested better name
 
-- Pattern: `test_<method/feature>_<scenario>[_<expected_result>]`
-- Flag: names < 3 words, generic names (test_1, test_something), redundant "test" in name
-- Flag: names that don't describe the scenario being tested
+### Phase 3: Audit 3As Structure (Arrange-Act-Assert)
+4. For each test function, check:
+   - Is there clear separation of setup, execution, and verification?
+   - Is all arrange code before the act?
+   - Are all assertions after the act?
+   - Are phases mixed? (e.g., assertions interleaved with setup)
+   - Does setup dominate the test? (> 60% of lines are setup — push into factories/fixtures)
 
-## 3As Structure (Arrange-Act-Assert)
+### Phase 4: Audit Single Responsibility
+5. For each test, count assertions:
+   - Flag tests with > 3 assertions testing **different** attributes (related assertions on the same result are OK)
+   - Suggest splitting into focused tests
+   - Note tests with zero assertions (test does nothing useful)
 
-- Clear separation of setup, execution, verification
-- All arrange code before act
-- All assertions after act
-- No mixing of phases
-- Flag tests where setup dominates — push into factories/fixtures
+### Phase 5: Audit Test Organization
+6. Check file-level organization:
+   - Are test classes used to group related tests?
+   - Are tests organized to mirror source file structure?
+   - Are there test files > 500 lines that should be split?
+   - Are there test files with < 3 tests (too granular)?
 
-## Single Responsibility
+### Phase 6: Create GitHub Issues
+7. Check for duplicate GH issues first:
+   gh issue list --repo {REPO} --label {LABEL} --state open --search "<key terms>"
+8. Create GH issues for NEW findings only, grouped by theme:
+   gh issue create --repo {REPO} --assignee {ASSIGNEE} --label {LABEL} --title "Test Quality: <theme>" --body "<details>"
 
-- One logical assertion group per test
-- Flag tests with > 3 assertions testing different attributes
-- Suggest splitting into focused tests
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on why this test quality issue matters>
 
-## Factory & Builder Patterns
+## Findings
+| Severity | File:Line | Test Name | Issue |
+|----------|-----------|-----------|-------|
+| <warning/suggestion> | <path:line> | <test_name> | <description> |
 
-- Check if `tests/helpers.py` has factories for common objects
-- Flag repeated inline object creation across tests — suggest factory
-- Builders should use fluent `.with_*()` syntax and `.build()` method
+## Suggested Fixes
+- [ ] <file:line> — Rename `test_init` to `test_<method>_<scenario>`
+- [ ] <file:line> — Split test with 6 assertions into 3 focused tests
+- [ ] <file:line> — Move setup into factory method
 
-## Anti-Patterns to Detect
-
-- **Multiple unrelated assertions**: > 3 assertions on different attributes
-- **Over-mocking**: Mocking private/internal methods instead of testing behavior
-- **Incomplete mock setup**: MagicMock without proper return_value/side_effect
-- **Repetitive setup**: Same object creation in 3+ tests (needs factory)
-- **Flaky patterns**: time.sleep(), random without seed, order-dependent tests
-- **Weak assertions**: `assert True`, `assert x is not None`, `assert result`
-- **Missing edge cases**: Only happy path tested, no error path coverage
-
-## Report Format
-
-Group findings by severity:
-
-### Critical (Fix Now)
-- [file:line] description
-
-### Warning (Fix Soon)
-- [file:line] description and recommended fix
-
-### Suggestion (Consider)
-- [file:line] description
-
-### Summary
-- Total test files: X
-- Total tests: Y
-- Factories found: Z
-- Tests with good 3As structure: X%
-- Recommended next actions (top 3)
+## Impact
+- Tests affected: <N>
+- Readability improvement: <description>
 ```
+
+## Grouping Strategy
+- "Test Quality: Improve test naming in <module>"
+- "Test Quality: Fix 3As structure violations"
+- "Test Quality: Split multi-assertion tests"
+- "Test Quality: Reorganize large test files"
+
+Focus on tests that are genuinely hard to understand or maintain. Skip minor naming quibbles.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 2: Anti-Patterns & Flaky Tests
+
+```
+You are a test quality auditor focused on anti-patterns and flakiness for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Read All Test Files
+1. Use Glob to find all test files: tests/test_*.py, tests/conftest.py, tests/helpers.py
+2. Read each file
+
+### Phase 2: Detect Mocking Anti-Patterns
+3. Find:
+   - **Over-mocking**: Mocking private/internal methods (`patch.object(x, '_private_method')`) instead of testing behavior
+   - **Excessive mock depth**: 4+ levels of nested `with patch(...)` blocks
+   - **Incomplete mock setup**: MagicMock without return_value or side_effect where the return value matters
+   - **Mock leakage**: Mocks applied at module level or class level that affect other tests
+   - **Wrong patch target**: Patching the definition site instead of the import site
+   For each finding, note: file, line, what's being mocked, and the better approach
+
+### Phase 3: Detect Weak Assertions
+4. Find:
+   - **Always-true assertions**: `assert True`, `assert result` (only checks truthiness)
+   - **Too generic**: `assert x is not None` when specific value should be checked
+   - **Missing assertions**: Test functions with no assert statements at all
+   - **Overly permissive**: `assert status in [200, 401, 403, 404, 500]`
+   - **String containment only**: `assert "error" in str(result)` instead of checking specific error type/message
+
+### Phase 4: Detect Flaky Patterns
+5. Find:
+   - **time.sleep()**: Sleeping in tests instead of async/mock timing
+   - **Random without seed**: Non-deterministic test behavior
+   - **Order dependency**: Tests that rely on other tests running first (shared state via class attributes)
+   - **Real system calls**: Actual file I/O, network calls, subprocess without mocking
+   - **Timestamp sensitivity**: Tests that compare exact timestamps (break across time zones or slow CI)
+   - **Global state mutation**: Tests that modify module-level globals without cleanup
+
+### Phase 5: Detect Isolation Issues
+6. Find:
+   - **Shared mutable fixtures**: Fixtures returning mutable objects shared across tests
+   - **Missing cleanup**: Tests that create files/dirs without teardown
+   - **Import side effects**: Test imports that trigger real initialization
+   - **Class-level state**: Test classes with mutable class attributes
+
+### Phase 6: Create GitHub Issues
+7. Check for duplicate GH issues first, then create themed issues
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on the anti-pattern risk>
+
+## Findings
+| Severity | File:Line | Pattern | Risk |
+|----------|-----------|---------|------|
+| <critical/warning> | <path:line> | <description> | <what could go wrong> |
+
+## Suggested Fixes
+- [ ] <file:line> — Replace `patch.object(x, '_method')` with behavior test
+- [ ] <file:line> — Add `assert result.status == 200` instead of `assert result`
+- [ ] <file:line> — Replace `time.sleep(1)` with async await
+
+## Impact
+- Flaky test risk: <high/medium/low>
+- False positive risk: <description>
+```
+
+## Grouping Strategy
+- "Test Quality: Fix over-mocking in <module> tests"
+- "Test Quality: Replace weak assertions with specific checks"
+- "Test Quality: Fix flaky test patterns (sleep/random/order)"
+- "Test Quality: Fix test isolation issues"
+
+Prioritize by risk: flaky tests and false positives are more dangerous than style issues.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 3: Factory/Fixture Gaps & Coverage
+
+```
+You are a test quality auditor focused on test infrastructure and coverage gaps for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Inventory Test Infrastructure
+1. Read tests/helpers.py and tests/conftest.py to catalog:
+   - All existing factory functions/classes
+   - All existing fixtures
+   - All existing builder patterns
+   - Helper utilities (make_config, make_state, etc.)
+2. Note what each factory/fixture creates and how it's used
+
+### Phase 2: Find Missing Factories
+3. For each test file, identify repeated object creation:
+   - Same constructor call with similar args in 3+ tests → needs factory
+   - Same mock setup repeated in 3+ tests → needs mock factory
+   - Same dict/config construction in 3+ tests → needs builder
+   - Complex arrange blocks (> 10 lines of setup) that could be a one-liner with a factory
+4. Cross-reference with existing helpers.py — is the factory already there but not used?
+
+### Phase 3: Find Coverage Gaps
+5. For each source module, check if corresponding tests exist:
+   - Every public function/method should have at least one test
+   - Every error path (except/raise) should have a test
+   - Every branch (if/elif/else) should have at least one test per path
+   - Every Pydantic model should have validation tests
+6. Identify untested modules (source files with no corresponding test file)
+7. Identify undertested modules (test file exists but < 50% of public functions tested)
+
+### Phase 4: Find Missing Edge Case Tests
+8. For each tested function, check if edge cases are covered:
+   - Empty inputs (empty string, empty list, empty dict, None)
+   - Boundary values (0, -1, MAX_INT, empty collection)
+   - Error conditions (network failure, file not found, permission denied)
+   - Concurrent access (if async code)
+   - Large inputs (if the function processes collections)
+
+### Phase 5: Audit Fixture Hygiene
+9. Check:
+   - Are fixtures scoped correctly? (session vs function vs module)
+   - Are there fixtures in test files that should be in conftest.py?
+   - Are there conftest fixtures that are only used by one test file?
+   - Are there fixture chains that are too deep? (fixture depends on fixture depends on fixture)
+
+### Phase 6: Create GitHub Issues
+10. Check for duplicate GH issues first, then create themed issues
+
+## Issue Body Format
+```markdown
+## Context
+<1-2 sentences on the test infrastructure gap>
+
+## Missing Factories
+| Object | Used In | Times Repeated | Suggested Factory |
+|--------|---------|---------------|-------------------|
+| <HydraConfig(...)> | <test_a, test_b, test_c> | <5> | <make_config() in helpers.py> |
+
+## Coverage Gaps
+| Source File | Public Functions | Tested | Untested |
+|-------------|-----------------|--------|----------|
+| <module.py> | <10> | <6> | <fn_a, fn_b, fn_c, fn_d> |
+
+## Suggested Fixes
+- [ ] Add `make_<object>()` factory to helpers.py for <repeated pattern>
+- [ ] Add tests for <untested_function> in <source_file>
+- [ ] Add edge case tests for <function>: empty input, None, error path
+
+## Factory Skeleton
+```python
+def make_<object>(**overrides):
+    defaults = { ... }
+    defaults.update(overrides)
+    return <Object>(**defaults)
+```
+```
+
+## Grouping Strategy
+- "Test Quality: Add missing factories for <pattern>"
+- "Test Quality: Add tests for untested functions in <module>"
+- "Test Quality: Add edge case tests for <module>"
+- "Test Quality: Clean up fixture organization"
+
+Focus on high-value gaps: untested error paths in critical modules, repeated setup that slows test writing.
+Skip trivial getters/setters and private helper functions.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Important Notes
+- Each agent should read files directly (no spawning sub-agents)
+- Each agent should check `gh issue list` before creating any issue to avoid duplicates
+- All issues should use the resolved `$REPO`, `$ASSIGNEE`, and `$LABEL`
+- Group related findings into single themed issues — don't create one issue per test
+- Title format: "Test Quality: <theme>" for consistency
+- Be pragmatic: focus on issues that genuinely hurt test reliability, not style preferences
+- Don't duplicate what ruff/pyright already catch — focus on semantic test quality issues
+- Skip the test-audit agent type — use general-purpose agents that can create GitHub issues


### PR DESCRIPTION
## Summary

- **New `/audit-code` command**: Launches 4 parallel agents that audit dead code, complexity/duplication, error handling, and type safety — each self-submits GitHub issues with `hydra-plan` label for Hydra to process
- **Updated `/audit-tests` command**: Rewrote from single report-only agent to 3 parallel agents (naming/structure, anti-patterns/flaky tests, factory gaps/coverage) that self-submit issues instead of just printing findings

Both commands follow the same pattern as `/audit-integration-tests`: resolve config, launch parallel background agents, agents create themed issues via `gh issue create`.

## Test plan

- [ ] Run `/audit-code` — verify agents create "Code Quality: ..." issues
- [ ] Run `/audit-tests` — verify agents create "Test Quality: ..." issues
- [ ] Verify duplicate detection works (running twice doesn't create duplicate issues)
- [ ] Verify issues are created with correct repo, assignee, and label

🤖 Generated with [Claude Code](https://claude.com/claude-code)