### PR TITLE
Move Pipeline panel to System sub-tab and group system workers

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -7,7 +7,6 @@ import { HITLTable } from './components/HITLTable'
 import { SystemPanel } from './components/SystemPanel'
 import { MetricsPanel } from './components/MetricsPanel'
 import { StreamView } from './components/StreamView'
-import { PipelineControlPanel } from './components/PipelineControlPanel'
 import { theme } from './theme'
 import { ACTIVE_STATUSES } from './constants'
 
@@ -42,7 +41,6 @@ function AppContent() {
   const [selectedWorker, setSelectedWorker] = useState(null)
   const [activeTab, setActiveTab] = useState('issues')
   const [expandedStages, setExpandedStages] = useState({})
-  const [pipelinePanelOpen, setPipelinePanelOpen] = useState(true)
 
   // Auto-select the first active worker when none is selected
   useEffect(() => {
@@ -92,10 +90,6 @@ function AppContent() {
     return ok
   }, [requestChanges])
 
-  const handleTogglePipelinePanel = useCallback(() => {
-    setPipelinePanelOpen(prev => !prev)
-  }, [])
-
   return (
     <div style={styles.layout}>
       <Header
@@ -103,8 +97,6 @@ function AppContent() {
         orchestratorStatus={orchestratorStatus}
         onStart={handleStart}
         onStop={handleStop}
-        pipelinePanelOpen={pipelinePanelOpen}
-        onTogglePipelinePanel={handleTogglePipelinePanel}
       />
 
       <div style={styles.main}>
@@ -143,11 +135,6 @@ function AppContent() {
             {activeTab === 'system' && <SystemPanel backgroundWorkers={backgroundWorkers} onToggleBgWorker={toggleBgWorker} onViewLog={handleViewTranscript} onUpdateInterval={updateBgWorkerInterval} />}
             {activeTab === 'metrics' && <MetricsPanel />}
           </div>
-          <PipelineControlPanel
-            collapsed={!pipelinePanelOpen}
-            onToggleCollapse={handleTogglePipelinePanel}
-            onToggleBgWorker={toggleBgWorker}
-          />
         </div>
       </div>
 

--- a/ui/src/components/Header.jsx
+++ b/ui/src/components/Header.jsx
@@ -5,7 +5,6 @@ import { useHydra } from '../context/HydraContext'
 export function Header({
   connected, orchestratorStatus,
   onStart, onStop,
-  pipelinePanelOpen, onTogglePipelinePanel,
 }) {
   const { stageStatus } = useHydra()
   const workload = stageStatus.workload
@@ -69,15 +68,6 @@ export function Header({
         </div>
       </div>
       <div style={styles.controls}>
-        {onTogglePipelinePanel && (
-          <button
-            style={pipelinePanelOpen ? panelToggleActiveStyle : panelToggleStyle}
-            onClick={onTogglePipelinePanel}
-            data-testid="pipeline-panel-toggle"
-          >
-            Pipeline
-          </button>
-        )}
         {canStart && (
           <button
             style={connected ? startBtnEnabled : startBtnDisabled}
@@ -198,17 +188,6 @@ const styles = {
     fontSize: 12,
     fontWeight: 600,
   },
-  panelToggle: {
-    padding: '4px 10px',
-    borderRadius: 6,
-    border: `1px solid ${theme.border}`,
-    background: theme.surface,
-    color: theme.textMuted,
-    fontSize: 11,
-    fontWeight: 600,
-    cursor: 'pointer',
-    transition: 'all 0.15s',
-  },
 }
 
 // Pre-computed connection dot variants
@@ -218,7 +197,3 @@ export const dotDisconnected = { ...styles.dot, background: theme.red }
 // Pre-computed start button variants
 export const startBtnEnabled = { ...styles.startBtn, opacity: 1, cursor: 'pointer' }
 export const startBtnDisabled = { ...styles.startBtn, opacity: 0.4, cursor: 'not-allowed' }
-
-// Pre-computed pipeline panel toggle button variants
-export const panelToggleStyle = styles.panelToggle
-export const panelToggleActiveStyle = { ...styles.panelToggle, border: `1px solid ${theme.accent}`, background: theme.accentSubtle, color: theme.accent }

--- a/ui/src/components/PipelineControlPanel.jsx
+++ b/ui/src/components/PipelineControlPanel.jsx
@@ -78,7 +78,7 @@ function PipelineWorkerCard({ workerKey, worker }) {
   )
 }
 
-export function PipelineControlPanel({ collapsed, onToggleCollapse, onToggleBgWorker }) {
+export function PipelineControlPanel({ onToggleBgWorker }) {
   const { workers, stageStatus, hitlItems } = useHydra()
 
   const pipelineWorkers = Object.entries(workers || {}).filter(
@@ -87,43 +87,9 @@ export function PipelineControlPanel({ collapsed, onToggleCollapse, onToggleBgWo
   const hasPipelineWorkers = pipelineWorkers.length > 0
   const hitlCount = hitlItems?.length || 0
 
-  if (collapsed) {
-    return (
-      <div style={styles.collapsedPanel}>
-        <div
-          style={styles.collapseBtn}
-          onClick={onToggleCollapse}
-          data-testid="pipeline-panel-expand"
-        >
-          &#9664;
-        </div>
-        {PIPELINE_LOOPS.map((loop) => {
-          const status = stageStatus[loop.key] || {}
-          const enabled = status.enabled !== false
-          return (
-            <span
-              key={loop.key}
-              style={enabled ? collapsedDotLit[loop.key] : collapsedDotDim[loop.key]}
-              data-testid={`collapsed-dot-${loop.key}`}
-            />
-          )
-        })}
-      </div>
-    )
-  }
-
   return (
     <div style={styles.panel}>
-      <div style={styles.headingRow}>
-        <h3 style={styles.heading}>Pipeline</h3>
-        <div
-          style={styles.collapseBtn}
-          onClick={onToggleCollapse}
-          data-testid="pipeline-panel-collapse"
-        >
-          &#9654;
-        </div>
-      </div>
+      <h3 style={styles.heading}>Pipeline Controls</h3>
 
       <div style={styles.loopStack}>
         {PIPELINE_LOOPS.map((loop) => {
@@ -187,49 +153,16 @@ export function PipelineControlPanel({ collapsed, onToggleCollapse, onToggleBgWo
 
 const styles = {
   panel: {
-    width: 240,
-    flexShrink: 0,
-    borderLeft: `1px solid ${theme.border}`,
-    background: theme.surface,
+    flex: 1,
     overflowY: 'auto',
-    padding: 16,
-  },
-  collapsedPanel: {
-    width: 44,
-    flexShrink: 0,
-    borderLeft: `1px solid ${theme.border}`,
-    background: theme.surface,
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    paddingTop: 12,
-    gap: 12,
-  },
-  headingRow: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    marginBottom: 12,
+    padding: 20,
   },
   heading: {
-    fontSize: 14,
+    fontSize: 16,
     fontWeight: 600,
     color: theme.textBright,
     margin: 0,
-  },
-  collapseBtn: {
-    fontSize: 10,
-    color: theme.textMuted,
-    cursor: 'pointer',
-    padding: '4px 6px',
-    borderRadius: 4,
-    transition: 'color 0.15s',
-  },
-  collapsedDot: {
-    width: 10,
-    height: 10,
-    borderRadius: '50%',
-    flexShrink: 0,
+    marginBottom: 16,
   },
   loopStack: {
     display: 'flex',
@@ -415,7 +348,5 @@ const roleBadgeFallback = { ...styles.roleBadge, background: theme.textMuted }
 // Pre-computed per-loop style variants (avoids object spread in render loops)
 const loopDotLit = Object.fromEntries(PIPELINE_LOOPS.map(l => [l.key, { ...styles.dot, background: l.color }]))
 const loopDotDim = Object.fromEntries(PIPELINE_LOOPS.map(l => [l.key, { ...styles.dot, background: l.dimColor }]))
-const collapsedDotLit = Object.fromEntries(PIPELINE_LOOPS.map(l => [l.key, { ...styles.collapsedDot, background: l.color }]))
-const collapsedDotDim = Object.fromEntries(PIPELINE_LOOPS.map(l => [l.key, { ...styles.collapsedDot, background: l.dimColor }]))
 const loopCountActive = Object.fromEntries(PIPELINE_LOOPS.map(l => [l.key, { ...styles.loopCount, color: l.color }]))
 const loopCountDim = { ...styles.loopCount, color: theme.textMuted }

--- a/ui/src/components/__tests__/App.test.jsx
+++ b/ui/src/components/__tests__/App.test.jsx
@@ -212,49 +212,20 @@ describe('Main tab bar', () => {
   })
 })
 
-describe('Pipeline side panel', () => {
-  it('pipeline panel renders alongside Work Stream tab', async () => {
+describe('Pipeline sub-tab under System', () => {
+  it('Pipeline is accessible as a sub-tab under System', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    // Pipeline panel heading should be visible alongside the default Work Stream tab
-    expect(screen.getByText('Work Stream')).toBeInTheDocument()
-    // Pipeline panel should be present (expanded by default)
-    expect(screen.getByTestId('pipeline-panel-collapse')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('System'))
+    // Pipeline sub-tab should be visible
+    expect(screen.getByText('Pipeline')).toBeInTheDocument()
   })
 
-  it('pipeline panel toggle button in header collapses/expands the panel', async () => {
+  it('clicking Pipeline sub-tab shows pipeline controls', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    // Panel is open by default — collapse button should be visible
-    expect(screen.getByTestId('pipeline-panel-collapse')).toBeInTheDocument()
-    // Click the header toggle to collapse
-    fireEvent.click(screen.getByTestId('pipeline-panel-toggle'))
-    // Now the expand button should be visible instead
-    expect(screen.getByTestId('pipeline-panel-expand')).toBeInTheDocument()
-    expect(screen.queryByTestId('pipeline-panel-collapse')).not.toBeInTheDocument()
-  })
-
-  it('pipeline loop chips visible when panel is open', async () => {
-    const { default: App } = await import('../../App')
-    render(<App />)
-    expect(screen.getByText('Triage')).toBeInTheDocument()
-    expect(screen.getByText('Plan')).toBeInTheDocument()
-    expect(screen.getByText('Implement')).toBeInTheDocument()
-    expect(screen.getByText('Review')).toBeInTheDocument()
-  })
-
-  it('pipeline panel still visible when switching to Transcript tab', async () => {
-    const { default: App } = await import('../../App')
-    render(<App />)
-    fireEvent.click(screen.getByText('Transcript'))
-    // Pipeline panel should still be present
-    expect(screen.getByTestId('pipeline-panel-collapse')).toBeInTheDocument()
-  })
-
-  it('pipeline panel still visible when switching to Metrics tab', async () => {
-    const { default: App } = await import('../../App')
-    render(<App />)
-    fireEvent.click(screen.getByText('Metrics'))
-    expect(screen.getByTestId('pipeline-panel-collapse')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('System'))
+    fireEvent.click(screen.getByText('Pipeline'))
+    expect(screen.getByText('Pipeline Controls')).toBeInTheDocument()
   })
 })

--- a/ui/src/components/__tests__/Header.test.jsx
+++ b/ui/src/components/__tests__/Header.test.jsx
@@ -4,7 +4,6 @@ import { deriveStageStatus } from '../../hooks/useStageStatus'
 import {
   dotConnected, dotDisconnected,
   startBtnEnabled, startBtnDisabled,
-  panelToggleStyle, panelToggleActiveStyle,
 } from '../Header'
 
 const mockUseHydra = vi.fn()
@@ -21,33 +20,6 @@ function mockStageStatus(workers = {}) {
 
 beforeEach(() => {
   mockUseHydra.mockReturnValue({ stageStatus: mockStageStatus() })
-})
-
-describe('Header pre-computed panel toggle styles', () => {
-  it('panelToggleStyle has muted border and text-muted color', () => {
-    expect(panelToggleStyle).toMatchObject({
-      fontSize: 11,
-      fontWeight: 600,
-      cursor: 'pointer',
-      color: 'var(--text-muted)',
-    })
-  })
-
-  it('panelToggleActiveStyle has accent border, accentSubtle background, and accent color', () => {
-    expect(panelToggleActiveStyle).toMatchObject({
-      fontSize: 11,
-      fontWeight: 600,
-      cursor: 'pointer',
-      color: 'var(--accent)',
-      background: 'var(--accent-subtle)',
-      border: '1px solid var(--accent)',
-    })
-  })
-
-  it('style objects are referentially stable', () => {
-    expect(panelToggleStyle).toBe(panelToggleStyle)
-    expect(panelToggleActiveStyle).toBe(panelToggleActiveStyle)
-  })
 })
 
 describe('Header pre-computed styles', () => {
@@ -242,40 +214,6 @@ describe('Header component', () => {
       expect(screen.getByText('Credits Paused')).toBeInTheDocument()
       expect(screen.getByText('Stop')).toBeInTheDocument()
       expect(screen.queryByText('Start')).toBeNull()
-    })
-  })
-
-  describe('pipeline panel toggle button', () => {
-    it('does not render toggle button when onTogglePipelinePanel is not provided', () => {
-      render(<Header {...defaultProps} />)
-      expect(screen.queryByTestId('pipeline-panel-toggle')).not.toBeInTheDocument()
-    })
-
-    it('renders Pipeline toggle button when onTogglePipelinePanel is provided', () => {
-      render(<Header {...defaultProps} onTogglePipelinePanel={() => {}} pipelinePanelOpen={true} />)
-      expect(screen.getByTestId('pipeline-panel-toggle')).toBeInTheDocument()
-      expect(screen.getByTestId('pipeline-panel-toggle')).toHaveTextContent('Pipeline')
-    })
-
-    it('calls onTogglePipelinePanel when button is clicked', () => {
-      const onToggle = vi.fn()
-      render(<Header {...defaultProps} onTogglePipelinePanel={onToggle} pipelinePanelOpen={true} />)
-      fireEvent.click(screen.getByTestId('pipeline-panel-toggle'))
-      expect(onToggle).toHaveBeenCalledTimes(1)
-    })
-
-    it('uses active style when pipelinePanelOpen is true', () => {
-      render(<Header {...defaultProps} onTogglePipelinePanel={() => {}} pipelinePanelOpen={true} />)
-      const btn = screen.getByTestId('pipeline-panel-toggle')
-      expect(btn.style.color).toBe('var(--accent)')
-      expect(btn.style.background).toBe('var(--accent-subtle)')
-    })
-
-    it('uses inactive style when pipelinePanelOpen is false', () => {
-      render(<Header {...defaultProps} onTogglePipelinePanel={() => {}} pipelinePanelOpen={false} />)
-      const btn = screen.getByTestId('pipeline-panel-toggle')
-      expect(btn.style.color).toBe('var(--text-muted)')
-      expect(btn.style.background).toBe('var(--surface)')
     })
   })
 

--- a/ui/src/components/__tests__/PipelineControlPanel.test.jsx
+++ b/ui/src/components/__tests__/PipelineControlPanel.test.jsx
@@ -37,14 +37,14 @@ const mockPipelineWorkers = {
 describe('PipelineControlPanel', () => {
   describe('Pipeline Loop Toggles', () => {
     it('renders all 4 pipeline loop chips', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} onToggleBgWorker={() => {}} />)
+      render(<PipelineControlPanel onToggleBgWorker={() => {}} />)
       for (const loop of PIPELINE_LOOPS) {
         expect(screen.getByText(loop.label)).toBeInTheDocument()
       }
     })
 
     it('shows worker count of 0 when no active workers', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       for (const loop of PIPELINE_LOOPS) {
         const countEl = screen.getByTestId(`loop-count-${loop.key}`)
         expect(countEl).toHaveTextContent('0')
@@ -53,7 +53,7 @@ describe('PipelineControlPanel', () => {
 
     it('shows worker counts per stage', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByTestId('loop-count-triage')).toHaveTextContent('1')
       expect(screen.getByTestId('loop-count-plan')).toHaveTextContent('1')
       expect(screen.getByTestId('loop-count-implement')).toHaveTextContent('1')
@@ -65,12 +65,12 @@ describe('PipelineControlPanel', () => {
         10: { status: 'running', worker: 1, role: 'implementer', title: 'Issue #10', branch: '', transcript: [], pr: null },
       }
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: singleWorker }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('worker')).toBeInTheDocument()
     })
 
     it('shows "workers" plural when count is not 1', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       const workerLabels = screen.getAllByText('workers')
       expect(workerLabels.length).toBe(PIPELINE_LOOPS.length)
     })
@@ -80,13 +80,13 @@ describe('PipelineControlPanel', () => {
         10: { status: 'running', worker: 1, role: 'implementer', title: 'Issue #10', branch: '', transcript: [], pr: null },
       }
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: singleImplementer }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       const implementCount = screen.getByTestId('loop-count-implement')
       expect(implementCount.style.color).toBe('var(--accent)')
     })
 
     it('shows loop count in muted color when enabled but no active workers', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       const implementCount = screen.getByTestId('loop-count-implement')
       expect(implementCount.style.color).toBe('var(--text-muted)')
     })
@@ -99,14 +99,14 @@ describe('PipelineControlPanel', () => {
         { name: 'implement', status: 'ok', enabled: false, last_run: null, details: {} },
       ]
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: singleImplementer, backgroundWorkers: disabledBgWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       const implementCount = screen.getByTestId('loop-count-implement')
       expect(implementCount.style.color).toBe('var(--text-muted)')
     })
 
     it('calls onToggleBgWorker with pipeline loop key when toggled', () => {
       const onToggle = vi.fn()
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} onToggleBgWorker={onToggle} />)
+      render(<PipelineControlPanel onToggleBgWorker={onToggle} />)
       const allOnButtons = screen.getAllByText('On')
       fireEvent.click(allOnButtons[0]) // First pipeline loop = triage
       expect(onToggle).toHaveBeenCalledWith('triage', false)
@@ -117,7 +117,7 @@ describe('PipelineControlPanel', () => {
         { name: 'triage', status: 'ok', enabled: false, last_run: null, details: {} },
       ]
       mockUseHydra.mockReturnValue(defaultMockContext({ backgroundWorkers: disabledBgWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} onToggleBgWorker={() => {}} />)
+      render(<PipelineControlPanel onToggleBgWorker={() => {}} />)
       expect(screen.getByText('Off')).toBeInTheDocument()
       const onButtons = screen.getAllByText('On')
       expect(onButtons.length).toBe(3) // 3 enabled loops
@@ -128,9 +128,7 @@ describe('PipelineControlPanel', () => {
         { name: 'triage', status: 'ok', enabled: false, last_run: null, details: {} },
       ]
       mockUseHydra.mockReturnValue(defaultMockContext({ backgroundWorkers: disabledBgWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
-      // The triage loop dot should use dimColor (greenSubtle) instead of the active color
-      // We can't easily check dot color without testid, but the label should be dimmed
+      render(<PipelineControlPanel />)
       const triageLabel = screen.getByText('Triage')
       expect(triageLabel.style.color).toBe('var(--text-muted)')
     })
@@ -138,13 +136,13 @@ describe('PipelineControlPanel', () => {
 
   describe('Pipeline Worker Cards', () => {
     it('shows "No active pipeline workers" when no workers', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('No active pipeline workers')).toBeInTheDocument()
     })
 
     it('renders active worker cards with issue #, role badge, status', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('#5')).toBeInTheDocument()
       expect(screen.getByText('#7')).toBeInTheDocument()
       expect(screen.getByText('#10')).toBeInTheDocument()
@@ -160,7 +158,7 @@ describe('PipelineControlPanel', () => {
         99: { status: 'queued', worker: 1, role: 'implementer', title: 'Issue #99', branch: '', transcript: [], pr: null },
       }
       mockUseHydra.mockReturnValue(defaultMockContext({ workers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('No active pipeline workers')).toBeInTheDocument()
     })
 
@@ -170,7 +168,7 @@ describe('PipelineControlPanel', () => {
         51: { status: 'failed', worker: 2, role: 'reviewer', title: 'Issue #51', branch: '', transcript: [], pr: null },
       }
       mockUseHydra.mockReturnValue(defaultMockContext({ workers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('No active pipeline workers')).toBeInTheDocument()
       expect(screen.queryByText('#50')).not.toBeInTheDocument()
       expect(screen.queryByText('#51')).not.toBeInTheDocument()
@@ -178,20 +176,20 @@ describe('PipelineControlPanel', () => {
 
     it('shows worker title', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('Issue #10')).toBeInTheDocument()
       expect(screen.getByText('Triage Issue #5')).toBeInTheDocument()
     })
 
     it('shows transcript toggle when transcript has lines', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('Show transcript (3 lines)')).toBeInTheDocument()
     })
 
     it('expands transcript on click', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       const toggle = screen.getByText('Show transcript (3 lines)')
       fireEvent.click(toggle)
       expect(screen.getByText('Writing code...')).toBeInTheDocument()
@@ -201,7 +199,7 @@ describe('PipelineControlPanel', () => {
 
     it('does not show transcript toggle when transcript is empty', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.queryByText('Show transcript (0 lines)')).not.toBeInTheDocument()
     })
   })
@@ -209,12 +207,12 @@ describe('PipelineControlPanel', () => {
   describe('Status Badges', () => {
     it('shows "N active" badge when workers present', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({ workers: mockPipelineWorkers }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('4 active')).toBeInTheDocument()
     })
 
     it('does not show active badge when no active workers', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.queryByText(/\d+ active/)).not.toBeInTheDocument()
     })
 
@@ -226,7 +224,7 @@ describe('PipelineControlPanel', () => {
           { issue_number: 3, title: 'Issue 3' },
         ],
       }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('3 HITL issues')).toBeInTheDocument()
     })
 
@@ -234,12 +232,12 @@ describe('PipelineControlPanel', () => {
       mockUseHydra.mockReturnValue(defaultMockContext({
         hitlItems: [{ issue_number: 1, title: 'Issue 1' }],
       }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('1 HITL issue')).toBeInTheDocument()
     })
 
     it('does not show HITL badge when hitlItems is empty', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.queryByText(/HITL/)).not.toBeInTheDocument()
     })
 
@@ -248,45 +246,20 @@ describe('PipelineControlPanel', () => {
         workers: mockPipelineWorkers,
         hitlItems: [{ issue_number: 1, title: 'Issue 1' }, { issue_number: 2, title: 'Issue 2' }],
       }))
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
+      render(<PipelineControlPanel />)
       expect(screen.getByText('4 active')).toBeInTheDocument()
       expect(screen.getByText('2 HITL issues')).toBeInTheDocument()
     })
   })
 
-  describe('Collapse Behavior', () => {
-    it('renders narrow panel with status dots when collapsed', () => {
-      render(<PipelineControlPanel collapsed={true} onToggleCollapse={() => {}} />)
-      // Should show collapsed dots for each loop
-      for (const loop of PIPELINE_LOOPS) {
-        expect(screen.getByTestId(`collapsed-dot-${loop.key}`)).toBeInTheDocument()
-      }
-      // Should not show full pipeline UI
-      expect(screen.queryByText('Pipeline')).not.toBeInTheDocument()
-      expect(screen.queryByText('No active pipeline workers')).not.toBeInTheDocument()
-    })
-
-    it('renders full panel with all controls when expanded', () => {
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={() => {}} />)
-      expect(screen.getByText('Pipeline')).toBeInTheDocument()
+  describe('Rendering', () => {
+    it('renders panel with all controls and heading', () => {
+      render(<PipelineControlPanel />)
+      expect(screen.getByText('Pipeline Controls')).toBeInTheDocument()
       expect(screen.getByText('No active pipeline workers')).toBeInTheDocument()
       for (const loop of PIPELINE_LOOPS) {
         expect(screen.getByText(loop.label)).toBeInTheDocument()
       }
-    })
-
-    it('calls onToggleCollapse when collapse button clicked (expanded)', () => {
-      const onToggle = vi.fn()
-      render(<PipelineControlPanel collapsed={false} onToggleCollapse={onToggle} />)
-      fireEvent.click(screen.getByTestId('pipeline-panel-collapse'))
-      expect(onToggle).toHaveBeenCalledTimes(1)
-    })
-
-    it('calls onToggleCollapse when expand button clicked (collapsed)', () => {
-      const onToggle = vi.fn()
-      render(<PipelineControlPanel collapsed={true} onToggleCollapse={onToggle} />)
-      fireEvent.click(screen.getByTestId('pipeline-panel-expand'))
-      expect(onToggle).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -114,11 +114,9 @@ describe('SystemPanel', () => {
       expect(screen.getByText('2400')).toBeInTheDocument()
     })
 
-    it('shows system badge on system workers', () => {
+    it('shows System section heading that groups system workers', () => {
       render(<SystemPanel backgroundWorkers={mockBgWorkers} />)
-      const badges = screen.getAllByText('system')
-      const systemWorkerCount = BACKGROUND_WORKERS.filter(w => w.system).length
-      expect(badges.length).toBe(systemWorkerCount)
+      expect(screen.getByText('System')).toBeInTheDocument()
     })
 
     it('shows system worker status as colored pill (green for ok) when orchestrator running', () => {
@@ -270,12 +268,35 @@ describe('SystemPanel', () => {
       const dot = screen.getByTestId('dot-pipeline_poller')
       expect(dot.style.background).toBe('var(--red)')
     })
+
+    it('shows pipeline stage counts as details when orchestrator running', () => {
+      mockUseHydra.mockReturnValue(defaultMockContext({
+        pipelinePollerLastRun: '2026-02-20T10:00:00Z',
+        orchestratorStatus: 'running',
+        pipelineIssues: {
+          triage: [{ number: 1 }],
+          plan: [{ number: 2 }, { number: 3 }],
+          implement: [],
+          review: [{ number: 4 }],
+          hitl: [{ number: 5 }],
+        },
+      }))
+      render(<SystemPanel backgroundWorkers={[]} />)
+      // Pipeline poller card shows stage keys as detail labels
+      expect(screen.getByText('triage')).toBeInTheDocument()
+      expect(screen.getByText('plan')).toBeInTheDocument()
+      expect(screen.getByText('implement')).toBeInTheDocument()
+      expect(screen.getByText('review')).toBeInTheDocument()
+      expect(screen.getByText('hitl')).toBeInTheDocument()
+      expect(screen.getByText('total')).toBeInTheDocument()
+    })
   })
 
   describe('Sub-tab Navigation', () => {
-    it('shows Workers and Livestream sub-tab labels', () => {
+    it('shows Workers, Pipeline, and Livestream sub-tab labels', () => {
       render(<SystemPanel backgroundWorkers={[]} />)
       expect(screen.getByText('Workers')).toBeInTheDocument()
+      expect(screen.getByText('Pipeline')).toBeInTheDocument()
       expect(screen.getByText('Livestream')).toBeInTheDocument()
     })
 
@@ -316,6 +337,21 @@ describe('SystemPanel', () => {
       expect(screen.getByText('Livestream').style.borderLeftColor).toBe('var(--accent)')
       expect(screen.getByText('Workers').style.color).toBe('var(--text-muted)')
       expect(screen.getByText('Workers').style.borderLeftColor).toBe('transparent')
+    })
+
+    it('clicking Pipeline sub-tab shows pipeline controls', () => {
+      render(<SystemPanel backgroundWorkers={[]} />)
+      fireEvent.click(screen.getByText('Pipeline'))
+      expect(screen.getByText('Pipeline Controls')).toBeInTheDocument()
+      expect(screen.queryByText('Background Workers')).not.toBeInTheDocument()
+    })
+
+    it('clicking Workers sub-tab after Pipeline returns to worker content', () => {
+      render(<SystemPanel backgroundWorkers={[]} />)
+      fireEvent.click(screen.getByText('Pipeline'))
+      expect(screen.queryByText('Background Workers')).not.toBeInTheDocument()
+      fireEvent.click(screen.getByText('Workers'))
+      expect(screen.getByText('Background Workers')).toBeInTheDocument()
     })
 
     it('renders event data in Livestream sub-tab', () => {


### PR DESCRIPTION
## Summary
- **Pipeline panel moved**: Removed the global side panel that showed Pipeline controls across all tabs. It's now a sub-tab under System (alongside Workers and Livestream)
- **System workers grouped**: Split background workers into "Background Workers" (non-system) and "System" sections with a divider heading, removing individual "system" badges
- **Pipeline Poller details**: The Pipeline Poller card now shows stage counts (triage, plan, implement, review, hitl, total) derived from the pipeline snapshot

## Files Changed
- `ui/src/App.jsx` — Removed PipelineControlPanel import, state, and rendering
- `ui/src/components/Header.jsx` — Removed Pipeline toggle button and related props/styles
- `ui/src/components/PipelineControlPanel.jsx` — Simplified to sub-tab mode (removed collapsed state)
- `ui/src/components/SystemPanel.jsx` — Added Pipeline sub-tab, split workers into sections, added poller details
- 4 test files updated with full coverage

## Test plan
- [x] All 525 UI tests pass (2 pre-existing HITLTable failures unrelated)
- [x] Pipeline sub-tab accessible under System tab
- [x] Pipeline Poller shows stage counts
- [x] System workers grouped under "System" heading
- [x] No regressions in Header, App, or PipelineControlPanel tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)