### PR TITLE
Fixes #383: Add triage label when resolving hydra-improve HITL items

### DIFF
--- a/dashboard_routes.py
+++ b/dashboard_routes.py
@@ -209,10 +209,23 @@ def create_router(
         orch = get_orchestrator()
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
+
+        # Read origin before clearing state
+        origin = state.get_hitl_origin(issue_number)
+
         orch.skip_hitl_issue(issue_number)
         state.remove_hitl_origin(issue_number)
+        state.remove_hitl_cause(issue_number)
         for lbl in config.hitl_label:
             await pr_manager.remove_label(issue_number, lbl)
+
+        # If this was an improve issue, transition to triage for implementation
+        if origin and origin in config.improve_label:
+            for lbl in config.improve_label:
+                await pr_manager.remove_label(issue_number, lbl)
+            if config.find_label:
+                await pr_manager.add_labels(issue_number, [config.find_label[0]])
+
         await event_bus.publish(
             HydraEvent(
                 type=EventType.HITL_UPDATE,

--- a/retrospective.py
+++ b/retrospective.py
@@ -310,7 +310,10 @@ class RetrospectiveCollector:
     async def _file_improvement_issue(self, title: str, body: str) -> None:
         """File a ``hydra-improve`` + ``hydra-hitl`` improvement proposal."""
         labels = self._config.improve_label[:1] + self._config.hitl_label[:1]
-        await self._prs.create_issue(title, body, labels)
+        issue_num = await self._prs.create_issue(title, body, labels)
+        if issue_num:
+            self._state.set_hitl_origin(issue_num, self._config.improve_label[0])
+            self._state.set_hitl_cause(issue_num, "Retrospective pattern detected")
 
     def _load_filed_patterns(self) -> set[str]:
         """Load the set of already-filed pattern keys."""

--- a/review_phase.py
+++ b/review_phase.py
@@ -536,7 +536,14 @@ class ReviewPhase:
                 desc = CATEGORY_DESCRIPTIONS.get(category, category)
                 title = f"[Review Insight] Recurring feedback: {desc}"
                 labels = self._config.improve_label[:1] + self._config.hitl_label[:1]
-                await self._prs.create_issue(title, body, labels)
+                issue_num = await self._prs.create_issue(title, body, labels)
+                if issue_num:
+                    self._state.set_hitl_origin(
+                        issue_num, self._config.improve_label[0]
+                    )
+                    self._state.set_hitl_cause(
+                        issue_num, f"Recurring review pattern: {desc}"
+                    )
                 self._insights.mark_category_proposed(category)
         except Exception:  # noqa: BLE001
             logger.warning(

--- a/tests/test_dashboard_routes.py
+++ b/tests/test_dashboard_routes.py
@@ -897,3 +897,144 @@ class TestPipelineEndpoint:
         assert data["stages"]["triage"][0]["issue_number"] == 1
         assert len(data["stages"]["implement"]) == 1
         assert data["stages"]["implement"][0]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# HITL skip with improve origin → triage transition
+# ---------------------------------------------------------------------------
+
+
+class TestHITLSkipImproveTransition:
+    """Tests that /api/hitl/{issue}/skip transitions improve issues to triage."""
+
+    def _make_router(self, config, event_bus, state, tmp_path, get_orch=None):
+        from dashboard_routes import create_router
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, event_bus)
+        pr_mgr.remove_label = AsyncMock()
+        pr_mgr.add_labels = AsyncMock()
+        return (
+            create_router(
+                config=config,
+                event_bus=event_bus,
+                state=state,
+                pr_manager=pr_mgr,
+                get_orchestrator=get_orch or (lambda: None),
+                set_orchestrator=lambda o: None,
+                set_run_task=lambda t: None,
+                ui_dist_dir=tmp_path / "no-dist",
+                template_dir=tmp_path / "no-templates",
+            ),
+            pr_mgr,
+        )
+
+    def _find_endpoint(self, router, path):
+        for route in router.routes:
+            if (
+                hasattr(route, "path")
+                and route.path == path
+                and hasattr(route, "endpoint")
+            ):
+                return route.endpoint
+        return None
+
+    @pytest.mark.asyncio
+    async def test_hitl_skip_improve_origin_transitions_to_triage(
+        self, config, event_bus, tmp_path
+    ) -> None:
+        """Skipping an improve-origin HITL item should remove improve and add find label."""
+        state = make_state(tmp_path)
+        state.set_hitl_origin(42, "hydra-improve")
+        state.set_hitl_cause(42, "Memory suggestion")
+
+        mock_orch = MagicMock()
+        mock_orch.skip_hitl_issue = MagicMock()
+        router, pr_mgr = self._make_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+
+        skip = self._find_endpoint(router, "/api/hitl/{issue_number}/skip")
+        assert skip is not None
+
+        response = await skip(42)
+        assert response.status_code == 200
+
+        # Verify improve label was removed
+        remove_calls = [c.args for c in pr_mgr.remove_label.call_args_list]
+        assert (42, "hydra-improve") in remove_calls
+
+        # Verify find/triage label was added
+        add_calls = [c.args for c in pr_mgr.add_labels.call_args_list]
+        assert (42, [config.find_label[0]]) in add_calls
+
+        # Verify state cleanup
+        assert state.get_hitl_origin(42) is None
+        assert state.get_hitl_cause(42) is None
+
+    @pytest.mark.asyncio
+    async def test_hitl_skip_non_improve_origin_no_triage_transition(
+        self, config, event_bus, tmp_path
+    ) -> None:
+        """Non-improve HITL items should not get triage label on skip."""
+        state = make_state(tmp_path)
+        state.set_hitl_origin(42, "hydra-review")
+
+        mock_orch = MagicMock()
+        mock_orch.skip_hitl_issue = MagicMock()
+        router, pr_mgr = self._make_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+
+        skip = self._find_endpoint(router, "/api/hitl/{issue_number}/skip")
+        assert skip is not None
+        await skip(42)
+
+        # Should NOT add find label for non-improve origins
+        add_calls = [c.args for c in pr_mgr.add_labels.call_args_list]
+        for call in add_calls:
+            assert call[1] != [config.find_label[0]]
+
+    @pytest.mark.asyncio
+    async def test_hitl_skip_no_origin_no_triage_transition(
+        self, config, event_bus, tmp_path
+    ) -> None:
+        """When no origin is set, skip should not add find label."""
+        state = make_state(tmp_path)
+
+        mock_orch = MagicMock()
+        mock_orch.skip_hitl_issue = MagicMock()
+        router, pr_mgr = self._make_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+
+        skip = self._find_endpoint(router, "/api/hitl/{issue_number}/skip")
+        assert skip is not None
+        await skip(42)
+
+        # Should NOT add find label when no origin
+        add_calls = [c.args for c in pr_mgr.add_labels.call_args_list]
+        for call in add_calls:
+            assert call[1] != [config.find_label[0]]
+
+    @pytest.mark.asyncio
+    async def test_hitl_skip_cleans_up_hitl_cause(
+        self, config, event_bus, tmp_path
+    ) -> None:
+        """Skip should clean up hitl_cause in addition to hitl_origin."""
+        state = make_state(tmp_path)
+        state.set_hitl_origin(42, "hydra-review")
+        state.set_hitl_cause(42, "CI failed after 2 fix attempt(s)")
+
+        mock_orch = MagicMock()
+        mock_orch.skip_hitl_issue = MagicMock()
+        router, _ = self._make_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+
+        skip = self._find_endpoint(router, "/api/hitl/{issue_number}/skip")
+        assert skip is not None
+        await skip(42)
+
+        assert state.get_hitl_origin(42) is None
+        assert state.get_hitl_cause(42) is None


### PR DESCRIPTION
## Summary

Closes #383.

## Issue

Add triage label when resolving hydra-improve HITL items

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra