### PR TITLE
Collapse unstick_max_workers into pr_unstick_batch_size

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,7 +52,6 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("git_command_timeout", "HYDRAFLOW_GIT_COMMAND_TIMEOUT", 30),
     ("summarizer_timeout", "HYDRAFLOW_SUMMARIZER_TIMEOUT", 120),
     ("error_output_max_chars", "HYDRAFLOW_ERROR_OUTPUT_MAX_CHARS", 3000),
-    ("unstick_max_workers", "HYDRAFLOW_UNSTICK_MAX_WORKERS", 3),
 ]
 
 _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
@@ -561,7 +560,7 @@ class HydraFlowConfig(BaseModel):
         default=10,
         ge=1,
         le=50,
-        description="Max HITL items to process per unsticker cycle",
+        description="Max PRs to unstick per cycle (fetch limit and parallel workers)",
     )
     unstick_auto_merge: bool = Field(
         default=True,
@@ -570,12 +569,6 @@ class HydraFlowConfig(BaseModel):
     unstick_all_causes: bool = Field(
         default=True,
         description="Process all HITL causes (not just merge conflicts)",
-    )
-    unstick_max_workers: int = Field(
-        default=3,
-        ge=1,
-        le=10,
-        description="Max parallel fix workers for the PR unsticker",
     )
 
     # Session retention

--- a/dashboard_routes.py
+++ b/dashboard_routes.py
@@ -440,7 +440,7 @@ def create_router(
                 batch_size=config.batch_size,
                 model=config.model,
                 memory_auto_approve=config.memory_auto_approve,
-                unstick_max_workers=config.unstick_max_workers,
+                pr_unstick_batch_size=config.pr_unstick_batch_size,
             ),
         )
         data = response.model_dump()
@@ -468,7 +468,6 @@ def create_router(
         "pr_unstick_interval",
         "pr_unstick_batch_size",
         "memory_auto_approve",
-        "unstick_max_workers",
         "unstick_auto_merge",
         "unstick_all_causes",
     }

--- a/models.py
+++ b/models.py
@@ -537,7 +537,7 @@ class ControlStatusConfig(BaseModel):
     batch_size: int = 0
     model: str = ""
     memory_auto_approve: bool = False
-    unstick_max_workers: int = 3
+    pr_unstick_batch_size: int = 10
 
 
 class ControlStatusResponse(BaseModel):

--- a/pr_unsticker.py
+++ b/pr_unsticker.py
@@ -141,11 +141,12 @@ class PRUnsticker:
         )
 
         # Apply batch size limit
-        batch = candidates[: self._config.pr_unstick_batch_size]
+        batch_size = self._config.pr_unstick_batch_size
+        batch = candidates[:batch_size]
         stats["skipped"] = len(hitl_items) - len(batch)
 
         # --- PARALLEL FIX PHASE ---
-        semaphore = asyncio.Semaphore(self._config.unstick_max_workers)
+        semaphore = asyncio.Semaphore(batch_size)
         fixed: list[HITLItem] = []
         stuck: list[HITLItem] = []
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -227,7 +227,6 @@ class ConfigFactory:
         error_output_max_chars: int = 3000,
         unstick_auto_merge: bool = True,
         unstick_all_causes: bool = True,
-        unstick_max_workers: int = 3,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -361,7 +360,6 @@ class ConfigFactory:
             error_output_max_chars=error_output_max_chars,
             unstick_auto_merge=unstick_auto_merge,
             unstick_all_causes=unstick_all_causes,
-            unstick_max_workers=unstick_max_workers,
         )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4110,56 +4110,6 @@ class TestUnstickConfigFields:
         )
         assert cfg.unstick_all_causes is True
 
-    def test_unstick_max_workers_default(self, tmp_path: Path) -> None:
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.unstick_max_workers == 3
-
-    def test_unstick_max_workers_custom(self, tmp_path: Path) -> None:
-        cfg = HydraFlowConfig(
-            unstick_max_workers=5,
-            repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.unstick_max_workers == 5
-
-    def test_unstick_max_workers_below_minimum_raises(self, tmp_path: Path) -> None:
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
-            HydraFlowConfig(
-                unstick_max_workers=0,
-                repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
-                state_file=tmp_path / "s.json",
-            )
-
-    def test_unstick_max_workers_above_maximum_raises(self, tmp_path: Path) -> None:
-        import pydantic
-
-        with pytest.raises(pydantic.ValidationError):
-            HydraFlowConfig(
-                unstick_max_workers=11,
-                repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
-                state_file=tmp_path / "s.json",
-            )
-
-    def test_unstick_max_workers_env_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_UNSTICK_MAX_WORKERS", "5")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.unstick_max_workers == 5
-
     def test_unstick_auto_merge_env_override(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -599,14 +599,14 @@ class TestPriorityOrdering:
 
 
 class TestParallelWorkers:
-    """Verify semaphore limits concurrent fixes to unstick_max_workers."""
+    """Verify semaphore limits concurrent fixes to pr_unstick_batch_size."""
 
     @pytest.mark.asyncio
     async def test_semaphore_limits_concurrency(self, tmp_path: Path) -> None:
         max_workers = 2
         unsticker, state, prs, agents, wt, fetcher, bus, _ = _make_unsticker(
             tmp_path,
-            unstick_max_workers=max_workers,
+            pr_unstick_batch_size=max_workers,
             unstick_all_causes=True,
             unstick_auto_merge=False,
         )

--- a/ui/src/components/SystemPanel.jsx
+++ b/ui/src/components/SystemPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react'
 import { theme } from '../theme'
-import { BACKGROUND_WORKERS, INTERVAL_PRESETS, EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS, UNSTICK_WORKER_OPTIONS } from '../constants'
+import { BACKGROUND_WORKERS, INTERVAL_PRESETS, EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS, UNSTICK_BATCH_OPTIONS } from '../constants'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { Livestream } from './Livestream'
 import { PipelineControlPanel } from './PipelineControlPanel'
@@ -283,7 +283,7 @@ function UnstickWorkersDropdown() {
   const { config } = useHydraFlow()
   const [localValue, setLocalValue] = useState(null)
 
-  const currentValue = localValue !== null ? localValue : (config?.unstick_max_workers ?? 3)
+  const currentValue = localValue !== null ? localValue : (config?.pr_unstick_batch_size ?? 3)
 
   const handleChange = useCallback(async (e) => {
     const newValue = parseInt(e.target.value, 10)
@@ -292,7 +292,7 @@ function UnstickWorkersDropdown() {
       const resp = await fetch('/api/control/config', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ unstick_max_workers: newValue, persist: true }),
+        body: JSON.stringify({ pr_unstick_batch_size: newValue, persist: true }),
       })
       if (!resp.ok) {
         setLocalValue(currentValue)
@@ -305,9 +305,9 @@ function UnstickWorkersDropdown() {
   return (
     <div style={styles.autoApproveRow}>
       <div style={styles.autoApproveLabel}>
-        <span style={styles.autoApproveText}>Parallel Workers</span>
+        <span style={styles.autoApproveText}>Max PRs</span>
         <span style={styles.autoApproveHint}>
-          Concurrent fix workers (1-10)
+          PRs to unstick per cycle
         </span>
       </div>
       <select
@@ -316,7 +316,7 @@ function UnstickWorkersDropdown() {
         style={styles.workersSelect}
         data-testid="unstick-workers-dropdown"
       >
-        {UNSTICK_WORKER_OPTIONS.map(n => (
+        {UNSTICK_BATCH_OPTIONS.map(n => (
           <option key={n} value={n}>{n}</option>
         ))}
       </select>

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -67,9 +67,9 @@ export const SYSTEM_WORKER_INTERVALS = {
 }
 
 /**
- * Options for the PR Unsticker workers dropdown (1-10).
+ * Options for the PR Unsticker batch size dropdown.
  */
-export const UNSTICK_WORKER_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+export const UNSTICK_BATCH_OPTIONS = [1, 2, 3, 5, 10, 15, 20, 30, 50]
 
 /**
  * Valid session statuses for the session sidebar.


### PR DESCRIPTION
## Summary
- Removes the redundant `unstick_max_workers` config field — `pr_unstick_batch_size` now controls both the fetch limit and the parallel fix concurrency (via `asyncio.Semaphore`)
- Renames UI dropdown from "Parallel Workers" to "Max PRs" with options [1, 2, 3, 5, 10, 15, 20, 30, 50]
- Removes associated env override, tests, and helper params

## Test plan
- [x] `make quality` passes (4231 tests, 0 failures)
- [x] UI builds cleanly
- [ ] Verify "Max PRs" dropdown appears in System Panel and persists changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)