### PR TITLE
docs: update README gh-issue instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ make quality
 
 - Fork it.
 - Run HydraFlow on HydraFlow. (via `make run` in the repo)
-- Use the tool to extend the tool.
-- Commit the agent-produced output.
+- /gh-issue "thing to change"
 - PR it back.
 - See `CLAUDE.md` for project conventions and lifecycle labels.
 


### PR DESCRIPTION
## Summary
- replace tool extension line with `/gh-issue "thing to change"`
- remove the line about committing agent-produced output

## Testing
- not applicable (documentation change)