### PR TITLE
Fixes #844: Test Quality: Clean up fixture organization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,9 @@ if TYPE_CHECKING:
         AnalysisResult,
         GitHubIssue,
         HITLResult,
-        PlanResult,
-        PRInfo,
         ReviewResult,
         ReviewVerdict,
         TriageResult,
-        WorkerResult,
     )
     from orchestrator import HydraFlowOrchestrator
     from state import StateTracker
@@ -138,11 +135,6 @@ class WorkerResultFactory:
         )
 
 
-@pytest.fixture
-def worker_result() -> WorkerResult:
-    return WorkerResultFactory.create()
-
-
 # --- Plan Result Factory ---
 
 
@@ -173,11 +165,6 @@ class PlanResultFactory:
         )
 
 
-@pytest.fixture
-def plan_result() -> PlanResult:
-    return PlanResultFactory.create()
-
-
 # --- PR Info Factory ---
 
 
@@ -202,11 +189,6 @@ class PRInfoFactory:
             url=url,
             draft=draft,
         )
-
-
-@pytest.fixture
-def pr_info() -> PRInfo:
-    return PRInfoFactory.create()
 
 
 # --- Review Result Factory ---
@@ -473,16 +455,6 @@ class LintScaffoldResultFactory:
         )
 
 
-# --- HITL Runner Fixture ---
-
-
-@pytest.fixture
-def hitl_runner(config, event_bus):
-    from hitl_runner import HITLRunner
-
-    return HITLRunner(config, event_bus)
-
-
 # --- Orchestrator Mock ---
 
 
@@ -501,11 +473,6 @@ def make_orchestrator_mock(
     orch.stop = AsyncMock()
     orch.request_stop = AsyncMock()
     return orch
-
-
-@pytest.fixture
-def orchestrator_mock():
-    return make_orchestrator_mock()
 
 
 # --- Subprocess Mock ---
@@ -540,12 +507,6 @@ class SubprocessMockBuilder:
 
         mock_create = AsyncMock(return_value=mock_proc)
         return mock_create
-
-
-@pytest.fixture
-def subprocess_mock() -> SubprocessMockBuilder:
-    """Return a builder for subprocess mocks."""
-    return SubprocessMockBuilder()
 
 
 # --- Review Mock Builder ---

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -28,6 +28,30 @@ class AsyncLineIter:
             raise StopAsyncIteration from None
 
 
+def make_proc(
+    returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""
+) -> AsyncMock:
+    """Build a minimal mock subprocess object (communicate style).
+
+    Unlike ``make_streaming_proc`` (which returns a callable factory mock that
+    can be passed directly to ``patch("asyncio.create_subprocess_exec", ...)``),
+    this helper returns the **raw process mock**.  Callers must wrap it when
+    patching::
+
+        proc = make_proc(returncode=0, stdout=b"output")
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            ...
+
+    The process mock's ``communicate()`` resolves to ``(stdout, stderr)`` bytes,
+    suitable for code paths that call ``await proc.communicate()`` rather than
+    iterating ``proc.stdout`` line by line.
+    """
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout, stderr))
+    return proc
+
+
 def make_streaming_proc(
     returncode: int = 0, stdout: str = "", stderr: str = ""
 ) -> AsyncMock:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -17,7 +17,7 @@ from base_runner import BaseRunner
 from events import EventBus, EventType
 from models import WorkerStatus
 from tests.conftest import IssueFactory
-from tests.helpers import ConfigFactory, make_streaming_proc
+from tests.helpers import ConfigFactory, make_proc, make_streaming_proc
 
 # ---------------------------------------------------------------------------
 # Inheritance
@@ -39,18 +39,6 @@ class TestAgentRunnerInheritance:
 # ---------------------------------------------------------------------------
 # Helpers (agent-specific)
 # ---------------------------------------------------------------------------
-
-
-def _make_proc(
-    returncode: int = 0,
-    stdout: bytes = b"",
-    stderr: bytes = b"",
-) -> AsyncMock:
-    """Build a minimal mock subprocess object (communicate style)."""
-    proc = AsyncMock()
-    proc.returncode = returncode
-    proc.communicate = AsyncMock(return_value=(stdout, stderr))
-    return proc
 
 
 # ---------------------------------------------------------------------------
@@ -737,7 +725,7 @@ class TestVerifyResult:
         """_verify_result should run make quality and return OK on success."""
         runner = AgentRunner(config, event_bus)
 
