### PR TITLE
Fixes #853: Skip re-review when no new commits since last review

### DIFF
--- a/models.py
+++ b/models.py
@@ -456,6 +456,7 @@ class StateData(BaseModel):
     metrics_last_synced: str | None = None
     worker_intervals: dict[str, int] = Field(default_factory=dict)
     interrupted_issues: dict[str, str] = Field(default_factory=dict)
+    last_reviewed_shas: dict[str, str] = Field(default_factory=dict)
     last_updated: str | None = None
 
 

--- a/pr_manager.py
+++ b/pr_manager.py
@@ -736,6 +736,80 @@ class PRManager:
 
         return False, f"Timeout after {timeout}s"
 
+    # --- PR activity query helpers ---
+
+    async def get_pr_head_sha(self, pr_number: int) -> str:
+        """Fetch the HEAD commit SHA for *pr_number*.
+
+        Returns the SHA string, or empty string on failure or in dry-run mode.
+        """
+        if self._config.dry_run:
+            logger.info("[dry-run] Would fetch HEAD SHA for PR #%d", pr_number)
+            return ""
+
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "pr",
+                "view",
+                str(pr_number),
+                "--repo",
+                self._repo,
+                "--json",
+                "headRefOid",
+            )
+            data = json.loads(raw)
+            return data.get("headRefOid", "")
+        except (RuntimeError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch HEAD SHA for PR #%d: %s", pr_number, exc)
+            return ""
+
+    async def get_pr_reviews(self, pr_number: int) -> list[dict[str, str]]:
+        """Fetch reviews for *pr_number* with author info.
+
+        Returns a list of dicts with ``author``, ``state``, ``submitted_at``,
+        and ``commit_id`` keys.  Returns ``[]`` on failure or in dry-run mode.
+        """
+        if self._config.dry_run:
+            logger.info("[dry-run] Would fetch reviews for PR #%d", pr_number)
+            return []
+
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "api",
+                f"repos/{self._repo}/pulls/{pr_number}/reviews",
+                "--jq",
+                "[.[] | {author: .user.login, state: .state, submitted_at: .submitted_at, commit_id: .commit_id}]",
+            )
+            return json.loads(raw)  # type: ignore[no-any-return]
+        except (RuntimeError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch reviews for PR #%d: %s", pr_number, exc)
+            return []
+
+    async def get_pr_comments(self, pr_number: int) -> list[dict[str, str]]:
+        """Fetch issue-level comments for *pr_number* with author info.
+
+        Returns a list of dicts with ``author`` and ``created_at`` keys.
+        Returns ``[]`` on failure or in dry-run mode.
+        """
+        if self._config.dry_run:
+            logger.info("[dry-run] Would fetch comments for PR #%d", pr_number)
+            return []
+
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "api",
+                f"repos/{self._repo}/issues/{pr_number}/comments",
+                "--jq",
+                "[.[] | {author: .user.login, created_at: .created_at}]",
+            )
+            return json.loads(raw)  # type: ignore[no-any-return]
+        except (RuntimeError, json.JSONDecodeError) as exc:
+            logger.warning("Could not fetch comments for PR #%d: %s", pr_number, exc)
+            return []
+
     # --- dashboard query helpers ---
 
     async def list_open_prs(self, labels: list[str]) -> list[PRListItem]:

--- a/review_phase.py
+++ b/review_phase.py
@@ -170,6 +170,24 @@ class ReviewPhase:
                 summary="Issue not found",
             )
 
+        # Skip guard: avoid re-reviewing when no new commits since last review
+        current_sha = await self._prs.get_pr_head_sha(pr.number)
+        if current_sha:
+            stored_sha = self._state.get_last_reviewed_sha(pr.issue_number)
+            if stored_sha and stored_sha == current_sha:
+                logger.info(
+                    "PR #%d (issue #%d): skipping review — no new commits since "
+                    "last review (SHA %s)",
+                    pr.number,
+                    pr.issue_number,
+                    current_sha[:12],
+                )
+                return ReviewResult(
+                    pr_number=pr.number,
+                    issue_number=pr.issue_number,
+                    summary="Skipped — no new commits since last review",
+                )
+
         wt_path = self._config.worktree_base / f"issue-{pr.issue_number}"
         if not wt_path.exists():
             wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
