### PR TITLE
Fixes #472: "pr_unsticker.py _save_transcript has same unguarded fi...

### DIFF
--- a/pr_unsticker.py
+++ b/pr_unsticker.py
@@ -280,4 +280,5 @@ class PRUnsticker:
                 "Could not save unsticker transcript to %s",
                 log_dir,
                 exc_info=True,
+                extra={"issue": issue_number},
             )

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -357,6 +357,4 @@ class TestSaveTranscript:
             mp.setattr(Path, "write_text", _raise_oserror)
             unsticker._save_transcript(42, 1, "transcript content here")
 
-        assert any(
-            "Could not save unsticker transcript" in msg for msg in caplog.messages
-        )
+        assert "Could not save unsticker transcript" in caplog.text


### PR DESCRIPTION
## Summary

Closes #472.

## Issue

"pr_unsticker.py _save_transcript has same unguarded file I/O pattern"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra