### PR TITLE
Fixes #786: Fix stage dots, session duplication, and sidebar session naming

### DIFF
--- a/ui/src/components/SessionSidebar.jsx
+++ b/ui/src/components/SessionSidebar.jsx
@@ -2,19 +2,6 @@ import React, { useState, useMemo } from 'react'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { theme } from '../theme'
 
-function relativeTime(isoString) {
-  if (!isoString) return ''
-  const diff = Date.now() - new Date(isoString).getTime()
-  const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return 'just now'
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
-
 export function SessionSidebar() {
   const { sessions, currentSessionId, selectedSessionId, selectSession } = useHydraFlow()
   const [expandedRepos, setExpandedRepos] = useState({})
@@ -85,7 +72,7 @@ export function SessionSidebar() {
                     <span style={isActive ? styles.dotActive : styles.dotCompleted} />
                     <div style={styles.sessionInfo}>
                       <span style={styles.sessionTime}>
-                        {relativeTime(session.started_at)}
+                        {session.started_at ? new Date(session.started_at).toLocaleString() : ''}
                       </span>
                       <div style={styles.sessionMeta}>
                         {issueCount > 0 && (

--- a/ui/src/components/StreamView.jsx
+++ b/ui/src/components/StreamView.jsx
@@ -101,12 +101,10 @@ function StageSection({ stage, issues, workerCount, intentMap, onViewTranscript,
             <span>{issues.length} merged</span>
           )}
         </span>
-        {hasRole && (
-          <span
-            style={{ ...styles.statusDot, background: dotColor }}
-            data-testid={`stage-dot-${stage.key}`}
-          />
-        )}
+        <span
+          style={{ ...styles.statusDot, background: dotColor }}
+          data-testid={`stage-dot-${stage.key}`}
+        />
       </div>
       {open && issues.map(issue => (
         <StreamCard
@@ -277,7 +275,9 @@ export function StreamView({ intents, expandedStages, onToggleStage, onViewTrans
         const enabled = status.enabled !== false
         const workerCount = status.workerCount || 0
         let dotColor
-        if (!enabled) {
+        if (!stage.role) {
+          dotColor = theme.green
+        } else if (!enabled) {
           dotColor = theme.red
         } else if (workerCount > 0) {
           dotColor = theme.green

--- a/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -227,3 +227,29 @@ describe('SessionSidebar active session state', () => {
     expect(screen.getByText('org/repo')).toBeDefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Session naming: date/time instead of relative time
+// ---------------------------------------------------------------------------
+
+describe('SessionSidebar session naming', () => {
+  it('displays formatted date/time instead of relative time', () => {
+    mockUseHydraFlow.mockReturnValue(
+      defaultContext({ sessions: [SESSION_A] })
+    )
+    render(<SessionSidebar />)
+    // Should show toLocaleString() output for the session's started_at
+    const expected = new Date(SESSION_A.started_at).toLocaleString()
+    expect(screen.getByText(expected)).toBeDefined()
+  })
+
+  it('does not show relative time strings', () => {
+    mockUseHydraFlow.mockReturnValue(
+      defaultContext({ sessions: [SESSION_A] })
+    )
+    render(<SessionSidebar />)
+    // Relative time strings like "Xm ago", "Xh ago", "Xd ago" should not appear
+    expect(screen.queryByText(/\d+[mhd] ago/)).toBeNull()
+    expect(screen.queryByText('just now')).toBeNull()
+  })
+})

--- a/ui/src/components/__tests__/StreamView.test.jsx
+++ b/ui/src/components/__tests__/StreamView.test.jsx
@@ -150,10 +150,12 @@ describe('StreamView stage indicators', () => {
     })
   })
 
-  describe('Merged stage exclusion', () => {
-    it('does not render status dot for merged stage', () => {
+  describe('Merged stage dot', () => {
+    it('renders green status dot for merged stage', () => {
       render(<StreamView {...defaultProps} />)
-      expect(screen.queryByTestId('stage-dot-merged')).not.toBeInTheDocument()
+      const dot = screen.getByTestId('stage-dot-merged')
+      expect(dot).toBeInTheDocument()
+      expect(dot.style.background).toBe('var(--green)')
     })
   })
 

--- a/ui/src/context/HydraFlowContext.jsx
+++ b/ui/src/context/HydraFlowContext.jsx
@@ -565,9 +565,10 @@ export function reducer(state, action) {
         issues_failed: 0,
         status: 'active',
       }
+      const filtered = state.sessions.filter(s => s.id !== action.data.session_id)
       return {
         ...addEvent(state, action),
-        sessions: [newSession, ...state.sessions],
+        sessions: [newSession, ...filtered],
         currentSessionId: action.data.session_id,
       }
     }
@@ -592,8 +593,13 @@ export function reducer(state, action) {
       }
     }
 
-    case 'SESSIONS':
-      return { ...state, sessions: action.data || [] }
+    case 'SESSIONS': {
+      const fetched = action.data || []
+      const fetchedIds = new Set(fetched.map(s => s.id))
+      // Keep any active session added via WS event that isn't in the HTTP response yet
+      const preserved = state.sessions.filter(s => s.status === 'active' && !fetchedIds.has(s.id))
+      return { ...state, sessions: [...preserved, ...fetched] }
+    }
 
     case 'SELECT_SESSION':
       return { ...state, selectedSessionId: action.data.sessionId }

--- a/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -446,6 +446,25 @@ describe('session_start reducer', () => {
     expect(result.sessions[0].id).toBe('new-session')
     expect(result.sessions[1].id).toBe('old-session')
   })
+
+  it('deduplicates when session_start fires for an existing session id', () => {
+    const state = {
+      ...initialState,
+      sessions: [
+        { id: 'sess-1', repo: 'test/repo', status: 'active', started_at: '2026-02-22T12:00:00Z' },
+        { id: 'old-session', repo: 'test/repo', status: 'completed', started_at: '2026-02-21T12:00:00Z' },
+      ],
+      currentSessionId: 'sess-1',
+    }
+    const result = reducer(state, {
+      type: 'session_start',
+      data: { session_id: 'sess-1', repo: 'test/repo' },
+      timestamp: '2026-02-22T12:00:01Z',
+    })
+    expect(result.sessions).toHaveLength(2)
+    expect(result.sessions[0].id).toBe('sess-1')
+    expect(result.sessions[1].id).toBe('old-session')
+  })
 })
 
 describe('session_end reducer', () => {
@@ -510,6 +529,38 @@ describe('SESSIONS reducer', () => {
   it('handles null data gracefully', () => {
     const result = reducer(initialState, { type: 'SESSIONS', data: null })
     expect(result.sessions).toEqual([])
+  })
+
+  it('preserves active WS session not yet in HTTP response', () => {
+    const state = {
+      ...initialState,
+      sessions: [
+        { id: 'ws-session', repo: 'test/repo', status: 'active', started_at: '2026-02-22T12:00:00Z' },
+      ],
+    }
+    const fetched = [
+      { id: 'old-session', repo: 'test/repo', status: 'completed', started_at: '2026-02-21T12:00:00Z' },
+    ]
+    const result = reducer(state, { type: 'SESSIONS', data: fetched })
+    expect(result.sessions).toHaveLength(2)
+    expect(result.sessions[0].id).toBe('ws-session')
+    expect(result.sessions[1].id).toBe('old-session')
+  })
+
+  it('does not duplicate active session already in HTTP response', () => {
+    const state = {
+      ...initialState,
+      sessions: [
+        { id: 's1', repo: 'test/repo', status: 'active', started_at: '2026-02-22T12:00:00Z' },
+      ],
+    }
+    const fetched = [
+      { id: 's1', repo: 'test/repo', status: 'active', started_at: '2026-02-22T12:00:00Z' },
+      { id: 's0', repo: 'test/repo', status: 'completed', started_at: '2026-02-21T12:00:00Z' },
+    ]
+    const result = reducer(state, { type: 'SESSIONS', data: fetched })
+    expect(result.sessions).toHaveLength(2)
+    expect(result.sessions.filter(s => s.id === 's1')).toHaveLength(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- **Session dedup**: `session_start` reducer now filters out any existing session with the same ID before prepending, preventing 3x duplicate sidebar entries from WS race conditions
- **SESSIONS merge**: HTTP-fetched sessions now preserve any active WS session not yet in the response, preventing clobber on reconnect
- **Merged stage dot**: Removed `hasRole` guard so the merged stage always renders a green status dot
- **Session naming**: Replaced `relativeTime()` with `toLocaleString()` for absolute date/time display (e.g. `2/22/2026, 5:19:59 PM`)

## Test plan
- [x] `cd ui && npx vitest run` — all 592 tests pass
- [x] `make lint` — no lint errors
- [ ] Manual: press Start, verify only 1 session entry appears in sidebar
- [ ] Manual: verify merged stage shows a green dot
- [ ] Manual: verify sidebar shows date/time instead of "Xm ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)