@@ -202,6 +220,12 @@ class ReviewPhase:
         self._state.mark_pr(pr.number, result.verdict.value)
         self._state.mark_issue(pr.issue_number, "reviewed")
         self._state.record_review_verdict(result.verdict.value, result.fixes_made)
+
+        # Record the current remote HEAD SHA so the skip guard works next cycle
+        post_review_sha = await self._prs.get_pr_head_sha(pr.number)
+        if post_review_sha:
+            self._state.set_last_reviewed_sha(pr.issue_number, post_review_sha)
+
         if result.duration_seconds > 0:
             self._state.record_review_duration(result.duration_seconds)
         await self._record_review_insight(result)

--- a/state.py
+++ b/state.py
@@ -211,6 +211,22 @@ class StateTracker:
         self._data.interrupted_issues = {}
         self.save()
 
+    # --- last reviewed SHA tracking ---
+
+    def set_last_reviewed_sha(self, issue_number: int, sha: str) -> None:
+        """Record the last-reviewed commit SHA for *issue_number*."""
+        self._data.last_reviewed_shas[str(issue_number)] = sha
+        self.save()
+
+    def get_last_reviewed_sha(self, issue_number: int) -> str | None:
+        """Return the last-reviewed commit SHA for *issue_number*, or *None*."""
+        return self._data.last_reviewed_shas.get(str(issue_number))
+
+    def clear_last_reviewed_sha(self, issue_number: int) -> None:
+        """Clear the last-reviewed commit SHA for *issue_number*."""
+        self._data.last_reviewed_shas.pop(str(issue_number), None)
+        self.save()
+
     # --- worker result metadata ---
 
     def set_worker_result_meta(self, issue_number: int, meta: dict[str, Any]) -> None:

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -3347,3 +3347,191 @@ class TestListHitlItemsExceptionHandling:
 
         assert result == []
         assert "Failed to fetch HITL items" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# get_pr_head_sha (issue #853)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrHeadSha:
