### PR TITLE
Fixes #837: PR unsticker must verify pipeline cycle history and rev...

### DIFF
--- a/models.py
+++ b/models.py
@@ -454,6 +454,7 @@ class StateData(BaseModel):
     metrics_last_snapshot_hash: str = ""
     metrics_last_synced: str | None = None
     worker_intervals: dict[str, int] = Field(default_factory=dict)
+    last_reviewed_sha: dict[str, str] = Field(default_factory=dict)
     last_updated: str | None = None
 
 

--- a/post_merge_handler.py
+++ b/post_merge_handler.py
@@ -83,6 +83,7 @@ class PostMergeHandler:
             self._state.mark_issue(pr.issue_number, "merged")
             self._state.record_pr_merged()
             self._state.record_issue_completed()
+            self._state.clear_last_reviewed_sha(pr.number)
             if result.ci_fix_attempts > 0:
                 self._state.record_ci_fix_rounds(result.ci_fix_attempts)
                 for _ in range(result.ci_fix_attempts):

--- a/pr_manager.py
+++ b/pr_manager.py
@@ -500,6 +500,41 @@ class PRManager:
             logger.error("Issue creation failed for %r: %s", title, exc)
             return 0
 
+    async def get_pr_reviews(self, pr_number: int) -> list[dict[str, str]]:
+        """Fetch reviews for *pr_number* with author and state info."""
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "api",
+                f"repos/{self._repo}/pulls/{pr_number}/reviews",
+                "--jq",
+                "[.[] | {author: .user.login, state: .state}]",
+            )
+            return json.loads(raw)  # type: ignore[no-any-return]
+        except (RuntimeError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch reviews for PR #%d: %s", pr_number, exc)
+            return []
+
+    async def get_pr_head_sha(self, pr_number: int) -> str:
+        """Fetch the HEAD commit SHA for *pr_number*. Returns empty string on failure."""
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                self._repo,
+                "--json",
+                "headRefOid",
+                "--jq",
+                ".headRefOid",
+            )
+            return raw.strip()
+        except RuntimeError as exc:
+            logger.warning("Could not get HEAD SHA for PR #%d: %s", pr_number, exc)
+            return ""
+
     async def get_pr_diff(self, pr_number: int) -> str:
         """Fetch the diff for *pr_number*."""
         try:

--- a/review_phase.py
+++ b/review_phase.py
@@ -140,6 +140,28 @@ class ReviewPhase:
 
         return results
 
+    async def _should_skip_review(self, pr: PRInfo) -> bool:
+        """Return True if this PR was already reviewed at its current HEAD.
+
+        Relies on internal state tracking (``last_reviewed_sha``) rather than
+        querying the GitHub Reviews API, since ``SelfReviewError`` means the
+        bot may not have a formal review on its own PRs.
+        """
+        head_sha = await self._prs.get_pr_head_sha(pr.number)
+        if not head_sha:
+            return False  # Can't determine — proceed with review
+
+        last_sha = self._state.get_last_reviewed_sha(pr.number)
+        if last_sha != head_sha:
+            return False  # New commits since last review — proceed
+
+        logger.info(
+            "PR #%d: skipping review — already reviewed at SHA %s",
+            pr.number,
+            head_sha[:8],
+        )
+        return True
+
     async def _review_one_inner(
         self,
         idx: int,
@@ -155,6 +177,13 @@ class ReviewPhase:
                 pr_number=pr.number,
                 issue_number=pr.issue_number,
                 summary="Issue not found",
+            )
+
+        if await self._should_skip_review(pr):
+            return ReviewResult(
+                pr_number=pr.number,
+                issue_number=pr.issue_number,
+                summary="Skipped — already reviewed at current HEAD",
             )
 
         wt_path = self._config.worktree_base / f"issue-{pr.issue_number}"
@@ -221,6 +250,11 @@ class ReviewPhase:
         if result.duration_seconds > 0:
             self._state.record_review_duration(result.duration_seconds)
         await self._record_review_insight(result)
+
+        # Record HEAD SHA so we can skip re-review if no new commits arrive
+        head_sha = await self._prs.get_pr_head_sha(pr.number)
+        if head_sha and isinstance(head_sha, str):
+            self._state.set_last_reviewed_sha(pr.number, head_sha)
 
         # Verdict-specific handling
         skip_worktree_cleanup = False
@@ -511,6 +545,7 @@ class ReviewPhase:
         self._state.set_hitl_origin(issue_number, origin_label)
         self._state.set_hitl_cause(issue_number, cause)
         self._state.record_hitl_escalation()
