### PR TITLE
Fix garbage review comments and improve conflict resolution

### DIFF
--- a/review_phase.py
+++ b/review_phase.py
@@ -932,8 +932,20 @@ class ReviewPhase:
             )
 
             try:
+                # Gather conflict-specific context for the prompt
+                conflicting_files = await self._worktrees.get_conflicting_files(wt_path)
+                main_diff = await self._worktrees.get_main_diff_for_files(
+                    wt_path, conflicting_files
+                )
+
                 prompt = build_conflict_prompt(
-                    issue, pr_changed_files, main_commits, last_error, attempt
+                    issue,
+                    pr_changed_files,
+                    main_commits,
+                    last_error,
+                    attempt,
+                    conflicting_files=conflicting_files,
+                    main_diff=main_diff,
                 )
                 cmd = self._agents._build_command(wt_path)
                 transcript = await self._agents._execute(


### PR DESCRIPTION
## Summary

- **Sanitize review summaries (#772):** Added `_JUNK_PATTERNS` + `_sanitize_summary()` to `reviewer.py` so internal tool output (e.g. `→ TaskOutput: {...}`) never leaks into PR review comments. The `_extract_summary()` fallback now walks transcript lines in reverse skipping garbage instead of blindly taking the last line.
- **Better conflict prompts (#773):** Added `get_conflicting_files()` and `get_main_diff_for_files()` to `worktree.py` so the conflict resolver agent gets the actual diff of what changed on main for the conflicting files. Simplified `conflict_prompt.py` instructions from an 8-step tutorial to a concise goal — the agent is a full Claude Code session, it just needs context not hand-holding. Added `gh issue view` reference so the agent can look up full issue history.

## Test plan

- [x] 15 new tests for `_sanitize_summary()` and garbage-resistant `_extract_summary()` scenarios
- [x] 10 new tests for `get_conflicting_files()` and `get_main_diff_for_files()`
- [x] 9 new tests for conflict prompt new sections, backward compat, and simplified instructions
- [x] 2 new integration tests for `_resolve_merge_conflicts()` wiring
- [x] All 3164 existing tests still pass
- [x] Lint + typecheck clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)