+    """Tests for PRManager.get_pr_head_sha."""
+
+    @pytest.mark.asyncio
+    async def test_returns_sha_on_success(self, event_bus, tmp_path):
+        """get_pr_head_sha should parse headRefOid from JSON response."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        response = '{"headRefOid":"abc123def456789"}'
+        mock_create = SubprocessMockBuilder().with_stdout(response).build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            sha = await mgr.get_pr_head_sha(101)
+
+        assert sha == "abc123def456789"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_failure(self, event_bus, tmp_path):
+        """get_pr_head_sha should return empty string on subprocess failure."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("not found").build()
+        )
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            sha = await mgr.get_pr_head_sha(999)
+
+        assert sha == ""
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_empty(self, dry_config, event_bus):
+        """In dry-run mode, get_pr_head_sha should return empty string."""
+        mgr = _make_manager(dry_config, event_bus)
+        mock_create = SubprocessMockBuilder().build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            sha = await mgr.get_pr_head_sha(101)
+
+        mock_create.assert_not_called()
+        assert sha == ""
+
+
+# ---------------------------------------------------------------------------
+# get_pr_reviews (issue #853)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrReviews:
+    """Tests for PRManager.get_pr_reviews."""
+
+    @pytest.mark.asyncio
+    async def test_returns_reviews_on_success(self, event_bus, tmp_path):
+        """get_pr_reviews should parse review data from JSON response."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        response = json.dumps(
+            [
+                {
+                    "author": "reviewer1",
+                    "state": "APPROVED",
+                    "submitted_at": "2025-01-01T00:00:00Z",
+                    "commit_id": "abc123",
+                }
+            ]
+        )
+        mock_create = SubprocessMockBuilder().with_stdout(response).build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            reviews = await mgr.get_pr_reviews(101)
+
+        assert len(reviews) == 1
+        assert reviews[0]["author"] == "reviewer1"
+        assert reviews[0]["state"] == "APPROVED"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_failure(self, event_bus, tmp_path):
+        """get_pr_reviews should return empty list on subprocess failure."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("not found").build()
+        )
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            reviews = await mgr.get_pr_reviews(999)
+
+        assert reviews == []
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_empty(self, dry_config, event_bus):
+        """In dry-run mode, get_pr_reviews should return empty list."""
+        mgr = _make_manager(dry_config, event_bus)
+        mock_create = SubprocessMockBuilder().build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            reviews = await mgr.get_pr_reviews(101)
+
+        mock_create.assert_not_called()
+        assert reviews == []
+
+
+# ---------------------------------------------------------------------------
+# get_pr_comments (issue #853)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrComments:
+    """Tests for PRManager.get_pr_comments."""
+
+    @pytest.mark.asyncio
+    async def test_returns_comments_on_success(self, event_bus, tmp_path):
+        """get_pr_comments should parse comment data from JSON response."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        response = json.dumps(
+            [
+                {
+                    "author": "commenter1",
+                    "created_at": "2025-01-01T12:00:00Z",
+                }
+            ]
+        )
+        mock_create = SubprocessMockBuilder().with_stdout(response).build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            comments = await mgr.get_pr_comments(101)
+
+        assert len(comments) == 1
+        assert comments[0]["author"] == "commenter1"
+        assert comments[0]["created_at"] == "2025-01-01T12:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_failure(self, event_bus, tmp_path):
+        """get_pr_comments should return empty list on subprocess failure."""
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mgr = _make_manager(cfg, event_bus)
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("not found").build()
+        )
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            comments = await mgr.get_pr_comments(999)
+
+        assert comments == []
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_empty(self, dry_config, event_bus):
+        """In dry-run mode, get_pr_comments should return empty list."""
+        mgr = _make_manager(dry_config, event_bus)
+        mock_create = SubprocessMockBuilder().build()
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            comments = await mgr.get_pr_comments(101)
+
+        mock_create.assert_not_called()
+        assert comments == []

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -1909,3 +1909,139 @@ class TestHandleSelfFixReReview:
 
         assert result is original
         assert diff == "old diff"
+
+
+# ---------------------------------------------------------------------------
+# Skip guard: no new commits since last review (issue #853)
+# ---------------------------------------------------------------------------
+
+
+class TestSkipGuardNoNewCommits:
+    """Tests for the skip guard that avoids re-reviewing when no new commits."""
+
+    @pytest.mark.asyncio
+    async def test_skips_when_same_sha(self, config: HydraFlowConfig) -> None:
+        """When stored SHA matches current HEAD, review should be skipped."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Pre-store the same SHA that get_pr_head_sha will return
+        phase._state.set_last_reviewed_sha(42, "abc123def456")
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="abc123def456")
+
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        results = await phase.review_prs([pr], [issue])
+
+        assert len(results) == 1
+        assert "skipped" in results[0].summary.lower()
+        assert "no new commits" in results[0].summary.lower()
+        # Reviewer should NOT have been called
+        phase._reviewers.review.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_proceeds_with_new_commits(self, config: HydraFlowConfig) -> None:
+        """When stored SHA differs from current HEAD, review should proceed."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Stored SHA differs from current
+        phase._state.set_last_reviewed_sha(42, "old_sha_111")
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="new_sha_222")
+
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        results = await phase.review_prs([pr], [issue])
+
+        assert len(results) == 1
+        phase._reviewers.review.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_no_prior_sha(self, config: HydraFlowConfig) -> None:
+        """When no stored SHA exists, review should proceed (first review)."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # No prior SHA stored
+        assert phase._state.get_last_reviewed_sha(42) is None
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="first_sha_abc")
+
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        results = await phase.review_prs([pr], [issue])
+
+        assert len(results) == 1
+        phase._reviewers.review.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sha_updated_after_review(self, config: HydraFlowConfig) -> None:
+        """After a successful review, the SHA should be stored in state."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Return different SHA on the post-review call
+        phase._prs.get_pr_head_sha = AsyncMock(
+            side_effect=["first_sha", "post_review_sha"]
+        )
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        await phase.review_prs([pr], [issue])
+
+        # The post-review SHA should be stored
+        assert phase._state.get_last_reviewed_sha(42) == "post_review_sha"
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_sha_fetch_fails(self, config: HydraFlowConfig) -> None:
+        """When get_pr_head_sha returns empty string (fail), review should proceed (fail-open)."""
+        phase = make_review_phase(config)
+        issue = IssueFactory.create()
+        pr = PRInfoFactory.create()
+
+        # Even with a stored SHA, an empty current SHA means we can't compare
+        phase._state.set_last_reviewed_sha(42, "old_sha")
+        phase._prs.get_pr_head_sha = AsyncMock(return_value="")
+
+        phase._reviewers.review = AsyncMock(return_value=ReviewResultFactory.create())
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_base / "issue-42"
+        wt.mkdir(parents=True, exist_ok=True)
+
+        results = await phase.review_prs([pr], [issue])
+
+        assert len(results) == 1
+        # Review should proceed despite SHA fetch failure
+        phase._reviewers.review.assert_awaited_once()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1654,6 +1654,57 @@ class TestRetriesPerStage:
 
 
 # ---------------------------------------------------------------------------
+# Last reviewed SHA tracking (issue #853)
+# ---------------------------------------------------------------------------
+
+
+class TestLastReviewedSha:
+    """Tests for set/get/clear_last_reviewed_sha."""
+
+    def test_set_and_get(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_last_reviewed_sha(42, "abc123def456")
+        assert tracker.get_last_reviewed_sha(42) == "abc123def456"
+
+    def test_get_returns_none_when_unset(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        assert tracker.get_last_reviewed_sha(999) is None
+
+    def test_clear_removes_entry(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_last_reviewed_sha(42, "abc123")
+        tracker.clear_last_reviewed_sha(42)
+        assert tracker.get_last_reviewed_sha(42) is None
+
+    def test_clear_nonexistent_is_noop(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        # Should not raise
+        tracker.clear_last_reviewed_sha(999)
+        assert tracker.get_last_reviewed_sha(999) is None
+
+    def test_persists_across_reload(self, tmp_path: Path) -> None:
+        state_file = tmp_path / "state.json"
+        tracker = StateTracker(state_file)
+        tracker.set_last_reviewed_sha(42, "deadbeef1234")
+
+        tracker2 = StateTracker(state_file)
+        assert tracker2.get_last_reviewed_sha(42) == "deadbeef1234"
+
+    def test_overwrite_updates(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_last_reviewed_sha(42, "sha-v1")
+        tracker.set_last_reviewed_sha(42, "sha-v2")
+        assert tracker.get_last_reviewed_sha(42) == "sha-v2"
+
+    def test_multiple_issues_independent(self, tmp_path: Path) -> None:
+        tracker = make_tracker(tmp_path)
+        tracker.set_last_reviewed_sha(1, "sha-issue-1")
+        tracker.set_last_reviewed_sha(2, "sha-issue-2")
+        assert tracker.get_last_reviewed_sha(1) == "sha-issue-1"
+        assert tracker.get_last_reviewed_sha(2) == "sha-issue-2"
+
+
+# ---------------------------------------------------------------------------
 # Narrowed exception handling (issue #879)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds SHA-based skip guard to the review phase — PRs aren't re-reviewed when no new commits have been pushed since the last cycle
- Adds `get_pr_head_sha`, `get_pr_reviews`, `get_pr_comments` helpers to `PRManager`
- Fail-open design: if SHA fetch fails, review proceeds normally

Replaces #979 (had merge conflicts with main).

## Test plan
- [x] Unit tests for `StateTracker.set/get/clear_last_reviewed_sha`
- [x] Unit tests for `PRManager.get_pr_head_sha/get_pr_reviews/get_pr_comments`
- [x] Unit tests for skip guard in `_review_one_inner` (skip, proceed, fail-open)
- [x] Full test suite passes (4253 tests)
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)