### PR TITLE
Fixes #1064: Type Safety: Deduplicate _parse_precheck_transcript be...

### DIFF
--- a/acceptance_criteria.py
+++ b/acceptance_criteria.py
@@ -9,9 +9,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from agent_cli import build_agent_command
-from escalation_gate import high_risk_diff_touched, should_escalate_debug
 from execution import get_default_runner
-from models import PrecheckResult, VerificationCriteria
+from models import VerificationCriteria
+from precheck import run_precheck_context
 from runner_utils import stream_claude_process
 
 if TYPE_CHECKING:
@@ -176,18 +176,6 @@ class AcceptanceCriteriaGenerator:
 
         return "".join(parts)
 
-    def _build_subskill_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.subskill_tool,
-            model=self._config.subskill_model,
-        )
-
-    def _build_debug_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.debug_tool,
-            model=self._config.debug_model,
-        )
-
     def _build_precheck_prompt(
         self, issue: GitHubIssue, issue_number: int, pr_number: int, diff_summary: str
     ) -> str:
@@ -206,45 +194,6 @@ Diff summary:
 {diff_summary[:3000]}
 """
 
-    @staticmethod
-    def _parse_precheck_transcript(
-        transcript: str,
-    ) -> PrecheckResult:
-        risk_match = re.search(
-            r"PRECHECK_RISK:\s*(low|medium|high)",
-            transcript,
-            re.IGNORECASE,
-        )
-        confidence_match = re.search(
-            r"PRECHECK_CONFIDENCE:\s*([0-9]*\.?[0-9]+)",
-            transcript,
-            re.IGNORECASE,
-        )
-        escalate_match = re.search(
-            r"PRECHECK_ESCALATE:\s*(yes|no)",
-            transcript,
-            re.IGNORECASE,
-        )
-        summary_match = re.search(
-            r"PRECHECK_SUMMARY:\s*(.*)",
-            transcript,
-            re.IGNORECASE,
-        )
-        parse_failed = not (
-            risk_match and confidence_match and escalate_match and summary_match
-        )
-        risk = risk_match.group(1).lower() if risk_match else "medium"
-        confidence = float(confidence_match.group(1)) if confidence_match else 0.0
-        escalate = bool(escalate_match and escalate_match.group(1).lower() == "yes")
-        summary = summary_match.group(1).strip() if summary_match else ""
-        return PrecheckResult(
-            risk=risk,
-            confidence=confidence,
-            escalate=escalate,
-            summary=summary,
-            parse_failed=parse_failed,
-        )
-
     async def _run_precheck_context(
         self,
         issue: GitHubIssue,
@@ -253,82 +202,35 @@ Diff summary:
         diff_summary: str,
         diff: str,
     ) -> str:
-        if self._config.max_subskill_attempts <= 0:
-            return "Low-tier precheck disabled."
         prompt = self._build_precheck_prompt(
             issue, issue_number, pr_number, diff_summary
         )
-        risk = "medium"
-        confidence = self._config.subskill_confidence_threshold
-        summary = ""
-        parse_failed = False
 
-        try:
-            for _attempt in range(self._config.max_subskill_attempts):
-                transcript = await stream_claude_process(
-                    cmd=self._build_subskill_command(),
-                    prompt=prompt,
-                    cwd=self._config.repo_root,
-                    active_procs=self._active_procs,
-                    event_bus=self._bus,
-                    event_data={
-                        "issue": issue_number,
-                        "pr": pr_number,
-                        "source": "ac_precheck",
-                    },
-                    logger=logger,
-                    timeout=self._config.agent_timeout,
-                    runner=self._runner,
-                )
-                precheck = self._parse_precheck_transcript(transcript)
-                risk = precheck.risk
-                confidence = precheck.confidence
-                summary = precheck.summary
-                parse_failed = precheck.parse_failed
-                if not parse_failed:
-                    break
-        except Exception:  # noqa: BLE001
-            return "Low-tier precheck failed; continuing without precheck context."
-
-        decision = should_escalate_debug(
-            enabled=self._config.debug_escalation_enabled,
-            confidence=confidence,
-            confidence_threshold=self._config.subskill_confidence_threshold,
-            parse_failed=parse_failed,
-            retry_count=self._config.max_subskill_attempts,
-            max_subskill_attempts=self._config.max_subskill_attempts,
-            risk=risk,
-            high_risk_files_touched=high_risk_diff_touched(diff),
-        )
-
-        context = [
-            f"Precheck risk: {risk}",
-            f"Precheck confidence: {confidence:.2f}",
-            f"Precheck summary: {summary or 'N/A'}",
-            f"Debug escalation: {'yes' if decision.escalate else 'no'}",
-        ]
-
-        if decision.escalate and self._config.max_debug_attempts > 0:
-            debug_transcript = await stream_claude_process(
-                cmd=self._build_debug_command(),
-                prompt=prompt + "\n\nDEBUG MODE: focus on ambiguity and failure modes.",
+        async def execute(cmd: list[str], p: str) -> str:
+            return await stream_claude_process(
+                cmd=cmd,
+                prompt=p,
                 cwd=self._config.repo_root,
                 active_procs=self._active_procs,
                 event_bus=self._bus,
                 event_data={
                     "issue": issue_number,
                     "pr": pr_number,
-                    "source": "ac_precheck_debug",
+                    "source": "ac_precheck",
                 },
                 logger=logger,
                 timeout=self._config.agent_timeout,
                 runner=self._runner,
             )
-            context.append("Debug precheck transcript:")
-            context.append(debug_transcript[:1000])
-            context.append(f"Escalation reasons: {', '.join(decision.reasons)}")
 
-        return "\n".join(context)
+        return await run_precheck_context(
+            config=self._config,
+            prompt=prompt,
+            diff=diff,
+            execute=execute,
+            debug_message="DEBUG MODE: focus on ambiguity and failure modes.",
+            logger=logger,
+        )
 
     def _read_plan_file(self, issue_number: int) -> str:
         """Read the plan from ``.hydraflow/plans/issue-N.md``."""

--- a/precheck.py
+++ b/precheck.py
@@ -1,0 +1,160 @@
+"""Shared precheck utilities for low-tier subskill and debug escalation.
+
+Consolidates ``parse_precheck_transcript``, ``build_subskill_command``,
+``build_debug_command``, and ``run_precheck_context`` which were
+previously duplicated across acceptance_criteria.py, verification_judge.py,
+and reviewer.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from agent_cli import build_agent_command
+from escalation_gate import high_risk_diff_touched, should_escalate_debug
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+#: Callback signature for executing a Claude subprocess.
+#: Takes (command, prompt) and returns the transcript string.
+ExecuteCallback = Callable[[list[str], str], Awaitable[str]]
+
+
+@dataclass(frozen=True, slots=True)
+class PrecheckResult:
+    """Parsed result of a low-tier precheck transcript."""
+
+    risk: str = "medium"
+    confidence: float = 0.0
+    escalate: bool = False
+    summary: str = ""
+    parse_failed: bool = True
+
+
+def parse_precheck_transcript(transcript: str) -> PrecheckResult:
+    """Parse structured PRECHECK_* fields from a transcript string."""
+    risk_match = re.search(
+        r"PRECHECK_RISK:\s*(low|medium|high)",
+        transcript,
+        re.IGNORECASE,
+    )
+    confidence_match = re.search(
+        r"PRECHECK_CONFIDENCE:\s*([0-9]*\.?[0-9]+)",
+        transcript,
+        re.IGNORECASE,
+    )
+    escalate_match = re.search(
+        r"PRECHECK_ESCALATE:\s*(yes|no)",
+        transcript,
+        re.IGNORECASE,
+    )
+    summary_match = re.search(
+        r"PRECHECK_SUMMARY:\s*(.*)",
+        transcript,
+        re.IGNORECASE,
+    )
+    parse_failed = not (
+        risk_match and confidence_match and escalate_match and summary_match
+    )
+    risk = risk_match.group(1).lower() if risk_match else "medium"
+    confidence = float(confidence_match.group(1)) if confidence_match else 0.0
+    escalate = bool(escalate_match and escalate_match.group(1).lower() == "yes")
+    summary = summary_match.group(1).strip() if summary_match else ""
+    return PrecheckResult(
+        risk=risk,
+        confidence=confidence,
+        escalate=escalate,
+        summary=summary,
+        parse_failed=parse_failed,
+    )
+
+
+def build_subskill_command(config: HydraFlowConfig) -> list[str]:
+    """Build a CLI command for the low-tier subskill agent."""
+    return build_agent_command(
+        tool=config.subskill_tool,
+        model=config.subskill_model,
+    )
+
+
+def build_debug_command(config: HydraFlowConfig) -> list[str]:
+    """Build a CLI command for the debug escalation agent."""
+    return build_agent_command(
+        tool=config.debug_tool,
+        model=config.debug_model,
+    )
+
+
+async def run_precheck_context(
+    *,
+    config: HydraFlowConfig,
+    prompt: str,
+    diff: str,
+    execute: ExecuteCallback,
+    debug_message: str,
+    logger: logging.Logger,
+) -> str:
+    """Run the shared precheck orchestration loop.
+
+    1. If disabled (``max_subskill_attempts <= 0``), return immediately.
+    2. Retry up to ``max_subskill_attempts`` times, breaking on successful parse.
+    3. Evaluate escalation gate; optionally run debug agent.
+    4. Return formatted context string.
+    """
+    if config.max_subskill_attempts <= 0:
+        return "Low-tier precheck disabled."
+
+    risk = "medium"
+    confidence = config.subskill_confidence_threshold
+    summary = ""
+    parse_failed = False
+
+    try:
+        for _attempt in range(config.max_subskill_attempts):
+            transcript = await execute(
+                build_subskill_command(config),
+                prompt,
+            )
+            result = parse_precheck_transcript(transcript)
+            risk = result.risk
+            confidence = result.confidence
+            summary = result.summary
+            parse_failed = result.parse_failed
+            if not parse_failed:
+                break
+    except Exception:  # noqa: BLE001
+        return "Low-tier precheck failed; continuing without precheck context."
+
+    decision = should_escalate_debug(
+        enabled=config.debug_escalation_enabled,
+        confidence=confidence,
+        confidence_threshold=config.subskill_confidence_threshold,
+        parse_failed=parse_failed,
+        retry_count=config.max_subskill_attempts,
+        max_subskill_attempts=config.max_subskill_attempts,
+        risk=risk,
+        high_risk_files_touched=high_risk_diff_touched(diff),
+    )
+
+    context = [
+        f"Precheck risk: {risk}",
+        f"Precheck confidence: {confidence:.2f}",
+        f"Precheck summary: {summary or 'N/A'}",
+        f"Debug escalation: {'yes' if decision.escalate else 'no'}",
+    ]
+
+    if decision.escalate and config.max_debug_attempts > 0:
+        debug_transcript = await execute(
+            build_debug_command(config),
+            prompt + f"\n\n{debug_message}",
+        )
+        context.append("Debug precheck transcript:")
+        context.append(debug_transcript[:1000])
+        context.append(f"Escalation reasons: {', '.join(decision.reasons)}")
+
+    return "\n".join(context)

--- a/reviewer.py
+++ b/reviewer.py
@@ -9,16 +9,9 @@ from pathlib import Path
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
-from escalation_gate import high_risk_diff_touched, should_escalate_debug
 from events import EventType, HydraFlowEvent
-from models import (
-    GitHubIssue,
-    PrecheckResult,
-    PRInfo,
-    ReviewerStatus,
-    ReviewResult,
-    ReviewVerdict,
-)
+from models import GitHubIssue, PRInfo, ReviewerStatus, ReviewResult, ReviewVerdict
+from precheck import run_precheck_context
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 from subprocess_util import CreditExhaustedError
 
@@ -402,18 +395,6 @@ SUMMARY: Implementation looks good, tests are comprehensive, all checks pass.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="review")}"""
 
-    def _build_subskill_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.subskill_tool,
-            model=self._config.subskill_model,
-        )
-
-    def _build_debug_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.debug_tool,
-            model=self._config.debug_model,
-        )
-
     def _build_precheck_prompt(self, pr: PRInfo, issue: GitHubIssue, diff: str) -> str:
         max_diff = min(len(diff), 6000)
         diff_snippet = diff[:max_diff]
@@ -437,109 +418,24 @@ Diff snippet:
 ```
 """
 
-    @staticmethod
-    def _parse_precheck_transcript(
-        transcript: str,
-    ) -> PrecheckResult:
-        risk_match = re.search(
-            r"PRECHECK_RISK:\s*(low|medium|high)",
-            transcript,
-            re.IGNORECASE,
-        )
-        confidence_match = re.search(
-            r"PRECHECK_CONFIDENCE:\s*([0-9]*\.?[0-9]+)",
-            transcript,
-            re.IGNORECASE,
-        )
-        escalate_match = re.search(
-            r"PRECHECK_ESCALATE:\s*(yes|no)",
-            transcript,
-            re.IGNORECASE,
-        )
-        summary_match = re.search(
-            r"PRECHECK_SUMMARY:\s*(.*)",
-            transcript,
-            re.IGNORECASE,
-        )
-        parse_failed = not (
-            risk_match and confidence_match and escalate_match and summary_match
-        )
-        risk = risk_match.group(1).lower() if risk_match else "medium"
-        confidence = float(confidence_match.group(1)) if confidence_match else 0.0
-        escalate = bool(escalate_match and escalate_match.group(1).lower() == "yes")
-        summary = summary_match.group(1).strip() if summary_match else ""
-        return PrecheckResult(
-            risk=risk,
-            confidence=confidence,
-            escalate=escalate,
-            summary=summary,
-            parse_failed=parse_failed,
-        )
-
     async def _run_precheck_context(
         self, pr: PRInfo, issue: GitHubIssue, diff: str, worktree_path: Path
     ) -> str:
-        if self._config.max_subskill_attempts <= 0:
-            return "Low-tier precheck disabled."
         prompt = self._build_precheck_prompt(pr, issue, diff)
-        summary = ""
-        parse_failed = False
-        risk = "medium"
-        confidence = self._config.subskill_confidence_threshold
-        max_subskill = self._config.max_subskill_attempts
 
-        try:
-            for _attempt in range(1, max_subskill + 1):
-                transcript = await self._execute(
-                    self._build_subskill_command(),
-                    prompt,
-                    worktree_path,
-                    {"pr": pr.number, "source": "reviewer"},
-                )
-                precheck = self._parse_precheck_transcript(transcript)
-                risk = precheck.risk
-                confidence = precheck.confidence
-                summary = precheck.summary
-                parse_failed = precheck.parse_failed
-                if not parse_failed:
-                    break
-        except Exception:  # noqa: BLE001
-            return "Low-tier precheck failed; continuing without precheck context."
+        async def execute(cmd: list[str], p: str) -> str:
+            return await self._execute(
+                cmd, p, worktree_path, {"pr": pr.number, "source": "reviewer"}
+            )
 
