### PR TITLE
Switch default model to opus for impl and review

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -65,7 +65,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--model",
         default=None,
-        help="Model for implementation agents (default: sonnet)",
+        help="Model for implementation agents (default: opus)",
     )
     parser.add_argument(
         "--review-model",

--- a/config.py
+++ b/config.py
@@ -62,10 +62,10 @@ class HydraConfig(BaseModel):
     max_budget_usd: float = Field(
         default=0, ge=0, description="USD cap per implementation agent (0 = unlimited)"
     )
-    model: str = Field(default="sonnet", description="Model for implementation agents")
+    model: str = Field(default="opus", description="Model for implementation agents")
 
     # Review configuration
-    review_model: str = Field(default="sonnet", description="Model for review agents")
+    review_model: str = Field(default="opus", description="Model for review agents")
     review_budget_usd: float = Field(
         default=0, ge=0, description="USD cap per review agent (0 = unlimited)"
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,8 +131,8 @@ class TestBuildConfig:
         assert cfg.max_hitl_workers == 1
         assert cfg.hitl_active_label == ["hydra-hitl-active"]
         assert cfg.max_budget_usd == pytest.approx(0)
-        assert cfg.model == "sonnet"
-        assert cfg.review_model == "sonnet"
+        assert cfg.model == "opus"
+        assert cfg.review_model == "opus"
         assert cfg.review_budget_usd == pytest.approx(0)
         assert cfg.ci_check_timeout == 600
         assert cfg.ci_poll_interval == 30
@@ -158,7 +158,7 @@ class TestBuildConfig:
         assert cfg.batch_size == 10
         # Other fields remain at defaults
         assert cfg.max_workers == 3
-        assert cfg.model == "sonnet"
+        assert cfg.model == "opus"
 
     def test_label_arg_parsed_to_list(self) -> None:
         """A comma-separated label CLI arg should become a list."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -374,7 +374,7 @@ class TestHydraConfigDefaults:
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.model == "sonnet"
+        assert cfg.model == "opus"
 
     def test_review_model_default(self, tmp_path: Path) -> None:
         cfg = HydraConfig(
@@ -382,7 +382,7 @@ class TestHydraConfigDefaults:
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.review_model == "sonnet"
+        assert cfg.review_model == "opus"
 
     def test_review_budget_usd_default(self, tmp_path: Path) -> None:
         cfg = HydraConfig(

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -192,7 +192,7 @@ class TestConfigFileMergePriority:
         )
 
         assert cfg.max_workers == 3  # Default
-        assert cfg.model == "sonnet"  # Default
+        assert cfg.model == "opus"  # Default
 
     def test_config_file_with_float_field(self, tmp_path: Path) -> None:
         """Float fields from config file should be preserved."""

--- a/tests/test_config_file_cli.py
+++ b/tests/test_config_file_cli.py
@@ -65,7 +65,7 @@ class TestBuildConfigWithConfigFile:
 
         # Should use defaults
         assert cfg.max_workers == 3
-        assert cfg.model == "sonnet"
+        assert cfg.model == "opus"
 
     def test_no_config_file_uses_defaults(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -77,7 +77,7 @@ class TestBuildConfigWithConfigFile:
         cfg = build_config(args)
 
         assert cfg.max_workers == 3
-        assert cfg.model == "sonnet"
+        assert cfg.model == "opus"
 
     def test_config_file_with_multiple_fields(self, tmp_path: Path) -> None:
         """Config file should support multiple fields."""


### PR DESCRIPTION
## Summary
- Changes `model` (implementation) and `review_model` defaults from `sonnet` to `opus` in `HydraConfig`
- Updates CLI `--model` help text to reflect new default
- Updates all test assertions across 4 test files

## Test plan
- [x] All 2545 tests pass
- [x] Pre-commit hooks pass (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)