### PR TITLE
Prep follow-up: fix Codex prompt delivery for hardening agents

### DIFF
--- a/runner_utils.py
+++ b/runner_utils.py
@@ -42,7 +42,8 @@ async def stream_claude_process(
     cmd:
         Command to execute (e.g. ``["claude", "-p", ...]`` or ``["codex", "exec", ...]``).
     prompt:
-        Text to write to the process's stdin.
+        Prompt text for the agent. Passed via stdin for Claude-style commands;
+        passed as a positional argument for Codex `exec`.
     cwd:
         Working directory for the subprocess.
     active_procs:
@@ -68,11 +69,17 @@ async def stream_claude_process(
 
     if runner is None:
         runner = get_default_runner()
+    use_codex_exec = len(cmd) >= 2 and cmd[0] == "codex" and cmd[1] == "exec"
+    cmd_to_run = [*cmd, prompt] if use_codex_exec else cmd
+    stdin_mode = (
+        asyncio.subprocess.DEVNULL if use_codex_exec else asyncio.subprocess.PIPE
+    )
+
     proc = await runner.create_streaming_process(
-        cmd,
+        cmd_to_run,
         cwd=str(cwd),
         env=env,
-        stdin=asyncio.subprocess.PIPE,
+        stdin=stdin_mode,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         limit=1024 * 1024,  # 1 MB — stream-json lines can exceed 64 KB default
@@ -81,15 +88,16 @@ async def stream_claude_process(
     active_procs.add(proc)
 
     try:
-        assert proc.stdin is not None
         assert proc.stdout is not None
         assert proc.stderr is not None
 
         stdout_stream = proc.stdout  # capture for nested function
 
-        proc.stdin.write(prompt.encode())
-        await proc.stdin.drain()
-        proc.stdin.close()
+        if not use_codex_exec:
+            assert proc.stdin is not None
+            proc.stdin.write(prompt.encode())
+            await proc.stdin.drain()
+            proc.stdin.close()
 
         # Drain stderr in background to prevent deadlock
         stderr_task = asyncio.create_task(proc.stderr.read())

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -186,6 +186,23 @@ class TestStreamClaudeProcessConfig:
         env = mock_exec.call_args[1]["env"]
         assert "CLAUDECODE" not in env
 
+    @pytest.mark.asyncio
+    async def test_codex_exec_passes_prompt_as_argument(self, event_bus) -> None:
+        """Codex exec should receive prompt as CLI arg, not stdin pipe."""
+        mock_create = make_streaming_proc(returncode=0, stdout="ok")
+        cmd = ["codex", "exec", "--json", "--model", "gpt-5.3"]
+        prompt = "do the thing"
+
+        with patch("asyncio.create_subprocess_exec", mock_create) as mock_exec:
+            await stream_claude_process(
+                **_default_kwargs(event_bus, cmd=cmd, prompt=prompt)
+            )
+
+        args = list(mock_exec.call_args[0])
+        kwargs = mock_exec.call_args[1]
+        assert args[-1] == prompt
+        assert kwargs["stdin"] == asyncio.subprocess.DEVNULL
+
 
 # ---------------------------------------------------------------------------
 # stream_claude_process — non-zero exit handling


### PR DESCRIPTION
## Summary
- pass prompt to `codex exec` as positional argument instead of stdin
- use `stdin=DEVNULL` for codex exec path
- keep stdin prompt flow for Claude path unchanged
- add regression test validating codex subprocess invocation

## Why
Prep hardening Codex runs were exiting with: `Reading prompt from stdin...` and code 1, causing repeated hardening failure loops.

## Validation
- focused tests for runner utils and codex behavior pass
- pre-push `make quality-lite` passed
