### PR TITLE
Fixes #389: Fix merged stage showing as pending in Work Stream

### DIFF
--- a/ui/src/components/StreamView.jsx
+++ b/ui/src/components/StreamView.jsx
@@ -74,16 +74,17 @@ const STAGE_INDEX = Object.fromEntries(STAGE_KEYS.map((k, i) => [k, i]))
  * Convert a PipelineIssue from the server into a StreamCard-compatible shape.
  * Builds a synthetic `stages` object based on current pipeline position.
  */
-function toStreamIssue(pipeIssue, stageKey, prs) {
+export function toStreamIssue(pipeIssue, stageKey, prs) {
   const currentIdx = STAGE_INDEX[stageKey] ?? 0
   const isActive = pipeIssue.status === 'active'
+  const isDone = pipeIssue.status === 'done'
   const stages = {}
   for (let i = 0; i < STAGE_KEYS.length; i++) {
     const k = STAGE_KEYS[i]
     if (i < currentIdx) {
       stages[k] = { status: 'done', startTime: null, endTime: null, transcript: [] }
     } else if (i === currentIdx) {
-      stages[k] = { status: isActive ? 'active' : 'pending', startTime: null, endTime: null, transcript: [] }
+      stages[k] = { status: isDone ? 'done' : isActive ? 'active' : 'pending', startTime: null, endTime: null, transcript: [] }
     } else {
       stages[k] = { status: 'pending', startTime: null, endTime: null, transcript: [] }
     }
@@ -97,7 +98,7 @@ function toStreamIssue(pipeIssue, stageKey, prs) {
     issueNumber: pipeIssue.issue_number,
     title: pipeIssue.title || `Issue #${pipeIssue.issue_number}`,
     currentStage: stageKey,
-    overallStatus: pipeIssue.status === 'hitl' ? 'hitl' : isActive ? 'active' : 'active',
+    overallStatus: pipeIssue.status === 'hitl' ? 'hitl' : isDone ? 'done' : 'active',
     startTime: null,
     endTime: null,
     pr,

--- a/ui/src/components/__tests__/StreamView.test.jsx
+++ b/ui/src/components/__tests__/StreamView.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { PIPELINE_STAGES } from '../../constants'
+import { STAGE_KEYS } from '../../hooks/useTimeline'
 
 const mockUseHydra = vi.fn()
 
@@ -8,7 +9,7 @@ vi.mock('../../context/HydraContext', () => ({
   useHydra: (...args) => mockUseHydra(...args),
 }))
 
-const { StreamView } = await import('../StreamView')
+const { StreamView, toStreamIssue } = await import('../StreamView')
 
 const defaultHydra = {
   pipelineIssues: { triage: [], plan: [], implement: [], review: [] },
@@ -208,5 +209,86 @@ describe('StreamView stage indicators', () => {
       expect(screen.getByTestId('stage-section-implement').style.opacity).toBe('0.5')
       expect(screen.getByTestId('stage-section-triage').style.opacity).toBe('1')
     })
+  })
+})
+
+describe('toStreamIssue', () => {
+  it('sets all stages to done for merged/done items', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'done' },
+      'merged',
+      []
+    )
+    for (const key of STAGE_KEYS) {
+      expect(result.stages[key].status).toBe('done')
+    }
+    expect(result.overallStatus).toBe('done')
+  })
+
+  it('sets current stage to active for active items', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'active' },
+      'implement',
+      []
+    )
+    expect(result.stages.triage.status).toBe('done')
+    expect(result.stages.plan.status).toBe('done')
+    expect(result.stages.implement.status).toBe('active')
+    expect(result.stages.review.status).toBe('pending')
+    expect(result.stages.merged.status).toBe('pending')
+    expect(result.overallStatus).toBe('active')
+  })
+
+  it('sets current stage to pending for queued items', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'queued' },
+      'plan',
+      []
+    )
+    expect(result.stages.triage.status).toBe('done')
+    expect(result.stages.plan.status).toBe('pending')
+    expect(result.stages.implement.status).toBe('pending')
+    expect(result.stages.review.status).toBe('pending')
+    expect(result.stages.merged.status).toBe('pending')
+    expect(result.overallStatus).toBe('active')
+  })
+
+  it('sets overallStatus to hitl for hitl items', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'hitl' },
+      'review',
+      []
+    )
+    expect(result.overallStatus).toBe('hitl')
+  })
+
+  it('matches PR from prs array', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'active' },
+      'review',
+      [{ pr: 42, issue: 10, url: 'https://github.com/test/pr/42' }]
+    )
+    expect(result.pr).toEqual({ number: 42, url: 'https://github.com/test/pr/42' })
+  })
+
+  it('returns null pr when no match found', () => {
+    const result = toStreamIssue(
+      { issue_number: 10, title: 'Test', status: 'active' },
+      'implement',
+      [{ pr: 42, issue: 99, url: 'https://github.com/test/pr/42' }]
+    )
+    expect(result.pr).toBeNull()
+  })
+})
+
+describe('Merged stage rendering', () => {
+  it('renders merged PR issues in the merged stage section', () => {
+    mockUseHydra.mockReturnValue({
+      ...defaultHydra,
+      prs: [{ pr: 42, issue: 10, title: 'Fix bug', merged: true, url: 'https://github.com/test/pr/42' }],
+    })
+    render(<StreamView {...defaultProps} />)
+    expect(screen.getByText('#10')).toBeInTheDocument()
+    expect(screen.getByText('Fix bug')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Closes #389.

## Issue

Fix merged stage showing as pending in Work Stream

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra