### PR TITLE
Fixes #456: Classify memory suggestions by type with HITL routing

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -352,10 +352,13 @@ If you discover a reusable pattern or insight during this implementation that wo
 
 MEMORY_SUGGESTION_START
 title: Short descriptive title
+type: knowledge | config | instruction | code
 learning: What was learned and why it matters
 context: How it was discovered (reference issue/PR numbers)
 MEMORY_SUGGESTION_END
 
+Types: knowledge (passive insight), config (suggests config change), instruction (new agent instruction), code (suggests code change).
+Actionable types (config, instruction, code) will be routed for human approval.
 Only suggest genuinely valuable learnings — not trivial observations.
 """
 

--- a/conflict_prompt.py
+++ b/conflict_prompt.py
@@ -144,9 +144,13 @@ def build_conflict_prompt(
         "you may output ONE suggestion:\n\n"
         "MEMORY_SUGGESTION_START\n"
         "title: Short descriptive title\n"
+        "type: knowledge | config | instruction | code\n"
         "learning: What was learned and why it matters\n"
         "context: How it was discovered (reference issue/PR numbers)\n"
         "MEMORY_SUGGESTION_END\n\n"
+        "Types: knowledge (passive insight), config (suggests config change), "
+        "instruction (new agent instruction), code (suggests code change).\n"
+        "Actionable types (config, instruction, code) will be routed for human approval.\n"
         "Only suggest genuinely valuable learnings — not trivial observations."
     )
 

--- a/hitl_runner.py
+++ b/hitl_runner.py
@@ -217,10 +217,13 @@ If you discover a reusable pattern or insight during this correction that would 
 
 MEMORY_SUGGESTION_START
 title: Short descriptive title
+type: knowledge | config | instruction | code
 learning: What was learned and why it matters
 context: How it was discovered (reference issue/PR numbers)
 MEMORY_SUGGESTION_END
 
+Types: knowledge (passive insight), config (suggests config change), instruction (new agent instruction), code (suggests code change).
+Actionable types (config, instruction, code) will be routed for human approval.
 Only suggest genuinely valuable learnings — not trivial observations.
 """
 

--- a/memory.py
+++ b/memory.py
@@ -12,7 +12,12 @@ from typing import TYPE_CHECKING
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from file_util import atomic_write
-from models import MemoryIssueData, MemorySyncResult
+from models import (
+    MEMORY_TYPE_DISPLAY_ORDER,
+    MemoryIssueData,
+    MemorySyncResult,
+    MemoryType,
+)
 from state import StateTracker
 from subprocess_util import make_clean_env
 
@@ -22,12 +27,27 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hydraflow.memory")
 
 
+def _parse_memory_type(raw: str) -> MemoryType:
+    """Normalise a raw type string to a ``MemoryType`` enum value.
+
+    Returns ``MemoryType.KNOWLEDGE`` for unknown or empty values.
+    """
+    cleaned = raw.strip().lower()
+    try:
+        return MemoryType(cleaned)
+    except ValueError:
+        return MemoryType.KNOWLEDGE
+
+
 def parse_memory_suggestion(transcript: str) -> dict[str, str] | None:
     """Parse a MEMORY_SUGGESTION block from an agent transcript.
 
-    Returns a dict with ``title``, ``learning``, and ``context`` keys,
-    or ``None`` if no block is found.  Only the first block is returned
-    (cap at 1 suggestion per agent run).
+    Returns a dict with ``title``, ``learning``, ``context``, and ``type``
+    keys, or ``None`` if no block is found.  Only the first block is
+    returned (cap at 1 suggestion per agent run).
+
+    The ``type`` field defaults to ``"knowledge"`` when absent or
+    unrecognised.
     """
     pattern = r"MEMORY_SUGGESTION_START\s*\n(.*?)\nMEMORY_SUGGESTION_END"
     match = re.search(pattern, transcript, re.DOTALL)
@@ -35,7 +55,7 @@ def parse_memory_suggestion(transcript: str) -> dict[str, str] | None:
         return None
 
     block = match.group(1)
-    result: dict[str, str] = {"title": "", "learning": "", "context": ""}
+    result: dict[str, str] = {"title": "", "learning": "", "context": "", "type": ""}
 
     for line in block.splitlines():
         stripped = line.strip()
@@ -45,19 +65,29 @@ def parse_memory_suggestion(transcript: str) -> dict[str, str] | None:
             result["learning"] = stripped[len("learning:") :].strip()
         elif stripped.startswith("context:"):
             result["context"] = stripped[len("context:") :].strip()
+        elif stripped.startswith("type:"):
+            result["type"] = stripped[len("type:") :].strip()
 
     if not result["title"] or not result["learning"]:
         return None
+
+    # Normalise type — default to knowledge when missing or invalid
+    result["type"] = _parse_memory_type(result["type"]).value
 
     return result
 
 
 def build_memory_issue_body(
-    learning: str, context: str, source: str, reference: str
+    learning: str,
+    context: str,
+    source: str,
+    reference: str,
+    memory_type: str = "knowledge",
 ) -> str:
     """Format a structured GitHub issue body for a memory suggestion."""
     return (
         f"## Memory Suggestion\n\n"
+        f"**Type:** {memory_type}\n\n"
         f"**Learning:** {learning}\n\n"
         f"**Context:** {context}\n\n"
         f"**Source:** {source} during {reference}\n"
@@ -93,25 +123,41 @@ async def file_memory_suggestion(
     prs: PRManager,
     state: StateTracker,
 ) -> None:
-    """Parse and file a memory suggestion from an agent transcript."""
+    """Parse and file a memory suggestion from an agent transcript.
+
+    Actionable types (``config``, ``instruction``, ``code``) are routed
+    through HITL for human approval.  Knowledge-type suggestions follow
+    the normal improve-label flow.
+    """
     suggestion = parse_memory_suggestion(transcript)
     if not suggestion:
         return
 
+    memory_type = MemoryType(suggestion.get("type", "knowledge"))
     body = build_memory_issue_body(
         learning=suggestion["learning"],
         context=suggestion["context"],
         source=source,
         reference=reference,
+        memory_type=memory_type.value,
     )
     title = f"[Memory] {suggestion['title']}"
-    labels = list(config.improve_label) + list(config.hitl_label)
+
+    # Actionable types get HITL routing for human approval
+    if MemoryType.is_actionable(memory_type):
+        labels = list(config.improve_label) + list(config.hitl_label)
+        hitl_cause = f"Actionable memory suggestion ({memory_type.value})"
+    else:
+        labels = list(config.improve_label) + list(config.hitl_label)
+        hitl_cause = "Memory suggestion"
+
     issue_num = await prs.create_issue(title, body, labels)
     if issue_num:
         state.set_hitl_origin(issue_num, config.improve_label[0])
-        state.set_hitl_cause(issue_num, "Memory suggestion")
+        state.set_hitl_cause(issue_num, hitl_cause)
         logger.info(
-            "Filed memory suggestion as issue #%d: %s",
+            "Filed %s memory suggestion as issue #%d: %s",
+            memory_type.value,
             issue_num,
             suggestion["title"],
         )
@@ -129,6 +175,10 @@ class MemorySyncWorker:
         self._config = config
         self._state = state
         self._bus = event_bus
+
+    # Type alias for typed learning tuples:
+    # (issue_number, learning_text, created_at, memory_type)
+    _TypedLearning = tuple[int, str, str, MemoryType]
 
     async def sync(self, issues: list[MemoryIssueData]) -> MemorySyncResult:
         """Main sync entry point.
@@ -163,13 +213,15 @@ class MemorySyncWorker:
                 "digest_chars": digest_chars,
             }
 
-        # Extract learnings and build digest
-        learnings: list[tuple[int, str, str]] = []
+        # Extract learnings (now typed) and build digest
+        learnings: list[MemorySyncWorker._TypedLearning] = []
         for issue in issues:
-            learning = self._extract_learning(issue.get("body", ""))
+            body = issue.get("body", "")
+            learning = self._extract_learning(body)
             created = issue.get("createdAt", "")
+            memory_type = self._extract_memory_type(body)
             if learning:
-                learnings.append((issue["number"], learning, created))
+                learnings.append((issue["number"], learning, created, memory_type))
 
         # Sort newest first
         learnings.sort(key=lambda x: x[2], reverse=True)
@@ -185,7 +237,7 @@ class MemorySyncWorker:
         # Write individual items
         items_dir = self._config.repo_root / ".hydraflow" / "memory" / "items"
         items_dir.mkdir(parents=True, exist_ok=True)
-        for num, learning, _ in learnings:
+        for num, learning, _, _ in learnings:
             item_path = items_dir / f"{num}.md"
             item_path.write_text(learning)
 
@@ -226,34 +278,69 @@ class MemorySyncWorker:
         return body.strip()
 
     @staticmethod
-    def _build_digest(learnings: list[tuple[int, str, str]]) -> str:
-        """Build the digest markdown from ``(issue_number, learning, created_at)`` tuples."""
+    def _extract_memory_type(body: str) -> MemoryType:
+        """Extract the memory type from an issue body.
+
+        Looks for a ``**Type:**`` line.  Defaults to ``MemoryType.KNOWLEDGE``
+        when the field is missing or unrecognised.
+        """
+        if not body:
+            return MemoryType.KNOWLEDGE
+
+        type_match = re.search(
+            r"\*\*Type:\*\*\s*(\S+)",
+            body,
+        )
+        if type_match:
+            return _parse_memory_type(type_match.group(1))
+
+        return MemoryType.KNOWLEDGE
+
+    @staticmethod
+    def _build_digest(learnings: list[_TypedLearning]) -> str:
+        """Build the digest markdown grouped by memory type.
+
+        Learnings are organised into sections by type (actionable types
+        first, then knowledge) for easy scanning by agents.
+        """
         now = datetime.now(UTC).isoformat()
         header = (
             f"## Accumulated Learnings\n"
             f"*{len(learnings)} learnings — last synced {now}*\n"
         )
-        sections = []
-        for num, learning, _ in learnings:
-            sections.append(f"- **#{num}:** {learning}")
+
+        # Group learnings by type
+        by_type: dict[MemoryType, list[tuple[int, str]]] = {}
+        for num, learning, _, mtype in learnings:
+            by_type.setdefault(mtype, []).append((num, learning))
+
+        sections: list[str] = []
+        for mtype in MEMORY_TYPE_DISPLAY_ORDER:
+            items = by_type.get(mtype, [])
+            if not items:
+                continue
+            type_header = f"### {mtype.value.title()}"
+            type_items = [f"- **#{num}:** {learning}" for num, learning in items]
+            sections.append(type_header + "\n" + "\n".join(type_items))
+
         return header + "\n" + "\n---\n".join(sections) + "\n"
 
     async def _compact_digest(
-        self, learnings: list[tuple[int, str, str]], max_chars: int
+        self, learnings: list[_TypedLearning], max_chars: int
     ) -> str:
         """Deduplicate and optionally summarise learnings to fit within *max_chars*.
 
         Pipeline:
         1. Keyword-overlap deduplication (>70% overlap → drop duplicate).
-        2. Rebuild digest from unique items.
+        2. Rebuild digest from unique items (grouped by type).
         3. If still over *max_chars*: call a cheap model to summarise.
         4. Final truncation safety-net in case the model returns too much.
         """
         # --- Step 1: Deduplicate by keyword overlap ---
         seen_keywords: list[set[str]] = []
-        unique: list[tuple[int, str, str]] = []
+        unique: list[MemorySyncWorker._TypedLearning] = []
 
-        for num, learning, created in learnings:
+        for num, learning, created, mtype in learnings:
             words = {
                 w.lower() for w in re.findall(r"[a-zA-Z]+", learning) if len(w) >= 4
             }
@@ -266,18 +353,28 @@ class MemorySyncWorker:
                     is_dup = True
                     break
             if not is_dup:
-                unique.append((num, learning, created))
+                unique.append((num, learning, created, mtype))
                 seen_keywords.append(words)
 
-        # --- Step 2: Build digest from unique items ---
+        # --- Step 2: Build digest from unique items (grouped by type) ---
         now = datetime.now(UTC).isoformat()
         header = (
             f"## Accumulated Learnings\n"
             f"*{len(unique)} learnings (compacted) — last synced {now}*\n"
         )
-        sections = []
-        for num, learning, _ in unique:
-            sections.append(f"- **#{num}:** {learning}")
+
+        by_type: dict[MemoryType, list[tuple[int, str]]] = {}
+        for num, learning, _, mtype in unique:
+            by_type.setdefault(mtype, []).append((num, learning))
+
+        sections: list[str] = []
+        for mtype in MEMORY_TYPE_DISPLAY_ORDER:
+            items = by_type.get(mtype, [])
+            if not items:
+                continue
+            type_header = f"### {mtype.value.title()}"
+            type_items = [f"- **#{num}:** {learning}" for num, learning in items]
+            sections.append(type_header + "\n" + "\n".join(type_items))
 
         digest = header + "\n" + "\n---\n".join(sections) + "\n"
 

--- a/models.py
+++ b/models.py
@@ -554,6 +554,35 @@ class BackgroundWorkerState(TypedDict):
     enabled: NotRequired[bool]  # added by get_bg_worker_states()
 
 
+class MemoryType(StrEnum):
+    """Classification of a memory suggestion.
+
+    - ``knowledge``: Passive insight — stored in digest for agent awareness.
+    - ``config``: Suggests a configuration change — routed through HITL approval.
+    - ``instruction``: Suggests a new agent instruction — routed through HITL approval.
+    - ``code``: Suggests a code change — routed through HITL approval.
+    """
+
+    KNOWLEDGE = "knowledge"
+    CONFIG = "config"
+    INSTRUCTION = "instruction"
+    CODE = "code"
+
+    @classmethod
+    def is_actionable(cls, memory_type: MemoryType) -> bool:
+        """Return True if the memory type requires HITL approval."""
+        return memory_type in (cls.CONFIG, cls.INSTRUCTION, cls.CODE)
+
+
+# Ordered list for digest grouping (actionable types first, then knowledge).
+MEMORY_TYPE_DISPLAY_ORDER: list[MemoryType] = [
+    MemoryType.CONFIG,
+    MemoryType.INSTRUCTION,
+    MemoryType.CODE,
+    MemoryType.KNOWLEDGE,
+]
+
+
 class MemoryIssueData(TypedDict):
     """Shape of issue dicts passed to ``MemorySyncWorker.sync``."""
 

--- a/planner.py
+++ b/planner.py
@@ -459,10 +459,13 @@ If you discover a reusable pattern or insight during exploration that would help
 
 MEMORY_SUGGESTION_START
 title: Short descriptive title
+type: knowledge | config | instruction | code
 learning: What was learned and why it matters
 context: How it was discovered (reference issue/PR numbers)
 MEMORY_SUGGESTION_END
 
+Types: knowledge (passive insight), config (suggests config change), instruction (new agent instruction), code (suggests code change).
+Actionable types (config, instruction, code) will be routed for human approval.
 Only suggest genuinely valuable learnings — not trivial observations.
 """
 

--- a/reviewer.py
+++ b/reviewer.py
@@ -391,10 +391,13 @@ If you discover a reusable pattern or insight during this review that would help
 
 MEMORY_SUGGESTION_START
 title: Short descriptive title
+type: knowledge | config | instruction | code
 learning: What was learned and why it matters
 context: How it was discovered (reference issue/PR numbers)
 MEMORY_SUGGESTION_END
 
+Types: knowledge (passive insight), config (suggests config change), instruction (new agent instruction), code (suggests code change).
+Actionable types (config, instruction, code) will be routed for human approval.
 Only suggest genuinely valuable learnings — not trivial observations.
 """
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -10,11 +10,13 @@ import pytest
 
 from memory import (
     MemorySyncWorker,
+    _parse_memory_type,
     build_memory_issue_body,
     file_memory_suggestion,
     load_memory_digest,
     parse_memory_suggestion,
 )
+from models import MEMORY_TYPE_DISPLAY_ORDER, MemoryType
 from state import StateTracker
 from tests.helpers import ConfigFactory
 
@@ -41,6 +43,8 @@ class TestParseMemorySuggestion:
             result["learning"] == "Running make lint first catches formatting issues."
         )
         assert result["context"] == "Discovered during implementation of issue #42."
+        # Default type when missing
+        assert result["type"] == "knowledge"
 
     def test_no_block_returns_none(self) -> None:
         transcript = "Just regular output with no suggestion"
@@ -108,6 +112,165 @@ class TestParseMemorySuggestion:
         assert result["context"] == ""
 
 
+# --- Memory type parsing tests ---
+
+
+class TestParseMemoryType:
+    """Tests for _parse_memory_type normalisation."""
+
+    def test_parse_memory_type__knowledge(self) -> None:
+        assert _parse_memory_type("knowledge") == MemoryType.KNOWLEDGE
+
+    def test_parse_memory_type__config(self) -> None:
+        assert _parse_memory_type("config") == MemoryType.CONFIG
+
+    def test_parse_memory_type__instruction(self) -> None:
+        assert _parse_memory_type("instruction") == MemoryType.INSTRUCTION
+
+    def test_parse_memory_type__code(self) -> None:
+        assert _parse_memory_type("code") == MemoryType.CODE
+
+    def test_parse_memory_type__case_insensitive(self) -> None:
+        assert _parse_memory_type("CONFIG") == MemoryType.CONFIG
+        assert _parse_memory_type("Knowledge") == MemoryType.KNOWLEDGE
+        assert _parse_memory_type("CODE") == MemoryType.CODE
+
+    def test_parse_memory_type__with_whitespace(self) -> None:
+        assert _parse_memory_type("  config  ") == MemoryType.CONFIG
+
+    def test_parse_memory_type__empty_defaults_to_knowledge(self) -> None:
+        assert _parse_memory_type("") == MemoryType.KNOWLEDGE
+
+    def test_parse_memory_type__unknown_defaults_to_knowledge(self) -> None:
+        assert _parse_memory_type("banana") == MemoryType.KNOWLEDGE
+        assert _parse_memory_type("foobar") == MemoryType.KNOWLEDGE
+
+
+class TestParseMemorySuggestionType:
+    """Tests for type field parsing in MEMORY_SUGGESTION blocks."""
+
+    def test_parse_memory_suggestion__type_knowledge(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: knowledge\n"
+            "learning: A learning\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "knowledge"
+
+    def test_parse_memory_suggestion__type_config(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: config\n"
+            "learning: A config suggestion\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "config"
+
+    def test_parse_memory_suggestion__type_instruction(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: instruction\n"
+            "learning: An instruction\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "instruction"
+
+    def test_parse_memory_suggestion__type_code(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: code\n"
+            "learning: A code suggestion\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "code"
+
+    def test_parse_memory_suggestion__missing_type_defaults_to_knowledge(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "learning: A learning\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "knowledge"
+
+    def test_parse_memory_suggestion__invalid_type_defaults_to_knowledge(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: banana\n"
+            "learning: A learning\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "knowledge"
+
+    def test_parse_memory_suggestion__empty_type_defaults_to_knowledge(self) -> None:
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Test\n"
+            "type: \n"
+            "learning: A learning\n"
+            "context: ctx\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+        result = parse_memory_suggestion(transcript)
+        assert result is not None
+        assert result["type"] == "knowledge"
+
+
+class TestMemoryTypeEnum:
+    """Tests for the MemoryType enum and its is_actionable classmethod."""
+
+    def test_memory_type__values(self) -> None:
+        assert MemoryType.KNOWLEDGE.value == "knowledge"
+        assert MemoryType.CONFIG.value == "config"
+        assert MemoryType.INSTRUCTION.value == "instruction"
+        assert MemoryType.CODE.value == "code"
+
+    def test_memory_type__is_actionable_knowledge(self) -> None:
+        assert MemoryType.is_actionable(MemoryType.KNOWLEDGE) is False
+
+    def test_memory_type__is_actionable_config(self) -> None:
+        assert MemoryType.is_actionable(MemoryType.CONFIG) is True
+
+    def test_memory_type__is_actionable_instruction(self) -> None:
+        assert MemoryType.is_actionable(MemoryType.INSTRUCTION) is True
+
+    def test_memory_type__is_actionable_code(self) -> None:
+        assert MemoryType.is_actionable(MemoryType.CODE) is True
+
+    def test_memory_type_display_order__contains_all_types(self) -> None:
+        assert set(MEMORY_TYPE_DISPLAY_ORDER) == set(MemoryType)
+
+    def test_memory_type_display_order__actionable_first(self) -> None:
+        """Actionable types should come before knowledge in display order."""
+        knowledge_idx = MEMORY_TYPE_DISPLAY_ORDER.index(MemoryType.KNOWLEDGE)
+        for mtype in [MemoryType.CONFIG, MemoryType.INSTRUCTION, MemoryType.CODE]:
+            assert MEMORY_TYPE_DISPLAY_ORDER.index(mtype) < knowledge_idx
+
+
 # --- build_memory_issue_body tests ---
 
 
@@ -125,6 +288,8 @@ class TestBuildMemoryIssueBody:
         assert "**Learning:** Always run lint first" in body
         assert "**Context:** Found during issue #42" in body
         assert "**Source:** planner during issue #42" in body
+        # Default type
+        assert "**Type:** knowledge" in body
 
     def test_includes_source_and_reference(self) -> None:
         body = build_memory_issue_body(
@@ -134,6 +299,25 @@ class TestBuildMemoryIssueBody:
             reference="PR #99",
         )
         assert "reviewer during PR #99" in body
+
+    def test_build_memory_issue_body__includes_type(self) -> None:
+        body = build_memory_issue_body(
+            learning="Increase timeout",
+            context="CI failures",
+            source="reviewer",
+            reference="PR #10",
+            memory_type="config",
+        )
+        assert "**Type:** config" in body
+
+    def test_build_memory_issue_body__default_type_is_knowledge(self) -> None:
+        body = build_memory_issue_body(
+            learning="Something",
+            context="Somewhere",
+            source="agent",
+            reference="issue #1",
+        )
+        assert "**Type:** knowledge" in body
 
 
 # --- load_memory_digest tests ---
@@ -237,9 +421,9 @@ class TestMemorySyncWorkerBuildDigest:
     """Tests for digest building."""
 
     def test_sorts_newest_first(self) -> None:
-        learnings = [
-            (1, "Old learning", "2024-01-01T00:00:00"),
-            (2, "New learning", "2024-06-01T00:00:00"),
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Old learning", "2024-01-01T00:00:00", MemoryType.KNOWLEDGE),
+            (2, "New learning", "2024-06-01T00:00:00", MemoryType.KNOWLEDGE),
         ]
         # Pre-sorted newest-first (caller's responsibility)
         learnings_sorted = sorted(learnings, key=lambda x: x[2], reverse=True)
@@ -250,21 +434,67 @@ class TestMemorySyncWorkerBuildDigest:
         assert pos_new < pos_old
 
     def test_formats_with_separators(self) -> None:
-        learnings = [
-            (1, "Learning one", "2024-01-01"),
-            (2, "Learning two", "2024-01-02"),
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Learning config", "2024-01-01", MemoryType.CONFIG),
+            (2, "Learning knowledge", "2024-01-02", MemoryType.KNOWLEDGE),
         ]
         digest = MemorySyncWorker._build_digest(learnings)
         assert "---" in digest
 
     def test_header_includes_count(self) -> None:
-        learnings = [
-            (1, "Learning one", "2024-01-01"),
-            (2, "Learning two", "2024-01-02"),
-            (3, "Learning three", "2024-01-03"),
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Learning one", "2024-01-01", MemoryType.KNOWLEDGE),
+            (2, "Learning two", "2024-01-02", MemoryType.KNOWLEDGE),
+            (3, "Learning three", "2024-01-03", MemoryType.KNOWLEDGE),
         ]
         digest = MemorySyncWorker._build_digest(learnings)
         assert "3 learnings" in digest
+
+    def test_build_digest__groups_by_type(self) -> None:
+        """Learnings should be grouped by type with section headers."""
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "A knowledge item", "2024-01-01", MemoryType.KNOWLEDGE),
+            (2, "A config suggestion", "2024-01-02", MemoryType.CONFIG),
+            (3, "An instruction", "2024-01-03", MemoryType.INSTRUCTION),
+            (4, "A code change", "2024-01-04", MemoryType.CODE),
+        ]
+        digest = MemorySyncWorker._build_digest(learnings)
+        assert "### Config" in digest
+        assert "### Instruction" in digest
+        assert "### Code" in digest
+        assert "### Knowledge" in digest
+
+    def test_build_digest__actionable_before_knowledge(self) -> None:
+        """Actionable type sections should appear before knowledge."""
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Knowledge item", "2024-01-01", MemoryType.KNOWLEDGE),
+            (2, "Config item", "2024-01-02", MemoryType.CONFIG),
+        ]
+        digest = MemorySyncWorker._build_digest(learnings)
+        config_pos = digest.index("### Config")
+        knowledge_pos = digest.index("### Knowledge")
+        assert config_pos < knowledge_pos
+
+    def test_build_digest__skips_empty_type_sections(self) -> None:
+        """Type sections with no learnings should not appear."""
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Knowledge only", "2024-01-01", MemoryType.KNOWLEDGE),
+        ]
+        digest = MemorySyncWorker._build_digest(learnings)
+        assert "### Knowledge" in digest
+        assert "### Config" not in digest
+        assert "### Instruction" not in digest
+        assert "### Code" not in digest
+
+    def test_build_digest__single_type_no_separator(self) -> None:
+        """When all learnings are the same type, no --- separator needed."""
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Item A", "2024-01-01", MemoryType.KNOWLEDGE),
+            (2, "Item B", "2024-01-02", MemoryType.KNOWLEDGE),
+        ]
+        digest = MemorySyncWorker._build_digest(learnings)
+        # Only one type section, so no ---
+        assert "---" not in digest
 
 
 class TestMemorySyncWorkerCompactDigest:
@@ -274,8 +504,8 @@ class TestMemorySyncWorkerCompactDigest:
     async def test_under_limit_no_truncation(self, tmp_path: Path) -> None:
         config = ConfigFactory.create(repo_root=tmp_path)
         worker = MemorySyncWorker(config, MagicMock(), MagicMock())
-        learnings = [
-            (1, "Short learning", "2024-01-01"),
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Short learning", "2024-01-01", MemoryType.KNOWLEDGE),
         ]
         result = await worker._compact_digest(learnings, max_chars=10000)
         assert "truncated" not in result
@@ -284,14 +514,25 @@ class TestMemorySyncWorkerCompactDigest:
     async def test_dedup_removes_near_duplicates(self, tmp_path: Path) -> None:
         config = ConfigFactory.create(repo_root=tmp_path)
         worker = MemorySyncWorker(config, MagicMock(), MagicMock())
-        learnings = [
+        learnings: list[MemorySyncWorker._TypedLearning] = [
             (
                 1,
                 "Always run make lint before make test to catch formatting",
                 "2024-01-01",
+                MemoryType.KNOWLEDGE,
             ),
-            (2, "Always run make lint before make test to catch issues", "2024-01-02"),
-            (3, "Use atomic writes for state persistence", "2024-01-03"),
+            (
+                2,
+                "Always run make lint before make test to catch issues",
+                "2024-01-02",
+                MemoryType.KNOWLEDGE,
+            ),
+            (
+                3,
+                "Use atomic writes for state persistence",
+                "2024-01-03",
+                MemoryType.KNOWLEDGE,
+            ),
         ]
         result = await worker._compact_digest(learnings, max_chars=10000)
         # Should have deduped the similar lint learnings
@@ -302,11 +543,12 @@ class TestMemorySyncWorkerCompactDigest:
         """When dedup isn't enough, the worker calls a cheap model for summarisation."""
         config = ConfigFactory.create(repo_root=tmp_path)
         worker = MemorySyncWorker(config, MagicMock(), MagicMock())
-        learnings = [
+        learnings: list[MemorySyncWorker._TypedLearning] = [
             (
                 i,
                 f"A very long learning about topic number {i} " * 10,
                 f"2024-01-{i:02d}",
+                MemoryType.KNOWLEDGE,
             )
             for i in range(1, 20)
         ]
@@ -325,11 +567,12 @@ class TestMemorySyncWorkerCompactDigest:
         """If the model call fails, fall back to truncation."""
         config = ConfigFactory.create(repo_root=tmp_path)
         worker = MemorySyncWorker(config, MagicMock(), MagicMock())
-        learnings = [
+        learnings: list[MemorySyncWorker._TypedLearning] = [
             (
                 i,
                 f"A very long learning about topic number {i} " * 10,
                 f"2024-01-{i:02d}",
+                MemoryType.KNOWLEDGE,
             )
             for i in range(1, 20)
         ]
@@ -338,6 +581,21 @@ class TestMemorySyncWorkerCompactDigest:
         result = await worker._compact_digest(learnings, max_chars=500)
         assert len(result) <= 520  # 500 + truncation marker
         assert "truncated" in result
+
+    @pytest.mark.asyncio
+    async def test_compact_digest__preserves_type_grouping(
+        self, tmp_path: Path
+    ) -> None:
+        """Compacted digest should still group by type."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        worker = MemorySyncWorker(config, MagicMock(), MagicMock())
+        learnings: list[MemorySyncWorker._TypedLearning] = [
+            (1, "Config learning alpha", "2024-01-01", MemoryType.CONFIG),
+            (2, "Knowledge learning beta", "2024-01-02", MemoryType.KNOWLEDGE),
+        ]
+        result = await worker._compact_digest(learnings, max_chars=10000)
+        assert "### Config" in result
+        assert "### Knowledge" in result
 
 
 class TestMemorySyncWorkerSync:
@@ -819,6 +1077,37 @@ class TestMemoryPRManager:
 # --- Orchestrator tests ---
 
 
+class TestExtractMemoryType:
+    """Tests for _extract_memory_type from issue bodies."""
+
+    def test_extract_memory_type__knowledge(self) -> None:
+        body = "## Memory Suggestion\n\n**Type:** knowledge\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.KNOWLEDGE
+
+    def test_extract_memory_type__config(self) -> None:
+        body = "## Memory Suggestion\n\n**Type:** config\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.CONFIG
+
+    def test_extract_memory_type__instruction(self) -> None:
+        body = "## Memory Suggestion\n\n**Type:** instruction\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.INSTRUCTION
+
+    def test_extract_memory_type__code(self) -> None:
+        body = "## Memory Suggestion\n\n**Type:** code\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.CODE
+
+    def test_extract_memory_type__missing_defaults_to_knowledge(self) -> None:
+        body = "## Memory Suggestion\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.KNOWLEDGE
+
+    def test_extract_memory_type__empty_body(self) -> None:
+        assert MemorySyncWorker._extract_memory_type("") == MemoryType.KNOWLEDGE
+
+    def test_extract_memory_type__unrecognised_defaults_to_knowledge(self) -> None:
+        body = "**Type:** banana\n\n**Learning:** Foo\n"
+        assert MemorySyncWorker._extract_memory_type(body) == MemoryType.KNOWLEDGE
+
+
 class TestFileSuggestionSetsOrigin:
     """Tests that file_memory_suggestion sets hitl_origin on created issues."""
 
@@ -886,6 +1175,234 @@ class TestFileSuggestionSetsOrigin:
 
         # No hitl_origin should be set when create_issue fails
         assert state.get_hitl_origin(0) is None
+
+
+class TestFileMemorySuggestionRouting:
+    """Tests for memory type routing in file_memory_suggestion."""
+
+    @pytest.mark.asyncio
+    async def test_file_memory_suggestion__knowledge_type_cause(
+        self, tmp_path: Path
+    ) -> None:
+        """Knowledge type should use the standard 'Memory suggestion' cause."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            state_file=tmp_path / "state.json",
+        )
+        state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=100)
+
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Knowledge insight\n"
+            "type: knowledge\n"
+            "learning: A passive insight\n"
+            "context: During review\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+
+        await file_memory_suggestion(
+            transcript, "reviewer", "PR #10", config, mock_prs, state
+        )
+
+        assert state.get_hitl_cause(100) == "Memory suggestion"
+        # Body should include type
+        call_body = mock_prs.create_issue.call_args.args[1]
+        assert "**Type:** knowledge" in call_body
+
+    @pytest.mark.asyncio
+    async def test_file_memory_suggestion__config_type_actionable_cause(
+        self, tmp_path: Path
+    ) -> None:
+        """Config type should use actionable cause and HITL routing."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            state_file=tmp_path / "state.json",
+        )
+        state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=101)
+
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Increase CI timeout\n"
+            "type: config\n"
+            "learning: CI timeout too low\n"
+            "context: During implementation\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+
+        await file_memory_suggestion(
+            transcript, "implementer", "issue #5", config, mock_prs, state
+        )
+
+        assert state.get_hitl_cause(101) == "Actionable memory suggestion (config)"
+        call_body = mock_prs.create_issue.call_args.args[1]
+        assert "**Type:** config" in call_body
+
+    @pytest.mark.asyncio
+    async def test_file_memory_suggestion__instruction_type_actionable_cause(
+        self, tmp_path: Path
+    ) -> None:
+        """Instruction type should use actionable cause."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            state_file=tmp_path / "state.json",
+        )
+        state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=102)
+
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Add lint step\n"
+            "type: instruction\n"
+            "learning: Always lint first\n"
+            "context: During review\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+
+        await file_memory_suggestion(
+            transcript, "reviewer", "PR #20", config, mock_prs, state
+        )
+
+        assert state.get_hitl_cause(102) == "Actionable memory suggestion (instruction)"
+
+    @pytest.mark.asyncio
+    async def test_file_memory_suggestion__code_type_actionable_cause(
+        self, tmp_path: Path
+    ) -> None:
+        """Code type should use actionable cause."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            state_file=tmp_path / "state.json",
+        )
+        state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=103)
+
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Refactor helper\n"
+            "type: code\n"
+            "learning: Should refactor shared helper\n"
+            "context: During implementation\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+
+        await file_memory_suggestion(
+            transcript, "implementer", "issue #30", config, mock_prs, state
+        )
+
+        assert state.get_hitl_cause(103) == "Actionable memory suggestion (code)"
+
+    @pytest.mark.asyncio
+    async def test_file_memory_suggestion__missing_type_defaults_to_knowledge(
+        self, tmp_path: Path
+    ) -> None:
+        """When type is missing, should default to knowledge cause."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path / "repo",
+            state_file=tmp_path / "state.json",
+        )
+        state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        mock_prs.create_issue = AsyncMock(return_value=104)
+
+        transcript = (
+            "MEMORY_SUGGESTION_START\n"
+            "title: Some insight\n"
+            "learning: Discovered something\n"
+            "context: During work\n"
+            "MEMORY_SUGGESTION_END\n"
+        )
+
+        await file_memory_suggestion(
+            transcript, "implementer", "issue #40", config, mock_prs, state
+        )
+
+        assert state.get_hitl_cause(104) == "Memory suggestion"
+
+
+class TestSyncWithTypedIssues:
+    """Tests for MemorySyncWorker.sync with typed issue bodies."""
+
+    @pytest.mark.asyncio
+    async def test_sync__typed_issues_produce_grouped_digest(
+        self, tmp_path: Path
+    ) -> None:
+        """Sync with typed issues should produce a digest grouped by type."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+
+        worker = MemorySyncWorker(config, state, bus)
+        issues = [
+            {
+                "number": 10,
+                "title": "[Memory] Config change",
+                "body": (
+                    "## Memory Suggestion\n\n"
+                    "**Type:** config\n\n"
+                    "**Learning:** Increase timeout\n\n"
+                    "**Context:** CI failures\n"
+                ),
+                "createdAt": "2024-06-01T00:00:00Z",
+            },
+            {
+                "number": 20,
+                "title": "[Memory] Knowledge item",
+                "body": (
+                    "## Memory Suggestion\n\n"
+                    "**Type:** knowledge\n\n"
+                    "**Learning:** Use type hints\n\n"
+                    "**Context:** Code review\n"
+                ),
+                "createdAt": "2024-05-01T00:00:00Z",
+            },
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["item_count"] == 2
+        digest_path = tmp_path / ".hydraflow" / "memory" / "digest.md"
+        content = digest_path.read_text()
+        assert "### Config" in content
+        assert "### Knowledge" in content
+        # Config should come before Knowledge
+        assert content.index("### Config") < content.index("### Knowledge")
+
+    @pytest.mark.asyncio
+    async def test_sync__untyped_issues_default_to_knowledge(
+        self, tmp_path: Path
+    ) -> None:
+        """Issues without a Type field should be grouped under Knowledge."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+
+        worker = MemorySyncWorker(config, state, bus)
+        issues = [
+            {
+                "number": 10,
+                "title": "[Memory] Legacy item",
+                "body": (
+                    "## Memory Suggestion\n\n"
+                    "**Learning:** Old learning without type\n\n"
+                    "**Context:** Before types existed\n"
+                ),
+                "createdAt": "2024-01-01T00:00:00Z",
+            },
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["item_count"] == 1
+        digest_path = tmp_path / ".hydraflow" / "memory" / "digest.md"
+        content = digest_path.read_text()
+        assert "### Knowledge" in content
+        assert "### Config" not in content
 
 
 # --- Orchestrator tests ---


### PR DESCRIPTION
## Summary
- Add `MemoryType` enum (`knowledge`, `config`, `instruction`, `code`) to `models.py` with `is_actionable()` classifier and `MEMORY_TYPE_DISPLAY_ORDER` for digest grouping
- Update `parse_memory_suggestion()` to extract `type:` field from agent transcripts, defaulting to `knowledge` for missing/invalid values
- Update `build_memory_issue_body()` to include `**Type:**` field in GitHub issue bodies
- Update `file_memory_suggestion()` to route actionable types (`config`, `instruction`, `code`) through HITL with descriptive cause strings, while knowledge types follow the existing flow
- Refactor `MemorySyncWorker._build_digest()` and `_compact_digest()` to group learnings by type with `### Type` section headers (actionable types first)
- Add `_extract_memory_type()` to parse type from issue bodies during sync
- Update all 5 agent prompt templates (`agent.py`, `reviewer.py`, `planner.py`, `hitl_runner.py`, `conflict_prompt.py`) to include `type:` field in `MEMORY_SUGGESTION` blocks

## Test plan
- [x] `TestParseMemoryType` -- 8 tests for `_parse_memory_type()` normalisation (valid types, case insensitivity, whitespace, empty/unknown defaults)
- [x] `TestParseMemorySuggestionType` -- 7 tests for type field parsing from transcript blocks (all 4 types, missing/invalid/empty defaults)
- [x] `TestMemoryTypeEnum` -- 5 tests for enum values, `is_actionable()` classification, display order
- [x] `TestBuildMemoryIssueBody` -- 2 new tests for type inclusion in issue bodies
- [x] `TestExtractMemoryType` -- 7 tests for `_extract_memory_type()` from issue bodies
- [x] `TestFileMemorySuggestionRouting` -- 5 tests for routing logic (knowledge/config/instruction/code causes, missing type default)
- [x] `TestSyncWithTypedIssues` -- 2 tests for typed digest grouping in sync
- [x] Updated all existing `_build_digest` and `_compact_digest` tests to use 4-tuple format
- [x] All 3345 tests pass, lint clean, pyright 0 errors, bandit 0 Medium/High

🤖 Generated with [Claude Code](https://claude.com/claude-code)