-        quality_proc = _make_proc(returncode=0, stdout=b"All checks passed")
+        quality_proc = make_proc(returncode=0, stdout=b"All checks passed")
 
         with (
             patch.object(
@@ -765,7 +753,7 @@ class TestVerifyResult:
         """_verify_result should return (False, ...) when make quality exits non-zero."""
         runner = AgentRunner(config, event_bus)
 
-        fail_proc = _make_proc(
+        fail_proc = make_proc(
             returncode=1, stdout=b"FAILED test_foo.py::test_bar", stderr=b""
         )
 
@@ -787,7 +775,7 @@ class TestVerifyResult:
         """_verify_result should include the last 3000 chars of output on failure."""
         runner = AgentRunner(config, event_bus)
 
-        fail_proc = _make_proc(
+        fail_proc = make_proc(
             returncode=1,
             stdout=b"error: type mismatch on line 42",
             stderr=b"pyright found 1 error",
@@ -838,7 +826,7 @@ class TestCountCommits:
     ) -> None:
         """_count_commits should return the integer from git rev-list output."""
         runner = AgentRunner(config, event_bus)
-        mock_proc = _make_proc(returncode=0, stdout=b"3\n")
+        mock_proc = make_proc(returncode=0, stdout=b"3\n")
 
         with patch(
             "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
@@ -864,7 +852,7 @@ class TestCountCommits:
     ) -> None:
         """_count_commits should correctly parse multi-digit counts."""
         runner = AgentRunner(config, event_bus)
-        mock_proc = _make_proc(returncode=0, stdout=b"15\n")
+        mock_proc = make_proc(returncode=0, stdout=b"15\n")
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             result = await runner._count_commits(tmp_path, "agent/issue-42")
@@ -877,7 +865,7 @@ class TestCountCommits:
     ) -> None:
         """_count_commits should return 0 when stdout is empty (ValueError)."""
         runner = AgentRunner(config, event_bus)
-        mock_proc = _make_proc(returncode=0, stdout=b"")
+        mock_proc = make_proc(returncode=0, stdout=b"")
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             result = await runner._count_commits(tmp_path, "agent/issue-42")
@@ -890,7 +878,7 @@ class TestCountCommits:
     ) -> None:
         """_count_commits should return 0 when git exits with non-zero code."""
         runner = AgentRunner(config, event_bus)
-        mock_proc = _make_proc(returncode=1, stdout=b"")
+        mock_proc = make_proc(returncode=1, stdout=b"")
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             result = await runner._count_commits(tmp_path, "agent/issue-42")

--- a/tests/test_hitl_runner.py
+++ b/tests/test_hitl_runner.py
@@ -16,6 +16,12 @@ from events import EventBus, EventType
 from hitl_runner import HITLRunner, _classify_cause
 from tests.conftest import HITLResultFactory, IssueFactory
 
+
+@pytest.fixture
+def hitl_runner(config, event_bus):
+    return HITLRunner(config, event_bus)
+
+
 # ---------------------------------------------------------------------------
 # Inheritance
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -104,15 +104,6 @@ def _make_manager(config, event_bus):
     return PRManager(config=config, event_bus=event_bus)
 
 
-def _make_subprocess_mock(returncode: int = 0, stdout: str = "", stderr: str = ""):
-    """Build a mock for asyncio.create_subprocess_exec."""
-    mock_proc = AsyncMock()
-    mock_proc.returncode = returncode
-    mock_proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
-    mock_proc.wait = AsyncMock(return_value=returncode)
-    return AsyncMock(return_value=mock_proc)
-
-
 def _assert_search_api_cmd(cmd: tuple[str, ...]) -> None:
     """Assert common structure of a gh API search command."""
     assert "api" in cmd
@@ -494,7 +485,7 @@ async def test_create_issue_passes_correct_gh_args(config, event_bus, tmp_path):
     )
     mgr = _make_manager(cfg, event_bus)
     issue_url = "https://github.com/test-org/test-repo/issues/99"
-    mock_create = _make_subprocess_mock(returncode=0, stdout=issue_url)
+    mock_create = SubprocessMockBuilder().with_stdout(issue_url).build()
 
     with patch("asyncio.create_subprocess_exec", mock_create):
         await mgr.create_issue("Bug found", "Details here", ["bug"])
@@ -650,7 +641,7 @@ async def test_create_pr_calls_gh_pr_create(config, event_bus, issue):
 async def test_create_pr_includes_required_flags(config, event_bus, issue):
     manager = _make_manager(config, event_bus)
     pr_url = "https://github.com/test-org/test-repo/pull/55"
-    mock_create = _make_subprocess_mock(returncode=0, stdout=pr_url)
+    mock_create = SubprocessMockBuilder().with_stdout(pr_url).build()
 
     with patch("asyncio.create_subprocess_exec", mock_create):
         await manager.create_pr(issue, "agent/issue-42")
@@ -819,7 +810,7 @@ async def test_merge_pr_calls_gh_pr_merge(config, event_bus):
 @pytest.mark.asyncio
 async def test_merge_pr_uses_squash_and_delete_branch(config, event_bus):
     manager = _make_manager(config, event_bus)
-    mock_create = _make_subprocess_mock(returncode=0, stdout="")
+    mock_create = SubprocessMockBuilder().build()
 
     with patch("asyncio.create_subprocess_exec", mock_create):
         await manager.merge_pr(101)
@@ -2302,7 +2293,7 @@ class TestCreatePrEdgeCases:
     ) -> None:
         """create_pr should return PRInfo(number=0) when gh output is empty."""
         manager = _make_manager(config, event_bus)
-        mock_create = _make_subprocess_mock(returncode=0, stdout="")
+        mock_create = SubprocessMockBuilder().build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await manager.create_pr(issue, "agent/issue-42")
@@ -2321,8 +2312,8 @@ class TestCreateIssueEdgeCases:
     ) -> None:
         """create_issue should return 0 when gh output is not a valid URL."""
         mgr = _make_manager(config, event_bus)
-        mock_create = _make_subprocess_mock(
-            returncode=0, stdout="Error: something went wrong"
+        mock_create = (
+            SubprocessMockBuilder().with_stdout("Error: something went wrong").build()
         )
 
         with patch("asyncio.create_subprocess_exec", mock_create):
@@ -2336,7 +2327,7 @@ class TestCreateIssueEdgeCases:
     ) -> None:
         """create_issue should return 0 when gh output is empty."""
         mgr = _make_manager(config, event_bus)
-        mock_create = _make_subprocess_mock(returncode=0, stdout="")
+        mock_create = SubprocessMockBuilder().build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await mgr.create_issue("Bug found", "Details here", ["bug"])
@@ -2457,7 +2448,7 @@ class TestListOpenPrsEdgeCases:
                 },
             ]
         )
-        mock_create = _make_subprocess_mock(returncode=0, stdout=pr_json)
+        mock_create = SubprocessMockBuilder().with_stdout(pr_json).build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await mgr.list_open_prs(["test-label"])
@@ -3015,7 +3006,7 @@ class TestFetchCiFailureLogs:
                 {"name": "Lint", "state": "SUCCESS", "detailsUrl": ""},
             ]
         )
-        mock_create = _make_subprocess_mock(returncode=0, stdout=checks_json)
+        mock_create = SubprocessMockBuilder().with_stdout(checks_json).build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await manager.fetch_ci_failure_logs(101)
@@ -3070,7 +3061,7 @@ class TestFetchCiFailureLogs:
                 {"name": "External", "state": "FAILURE", "detailsUrl": ""},
             ]
         )
-        mock_create = _make_subprocess_mock(returncode=0, stdout=checks_json)
+        mock_create = SubprocessMockBuilder().with_stdout(checks_json).build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await manager.fetch_ci_failure_logs(101)
@@ -3081,7 +3072,9 @@ class TestFetchCiFailureLogs:
     async def test_handles_gh_error_gracefully(self, config, event_bus):
         """RuntimeError from gh returns empty string."""
         manager = _make_manager(config, event_bus)
-        mock_create = _make_subprocess_mock(returncode=1, stderr="not found")
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("not found").build()
+        )
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await manager.fetch_ci_failure_logs(101)
@@ -3143,7 +3136,7 @@ class TestFetchCiFailureLogs:
                 },
             ]
         )
-        mock_create = _make_subprocess_mock(returncode=0, stdout=checks_json)
+        mock_create = SubprocessMockBuilder().with_stdout(checks_json).build()
 
         with patch("asyncio.create_subprocess_exec", mock_create):
             result = await manager.fetch_ci_failure_logs(101)
@@ -3200,7 +3193,7 @@ class TestListOpenPrsExceptionHandling:
         mgr = _make_manager(config, event_bus)
         # JSON with one item missing the 'number' key
         pr_json = json.dumps([{"url": "...", "headRefName": "agent/issue-1"}])
-        mock_create = _make_subprocess_mock(returncode=0, stdout=pr_json)
+        mock_create = SubprocessMockBuilder().with_stdout(pr_json).build()
 
         with (
             caplog.at_level(logging.DEBUG, logger="hydraflow.pr_manager"),
@@ -3219,7 +3212,9 @@ class TestListOpenPrsExceptionHandling:
         import logging
 
         mgr = _make_manager(config, event_bus)
-        mock_create = _make_subprocess_mock(returncode=1, stderr="gh error")
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("gh error").build()
+        )
 
         with (
             caplog.at_level(logging.DEBUG, logger="hydraflow.pr_manager"),
@@ -3251,7 +3246,9 @@ class TestListHitlItemsExceptionHandling:
             state_file=tmp_path / "state.json",
         )
         mgr = _make_manager(cfg, event_bus)
-        mock_create = _make_subprocess_mock(returncode=1, stderr="gh error")
+        mock_create = (
+            SubprocessMockBuilder().with_returncode(1).with_stderr("gh error").build()
+        )
 
         with (
             caplog.at_level(logging.WARNING, logger="hydraflow.pr_manager"),
@@ -3333,7 +3330,7 @@ class TestListHitlItemsExceptionHandling:
         # Issue list succeeds, but branch_for_issue raises KeyError
         # which is outside the inner try/except blocks
         issues_json = json.dumps([{"number": 42, "title": "Test", "url": ""}])
-        mock_create = _make_subprocess_mock(returncode=0, stdout=issues_json)
+        mock_create = SubprocessMockBuilder().with_stdout(issues_json).build()
 
         with (
             caplog.at_level(logging.WARNING, logger="hydraflow.pr_manager"),

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from models import GitHubIssue, HITLItem
 from pr_unsticker import FailureCause, PRUnsticker, _classify_cause
-from state import StateTracker
+from tests.conftest import make_state
 from tests.helpers import ConfigFactory
 
 
@@ -30,10 +30,6 @@ def _make_config(tmp_path: Path, **overrides) -> MagicMock:
     )
 
 
-def _make_state(tmp_path: Path) -> StateTracker:
-    return StateTracker(tmp_path / "state.json")
-
-
 def _make_unsticker(
     tmp_path: Path,
     *,
@@ -48,7 +44,7 @@ def _make_unsticker(
     **config_overrides,
 ):
     cfg = config or _make_config(tmp_path, **config_overrides)
-    st = state or _make_state(tmp_path)
+    st = state or make_state(tmp_path)
     bus = AsyncMock()
     bus.publish = AsyncMock()
     prs = pr_manager or AsyncMock()

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -16,7 +16,14 @@ from escalation_gate import EscalationDecision
 from events import EventType
 from models import ReviewerStatus, ReviewVerdict
 from reviewer import ReviewRunner
+from tests.conftest import PRInfoFactory
 from tests.helpers import ConfigFactory, make_streaming_proc
+
+
+@pytest.fixture
+def pr_info():
+    return PRInfoFactory.create()
+
 
 # ---------------------------------------------------------------------------
 # Inheritance

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,16 +8,11 @@ import pytest
 from pydantic import ValidationError
 
 from models import SessionLog
-from state import StateTracker
+from tests.conftest import make_state
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def make_tracker(tmp_path: Path, *, filename: str = "state.json") -> StateTracker:
-    """Return a StateTracker backed by a temp file."""
-    return StateTracker(tmp_path / filename)
 
 
 def make_session(
@@ -115,14 +110,14 @@ class TestSessionLogModel:
 
 class TestSessionPersistence:
     def test_save_session_creates_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         session = make_session()
         tracker.save_session(session)
         sessions_file = tmp_path / "sessions.jsonl"
         assert sessions_file.exists()
 
     def test_save_session_appends_to_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         s1 = make_session(id="s1", started_at="2024-01-01T00:00:00")
         s2 = make_session(id="s2", started_at="2024-01-02T00:00:00")
         tracker.save_session(s1)
@@ -131,7 +126,7 @@ class TestSessionPersistence:
         assert len(lines) == 2
 
     def test_load_sessions_returns_newest_first(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         s1 = make_session(id="s1", started_at="2024-01-01T00:00:00")
         s2 = make_session(id="s2", started_at="2024-01-02T00:00:00")
         s3 = make_session(id="s3", started_at="2024-01-03T00:00:00")
@@ -142,12 +137,12 @@ class TestSessionPersistence:
         assert [s.id for s in sessions] == ["s3", "s2", "s1"]
 
     def test_load_sessions_empty_when_no_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions = tracker.load_sessions()
         assert sessions == []
 
     def test_load_sessions_filter_by_repo(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         s1 = make_session(id="s1", repo="org/repo-a", started_at="2024-01-01T00:00:00")
         s2 = make_session(id="s2", repo="org/repo-b", started_at="2024-01-02T00:00:00")
         s3 = make_session(id="s3", repo="org/repo-a", started_at="2024-01-03T00:00:00")
@@ -159,7 +154,7 @@ class TestSessionPersistence:
         assert all(s.repo == "org/repo-a" for s in result)
 
     def test_load_sessions_respects_limit(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         for i in range(5):
             tracker.save_session(
                 make_session(id=f"s{i}", started_at=f"2024-01-0{i + 1}T00:00:00")
@@ -168,7 +163,7 @@ class TestSessionPersistence:
         assert len(result) == 3
 
     def test_get_session_returns_matching(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         s1 = make_session(id="target-session")
         tracker.save_session(s1)
         result = tracker.get_session("target-session")
@@ -176,19 +171,19 @@ class TestSessionPersistence:
         assert result.id == "target-session"
 
     def test_get_session_returns_none_for_nonexistent(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         tracker.save_session(make_session(id="other"))
         result = tracker.get_session("nonexistent")
         assert result is None
 
     def test_get_session_returns_none_when_no_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         result = tracker.get_session("anything")
         assert result is None
 
     def test_load_sessions_deduplicates_by_id(self, tmp_path: Path) -> None:
         """Saving a session twice (start then end) must not produce duplicate entries."""
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         # Simulate orchestrator: save at start (active), then again at end (completed)
         session = make_session(id="s1", status="active")
         tracker.save_session(session)
@@ -205,7 +200,7 @@ class TestSessionPersistence:
 
     def test_get_session_returns_last_written_state(self, tmp_path: Path) -> None:
         """get_session must return the most-recently-written entry, not the first."""
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         session = make_session(id="s1", status="active")
         tracker.save_session(session)
         session.status = "completed"
@@ -221,7 +216,7 @@ class TestSessionPersistence:
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
     ) -> None:
         """Corrupt JSONL lines produce warning logs in delete/prune paths."""
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         s1 = make_session(id="valid", status="completed")
         with open(sessions_file, "w") as f:
@@ -231,7 +226,7 @@ class TestSessionPersistence:
         assert "Skipping corrupt session line" in caplog.text
 
     def test_corrupt_lines_are_skipped(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         s1 = make_session(id="valid")
@@ -251,7 +246,7 @@ class TestSessionPersistence:
 
 class TestSessionPruning:
     def test_prune_keeps_newest(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         for i in range(5):
             tracker.save_session(
                 make_session(id=f"s{i}", started_at=f"2024-01-0{i + 1}T00:00:00")
@@ -263,7 +258,7 @@ class TestSessionPruning:
         assert result[1].id == "s3"
 
     def test_prune_preserves_other_repos(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         for i in range(3):
             tracker.save_session(
                 make_session(
@@ -288,14 +283,14 @@ class TestSessionPruning:
         assert len(repo_b) == 1
 
     def test_prune_noop_when_below_limit(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         tracker.save_session(make_session(id="s0"))
         tracker.prune_sessions("test-org/test-repo", max_keep=10)
         result = tracker.load_sessions()
         assert len(result) == 1
 
     def test_prune_noop_when_no_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         # Should not raise
         tracker.prune_sessions("test-org/test-repo", max_keep=5)
 
@@ -305,7 +300,7 @@ class TestSessionPruning:
         If each session is saved twice (start + end), max_keep=2 should keep
         2 unique sessions, not 1 session with 2 lines.
         """
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         for i in range(3):
             session = make_session(
                 id=f"s{i}",
@@ -323,7 +318,7 @@ class TestSessionPruning:
         assert result[1].id == "s1"
 
     def test_prune_handles_empty_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         sessions_file.write_text("")
@@ -337,7 +332,7 @@ class TestSessionPruning:
 
 class TestSessionDeletion:
     def test_delete_completed_session(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         s1 = make_session(id="s1", status="completed", started_at="2024-01-01T00:00:00")
         s2 = make_session(id="s2", status="completed", started_at="2024-01-02T00:00:00")
         tracker.save_session(s1)
@@ -349,24 +344,24 @@ class TestSessionDeletion:
         assert sessions[0].id == "s2"
 
     def test_delete_nonexistent_returns_false(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         tracker.save_session(make_session(id="s1", status="completed"))
         result = tracker.delete_session("nonexistent")
         assert result is False
 
     def test_delete_active_session_raises(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         tracker.save_session(make_session(id="s1", status="active"))
         with pytest.raises(ValueError, match="Cannot delete active session"):
             tracker.delete_session("s1")
 
     def test_delete_returns_false_when_no_file(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         result = tracker.delete_session("anything")
         assert result is False
 
     def test_delete_preserves_other_sessions(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         for i in range(3):
             tracker.save_session(
                 make_session(
@@ -383,7 +378,7 @@ class TestSessionDeletion:
 
     def test_delete_deduplicates_before_removal(self, tmp_path: Path) -> None:
         """Session saved twice (start + end) should be fully removed."""
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         session = make_session(id="s1", status="active")
         tracker.save_session(session)
         session.status = "completed"
@@ -396,7 +391,7 @@ class TestSessionDeletion:
         assert len(sessions) == 0
 
     def test_delete_persists_across_reload(self, tmp_path: Path) -> None:
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         tracker.save_session(make_session(id="s1", status="completed"))
         tracker.save_session(
             make_session(id="s2", status="completed", started_at="2024-01-02T00:00:00")
@@ -404,7 +399,7 @@ class TestSessionDeletion:
         tracker.delete_session("s1")
 
         # Reload from fresh tracker
-        tracker2 = make_tracker(tmp_path)
+        tracker2 = make_state(tmp_path)
         sessions = tracker2.load_sessions()
         assert len(sessions) == 1
         assert sessions[0].id == "s2"
@@ -452,7 +447,7 @@ class TestNarrowedExceptionHandling:
         """load_sessions should log a warning for each corrupt line."""
         import logging
 
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         valid = make_session(id="valid-session")
@@ -474,7 +469,7 @@ class TestNarrowedExceptionHandling:
         """load_sessions warning logs should include exc_info for tracebacks."""
         import logging
 
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         with open(sessions_file, "w") as f:
@@ -492,7 +487,7 @@ class TestNarrowedExceptionHandling:
         """get_session should log debug for corrupt lines."""
         import logging
 
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         valid = make_session(id="target")
@@ -513,7 +508,7 @@ class TestNarrowedExceptionHandling:
         """delete_session should log debug for corrupt lines."""
         import logging
 
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         valid = make_session(id="s1", status="completed")
@@ -533,7 +528,7 @@ class TestNarrowedExceptionHandling:
         """prune_sessions should log debug for corrupt lines."""
         import logging
 
-        tracker = make_tracker(tmp_path)
+        tracker = make_state(tmp_path)
         sessions_file = tmp_path / "sessions.jsonl"
         sessions_file.parent.mkdir(parents=True, exist_ok=True)
         valid = make_session(id="s1")

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -12,22 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.helpers import make_proc
 from worktree import WorktreeManager
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_proc(
-    returncode: int = 0, stdout: bytes = b"", stderr: bytes = b""
-) -> AsyncMock:
-    """Build a minimal mock subprocess object."""
-    proc = AsyncMock()
-    proc.returncode = returncode
-    proc.communicate = AsyncMock(return_value=(stdout, stderr))
-    return proc
-
 
 # ---------------------------------------------------------------------------
 # WorktreeManager.create
@@ -47,7 +33,7 @@ class TestCreate:
         # Pre-create the base directory so mkdir doesn't cause issues
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with (
             patch(
@@ -78,7 +64,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with (
             patch(
@@ -115,7 +101,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with (
             patch(
@@ -141,7 +127,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         setup_env = MagicMock()
         create_venv = AsyncMock()
@@ -168,7 +154,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with (
             patch("asyncio.create_subprocess_exec", return_value=success_proc),
@@ -203,7 +189,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: network error")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
         with (
             patch("asyncio.create_subprocess_exec", return_value=fail_proc),
@@ -220,8 +206,8 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: worktree add failed")
+        success_proc = make_proc(returncode=0)
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: worktree add failed")
 
         call_count = 0
 
@@ -249,7 +235,7 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with (
             patch("asyncio.create_subprocess_exec", return_value=success_proc),
@@ -270,8 +256,8 @@ class TestCreate:
         manager = WorktreeManager(config)
         config.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc(returncode=0)
-        fail_proc = _make_proc(returncode=1, stderr=b"uv sync failed")
+        success_proc = make_proc(returncode=0)
+        fail_proc = make_proc(returncode=1, stderr=b"uv sync failed")
 
         call_count = 0
 
@@ -314,7 +300,7 @@ class TestDestroy:
         wt_path = config.worktree_base / "issue-7"
         wt_path.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -333,7 +319,7 @@ class TestDestroy:
         manager = WorktreeManager(config)
 
         # wt_path does NOT exist — destroy should not call worktree remove
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -357,8 +343,8 @@ class TestDestroy:
         wt_path = config.worktree_base / "issue-7"
         wt_path.mkdir(parents=True, exist_ok=True)
 
-        remove_proc = _make_proc(returncode=0)
-        branch_delete_proc = _make_proc(returncode=1, stderr=b"error: branch not found")
+        remove_proc = make_proc(returncode=0)
+        branch_delete_proc = make_proc(returncode=1, stderr=b"error: branch not found")
 
         call_count = 0
 
@@ -383,7 +369,7 @@ class TestDestroy:
         wt_path = config.worktree_base / "issue-7"
         wt_path.mkdir(parents=True, exist_ok=True)
 
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: dirty worktree")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: dirty worktree")
 
         with (
             patch("asyncio.create_subprocess_exec", return_value=fail_proc),
@@ -484,7 +470,7 @@ class TestFetchAndMergeMain:
     async def test_success_returns_true(self, config, tmp_path: Path) -> None:
         """_fetch_and_merge_main should return True when all 3 git commands succeed."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch("asyncio.create_subprocess_exec", return_value=success_proc):
             result = await manager._fetch_and_merge_main(tmp_path, "agent/issue-7")
@@ -497,7 +483,7 @@ class TestFetchAndMergeMain:
     ) -> None:
         """_fetch_and_merge_main should raise RuntimeError when fetch fails."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: network error")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
         with (
             patch("asyncio.create_subprocess_exec", return_value=fail_proc),
@@ -511,8 +497,8 @@ class TestFetchAndMergeMain:
     ) -> None:
         """_fetch_and_merge_main should raise RuntimeError when ff-only merge fails."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc(returncode=0)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: not a fast-forward")
+        success_proc = make_proc(returncode=0)
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: not a fast-forward")
 
         call_count = 0
 
@@ -535,8 +521,8 @@ class TestFetchAndMergeMain:
     ) -> None:
         """_fetch_and_merge_main should raise RuntimeError when merge origin/main fails."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc(returncode=0)
-        fail_proc = _make_proc(
+        success_proc = make_proc(returncode=0)
+        fail_proc = make_proc(
             returncode=1, stderr=b"CONFLICT (content): Merge conflict"
         )
 
@@ -559,7 +545,7 @@ class TestFetchAndMergeMain:
     async def test_correct_git_commands(self, config, tmp_path: Path) -> None:
         """_fetch_and_merge_main should issue the 3 correct git commands in order."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -595,7 +581,7 @@ class TestMergeMain:
     ) -> None:
         """merge_main should return True when fetch, ff-pull, and merge succeed."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch("asyncio.create_subprocess_exec", return_value=success_proc):
             result = await manager.merge_main(tmp_path, "agent/issue-7")
@@ -609,11 +595,11 @@ class TestMergeMain:
         """merge_main should abort and return False when conflicts occur."""
         manager = WorktreeManager(config)
 
-        success_proc = _make_proc(returncode=0)
-        merge_fail_proc = _make_proc(
+        success_proc = make_proc(returncode=0)
+        merge_fail_proc = make_proc(
             returncode=1, stderr=b"CONFLICT (content): Merge conflict"
         )
-        abort_proc = _make_proc(returncode=0)
+        abort_proc = make_proc(returncode=0)
 
         call_count = 0
 
@@ -643,8 +629,8 @@ class TestMergeMain:
         """merge_main should return False if the initial fetch fails."""
         manager = WorktreeManager(config)
 
-        fetch_fail_proc = _make_proc(returncode=1, stderr=b"fatal: network error")
-        abort_proc = _make_proc(returncode=0)
+        fetch_fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
+        abort_proc = make_proc(returncode=0)
 
         call_count = 0
 
@@ -673,7 +659,7 @@ class TestDeleteLocalBranch:
     async def test_deletes_existing_branch(self, config, tmp_path: Path) -> None:
         """Should call git branch -D for the given branch."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -689,7 +675,7 @@ class TestDeleteLocalBranch:
     ) -> None:
         """Should not raise when the branch does not exist."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"error: branch not found")
+        fail_proc = make_proc(returncode=1, stderr=b"error: branch not found")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             # Should not raise
@@ -709,7 +695,7 @@ class TestRemoteBranchExists:
         self, config, tmp_path: Path
     ) -> None:
         manager = WorktreeManager(config)
-        proc = _make_proc(returncode=0, stdout=b"abc123\trefs/heads/agent/issue-7")
+        proc = make_proc(returncode=0, stdout=b"abc123\trefs/heads/agent/issue-7")
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager._remote_branch_exists("agent/issue-7")
@@ -721,7 +707,7 @@ class TestRemoteBranchExists:
         self, config, tmp_path: Path
     ) -> None:
         manager = WorktreeManager(config)
-        proc = _make_proc(returncode=0, stdout=b"")
+        proc = make_proc(returncode=0, stdout=b"")
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager._remote_branch_exists("agent/issue-99")
@@ -731,7 +717,7 @@ class TestRemoteBranchExists:
     @pytest.mark.asyncio
     async def test_returns_false_on_error(self, config, tmp_path: Path) -> None:
         manager = WorktreeManager(config)
-        proc = _make_proc(returncode=1, stderr=b"fatal: network error")
+        proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager._remote_branch_exists("agent/issue-7")
@@ -1107,7 +1093,7 @@ class TestConfigureGitIdentity:
             state_file=tmp_path / "state.json",
         )
         manager = WorktreeManager(cfg)
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1159,7 +1145,7 @@ class TestConfigureGitIdentity:
             state_file=tmp_path / "state.json",
         )
         manager = WorktreeManager(cfg)
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1188,7 +1174,7 @@ class TestConfigureGitIdentity:
             state_file=tmp_path / "state.json",
         )
         manager = WorktreeManager(cfg)
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1214,7 +1200,7 @@ class TestConfigureGitIdentity:
         manager = WorktreeManager(cfg)
         cfg.worktree_base.mkdir(parents=True, exist_ok=True)
 
-        success_proc = _make_proc()
+        success_proc = make_proc()
         configure_identity = AsyncMock()
 
         with (
@@ -1243,7 +1229,7 @@ class TestCreateVenv:
     async def test_create_venv_runs_uv_sync(self, config, tmp_path: Path) -> None:
         """_create_venv should run 'uv sync' in the worktree."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1257,7 +1243,7 @@ class TestCreateVenv:
     async def test_create_venv_swallows_errors(self, config, tmp_path: Path) -> None:
         """_create_venv should not propagate errors if uv sync fails."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"uv not found")
+        fail_proc = make_proc(returncode=1, stderr=b"uv not found")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             # Should not raise
@@ -1289,7 +1275,7 @@ class TestInstallHooks:
     async def test_install_hooks_sets_hooks_path(self, config, tmp_path: Path) -> None:
         """_install_hooks should set core.hooksPath to .githooks."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1308,7 +1294,7 @@ class TestInstallHooks:
     async def test_install_hooks_swallows_errors(self, config, tmp_path: Path) -> None:
         """_install_hooks should not propagate errors if git config fails."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"error")
+        fail_proc = make_proc(returncode=1, stderr=b"error")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             # Should not raise
@@ -1329,7 +1315,7 @@ class TestStartMergeMain:
     ) -> None:
         """start_merge_main should return True when all commands succeed."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch("asyncio.create_subprocess_exec", return_value=success_proc):
             result = await manager.start_merge_main(tmp_path, "agent/issue-7")
@@ -1343,8 +1329,8 @@ class TestStartMergeMain:
         """start_merge_main should return False on conflict and NOT call --abort."""
         manager = WorktreeManager(config)
 
-        success_proc = _make_proc(returncode=0)
-        merge_fail_proc = _make_proc(
+        success_proc = make_proc(returncode=0)
+        merge_fail_proc = make_proc(
             returncode=1, stderr=b"CONFLICT (content): Merge conflict"
         )
 
@@ -1377,7 +1363,7 @@ class TestStartMergeMain:
         """start_merge_main should return False if fetch fails."""
         manager = WorktreeManager(config)
 
-        fetch_fail_proc = _make_proc(returncode=1, stderr=b"fatal: network error")
+        fetch_fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
         with patch("asyncio.create_subprocess_exec", return_value=fetch_fail_proc):
             result = await manager.start_merge_main(tmp_path, "agent/issue-7")
@@ -1399,7 +1385,7 @@ class TestAbortMerge:
     ) -> None:
         """abort_merge should call 'git merge --abort' with correct cwd."""
         manager = WorktreeManager(config)
-        success_proc = _make_proc(returncode=0)
+        success_proc = make_proc(returncode=0)
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -1416,7 +1402,7 @@ class TestAbortMerge:
     ) -> None:
         """abort_merge should suppress RuntimeError via contextlib.suppress."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: no merge in progress")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: no merge in progress")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             # Should not raise
@@ -1438,7 +1424,7 @@ class TestGetConflictingFiles:
         """Should return file names from git diff --name-only --diff-filter=U."""
         manager = WorktreeManager(config)
         output = b"src/foo.py\nsrc/bar.py\n"
-        proc = _make_proc(returncode=0, stdout=output)
+        proc = make_proc(returncode=0, stdout=output)
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager.get_conflicting_files(tmp_path)
@@ -1451,7 +1437,7 @@ class TestGetConflictingFiles:
     ) -> None:
         """Should return empty list when no files have conflicts."""
         manager = WorktreeManager(config)
-        proc = _make_proc(returncode=0, stdout=b"")
+        proc = make_proc(returncode=0, stdout=b"")
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager.get_conflicting_files(tmp_path)
@@ -1462,7 +1448,7 @@ class TestGetConflictingFiles:
     async def test_returns_empty_on_failure(self, config, tmp_path: Path) -> None:
         """Should return empty list when git command fails."""
         manager = WorktreeManager(config)
-        proc = _make_proc(returncode=1, stderr=b"fatal: not a git repo")
+        proc = make_proc(returncode=1, stderr=b"fatal: not a git repo")
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager.get_conflicting_files(tmp_path)
@@ -1476,7 +1462,7 @@ class TestGetConflictingFiles:
         """Should strip leading/trailing whitespace from each filename."""
         manager = WorktreeManager(config)
         output = b"  foo.py  \n  bar.py  \n\n"
-        proc = _make_proc(returncode=0, stdout=output)
+        proc = make_proc(returncode=0, stdout=output)
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
             result = await manager.get_conflicting_files(tmp_path)
@@ -1498,8 +1484,8 @@ class TestGetMainDiffForFiles:
     ) -> None:
         """Should return the diff output for the given files."""
         manager = WorktreeManager(config)
-        merge_base_proc = _make_proc(returncode=0, stdout=b"abc123\n")
-        diff_proc = _make_proc(
+        merge_base_proc = make_proc(returncode=0, stdout=b"abc123\n")
+        diff_proc = make_proc(
             returncode=0, stdout=b"diff --git a/foo.py b/foo.py\n+added\n"
         )
 
@@ -1535,9 +1521,9 @@ class TestGetMainDiffForFiles:
     async def test_truncates_large_diff(self, config, tmp_path: Path) -> None:
         """Should truncate diff exceeding max_chars and append marker."""
         manager = WorktreeManager(config)
-        merge_base_proc = _make_proc(returncode=0, stdout=b"abc123\n")
+        merge_base_proc = make_proc(returncode=0, stdout=b"abc123\n")
         large_diff = b"x" * 50_000
-        diff_proc = _make_proc(returncode=0, stdout=large_diff)
+        diff_proc = make_proc(returncode=0, stdout=large_diff)
 
         call_count = 0
 
@@ -1562,7 +1548,7 @@ class TestGetMainDiffForFiles:
     ) -> None:
         """Should return empty string when git merge-base fails."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: bad revision")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: bad revision")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             result = await manager.get_main_diff_for_files(tmp_path, ["foo.py"])
@@ -1573,8 +1559,8 @@ class TestGetMainDiffForFiles:
     async def test_returns_empty_on_diff_failure(self, config, tmp_path: Path) -> None:
         """Should return empty string when git diff fails."""
         manager = WorktreeManager(config)
-        merge_base_proc = _make_proc(returncode=0, stdout=b"abc123\n")
-        diff_fail_proc = _make_proc(returncode=1, stderr=b"fatal: bad path")
+        merge_base_proc = make_proc(returncode=0, stdout=b"abc123\n")
+        diff_fail_proc = make_proc(returncode=1, stderr=b"fatal: bad path")
 
         call_count = 0
 
@@ -1594,8 +1580,8 @@ class TestGetMainDiffForFiles:
     async def test_passes_multiple_files(self, config, tmp_path: Path) -> None:
         """Should pass all files to the git diff command."""
         manager = WorktreeManager(config)
-        merge_base_proc = _make_proc(returncode=0, stdout=b"abc123\n")
-        diff_proc = _make_proc(returncode=0, stdout=b"combined diff\n")
+        merge_base_proc = make_proc(returncode=0, stdout=b"abc123\n")
+        diff_proc = make_proc(returncode=0, stdout=b"combined diff\n")
 
         call_count = 0
 
@@ -1633,9 +1619,9 @@ class TestGetMainCommitsSinceDiverge:
         """Should return oneline commits from HEAD..origin/main."""
         manager = WorktreeManager(config)
 
-        fetch_proc = _make_proc(returncode=0)
+        fetch_proc = make_proc(returncode=0)
         log_output = b"abc1234 Add feature X\ndef5678 Fix bug Y\n"
-        log_proc = _make_proc(returncode=0, stdout=log_output)
+        log_proc = make_proc(returncode=0, stdout=log_output)
 
         call_count = 0
 
@@ -1656,7 +1642,7 @@ class TestGetMainCommitsSinceDiverge:
     async def test_returns_empty_on_fetch_failure(self, config, tmp_path: Path) -> None:
         """Should return empty string when git fetch fails."""
         manager = WorktreeManager(config)
-        fail_proc = _make_proc(returncode=1, stderr=b"fatal: network error")
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
         with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
             result = await manager.get_main_commits_since_diverge(tmp_path)
@@ -1668,8 +1654,8 @@ class TestGetMainCommitsSinceDiverge:
         """Should return empty string when git log fails."""
         manager = WorktreeManager(config)
 
-        fetch_proc = _make_proc(returncode=0)
-        log_fail_proc = _make_proc(returncode=1, stderr=b"fatal: bad revision")
+        fetch_proc = make_proc(returncode=0)
+        log_fail_proc = make_proc(returncode=1, stderr=b"fatal: bad revision")
 
         call_count = 0
 
@@ -1692,8 +1678,8 @@ class TestGetMainCommitsSinceDiverge:
         """Should return empty string when branch is up to date with main."""
         manager = WorktreeManager(config)
 
-        fetch_proc = _make_proc(returncode=0)
-        log_proc = _make_proc(returncode=0, stdout=b"")
+        fetch_proc = make_proc(returncode=0)
+        log_proc = make_proc(returncode=0, stdout=b"")
 
         call_count = 0
 
@@ -1714,7 +1700,7 @@ class TestGetMainCommitsSinceDiverge:
         """Should pass -30 to limit the number of commits."""
         manager = WorktreeManager(config)
 
-        success_proc = _make_proc(returncode=0, stdout=b"abc123 commit\n")
+        success_proc = make_proc(returncode=0, stdout=b"abc123 commit\n")
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc
@@ -2074,7 +2060,7 @@ class TestInstallHooksDocker:
         """Confirm host mode still sets core.hooksPath (regression check)."""
         assert config.execution_mode == "host"
         manager = WorktreeManager(config)
-        success_proc = _make_proc()
+        success_proc = make_proc()
 
         with patch(
             "asyncio.create_subprocess_exec", return_value=success_proc


### PR DESCRIPTION
## Summary
- Removed 6 unused fixture wrappers from `conftest.py` (worker_result, plan_result, pr_info, hitl_runner, orchestrator_mock, subprocess_mock)
- Extracted shared `make_proc` helper into `tests/helpers.py`; replaced local `_make_proc` in test_agent.py and test_worktree.py
- Replaced `_make_subprocess_mock` in test_pr_manager.py with `SubprocessMockBuilder` pattern
- Replaced `make_tracker` → `make_state` in test_session.py and `_make_state` → `make_state` in test_pr_unsticker.py
- Added local fixtures in test_hitl_runner.py and test_reviewer.py for self-contained tests

## Test plan
- [x] `make quality` passes (4232 tests, lint, typecheck all clean)
- [x] No fixture is left unused in conftest.py
- [x] All test files use shared helpers from `tests/helpers.py`

Replaces #898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)