### PR TITLE
Fixes #517: Fix gh CLI pagination cap causing undercounted metrics

### DIFF
--- a/pr_manager.py
+++ b/pr_manager.py
@@ -839,7 +839,7 @@ class PRManager:
                         "api",
                         "search/issues",
                         "-f",
-                        f"q=repo:{self._repo} is:issue is:open label:{label}",
+                        f'q=repo:{self._repo} is:issue is:open label:"{label}"',
                         "--jq",
                         ".total_count",
                     )
@@ -863,7 +863,7 @@ class PRManager:
                     "api",
                     "search/issues",
                     "-f",
-                    f"q=repo:{self._repo} is:issue is:closed label:{label}",
+                    f'q=repo:{self._repo} is:issue is:closed label:"{label}"',
                     "--jq",
                     ".total_count",
                 )
@@ -884,7 +884,7 @@ class PRManager:
                 "api",
                 "search/issues",
                 "-f",
-                f"q=repo:{self._repo} is:pr is:merged label:{label}",
+                f'q=repo:{self._repo} is:pr is:merged label:"{label}"',
                 "--jq",
                 ".total_count",
             )

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -2743,6 +2743,12 @@ class TestCountHelpers:
         assert "search/issues" in cmd
         assert ".total_count" in cmd
         assert "--limit" not in cmd
+        # Verify query string contains correct filters
+        query_arg = [c for c in cmd if c.startswith("q=")][0]
+        assert "repo:test-org/test-repo" in query_arg
+        assert "is:issue" in query_arg
+        assert "is:open" in query_arg
+        assert 'label:"hydra-plan"' in query_arg
 
     @pytest.mark.asyncio
     async def test_count_closed_issues_uses_search_api(
@@ -2774,6 +2780,12 @@ class TestCountHelpers:
         assert "search/issues" in cmd
         assert ".total_count" in cmd
         assert "--limit" not in cmd
+        # Verify query string contains correct filters
+        query_arg = [c for c in cmd if c.startswith("q=")][0]
+        assert "repo:test-org/test-repo" in query_arg
+        assert "is:issue" in query_arg
+        assert "is:closed" in query_arg
+        assert 'label:"hydra-fixed"' in query_arg
 
     @pytest.mark.asyncio
     async def test_count_merged_prs_uses_search_api(self, config, event_bus, tmp_path):
@@ -2803,6 +2815,12 @@ class TestCountHelpers:
         assert "search/issues" in cmd
         assert ".total_count" in cmd
         assert "--limit" not in cmd
+        # Verify query string contains correct filters
+        query_arg = [c for c in cmd if c.startswith("q=")][0]
+        assert "repo:test-org/test-repo" in query_arg
+        assert "is:pr" in query_arg
+        assert "is:merged" in query_arg
+        assert 'label:"hydra-fixed"' in query_arg
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #517.

## Issue

Fix gh CLI pagination cap causing undercounted metrics

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra