### PR TITLE
Prep follow-up: fix Codex CLI flags and reduce Makefile scaffold false warnings

### DIFF
--- a/agent_cli.py
+++ b/agent_cli.py
@@ -46,7 +46,6 @@ def _build_codex_command(*, model: str) -> list[str]:
         model,
         "--sandbox",
         "danger-full-access",
-        "--ask-for-approval",
-        "never",
+        "--dangerously-bypass-approvals-and-sandbox",
         "--skip-git-repo-check",
     ]

--- a/makefile_scaffold.py
+++ b/makefile_scaffold.py
@@ -290,8 +290,15 @@ def parse_makefile(content: str) -> dict[str, str]:
     targets: dict[str, str] = {}
     current_target: str | None = None
     recipe_lines: list[str] = []
+    heredoc_delimiter: str | None = None
 
     for line in content.split("\n"):
+        if heredoc_delimiter is not None and current_target is not None:
+            recipe_lines.append(line)
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            continue
+
         # Skip .PHONY declarations
         if line.startswith(".PHONY"):
             continue
@@ -309,7 +316,13 @@ def parse_makefile(content: str) -> dict[str, str]:
 
         # Recipe line (tab-indented)
         if line.startswith("\t") and current_target is not None:
-            recipe_lines.append(line.lstrip("\t"))
+            stripped = line.lstrip("\t")
+            recipe_lines.append(stripped)
+            heredoc_match = re.search(
+                r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?$", stripped
+            )
+            if heredoc_match:
+                heredoc_delimiter = heredoc_match.group(1)
             continue
 
         # Blank or non-recipe line ends current target
@@ -394,13 +407,19 @@ def merge_makefile(existing_content: str, language: str) -> tuple[str, list[str]
     warnings: list[str] = []
     targets_to_add: list[str] = []
 
+    def _normalize_recipe(recipe: str) -> str:
+        lines = [line.strip() for line in recipe.strip().splitlines()]
+        return "\n".join(lines)
+
     for name, template_recipe in all_template.items():
         if name in existing_targets:
             # Compare recipes (only for targets with recipe bodies)
             if template_recipe is not None:
                 existing_recipe = existing_targets[name]
                 expected_recipe = template_recipe.strip("\n").lstrip("\t")
-                if existing_recipe.strip() != expected_recipe.strip():
+                if _normalize_recipe(existing_recipe) != _normalize_recipe(
+                    expected_recipe
+                ):
                     warnings.append(
                         f"Target '{name}' exists with different recipe: "
                         f"found '{existing_recipe.strip()}', "

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -117,6 +117,8 @@ class TestBuildCommand:
         assert cmd[:3] == ["codex", "exec", "--json"]
         assert "--model" in cmd
         assert cmd[cmd.index("--model") + 1] == "gpt-5-codex"
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
+        assert "--ask-for-approval" not in cmd
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_makefile_scaffold.py
+++ b/tests/test_makefile_scaffold.py
@@ -65,6 +65,14 @@ class TestParseMakefile:
         assert "ruff check . --fix" in result["lint"]
         assert "ruff format ." in result["lint"]
 
+    def test_handles_heredoc_recipe_body(self) -> None:
+        content = "coverage-check:\n\t@python - <<'PY'\nimport json\nprint('ok')\nPY\n"
+        result = parse_makefile(content)
+        assert "coverage-check" in result
+        assert "@python - <<'PY'" in result["coverage-check"]
+        assert "import json" in result["coverage-check"]
+        assert "PY" in result["coverage-check"]
+
     def test_handles_phony_declaration(self) -> None:
         content = ".PHONY: lint test\n\nlint:\n\truff check .\n"
         result = parse_makefile(content)
@@ -163,6 +171,27 @@ class TestMergeMakefile:
         existing = "test:\n\tnpm test\n"
         _, warnings = merge_makefile(existing, "python")
         assert any("test" in w for w in warnings)
+
+    def test_no_warning_for_recipe_indent_only_differences(self) -> None:
+        existing = (
+            "help:\n"
+            '\t@echo "Available targets:"   \n'
+            '\t@echo "  help         Show this help"  \n'
+            '\t@echo "  lint         Run lint auto-fixes" \n'
+            '\t@echo "  lint-check   Run lint checks" \n'
+            '\t@echo "  lint-fix     Alias for lint" \n'
+            '\t@echo "  typecheck    Run type checks" \n'
+            '\t@echo "  security     Run security checks" \n'
+            '\t@echo "  test         Run tests" \n'
+            '\t@echo "  coverage-check Enforce coverage floor from reports" \n'
+            '\t@echo "  coverage vars COVERAGE_MIN=70 COVERAGE_TARGET=70" \n'
+            '\t@echo "  quality-lite Run lint/type/security" \n'
+            '\t@echo "  quality      Run quality-lite + tests" \n'
+        )
+        _, warnings = merge_makefile(existing, "python")
+        assert not any(
+            "Target 'help' exists with different recipe" in w for w in warnings
+        )
 
     def test_preserves_existing_content_order(self) -> None:
         existing = "clean:\n\trm -rf dist\n\nbuild:\n\tpython -m build\n"


### PR DESCRIPTION
## Summary
- fix Codex prep driver command to use current CLI flags (`--dangerously-bypass-approvals-and-sandbox`)
- remove obsolete `--ask-for-approval never` that caused prep hardening agent runs to fail immediately
- improve Makefile scaffold parsing for heredoc recipe bodies (`<<'PY' ... PY`)
- normalize recipe comparison to avoid whitespace-only false warning spam
- add regression tests for Codex command flags and Makefile parser/scaffold behavior

## Why
`make prep` with Codex failed before running any workflow due to an invalid CLI argument. In parallel, scaffold warnings were noisy for equivalent recipes, hiding real issues.

## Validation
- focused tests: scaffold + codex command coverage pass
- pre-push hooks: `make quality-lite` pass
