### PR TITLE
Detect 'You've hit your limit' as credit exhaustion

### DIFF
--- a/subprocess_util.py
+++ b/subprocess_util.py
@@ -46,11 +46,13 @@ _AUTH_PATTERNS = ("401", "not logged in", "authentication required", "auth token
 _CREDIT_PATTERNS = (
     "usage limit reached",
     "credit balance is too low",
+    "you've hit your limit",
 )
 
-# Matches e.g. "reset at 3pm (America/New_York)" or "reset at 3am"
+# Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",
+# "resets 5am (America/Denver)", "resets at 5am"
 _RESET_TIME_RE = re.compile(
-    r"reset\s+at\s+(\d{1,2})\s*(am|pm)"
+    r"resets?\s+(?:at\s+)?(\d{1,2})\s*(am|pm)"
     r"(?:\s*\(([^)]+)\))?",
     re.IGNORECASE,
 )
@@ -65,9 +67,10 @@ def is_credit_exhaustion(text: str) -> bool:
 def parse_credit_resume_time(text: str) -> datetime | None:
     """Extract the credit reset time from an error message.
 
-    Looks for patterns like ``"reset at 3pm (America/New_York)"`` or
-    ``"reset at 3am"``. Returns a timezone-aware UTC datetime, or
-    ``None`` if no parseable time is found.
+    Looks for patterns like ``"reset at 3pm (America/New_York)"``,
+    ``"reset at 3am"``, or ``"resets 5am (America/Denver)"``.
+    Returns a timezone-aware UTC datetime, or ``None`` if no
+    parseable time is found.
 
     When the parsed time is already past, we assume the reset is
     tomorrow at the same time.

--- a/tests/test_credit_pause.py
+++ b/tests/test_credit_pause.py
@@ -82,9 +82,13 @@ class TestIsCreditExhaustion:
     def test_returns_false_for_normal_text(self) -> None:
         assert is_credit_exhaustion("Everything is fine") is False
 
+    def test_detects_youve_hit_your_limit(self) -> None:
+        assert is_credit_exhaustion("You've hit your limit · resets 5am") is True
+
     def test_is_case_insensitive(self) -> None:
         assert is_credit_exhaustion("USAGE LIMIT REACHED") is True
         assert is_credit_exhaustion("Credit Balance Is Too Low") is True
+        assert is_credit_exhaustion("YOU'VE HIT YOUR LIMIT") is True
 
 
 # ===========================================================================
@@ -158,6 +162,20 @@ class TestParseCreditResumeTime:
         assert parse_credit_resume_time("reset at 0am") is None
         assert parse_credit_resume_time("reset at 13pm") is None
         assert parse_credit_resume_time("reset at 99am") is None
+
+    def test_extracts_resets_format(self) -> None:
+        """Matches 'resets 5am (America/Denver)' — no 'at', verb is 'resets'."""
+        text = "You've hit your limit · resets 5am (America/Denver)"
+        result = parse_credit_resume_time(text)
+        assert result is not None
+        denver = result.astimezone(ZoneInfo("America/Denver"))
+        assert denver.hour == 5
+
+    def test_extracts_resets_at_format(self) -> None:
+        """Matches 'resets at 5am' — 'resets' + 'at'."""
+        text = "resets at 5am"
+        result = parse_credit_resume_time(text)
+        assert result is not None
 
     def test_invalid_timezone_falls_back(self) -> None:
         """Unknown timezone should not crash, falls back to local time."""
@@ -268,6 +286,27 @@ class TestStreamClaudeProcessCreditDetection:
             await stream_claude_process(
                 **_default_stream_kwargs(event_bus, on_output=kill_immediately)
             )
+
+    @pytest.mark.asyncio
+    async def test_raises_credit_exhausted_on_hit_limit_message(
+        self, event_bus
+    ) -> None:
+        """'You've hit your limit' in stdout triggers CreditExhaustedError with parsed resume_at."""
+        mock_create = make_streaming_proc(
+            returncode=1,
+            stdout="You've hit your limit · resets 5am (America/Denver)",
+            stderr="",
+        )
+
+        with (
+            patch("asyncio.create_subprocess_exec", mock_create),
+            pytest.raises(CreditExhaustedError) as exc_info,
+        ):
+            await stream_claude_process(**_default_stream_kwargs(event_bus))
+
+        assert exc_info.value.resume_at is not None
+        denver = exc_info.value.resume_at.astimezone(ZoneInfo("America/Denver"))
+        assert denver.hour == 5
 
     @pytest.mark.asyncio
     async def test_credit_exhausted_with_no_time_has_none_resume(


### PR DESCRIPTION
## Summary
- Adds `"you've hit your limit"` to `_CREDIT_PATTERNS` in `subprocess_util.py` so the existing `_pause_for_credits()` mechanism triggers on Claude's account-level usage limit message
- Fixes `_RESET_TIME_RE` to match `"resets 5am (America/Denver)"` format (plural verb, no "at", no space before am/pm)
- Adds 4 new tests covering the new pattern, regex variants, and end-to-end `stream_claude_process` detection

## Test plan
- [x] `make quality` passes (lint + typecheck + 3963 tests)
- [x] `pytest tests/test_credit_pause.py -v` — all 38 tests pass including 4 new ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)