### PR TITLE
Refactor: split config, review_phase, and orchestrator into focused modules

### DIFF
--- a/config.py
+++ b/config.py
@@ -29,11 +29,15 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("max_merge_conflict_fix_attempts", "HYDRAFLOW_MAX_MERGE_CONFLICT_FIX_ATTEMPTS", 3),
     ("data_poll_interval", "HYDRAFLOW_DATA_POLL_INTERVAL", 60),
     ("max_sessions_per_repo", "HYDRAFLOW_MAX_SESSIONS_PER_REPO", 10),
+    ("max_transcript_summary_chars", "HYDRAFLOW_MAX_TRANSCRIPT_SUMMARY_CHARS", 50_000),
+    ("pr_unstick_interval", "HYDRAFLOW_PR_UNSTICK_INTERVAL", 3600),
+    ("pr_unstick_batch_size", "HYDRAFLOW_PR_UNSTICK_BATCH_SIZE", 10),
 ]
 
 _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
     ("test_command", "HYDRAFLOW_TEST_COMMAND", "make test"),
     ("docker_image", "HYDRAFLOW_DOCKER_IMAGE", "ghcr.io/t-rav/hydraflow-agent:latest"),
+    ("transcript_summary_model", "HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL", "haiku"),
 ]
 
 _ENV_FLOAT_OVERRIDES: list[tuple[str, str, float]] = [
@@ -44,7 +48,28 @@ _ENV_FLOAT_OVERRIDES: list[tuple[str, str, float]] = [
 _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ("docker_read_only_root", "HYDRAFLOW_DOCKER_READ_ONLY_ROOT", True),
     ("docker_no_new_privileges", "HYDRAFLOW_DOCKER_NO_NEW_PRIVILEGES", True),
+    (
+        "transcript_summarization_enabled",
+        "HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED",
+        True,
+    ),
 ]
+
+# Label env var overrides — maps env key → (field_name, default_value)
+_ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
+    "HYDRAFLOW_LABEL_FIND": ("find_label", ["hydraflow-find"]),
+    "HYDRAFLOW_LABEL_PLAN": ("planner_label", ["hydraflow-plan"]),
+    "HYDRAFLOW_LABEL_READY": ("ready_label", ["hydraflow-ready"]),
+    "HYDRAFLOW_LABEL_REVIEW": ("review_label", ["hydraflow-review"]),
+    "HYDRAFLOW_LABEL_HITL": ("hitl_label", ["hydraflow-hitl"]),
+    "HYDRAFLOW_LABEL_HITL_ACTIVE": ("hitl_active_label", ["hydraflow-hitl-active"]),
+    "HYDRAFLOW_LABEL_FIXED": ("fixed_label", ["hydraflow-fixed"]),
+    "HYDRAFLOW_LABEL_IMPROVE": ("improve_label", ["hydraflow-improve"]),
+    "HYDRAFLOW_LABEL_MEMORY": ("memory_label", ["hydraflow-memory"]),
+    "HYDRAFLOW_LABEL_METRICS": ("metrics_label", ["hydraflow-metrics"]),
+    "HYDRAFLOW_LABEL_DUP": ("dup_label", ["hydraflow-dup"]),
+    "HYDRAFLOW_LABEL_EPIC": ("epic_label", ["hydraflow-epic"]),
+}
 
 
 class HydraFlowConfig(BaseModel):
@@ -539,324 +564,203 @@ class HydraFlowConfig(BaseModel):
             HYDRAFLOW_LABEL_MEMORY      → memory_label
             HYDRAFLOW_LABEL_DUP         → dup_label
         """
-        # Paths
-        if self.repo_root == Path("."):
-            self.repo_root = _find_repo_root()
-        if self.worktree_base == Path("."):
-            self.worktree_base = self.repo_root.parent / "hydraflow-worktrees"
-        if self.state_file == Path("."):
-            self.state_file = self.repo_root / ".hydraflow" / "state.json"
-        if self.event_log_path == Path("."):
-            self.event_log_path = self.repo_root / ".hydraflow" / "events.jsonl"
-
-        # Repo slug: env var → git remote → empty
-        if not self.repo:
-            self.repo = os.environ.get(
-                "HYDRAFLOW_GITHUB_REPO", ""
-            ) or _detect_repo_slug(self.repo_root)
-
-        # GitHub token: explicit value → HYDRAFLOW_GH_TOKEN env var → inherited GH_TOKEN
-        if not self.gh_token:
-            env_token = os.environ.get("HYDRAFLOW_GH_TOKEN", "")
-            if env_token:
-                object.__setattr__(self, "gh_token", env_token)
-
-        # Git identity: explicit value → HYDRAFLOW_GIT_USER_NAME/EMAIL env var
-        if not self.git_user_name:
-            env_name = os.environ.get("HYDRAFLOW_GIT_USER_NAME", "")
-            if env_name:
-                object.__setattr__(self, "git_user_name", env_name)
-        if not self.git_user_email:
-            env_email = os.environ.get("HYDRAFLOW_GIT_USER_EMAIL", "")
-            if env_email:
-                object.__setattr__(self, "git_user_email", env_email)
-
-        # Data-driven env var overrides (int fields)
-        for field, env_key, default in _ENV_INT_OVERRIDES:
-            if getattr(self, field) == default:
-                env_val = os.environ.get(env_key)
-                if env_val is not None:
-                    with contextlib.suppress(ValueError):
-                        object.__setattr__(self, field, int(env_val))
-
-        # Data-driven env var overrides (str fields)
-        for field, env_key, default in _ENV_STR_OVERRIDES:
-            if getattr(self, field) == default:
-                env_val = os.environ.get(env_key)
-                if env_val is not None:
-                    object.__setattr__(self, field, env_val)
-
-        # Data-driven env var overrides (float fields)
-        for field, env_key, default in _ENV_FLOAT_OVERRIDES:
-            if getattr(self, field) == default:
-                env_val = os.environ.get(env_key)
-                if env_val is not None:
-                    with contextlib.suppress(ValueError):
-                        new_val = float(env_val)
-                        for constraint in HydraFlowConfig.model_fields[field].metadata:
-                            ge = getattr(constraint, "ge", None)
-                            le = getattr(constraint, "le", None)
-                            if ge is not None and new_val < ge:
-                                raise ValueError(
-                                    f"{env_key}={new_val} is below minimum {ge}"
-                                )
-                            if le is not None and new_val > le:
-                                raise ValueError(
-                                    f"{env_key}={new_val} is above maximum {le}"
-                                )
-                        object.__setattr__(self, field, new_val)
-
-        # Data-driven env var overrides (bool fields)
-        for field, env_key, default in _ENV_BOOL_OVERRIDES:
-            if getattr(self, field) == default:
-                env_val = os.environ.get(env_key)
-                if env_val is not None:
-                    object.__setattr__(
-                        self,
-                        field,
-                        env_val.lower() not in ("0", "false", "no"),
-                    )
-
-        # Literal-typed env var overrides (validated before setting)
-        if self.execution_mode == "host":
-            env_exec = os.environ.get("HYDRAFLOW_EXECUTION_MODE")
-            if env_exec in ("host", "docker"):
-                object.__setattr__(self, "execution_mode", env_exec)
-
-        if self.docker_network_mode == "bridge":
-            env_net = os.environ.get("HYDRAFLOW_DOCKER_NETWORK_MODE")
-            if env_net in ("bridge", "none", "host"):
-                object.__setattr__(self, "docker_network_mode", env_net)
-
-        # Lite plan labels (comma-separated list, special-case)
-        env_lite_labels = os.environ.get("HYDRAFLOW_LITE_PLAN_LABELS")
-        if env_lite_labels is not None and self.lite_plan_labels == [
-            "bug",
-            "typo",
-            "docs",
-        ]:
-            parsed = [lbl.strip() for lbl in env_lite_labels.split(",") if lbl.strip()]
-            if parsed:
-                object.__setattr__(self, "lite_plan_labels", parsed)
-
-        # Review fix attempts override
-        if self.max_review_fix_attempts == 2:  # still at default
-            env_review_fix = os.environ.get("HYDRAFLOW_MAX_REVIEW_FIX_ATTEMPTS")
-            if env_review_fix is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "max_review_fix_attempts", int(env_review_fix)
-                    )
-
-        # Min review findings override
-        if self.min_review_findings == 3:  # still at default
-            env_min_findings = os.environ.get("HYDRAFLOW_MIN_REVIEW_FINDINGS")
-            if env_min_findings is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "min_review_findings", int(env_min_findings)
-                    )
-
-        # Agent prompt config overrides
-        env_test_cmd = os.environ.get("HYDRAFLOW_TEST_COMMAND")
-        if env_test_cmd is not None and self.test_command == "make test":
-            object.__setattr__(self, "test_command", env_test_cmd)
-
-        env_max_body = os.environ.get("HYDRAFLOW_MAX_ISSUE_BODY_CHARS")
-        if env_max_body is not None and self.max_issue_body_chars == 10_000:
-            with contextlib.suppress(ValueError):
-                object.__setattr__(self, "max_issue_body_chars", int(env_max_body))
-
-        env_max_diff = os.environ.get("HYDRAFLOW_MAX_REVIEW_DIFF_CHARS")
-        if env_max_diff is not None and self.max_review_diff_chars == 15_000:
-            with contextlib.suppress(ValueError):
-                object.__setattr__(self, "max_review_diff_chars", int(env_max_diff))
-
-        # gh retry override
-        if self.gh_max_retries == 3:  # still at default
-            env_retries = os.environ.get("HYDRAFLOW_GH_MAX_RETRIES")
-            if env_retries is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(self, "gh_max_retries", int(env_retries))
-
-        # issue attempt cap override
-        if self.max_issue_attempts == 3:  # still at default
-            env_issue_attempts = os.environ.get("HYDRAFLOW_MAX_ISSUE_ATTEMPTS")
-            if env_issue_attempts is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "max_issue_attempts", int(env_issue_attempts)
-                    )
-
-        # Memory sync interval override
-        if self.memory_sync_interval == 3600:  # still at default
-            env_mem_sync = os.environ.get("HYDRAFLOW_MEMORY_SYNC_INTERVAL")
-            if env_mem_sync is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(self, "memory_sync_interval", int(env_mem_sync))
-
-        # Metrics sync interval override
-        if self.metrics_sync_interval == 7200:  # still at default
-            env_metrics_sync = os.environ.get("HYDRAFLOW_METRICS_SYNC_INTERVAL")
-            if env_metrics_sync is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "metrics_sync_interval", int(env_metrics_sync)
-                    )
-
-        # merge conflict fix attempts override
-        if self.max_merge_conflict_fix_attempts == 3:  # still at default
-            env_attempts = os.environ.get("HYDRAFLOW_MAX_MERGE_CONFLICT_FIX_ATTEMPTS")
-            if env_attempts is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "max_merge_conflict_fix_attempts", int(env_attempts)
-                    )
-
-        # Data poll interval override
-        if self.data_poll_interval == 60:  # still at default
-            env_data_poll = os.environ.get("HYDRAFLOW_DATA_POLL_INTERVAL")
-            if env_data_poll is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(self, "data_poll_interval", int(env_data_poll))
-
-        # Transcript summarization overrides
-        env_ts_enabled = os.environ.get("HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED")
-        if env_ts_enabled is not None and self.transcript_summarization_enabled is True:
-            object.__setattr__(
-                self,
-                "transcript_summarization_enabled",
-                env_ts_enabled.lower() not in ("0", "false", "no"),
-            )
-
-        env_ts_model = os.environ.get("HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL")
-        if env_ts_model is not None and self.transcript_summary_model == "haiku":
-            object.__setattr__(self, "transcript_summary_model", env_ts_model)
-
-        if self.max_transcript_summary_chars == 50_000:  # still at default
-            env_ts_chars = os.environ.get("HYDRAFLOW_MAX_TRANSCRIPT_SUMMARY_CHARS")
-            if env_ts_chars is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "max_transcript_summary_chars", int(env_ts_chars)
-                    )
-
-        # PR unstick interval override
-        if self.pr_unstick_interval == 3600:  # still at default
-            env_unstick = os.environ.get("HYDRAFLOW_PR_UNSTICK_INTERVAL")
-            if env_unstick is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(self, "pr_unstick_interval", int(env_unstick))
-
-        # PR unstick batch size override
-        if self.pr_unstick_batch_size == 10:  # still at default
-            env_batch = os.environ.get("HYDRAFLOW_PR_UNSTICK_BATCH_SIZE")
-            if env_batch is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(self, "pr_unstick_batch_size", int(env_batch))
-
-        # Docker resource limit overrides (validated fields handled manually
-        # because str/int overrides need format/bounds validation that
-        # the data-driven tables don't provide)
-        if self.docker_memory_limit == "4g":  # still at default
-            env_mem = os.environ.get("HYDRAFLOW_DOCKER_MEMORY_LIMIT")
-            if env_mem is not None:
-                if not re.fullmatch(r"\d+[bkmg]", env_mem, re.IGNORECASE):
-                    msg = f"Invalid HYDRAFLOW_DOCKER_MEMORY_LIMIT '{env_mem}'; expected digits followed by b/k/m/g (e.g., '4g', '512m')"
-                    raise ValueError(msg)
-                object.__setattr__(self, "docker_memory_limit", env_mem)
-
-        if self.docker_tmp_size == "1g":  # still at default
-            env_tmp = os.environ.get("HYDRAFLOW_DOCKER_TMP_SIZE")
-            if env_tmp is not None:
-                if not re.fullmatch(r"\d+[bkmg]", env_tmp, re.IGNORECASE):
-                    msg = f"Invalid HYDRAFLOW_DOCKER_TMP_SIZE '{env_tmp}'; expected digits followed by b/k/m/g (e.g., '1g', '512m')"
-                    raise ValueError(msg)
-                object.__setattr__(self, "docker_tmp_size", env_tmp)
-
-        if self.docker_pids_limit == 256:  # still at default
-            env_pids = os.environ.get("HYDRAFLOW_DOCKER_PIDS_LIMIT")
-            if env_pids is not None:
-                try:
-                    pids_val = int(env_pids)
-                except ValueError:
-                    pass
-                else:
-                    if not (16 <= pids_val <= 4096):
-                        msg = f"HYDRAFLOW_DOCKER_PIDS_LIMIT must be between 16 and 4096, got {pids_val}"
-                        raise ValueError(msg)
-                    object.__setattr__(self, "docker_pids_limit", pids_val)
-
-        # Label env var overrides (only apply when still at the default)
-        _ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
-            "HYDRAFLOW_LABEL_FIND": ("find_label", ["hydraflow-find"]),
-            "HYDRAFLOW_LABEL_PLAN": ("planner_label", ["hydraflow-plan"]),
-            "HYDRAFLOW_LABEL_READY": ("ready_label", ["hydraflow-ready"]),
-            "HYDRAFLOW_LABEL_REVIEW": ("review_label", ["hydraflow-review"]),
-            "HYDRAFLOW_LABEL_HITL": ("hitl_label", ["hydraflow-hitl"]),
-            "HYDRAFLOW_LABEL_HITL_ACTIVE": (
-                "hitl_active_label",
-                ["hydraflow-hitl-active"],
-            ),
-            "HYDRAFLOW_LABEL_FIXED": ("fixed_label", ["hydraflow-fixed"]),
-            "HYDRAFLOW_LABEL_IMPROVE": ("improve_label", ["hydraflow-improve"]),
-            "HYDRAFLOW_LABEL_MEMORY": ("memory_label", ["hydraflow-memory"]),
-            "HYDRAFLOW_LABEL_METRICS": ("metrics_label", ["hydraflow-metrics"]),
-            "HYDRAFLOW_LABEL_DUP": ("dup_label", ["hydraflow-dup"]),
-            "HYDRAFLOW_LABEL_EPIC": ("epic_label", ["hydraflow-epic"]),
-        }
-        for env_key, (field_name, default_val) in _ENV_LABEL_MAP.items():
-            current = getattr(self, field_name)
-            env_val = os.environ.get(env_key)
-            if env_val is not None and current == default_val:
-                # Empty string → empty list (scan-all mode); otherwise split on comma
-                labels = (
-                    [part.strip() for part in env_val.split(",") if part.strip()]
-                    if env_val
-                    else []
-                )
-                object.__setattr__(self, field_name, labels)
-
-        # Validate Docker availability when execution_mode is "docker"
-        if self.execution_mode == "docker":
-            import shutil  # noqa: PLC0415
-
-            if shutil.which("docker") is None:
-                msg = (
-                    "execution_mode is 'docker' but the 'docker' command "
-                    "was not found on PATH"
-                )
-                raise ValueError(msg)
-
-        # Docker execution overrides (PR #545)
-        env_docker_enabled = os.environ.get("HYDRA_DOCKER_ENABLED")
-        if env_docker_enabled is not None and self.docker_enabled is False:
-            object.__setattr__(
-                self,
-                "docker_enabled",
-                env_docker_enabled.lower() in ("1", "true", "yes"),
-            )
-
-        env_docker_image = os.environ.get("HYDRA_DOCKER_IMAGE")
-        if (
-            env_docker_image is not None
-            and self.docker_image == "ghcr.io/t-rav/hydraflow-agent:latest"
-        ):
-            object.__setattr__(self, "docker_image", env_docker_image)
-
-        env_docker_network = os.environ.get("HYDRA_DOCKER_NETWORK")
-        if env_docker_network is not None and not self.docker_network:
-            object.__setattr__(self, "docker_network", env_docker_network)
-
-        if self.docker_spawn_delay == 2.0:  # still at default
-            env_spawn_delay = os.environ.get("HYDRA_DOCKER_SPAWN_DELAY")
-            if env_spawn_delay is not None:
-                with contextlib.suppress(ValueError):
-                    object.__setattr__(
-                        self, "docker_spawn_delay", float(env_spawn_delay)
-                    )
-
+        _resolve_paths(self)
+        _resolve_repo_and_identity(self)
+        _apply_env_overrides(self)
+        _validate_docker(self)
         return self
+
+
+def _resolve_paths(config: HydraFlowConfig) -> None:
+    """Resolve repo_root, worktree_base, state_file, and event_log_path."""
+    if config.repo_root == Path("."):
+        config.repo_root = _find_repo_root()
+    if config.worktree_base == Path("."):
+        config.worktree_base = config.repo_root.parent / "hydraflow-worktrees"
+    if config.state_file == Path("."):
+        config.state_file = config.repo_root / ".hydraflow" / "state.json"
+    if config.event_log_path == Path("."):
+        config.event_log_path = config.repo_root / ".hydraflow" / "events.jsonl"
+
+
+def _resolve_repo_and_identity(config: HydraFlowConfig) -> None:
+    """Resolve repo slug, GitHub token, and git identity from env vars."""
+    # Repo slug: env var → git remote → empty
+    if not config.repo:
+        config.repo = os.environ.get("HYDRAFLOW_GITHUB_REPO", "") or _detect_repo_slug(
+            config.repo_root
+        )
+
+    # GitHub token: explicit value → HYDRAFLOW_GH_TOKEN env var → inherited GH_TOKEN
+    if not config.gh_token:
+        env_token = os.environ.get("HYDRAFLOW_GH_TOKEN", "")
+        if env_token:
+            object.__setattr__(config, "gh_token", env_token)
+
+    # Git identity: explicit value → HYDRAFLOW_GIT_USER_NAME/EMAIL env var
+    if not config.git_user_name:
+        env_name = os.environ.get("HYDRAFLOW_GIT_USER_NAME", "")
+        if env_name:
+            object.__setattr__(config, "git_user_name", env_name)
+    if not config.git_user_email:
+        env_email = os.environ.get("HYDRAFLOW_GIT_USER_EMAIL", "")
+        if env_email:
+            object.__setattr__(config, "git_user_email", env_email)
+
+
+def _apply_env_overrides(config: HydraFlowConfig) -> None:
+    """Apply all data-driven and special-case env var overrides."""
+    # Data-driven env var overrides (int fields)
+    for field, env_key, default in _ENV_INT_OVERRIDES:
+        if getattr(config, field) == default:
+            env_val = os.environ.get(env_key)
+            if env_val is not None:
+                with contextlib.suppress(ValueError):
+                    object.__setattr__(config, field, int(env_val))
+
+    # Data-driven env var overrides (str fields)
+    for field, env_key, default in _ENV_STR_OVERRIDES:
+        if getattr(config, field) == default:
+            env_val = os.environ.get(env_key)
+            if env_val is not None:
+                object.__setattr__(config, field, env_val)
+
+    # Data-driven env var overrides (float fields)
+    for field, env_key, default in _ENV_FLOAT_OVERRIDES:
+        if getattr(config, field) == default:
+            env_val = os.environ.get(env_key)
+            if env_val is not None:
+                with contextlib.suppress(ValueError):
+                    new_val = float(env_val)
+                    for constraint in HydraFlowConfig.model_fields[field].metadata:
+                        ge = getattr(constraint, "ge", None)
+                        le = getattr(constraint, "le", None)
+                        if ge is not None and new_val < ge:
+                            raise ValueError(
+                                f"{env_key}={new_val} is below minimum {ge}"
+                            )
+                        if le is not None and new_val > le:
+                            raise ValueError(
+                                f"{env_key}={new_val} is above maximum {le}"
+                            )
+                    object.__setattr__(config, field, new_val)
+
+    # Data-driven env var overrides (bool fields)
+    for field, env_key, default in _ENV_BOOL_OVERRIDES:
+        if getattr(config, field) == default:
+            env_val = os.environ.get(env_key)
+            if env_val is not None:
+                object.__setattr__(
+                    config,
+                    field,
+                    env_val.lower() not in ("0", "false", "no"),
+                )
+
+    # Literal-typed env var overrides (validated before setting)
+    if config.execution_mode == "host":
+        env_exec = os.environ.get("HYDRAFLOW_EXECUTION_MODE")
+        if env_exec in ("host", "docker"):
+            object.__setattr__(config, "execution_mode", env_exec)
+
+    if config.docker_network_mode == "bridge":
+        env_net = os.environ.get("HYDRAFLOW_DOCKER_NETWORK_MODE")
+        if env_net in ("bridge", "none", "host"):
+            object.__setattr__(config, "docker_network_mode", env_net)
+
+    # Lite plan labels (comma-separated list, special-case)
+    env_lite_labels = os.environ.get("HYDRAFLOW_LITE_PLAN_LABELS")
+    if env_lite_labels is not None and config.lite_plan_labels == [
+        "bug",
+        "typo",
+        "docs",
+    ]:
+        parsed = [lbl.strip() for lbl in env_lite_labels.split(",") if lbl.strip()]
+        if parsed:
+            object.__setattr__(config, "lite_plan_labels", parsed)
+
+    # Docker resource limit overrides (validated fields handled manually
+    # because str/int overrides need format/bounds validation that
+    # the data-driven tables don't provide)
+    if config.docker_memory_limit == "4g":  # still at default
+        env_mem = os.environ.get("HYDRAFLOW_DOCKER_MEMORY_LIMIT")
+        if env_mem is not None:
+            if not re.fullmatch(r"\d+[bkmg]", env_mem, re.IGNORECASE):
+                msg = f"Invalid HYDRAFLOW_DOCKER_MEMORY_LIMIT '{env_mem}'; expected digits followed by b/k/m/g (e.g., '4g', '512m')"
+                raise ValueError(msg)
+            object.__setattr__(config, "docker_memory_limit", env_mem)
+
+    if config.docker_tmp_size == "1g":  # still at default
+        env_tmp = os.environ.get("HYDRAFLOW_DOCKER_TMP_SIZE")
+        if env_tmp is not None:
+            if not re.fullmatch(r"\d+[bkmg]", env_tmp, re.IGNORECASE):
+                msg = f"Invalid HYDRAFLOW_DOCKER_TMP_SIZE '{env_tmp}'; expected digits followed by b/k/m/g (e.g., '1g', '512m')"
+                raise ValueError(msg)
+            object.__setattr__(config, "docker_tmp_size", env_tmp)
+
+    if config.docker_pids_limit == 256:  # still at default
+        env_pids = os.environ.get("HYDRAFLOW_DOCKER_PIDS_LIMIT")
+        if env_pids is not None:
+            try:
+                pids_val = int(env_pids)
+            except ValueError:
+                pass
+            else:
+                if not (16 <= pids_val <= 4096):
+                    msg = f"HYDRAFLOW_DOCKER_PIDS_LIMIT must be between 16 and 4096, got {pids_val}"
+                    raise ValueError(msg)
+                object.__setattr__(config, "docker_pids_limit", pids_val)
+
+    # Label env var overrides (only apply when still at the default)
+    for env_key, (field_name, default_val) in _ENV_LABEL_MAP.items():
+        current = getattr(config, field_name)
+        env_val = os.environ.get(env_key)
+        if env_val is not None and current == default_val:
+            # Empty string → empty list (scan-all mode); otherwise split on comma
+            labels = (
+                [part.strip() for part in env_val.split(",") if part.strip()]
+                if env_val
+                else []
+            )
+            object.__setattr__(config, field_name, labels)
+
+    # Docker execution overrides (PR #545)
+    env_docker_enabled = os.environ.get("HYDRA_DOCKER_ENABLED")
+    if env_docker_enabled is not None and config.docker_enabled is False:
+        object.__setattr__(
+            config,
+            "docker_enabled",
+            env_docker_enabled.lower() in ("1", "true", "yes"),
+        )
+
+    env_docker_image = os.environ.get("HYDRA_DOCKER_IMAGE")
+    if (
+        env_docker_image is not None
+        and config.docker_image == "ghcr.io/t-rav/hydraflow-agent:latest"
+    ):
+        object.__setattr__(config, "docker_image", env_docker_image)
+
+    env_docker_network = os.environ.get("HYDRA_DOCKER_NETWORK")
+    if env_docker_network is not None and not config.docker_network:
+        object.__setattr__(config, "docker_network", env_docker_network)
+
+    if config.docker_spawn_delay == 2.0:  # still at default
+        env_spawn_delay = os.environ.get("HYDRA_DOCKER_SPAWN_DELAY")
+        if env_spawn_delay is not None:
+            with contextlib.suppress(ValueError):
+                object.__setattr__(config, "docker_spawn_delay", float(env_spawn_delay))
+
+
+def _validate_docker(config: HydraFlowConfig) -> None:
+    """Validate Docker availability when execution_mode is 'docker'."""
+    if config.execution_mode == "docker":
+        import shutil  # noqa: PLC0415
+
+        if shutil.which("docker") is None:
+            msg = (
+                "execution_mode is 'docker' but the 'docker' command "
+                "was not found on PATH"
+            )
+            raise ValueError(msg)
 
 
 def _find_repo_root() -> Path:

--- a/merge_conflict_resolver.py
+++ b/merge_conflict_resolver.py
@@ -1,0 +1,270 @@
+"""Merge conflict resolution for the HydraFlow review pipeline."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Coroutine
+from pathlib import Path
+from typing import Any
+
+from agent import AgentRunner
+from config import HydraFlowConfig
+from events import EventBus, EventType, HydraFlowEvent
+from memory import file_memory_suggestion
+from models import GitHubIssue, PRInfo, WorkerStatus
+from pr_manager import PRManager
+from state import StateTracker
+from transcript_summarizer import TranscriptSummarizer
+from worktree import WorktreeManager
+
+logger = logging.getLogger("hydraflow.merge_conflict_resolver")
+
+
+class MergeConflictResolver:
+    """Resolves merge conflicts between PR branches and main."""
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        worktrees: WorktreeManager,
+        agents: AgentRunner | None,
+        prs: PRManager,
+        bus: EventBus,
+        state: StateTracker,
+        summarizer: TranscriptSummarizer | None,
+    ) -> None:
+        self._config = config
+        self._worktrees = worktrees
+        self._agents = agents
+        self._prs = prs
+        self._bus = bus
+        self._state = state
+        self._summarizer = summarizer
+
+    async def merge_with_main(
+        self,
+        pr: PRInfo,
+        issue: GitHubIssue,
+        wt_path: Path,
+        worker_id: int,
+        escalate_fn: Callable[..., Coroutine[Any, Any, None]],
+        publish_fn: Callable[..., Coroutine[Any, Any, None]],
+    ) -> bool:
+        """Merge main into the PR branch, resolving conflicts if needed.
+
+        Returns True on success, False on failure (escalates to HITL).
+        """
+        await publish_fn(pr, worker_id, "merge_main")
+        merged = await self._worktrees.merge_main(wt_path, pr.branch)
+        if not merged:
+            logger.info(
+                "PR #%d has conflicts with %s — running agent to resolve",
+                pr.number,
+                self._config.main_branch,
+            )
+            await publish_fn(pr, worker_id, WorkerStatus.MERGE_FIX.value)
+            merged = await self.resolve_merge_conflicts(
+                pr, issue, wt_path, worker_id=worker_id
+            )
+        if merged:
+            await self._prs.push_branch(wt_path, pr.branch)
+            return True
+
+        logger.warning(
+            "PR #%d merge conflict resolution failed — escalating to HITL",
+            pr.number,
+        )
+        await publish_fn(pr, worker_id, "escalating")
+        await escalate_fn(
+            pr.issue_number,
+            pr.number,
+            cause="Merge conflict with main branch",
+            origin_label=self._config.review_label[0],
+            comment=(
+                f"**Merge conflicts** with "
+                f"`{self._config.main_branch}` could not be "
+                "resolved automatically. "
+                "Escalating to human review."
+            ),
+            event_cause="merge_conflict",
+        )
+        return False
+
+    async def resolve_merge_conflicts(
+        self,
+        pr: PRInfo,
+        issue: GitHubIssue,
+        wt_path: Path,
+        worker_id: int,
+    ) -> bool:
+        """Use the implementation agent to resolve merge conflicts.
+
+        Retries up to ``config.max_merge_conflict_fix_attempts`` times.
+        Each attempt starts a merge (leaving conflict markers), runs the
+        agent to resolve them, and verifies with ``make quality``.
+        Returns *True* if the conflicts were resolved successfully.
+        """
+        from conflict_prompt import build_conflict_prompt
+
+        if self._agents is None:
+            logger.warning(
+                "No agent runner available for conflict resolution on PR #%d",
+                pr.number,
+            )
+            return False
+
+        max_attempts = self._config.max_merge_conflict_fix_attempts
+        last_error: str | None = None
+
+        # Fetch context once before the attempt loop
+        pr_changed_files = await self._prs.get_pr_diff_names(pr.number)
+        main_commits = await self._worktrees.get_main_commits_since_diverge(wt_path)
+
+        for attempt in range(1, max_attempts + 1):
+            # Abort any prior failed merge before retrying
+            if attempt > 1:
+                await self._worktrees.abort_merge(wt_path)
+
+            # Start merge leaving conflict markers in place
+            clean = await self._worktrees.start_merge_main(wt_path, pr.branch)
+            if clean:
+                return True
+
+            logger.info(
+                "Conflict resolution attempt %d/%d for PR #%d",
+                attempt,
+                max_attempts,
+                pr.number,
+            )
+            await self._publish_review_status(
+                pr, worker_id, WorkerStatus.MERGE_FIX.value
+            )
+
+            try:
+                # Gather conflict-specific context for the prompt
+                conflicting_files = await self._worktrees.get_conflicting_files(wt_path)
+                main_diff = await self._worktrees.get_main_diff_for_files(
+                    wt_path, conflicting_files
+                )
+
+                prompt = build_conflict_prompt(
+                    issue,
+                    pr_changed_files,
+                    main_commits,
+                    last_error,
+                    attempt,
+                    conflicting_files=conflicting_files,
+                    main_diff=main_diff,
+                )
+                cmd = self._agents._build_command(wt_path)
+                transcript = await self._agents._execute(
+                    cmd, prompt, wt_path, issue.number
+                )
+
+                self._save_conflict_transcript(
+                    pr.number, issue.number, attempt, transcript
+                )
+
+                try:
+                    await file_memory_suggestion(
+                        transcript,
+                        "conflict_resolver",
+                        f"PR #{pr.number}",
+                        self._config,
+                        self._prs,
+                        self._state,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to file memory suggestion for conflict resolution on PR #%d",
+                        pr.number,
+                    )
+
+                success, error_msg = await self._agents._verify_result(
+                    wt_path, pr.branch
+                )
+                if success:
+                    await self._maybe_summarize_conflict(
+                        transcript, issue.number, pr.number
+                    )
+                    return True
+
+                last_error = error_msg
+                logger.warning(
+                    "Conflict resolution attempt %d/%d failed for PR #%d: %s",
+                    attempt,
+                    max_attempts,
+                    pr.number,
+                    error_msg[:200] if error_msg else "",
+                )
+                # Summarize final failed attempt
+                if attempt == max_attempts:
+                    await self._maybe_summarize_conflict(
+                        transcript, issue.number, pr.number
+                    )
+            except Exception as exc:
+                logger.error(
+                    "Conflict resolution agent failed for PR #%d (attempt %d/%d): %s",
+                    pr.number,
+                    attempt,
+                    max_attempts,
+                    exc,
+                )
+                last_error = str(exc)
+
+        # All attempts exhausted — abort and let caller escalate
+        await self._worktrees.abort_merge(wt_path)
+        return False
+
+    async def _maybe_summarize_conflict(
+        self, transcript: str, issue_number: int, pr_number: int
+    ) -> None:
+        """Summarize a conflict resolution transcript if summarizer is available."""
+        if self._summarizer is None:
+            return
+        try:
+            await self._summarizer.summarize_and_publish(
+                transcript=transcript,
+                issue_number=issue_number,
+                phase="conflict_resolution",
+            )
+        except Exception:
+            logger.exception(
+                "Failed to file transcript summary for conflict resolution on PR #%d",
+                pr_number,
+            )
+
+    def _save_conflict_transcript(
+        self,
+        pr_number: int,
+        issue_number: int,
+        attempt: int,
+        transcript: str,
+    ) -> None:
+        """Save a conflict resolution transcript to ``.hydraflow/logs/``."""
+        log_dir = self._config.repo_root / ".hydraflow" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        path = log_dir / f"conflict-pr-{pr_number}-attempt-{attempt}.txt"
+        path.write_text(transcript)
+        logger.info(
+            "Conflict resolution transcript saved to %s",
+            path,
+            extra={"issue": issue_number},
+        )
+
+    async def _publish_review_status(
+        self, pr: PRInfo, worker_id: int, status: str
+    ) -> None:
+        """Emit a REVIEW_UPDATE event with the given status."""
+        await self._bus.publish(
+            HydraFlowEvent(
+                type=EventType.REVIEW_UPDATE,
+                data={
+                    "pr": pr.number,
+                    "issue": pr.issue_number,
+                    "worker": worker_id,
+                    "status": status,
+                    "role": "reviewer",
+                },
+            )
+        )

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -9,40 +9,18 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
-from acceptance_criteria import AcceptanceCriteriaGenerator
-from agent import AgentRunner
 from config import HydraFlowConfig
-from epic import EpicCompletionChecker
 from events import EventBus, EventType, HydraFlowEvent
-from execution import get_default_runner
-from hitl_phase import HITLPhase
-from hitl_runner import HITLRunner
-from implement_phase import ImplementPhase
-from issue_fetcher import IssueFetcher
-from issue_store import IssueStore
-from memory import MemorySyncWorker, file_memory_suggestion
-from memory_sync_loop import MemorySyncLoop
-from metrics_sync_loop import MetricsSyncLoop
+from memory import file_memory_suggestion
 from models import BackgroundWorkerState, Phase, SessionLog
-from plan_phase import PlanPhase
-from planner import PlannerRunner
-from pr_manager import PRManager
-from pr_unsticker import PRUnsticker
-from pr_unsticker_loop import PRUnstickerLoop
-from retrospective import RetrospectiveCollector
-from review_phase import ReviewPhase
-from reviewer import ReviewRunner
-from run_recorder import RunRecorder
+from service_registry import OrchestratorCallbacks, build_services
 from state import StateTracker
 from subprocess_util import AuthenticationError, CreditExhaustedError
-from transcript_summarizer import TranscriptSummarizer
-from triage import TriageRunner
-from triage_phase import TriagePhase
-from verification_judge import VerificationJudge
-from worktree import WorktreeManager
 
 if TYPE_CHECKING:
+    from issue_store import IssueStore
     from metrics_manager import MetricsManager
+    from run_recorder import RunRecorder
 
 logger = logging.getLogger("hydraflow.orchestrator")
 
@@ -64,23 +42,6 @@ class HydraFlowOrchestrator:
         self._config = config
         self._bus = event_bus or EventBus()
         self._state = state or StateTracker(config.state_file)
-        self._worktrees = WorktreeManager(config)
-        self._subprocess_runner = get_default_runner()
-        self._agents = AgentRunner(config, self._bus, runner=self._subprocess_runner)
-        self._planners = PlannerRunner(
-            config, self._bus, runner=self._subprocess_runner
-        )
-        self._prs = PRManager(config, self._bus)
-        self._reviewers = ReviewRunner(
-            config, self._bus, runner=self._subprocess_runner
-        )
-        self._hitl_runner = HITLRunner(
-            config, self._bus, runner=self._subprocess_runner
-        )
-        self._triage = TriageRunner(config, self._bus)
-        self._summarizer = TranscriptSummarizer(
-            config, self._prs, self._bus, self._state
-        )
         self._dashboard: object | None = None
         # Pending human-input requests: {issue_number: question}
         self._human_input_requests: dict[int, str] = {}
@@ -109,123 +70,49 @@ class HydraFlowOrchestrator:
         self._current_session: SessionLog | None = None
         self._session_issue_results: dict[int, bool] = {}
 
-        # Centralized issue store and fetcher
-        self._fetcher = IssueFetcher(config)
-        self._store = IssueStore(config, self._fetcher, self._bus)
+        # Build all services via the factory
+        svc = build_services(
+            config,
+            self._bus,
+            self._state,
+            self._stop_event,
+            OrchestratorCallbacks(
+                sync_active_issue_numbers=self._sync_active_issue_numbers,
+                update_bg_worker_status=self.update_bg_worker_status,
+                is_bg_worker_enabled=self.is_bg_worker_enabled,
+                sleep_or_stop=self._sleep_or_stop,
+                get_bg_worker_interval=self.get_bg_worker_interval,
+            ),
+        )
 
-        # Delegate phases to focused modules
-        self._triager = TriagePhase(
-            config,
-            self._state,
-            self._store,
-            self._triage,
-            self._prs,
-            self._bus,
-            self._stop_event,
-        )
-        self._planner_phase = PlanPhase(
-            config,
-            self._state,
-            self._store,
-            self._planners,
-            self._prs,
-            self._bus,
-            self._stop_event,
-        )
-        self._hitl_phase = HITLPhase(
-            config,
-            self._state,
-            self._store,
-            self._fetcher,
-            self._worktrees,
-            self._hitl_runner,
-            self._prs,
-            self._bus,
-            self._stop_event,
-            active_issues_cb=self._sync_active_issue_numbers,
-        )
-        self._run_recorder = RunRecorder(config)
-        self._implementer = ImplementPhase(
-            config,
-            self._state,
-            self._worktrees,
-            self._agents,
-            self._prs,
-            self._store,
-            self._stop_event,
-            run_recorder=self._run_recorder,
-        )
-        from metrics_manager import MetricsManager
-
-        self._metrics_manager = MetricsManager(
-            config, self._state, self._prs, self._bus
-        )
-        self._pr_unsticker = PRUnsticker(
-            config,
-            self._state,
-            self._bus,
-            self._prs,
-            self._agents,
-            self._worktrees,
-            self._fetcher,
-        )
-        self._memory_sync = MemorySyncWorker(config, self._state, self._bus)
-        self._retrospective = RetrospectiveCollector(config, self._state, self._prs)
-        self._ac_generator = AcceptanceCriteriaGenerator(
-            config, self._prs, self._bus, runner=self._subprocess_runner
-        )
-        self._verification_judge = VerificationJudge(
-            config, self._bus, runner=self._subprocess_runner
-        )
-        self._epic_checker = EpicCompletionChecker(config, self._prs, self._fetcher)
-        self._reviewer = ReviewPhase(
-            config,
-            self._state,
-            self._worktrees,
-            self._reviewers,
-            self._prs,
-            self._stop_event,
-            self._store,
-            agents=self._agents,
-            event_bus=self._bus,
-            retrospective=self._retrospective,
-            ac_generator=self._ac_generator,
-            verification_judge=self._verification_judge,
-            transcript_summarizer=self._summarizer,
-            epic_checker=self._epic_checker,
-        )
-        self._memory_sync_bg = MemorySyncLoop(
-            config,
-            self._fetcher,
-            self._memory_sync,
-            self._bus,
-            self._stop_event,
-            status_cb=self.update_bg_worker_status,
-            enabled_cb=self.is_bg_worker_enabled,
-            sleep_fn=self._sleep_or_stop,
-            interval_cb=self.get_bg_worker_interval,
-        )
-        self._metrics_sync_bg = MetricsSyncLoop(
-            config,
-            self._store,
-            self._metrics_manager,
-            self._bus,
-            self._stop_event,
-            status_cb=self.update_bg_worker_status,
-            enabled_cb=self.is_bg_worker_enabled,
-            sleep_fn=self._sleep_or_stop,
-            interval_cb=self.get_bg_worker_interval,
-        )
-        self._pr_unsticker_loop = PRUnstickerLoop(
-            config,
-            self._pr_unsticker,
-            self._prs,
-            self._bus,
-            self._stop_event,
-            status_cb=self.update_bg_worker_status,
-            enabled_cb=self.is_bg_worker_enabled,
-            sleep_fn=self._sleep_or_stop,
-        )
+        # Expose services as instance attributes for backward compatibility
+        self._worktrees = svc.worktrees
+        self._subprocess_runner = svc.subprocess_runner
+        self._agents = svc.agents
+        self._planners = svc.planners
+        self._prs = svc.prs
+        self._reviewers = svc.reviewers
+        self._hitl_runner = svc.hitl_runner
+        self._triage = svc.triage
+        self._summarizer = svc.summarizer
+        self._fetcher = svc.fetcher
+        self._store = svc.store
+        self._triager = svc.triager
+        self._planner_phase = svc.planner_phase
+        self._hitl_phase = svc.hitl_phase
+        self._run_recorder = svc.run_recorder
+        self._implementer = svc.implementer
+        self._metrics_manager = svc.metrics_manager
+        self._pr_unsticker = svc.pr_unsticker
+        self._memory_sync = svc.memory_sync
+        self._retrospective = svc.retrospective
+        self._ac_generator = svc.ac_generator
+        self._verification_judge = svc.verification_judge
+        self._epic_checker = svc.epic_checker
+        self._reviewer = svc.reviewer
+        self._memory_sync_bg = svc.memory_sync_bg
+        self._metrics_sync_bg = svc.metrics_sync_bg
+        self._pr_unsticker_loop = svc.pr_unsticker_loop
 
     @property
     def event_bus(self) -> EventBus:

--- a/post_merge_handler.py
+++ b/post_merge_handler.py
@@ -1,0 +1,270 @@
+"""Post-merge handling for the HydraFlow review pipeline."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from typing import Any
+
+from acceptance_criteria import AcceptanceCriteriaGenerator
+from config import HydraFlowConfig
+from epic import EpicCompletionChecker
+from events import EventBus, EventType, HydraFlowEvent
+from models import (
+    CriterionVerdict,
+    GitHubIssue,
+    JudgeResult,
+    JudgeVerdict,
+    PRInfo,
+    ReviewResult,
+    VerificationCriterion,
+)
+from pr_manager import PRManager
+from retrospective import RetrospectiveCollector
+from state import StateTracker
+from verification import format_verification_issue_body
+from verification_judge import VerificationJudge
+
+logger = logging.getLogger("hydraflow.post_merge_handler")
+
+
+class PostMergeHandler:
+    """Handles post-merge operations: AC generation, retrospective, judge, epic checks."""
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        state: StateTracker,
+        prs: PRManager,
+        bus: EventBus,
+        ac_generator: AcceptanceCriteriaGenerator | None,
+        retrospective: RetrospectiveCollector | None,
+        verification_judge: VerificationJudge | None,
+        epic_checker: EpicCompletionChecker | None,
+    ) -> None:
+        self._config = config
+        self._state = state
+        self._prs = prs
+        self._bus = bus
+        self._ac_generator = ac_generator
+        self._retrospective = retrospective
+        self._verification_judge = verification_judge
+        self._epic_checker = epic_checker
+
+    async def handle_approved(
+        self,
+        pr: PRInfo,
+        issue: GitHubIssue,
+        result: ReviewResult,
+        diff: str,
+        worker_id: int,
+        ci_gate_fn: Callable[..., Coroutine[Any, Any, bool]],
+        escalate_fn: Callable[..., Coroutine[Any, Any, None]],
+        publish_fn: Callable[..., Coroutine[Any, Any, None]],
+    ) -> None:
+        """Attempt merge for an approved PR (with optional CI gate)."""
+        should_merge = True
+        if self._config.max_ci_fix_attempts > 0:
+            should_merge = await ci_gate_fn(
+                pr,
+                issue,
+                self._config.worktree_base / f"issue-{pr.issue_number}",
+                result,
+                worker_id,
+            )
+        if not should_merge:
+            return
+
+        await publish_fn(pr, worker_id, "merging")
+        success = await self._prs.merge_pr(pr.number)
+        if success:
+            result.merged = True
+            self._state.mark_issue(pr.issue_number, "merged")
+            self._state.record_pr_merged()
+            self._state.record_issue_completed()
+            if result.ci_fix_attempts > 0:
+                self._state.record_ci_fix_rounds(result.ci_fix_attempts)
+                for _ in range(result.ci_fix_attempts):
+                    self._state.record_stage_retry(pr.issue_number, "ci_fix")
+            # Track time-to-merge
+            if issue.created_at:
+                try:
+                    created = datetime.fromisoformat(issue.created_at)
+                    merge_seconds = (datetime.now(UTC) - created).total_seconds()
+                    self._state.record_merge_duration(merge_seconds)
+                except (ValueError, TypeError):
+                    pass
+            # Check thresholds and publish alerts
+            proposals = self._state.check_thresholds(
+                self._config.quality_fix_rate_threshold,
+                self._config.approval_rate_threshold,
+                self._config.hitl_rate_threshold,
+            )
+            for proposal in proposals:
+                self._state.mark_threshold_fired(proposal["name"])
+                await self._bus.publish(
+                    HydraFlowEvent(
+                        type=EventType.SYSTEM_ALERT,
+                        data={
+                            "message": (
+                                f"Threshold breached: {proposal['metric']} "
+                                f"({proposal['value']:.2f} vs {proposal['threshold']:.2f}). "
+                                f"{proposal['action']}"
+                            ),
+                            "source": "threshold_check",
+                            "threshold": proposal,
+                        },
+                    )
+                )
+            self._state.reset_review_attempts(pr.issue_number)
+            self._state.reset_issue_attempts(pr.issue_number)
+            self._state.clear_review_feedback(pr.issue_number)
+            await self._prs.swap_pipeline_labels(
+                pr.issue_number, self._config.fixed_label[0]
+            )
+            await self._run_post_merge_hooks(pr, issue, result, diff)
+        else:
+            logger.warning("PR #%d merge failed — escalating to HITL", pr.number)
+            await publish_fn(pr, worker_id, "escalating")
+            await escalate_fn(
+                pr.issue_number,
+                pr.number,
+                cause="PR merge failed on GitHub",
+                origin_label=self._config.review_label[0],
+                comment=(
+                    "**Merge failed** — PR could not be merged. "
+                    "Escalating to human review."
+                ),
+                event_cause="merge_failed",
+            )
+
+    async def _run_post_merge_hooks(
+        self,
+        pr: PRInfo,
+        issue: GitHubIssue,
+        result: ReviewResult,
+        diff: str,
+    ) -> None:
+        """Run non-blocking post-merge hooks (AC, retrospective, judge, epic)."""
+        if self._ac_generator:
+            try:
+                await self._ac_generator.generate(
+                    issue_number=pr.issue_number,
+                    pr_number=pr.number,
+                    issue=issue,
+                    diff=diff,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Acceptance criteria generation failed for issue #%d",
+                    pr.issue_number,
+                    exc_info=True,
+                )
+        if self._retrospective:
+            try:
+                await self._retrospective.record(
+                    issue_number=pr.issue_number,
+                    pr_number=pr.number,
+                    review_result=result,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Retrospective record failed for issue #%d",
+                    pr.issue_number,
+                    exc_info=True,
+                )
+        verdict: JudgeVerdict | None = None
+        if self._verification_judge:
+            try:
+                verdict = await self._verification_judge.judge(
+                    issue_number=pr.issue_number,
+                    pr_number=pr.number,
+                    diff=diff,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Verification judge failed for issue #%d",
+                    pr.issue_number,
+                    exc_info=True,
+                )
+
+        judge_result = self._get_judge_result(issue, pr, verdict)
+        if judge_result is not None:
+            try:
+                await self._create_verification_issue(issue, pr, judge_result)
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Verification issue creation failed for issue #%d",
+                    pr.issue_number,
+                    exc_info=True,
+                )
+
+        # Check if any parent epics can be closed
+        if self._epic_checker:
+            try:
+                await self._epic_checker.check_and_close_epics(
+                    pr.issue_number,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Epic completion check failed for issue #%d",
+                    pr.issue_number,
+                    exc_info=True,
+                )
+
+    def _get_judge_result(
+        self,
+        issue: GitHubIssue,
+        pr: PRInfo,
+        verdict: JudgeVerdict | None,
+    ) -> JudgeResult | None:
+        """Convert a JudgeVerdict into a JudgeResult for verification issue creation."""
+        if verdict is None:
+            return None
+
+        criteria = [
+            VerificationCriterion(
+                description=cr.criterion,
+                passed=cr.verdict == CriterionVerdict.PASS,
+                details=cr.reasoning,
+            )
+            for cr in verdict.criteria_results
+        ]
+
+        return JudgeResult(
+            issue_number=issue.number,
+            pr_number=pr.number,
+            criteria=criteria,
+            verification_instructions=verdict.verification_instructions,
+            summary=verdict.summary,
+        )
+
+    async def _create_verification_issue(
+        self,
+        issue: GitHubIssue,
+        pr: PRInfo,
+        judge_result: JudgeResult,
+    ) -> int:
+        """Create a linked verification issue for human review.
+
+        Returns the created issue number (0 on failure).
+        """
+        title = f"Verify: {issue.title}"
+        if len(title) > 256:
+            title = title[:253] + "..."
+
+        body = format_verification_issue_body(judge_result, issue, pr)
+        label = self._config.hitl_label[0]
+        issue_number = await self._prs.create_issue(title, body, [label])
+
+        if issue_number > 0:
+            self._state.set_verification_issue(issue.number, issue_number)
+            logger.info(
+                "Created verification issue #%d for issue #%d (PR #%d)",
+                issue_number,
+                issue.number,
+                pr.number,
+            )
+
+        return issue_number

--- a/review_phase.py
+++ b/review_phase.py
@@ -14,18 +14,14 @@ from config import HydraFlowConfig
 from epic import EpicCompletionChecker
 from events import EventBus, EventType, HydraFlowEvent
 from issue_store import IssueStore
-from memory import file_memory_suggestion
+from merge_conflict_resolver import MergeConflictResolver
 from models import (
-    CriterionVerdict,
     GitHubIssue,
-    JudgeResult,
-    JudgeVerdict,
     PRInfo,
     ReviewResult,
     ReviewVerdict,
-    VerificationCriterion,
-    WorkerStatus,
 )
+from post_merge_handler import PostMergeHandler
 from pr_manager import PRManager, SelfReviewError
 from retrospective import RetrospectiveCollector
 from review_insights import (
@@ -39,7 +35,6 @@ from review_insights import (
 from reviewer import ReviewRunner
 from state import StateTracker
 from transcript_summarizer import TranscriptSummarizer
-from verification import format_verification_issue_body
 from verification_judge import VerificationJudge
 from worktree import WorktreeManager
 
@@ -82,6 +77,25 @@ class ReviewPhase:
         self._epic_checker = epic_checker
         self._insights = ReviewInsightStore(config.repo_root / ".hydraflow" / "memory")
         self._active_issues: set[int] = set()
+        self._conflict_resolver = MergeConflictResolver(
+            config=config,
+            worktrees=worktrees,
+            agents=agents,
+            prs=prs,
+            bus=self._bus,
+            state=state,
+            summarizer=transcript_summarizer,
+        )
+        self._post_merge = PostMergeHandler(
+            config=config,
+            state=state,
+            prs=prs,
+            bus=self._bus,
+            ac_generator=ac_generator,
+            retrospective=retrospective,
+            verification_judge=verification_judge,
+            epic_checker=epic_checker,
+        )
 
     async def review_prs(
         self,
@@ -242,43 +256,14 @@ class ReviewPhase:
 
         Returns True on success, False on failure (escalates to HITL).
         """
-        await self._publish_review_status(pr, worker_id, "merge_main")
-        merged = await self._worktrees.merge_main(wt_path, pr.branch)
-        if not merged:
-            logger.info(
-                "PR #%d has conflicts with %s — running agent to resolve",
-                pr.number,
-                self._config.main_branch,
-            )
-            await self._publish_review_status(
-                pr, worker_id, WorkerStatus.MERGE_FIX.value
-            )
-            merged = await self._resolve_merge_conflicts(
-                pr, issue, wt_path, worker_id=worker_id
-            )
-        if merged:
-            await self._prs.push_branch(wt_path, pr.branch)
-            return True
-
-        logger.warning(
-            "PR #%d merge conflict resolution failed — escalating to HITL",
-            pr.number,
+        return await self._conflict_resolver.merge_with_main(
+            pr,
+            issue,
+            wt_path,
+            worker_id,
+            escalate_fn=self._escalate_to_hitl,
+            publish_fn=self._publish_review_status,
         )
-        await self._publish_review_status(pr, worker_id, "escalating")
-        await self._escalate_to_hitl(
-            pr.issue_number,
-            pr.number,
-            cause="Merge conflict with main branch",
-            origin_label=self._config.review_label[0],
-            comment=(
-                f"**Merge conflicts** with "
-                f"`{self._config.main_branch}` could not be "
-                "resolved automatically. "
-                "Escalating to human review."
-            ),
-            event_cause="merge_conflict",
-        )
-        return False
 
     async def _run_and_post_review(
         self,
@@ -364,154 +349,16 @@ class ReviewPhase:
         worker_id: int,
     ) -> None:
         """Attempt merge for an approved PR (with optional CI gate)."""
-        should_merge = True
-        if self._config.max_ci_fix_attempts > 0:
-            should_merge = await self.wait_and_fix_ci(
-                pr,
-                issue,
-                self._config.worktree_base / f"issue-{pr.issue_number}",
-                result,
-                worker_id,
-            )
-        if not should_merge:
-            return
-
-        await self._publish_review_status(pr, worker_id, "merging")
-        success = await self._prs.merge_pr(pr.number)
-        if success:
-            result.merged = True
-            self._state.mark_issue(pr.issue_number, "merged")
-            self._state.record_pr_merged()
-            self._state.record_issue_completed()
-            if result.ci_fix_attempts > 0:
-                self._state.record_ci_fix_rounds(result.ci_fix_attempts)
-                for _ in range(result.ci_fix_attempts):
-                    self._state.record_stage_retry(pr.issue_number, "ci_fix")
-            # Track time-to-merge
-            if issue.created_at:
-                try:
-                    created = datetime.fromisoformat(issue.created_at)
-                    merge_seconds = (datetime.now(UTC) - created).total_seconds()
-                    self._state.record_merge_duration(merge_seconds)
-                except (ValueError, TypeError):
-                    pass
-            # Check thresholds and publish alerts
-            proposals = self._state.check_thresholds(
-                self._config.quality_fix_rate_threshold,
-                self._config.approval_rate_threshold,
-                self._config.hitl_rate_threshold,
-            )
-            for proposal in proposals:
-                self._state.mark_threshold_fired(proposal["name"])
-                await self._bus.publish(
-                    HydraFlowEvent(
-                        type=EventType.SYSTEM_ALERT,
-                        data={
-                            "message": (
-                                f"Threshold breached: {proposal['metric']} "
-                                f"({proposal['value']:.2f} vs {proposal['threshold']:.2f}). "
-                                f"{proposal['action']}"
-                            ),
-                            "source": "threshold_check",
-                            "threshold": proposal,
-                        },
-                    )
-                )
-            self._state.reset_review_attempts(pr.issue_number)
-            self._state.reset_issue_attempts(pr.issue_number)
-            self._state.clear_review_feedback(pr.issue_number)
-            await self._prs.swap_pipeline_labels(
-                pr.issue_number, self._config.fixed_label[0]
-            )
-            await self._run_post_merge_hooks(pr, issue, result, diff)
-        else:
-            logger.warning("PR #%d merge failed — escalating to HITL", pr.number)
-            await self._publish_review_status(pr, worker_id, "escalating")
-            await self._escalate_to_hitl(
-                pr.issue_number,
-                pr.number,
-                cause="PR merge failed on GitHub",
-                origin_label=self._config.review_label[0],
-                comment=(
-                    "**Merge failed** — PR could not be merged. "
-                    "Escalating to human review."
-                ),
-                event_cause="merge_failed",
-            )
-
-    async def _run_post_merge_hooks(
-        self,
-        pr: PRInfo,
-        issue: GitHubIssue,
-        result: ReviewResult,
-        diff: str,
-    ) -> None:
-        """Run non-blocking post-merge hooks (AC, retrospective, judge, epic)."""
-        if self._ac_generator:
-            try:
-                await self._ac_generator.generate(
-                    issue_number=pr.issue_number,
-                    pr_number=pr.number,
-                    issue=issue,
-                    diff=diff,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Acceptance criteria generation failed for issue #%d",
-                    pr.issue_number,
-                    exc_info=True,
-                )
-        if self._retrospective:
-            try:
-                await self._retrospective.record(
-                    issue_number=pr.issue_number,
-                    pr_number=pr.number,
-                    review_result=result,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Retrospective record failed for issue #%d",
-                    pr.issue_number,
-                    exc_info=True,
-                )
-        verdict: JudgeVerdict | None = None
-        if self._verification_judge:
-            try:
-                verdict = await self._verification_judge.judge(
-                    issue_number=pr.issue_number,
-                    pr_number=pr.number,
-                    diff=diff,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Verification judge failed for issue #%d",
-                    pr.issue_number,
-                    exc_info=True,
-                )
-
-        judge_result = self._get_judge_result(issue, pr, verdict)
-        if judge_result is not None:
-            try:
-                await self._create_verification_issue(issue, pr, judge_result)
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Verification issue creation failed for issue #%d",
-                    pr.issue_number,
-                    exc_info=True,
-                )
-
-        # Check if any parent epics can be closed
-        if self._epic_checker:
-            try:
-                await self._epic_checker.check_and_close_epics(
-                    pr.issue_number,
-                )
-            except Exception:  # noqa: BLE001
-                logger.warning(
-                    "Epic completion check failed for issue #%d",
-                    pr.issue_number,
-                    exc_info=True,
-                )
+        await self._post_merge.handle_approved(
+            pr,
+            issue,
+            result,
+            diff,
+            worker_id,
+            ci_gate_fn=self.wait_and_fix_ci,
+            escalate_fn=self._escalate_to_hitl,
+            publish_fn=self._publish_review_status,
+        )
 
     async def wait_and_fix_ci(
         self,
@@ -825,220 +672,33 @@ class ReviewPhase:
             )
             return False  # Destroy worktree
 
-    def _get_judge_result(
-        self,
-        issue: GitHubIssue,
-        pr: PRInfo,
-        verdict: JudgeVerdict | None,
-    ) -> JudgeResult | None:
-        """Convert a JudgeVerdict into a JudgeResult for verification issue creation."""
-        if verdict is None:
-            return None
+    # Delegate properties for backward compatibility in tests
+    @property
+    def _resolve_merge_conflicts(self):  # noqa: ANN202
+        """Backward-compatible access to conflict resolver."""
+        return self._conflict_resolver.resolve_merge_conflicts
 
-        criteria = [
-            VerificationCriterion(
-                description=cr.criterion,
-                passed=cr.verdict == CriterionVerdict.PASS,
-                details=cr.reasoning,
-            )
-            for cr in verdict.criteria_results
-        ]
+    @property
+    def _get_judge_result(self):  # noqa: ANN202
+        """Backward-compatible access to judge result helper."""
+        return self._post_merge._get_judge_result
 
-        return JudgeResult(
-            issue_number=issue.number,
-            pr_number=pr.number,
-            criteria=criteria,
-            verification_instructions=verdict.verification_instructions,
-            summary=verdict.summary,
-        )
+    @property
+    def _create_verification_issue(self):  # noqa: ANN202
+        """Backward-compatible access to verification issue creation."""
+        return self._post_merge._create_verification_issue
 
-    async def _create_verification_issue(
-        self,
-        issue: GitHubIssue,
-        pr: PRInfo,
-        judge_result: JudgeResult,
-    ) -> int:
-        """Create a linked verification issue for human review.
+    @property
+    def _run_post_merge_hooks(self):  # noqa: ANN202
+        """Backward-compatible access to post-merge hooks."""
+        return self._post_merge._run_post_merge_hooks
 
-        Returns the created issue number (0 on failure).
-        """
-        title = f"Verify: {issue.title}"
-        if len(title) > 256:
-            title = title[:253] + "..."
+    @property
+    def _save_conflict_transcript(self):  # noqa: ANN202
+        """Backward-compatible access to conflict transcript saving."""
+        return self._conflict_resolver._save_conflict_transcript
 
-        body = format_verification_issue_body(judge_result, issue, pr)
-        label = self._config.hitl_label[0]
-        issue_number = await self._prs.create_issue(title, body, [label])
-
-        if issue_number > 0:
-            self._state.set_verification_issue(issue.number, issue_number)
-            logger.info(
-                "Created verification issue #%d for issue #%d (PR #%d)",
-                issue_number,
-                issue.number,
-                pr.number,
-            )
-
-        return issue_number
-
-    async def _resolve_merge_conflicts(
-        self,
-        pr: PRInfo,
-        issue: GitHubIssue,
-        wt_path: Path,
-        worker_id: int,
-    ) -> bool:
-        """Use the implementation agent to resolve merge conflicts.
-
-        Retries up to ``config.max_merge_conflict_fix_attempts`` times.
-        Each attempt starts a merge (leaving conflict markers), runs the
-        agent to resolve them, and verifies with ``make quality``.
-        Returns *True* if the conflicts were resolved successfully.
-        """
-        from conflict_prompt import build_conflict_prompt
-
-        if self._agents is None:
-            logger.warning(
-                "No agent runner available for conflict resolution on PR #%d",
-                pr.number,
-            )
-            return False
-
-        max_attempts = self._config.max_merge_conflict_fix_attempts
-        last_error: str | None = None
-
-        # Fetch context once before the attempt loop
-        pr_changed_files = await self._prs.get_pr_diff_names(pr.number)
-        main_commits = await self._worktrees.get_main_commits_since_diverge(wt_path)
-
-        for attempt in range(1, max_attempts + 1):
-            # Abort any prior failed merge before retrying
-            if attempt > 1:
-                await self._worktrees.abort_merge(wt_path)
-
-            # Start merge leaving conflict markers in place
-            clean = await self._worktrees.start_merge_main(wt_path, pr.branch)
-            if clean:
-                return True
-
-            logger.info(
-                "Conflict resolution attempt %d/%d for PR #%d",
-                attempt,
-                max_attempts,
-                pr.number,
-            )
-            await self._publish_review_status(
-                pr, worker_id, WorkerStatus.MERGE_FIX.value
-            )
-
-            try:
-                # Gather conflict-specific context for the prompt
-                conflicting_files = await self._worktrees.get_conflicting_files(wt_path)
-                main_diff = await self._worktrees.get_main_diff_for_files(
-                    wt_path, conflicting_files
-                )
-
-                prompt = build_conflict_prompt(
-                    issue,
-                    pr_changed_files,
-                    main_commits,
-                    last_error,
-                    attempt,
-                    conflicting_files=conflicting_files,
-                    main_diff=main_diff,
-                )
-                cmd = self._agents._build_command(wt_path)
-                transcript = await self._agents._execute(
-                    cmd, prompt, wt_path, issue.number
-                )
-
-                self._save_conflict_transcript(
-                    pr.number, issue.number, attempt, transcript
-                )
-
-                try:
-                    await file_memory_suggestion(
-                        transcript,
-                        "conflict_resolver",
-                        f"PR #{pr.number}",
-                        self._config,
-                        self._prs,
-                        self._state,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to file memory suggestion for conflict resolution on PR #%d",
-                        pr.number,
-                    )
-
-                success, error_msg = await self._agents._verify_result(
-                    wt_path, pr.branch
-                )
-                if success:
-                    await self._maybe_summarize_conflict(
-                        transcript, issue.number, pr.number
-                    )
-                    return True
-
-                last_error = error_msg
-                logger.warning(
-                    "Conflict resolution attempt %d/%d failed for PR #%d: %s",
-                    attempt,
-                    max_attempts,
-                    pr.number,
-                    error_msg[:200] if error_msg else "",
-                )
-                # Summarize final failed attempt
-                if attempt == max_attempts:
-                    await self._maybe_summarize_conflict(
-                        transcript, issue.number, pr.number
-                    )
-            except Exception as exc:
-                logger.error(
-                    "Conflict resolution agent failed for PR #%d (attempt %d/%d): %s",
-                    pr.number,
-                    attempt,
-                    max_attempts,
-                    exc,
-                )
-                last_error = str(exc)
-
-        # All attempts exhausted — abort and let caller escalate
-        await self._worktrees.abort_merge(wt_path)
-        return False
-
-    async def _maybe_summarize_conflict(
-        self, transcript: str, issue_number: int, pr_number: int
-    ) -> None:
-        """Summarize a conflict resolution transcript if summarizer is available."""
-        if self._summarizer is None:
-            return
-        try:
-            await self._summarizer.summarize_and_publish(
-                transcript=transcript,
-                issue_number=issue_number,
-                phase="conflict_resolution",
-            )
-        except Exception:
-            logger.exception(
-                "Failed to file transcript summary for conflict resolution on PR #%d",
-                pr_number,
-            )
-
-    def _save_conflict_transcript(
-        self,
-        pr_number: int,
-        issue_number: int,
-        attempt: int,
-        transcript: str,
-    ) -> None:
-        """Save a conflict resolution transcript to ``.hydraflow/logs/``."""
-        log_dir = self._config.repo_root / ".hydraflow" / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        path = log_dir / f"conflict-pr-{pr_number}-attempt-{attempt}.txt"
-        path.write_text(transcript)
-        logger.info(
-            "Conflict resolution transcript saved to %s",
-            path,
-            extra={"issue": issue_number},
-        )
+    @property
+    def _maybe_summarize_conflict(self):  # noqa: ANN202
+        """Backward-compatible access to conflict summary."""
+        return self._conflict_resolver._maybe_summarize_conflict

--- a/service_registry.py
+++ b/service_registry.py
@@ -1,0 +1,240 @@
+"""Service registry and factory for the HydraFlow orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from acceptance_criteria import AcceptanceCriteriaGenerator
+from agent import AgentRunner
+from config import HydraFlowConfig
+from epic import EpicCompletionChecker
+from events import EventBus
+from execution import get_default_runner
+from hitl_phase import HITLPhase
+from hitl_runner import HITLRunner
+from implement_phase import ImplementPhase
+from issue_fetcher import IssueFetcher
+from issue_store import IssueStore
+from memory import MemorySyncWorker
+from memory_sync_loop import MemorySyncLoop
+from metrics_sync_loop import MetricsSyncLoop
+from plan_phase import PlanPhase
+from planner import PlannerRunner
+from pr_manager import PRManager
+from pr_unsticker import PRUnsticker
+from pr_unsticker_loop import PRUnstickerLoop
+from retrospective import RetrospectiveCollector
+from review_phase import ReviewPhase
+from reviewer import ReviewRunner
+from run_recorder import RunRecorder
+from state import StateTracker
+from transcript_summarizer import TranscriptSummarizer
+from triage import TriageRunner
+from triage_phase import TriagePhase
+from verification_judge import VerificationJudge
+from worktree import WorktreeManager
+
+if TYPE_CHECKING:
+    from metrics_manager import MetricsManager
+
+
+@dataclass
+class ServiceRegistry:
+    """Holds all service instances for the orchestrator."""
+
+    # Core infrastructure
+    worktrees: WorktreeManager
+    subprocess_runner: Any
+    agents: AgentRunner
+    planners: PlannerRunner
+    prs: PRManager
+    reviewers: ReviewRunner
+    hitl_runner: HITLRunner
+    triage: TriageRunner
+    summarizer: TranscriptSummarizer
+
+    # Data layer
+    fetcher: IssueFetcher
+    store: IssueStore
+
+    # Phase coordinators
+    triager: TriagePhase
+    planner_phase: PlanPhase
+    hitl_phase: HITLPhase
+    implementer: ImplementPhase
+    reviewer: ReviewPhase
+
+    # Background workers and support
+    run_recorder: RunRecorder
+    metrics_manager: MetricsManager
+    pr_unsticker: PRUnsticker
+    memory_sync: MemorySyncWorker
+    retrospective: RetrospectiveCollector
+    ac_generator: AcceptanceCriteriaGenerator
+    verification_judge: VerificationJudge
+    epic_checker: EpicCompletionChecker
+
+    # Background loops
+    memory_sync_bg: MemorySyncLoop
+    metrics_sync_bg: MetricsSyncLoop
+    pr_unsticker_loop: PRUnstickerLoop
+
+
+@dataclass
+class OrchestratorCallbacks:
+    """Callbacks from the orchestrator needed during service construction."""
+
+    sync_active_issue_numbers: Callable[[], None]
+    update_bg_worker_status: Callable[..., None]
+    is_bg_worker_enabled: Callable[[str], bool]
+    sleep_or_stop: Callable[[int | float], Coroutine[Any, Any, None]]
+    get_bg_worker_interval: Callable[[str], int]
+
+
+def build_services(
+    config: HydraFlowConfig,
+    bus: EventBus,
+    state: StateTracker,
+    stop_event: asyncio.Event,
+    callbacks: OrchestratorCallbacks,
+) -> ServiceRegistry:
+    """Create all services wired together.
+
+    This replaces the 170-line orchestrator constructor body.
+    """
+    # Core runners
+    worktrees = WorktreeManager(config)
+    subprocess_runner = get_default_runner()
+    agents = AgentRunner(config, bus, runner=subprocess_runner)
+    planners = PlannerRunner(config, bus, runner=subprocess_runner)
+    prs = PRManager(config, bus)
+    reviewers = ReviewRunner(config, bus, runner=subprocess_runner)
+    hitl_runner = HITLRunner(config, bus, runner=subprocess_runner)
+    triage = TriageRunner(config, bus)
+    summarizer = TranscriptSummarizer(config, prs, bus, state)
+
+    # Data layer
+    fetcher = IssueFetcher(config)
+    store = IssueStore(config, fetcher, bus)
+
+    # Phase coordinators
+    triager = TriagePhase(config, state, store, triage, prs, bus, stop_event)
+    planner_phase = PlanPhase(config, state, store, planners, prs, bus, stop_event)
+    hitl_phase = HITLPhase(
+        config,
+        state,
+        store,
+        fetcher,
+        worktrees,
+        hitl_runner,
+        prs,
+        bus,
+        stop_event,
+        active_issues_cb=callbacks.sync_active_issue_numbers,
+    )
+    run_recorder = RunRecorder(config)
+    implementer = ImplementPhase(
+        config,
+        state,
+        worktrees,
+        agents,
+        prs,
+        store,
+        stop_event,
+        run_recorder=run_recorder,
+    )
+
+    from metrics_manager import MetricsManager
+
+    metrics_manager = MetricsManager(config, state, prs, bus)
+    pr_unsticker = PRUnsticker(config, state, bus, prs, agents, worktrees, fetcher)
+    memory_sync = MemorySyncWorker(config, state, bus)
+    retrospective = RetrospectiveCollector(config, state, prs)
+    ac_generator = AcceptanceCriteriaGenerator(
+        config, prs, bus, runner=subprocess_runner
+    )
+    verification_judge = VerificationJudge(config, bus, runner=subprocess_runner)
+    epic_checker = EpicCompletionChecker(config, prs, fetcher)
+    reviewer = ReviewPhase(
+        config,
+        state,
+        worktrees,
+        reviewers,
+        prs,
+        stop_event,
+        store,
+        agents=agents,
+        event_bus=bus,
+        retrospective=retrospective,
+        ac_generator=ac_generator,
+        verification_judge=verification_judge,
+        transcript_summarizer=summarizer,
+        epic_checker=epic_checker,
+    )
+
+    # Background loops
+    memory_sync_bg = MemorySyncLoop(
+        config,
+        fetcher,
+        memory_sync,
+        bus,
+        stop_event,
+        status_cb=callbacks.update_bg_worker_status,
+        enabled_cb=callbacks.is_bg_worker_enabled,
+        sleep_fn=callbacks.sleep_or_stop,
+        interval_cb=callbacks.get_bg_worker_interval,
+    )
+    metrics_sync_bg = MetricsSyncLoop(
+        config,
+        store,
+        metrics_manager,
+        bus,
+        stop_event,
+        status_cb=callbacks.update_bg_worker_status,
+        enabled_cb=callbacks.is_bg_worker_enabled,
+        sleep_fn=callbacks.sleep_or_stop,
+        interval_cb=callbacks.get_bg_worker_interval,
+    )
+    pr_unsticker_loop = PRUnstickerLoop(
+        config,
+        pr_unsticker,
+        prs,
+        bus,
+        stop_event,
+        status_cb=callbacks.update_bg_worker_status,
+        enabled_cb=callbacks.is_bg_worker_enabled,
+        sleep_fn=callbacks.sleep_or_stop,
+    )
+
+    return ServiceRegistry(
+        worktrees=worktrees,
+        subprocess_runner=subprocess_runner,
+        agents=agents,
+        planners=planners,
+        prs=prs,
+        reviewers=reviewers,
+        hitl_runner=hitl_runner,
+        triage=triage,
+        summarizer=summarizer,
+        fetcher=fetcher,
+        store=store,
+        triager=triager,
+        planner_phase=planner_phase,
+        hitl_phase=hitl_phase,
+        implementer=implementer,
+        reviewer=reviewer,
+        run_recorder=run_recorder,
+        metrics_manager=metrics_manager,
+        pr_unsticker=pr_unsticker,
+        memory_sync=memory_sync,
+        retrospective=retrospective,
+        ac_generator=ac_generator,
+        verification_judge=verification_judge,
+        epic_checker=epic_checker,
+        memory_sync_bg=memory_sync_bg,
+        metrics_sync_bg=metrics_sync_bg,
+        pr_unsticker_loop=pr_unsticker_loop,
+    )

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -1,0 +1,163 @@
+"""Tests for merge_conflict_resolver.py — MergeConflictResolver class."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+from events import EventBus
+from merge_conflict_resolver import MergeConflictResolver
+from state import StateTracker
+from tests.conftest import IssueFactory, PRInfoFactory
+
+
+def _make_resolver(config: HydraFlowConfig, *, agents=None) -> MergeConflictResolver:
+    """Build a MergeConflictResolver with standard mock dependencies."""
+    state = StateTracker(config.state_file)
+    return MergeConflictResolver(
+        config=config,
+        worktrees=AsyncMock(),
+        agents=agents,
+        prs=AsyncMock(),
+        bus=EventBus(),
+        state=state,
+        summarizer=None,
+    )
+
+
+class TestMergeConflictResolver:
+    """Tests for the MergeConflictResolver class."""
+
+    @pytest.mark.asyncio
+    async def test_merge_with_main_clean_merge(self, config: HydraFlowConfig) -> None:
+        """When merge_main succeeds, should push and return True."""
+        resolver = _make_resolver(config)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.merge_main = AsyncMock(return_value=True)
+        resolver._prs.push_branch = AsyncMock(return_value=True)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+
+        result = await resolver.merge_with_main(
+            pr,
+            issue,
+            config.worktree_base / "issue-42",
+            0,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        assert result is True
+        resolver._prs.push_branch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_merge_with_main_escalates_on_failure(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When conflict resolution fails, should escalate and return False."""
+        resolver = _make_resolver(config)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.merge_main = AsyncMock(return_value=False)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+
+        result = await resolver.merge_with_main(
+            pr,
+            issue,
+            config.worktree_base / "issue-42",
+            0,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        assert result is False
+        escalate_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_false_when_no_agents(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Without an agent runner, should return False immediately."""
+        resolver = _make_resolver(config)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        result = await resolver.resolve_merge_conflicts(
+            pr, issue, config.worktree_base / "issue-42", worker_id=0
+        )
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_true_on_clean_merge(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """If start_merge_main returns True (no conflicts), return True."""
+        mock_agents = AsyncMock()
+        resolver = _make_resolver(config, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.start_merge_main = AsyncMock(return_value=True)
+
+        result = await resolver.resolve_merge_conflicts(
+            pr, issue, config.worktree_base / "issue-42", worker_id=0
+        )
+
+        assert result is True
+        mock_agents._execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_runs_agent_on_conflicts(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Should run the agent and verify quality when there are conflicts."""
+        mock_agents = AsyncMock()
+        mock_agents._execute = AsyncMock(return_value="transcript")
+        mock_agents._verify_result = AsyncMock(return_value=(True, ""))
+        resolver = _make_resolver(config, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+
+        result = await resolver.resolve_merge_conflicts(
+            pr, issue, config.worktree_base / "issue-42", worker_id=0
+        )
+
+        assert result is True
+        mock_agents._build_command.assert_called_once()
+        mock_agents._execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_saves_transcript(self, config: HydraFlowConfig) -> None:
+        """A transcript file should be saved for each attempt."""
+        mock_agents = AsyncMock()
+        mock_agents._execute = AsyncMock(return_value="transcript content")
+        mock_agents._verify_result = AsyncMock(return_value=(True, ""))
+        resolver = _make_resolver(config, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+
+        await resolver.resolve_merge_conflicts(
+            pr, issue, config.worktree_base / "issue-42", worker_id=0
+        )
+
+        log_dir = config.repo_root / ".hydraflow" / "logs"
+        assert (log_dir / "conflict-pr-101-attempt-1.txt").exists()

--- a/tests/test_post_merge_handler.py
+++ b/tests/test_post_merge_handler.py
@@ -1,0 +1,207 @@
+"""Tests for post_merge_handler.py — PostMergeHandler class."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+from events import EventBus
+from models import (
+    CriterionResult,
+    CriterionVerdict,
+    JudgeVerdict,
+)
+from post_merge_handler import PostMergeHandler
+from state import StateTracker
+from tests.conftest import IssueFactory, PRInfoFactory, ReviewResultFactory
+
+
+def _make_handler(
+    config: HydraFlowConfig,
+    *,
+    ac_generator=None,
+    retrospective=None,
+    verification_judge=None,
+    epic_checker=None,
+) -> PostMergeHandler:
+    """Build a PostMergeHandler with standard mock dependencies."""
+    state = StateTracker(config.state_file)
+    return PostMergeHandler(
+        config=config,
+        state=state,
+        prs=AsyncMock(),
+        bus=EventBus(),
+        ac_generator=ac_generator,
+        retrospective=retrospective,
+        verification_judge=verification_judge,
+        epic_checker=epic_checker,
+    )
+
+
+class TestPostMergeHandler:
+    """Tests for the PostMergeHandler class."""
+
+    @pytest.mark.asyncio
+    async def test_handle_approved_merges_and_labels(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """On successful merge, should mark issue and swap labels."""
+        handler = _make_handler(config)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(return_value=True)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+        ci_gate_fn = AsyncMock(return_value=True)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=ci_gate_fn,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        assert result.merged is True
+        handler._prs.swap_pipeline_labels.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_approved_escalates_on_merge_failure(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When merge fails, should escalate to HITL."""
+        handler = _make_handler(config)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(return_value=False)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+        ci_gate_fn = AsyncMock(return_value=True)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=ci_gate_fn,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        escalate_fn.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_judge_result_none(self, config: HydraFlowConfig) -> None:
+        """When verdict is None, should return None."""
+        handler = _make_handler(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        result = handler._get_judge_result(issue, pr, None)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_judge_result_converts_verdict(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Should convert JudgeVerdict into JudgeResult."""
+        handler = _make_handler(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+        verdict = JudgeVerdict(
+            issue_number=42,
+            criteria_results=[
+                CriterionResult(
+                    criterion="AC-1",
+                    verdict=CriterionVerdict.PASS,
+                    reasoning="OK",
+                ),
+            ],
+            summary="1/1 passed",
+            verification_instructions="Check it",
+        )
+
+        result = handler._get_judge_result(issue, pr, verdict)
+
+        assert result is not None
+        assert len(result.criteria) == 1
+        assert result.criteria[0].passed is True
+        assert result.verification_instructions == "Check it"
+
+    @pytest.mark.asyncio
+    async def test_retrospective_called_after_merge(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """retrospective.record() should be called after successful merge."""
+        mock_retro = AsyncMock()
+        handler = _make_handler(config, retrospective=mock_retro)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(return_value=True)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+        ci_gate_fn = AsyncMock(return_value=True)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=ci_gate_fn,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        mock_retro.record.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hook_failure_does_not_block_others(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """If AC generation fails, retrospective should still be called."""
+        mock_ac = AsyncMock()
+        mock_ac.generate = AsyncMock(side_effect=RuntimeError("AC failed"))
+        mock_retro = AsyncMock()
+        handler = _make_handler(config, ac_generator=mock_ac, retrospective=mock_retro)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(return_value=True)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+        ci_gate_fn = AsyncMock(return_value=True)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=ci_gate_fn,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        mock_retro.record.assert_awaited_once()

--- a/tests/test_review_phase.py
+++ b/tests/test_review_phase.py
@@ -1525,7 +1525,7 @@ class TestResolveMergeConflicts:
         phase._prs.get_pr_diff_names = AsyncMock(return_value=[])
 
         with patch(
-            "review_phase.file_memory_suggestion", new_callable=AsyncMock
+            "merge_conflict_resolver.file_memory_suggestion", new_callable=AsyncMock
         ) as mock_fms:
             await phase._resolve_merge_conflicts(
                 pr, issue, config.worktree_base / "issue-42", worker_id=0
@@ -1557,7 +1557,7 @@ class TestResolveMergeConflicts:
         phase._prs.get_pr_diff_names = AsyncMock(return_value=[])
 
         with patch(
-            "review_phase.file_memory_suggestion",
+            "merge_conflict_resolver.file_memory_suggestion",
             new_callable=AsyncMock,
             side_effect=RuntimeError("network error"),
         ):
@@ -1587,7 +1587,9 @@ class TestResolveMergeConflicts:
             return_value="diff --git a/src/foo.py\n+added"
         )
 
-        with patch("review_phase.file_memory_suggestion", new_callable=AsyncMock):
+        with patch(
+            "merge_conflict_resolver.file_memory_suggestion", new_callable=AsyncMock
+        ):
             await phase._resolve_merge_conflicts(
                 pr, issue, config.worktree_base / "issue-42", worker_id=0
             )
@@ -1618,7 +1620,9 @@ class TestResolveMergeConflicts:
         phase._worktrees.get_conflicting_files = AsyncMock(return_value=[])
         phase._worktrees.get_main_diff_for_files = AsyncMock(return_value="")
 
-        with patch("review_phase.file_memory_suggestion", new_callable=AsyncMock):
+        with patch(
+            "merge_conflict_resolver.file_memory_suggestion", new_callable=AsyncMock
+        ):
             result = await phase._resolve_merge_conflicts(
                 pr, issue, config.worktree_base / "issue-42", worker_id=0
             )
@@ -2266,6 +2270,7 @@ class TestRetrospectiveIntegration:
         mock_retro = AsyncMock()
         phase = make_review_phase(config)
         phase._retrospective = mock_retro
+        phase._post_merge._retrospective = mock_retro
 
         issue = IssueFactory.create()
         pr = PRInfoFactory.create()
@@ -2296,6 +2301,7 @@ class TestRetrospectiveIntegration:
         mock_retro = AsyncMock()
         phase = make_review_phase(config)
         phase._retrospective = mock_retro
+        phase._post_merge._retrospective = mock_retro
 
         issue = IssueFactory.create()
         pr = PRInfoFactory.create()
@@ -2327,6 +2333,7 @@ class TestRetrospectiveIntegration:
         mock_retro.record = AsyncMock(side_effect=RuntimeError("retro boom"))
         phase = make_review_phase(config)
         phase._retrospective = mock_retro
+        phase._post_merge._retrospective = mock_retro
 
         issue = IssueFactory.create()
         pr = PRInfoFactory.create()
@@ -4422,6 +4429,7 @@ class TestRunPostMergeHooks:
         mock_retro = AsyncMock()
         phase = make_review_phase(config)
         phase._retrospective = mock_retro
+        phase._post_merge._retrospective = mock_retro
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
         result = ReviewResultFactory.create()
@@ -4440,6 +4448,7 @@ class TestRunPostMergeHooks:
         mock_retro = AsyncMock()
         phase = make_review_phase(config, ac_generator=mock_ac)
         phase._retrospective = mock_retro
+        phase._post_merge._retrospective = mock_retro
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
         result = ReviewResultFactory.create()
@@ -4486,6 +4495,7 @@ class TestRunPostMergeHooks:
         mock_judge.judge = AsyncMock(return_value=verdict)
         phase = make_review_phase(config)
         phase._verification_judge = mock_judge
+        phase._post_merge._verification_judge = mock_judge
         phase._prs.create_issue = AsyncMock(return_value=500)
         pr = PRInfoFactory.create()
         result = ReviewResultFactory.create()
@@ -4507,6 +4517,7 @@ class TestRunPostMergeHooks:
         mock_judge.judge = AsyncMock(return_value=None)
         phase = make_review_phase(config)
         phase._verification_judge = mock_judge
+        phase._post_merge._verification_judge = mock_judge
         phase._prs.create_issue = AsyncMock(return_value=0)
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
@@ -4526,6 +4537,7 @@ class TestRunPostMergeHooks:
         mock_judge.judge = AsyncMock(side_effect=RuntimeError("judge failed"))
         phase = make_review_phase(config)
         phase._verification_judge = mock_judge
+        phase._post_merge._verification_judge = mock_judge
         phase._prs.create_issue = AsyncMock(return_value=0)
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
@@ -4546,8 +4558,10 @@ class TestRunPostMergeHooks:
         mock_epic = AsyncMock()
         phase = make_review_phase(config)
         phase._verification_judge = mock_judge
+        phase._post_merge._verification_judge = mock_judge
         phase._prs.create_issue = AsyncMock(side_effect=RuntimeError("API failure"))
         phase._epic_checker = mock_epic
+        phase._post_merge._epic_checker = mock_epic
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
         result = ReviewResultFactory.create()

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -1,0 +1,81 @@
+"""Tests for service_registry.py — ServiceRegistry and build_services factory."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+from events import EventBus
+from service_registry import OrchestratorCallbacks, ServiceRegistry, build_services
+from state import StateTracker
+
+
+def _make_callbacks() -> OrchestratorCallbacks:
+    """Create a stub OrchestratorCallbacks."""
+    return OrchestratorCallbacks(
+        sync_active_issue_numbers=lambda: None,
+        update_bg_worker_status=lambda *args, **kwargs: None,
+        is_bg_worker_enabled=lambda name: True,
+        sleep_or_stop=AsyncMock(),
+        get_bg_worker_interval=lambda name: 60,
+    )
+
+
+class TestBuildServices:
+    """Tests for the build_services factory function."""
+
+    def test_returns_service_registry(self, config: HydraFlowConfig) -> None:
+        """build_services should return a ServiceRegistry instance."""
+        bus = EventBus()
+        state = StateTracker(config.state_file)
+        stop_event = asyncio.Event()
+        callbacks = _make_callbacks()
+
+        registry = build_services(config, bus, state, stop_event, callbacks)
+
+        assert isinstance(registry, ServiceRegistry)
+
+    def test_all_fields_are_set(self, config: HydraFlowConfig) -> None:
+        """All ServiceRegistry fields should be non-None."""
+        bus = EventBus()
+        state = StateTracker(config.state_file)
+        stop_event = asyncio.Event()
+        callbacks = _make_callbacks()
+
+        registry = build_services(config, bus, state, stop_event, callbacks)
+
+        for field_name in ServiceRegistry.__dataclass_fields__:
+            assert getattr(registry, field_name) is not None, f"{field_name} is None"
+
+    def test_agents_runner_is_shared(self, config: HydraFlowConfig) -> None:
+        """Agents, planners, reviewers, and HITL runner should share the subprocess runner."""
+        bus = EventBus()
+        state = StateTracker(config.state_file)
+        stop_event = asyncio.Event()
+        callbacks = _make_callbacks()
+
+        registry = build_services(config, bus, state, stop_event, callbacks)
+
+        assert registry.agents._runner is registry.subprocess_runner
+        assert registry.planners._runner is registry.subprocess_runner
+        assert registry.reviewers._runner is registry.subprocess_runner
+
+    def test_store_uses_fetcher(self, config: HydraFlowConfig) -> None:
+        """IssueStore should be initialized with the fetcher."""
+        bus = EventBus()
+        state = StateTracker(config.state_file)
+        stop_event = asyncio.Event()
+        callbacks = _make_callbacks()
+
+        registry = build_services(config, bus, state, stop_event, callbacks)
+
+        assert registry.store._fetcher is registry.fetcher


### PR DESCRIPTION
## Summary

- **config.py** (934→838 lines): Expand data-driven env-var override tables to eliminate duplicate manual overrides. Split `resolve_defaults()` into four focused helpers: `_resolve_paths`, `_resolve_repo_and_identity`, `_apply_env_overrides`, `_validate_docker`.
- **review_phase.py** (1044→704 lines): Extract `MergeConflictResolver` → `merge_conflict_resolver.py` and `PostMergeHandler` → `post_merge_handler.py`. ReviewPhase delegates via composition with backward-compatible proxy properties.
- **orchestrator.py** (878→765 lines): Extract `ServiceRegistry` dataclass, `OrchestratorCallbacks`, and `build_services()` factory → `service_registry.py`. 170-line constructor replaced with factory call.

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `merge_conflict_resolver.py` | ~270 | Merge conflict detection, agent-based resolution, transcript saving |
| `post_merge_handler.py` | ~270 | Post-merge hooks: AC generation, retrospective, verification judge, epic check |
| `service_registry.py` | ~240 | `ServiceRegistry` dataclass + `build_services()` factory |
| `tests/test_merge_conflict_resolver.py` | 6 tests | Unit tests for MergeConflictResolver |
| `tests/test_post_merge_handler.py` | 6 tests | Unit tests for PostMergeHandler |
| `tests/test_service_registry.py` | 4 tests | Unit tests for build_services factory |

## Test plan

- [x] All 3241 tests pass (3225 existing + 16 new)
- [x] Lint clean (`make lint-check`)
- [x] No new typecheck errors (`make typecheck`)
- [x] Backward-compatible proxy properties maintain existing test compatibility
- [ ] CI passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