-        decision = should_escalate_debug(
-            enabled=self._config.debug_escalation_enabled,
-            confidence=confidence,
-            confidence_threshold=self._config.subskill_confidence_threshold,
-            parse_failed=parse_failed,
-            retry_count=max_subskill,
-            max_subskill_attempts=max_subskill,
-            risk=risk,
-            high_risk_files_touched=high_risk_diff_touched(diff),
+        return await run_precheck_context(
+            config=self._config,
+            prompt=prompt,
+            diff=diff,
+            execute=execute,
+            debug_message="DEBUG MODE: Focus on root causes and concrete risky files.",
+            logger=logger,
         )
-
-        context_lines = [
-            f"Precheck risk: {risk}",
-            f"Precheck confidence: {confidence:.2f}",
-            f"Precheck summary: {summary or 'N/A'}",
-            f"Debug escalation: {'yes' if decision.escalate else 'no'}",
-        ]
-
-        if decision.escalate and self._config.max_debug_attempts > 0:
-            debug_prompt = (
-                prompt
-                + "\n\nDEBUG MODE: Focus on root causes and concrete risky files."
-            )
-            debug_transcript = await self._execute(
-                self._build_debug_command(),
-                debug_prompt,
-                worktree_path,
-                {"pr": pr.number, "source": "reviewer"},
-            )
-            context_lines.append("Debug precheck transcript:")
-            context_lines.append(debug_transcript[:1000])
-            context_lines.append(f"Escalation reasons: {', '.join(decision.reasons)}")
-
-        return "\n".join(context_lines)
 
     def _parse_verdict(self, transcript: str) -> ReviewVerdict:
         """Extract the verdict from the reviewer transcript."""

--- a/tests/test_acceptance_criteria.py
+++ b/tests/test_acceptance_criteria.py
@@ -22,7 +22,6 @@ from acceptance_criteria import (
     _VERIFY_START,
     AcceptanceCriteriaGenerator,
 )
-from escalation_gate import EscalationDecision
 from models import VerificationCriteria
 from tests.conftest import IssueFactory
 from tests.helpers import ConfigFactory
@@ -642,128 +641,6 @@ class TestGenerate:
 
 
 # ---------------------------------------------------------------------------
-# _parse_precheck_transcript
-# ---------------------------------------------------------------------------
-
-
-class TestParsePrecheckTranscript:
-    """Tests for AcceptanceCriteriaGenerator._parse_precheck_transcript."""
-
-    def test_all_fields_present(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All looks good.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.risk == "low"
-        assert result.confidence == 0.95
-        assert result.escalate is False
-        assert result.summary == "All looks good."
-        assert result.parse_failed is False
-
-    def test_missing_risk_defaults_to_medium(self) -> None:
-        transcript = (
-            "PRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\nPRECHECK_SUMMARY: Fine.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.risk == "medium"
-        assert result.parse_failed is True
-
-    def test_missing_confidence_defaults_to_zero(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\nPRECHECK_ESCALATE: yes\nPRECHECK_SUMMARY: Risky.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.confidence == 0.0
-        assert result.parse_failed is True
-
-    def test_escalate_yes(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Needs debug.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.escalate is True
-
-    def test_escalate_no(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: OK.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.escalate is False
-
-    def test_case_insensitive_parsing(self) -> None:
-        transcript = (
-            "precheck_risk: HIGH\n"
-            "precheck_confidence: 0.42\n"
-            "precheck_escalate: YES\n"
-            "precheck_summary: Mixed case.\n"
-        )
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript(transcript)
-        assert result.risk == "high"
-        assert result.confidence == 0.42
-        assert result.escalate is True
-        assert result.summary == "Mixed case."
-        assert result.parse_failed is False
-
-    def test_empty_string_returns_defaults(self) -> None:
-        result = AcceptanceCriteriaGenerator._parse_precheck_transcript("")
-        assert result.risk == "medium"
-        assert result.confidence == 0.0
-        assert result.escalate is False
-        assert result.summary == ""
-        assert result.parse_failed is True
-
-
-# ---------------------------------------------------------------------------
-# _build_subskill_command / _build_debug_command
-# ---------------------------------------------------------------------------
-
-
-class TestBuildSubskillAndDebugCommands:
-    """Tests for AC generator _build_subskill_command and _build_debug_command."""
-
-    def test_subskill_command_uses_config_tool_and_model(
-        self, config, event_bus
-    ) -> None:
-        gen, _ = _make_generator(config, event_bus)
-        cmd = gen._build_subskill_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "haiku"
-
-    def test_subskill_command_codex_backend(self, event_bus) -> None:
-        cfg = ConfigFactory.create(subskill_tool="codex", subskill_model="gpt-4")
-        gen, _ = _make_generator(cfg, event_bus)
-        cmd = gen._build_subskill_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert cmd[cmd.index("--model") + 1] == "gpt-4"
-
-    def test_debug_command_uses_config_tool_and_model(self, config, event_bus) -> None:
-        gen, _ = _make_generator(config, event_bus)
-        cmd = gen._build_debug_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "opus"
-
-    def test_debug_command_codex_backend(self, event_bus) -> None:
-        cfg = ConfigFactory.create(debug_tool="codex", debug_model="gpt-5")
-        gen, _ = _make_generator(cfg, event_bus)
-        cmd = gen._build_debug_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert cmd[cmd.index("--model") + 1] == "gpt-5"
-
-
-# ---------------------------------------------------------------------------
 # _build_precheck_prompt
 # ---------------------------------------------------------------------------
 
@@ -790,183 +667,22 @@ class TestBuildPrecheckPrompt:
 
 
 # ---------------------------------------------------------------------------
-# _run_precheck_context
+# _run_precheck_context (wiring tests — shared logic tested in test_precheck.py)
 # ---------------------------------------------------------------------------
 
 
 class TestRunPrecheckContext:
-    """Tests for AcceptanceCriteriaGenerator._run_precheck_context."""
+    """Tests for AcceptanceCriteriaGenerator._run_precheck_context wiring."""
 
     @pytest.mark.asyncio
-    async def test_disabled_when_max_subskill_zero(self, config, event_bus) -> None:
-        gen, _ = _make_generator(config, event_bus)
-        issue = IssueFactory.create()
-        result = await gen._run_precheck_context(issue, 42, 101, "diff summary", "")
-        assert result == "Low-tier precheck disabled."
-
-    @pytest.mark.asyncio
-    async def test_success_no_escalation(self, event_bus, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            subskill_confidence_threshold=0.7,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All clear.\n"
-        )
-
-        with patch(
-            "acceptance_criteria.stream_claude_process",
-            new_callable=AsyncMock,
-            return_value=valid_transcript,
-        ) as mock_stream:
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
-
-        assert "Precheck risk: low" in result
-        assert "Precheck confidence: 0.95" in result
-        assert "Precheck summary: All clear." in result
-        assert "Debug escalation: no" in result
-        mock_stream.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_retries_on_parse_failure(self, event_bus, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=3,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        garbage = "No parseable fields here."
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: Finally parsed.\n"
-        )
-
-        with patch(
-            "acceptance_criteria.stream_claude_process",
-            new_callable=AsyncMock,
-            side_effect=[garbage, garbage, valid_transcript],
-        ) as mock_stream:
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
-
-        assert mock_stream.call_count == 3
-        assert "Precheck risk: low" in result
-        assert "Precheck summary: Finally parsed." in result
-
-    @pytest.mark.asyncio
-    async def test_escalates_to_debug(self, event_bus, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky change.\n"
-        )
-        debug_transcript = "Debug: found critical issues."
-
-        with patch(
-            "acceptance_criteria.stream_claude_process",
-            new_callable=AsyncMock,
-            side_effect=[high_risk_transcript, debug_transcript],
-        ) as mock_stream:
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
-
-        assert mock_stream.call_count == 2
-        assert "Precheck risk: high" in result
-        assert "Debug escalation: yes" in result
-        assert "Debug precheck transcript:" in result
-        assert "Debug: found critical issues." in result
-        assert "Escalation reasons:" in result
-
-    @pytest.mark.asyncio
-    async def test_no_debug_when_max_debug_zero(self, event_bus, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=0,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-
-        with patch(
-            "acceptance_criteria.stream_claude_process",
-            new_callable=AsyncMock,
-            return_value=high_risk_transcript,
-        ) as mock_stream:
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
-
-        assert mock_stream.call_count == 1
-        assert "Debug escalation: yes" in result
-        assert "Debug precheck transcript:" not in result
-
-    @pytest.mark.asyncio
-    async def test_exception_returns_fallback(self, event_bus, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        with patch(
-            "acceptance_criteria.stream_claude_process",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("subprocess crashed"),
-        ):
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
-
-        assert (
-            result == "Low-tier precheck failed; continuing without precheck context."
-        )
-
-    @pytest.mark.asyncio
-    async def test_debug_transcript_truncated_to_1000_chars(
+    async def test_delegates_to_shared_run_precheck_context(
         self, event_bus, tmp_path
     ) -> None:
+        """Verify AC generator delegates to the shared precheck module."""
         cfg = ConfigFactory.create(
             max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
             subskill_confidence_threshold=0.7,
+            debug_escalation_enabled=False,
             repo_root=tmp_path / "repo",
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
@@ -974,108 +690,58 @@ class TestRunPrecheckContext:
         gen, _ = _make_generator(cfg, event_bus)
         issue = IssueFactory.create()
 
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-        long_debug = "D" * 2000
+        with patch(
+            "acceptance_criteria.run_precheck_context",
+            new_callable=AsyncMock,
+            return_value="Precheck risk: low",
+        ) as mock_rpc:
+            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
 
+        mock_rpc.assert_awaited_once()
+        assert result == "Precheck risk: low"
+        # Verify correct config and debug_message are passed
+        call_kwargs = mock_rpc.call_args[1]
+        assert call_kwargs["config"] is cfg
+        assert "ambiguity" in call_kwargs["debug_message"]
+
+    @pytest.mark.asyncio
+    async def test_execute_closure_calls_stream_claude_process(
+        self, event_bus, tmp_path
+    ) -> None:
+        """Verify the execute closure wires through to stream_claude_process."""
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            debug_escalation_enabled=False,
+            repo_root=tmp_path / "repo",
+            worktree_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        gen, _ = _make_generator(cfg, event_bus)
+        issue = IssueFactory.create()
+
+        captured_execute = {}
+
+        async def capture_rpc(**kwargs):
+            captured_execute["fn"] = kwargs["execute"]
+            return "Precheck risk: low"
+
+        with patch(
+            "acceptance_criteria.run_precheck_context",
+            side_effect=capture_rpc,
+        ):
+            await gen._run_precheck_context(issue, 42, 101, "diff", "")
+
+        # Call the captured execute closure
         with patch(
             "acceptance_criteria.stream_claude_process",
             new_callable=AsyncMock,
-            side_effect=[high_risk_transcript, long_debug],
-        ):
-            result = await gen._run_precheck_context(issue, 42, 101, "diff", "")
+            return_value="transcript",
+        ) as mock_stream:
+            result = await captured_execute["fn"](["cmd"], "prompt")
 
-        assert "D" * 1000 in result
-        assert "D" * 1001 not in result
-
-
-# ---------------------------------------------------------------------------
-# TestPrecheckHighRiskFiles
-# ---------------------------------------------------------------------------
-
-
-HIGH_RISK_DIFF = """\
-diff --git a/src/auth/login.py b/src/auth/login.py
-index abc123..def456 100644
---- a/src/auth/login.py
-+++ b/src/auth/login.py
-@@ -1,3 +1,8 @@
-+def new_login():
-+    pass
-"""
-
-SAFE_DIFF = """\
-diff --git a/src/utils.py b/src/utils.py
-index abc123..def456 100644
---- a/src/utils.py
-+++ b/src/utils.py
-@@ -1,3 +1,8 @@
-+def helper():
-+    pass
-"""
-
-
-class TestPrecheckHighRiskFiles:
-    """Verify _run_precheck_context passes high_risk_files_touched correctly."""
-
-    @pytest.mark.asyncio
-    async def test_high_risk_diff_passes_true(self, event_bus) -> None:
-        cfg = ConfigFactory.create(max_subskill_attempts=1)
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        precheck_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.5\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: risky auth change\n"
-        )
-
-        with (
-            patch(
-                "acceptance_criteria.stream_claude_process",
-                new_callable=AsyncMock,
-                return_value=precheck_transcript,
-            ),
-            patch(
-                "acceptance_criteria.should_escalate_debug",
-                return_value=EscalationDecision(escalate=False, reasons=[]),
-            ) as mock_escalate,
-        ):
-            await gen._run_precheck_context(issue, 42, 101, "summary", HIGH_RISK_DIFF)
-
-        mock_escalate.assert_called_once()
-        assert mock_escalate.call_args[1]["high_risk_files_touched"] is True
-
-    @pytest.mark.asyncio
-    async def test_safe_diff_passes_false(self, event_bus) -> None:
-        cfg = ConfigFactory.create(max_subskill_attempts=1)
-        gen, _ = _make_generator(cfg, event_bus)
-        issue = IssueFactory.create()
-
-        precheck_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: safe change\n"
-        )
-
-        with (
-            patch(
-                "acceptance_criteria.stream_claude_process",
-                new_callable=AsyncMock,
-                return_value=precheck_transcript,
-            ),
-            patch(
-                "acceptance_criteria.should_escalate_debug",
-                return_value=EscalationDecision(escalate=False, reasons=[]),
-            ) as mock_escalate,
-        ):
-            await gen._run_precheck_context(issue, 42, 101, "summary", SAFE_DIFF)
-
-        mock_escalate.assert_called_once()
-        assert mock_escalate.call_args[1]["high_risk_files_touched"] is False
+        assert result == "transcript"
+        mock_stream.assert_called_once()
+        call_kwargs = mock_stream.call_args[1]
+        assert call_kwargs["cmd"] == ["cmd"]
+        assert call_kwargs["prompt"] == "prompt"
+        assert call_kwargs["event_data"]["source"] == "ac_precheck"

--- a/tests/test_precheck.py
+++ b/tests/test_precheck.py
@@ -1,0 +1,491 @@
+"""Tests for precheck.py — shared precheck utilities."""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from escalation_gate import EscalationDecision
+from precheck import (
+    PrecheckResult,
+    build_debug_command,
+    build_subskill_command,
+    parse_precheck_transcript,
+    run_precheck_context,
+)
+from tests.helpers import ConfigFactory
+
+# ---------------------------------------------------------------------------
+# PrecheckResult dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPrecheckResult:
+    """Tests for the PrecheckResult frozen dataclass."""
+
+    def test_defaults(self) -> None:
+        result = PrecheckResult()
+        assert result.risk == "medium"
+        assert result.confidence == 0.0
+        assert result.escalate is False
+        assert result.summary == ""
+        assert result.parse_failed is True
+
+    def test_custom_values(self) -> None:
+        result = PrecheckResult(
+            risk="high",
+            confidence=0.85,
+            escalate=True,
+            summary="Risky change.",
+            parse_failed=False,
+        )
+        assert result.risk == "high"
+        assert result.confidence == 0.85
+        assert result.escalate is True
+        assert result.summary == "Risky change."
+        assert result.parse_failed is False
+
+    def test_frozen(self) -> None:
+        result = PrecheckResult()
+        with pytest.raises(FrozenInstanceError):
+            result.risk = "high"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# parse_precheck_transcript
+# ---------------------------------------------------------------------------
+
+
+class TestParsePrecheckTranscript:
+    """Tests for parse_precheck_transcript module-level function."""
+
+    def test_all_fields_present(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.95\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: All looks good.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.risk == "low"
+        assert result.confidence == 0.95
+        assert result.escalate is False
+        assert result.summary == "All looks good."
+        assert result.parse_failed is False
+
+    def test_missing_risk_defaults_to_medium(self) -> None:
+        transcript = (
+            "PRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\nPRECHECK_SUMMARY: Fine.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.risk == "medium"
+        assert result.parse_failed is True
+
+    def test_missing_confidence_defaults_to_zero(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: high\nPRECHECK_ESCALATE: yes\nPRECHECK_SUMMARY: Risky.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.confidence == 0.0
+        assert result.parse_failed is True
+
+    def test_escalate_yes(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.3\n"
+            "PRECHECK_ESCALATE: yes\n"
+            "PRECHECK_SUMMARY: Needs debug.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.escalate is True
+
+    def test_escalate_no(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.9\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: OK.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.escalate is False
+
+    def test_case_insensitive_parsing(self) -> None:
+        transcript = (
+            "precheck_risk: HIGH\n"
+            "precheck_confidence: 0.42\n"
+            "precheck_escalate: YES\n"
+            "precheck_summary: Mixed case.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.risk == "high"
+        assert result.confidence == 0.42
+        assert result.escalate is True
+        assert result.summary == "Mixed case."
+        assert result.parse_failed is False
+
+    def test_empty_string_returns_defaults(self) -> None:
+        result = parse_precheck_transcript("")
+        assert result.risk == "medium"
+        assert result.confidence == 0.0
+        assert result.escalate is False
+        assert result.summary == ""
+        assert result.parse_failed is True
+
+    def test_missing_summary_only(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: low\nPRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.risk == "low"
+        assert result.confidence == 0.8
+        assert result.escalate is False
+        assert result.summary == ""
+        assert result.parse_failed is True
+
+    def test_missing_escalate_only(self) -> None:
+        transcript = (
+            "PRECHECK_RISK: medium\n"
+            "PRECHECK_CONFIDENCE: 0.5\n"
+            "PRECHECK_SUMMARY: Partial.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.escalate is False
+        assert result.parse_failed is True
+
+    def test_preamble_text_ignored(self) -> None:
+        transcript = (
+            "Some preamble.\n"
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.95\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: All looks good.\n"
+        )
+        result = parse_precheck_transcript(transcript)
+        assert result.risk == "low"
+        assert result.confidence == 0.95
+        assert result.parse_failed is False
+
+
+# ---------------------------------------------------------------------------
+# build_subskill_command / build_debug_command
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSubskillCommand:
+    """Tests for build_subskill_command."""
+
+    def test_claude_backend(self) -> None:
+        cfg = ConfigFactory.create(subskill_tool="claude", subskill_model="haiku")
+        cmd = build_subskill_command(cfg)
+        assert "claude" in cmd
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "haiku"
+
+    def test_codex_backend(self) -> None:
+        cfg = ConfigFactory.create(subskill_tool="codex", subskill_model="gpt-4")
+        cmd = build_subskill_command(cfg)
+        assert cmd[:3] == ["codex", "exec", "--json"]
+        assert cmd[cmd.index("--model") + 1] == "gpt-4"
+
+
+class TestBuildDebugCommand:
+    """Tests for build_debug_command."""
+
+    def test_claude_backend(self) -> None:
+        cfg = ConfigFactory.create(debug_tool="claude", debug_model="opus")
+        cmd = build_debug_command(cfg)
+        assert "claude" in cmd
+        assert "--model" in cmd
+        idx = cmd.index("--model")
+        assert cmd[idx + 1] == "opus"
+
+    def test_codex_backend(self) -> None:
+        cfg = ConfigFactory.create(debug_tool="codex", debug_model="gpt-5")
+        cmd = build_debug_command(cfg)
+        assert cmd[:3] == ["codex", "exec", "--json"]
+        assert cmd[cmd.index("--model") + 1] == "gpt-5"
+
+
+# ---------------------------------------------------------------------------
+# run_precheck_context
+# ---------------------------------------------------------------------------
+
+
+class TestRunPrecheckContext:
+    """Tests for run_precheck_context shared orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_message(self) -> None:
+        cfg = ConfigFactory.create(max_subskill_attempts=0)
+        mock_execute = AsyncMock()
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert result == "Low-tier precheck disabled."
+        mock_execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_no_escalation(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            subskill_confidence_threshold=0.7,
+            debug_escalation_enabled=False,
+            repo_root=tmp_path / "repo",
+        )
+        valid_transcript = (
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.95\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: All clear.\n"
+        )
+        mock_execute = AsyncMock(return_value=valid_transcript)
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert "Precheck risk: low" in result
+        assert "Precheck confidence: 0.95" in result
+        assert "Precheck summary: All clear." in result
+        assert "Debug escalation: no" in result
+        mock_execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_retries_on_parse_failure(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=3,
+            debug_escalation_enabled=False,
+            repo_root=tmp_path / "repo",
+        )
+        garbage = "No parseable fields here."
+        valid_transcript = (
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.9\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: Finally parsed.\n"
+        )
+        mock_execute = AsyncMock(side_effect=[garbage, garbage, valid_transcript])
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert mock_execute.call_count == 3
+        assert "Precheck risk: low" in result
+        assert "Precheck summary: Finally parsed." in result
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_debug(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            debug_escalation_enabled=True,
+            max_debug_attempts=1,
+            subskill_confidence_threshold=0.7,
+            repo_root=tmp_path / "repo",
+        )
+        high_risk_transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.3\n"
+            "PRECHECK_ESCALATE: yes\n"
+            "PRECHECK_SUMMARY: Risky change.\n"
+        )
+        debug_transcript = "Debug: found critical issues."
+        mock_execute = AsyncMock(side_effect=[high_risk_transcript, debug_transcript])
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG MODE: focus on ambiguity.",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert mock_execute.call_count == 2
+        assert "Precheck risk: high" in result
+        assert "Debug escalation: yes" in result
+        assert "Debug precheck transcript:" in result
+        assert "Debug: found critical issues." in result
+        assert "Escalation reasons:" in result
+
+    @pytest.mark.asyncio
+    async def test_no_debug_when_max_debug_zero(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            debug_escalation_enabled=True,
+            max_debug_attempts=0,
+            subskill_confidence_threshold=0.7,
+            repo_root=tmp_path / "repo",
+        )
+        high_risk_transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.3\n"
+            "PRECHECK_ESCALATE: yes\n"
+            "PRECHECK_SUMMARY: Risky.\n"
+        )
+        mock_execute = AsyncMock(return_value=high_risk_transcript)
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert mock_execute.call_count == 1
+        assert "Debug escalation: yes" in result
+        assert "Debug precheck transcript:" not in result
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_fallback(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            repo_root=tmp_path / "repo",
+        )
+        mock_execute = AsyncMock(side_effect=RuntimeError("subprocess crashed"))
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert (
+            result == "Low-tier precheck failed; continuing without precheck context."
+        )
+
+    @pytest.mark.asyncio
+    async def test_debug_transcript_truncated_to_1000(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            debug_escalation_enabled=True,
+            max_debug_attempts=1,
+            subskill_confidence_threshold=0.7,
+            repo_root=tmp_path / "repo",
+        )
+        high_risk_transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.3\n"
+            "PRECHECK_ESCALATE: yes\n"
+            "PRECHECK_SUMMARY: Risky.\n"
+        )
+        long_debug = "D" * 2000
+        mock_execute = AsyncMock(side_effect=[high_risk_transcript, long_debug])
+        result = await run_precheck_context(
+            config=cfg,
+            prompt="test prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG",
+            logger=__import__("logging").getLogger("test"),
+        )
+        assert "D" * 1000 in result
+        assert "D" * 1001 not in result
+
+    @pytest.mark.asyncio
+    async def test_high_risk_diff_passes_true(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            repo_root=tmp_path / "repo",
+        )
+        precheck_transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.5\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: risky auth change\n"
+        )
+        auth_diff = "diff --git a/src/auth/login.py b/src/auth/login.py\n+pass"
+        mock_execute = AsyncMock(return_value=precheck_transcript)
+
+        with patch(
+            "precheck.should_escalate_debug",
+            return_value=EscalationDecision(escalate=False, reasons=[]),
+        ) as mock_escalate:
+            await run_precheck_context(
+                config=cfg,
+                prompt="test prompt",
+                diff=auth_diff,
+                execute=mock_execute,
+                debug_message="DEBUG",
+                logger=__import__("logging").getLogger("test"),
+            )
+
+        mock_escalate.assert_called_once()
+        assert mock_escalate.call_args[1]["high_risk_files_touched"] is True
+
+    @pytest.mark.asyncio
+    async def test_safe_diff_passes_false(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            repo_root=tmp_path / "repo",
+        )
+        precheck_transcript = (
+            "PRECHECK_RISK: low\n"
+            "PRECHECK_CONFIDENCE: 0.9\n"
+            "PRECHECK_ESCALATE: no\n"
+            "PRECHECK_SUMMARY: safe change\n"
+        )
+        safe_diff = "diff --git a/src/utils.py b/src/utils.py\n+pass"
+        mock_execute = AsyncMock(return_value=precheck_transcript)
+
+        with patch(
+            "precheck.should_escalate_debug",
+            return_value=EscalationDecision(escalate=False, reasons=[]),
+        ) as mock_escalate:
+            await run_precheck_context(
+                config=cfg,
+                prompt="test prompt",
+                diff=safe_diff,
+                execute=mock_execute,
+                debug_message="DEBUG",
+                logger=__import__("logging").getLogger("test"),
+            )
+
+        mock_escalate.assert_called_once()
+        assert mock_escalate.call_args[1]["high_risk_files_touched"] is False
+
+    @pytest.mark.asyncio
+    async def test_debug_message_appended_to_prompt(self, tmp_path) -> None:
+        cfg = ConfigFactory.create(
+            max_subskill_attempts=1,
+            debug_escalation_enabled=True,
+            max_debug_attempts=1,
+            subskill_confidence_threshold=0.7,
+            repo_root=tmp_path / "repo",
+        )
+        high_risk_transcript = (
+            "PRECHECK_RISK: high\n"
+            "PRECHECK_CONFIDENCE: 0.3\n"
+            "PRECHECK_ESCALATE: yes\n"
+            "PRECHECK_SUMMARY: Risky.\n"
+        )
+        mock_execute = AsyncMock(side_effect=[high_risk_transcript, "debug output"])
+        await run_precheck_context(
+            config=cfg,
+            prompt="original prompt",
+            diff="diff",
+            execute=mock_execute,
+            debug_message="DEBUG MODE: focus on ambiguity.",
+            logger=__import__("logging").getLogger("test"),
+        )
+        # The debug call (second call) should include the debug message
+        debug_call_prompt = mock_execute.call_args_list[1][0][1]
+        assert "DEBUG MODE: focus on ambiguity." in debug_call_prompt
+        assert "original prompt" in debug_call_prompt

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from base_runner import BaseRunner
-from escalation_gate import EscalationDecision
 from events import EventType
 from models import ReviewerStatus, ReviewVerdict
 from reviewer import ReviewRunner
@@ -1297,151 +1296,6 @@ async def test_has_changes_timeout_returns_false(config, event_bus, tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# _parse_precheck_transcript
-# ---------------------------------------------------------------------------
-
-
-class TestParsePrecheckTranscript:
-    """Tests for ReviewRunner._parse_precheck_transcript."""
-
-    def test_all_fields_present(self) -> None:
-        transcript = (
-            "Some preamble.\n"
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All looks good.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.risk == "low"
-        assert result.confidence == 0.95
-        assert result.escalate is False
-        assert result.summary == "All looks good."
-        assert result.parse_failed is False
-
-    def test_missing_risk_defaults_to_medium(self) -> None:
-        transcript = (
-            "PRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\nPRECHECK_SUMMARY: Fine.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.risk == "medium"
-        assert result.parse_failed is True
-
-    def test_missing_confidence_defaults_to_zero(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\nPRECHECK_ESCALATE: yes\nPRECHECK_SUMMARY: Risky.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.confidence == 0.0
-        assert result.parse_failed is True
-
-    def test_escalate_yes(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Needs debug.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.escalate is True
-
-    def test_escalate_no(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: OK.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.escalate is False
-
-    def test_case_insensitive_parsing(self) -> None:
-        transcript = (
-            "precheck_risk: HIGH\n"
-            "precheck_confidence: 0.42\n"
-            "precheck_escalate: YES\n"
-            "precheck_summary: Mixed case test.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.risk == "high"
-        assert result.confidence == 0.42
-        assert result.escalate is True
-        assert result.summary == "Mixed case test."
-        assert result.parse_failed is False
-
-    def test_empty_string_returns_defaults(self) -> None:
-        result = ReviewRunner._parse_precheck_transcript("")
-        assert result.risk == "medium"
-        assert result.confidence == 0.0
-        assert result.escalate is False
-        assert result.summary == ""
-        assert result.parse_failed is True
-
-    def test_missing_summary_only(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\nPRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.risk == "low"
-        assert result.confidence == 0.8
-        assert result.escalate is False
-        assert result.summary == ""
-        assert result.parse_failed is True
-
-    def test_missing_escalate_only(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: medium\n"
-            "PRECHECK_CONFIDENCE: 0.5\n"
-            "PRECHECK_SUMMARY: Partial.\n"
-        )
-        result = ReviewRunner._parse_precheck_transcript(transcript)
-        assert result.escalate is False
-        assert result.parse_failed is True
-
-
-# ---------------------------------------------------------------------------
-# _build_subskill_command / _build_debug_command
-# ---------------------------------------------------------------------------
-
-
-class TestBuildSubskillAndDebugCommands:
-    """Tests for ReviewRunner._build_subskill_command and _build_debug_command."""
-
-    def test_subskill_command_uses_config_tool_and_model(
-        self, config, event_bus
-    ) -> None:
-        runner = _make_runner(config, event_bus)
-        cmd = runner._build_subskill_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "haiku"
-
-    def test_subskill_command_codex_backend(self, event_bus) -> None:
-        cfg = ConfigFactory.create(subskill_tool="codex", subskill_model="gpt-4")
-        runner = _make_runner(cfg, event_bus)
-        cmd = runner._build_subskill_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert "--model" in cmd
-        assert cmd[cmd.index("--model") + 1] == "gpt-4"
-
-    def test_debug_command_uses_config_tool_and_model(self, config, event_bus) -> None:
-        runner = _make_runner(config, event_bus)
-        cmd = runner._build_debug_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "opus"
-
-    def test_debug_command_codex_backend(self, event_bus) -> None:
-        cfg = ConfigFactory.create(debug_tool="codex", debug_model="gpt-5")
-        runner = _make_runner(cfg, event_bus)
-        cmd = runner._build_debug_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert cmd[cmd.index("--model") + 1] == "gpt-5"
-
-
-# ---------------------------------------------------------------------------
 # _build_precheck_prompt
 # ---------------------------------------------------------------------------
 
@@ -1477,163 +1331,40 @@ class TestBuildPrecheckPrompt:
 
 
 # ---------------------------------------------------------------------------
-# _run_precheck_context
+# _run_precheck_context (wiring tests — shared logic tested in test_precheck.py)
 # ---------------------------------------------------------------------------
 
 
 class TestRunPrecheckContext:
-    """Tests for ReviewRunner._run_precheck_context."""
+    """Tests for ReviewRunner._run_precheck_context wiring."""
 
     @pytest.mark.asyncio
-    async def test_disabled_when_max_subskill_zero(
+    async def test_delegates_to_shared_run_precheck_context(
         self, config, event_bus, pr_info, issue, tmp_path
     ) -> None:
-        """max_subskill_attempts=0 should return disabled message without subprocess calls."""
+        """Verify ReviewRunner delegates to the shared precheck module."""
         runner = _make_runner(config, event_bus)
-        mock_execute = AsyncMock()
-        with patch.object(runner, "_execute", mock_execute):
+
+        with patch(
+            "reviewer.run_precheck_context",
+            new_callable=AsyncMock,
+            return_value="Precheck risk: low",
+        ) as mock_rpc:
             result = await runner._run_precheck_context(
                 pr_info, issue, "diff", tmp_path
             )
-        assert result == "Low-tier precheck disabled."
-        mock_execute.assert_not_called()
+
+        mock_rpc.assert_awaited_once()
+        assert result == "Precheck risk: low"
+        call_kwargs = mock_rpc.call_args[1]
+        assert call_kwargs["config"] is runner._config
+        assert "root causes" in call_kwargs["debug_message"]
 
     @pytest.mark.asyncio
-    async def test_success_no_escalation(
+    async def test_execute_closure_calls_self_execute(
         self, event_bus, pr_info, issue, tmp_path
     ) -> None:
-        """Successful precheck with high confidence should not escalate when disabled."""
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            subskill_confidence_threshold=0.7,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        runner = _make_runner(cfg, event_bus)
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All clear.\n"
-        )
-        mock_execute = AsyncMock(return_value=valid_transcript)
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "safe diff", tmp_path
-            )
-        assert "Precheck risk: low" in result
-        assert "Precheck confidence: 0.95" in result
-        assert "Precheck summary: All clear." in result
-        assert "Debug escalation: no" in result
-        mock_execute.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_retries_on_parse_failure(
-        self, event_bus, pr_info, issue, tmp_path
-    ) -> None:
-        """Should retry on parse failure and succeed on final attempt."""
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=3,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        runner = _make_runner(cfg, event_bus)
-
-        garbage = "No parseable fields here."
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: Finally parsed.\n"
-        )
-
-        mock_execute = AsyncMock(side_effect=[garbage, garbage, valid_transcript])
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "diff", tmp_path
-            )
-        assert mock_execute.call_count == 3
-        assert "Precheck risk: low" in result
-        assert "Precheck summary: Finally parsed." in result
-
-    @pytest.mark.asyncio
-    async def test_escalates_to_debug(
-        self, event_bus, pr_info, issue, tmp_path
-    ) -> None:
-        """High risk + low confidence should trigger debug escalation."""
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        runner = _make_runner(cfg, event_bus)
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky change.\n"
-        )
-        debug_transcript = "Debug analysis: found critical issues in auth module."
-
-        mock_execute = AsyncMock(side_effect=[high_risk_transcript, debug_transcript])
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "diff /auth/login.py", tmp_path
-            )
-        assert mock_execute.call_count == 2
-        assert "Precheck risk: high" in result
-        assert "Debug escalation: yes" in result
-        assert "Debug precheck transcript:" in result
-        assert "Debug analysis: found critical" in result
-        assert "Escalation reasons:" in result
-
-    @pytest.mark.asyncio
-    async def test_no_debug_when_max_debug_zero(
-        self, event_bus, pr_info, issue, tmp_path
-    ) -> None:
-        """Escalation decision may say yes but max_debug_attempts=0 prevents debug call."""
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=0,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        runner = _make_runner(cfg, event_bus)
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-        mock_execute = AsyncMock(return_value=high_risk_transcript)
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "diff /auth/login.py", tmp_path
-            )
-        # Only 1 call (subskill), no debug call
-        assert mock_execute.call_count == 1
-        assert "Debug escalation: yes" in result
-        # No debug transcript appended
-        assert "Debug precheck transcript:" not in result
-
-    @pytest.mark.asyncio
-    async def test_exception_returns_fallback(
-        self, event_bus, pr_info, issue, tmp_path
-    ) -> None:
-        """RuntimeError during execution should return fallback message."""
+        """Verify the execute closure wires through to self._execute."""
         cfg = ConfigFactory.create(
             max_subskill_attempts=1,
             repo_root=tmp_path / "repo",
@@ -1642,108 +1373,27 @@ class TestRunPrecheckContext:
         )
         runner = _make_runner(cfg, event_bus)
 
-        mock_execute = AsyncMock(side_effect=RuntimeError("subprocess crashed"))
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "diff", tmp_path
-            )
-        assert (
-            result == "Low-tier precheck failed; continuing without precheck context."
+        captured_execute = {}
+
+        async def capture_rpc(**kwargs):
+            captured_execute["fn"] = kwargs["execute"]
+            return "Precheck risk: low"
+
+        with patch(
+            "reviewer.run_precheck_context",
+            side_effect=capture_rpc,
+        ):
+            await runner._run_precheck_context(pr_info, issue, "diff", tmp_path)
+
+        # Call the captured execute closure
+        mock_self_execute = AsyncMock(return_value="transcript")
+        with patch.object(runner, "_execute", mock_self_execute):
+            result = await captured_execute["fn"](["cmd"], "prompt")
+
+        assert result == "transcript"
+        mock_self_execute.assert_called_once_with(
+            ["cmd"], "prompt", tmp_path, {"pr": pr_info.number, "source": "reviewer"}
         )
-
-    @pytest.mark.asyncio
-    async def test_debug_transcript_truncated_to_1000_chars(
-        self, event_bus, pr_info, issue, tmp_path
-    ) -> None:
-        """Debug transcript should be truncated to 1000 chars in context output."""
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        runner = _make_runner(cfg, event_bus)
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-        long_debug = "D" * 2000
-
-        mock_execute = AsyncMock(side_effect=[high_risk_transcript, long_debug])
-        with patch.object(runner, "_execute", mock_execute):
-            result = await runner._run_precheck_context(
-                pr_info, issue, "diff /auth/login.py", tmp_path
-            )
-        # The debug transcript in the output should be truncated to 1000 chars
-        assert "D" * 1000 in result
-        assert "D" * 1001 not in result
-
-
-# ---------------------------------------------------------------------------
-# _run_precheck_context — high-risk files
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_precheck_passes_high_risk_true_for_auth_diff(
-    event_bus, pr_info, issue, tmp_path
-):
-    cfg = ConfigFactory.create(max_subskill_attempts=1)
-    runner = _make_runner(cfg, event_bus)
-
-    precheck_transcript = (
-        "PRECHECK_RISK: high\n"
-        "PRECHECK_CONFIDENCE: 0.5\n"
-        "PRECHECK_ESCALATE: no\n"
-        "PRECHECK_SUMMARY: auth change\n"
-    )
-    auth_diff = "diff --git a/src/auth/login.py b/src/auth/login.py\n+pass"
-
-    with (
-        patch.object(runner, "_execute", AsyncMock(return_value=precheck_transcript)),
-        patch(
-            "reviewer.should_escalate_debug",
-            return_value=EscalationDecision(escalate=False, reasons=[]),
-        ) as mock_escalate,
-    ):
-        await runner._run_precheck_context(pr_info, issue, auth_diff, tmp_path)
-
-    mock_escalate.assert_called_once()
-    assert mock_escalate.call_args[1]["high_risk_files_touched"] is True
-
-
-@pytest.mark.asyncio
-async def test_precheck_passes_high_risk_false_for_safe_diff(
-    event_bus, pr_info, issue, tmp_path
-):
-    cfg = ConfigFactory.create(max_subskill_attempts=1)
-    runner = _make_runner(cfg, event_bus)
-
-    precheck_transcript = (
-        "PRECHECK_RISK: low\n"
-        "PRECHECK_CONFIDENCE: 0.9\n"
-        "PRECHECK_ESCALATE: no\n"
-        "PRECHECK_SUMMARY: safe change\n"
-    )
-    safe_diff = "diff --git a/src/utils.py b/src/utils.py\n+def helper(): pass"
-
-    with (
-        patch.object(runner, "_execute", AsyncMock(return_value=precheck_transcript)),
-        patch(
-            "reviewer.should_escalate_debug",
-            return_value=EscalationDecision(escalate=False, reasons=[]),
-        ) as mock_escalate,
-    ):
-        await runner._run_precheck_context(pr_info, issue, safe_diff, tmp_path)
-
-    mock_escalate.assert_called_once()
-    assert mock_escalate.call_args[1]["high_risk_files_touched"] is False
 
 
 # _build_ci_fix_prompt — CI log injection

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -11,7 +11,6 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from escalation_gate import EscalationDecision
 from events import EventBus, EventType
 from models import (
     CriterionResult,
@@ -19,7 +18,6 @@ from models import (
     GitHubIssue,
     InstructionsQuality,
     JudgeVerdict,
-    PrecheckResult,
     PRInfo,
 )
 from tests.conftest import ReviewResultFactory
@@ -1082,66 +1080,22 @@ class TestTerminate:
 # ---------------------------------------------------------------------------
 
 
-HIGH_RISK_DIFF = (
-    "diff --git a/src/auth/login.py b/src/auth/login.py\n+def login(): pass\n"
-)
-SAFE_DIFF = "diff --git a/src/utils.py b/src/utils.py\n+def helper(): pass\n"
-
-
-class TestPrecheckHighRiskFiles:
-    """Verify _run_precheck_context passes high_risk_files_touched correctly."""
+class TestPrecheckDiffPassthrough:
+    """Verify _run_precheck_context passes diff to the shared precheck module."""
 
     @pytest.mark.asyncio
-    async def test_high_risk_diff_passes_true(self, tmp_path) -> None:
+    async def test_passes_diff_to_shared_module(self, tmp_path) -> None:
         cfg = ConfigFactory.create(max_subskill_attempts=1, repo_root=tmp_path)
         judge = VerificationJudge(cfg, EventBus())
 
-        precheck_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.5\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: risky auth change\n"
-        )
+        with patch(
+            "verification_judge.run_precheck_context",
+            new_callable=AsyncMock,
+            return_value="Precheck risk: low",
+        ) as mock_rpc:
+            await judge._run_precheck_context(42, "criteria text", "some diff")
 
-        with (
-            patch.object(
-                judge, "_execute", AsyncMock(return_value=precheck_transcript)
-            ),
-            patch(
-                "verification_judge.should_escalate_debug",
-                return_value=EscalationDecision(escalate=False, reasons=[]),
-            ) as mock_escalate,
-        ):
-            await judge._run_precheck_context(42, "criteria text", HIGH_RISK_DIFF)
-
-        mock_escalate.assert_called_once()
-        assert mock_escalate.call_args[1]["high_risk_files_touched"] is True
-
-    @pytest.mark.asyncio
-    async def test_safe_diff_passes_false(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(max_subskill_attempts=1, repo_root=tmp_path)
-        judge = VerificationJudge(cfg, EventBus())
-
-        precheck_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: safe change\n"
-        )
-
-        with (
-            patch.object(
-                judge, "_execute", AsyncMock(return_value=precheck_transcript)
-            ),
-            patch(
-                "verification_judge.should_escalate_debug",
-                return_value=EscalationDecision(escalate=False, reasons=[]),
-            ) as mock_escalate,
-        ):
-            await judge._run_precheck_context(42, "criteria text", SAFE_DIFF)
-
-        mock_escalate.assert_called_once()
-        assert mock_escalate.call_args[1]["high_risk_files_touched"] is False
+        assert mock_rpc.call_args[1]["diff"] == "some diff"
 
 
 # ---------------------------------------------------------------------------
@@ -1288,135 +1242,6 @@ class TestReviewPhaseWiring:
 
 
 # ---------------------------------------------------------------------------
-# _parse_precheck_transcript
-# ---------------------------------------------------------------------------
-
-
-class TestParsePrecheckTranscript:
-    """Tests for VerificationJudge._parse_precheck_transcript."""
-
-    def test_all_fields_present(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All looks good.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert isinstance(result, PrecheckResult)
-        assert result.risk == "low"
-        assert result.confidence == 0.95
-        assert result.escalate is False
-        assert result.summary == "All looks good."
-        assert result.parse_failed is False
-
-    def test_missing_risk_defaults_to_medium(self) -> None:
-        transcript = (
-            "PRECHECK_CONFIDENCE: 0.8\nPRECHECK_ESCALATE: no\nPRECHECK_SUMMARY: Fine.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert result.risk == "medium"
-        assert result.parse_failed is True
-
-    def test_missing_confidence_defaults_to_zero(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\nPRECHECK_ESCALATE: yes\nPRECHECK_SUMMARY: Risky.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert result.confidence == 0.0
-        assert result.parse_failed is True
-
-    def test_escalate_yes(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Needs debug.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert result.escalate is True
-
-    def test_escalate_no(self) -> None:
-        transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: OK.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert result.escalate is False
-
-    def test_case_insensitive_parsing(self) -> None:
-        transcript = (
-            "precheck_risk: HIGH\n"
-            "precheck_confidence: 0.42\n"
-            "precheck_escalate: YES\n"
-            "precheck_summary: Mixed case.\n"
-        )
-        result = VerificationJudge._parse_precheck_transcript(transcript)
-        assert result.risk == "high"
-        assert result.confidence == 0.42
-        assert result.escalate is True
-        assert result.summary == "Mixed case."
-        assert result.parse_failed is False
-
-    def test_empty_string_returns_defaults(self) -> None:
-        result = VerificationJudge._parse_precheck_transcript("")
-        assert result.risk == "medium"
-        assert result.confidence == 0.0
-        assert result.escalate is False
-        assert result.summary == ""
-        assert result.parse_failed is True
-
-
-# ---------------------------------------------------------------------------
-# _build_subskill_command / _build_debug_command
-# ---------------------------------------------------------------------------
-
-
-class TestBuildSubskillAndDebugCommands:
-    """Tests for VerificationJudge _build_subskill_command and _build_debug_command."""
-
-    def test_subskill_command_uses_config_tool_and_model(self, config) -> None:
-        judge = _make_judge(config)
-        cmd = judge._build_subskill_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "haiku"
-
-    def test_subskill_command_codex_backend(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            subskill_tool="codex",
-            subskill_model="gpt-4",
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-        cmd = judge._build_subskill_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert cmd[cmd.index("--model") + 1] == "gpt-4"
-
-    def test_debug_command_uses_config_tool_and_model(self, config) -> None:
-        judge = _make_judge(config)
-        cmd = judge._build_debug_command()
-        assert "claude" in cmd
-        assert "--model" in cmd
-        idx = cmd.index("--model")
-        assert cmd[idx + 1] == "opus"
-
-    def test_debug_command_codex_backend(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            debug_tool="codex",
-            debug_model="gpt-5",
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-        cmd = judge._build_debug_command()
-        assert cmd[:3] == ["codex", "exec", "--json"]
-        assert cmd[cmd.index("--model") + 1] == "gpt-5"
-
-
-# ---------------------------------------------------------------------------
 # _build_precheck_prompt
 # ---------------------------------------------------------------------------
 
@@ -1447,164 +1272,56 @@ class TestBuildPrecheckPrompt:
 
 
 # ---------------------------------------------------------------------------
-# _run_precheck_context
+# _run_precheck_context (wiring tests — shared logic tested in test_precheck.py)
 # ---------------------------------------------------------------------------
 
 
 class TestRunPrecheckContext:
-    """Tests for VerificationJudge._run_precheck_context."""
+    """Tests for VerificationJudge._run_precheck_context wiring."""
 
     @pytest.mark.asyncio
-    async def test_disabled_when_max_subskill_zero(self, config) -> None:
+    async def test_delegates_to_shared_run_precheck_context(self, config) -> None:
+        """Verify VJ delegates to the shared precheck module."""
         judge = _make_judge(config)
-        result = await judge._run_precheck_context(42, "criteria", "diff")
-        assert result == "Low-tier precheck disabled."
 
-    @pytest.mark.asyncio
-    async def test_success_no_escalation(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            subskill_confidence_threshold=0.7,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.95\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: All clear.\n"
-        )
-        mock_execute = AsyncMock(return_value=valid_transcript)
-        with patch.object(judge, "_execute", mock_execute):
+        with patch(
+            "verification_judge.run_precheck_context",
+            new_callable=AsyncMock,
+            return_value="Precheck risk: low",
+        ) as mock_rpc:
             result = await judge._run_precheck_context(42, "criteria", "diff")
 
-        assert "Precheck risk: low" in result
-        assert "Precheck confidence: 0.95" in result
-        assert "Precheck summary: All clear." in result
-        assert "Debug escalation: no" in result
-        mock_execute.assert_called_once()
+        mock_rpc.assert_awaited_once()
+        assert result == "Precheck risk: low"
+        call_kwargs = mock_rpc.call_args[1]
+        assert call_kwargs["config"] is judge._config
+        assert "ambiguity" in call_kwargs["debug_message"]
 
     @pytest.mark.asyncio
-    async def test_retries_on_parse_failure(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=3,
-            debug_escalation_enabled=False,
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-
-        garbage = "No parseable fields here."
-        valid_transcript = (
-            "PRECHECK_RISK: low\n"
-            "PRECHECK_CONFIDENCE: 0.9\n"
-            "PRECHECK_ESCALATE: no\n"
-            "PRECHECK_SUMMARY: Finally parsed.\n"
-        )
-
-        mock_execute = AsyncMock(side_effect=[garbage, garbage, valid_transcript])
-        with patch.object(judge, "_execute", mock_execute):
-            result = await judge._run_precheck_context(42, "criteria", "diff")
-
-        assert mock_execute.call_count == 3
-        assert "Precheck risk: low" in result
-        assert "Precheck summary: Finally parsed." in result
-
-    @pytest.mark.asyncio
-    async def test_escalates_to_debug(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky change.\n"
-        )
-        debug_transcript = "Debug: found critical issues."
-
-        mock_execute = AsyncMock(side_effect=[high_risk_transcript, debug_transcript])
-        with patch.object(judge, "_execute", mock_execute):
-            result = await judge._run_precheck_context(42, "criteria", "diff")
-
-        assert mock_execute.call_count == 2
-        assert "Precheck risk: high" in result
-        assert "Debug escalation: yes" in result
-        assert "Debug precheck transcript:" in result
-        assert "Debug: found critical issues." in result
-        assert "Escalation reasons:" in result
-
-    @pytest.mark.asyncio
-    async def test_no_debug_when_max_debug_zero(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=0,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
-
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-
-        mock_execute = AsyncMock(return_value=high_risk_transcript)
-        with patch.object(judge, "_execute", mock_execute):
-            result = await judge._run_precheck_context(42, "criteria", "diff")
-
-        assert mock_execute.call_count == 1
-        assert "Debug escalation: yes" in result
-        assert "Debug precheck transcript:" not in result
-
-    @pytest.mark.asyncio
-    async def test_exception_returns_fallback(self, tmp_path) -> None:
+    async def test_execute_closure_calls_self_execute(self, tmp_path) -> None:
+        """Verify the execute closure wires through to self._execute."""
         cfg = ConfigFactory.create(
             max_subskill_attempts=1,
             repo_root=tmp_path / "repo",
         )
         judge = _make_judge(cfg)
 
-        mock_execute = AsyncMock(side_effect=RuntimeError("subprocess crashed"))
-        with patch.object(judge, "_execute", mock_execute):
-            result = await judge._run_precheck_context(42, "criteria", "diff")
+        captured_execute = {}
 
-        assert (
-            result == "Low-tier precheck failed; continuing without precheck context."
-        )
+        async def capture_rpc(**kwargs):
+            captured_execute["fn"] = kwargs["execute"]
+            return "Precheck risk: low"
 
-    @pytest.mark.asyncio
-    async def test_debug_transcript_truncated_to_1000_chars(self, tmp_path) -> None:
-        cfg = ConfigFactory.create(
-            max_subskill_attempts=1,
-            debug_escalation_enabled=True,
-            max_debug_attempts=1,
-            subskill_confidence_threshold=0.7,
-            repo_root=tmp_path / "repo",
-        )
-        judge = _make_judge(cfg)
+        with patch(
+            "verification_judge.run_precheck_context",
+            side_effect=capture_rpc,
+        ):
+            await judge._run_precheck_context(42, "criteria", "diff")
 
-        high_risk_transcript = (
-            "PRECHECK_RISK: high\n"
-            "PRECHECK_CONFIDENCE: 0.3\n"
-            "PRECHECK_ESCALATE: yes\n"
-            "PRECHECK_SUMMARY: Risky.\n"
-        )
-        long_debug = "D" * 2000
+        # Call the captured execute closure
+        mock_self_execute = AsyncMock(return_value="transcript")
+        with patch.object(judge, "_execute", mock_self_execute):
+            result = await captured_execute["fn"](["cmd"], "prompt")
 
-        mock_execute = AsyncMock(side_effect=[high_risk_transcript, long_debug])
-        with patch.object(judge, "_execute", mock_execute):
-            result = await judge._run_precheck_context(42, "criteria", "diff")
-
-        assert "D" * 1000 in result
-        assert "D" * 1001 not in result
+        assert result == "transcript"
+        mock_self_execute.assert_called_once_with(["cmd"], "prompt", 42)

--- a/verification_judge.py
+++ b/verification_judge.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 from agent_cli import build_agent_command
 from config import HydraFlowConfig
-from escalation_gate import high_risk_diff_touched, should_escalate_debug
 from events import EventBus, EventType, HydraFlowEvent
 from execution import get_default_runner
 from models import (
@@ -19,8 +18,8 @@ from models import (
     InstructionsQualityResult,
     JudgeVerdict,
     ParsedCriteria,
-    PrecheckResult,
 )
+from precheck import run_precheck_context
 from runner_utils import stream_claude_process, terminate_processes
 from subprocess_util import CreditExhaustedError
 
@@ -354,18 +353,6 @@ REFINED_INSTRUCTIONS_END
             disallowed_tools="Write,Edit,NotebookEdit",
         )
 
-    def _build_subskill_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.subskill_tool,
-            model=self._config.subskill_model,
-        )
-
-    def _build_debug_command(self) -> list[str]:
-        return build_agent_command(
-            tool=self._config.debug_tool,
-            model=self._config.debug_model,
-        )
-
     def _build_precheck_prompt(
         self, issue_number: int, criteria: str, diff: str
     ) -> str:
@@ -384,102 +371,22 @@ Diff excerpt:
 {diff[:3000]}
 """
 
-    @staticmethod
-    def _parse_precheck_transcript(
-        transcript: str,
-    ) -> PrecheckResult:
-        risk_match = re.search(
-            r"PRECHECK_RISK:\s*(low|medium|high)",
-            transcript,
-            re.IGNORECASE,
-        )
-        confidence_match = re.search(
-            r"PRECHECK_CONFIDENCE:\s*([0-9]*\.?[0-9]+)",
-            transcript,
-            re.IGNORECASE,
-        )
-        escalate_match = re.search(
-            r"PRECHECK_ESCALATE:\s*(yes|no)",
-            transcript,
-            re.IGNORECASE,
-        )
-        summary_match = re.search(
-            r"PRECHECK_SUMMARY:\s*(.*)",
-            transcript,
-            re.IGNORECASE,
-        )
-        parse_failed = not (
-            risk_match and confidence_match and escalate_match and summary_match
-        )
-        risk = risk_match.group(1).lower() if risk_match else "medium"
-        confidence = float(confidence_match.group(1)) if confidence_match else 0.0
-        escalate = bool(escalate_match and escalate_match.group(1).lower() == "yes")
-        summary = summary_match.group(1).strip() if summary_match else ""
-        return PrecheckResult(
-            risk=risk,
-            confidence=confidence,
-            escalate=escalate,
-            summary=summary,
-            parse_failed=parse_failed,
-        )
-
     async def _run_precheck_context(
         self, issue_number: int, criteria_text: str, diff: str
     ) -> str:
-        if self._config.max_subskill_attempts <= 0:
-            return "Low-tier precheck disabled."
         prompt = self._build_precheck_prompt(issue_number, criteria_text, diff)
-        risk = "medium"
-        confidence = self._config.subskill_confidence_threshold
-        summary = ""
-        parse_failed = False
 
-        try:
-            for _attempt in range(self._config.max_subskill_attempts):
-                transcript = await self._execute(
-                    self._build_subskill_command(),
-                    prompt,
-                    issue_number,
-                )
-                precheck = self._parse_precheck_transcript(transcript)
-                risk = precheck.risk
-                confidence = precheck.confidence
-                summary = precheck.summary
-                parse_failed = precheck.parse_failed
-                if not parse_failed:
-                    break
-        except Exception:  # noqa: BLE001
-            return "Low-tier precheck failed; continuing without precheck context."
+        async def execute(cmd: list[str], p: str) -> str:
+            return await self._execute(cmd, p, issue_number)
 
-        decision = should_escalate_debug(
-            enabled=self._config.debug_escalation_enabled,
-            confidence=confidence,
-            confidence_threshold=self._config.subskill_confidence_threshold,
-            parse_failed=parse_failed,
-            retry_count=self._config.max_subskill_attempts,
-            max_subskill_attempts=self._config.max_subskill_attempts,
-            risk=risk,
-            high_risk_files_touched=high_risk_diff_touched(diff),
+        return await run_precheck_context(
+            config=self._config,
+            prompt=prompt,
+            diff=diff,
+            execute=execute,
+            debug_message="DEBUG MODE: focus on failure and ambiguity hotspots.",
+            logger=logger,
         )
-
-        context = [
-            f"Precheck risk: {risk}",
-            f"Precheck confidence: {confidence:.2f}",
-            f"Precheck summary: {summary or 'N/A'}",
-            f"Debug escalation: {'yes' if decision.escalate else 'no'}",
-        ]
-
-        if decision.escalate and self._config.max_debug_attempts > 0:
-            debug_transcript = await self._execute(
-                self._build_debug_command(),
-                prompt + "\n\nDEBUG MODE: focus on failure and ambiguity hotspots.",
-                issue_number,
-            )
-            context.append("Debug precheck transcript:")
-            context.append(debug_transcript[:1000])
-            context.append(f"Escalation reasons: {', '.join(decision.reasons)}")
-
-        return "\n".join(context)
 
     def _parse_criteria_results(self, transcript: str) -> list[CriterionResult]:
         """Parse criterion results from the transcript."""


### PR DESCRIPTION
## Summary

Closes #1064.

## Issue

Type Safety: Deduplicate _parse_precheck_transcript between AcceptanceCriteriaGenerator and VerificationJudge

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow