### PR TITLE
Fixes #742: Add label to Work Stream pipeline flow indicator

### DIFF
--- a/ui/src/components/StreamView.jsx
+++ b/ui/src/components/StreamView.jsx
@@ -21,6 +21,8 @@ function PendingIntentCard({ intent }) {
 function PipelineFlow({ stageGroups }) {
   return (
     <div style={styles.flowContainer} data-testid="pipeline-flow">
+      <span style={styles.flowTitle}>Pipeline Flow</span>
+      <div style={styles.flowConnector} />
       {stageGroups.map((group, idx) => (
         <React.Fragment key={group.stage.key}>
           <div style={styles.flowStage}>
@@ -357,6 +359,15 @@ const styles = {
     height: 1,
     background: theme.border,
     flexShrink: 0,
+  },
+  flowTitle: {
+    fontSize: 9,
+    fontWeight: 600,
+    color: theme.textMuted,
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
   },
   empty: {
     display: 'flex',

--- a/ui/src/components/__tests__/StreamView.test.jsx
+++ b/ui/src/components/__tests__/StreamView.test.jsx
@@ -454,6 +454,18 @@ describe('Stage header failed/hitl counts', () => {
 })
 
 describe('PipelineFlow visualization', () => {
+  it('renders "Pipeline Flow" label in the flow indicator', () => {
+    mockUseHydra.mockReturnValue(defaultHydraContext({
+      pipelineIssues: {
+        triage: [{ issue_number: 1, title: 'Test', status: 'queued' }],
+        plan: [], implement: [], review: [],
+      },
+    }))
+    render(<StreamView {...defaultProps} />)
+    const flow = screen.getByTestId('pipeline-flow')
+    expect(flow.textContent).toContain('Pipeline Flow')
+  })
+
   it('renders all pipeline stage labels in the flow', () => {
     mockUseHydra.mockReturnValue(defaultHydraContext({
       pipelineIssues: {


### PR DESCRIPTION
## Summary

Closes #742.

## Issue

Add label to Work Stream pipeline flow indicator

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by Hydra