+        self._state.clear_last_reviewed_sha(pr_number)
 
         await self._prs.swap_pipeline_labels(
             issue_number,
@@ -626,6 +661,7 @@ class ReviewPhase:
             # Under cap: re-queue for implementation with feedback
             new_count = self._state.increment_review_attempts(pr.issue_number)
             self._state.set_review_feedback(pr.issue_number, result.summary)
+            self._state.clear_last_reviewed_sha(pr.number)
 
             # Swap labels: review → ready (issue and PR)
             await self._prs.swap_pipeline_labels(

--- a/state.py
+++ b/state.py
@@ -329,6 +329,22 @@ class StateTracker:
             self._data.manifest_last_updated,
         )
 
+    # --- last reviewed SHA tracking ---
+
+    def set_last_reviewed_sha(self, pr_number: int, sha: str) -> None:
+        """Record the commit SHA at which *pr_number* was last reviewed."""
+        self._data.last_reviewed_sha[str(pr_number)] = sha
+        self.save()
+
+    def get_last_reviewed_sha(self, pr_number: int) -> str | None:
+        """Return the SHA at which *pr_number* was last reviewed, or *None*."""
+        return self._data.last_reviewed_sha.get(str(pr_number))
+
+    def clear_last_reviewed_sha(self, pr_number: int) -> None:
+        """Clear the last reviewed SHA for *pr_number*."""
+        self._data.last_reviewed_sha.pop(str(pr_number), None)
+        self.save()
+
     # --- worker interval overrides ---
 
     def get_worker_intervals(self) -> dict[str, int]:

--- a/tests/test_review_skip_guard.py
+++ b/tests/test_review_skip_guard.py
@@ -1,0 +1,441 @@
+"""Tests for the review skip guard — preventing re-review when no new commits."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+from models import ReviewVerdict, StateData
+from tests.conftest import IssueFactory, PRInfoFactory, ReviewResultFactory
+from tests.helpers import make_review_phase
+
+# ---------------------------------------------------------------------------
+# StateData model — last_reviewed_sha field
+# ---------------------------------------------------------------------------
+
+
+class TestStateDataLastReviewedSha:
+    """Tests for the last_reviewed_sha field on StateData."""
+
+    def test_defaults_to_empty_dict(self) -> None:
+        data = StateData()
+        assert data.last_reviewed_sha == {}
+
+    def test_migration_from_old_state_file(self, tmp_path: Path) -> None:
+        """Loading a state file without last_reviewed_sha should default to {}."""
+        from state import StateTracker
+
+        state_file = tmp_path / "state.json"
+        old_data = {
+            "current_batch": 5,
+            "processed_issues": {"1": "success"},
+            "active_worktrees": {},
+            "active_branches": {},
+            "reviewed_prs": {},
+            "last_updated": None,
+        }
+        state_file.write_text(json.dumps(old_data))
+
+        tracker = StateTracker(state_file)
+        assert tracker.get_last_reviewed_sha(101) is None
+        assert tracker.get_current_batch() == 5
+
+
+# ---------------------------------------------------------------------------
+# StateTracker — last_reviewed_sha methods
+# ---------------------------------------------------------------------------
+
+
+class TestStateTrackerLastReviewedSha:
+    """Tests for set/get/clear last_reviewed_sha on StateTracker."""
+
+    def test_set_and_get_last_reviewed_sha(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.set_last_reviewed_sha(101, "abc123")
+        assert tracker.get_last_reviewed_sha(101) == "abc123"
+
+    def test_get_returns_none_for_unknown(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        assert tracker.get_last_reviewed_sha(999) is None
+
+    def test_clear_last_reviewed_sha(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.set_last_reviewed_sha(101, "abc123")
+        tracker.clear_last_reviewed_sha(101)
+        assert tracker.get_last_reviewed_sha(101) is None
+
+    def test_clear_nonexistent_is_noop(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.clear_last_reviewed_sha(999)
+        assert tracker.get_last_reviewed_sha(999) is None
+
+    def test_persists_across_reload(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        state_file = tmp_path / "state.json"
+        tracker = StateTracker(state_file)
+        tracker.set_last_reviewed_sha(101, "abc123")
+
+        tracker2 = StateTracker(state_file)
+        assert tracker2.get_last_reviewed_sha(101) == "abc123"
+
+    def test_set_overwrites_previous(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.set_last_reviewed_sha(101, "abc123")
+        tracker.set_last_reviewed_sha(101, "def456")
+        assert tracker.get_last_reviewed_sha(101) == "def456"
+
+    def test_multiple_prs_tracked_independently(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.set_last_reviewed_sha(101, "sha_a")
+        tracker.set_last_reviewed_sha(102, "sha_b")
+        assert tracker.get_last_reviewed_sha(101) == "sha_a"
+        assert tracker.get_last_reviewed_sha(102) == "sha_b"
+
+    def test_reset_clears_last_reviewed_sha(self, tmp_path: Path) -> None:
+        from state import StateTracker
+
+        tracker = StateTracker(tmp_path / "state.json")
+        tracker.set_last_reviewed_sha(101, "abc123")
+        tracker.reset()
+        assert tracker.get_last_reviewed_sha(101) is None
+
+
+# ---------------------------------------------------------------------------
+# PRManager — get_pr_reviews
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrReviews:
+    """Tests for PRManager.get_pr_reviews."""
+
+    @pytest.mark.asyncio
+    async def test_returns_review_list(self, config: HydraFlowConfig) -> None:
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, AsyncMock())
+        reviews = [
+            {"author": "bot-user", "state": "CHANGES_REQUESTED"},
+            {"author": "human", "state": "APPROVED"},
+        ]
+        pr_mgr._run_gh = AsyncMock(return_value=json.dumps(reviews))
+
+        result = await pr_mgr.get_pr_reviews(101)
+        assert len(result) == 2
+        assert result[0]["state"] == "CHANGES_REQUESTED"
+        assert result[1]["author"] == "human"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_error(self, config: HydraFlowConfig) -> None:
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, AsyncMock())
+        pr_mgr._run_gh = AsyncMock(side_effect=RuntimeError("API error"))
+
+        result = await pr_mgr.get_pr_reviews(101)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_json_decode_error(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, AsyncMock())
+        pr_mgr._run_gh = AsyncMock(return_value="not json")
+
+        result = await pr_mgr.get_pr_reviews(101)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# PRManager — get_pr_head_sha
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrHeadSha:
+    """Tests for PRManager.get_pr_head_sha."""
+
+    @pytest.mark.asyncio
+    async def test_returns_sha_string(self, config: HydraFlowConfig) -> None:
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, AsyncMock())
+        pr_mgr._run_gh = AsyncMock(return_value="abc123def456\n")
+
+        result = await pr_mgr.get_pr_head_sha(101)
+        assert result == "abc123def456"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_error(self, config: HydraFlowConfig) -> None:
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, AsyncMock())
+        pr_mgr._run_gh = AsyncMock(side_effect=RuntimeError("API error"))
+
+        result = await pr_mgr.get_pr_head_sha(101)
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# ReviewPhase — _should_skip_review
+# ---------------------------------------------------------------------------
+
+
+class TestShouldSkipReview:
+    """Tests for ReviewPhase._should_skip_review."""
+
+    @pytest.mark.asyncio
+    async def test_skip_when_sha_matches(self, config: HydraFlowConfig) -> None:
+        """Skip review when last reviewed SHA matches current HEAD."""
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create()
+
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="abc123")
+        phase._state.set_last_reviewed_sha(pr.number, "abc123")
+
+        assert await phase._should_skip_review(pr) is True
+
+    @pytest.mark.asyncio
+    async def test_proceed_when_sha_differs(self, config: HydraFlowConfig) -> None:
+        """Proceed when new commits have been pushed since last review."""
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create()
+
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="new_sha")
+        phase._state.set_last_reviewed_sha(pr.number, "old_sha")
+
+        assert await phase._should_skip_review(pr) is False
+
+    @pytest.mark.asyncio
+    async def test_proceed_when_no_prior_review(self, config: HydraFlowConfig) -> None:
+        """Proceed when no last_reviewed_sha exists (first review)."""
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create()
+
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="abc123")
+        # No set_last_reviewed_sha call — returns None
+
+        assert await phase._should_skip_review(pr) is False
+
+    @pytest.mark.asyncio
+    async def test_proceed_when_head_sha_fetch_fails(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Proceed (safe fallback) when HEAD SHA cannot be determined."""
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create()
+
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="")
+
+        assert await phase._should_skip_review(pr) is False
+
+
+# ---------------------------------------------------------------------------
+# ReviewPhase — SHA recorded after review
+# ---------------------------------------------------------------------------
+
+
+class TestShaRecordedAfterReview:
+    """Tests that last_reviewed_sha is set after a review completes."""
+
+    @pytest.mark.asyncio
+    async def test_sha_recorded_during_review(self, config: HydraFlowConfig) -> None:
+        """Verify set_last_reviewed_sha is called with the HEAD SHA after review."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.get_pr_diff_names = AsyncMock(return_value=[])
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="review_sha_123")
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.submit_review = AsyncMock(return_value=True)
+        phase._prs.swap_pipeline_labels = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # Ensure worktree path exists
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        # Spy on set_last_reviewed_sha to verify it was called
+        with patch.object(
+            phase._state,
+            "set_last_reviewed_sha",
+            wraps=phase._state.set_last_reviewed_sha,
+        ) as spy:
+            await phase.review_prs([pr], [issue])
+            spy.assert_called_with(pr.number, "review_sha_123")
+
+    @pytest.mark.asyncio
+    async def test_sha_cleared_after_successful_merge(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # APPROVE verdict with successful merge — SHA recorded then cleared
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.get_pr_diff_names = AsyncMock(return_value=[])
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="review_sha_123")
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.submit_review = AsyncMock(return_value=True)
+        phase._prs.swap_pipeline_labels = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # Ensure worktree path exists
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        await phase.review_prs([pr], [issue])
+
+        # SHA should be cleared after successful merge
+        assert phase._state.get_last_reviewed_sha(pr.number) is None
+
+
+# ---------------------------------------------------------------------------
+# ReviewPhase — SHA cleared on re-queue
+# ---------------------------------------------------------------------------
+
+
+class TestShaClearedOnRequeue:
+    """Tests that last_reviewed_sha is cleared when PR is re-queued."""
+
+    @pytest.mark.asyncio
+    async def test_sha_cleared_on_rejected_review_requeue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Set up a REQUEST_CHANGES result so the PR is re-queued
+        reject_result = ReviewResultFactory.create(
+            verdict=ReviewVerdict.REQUEST_CHANGES,
+            summary="Needs fixes",
+            transcript="review",
+        )
+        phase._reviewers.review = AsyncMock(return_value=reject_result)
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.get_pr_diff_names = AsyncMock(return_value=[])
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="sha_before_requeue")
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.submit_review = AsyncMock(return_value=True)
+        phase._prs.swap_pipeline_labels = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+        phase._prs.post_comment = AsyncMock()
+
+        # Pre-set SHA to verify it gets cleared
+        phase._state.set_last_reviewed_sha(pr.number, "old_sha")
+
+        # Ensure worktree path exists
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        await phase.review_prs([pr], [issue])
+
+        # SHA should be cleared since the PR was re-queued for implementation
+        assert phase._state.get_last_reviewed_sha(pr.number) is None
+
+
+# ---------------------------------------------------------------------------
+# ReviewPhase — SHA cleared on HITL escalation
+# ---------------------------------------------------------------------------
+
+
+class TestShaClearedOnHitlEscalation:
+    """Tests that last_reviewed_sha is cleared on HITL escalation."""
+
+    @pytest.mark.asyncio
+    async def test_sha_cleared_on_hitl_escalation(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create()
+
+        # Pre-set SHA
+        phase._state.set_last_reviewed_sha(pr.number, "some_sha")
+
+        phase._prs.swap_pipeline_labels = AsyncMock()
+        phase._prs.post_pr_comment = AsyncMock()
+
+        await phase._escalate_to_hitl(
+            issue_number=pr.issue_number,
+            pr_number=pr.number,
+            cause="Test escalation",
+            origin_label="hydraflow-review",
+            comment="Escalating for test",
+        )
+
+        assert phase._state.get_last_reviewed_sha(pr.number) is None
+
+
+# ---------------------------------------------------------------------------
+# ReviewPhase — skipped PR returns benign ReviewResult
+# ---------------------------------------------------------------------------
+
+
+class TestSkippedPrReturnsResult:
+    """Tests that a skipped PR returns a ReviewResult without errors."""
+
+    @pytest.mark.asyncio
+    async def test_skipped_pr_returns_result_with_summary(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Set up skip condition: SHA matches
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="matched_sha")
+        phase._state.set_last_reviewed_sha(pr.number, "matched_sha")
+
+        # Ensure worktree path exists
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        results = await phase.review_prs([pr], [issue])
+
+        assert len(results) == 1
+        assert results[0].summary == "Skipped — already reviewed at current HEAD"
+        assert results[0].pr_number == pr.number
+        assert results[0].issue_number == pr.issue_number
+
+        # review() should NOT have been called
+        phase._reviewers.review.assert_not_awaited()  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

Closes #837.

## Issue

PR unsticker must verify pipeline cycle history and review issues before acting

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow