### PR TITLE
feat: fresh branch rebuild fallback for intractable merge conflicts

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,6 +86,11 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ("inject_runtime_logs", "HYDRAFLOW_INJECT_RUNTIME_LOGS", False),
     ("unstick_auto_merge", "HYDRAFLOW_UNSTICK_AUTO_MERGE", True),
     ("unstick_all_causes", "HYDRAFLOW_UNSTICK_ALL_CAUSES", True),
+    (
+        "enable_fresh_branch_rebuild",
+        "HYDRAFLOW_ENABLE_FRESH_BRANCH_REBUILD",
+        True,
+    ),
 ]
 
 # Label env var overrides — maps env key → (field_name, default_value)
@@ -569,6 +574,11 @@ class HydraFlowConfig(BaseModel):
     unstick_all_causes: bool = Field(
         default=True,
         description="Process all HITL causes (not just merge conflicts)",
+    )
+    enable_fresh_branch_rebuild: bool = Field(
+        default=True,
+        description="After merge conflict resolution exhausts all attempts, "
+        "try rebuilding on a fresh branch from main before escalating to HITL",
     )
 
     # Session retention

--- a/conflict_prompt.py
+++ b/conflict_prompt.py
@@ -93,3 +93,101 @@ def build_conflict_prompt(
     )
 
     return "\n\n".join(sections)
+
+
+def build_rebuild_prompt(
+    issue_url: str,
+    pr_url: str,
+    issue_number: int,
+    pr_diff: str,
+    *,
+    config: HydraFlowConfig | None = None,
+) -> str:
+    """Build a prompt for re-applying PR changes on a fresh branch from main.
+
+    Parameters
+    ----------
+    issue_url:
+        Full GitHub URL for the issue.
+    pr_url:
+        Full GitHub URL for the pull request.
+    issue_number:
+        Issue number for the commit message.
+    pr_diff:
+        The diff of the original PR (truncated to ``max_review_diff_chars``).
+    config:
+        Optional config for injecting project manifest and memory digest.
+    """
+    max_diff_chars = config.max_review_diff_chars if config is not None else 15_000
+    truncated_diff = pr_diff[:max_diff_chars]
+
+    sections: list[str] = []
+
+    # --- Header ---
+    sections.append(
+        "You are re-applying changes from a pull request onto a fresh branch "
+        "from main.\n\n"
+        "The original PR had merge conflicts that could not be resolved "
+        "automatically. You are now on a **clean branch from current main** "
+        "— no conflicts.\n\n"
+        f"- Issue: {issue_url}\n"
+        f"- PR: {pr_url}"
+    )
+
+    # --- Project manifest & memory digest ---
+    if config is not None:
+        manifest = load_project_manifest(config)
+        if manifest:
+            sections.append(f"## Project Context\n\n{manifest}")
+        digest = load_memory_digest(config)
+        if digest:
+            sections.append(f"## Accumulated Learnings\n\n{digest}")
+
+    # --- Original PR diff ---
+    sections.append(
+        "## Original PR Diff\n\n"
+        "Below is the diff of what the PR changed. Re-apply these logical "
+        "changes to the current codebase. The code on main may have evolved, "
+        "so adapt accordingly — do NOT blindly paste.\n\n"
+        f"```diff\n{truncated_diff}\n```"
+    )
+
+    # --- Instructions ---
+    sections.append(
+        "## Instructions\n\n"
+        "1. Study the diff to understand what the PR accomplished.\n"
+        "2. Read the issue for full requirements context.\n"
+        "3. Apply the same logical changes to the current codebase.\n"
+        "4. Write or update tests as needed.\n"
+        "5. Run `make quality` to verify everything passes.\n"
+        f'6. Commit with message: "Rebuild: Fixes #{issue_number}"'
+    )
+
+    # --- Rules ---
+    sections.append(
+        "## Rules\n\n"
+        "- Follow CLAUDE.md strictly.\n"
+        "- Tests are mandatory.\n"
+        "- Do NOT push or create PRs.\n"
+        "- Ensure `make quality` passes."
+    )
+
+    # --- Optional memory suggestion ---
+    sections.append(
+        "## Optional: Memory Suggestion\n\n"
+        "If you discover a reusable pattern or insight during this "
+        "rebuild that would help future agent runs, "
+        "you may output ONE suggestion:\n\n"
+        "MEMORY_SUGGESTION_START\n"
+        "title: Short descriptive title\n"
+        "type: knowledge | config | instruction | code\n"
+        "learning: What was learned and why it matters\n"
+        "context: How it was discovered (reference issue/PR numbers)\n"
+        "MEMORY_SUGGESTION_END\n\n"
+        "Types: knowledge (passive insight), config (suggests config change), "
+        "instruction (new agent instruction), code (suggests code change).\n"
+        "Actionable types (config, instruction, code) will be routed for human approval.\n"
+        "Only suggest genuinely valuable learnings — not trivial observations."
+    )
+
+    return "\n\n".join(sections)

--- a/merge_conflict_resolver.py
+++ b/merge_conflict_resolver.py
@@ -56,6 +56,7 @@ class MergeConflictResolver:
         """
         await publish_fn(pr, worker_id, "merge_main")
         merged = await self._worktrees.merge_main(wt_path, pr.branch)
+        used_rebuild = False
         if not merged:
             logger.info(
                 "PR #%d has conflicts with %s — running agent to resolve",
@@ -63,11 +64,16 @@ class MergeConflictResolver:
                 self._config.main_branch,
             )
             await publish_fn(pr, worker_id, WorkerStatus.MERGE_FIX.value)
-            merged = await self.resolve_merge_conflicts(
+            merged, used_rebuild = await self.resolve_merge_conflicts(
                 pr, issue, wt_path, worker_id=worker_id
             )
         if merged:
-            await self._prs.push_branch(wt_path, pr.branch)
+            if used_rebuild:
+                # Branch history was rewritten — need force-push
+                new_wt = self._config.worktree_path_for_issue(pr.issue_number)
+                await self._prs.force_push_branch(new_wt, pr.branch)
+            else:
+                await self._prs.push_branch(wt_path, pr.branch)
             return True
 
         logger.warning(
@@ -96,13 +102,19 @@ class MergeConflictResolver:
         issue: GitHubIssue,
         wt_path: Path,
         worker_id: int,
-    ) -> bool:
+    ) -> tuple[bool, bool]:
         """Use the implementation agent to resolve merge conflicts.
 
         Retries up to ``config.max_merge_conflict_fix_attempts`` times.
         Each attempt starts a merge (leaving conflict markers), runs the
         agent to resolve them, and verifies with ``make quality``.
-        Returns *True* if the conflicts were resolved successfully.
+
+        If all merge attempts fail, falls back to :meth:`fresh_branch_rebuild`
+        which destroys the worktree and re-applies the PR diff on a clean
+        branch from main.
+
+        Returns ``(success, used_rebuild)`` — *used_rebuild* is True when
+        the fresh rebuild path was taken (caller should force-push).
         """
         from conflict_prompt import build_conflict_prompt
 
@@ -111,7 +123,7 @@ class MergeConflictResolver:
                 "No agent runner available for conflict resolution on PR #%d",
                 pr.number,
             )
-            return False
+            return False, False
 
         max_attempts = self._config.max_merge_conflict_fix_attempts
         last_error: str | None = None
@@ -124,7 +136,7 @@ class MergeConflictResolver:
             # Start merge leaving conflict markers in place
             clean = await self._worktrees.start_merge_main(wt_path, pr.branch)
             if clean:
-                return True
+                return True, False
 
             logger.info(
                 "Conflict resolution attempt %d/%d for PR #%d",
@@ -174,7 +186,7 @@ class MergeConflictResolver:
                     await self._maybe_summarize_conflict(
                         transcript, issue.number, pr.number
                     )
-                    return True
+                    return True, False
 
                 last_error = error_msg
                 logger.warning(
@@ -199,9 +211,120 @@ class MergeConflictResolver:
                 )
                 last_error = str(exc)
 
-        # All attempts exhausted — abort and let caller escalate
+        # All merge attempts exhausted — abort merge and try fresh rebuild
         await self._worktrees.abort_merge(wt_path)
-        return False
+
+        logger.info(
+            "All %d merge attempts exhausted for PR #%d — trying fresh branch rebuild",
+            max_attempts,
+            pr.number,
+        )
+        rebuilt = await self.fresh_branch_rebuild(pr, issue, worker_id)
+        if rebuilt:
+            return True, True
+
+        return False, False
+
+    async def fresh_branch_rebuild(
+        self,
+        pr: PRInfo,
+        issue: GitHubIssue,
+        worker_id: int,
+    ) -> bool:
+        """Rebuild the PR branch from scratch on a fresh branch from main.
+
+        Fetches the PR diff, destroys the old conflicted worktree, creates a
+        fresh worktree from main, and runs an agent to re-apply the changes.
+        Returns *True* if the rebuild succeeded and verified.
+        """
+        from conflict_prompt import build_rebuild_prompt
+
+        if not self._config.enable_fresh_branch_rebuild:
+            logger.info(
+                "Fresh branch rebuild disabled — skipping for PR #%d", pr.number
+            )
+            return False
+
+        if self._agents is None:
+            logger.warning("No agent runner for fresh rebuild on PR #%d", pr.number)
+            return False
+
+        # Fetch the PR diff
+        pr_diff = await self._prs.get_pr_diff(pr.number)
+        if not pr_diff.strip():
+            logger.warning(
+                "Empty PR diff for PR #%d — skipping fresh rebuild", pr.number
+            )
+            return False
+
+        await self._publish_review_status(
+            pr, worker_id, WorkerStatus.FRESH_REBUILD.value
+        )
+
+        # Destroy old worktree and create fresh one from main
+        await self._worktrees.destroy(pr.issue_number)
+        new_wt = await self._worktrees.create(pr.issue_number, pr.branch)
+
+        logger.info(
+            "Fresh branch rebuild: created clean worktree at %s for PR #%d",
+            new_wt,
+            pr.number,
+        )
+
+        try:
+            prompt = build_rebuild_prompt(
+                issue.url,
+                pr.url,
+                issue.number,
+                pr_diff,
+                config=self._config,
+            )
+            cmd = self._agents._build_command(new_wt)
+            transcript = await self._agents._execute(
+                cmd,
+                prompt,
+                new_wt,
+                {"issue": issue.number, "source": "fresh_rebuild"},
+            )
+
+            self._save_conflict_transcript(pr.number, issue.number, 0, transcript)
+
+            try:
+                await file_memory_suggestion(
+                    transcript,
+                    "fresh_rebuild",
+                    f"PR #{pr.number}",
+                    self._config,
+                    self._prs,
+                    self._state,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to file memory suggestion for fresh rebuild on PR #%d",
+                    pr.number,
+                )
+
+            success, error_msg = await self._agents._verify_result(new_wt, pr.branch)
+            if success:
+                await self._maybe_summarize_conflict(
+                    transcript, issue.number, pr.number
+                )
+                logger.info("Fresh branch rebuild succeeded for PR #%d", pr.number)
+                return True
+
+            logger.warning(
+                "Fresh branch rebuild verification failed for PR #%d: %s",
+                pr.number,
+                error_msg[:200] if error_msg else "",
+            )
+            return False
+        except Exception as exc:
+            logger.error(
+                "Fresh branch rebuild agent failed for PR #%d: %s",
+                pr.number,
+                exc,
+            )
+            return False
 
     async def _maybe_summarize_conflict(
         self, transcript: str, issue_number: int, pr_number: int

--- a/models.py
+++ b/models.py
@@ -193,6 +193,7 @@ class WorkerStatus(StrEnum):
     COMMITTING = "committing"
     QUALITY_FIX = "quality_fix"
     MERGE_FIX = "merge_fix"
+    FRESH_REBUILD = "fresh_rebuild"
     DONE = "done"
     FAILED = "failed"
 

--- a/pr_manager.py
+++ b/pr_manager.py
@@ -88,6 +88,34 @@ class PRManager:
             logger.error("Push failed for %s: %s", branch, exc)
             return False
 
+    async def force_push_branch(self, worktree_path: Path, branch: str) -> bool:
+        """Force-push *branch* to origin using ``--force-with-lease``.
+
+        Safer than ``--force`` — prevents clobbering concurrent pushes.
+        Used after fresh-branch rebuilds where branch history is rewritten.
+        Returns *True* on success.
+        """
+        if self._config.dry_run:
+            logger.info("[dry-run] Would force-push branch %s", branch)
+            return True
+
+        try:
+            await run_subprocess(
+                "git",
+                "push",
+                "--no-verify",
+                "--force-with-lease",
+                "-u",
+                "origin",
+                branch,
+                cwd=worktree_path,
+                gh_token=self._config.gh_token,
+            )
+            return True
+        except RuntimeError as exc:
+            logger.error("Force-push failed for %s: %s", branch, exc)
+            return False
+
     async def create_pr(
         self,
         issue: GitHubIssue,

--- a/pr_unsticker.py
+++ b/pr_unsticker.py
@@ -251,13 +251,23 @@ class PRUnsticker:
             self._state.set_worktree(issue_number, str(wt_path))
 
             # Dispatch to cause-specific resolver
-            resolved = await self._resolve_by_cause(
-                cause, issue_number, issue, wt_path, branch, item.prUrl
+            resolved, used_rebuild = await self._resolve_by_cause(
+                cause,
+                issue_number,
+                issue,
+                wt_path,
+                branch,
+                item.prUrl,
+                pr_number=item.pr,
             )
 
             if resolved:
                 # Push the fixed branch
-                await self._prs.push_branch(wt_path, branch)
+                if used_rebuild:
+                    new_wt = self._config.worktree_path_for_issue(issue_number)
+                    await self._prs.force_push_branch(new_wt, branch)
+                else:
+                    await self._prs.push_branch(wt_path, branch)
 
                 if not self._config.unstick_auto_merge:
                     # Restore origin label when not auto-merging
@@ -307,17 +317,29 @@ class PRUnsticker:
         wt_path: Path,
         branch: str,
         pr_url: str,
-    ) -> bool:
-        """Dispatch to the appropriate resolver based on cause classification."""
+        pr_number: int = 0,
+    ) -> tuple[bool, bool]:
+        """Dispatch to the appropriate resolver based on cause classification.
+
+        Returns ``(resolved, used_rebuild)`` — *used_rebuild* is True when
+        the fresh-branch rebuild path was taken (caller should force-push).
+        """
         if cause == FailureCause.MERGE_CONFLICT:
             return await self._resolve_conflicts(
-                issue_number, issue, wt_path, branch, pr_url=pr_url
+                issue_number,
+                issue,
+                wt_path,
+                branch,
+                pr_url=pr_url,
+                pr_number=pr_number,
             )
         if cause in (FailureCause.CI_FAILURE, FailureCause.REVIEW_FIX_CAP):
-            return await self._resolve_ci_or_quality(
+            result = await self._resolve_ci_or_quality(
                 issue_number, issue, wt_path, branch, pr_url=pr_url
             )
-        return await self._resolve_generic(issue_number, issue, wt_path, branch)
+            return result, False
+        result = await self._resolve_generic(issue_number, issue, wt_path, branch)
+        return result, False
 
     async def _resolve_ci_or_quality(
         self,
@@ -524,8 +546,13 @@ PR URL: {pr_url}
         wt_path: Path,
         branch: str,
         pr_url: str,
-    ) -> bool:
-        """Run the conflict resolution loop, mirroring ReviewPhase logic."""
+        pr_number: int = 0,
+    ) -> tuple[bool, bool]:
+        """Run the conflict resolution loop, mirroring ReviewPhase logic.
+
+        Returns ``(resolved, used_rebuild)`` — *used_rebuild* is True when
+        the fresh-branch rebuild path was taken.
+        """
         from conflict_prompt import build_conflict_prompt
 
         max_attempts = self._config.max_merge_conflict_fix_attempts
@@ -539,7 +566,7 @@ PR URL: {pr_url}
             # Start merge leaving conflict markers in place
             clean = await self._worktrees.start_merge_main(wt_path, branch)
             if clean:
-                return True
+                return True, False
 
             logger.info(
                 "Unsticker conflict resolution attempt %d/%d for issue #%d",
@@ -579,7 +606,7 @@ PR URL: {pr_url}
 
                 success, error_msg = await self._agents._verify_result(wt_path, branch)
                 if success:
-                    return True
+                    return True, False
 
                 last_error = error_msg
                 logger.warning(
@@ -599,9 +626,119 @@ PR URL: {pr_url}
                 )
                 last_error = str(exc)
 
-        # All attempts exhausted — abort the merge
+        # All merge attempts exhausted — abort and try fresh rebuild
         await self._worktrees.abort_merge(wt_path)
-        return False
+
+        rebuilt = await self._fresh_branch_rebuild(
+            issue_number, issue, branch, pr_url, pr_number
+        )
+        if rebuilt:
+            return True, True
+
+        return False, False
+
+    async def _fresh_branch_rebuild(
+        self,
+        issue_number: int,
+        issue: GitHubIssue,
+        branch: str,
+        pr_url: str,
+        pr_number: int,
+    ) -> bool:
+        """Rebuild the PR branch from scratch on a fresh branch from main.
+
+        Fetches the PR diff, destroys the old conflicted worktree, creates a
+        fresh worktree from main, and runs an agent to re-apply the changes.
+        Returns *True* if the rebuild succeeded and verified.
+        """
+        from conflict_prompt import build_rebuild_prompt
+
+        if not self._config.enable_fresh_branch_rebuild:
+            logger.info(
+                "Fresh branch rebuild disabled — skipping for issue #%d",
+                issue_number,
+            )
+            return False
+
+        if not pr_number:
+            logger.warning(
+                "No PR number for issue #%d — cannot fetch diff for rebuild",
+                issue_number,
+            )
+            return False
+
+        # Fetch the PR diff
+        pr_diff = await self._prs.get_pr_diff(pr_number)
+        if not pr_diff.strip():
+            logger.warning(
+                "Empty PR diff for issue #%d — skipping fresh rebuild",
+                issue_number,
+            )
+            return False
+
+        logger.info(
+            "Attempting fresh branch rebuild for issue #%d (PR #%d)",
+            issue_number,
+            pr_number,
+        )
+
+        # Destroy old worktree and create fresh one from main
+        await self._worktrees.destroy(issue_number)
+        new_wt = await self._worktrees.create(issue_number, branch)
+
+        try:
+            prompt = build_rebuild_prompt(
+                issue.url,
+                pr_url,
+                issue_number,
+                pr_diff,
+                config=self._config,
+            )
+            cmd = self._agents._build_command(new_wt)
+            transcript = await self._agents._execute(
+                cmd,
+                prompt,
+                new_wt,
+                {"issue": issue_number, "source": "fresh_rebuild"},
+            )
+
+            self._save_transcript(issue_number, 0, transcript)
+
+            try:
+                await file_memory_suggestion(
+                    transcript,
+                    "fresh_rebuild",
+                    f"issue #{issue_number}",
+                    self._config,
+                    self._prs,
+                    self._state,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to file memory suggestion for fresh rebuild on issue #%d",
+                    issue_number,
+                )
+
+            success, error_msg = await self._agents._verify_result(new_wt, branch)
+            if success:
+                logger.info(
+                    "Fresh branch rebuild succeeded for issue #%d", issue_number
+                )
+                return True
+
+            logger.warning(
+                "Fresh branch rebuild verification failed for issue #%d: %s",
+                issue_number,
+                error_msg[:200] if error_msg else "",
+            )
+            return False
+        except Exception as exc:
+            logger.error(
+                "Fresh branch rebuild agent failed for issue #%d: %s",
+                issue_number,
+                exc,
+            )
+            return False
 
     async def _release_back_to_hitl(self, issue_number: int, reason: str) -> None:
         """Remove active label and re-add HITL label."""

--- a/review_phase.py
+++ b/review_phase.py
@@ -799,7 +799,9 @@ class ReviewPhase:
 
     # Delegate properties for backward compatibility in tests
     @property
-    def _resolve_merge_conflicts(self) -> Callable[..., Coroutine[Any, Any, bool]]:
+    def _resolve_merge_conflicts(
+        self,
+    ) -> Callable[..., Coroutine[Any, Any, tuple[bool, bool]]]:
         """Backward-compatible access to conflict resolver."""
         return self._conflict_resolver.resolve_merge_conflicts
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -251,6 +251,7 @@ class ConfigFactory:
         error_output_max_chars: int = 3000,
         unstick_auto_merge: bool = True,
         unstick_all_causes: bool = True,
+        enable_fresh_branch_rebuild: bool = True,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -384,6 +385,7 @@ class ConfigFactory:
             error_output_max_chars=error_output_max_chars,
             unstick_auto_merge=unstick_auto_merge,
             unstick_all_causes=unstick_all_causes,
+            enable_fresh_branch_rebuild=enable_fresh_branch_rebuild,
         )
 
 

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -19,6 +19,7 @@ from events import EventBus
 from merge_conflict_resolver import MergeConflictResolver
 from state import StateTracker
 from tests.conftest import IssueFactory, PRInfoFactory
+from tests.helpers import ConfigFactory
 
 
 def _make_resolver(config: HydraFlowConfig, *, agents=None) -> MergeConflictResolver:
@@ -100,7 +101,7 @@ class TestMergeConflictResolver:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result == (False, False)
 
     @pytest.mark.asyncio
     async def test_resolve_returns_true_on_clean_merge(
@@ -118,7 +119,7 @@ class TestMergeConflictResolver:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is True
+        assert result == (True, False)
         mock_agents._execute.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -139,7 +140,7 @@ class TestMergeConflictResolver:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is True
+        assert result == (True, False)
         mock_agents._build_command.assert_called_once()
         mock_agents._execute.assert_awaited_once()
 
@@ -161,3 +162,180 @@ class TestMergeConflictResolver:
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
         assert (log_dir / "conflict-pr-101-attempt-1.txt").exists()
+
+
+class TestFreshBranchRebuild:
+    """Tests for the fresh branch rebuild fallback."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_called_after_merge_exhaustion(
+        self, tmp_path: Path
+    ) -> None:
+        """All merge attempts fail → rebuild is attempted."""
+        cfg = ConfigFactory.create(
+            max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=True,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mock_agents = AsyncMock()
+        mock_agents._execute = AsyncMock(return_value="transcript")
+        # First call (merge attempt) fails, second call (rebuild) succeeds
+        mock_agents._verify_result = AsyncMock(
+            side_effect=[(False, "quality failed"), (True, "")]
+        )
+        resolver = _make_resolver(cfg, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._worktrees.abort_merge = AsyncMock()
+        resolver._worktrees.destroy = AsyncMock()
+        resolver._worktrees.create = AsyncMock(
+            return_value=tmp_path / "worktrees" / "issue-42"
+        )
+        resolver._prs.get_pr_diff = AsyncMock(return_value="diff --git a/foo.py\n+bar")
+
+        success, used_rebuild = await resolver.resolve_merge_conflicts(
+            pr, issue, tmp_path / "worktrees" / "issue-42", worker_id=0
+        )
+
+        assert success is True
+        assert used_rebuild is True
+        resolver._worktrees.destroy.assert_awaited_once()
+        resolver._worktrees.create.assert_awaited_once()
+        resolver._prs.get_pr_diff.assert_awaited_once_with(pr.number)
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_succeeds(self, tmp_path: Path) -> None:
+        """Full rebuild flow: get diff, destroy, create, agent, verify."""
+        cfg = ConfigFactory.create(
+            enable_fresh_branch_rebuild=True,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mock_agents = AsyncMock()
+        mock_agents._execute = AsyncMock(return_value="rebuilt transcript")
+        mock_agents._verify_result = AsyncMock(return_value=(True, ""))
+        resolver = _make_resolver(cfg, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        new_wt = tmp_path / "worktrees" / "issue-42"
+        resolver._worktrees.destroy = AsyncMock()
+        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
+
+        result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
+
+        assert result is True
+        resolver._worktrees.destroy.assert_awaited_once_with(pr.issue_number)
+        resolver._worktrees.create.assert_awaited_once_with(pr.issue_number, pr.branch)
+        mock_agents._build_command.assert_called_once_with(new_wt)
+        mock_agents._execute.assert_awaited_once()
+        mock_agents._verify_result.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_skipped_when_disabled(self, tmp_path: Path) -> None:
+        """Config flag off → returns False directly."""
+        cfg = ConfigFactory.create(
+            enable_fresh_branch_rebuild=False,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mock_agents = AsyncMock()
+        resolver = _make_resolver(cfg, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
+
+        assert result is False
+        mock_agents._execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_skipped_when_no_agents(self, tmp_path: Path) -> None:
+        """No agent runner → returns False."""
+        cfg = ConfigFactory.create(
+            enable_fresh_branch_rebuild=True,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        resolver = _make_resolver(cfg, agents=None)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_skipped_when_empty_diff(self, tmp_path: Path) -> None:
+        """Empty diff → returns False without creating worktree."""
+        cfg = ConfigFactory.create(
+            enable_fresh_branch_rebuild=True,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mock_agents = AsyncMock()
+        resolver = _make_resolver(cfg, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        resolver._prs.get_pr_diff = AsyncMock(return_value="")
+
+        result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
+
+        assert result is False
+        resolver._worktrees.destroy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_uses_force_push(self, tmp_path: Path) -> None:
+        """After rebuild, merge_with_main should use force_push_branch."""
+        cfg = ConfigFactory.create(
+            max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=True,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        mock_agents = AsyncMock()
+        mock_agents._execute = AsyncMock(return_value="transcript")
+        # Merge attempt fails, rebuild succeeds
+        mock_agents._verify_result = AsyncMock(
+            side_effect=[(False, "failed"), (True, "")]
+        )
+        resolver = _make_resolver(cfg, agents=mock_agents)
+        pr = PRInfoFactory.create()
+        issue = IssueFactory.create()
+
+        new_wt = tmp_path / "worktrees" / "issue-42"
+        resolver._worktrees.merge_main = AsyncMock(return_value=False)
+        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._worktrees.abort_merge = AsyncMock()
+        resolver._worktrees.destroy = AsyncMock()
+        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
+        resolver._prs.push_branch = AsyncMock(return_value=True)
+        resolver._prs.force_push_branch = AsyncMock(return_value=True)
+
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+
+        result = await resolver.merge_with_main(
+            pr,
+            issue,
+            new_wt,
+            0,
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+        )
+
+        assert result is True
+        resolver._prs.force_push_branch.assert_awaited_once()
+        resolver._prs.push_branch.assert_not_awaited()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -411,9 +411,9 @@ class TestWorkerStatus:
         # Assert
         assert isinstance(WorkerStatus.DONE, str)
 
-    def test_all_nine_members_present(self) -> None:
+    def test_all_ten_members_present(self) -> None:
         # Assert
-        assert len(WorkerStatus) == 9
+        assert len(WorkerStatus) == 10
 
     def test_lookup_by_value(self) -> None:
         # Act

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -618,6 +618,53 @@ async def test_push_branch_failure_returns_false(config, event_bus, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# force_push_branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_push_branch_success(config, event_bus, tmp_path):
+    manager = _make_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout("").build()
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await manager.force_push_branch(tmp_path, "agent/issue-42")
+
+    assert result is True
+    args = mock_create.call_args[0]
+    assert args[0] == "git"
+    assert args[1] == "push"
+    assert "--force-with-lease" in args
+    assert "--no-verify" in args
+    assert "-u" in args
+    assert "origin" in args
+    assert "agent/issue-42" in args
+
+
+@pytest.mark.asyncio
+async def test_force_push_branch_failure(config, event_bus, tmp_path):
+    manager = _make_manager(config, event_bus)
+    mock_create = (
+        SubprocessMockBuilder()
+        .with_returncode(1)
+        .with_stderr("error: failed to push")
+        .build()
+    )
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await manager.force_push_branch(tmp_path, "agent/issue-99")
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_force_push_branch_dry_run(dry_config, event_bus, tmp_path):
+    manager = _make_manager(dry_config, event_bus)
+    result = await manager.force_push_branch(tmp_path, "agent/issue-42")
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
 # create_pr
 # ---------------------------------------------------------------------------
 

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -834,3 +834,135 @@ class TestMemorySuggestionExtraction:
             stats = await unsticker.unstick([_make_hitl_item(42)])
 
             assert stats["resolved"] == 1
+
+
+class TestFreshBranchRebuild:
+    """Tests for the fresh branch rebuild fallback in the unsticker."""
+
+    @pytest.mark.asyncio
+    async def test_conflict_falls_back_to_fresh_rebuild(self, tmp_path: Path) -> None:
+        """Merge exhaustion → fresh rebuild is attempted and succeeds."""
+        issue = GitHubIssue(
+            number=42,
+            title="Test issue",
+            body="body",
+            labels=["hydraflow-hitl"],
+            url="https://github.com/test-org/test-repo/issues/42",
+        )
+        unsticker, state, prs, agents, wt, fetcher, bus, _ = _make_unsticker(
+            tmp_path,
+            max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=True,
+            unstick_auto_merge=False,
+        )
+        state.set_hitl_cause(42, "Merge conflict")
+        state.set_hitl_origin(42, "hydraflow-review")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        wt.start_merge_main = AsyncMock(return_value=False)
+        wt.abort_merge = AsyncMock()
+        wt.destroy = AsyncMock()
+        new_wt = tmp_path / "worktrees" / "issue-42"
+        wt.create = AsyncMock(return_value=new_wt)
+
+        # First call (merge attempt) fails, second (rebuild) succeeds
+        agents._build_command = MagicMock(return_value=["claude", "-p"])
+        agents._execute = AsyncMock(return_value="transcript")
+        agents._verify_result = AsyncMock(
+            side_effect=[(False, "quality failed"), (True, "OK")]
+        )
+
+        prs.get_pr_diff = AsyncMock(return_value="diff --git a/foo.py\n+bar")
+        prs.force_push_branch = AsyncMock(return_value=True)
+        prs.push_branch = AsyncMock(return_value=True)
+
+        new_wt.mkdir(parents=True)
+        (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
+
+        pr_url = "https://github.com/test-org/test-repo/pull/100"
+        stats = await unsticker.unstick([_make_hitl_item(42, pr=100, prUrl=pr_url)])
+
+        assert stats["resolved"] == 1
+        wt.destroy.assert_awaited_once()
+        prs.get_pr_diff.assert_awaited_once_with(100)
+        # Should use force_push, not regular push
+        prs.force_push_branch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fresh_rebuild_disabled_skips(self, tmp_path: Path) -> None:
+        """Config flag off → goes straight to HITL without rebuild."""
+        issue = GitHubIssue(
+            number=42,
+            title="Test issue",
+            body="body",
+            labels=["hydraflow-hitl"],
+        )
+        unsticker, state, prs, agents, wt, fetcher, bus, _ = _make_unsticker(
+            tmp_path,
+            max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=False,
+            unstick_auto_merge=False,
+        )
+        state.set_hitl_cause(42, "Merge conflict")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        wt.start_merge_main = AsyncMock(return_value=False)
+        wt.abort_merge = AsyncMock()
+
+        agents._build_command = MagicMock(return_value=["claude", "-p"])
+        agents._execute = AsyncMock(return_value="transcript")
+        agents._verify_result = AsyncMock(return_value=(False, "quality failed"))
+
+        (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+        (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
+
+        stats = await unsticker.unstick([_make_hitl_item(42)])
+
+        assert stats["failed"] == 1
+        assert stats["resolved"] == 0
+        # destroy should not have been called (no rebuild)
+        wt.destroy.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pr_number_threaded_to_resolve_conflicts(
+        self, tmp_path: Path
+    ) -> None:
+        """pr_number from HITLItem flows through to _resolve_conflicts."""
+        issue = GitHubIssue(
+            number=42,
+            title="Test issue",
+            body="body",
+            labels=["hydraflow-hitl"],
+            url="https://github.com/test-org/test-repo/issues/42",
+        )
+        unsticker, state, prs, agents, wt, fetcher, bus, _ = _make_unsticker(
+            tmp_path,
+            max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=True,
+            unstick_auto_merge=False,
+        )
+        state.set_hitl_cause(42, "Merge conflict")
+        state.set_hitl_origin(42, "hydraflow-review")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        wt.start_merge_main = AsyncMock(return_value=False)
+        wt.abort_merge = AsyncMock()
+        wt.destroy = AsyncMock()
+        wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
+
+        agents._build_command = MagicMock(return_value=["claude", "-p"])
+        agents._execute = AsyncMock(return_value="transcript")
+        # Merge fails, rebuild also fails
+        agents._verify_result = AsyncMock(return_value=(False, "failed"))
+
+        prs.get_pr_diff = AsyncMock(return_value="diff content")
+        prs.push_branch = AsyncMock(return_value=True)
+
+        (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+        (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
+
+        pr_url = "https://github.com/test-org/test-repo/pull/200"
+        await unsticker.unstick([_make_hitl_item(42, pr=200, prUrl=pr_url)])
+
+        # get_pr_diff should have been called with the PR number
+        prs.get_pr_diff.assert_awaited_once_with(200)

--- a/tests/test_review_phase_merge.py
+++ b/tests/test_review_phase_merge.py
@@ -40,7 +40,7 @@ class TestResolveMergeConflicts:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result == (False, False)
 
     @pytest.mark.asyncio
     async def test_returns_true_when_start_merge_is_clean(
@@ -58,7 +58,7 @@ class TestResolveMergeConflicts:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is True
+        assert result == (True, False)
         # Agent should NOT have been invoked
         mock_agents._execute.assert_not_awaited()
 
@@ -80,7 +80,7 @@ class TestResolveMergeConflicts:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is True
+        assert result == (True, False)
         mock_agents._build_command.assert_called_once()
         mock_agents._execute.assert_awaited_once()
         mock_agents._verify_result.assert_awaited_once()
@@ -103,7 +103,7 @@ class TestResolveMergeConflicts:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result[0] is False
         # abort_merge called between retries + final abort
         assert phase._worktrees.abort_merge.await_count >= 1
 
@@ -126,7 +126,7 @@ class TestResolveMergeConflicts:
             pr, issue, config.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is True
+        assert result == (True, False)
         assert mock_agents._execute.await_count == 2
         assert mock_agents._verify_result.await_count == 2
 
@@ -135,10 +135,18 @@ class TestResolveMergeConflicts:
         self, config: HydraFlowConfig
     ) -> None:
         """When all attempts fail verification, should return False."""
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            enable_fresh_branch_rebuild=False,
+            repo_root=config.repo_root,
+            worktree_base=config.worktree_base,
+            state_file=config.state_file,
+        )
         mock_agents = AsyncMock()
         mock_agents._execute = AsyncMock(return_value="transcript")
         mock_agents._verify_result = AsyncMock(return_value=(False, "quality failed"))
-        phase = make_review_phase(config, agents=mock_agents)
+        phase = make_review_phase(cfg, agents=mock_agents)
         pr = PRInfoFactory.create()
         issue = IssueFactory.create()
 
@@ -146,10 +154,10 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, cfg.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result == (False, False)
         # Default is 3 attempts
         assert mock_agents._execute.await_count == 3
         assert mock_agents._verify_result.await_count == 3
@@ -231,6 +239,7 @@ class TestResolveMergeConflicts:
 
         cfg = ConfigFactory.create(
             max_merge_conflict_fix_attempts=1,
+            enable_fresh_branch_rebuild=False,
             repo_root=config.repo_root,
             worktree_base=config.worktree_base,
             state_file=config.state_file,
@@ -249,7 +258,7 @@ class TestResolveMergeConflicts:
             pr, issue, cfg.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result == (False, False)
         assert mock_agents._execute.await_count == 1
 
     @pytest.mark.asyncio
@@ -259,6 +268,7 @@ class TestResolveMergeConflicts:
 
         cfg = ConfigFactory.create(
             max_merge_conflict_fix_attempts=0,
+            enable_fresh_branch_rebuild=False,
             repo_root=config.repo_root,
             worktree_base=config.worktree_base,
             state_file=config.state_file,
@@ -275,7 +285,7 @@ class TestResolveMergeConflicts:
             pr, issue, cfg.worktree_base / "issue-42", worker_id=0
         )
 
-        assert result is False
+        assert result == (False, False)
         mock_agents._execute.assert_not_awaited()
         # Final abort_merge should still be called
         phase._worktrees.abort_merge.assert_awaited_once()
@@ -333,7 +343,7 @@ class TestResolveMergeConflicts:
                 pr, issue, config.worktree_base / "issue-42", worker_id=0
             )
 
-            assert result is True
+            assert result == (True, False)
 
 
 class TestMergeWithMain:


### PR DESCRIPTION
## Summary

- When merge-based conflict resolution exhausts all attempts (default 3), instead of escalating to HITL immediately, attempts a **fresh branch rebuild**: fetches the PR diff, destroys the conflicted worktree, creates a clean worktree from main, and runs an agent to re-apply the logical changes
- Adds `force_push_branch()` using `--force-with-lease` for safe force-pushing after rebuild (GitHub PR auto-updates since it tracks by branch name)
- New `build_rebuild_prompt()` in `conflict_prompt.py` provides the agent with the PR diff + issue context for re-applying changes
- Gated by `enable_fresh_branch_rebuild` config flag (default: `true`, env: `HYDRAFLOW_ENABLE_FRESH_BRANCH_REBUILD`)
- Applied to both `MergeConflictResolver` (review loop) and `PRUnsticker` (unstick loop)

## Test plan

- [x] 6 tests in `test_merge_conflict_resolver.py` — rebuild flow, guards (disabled/no agents/empty diff), force-push
- [x] 3 tests in `test_pr_unsticker.py` — rebuild fallback, disabled config, pr_number threading
- [x] 3 tests in `test_pr_manager.py` — force-push success, failure, dry-run
- [x] Updated existing tests in `test_review_phase_merge.py` for tuple return type
- [x] `make quality` passes (lint + typecheck + 4269 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)