### PR TITLE
Fixes #813: Move Memory Auto-Approve toggle onto the Memory Manager...

### DIFF
--- a/ui/src/components/SystemPanel.jsx
+++ b/ui/src/components/SystemPanel.jsx
@@ -194,7 +194,6 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
           ))}
         </div>
       )}
-      {extraContent}
       {hasDetails && (
         <div style={isError ? (onViewLog ? styles.detailsErrorCompact : styles.detailsError) : styles.details}>
           {Object.entries(details).map(([k, v]) => (
@@ -205,6 +204,7 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
           ))}
         </div>
       )}
+      {extraContent}
       {onViewLog && (
         <div style={styles.cardActions}>
           <span

--- a/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -209,10 +209,8 @@ describe('SystemPanel', () => {
       const onToggle = vi.fn()
       mockUseHydraFlow.mockReturnValue(defaultMockContext({ orchestratorStatus: 'running', backgroundWorkers: mockBgWorkers }))
       render(<SystemPanel backgroundWorkers={mockBgWorkers} onToggleBgWorker={onToggle} />)
-      // Click the worker Off button (not the memory auto-approve toggle)
-      const offButtons = screen.getAllByText('Off')
-      const workerOffButton = offButtons.find(btn => btn.dataset.testid !== 'memory-auto-approve-toggle')
-      fireEvent.click(workerOffButton)
+      const reviewInsightsCard = screen.getByTestId('worker-card-review_insights')
+      fireEvent.click(within(reviewInsightsCard).getByText('Off'))
       expect(onToggle).toHaveBeenCalledWith('review_insights', true)
     })
 


### PR DESCRIPTION
## Summary

Closes #813.

## Issue

Move Memory Auto-Approve toggle onto the Memory Manager card

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow