### PR TITLE
Fix gaps in #769 manifest tracking: wire refresh loop, inject into HITL/conflict

### DIFF
--- a/conflict_prompt.py
+++ b/conflict_prompt.py
@@ -9,12 +9,18 @@ additional context it needs via ``gh`` CLI.
 
 from __future__ import annotations
 
+from config import HydraFlowConfig
+from manifest import load_project_manifest
+from memory import load_memory_digest
+
 
 def build_conflict_prompt(
     issue_url: str,
     pr_url: str,
     last_error: str | None,
     attempt: int,
+    *,
+    config: HydraFlowConfig | None = None,
 ) -> str:
     """Build a conflict resolution prompt.
 
@@ -39,6 +45,15 @@ def build_conflict_prompt(
         "Resolve all conflicts, then run `make quality` to verify "
         "everything passes. Do not push."
     )
+
+    # --- Project manifest & memory digest ---
+    if config is not None:
+        manifest = load_project_manifest(config)
+        if manifest:
+            sections.append(f"## Project Context\n\n{manifest}")
+        digest = load_memory_digest(config)
+        if digest:
+            sections.append(f"## Accumulated Learnings\n\n{digest}")
 
     # --- Previous attempt error ---
     if last_error and attempt > 1:

--- a/hitl_runner.py
+++ b/hitl_runner.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from execution import get_default_runner
+from manifest import load_project_manifest
+from memory import load_memory_digest
 from models import GitHubIssue, HITLResult
 from runner_utils import stream_claude_process, terminate_processes
 from subprocess_util import CreditExhaustedError
@@ -185,11 +187,23 @@ class HITLRunner:
             "#{issue}", f"#{issue.number}"
         )
 
+        # Project manifest injection
+        manifest_section = ""
+        manifest = load_project_manifest(self._config)
+        if manifest:
+            manifest_section = f"\n\n## Project Context\n\n{manifest}"
+
+        # Memory digest injection
+        memory_section = ""
+        digest = load_memory_digest(self._config)
+        if digest:
+            memory_section = f"\n\n## Accumulated Learnings\n\n{digest}"
+
         return f"""You are applying a human-in-the-loop correction for GitHub issue #{issue.number}.
 
 ## Issue: {issue.title}
 
-{issue.body}
+{issue.body}{manifest_section}{memory_section}
 
 ## Escalation Reason
 

--- a/manifest_refresh_loop.py
+++ b/manifest_refresh_loop.py
@@ -1,0 +1,102 @@
+"""Background worker loop -- project manifest refresh.
+
+Periodically re-scans the repository for language markers, build systems,
+test frameworks, and CI configuration, then persists the updated manifest
+so agents have up-to-date project context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from config import HydraFlowConfig
+from events import EventBus, EventType, HydraFlowEvent
+from manifest import ProjectManifestManager
+from state import StateTracker
+from subprocess_util import AuthenticationError, CreditExhaustedError
+
+logger = logging.getLogger("hydraflow.manifest_refresh_loop")
+
+
+class ManifestRefreshLoop:
+    """Periodically rescans the repo and updates the project manifest file.
+
+    Follows the same background-worker pattern as
+    :class:`MemorySyncLoop` and :class:`MetricsSyncLoop`.
+    """
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        manifest_manager: ProjectManifestManager,
+        state: StateTracker,
+        bus: EventBus,
+        stop_event: asyncio.Event,
+        status_cb: Callable[[str, str, dict[str, Any] | None], None],
+        enabled_cb: Callable[[str], bool],
+        sleep_fn: Callable[[int | float], Coroutine[Any, Any, None]],
+        interval_cb: Callable[[str], int] | None = None,
+    ) -> None:
+        self._config = config
+        self._manifest_manager = manifest_manager
+        self._state = state
+        self._bus = bus
+        self._stop_event = stop_event
+        self._status_cb = status_cb
+        self._enabled_cb = enabled_cb
+        self._sleep_fn = sleep_fn
+        self._interval_cb = interval_cb
+
+    def _get_interval(self) -> int:
+        """Return the effective interval, preferring dynamic override."""
+        if self._interval_cb is not None:
+            return self._interval_cb("manifest_refresh")
+        return self._config.manifest_refresh_interval
+
+    async def run(self) -> None:
+        """Continuously rescan the repo and update the manifest file."""
+        # Perform an initial refresh immediately on startup so the
+        # manifest is available before the first agent run.
+        await self._do_refresh()
+
+        while not self._stop_event.is_set():
+            interval = self._get_interval()
+            await self._sleep_fn(interval)
+            if self._stop_event.is_set():
+                break
+            if not self._enabled_cb("manifest_refresh"):
+                continue
+            await self._do_refresh()
+
+    async def _do_refresh(self) -> None:
+        """Execute a single refresh cycle."""
+        try:
+            content, digest_hash = self._manifest_manager.refresh()
+            self._state.update_manifest_state(digest_hash)
+            self._status_cb(
+                "manifest_refresh",
+                "ok",
+                {"hash": digest_hash, "length": len(content)},
+            )
+            logger.info(
+                "Project manifest refreshed (hash=%s, %d chars)",
+                digest_hash,
+                len(content),
+            )
+        except (AuthenticationError, CreditExhaustedError):
+            raise
+        except Exception:
+            logger.exception("Manifest refresh failed -- will retry next cycle")
+            self._status_cb("manifest_refresh", "error", None)
+            await self._bus.publish(
+                HydraFlowEvent(
+                    type=EventType.ERROR,
+                    data={
+                        "message": "Manifest refresh loop error",
+                        "source": "manifest_refresh",
+                    },
+                )
+            )

--- a/merge_conflict_resolver.py
+++ b/merge_conflict_resolver.py
@@ -137,7 +137,9 @@ class MergeConflictResolver:
             )
 
             try:
-                prompt = build_conflict_prompt(issue.url, pr.url, last_error, attempt)
+                prompt = build_conflict_prompt(
+                    issue.url, pr.url, last_error, attempt, config=self._config
+                )
                 cmd = self._agents._build_command(wt_path)
                 transcript = await self._agents._execute(
                     cmd, prompt, wt_path, issue.number

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -113,6 +113,7 @@ class HydraFlowOrchestrator:
         self._memory_sync_bg = svc.memory_sync_bg
         self._metrics_sync_bg = svc.metrics_sync_bg
         self._pr_unsticker_loop = svc.pr_unsticker_loop
+        self._manifest_refresh_loop = svc.manifest_refresh_loop
 
     @property
     def event_bus(self) -> EventBus:
@@ -293,6 +294,8 @@ class HydraFlowOrchestrator:
             return self._config.metrics_sync_interval
         if name == "pr_unsticker":
             return self._config.pr_unstick_interval
+        if name == "manifest_refresh":
+            return self._config.manifest_refresh_interval
         return self._config.poll_interval
 
     async def _publish_status(self) -> None:
@@ -427,6 +430,7 @@ class HydraFlowOrchestrator:
             ("memory_sync", self._memory_sync_loop),
             ("metrics", self._metrics_sync_loop),
             ("pr_unsticker", self._pr_unsticker_loop.run),
+            ("manifest_refresh", self._manifest_refresh_bg_loop),
         ]
         tasks: dict[str, asyncio.Task[None]] = {}
         for name, factory in loop_factories:
@@ -575,6 +579,10 @@ class HydraFlowOrchestrator:
     async def _metrics_sync_loop(self) -> None:
         """Continuously aggregate and persist metrics snapshots."""
         await self._metrics_sync_bg.run()
+
+    async def _manifest_refresh_bg_loop(self) -> None:
+        """Continuously rescan the repo and update the project manifest."""
+        await self._manifest_refresh_loop.run()
 
     async def _do_implement_work(self) -> None:
         """Work function for the implement loop."""

--- a/pr_unsticker.py
+++ b/pr_unsticker.py
@@ -207,7 +207,9 @@ class PRUnsticker:
             )
 
             try:
-                prompt = build_conflict_prompt(issue.url, pr_url, last_error, attempt)
+                prompt = build_conflict_prompt(
+                    issue.url, pr_url, last_error, attempt, config=self._config
+                )
                 cmd = self._agents._build_command(wt_path)
                 transcript = await self._agents._execute(
                     cmd, prompt, wt_path, issue_number

--- a/service_registry.py
+++ b/service_registry.py
@@ -18,6 +18,8 @@ from hitl_runner import HITLRunner
 from implement_phase import ImplementPhase
 from issue_fetcher import IssueFetcher
 from issue_store import IssueStore
+from manifest import ProjectManifestManager
+from manifest_refresh_loop import ManifestRefreshLoop
 from memory import MemorySyncWorker
 from memory_sync_loop import MemorySyncLoop
 from metrics_sync_loop import MetricsSyncLoop
@@ -81,6 +83,7 @@ class ServiceRegistry:
     memory_sync_bg: MemorySyncLoop
     metrics_sync_bg: MetricsSyncLoop
     pr_unsticker_loop: PRUnstickerLoop
+    manifest_refresh_loop: ManifestRefreshLoop
 
 
 @dataclass
@@ -208,6 +211,18 @@ def build_services(
         enabled_cb=callbacks.is_bg_worker_enabled,
         sleep_fn=callbacks.sleep_or_stop,
     )
+    manifest_manager = ProjectManifestManager(config)
+    manifest_refresh_loop = ManifestRefreshLoop(
+        config,
+        manifest_manager,
+        state,
+        bus,
+        stop_event,
+        status_cb=callbacks.update_bg_worker_status,
+        enabled_cb=callbacks.is_bg_worker_enabled,
+        sleep_fn=callbacks.sleep_or_stop,
+        interval_cb=callbacks.get_bg_worker_interval,
+    )
 
     return ServiceRegistry(
         worktrees=worktrees,
@@ -237,4 +252,5 @@ def build_services(
         memory_sync_bg=memory_sync_bg,
         metrics_sync_bg=metrics_sync_bg,
         pr_unsticker_loop=pr_unsticker_loop,
+        manifest_refresh_loop=manifest_refresh_loop,
     )

--- a/tests/test_conflict_prompt.py
+++ b/tests/test_conflict_prompt.py
@@ -8,6 +8,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from conflict_prompt import build_conflict_prompt
+from tests.helpers import ConfigFactory
 
 ISSUE_URL = "https://github.com/test-org/test-repo/issues/42"
 PR_URL = "https://github.com/test-org/test-repo/pull/101"
@@ -60,3 +61,46 @@ class TestBuildConflictPrompt:
         assert "MEMORY_SUGGESTION_START" in prompt
         assert "MEMORY_SUGGESTION_END" in prompt
         assert "## Optional: Memory Suggestion" in prompt
+
+    def test_includes_project_context_when_config_provided(
+        self, tmp_path: Path
+    ) -> None:
+        """When config is provided and manifest exists, prompt includes project context."""
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = config.repo_root / ".hydraflow" / "memory" / "manifest.md"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("## Project Manifest\npython, make, pytest")
+
+        prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1, config=config)
+        assert "## Project Context" in prompt
+        assert "python, make, pytest" in prompt
+
+    def test_includes_accumulated_learnings_when_config_provided(
+        self, tmp_path: Path
+    ) -> None:
+        """When config is provided and digest exists, prompt includes learnings."""
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        digest_path = config.repo_root / ".hydraflow" / "memory" / "digest.md"
+        digest_path.parent.mkdir(parents=True, exist_ok=True)
+        digest_path.write_text("## Memory Digest\nAlways check edge cases")
+
+        prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1, config=config)
+        assert "## Accumulated Learnings" in prompt
+        assert "Always check edge cases" in prompt
+
+    def test_omits_project_context_when_no_config(self) -> None:
+        """Without config parameter, no project context section."""
+        prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1)
+        assert "## Project Context" not in prompt
+
+    def test_omits_project_context_when_config_but_no_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        """With config but no manifest file, no project context section."""
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+
+        prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1, config=config)
+        assert "## Project Context" not in prompt

--- a/tests/test_hitl_runner.py
+++ b/tests/test_hitl_runner.py
@@ -119,6 +119,50 @@ class TestBuildPrompt:
         assert "MEMORY_SUGGESTION_START" in prompt
         assert "MEMORY_SUGGESTION_END" in prompt
 
+    def test_prompt_includes_project_context_when_manifest_exists(
+        self, config, event_bus
+    ) -> None:
+        """Manifest content appears in prompt as ## Project Context."""
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = config.repo_root / ".hydraflow" / "memory" / "manifest.md"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("## Project Manifest\npython, make, pytest")
+
+        runner = HITLRunner(config, event_bus)
+        issue = IssueFactory.create(number=42)
+        prompt = runner._build_prompt(issue, "Fix", "CI failed")
+        assert "## Project Context" in prompt
+        assert "python, make, pytest" in prompt
+
+    def test_prompt_omits_project_context_when_no_manifest(self, hitl_runner) -> None:
+        """Without a manifest file, ## Project Context is not in the prompt."""
+        issue = IssueFactory.create(number=42)
+        prompt = hitl_runner._build_prompt(issue, "Fix", "CI failed")
+        assert "## Project Context" not in prompt
+
+    def test_prompt_includes_accumulated_learnings_when_digest_exists(
+        self, config, event_bus
+    ) -> None:
+        """Memory digest content appears in prompt as ## Accumulated Learnings."""
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        digest_path = config.repo_root / ".hydraflow" / "memory" / "digest.md"
+        digest_path.parent.mkdir(parents=True, exist_ok=True)
+        digest_path.write_text("## Memory Digest\nAlways check edge cases")
+
+        runner = HITLRunner(config, event_bus)
+        issue = IssueFactory.create(number=42)
+        prompt = runner._build_prompt(issue, "Fix", "CI failed")
+        assert "## Accumulated Learnings" in prompt
+        assert "Always check edge cases" in prompt
+
+    def test_prompt_omits_accumulated_learnings_when_no_digest(
+        self, hitl_runner
+    ) -> None:
+        """Without a digest file, ## Accumulated Learnings is not in the prompt."""
+        issue = IssueFactory.create(number=42)
+        prompt = hitl_runner._build_prompt(issue, "Fix", "CI failed")
+        assert "## Accumulated Learnings" not in prompt
+
 
 # ---------------------------------------------------------------------------
 # Command building

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -455,6 +455,99 @@ class TestManifestConfig:
 
 
 # ---------------------------------------------------------------------------
+# Prompt injection in agent runners
+# ---------------------------------------------------------------------------
+
+
+class TestManifestInjectionInRunners:
+    """Verify that all agent runners inject ## Project Context when manifest exists."""
+
+    def test_agent_runner__injects_manifest(self, tmp_path: Path) -> None:
+        """AgentRunner._build_prompt includes ## Project Context from manifest."""
+        from agent import AgentRunner
+        from events import EventBus
+
+        config = ConfigFactory.create(repo_root=tmp_path)
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = config.repo_root / ".hydraflow" / "memory" / "manifest.md"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("## Project Manifest\npython, make")
+
+        runner = AgentRunner(config, EventBus())
+        from models import GitHubIssue
+
+        issue = GitHubIssue(
+            number=1,
+            title="Test",
+            body="body",
+            labels=[],
+            comments=[],
+        )
+        prompt = runner._build_prompt(issue)
+        assert "## Project Context" in prompt
+        assert "python, make" in prompt
+
+    def test_hitl_runner__injects_manifest(self, tmp_path: Path) -> None:
+        """HITLRunner._build_prompt includes ## Project Context from manifest."""
+        from events import EventBus
+        from hitl_runner import HITLRunner
+
+        config = ConfigFactory.create(repo_root=tmp_path)
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = config.repo_root / ".hydraflow" / "memory" / "manifest.md"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("## Project Manifest\nrust, cargo")
+
+        runner = HITLRunner(config, EventBus())
+        from models import GitHubIssue
+
+        issue = GitHubIssue(
+            number=1,
+            title="Test",
+            body="body",
+            labels=[],
+            comments=[],
+        )
+        prompt = runner._build_prompt(issue, "fix it", "CI failed")
+        assert "## Project Context" in prompt
+        assert "rust, cargo" in prompt
+
+    def test_conflict_prompt__injects_manifest_with_config(
+        self, tmp_path: Path
+    ) -> None:
+        """build_conflict_prompt includes ## Project Context when config is given."""
+        from conflict_prompt import build_conflict_prompt
+
+        config = ConfigFactory.create(repo_root=tmp_path)
+        config.repo_root.mkdir(parents=True, exist_ok=True)
+        manifest_path = config.repo_root / ".hydraflow" / "memory" / "manifest.md"
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text("## Project Manifest\ngo, make")
+
+        prompt = build_conflict_prompt(
+            "https://github.com/org/repo/issues/1",
+            "https://github.com/org/repo/pull/2",
+            None,
+            1,
+            config=config,
+        )
+        assert "## Project Context" in prompt
+        assert "go, make" in prompt
+
+    def test_conflict_prompt__omits_manifest_without_config(self) -> None:
+        """build_conflict_prompt omits ## Project Context without config."""
+        from conflict_prompt import build_conflict_prompt
+
+        prompt = build_conflict_prompt(
+            "https://github.com/org/repo/issues/1",
+            "https://github.com/org/repo/pull/2",
+            None,
+            1,
+        )
+        assert "## Project Context" not in prompt
+
+
+# ---------------------------------------------------------------------------
 # Marker consolidation verification
 # ---------------------------------------------------------------------------
 

--- a/tests/test_manifest_refresh_loop.py
+++ b/tests/test_manifest_refresh_loop.py
@@ -1,0 +1,186 @@
+"""Tests for the ManifestRefreshLoop background worker."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from events import EventBus, EventType
+from manifest import ProjectManifestManager
+from manifest_refresh_loop import ManifestRefreshLoop
+from state import StateTracker
+from tests.helpers import ConfigFactory
+
+
+def _make_loop(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+    interval: int = 60,
+) -> tuple[ManifestRefreshLoop, asyncio.Event, ProjectManifestManager, StateTracker]:
+    """Build a ManifestRefreshLoop with test-friendly defaults."""
+    config = ConfigFactory.create(
+        repo_root=tmp_path / "repo",
+        manifest_refresh_interval=interval,
+    )
+    # Create a minimal repo structure so scan produces content
+    repo_root = config.repo_root
+    repo_root.mkdir(parents=True, exist_ok=True)
+    (repo_root / "pyproject.toml").write_text("[project]")
+
+    manager = ProjectManifestManager(config)
+    state = StateTracker(tmp_path / "state.json")
+    bus = EventBus()
+    stop_event = asyncio.Event()
+
+    loop = ManifestRefreshLoop(
+        config=config,
+        manifest_manager=manager,
+        state=state,
+        bus=bus,
+        stop_event=stop_event,
+        status_cb=MagicMock(),
+        enabled_cb=lambda _name: enabled,
+        sleep_fn=_instant_sleep_factory(stop_event),
+    )
+    return loop, stop_event, manager, state
+
+
+def _instant_sleep_factory(stop_event: asyncio.Event):
+    """Return a sleep function that stops after a few iterations."""
+    call_count = 0
+
+    async def sleep(seconds: int | float) -> None:
+        nonlocal call_count
+        call_count += 1
+        # Stop after 2 sleep cycles to prevent infinite loops
+        if call_count >= 2:
+            stop_event.set()
+        await asyncio.sleep(0)
+
+    return sleep
+
+
+class TestManifestRefreshLoopRun:
+    """Tests for ManifestRefreshLoop.run."""
+
+    @pytest.mark.asyncio
+    async def test_run__initial_refresh_writes_manifest(self, tmp_path: Path) -> None:
+        """The loop performs an initial refresh immediately on startup."""
+        loop, stop_event, manager, state = _make_loop(tmp_path)
+        # Stop immediately after initial refresh
+        stop_event.set()
+
+        await loop.run()
+
+        assert manager.manifest_path.is_file()
+        content = manager.manifest_path.read_text()
+        assert "python" in content
+
+    @pytest.mark.asyncio
+    async def test_run__updates_state_hash(self, tmp_path: Path) -> None:
+        """The loop updates the state tracker with the manifest hash."""
+        loop, stop_event, _manager, state = _make_loop(tmp_path)
+        stop_event.set()
+
+        await loop.run()
+
+        manifest_hash, last_updated = state.get_manifest_state()
+        assert manifest_hash != ""
+        assert last_updated is not None
+
+    @pytest.mark.asyncio
+    async def test_run__calls_status_cb_on_success(self, tmp_path: Path) -> None:
+        """The loop calls the status callback with 'ok' on success."""
+        loop, stop_event, _manager, _state = _make_loop(tmp_path)
+        stop_event.set()
+
+        await loop.run()
+
+        loop._status_cb.assert_called()
+        args = loop._status_cb.call_args
+        assert args[0][0] == "manifest_refresh"
+        assert args[0][1] == "ok"
+        assert "hash" in args[0][2]
+        assert "length" in args[0][2]
+
+    @pytest.mark.asyncio
+    async def test_run__continues_on_error(self, tmp_path: Path) -> None:
+        """The loop survives exceptions in _do_refresh and retries."""
+        loop, stop_event, manager, _state = _make_loop(tmp_path)
+
+        call_count = 0
+        original_refresh = manager.refresh
+
+        def failing_then_ok() -> tuple[str, str]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("disk full")
+            return original_refresh()
+
+        manager.refresh = failing_then_ok  # type: ignore[method-assign]
+
+        await loop.run()
+
+        # Should have been called at least twice (initial + retry after error)
+        assert call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_run__publishes_error_event_on_failure(self, tmp_path: Path) -> None:
+        """The loop publishes an ERROR event when refresh fails."""
+        loop, stop_event, manager, _state = _make_loop(tmp_path)
+        stop_event.set()
+
+        manager.refresh = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("broken")
+        )
+
+        await loop.run()
+
+        error_events = [e for e in loop._bus.get_history() if e.type == EventType.ERROR]
+        assert len(error_events) == 1
+        assert error_events[0].data["source"] == "manifest_refresh"
+
+    @pytest.mark.asyncio
+    async def test_run__skips_when_disabled(self, tmp_path: Path) -> None:
+        """The loop skips refresh when the enabled callback returns False."""
+        loop, stop_event, manager, _state = _make_loop(tmp_path, enabled=False)
+
+        # Override to verify refresh is only called once (initial, before
+        # the enabled check in the loop body)
+        refresh_count = 0
+        original_refresh = manager.refresh
+
+        def counting_refresh() -> tuple[str, str]:
+            nonlocal refresh_count
+            refresh_count += 1
+            return original_refresh()
+
+        manager.refresh = counting_refresh  # type: ignore[method-assign]
+
+        await loop.run()
+
+        # Initial refresh always runs; subsequent cycles skipped
+        assert refresh_count == 1
+
+
+class TestManifestRefreshLoopInterval:
+    """Tests for ManifestRefreshLoop interval handling."""
+
+    def test_get_interval__uses_config_default(self, tmp_path: Path) -> None:
+        """Without an interval callback, uses config.manifest_refresh_interval."""
+        loop, _stop, _mgr, _state = _make_loop(tmp_path, interval=900)
+        assert loop._get_interval() == 900
+
+    def test_get_interval__prefers_callback(self, tmp_path: Path) -> None:
+        """With an interval callback, uses the callback result."""
+        loop, _stop, _mgr, _state = _make_loop(tmp_path, interval=900)
+        loop._interval_cb = lambda name: 42
+        assert loop._get_interval() == 42

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1036,6 +1036,65 @@ class TestConcurrentLoops:
 
 
 # ---------------------------------------------------------------------------
+# Manifest refresh loop integration
+# ---------------------------------------------------------------------------
+
+
+class TestManifestRefreshIntegration:
+    """Tests for manifest refresh loop wired into the orchestrator."""
+
+    def test_manifest_refresh_loop_exists(self, config: HydraFlowConfig) -> None:
+        """Orchestrator should have a _manifest_refresh_loop attribute."""
+        from manifest_refresh_loop import ManifestRefreshLoop
+
+        orch = HydraFlowOrchestrator(config)
+        assert isinstance(orch._manifest_refresh_loop, ManifestRefreshLoop)
+
+    def test_manifest_refresh_bg_loop_method_exists(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Orchestrator should have a _manifest_refresh_bg_loop async method."""
+        orch = HydraFlowOrchestrator(config)
+        assert hasattr(orch, "_manifest_refresh_bg_loop")
+        assert asyncio.iscoroutinefunction(orch._manifest_refresh_bg_loop)
+
+    @pytest.mark.asyncio
+    async def test_manifest_refresh_loop_runs_in_supervisor(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """The manifest refresh loop should run as part of _supervise_loops."""
+        orch = HydraFlowOrchestrator(config)
+        orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        _mock_fetcher_noop(orch)
+
+        manifest_ran = False
+
+        async def tracking_manifest_loop() -> None:
+            nonlocal manifest_ran
+            manifest_ran = True
+            orch._stop_event.set()
+
+        orch._manifest_refresh_bg_loop = tracking_manifest_loop  # type: ignore[method-assign]
+        orch._triager.triage_issues = AsyncMock()  # type: ignore[method-assign]
+        orch._planner_phase.plan_issues = AsyncMock(return_value=[])  # type: ignore[method-assign]
+        orch._implementer.run_batch = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+
+        await orch.run()
+
+        assert manifest_ran
+
+    def test_get_bg_worker_interval_returns_manifest_interval(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """get_bg_worker_interval should return manifest_refresh_interval."""
+        orch = HydraFlowOrchestrator(config)
+        assert (
+            orch.get_bg_worker_interval("manifest_refresh")
+            == config.manifest_refresh_interval
+        )
+
+
+# ---------------------------------------------------------------------------
 # HITL correction tracking
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes gaps identified in the merged PR #780 (issue #769 -- project manifest tracking):

- **ManifestRefreshLoop background worker**: Created `manifest_refresh_loop.py` following the `MemorySyncLoop`/`MetricsSyncLoop` pattern. Performs an initial refresh on startup, then periodically rescans the repo. Wired through `service_registry.py` -> `orchestrator.py` supervisor loop.
- **Manifest injection into HITL runner**: `hitl_runner._build_prompt()` now injects `## Project Context` (from manifest) and `## Accumulated Learnings` (from memory digest), matching the pattern in `agent.py`, `planner.py`, and `reviewer.py`.
- **Manifest injection into conflict prompt**: `build_conflict_prompt()` accepts an optional `config` kwarg. When provided, injects manifest and memory digest. Updated both callers (`pr_unsticker.py`, `merge_conflict_resolver.py`) to pass config.
- **Comprehensive tests**: 19 new tests covering all new/changed code paths.

## Test plan

- [x] `make lint` passes (0 errors)
- [x] `make typecheck` passes (pyright 0 errors)
- [x] All new/modified test files pass (260 tests, 0 failures)
- [x] `make quality` passes (only pre-existing Docker module failures)
- [x] ManifestRefreshLoop: initial refresh, state hash update, status callback, error handling, error event publishing, disabled skipping, interval handling
- [x] HITL runner: manifest present/absent, digest present/absent
- [x] Conflict prompt: manifest with config, learnings with config, no config, config but no file
- [x] Orchestrator: loop exists, method exists, runs in supervisor, interval returns correct value
- [x] Cross-runner manifest injection: agent, hitl, conflict_prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)