### PR TITLE
ui: make triage yellow and keep merged green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ HydraFlow runs five concurrent async loops from `orchestrator.py`:
 
 ## Worktree Management
 
-HydraFlow creates isolated git worktrees for each issue. **Always clean up worktrees when their PRs are merged or issues are closed.**
+HydraFlow creates isolated git worktrees for each issue. **Always clean up worktrees when their PRs are merged or issues are closed. Always implement issue work on a dedicated git worktree branch; do not implement directly in the primary repo checkout.**
 
 - **Default location:** `../hydraflow-worktrees/` (sibling to repo root)
 - **Naming:** `issue-{issue_number}/`

--- a/ui/src/components/__tests__/constants.test.js
+++ b/ui/src/components/__tests__/constants.test.js
@@ -50,7 +50,7 @@ describe('PIPELINE_STAGES', () => {
   it('maps each stage to the correct theme color', () => {
     const colorMap = Object.fromEntries(PIPELINE_STAGES.map(s => [s.key, s.color]))
     expect(colorMap).toEqual({
-      triage: theme.triageGreen,
+      triage: theme.yellow,
       plan: theme.purple,
       implement: theme.accent,
       review: theme.orange,
@@ -83,7 +83,7 @@ describe('PIPELINE_STAGES', () => {
   it('maps each stage to the correct subtle color', () => {
     const subtleMap = Object.fromEntries(PIPELINE_STAGES.map(s => [s.key, s.subtleColor]))
     expect(subtleMap).toEqual({
-      triage: theme.greenSubtle,
+      triage: theme.yellowSubtle,
       plan: theme.purpleSubtle,
       implement: theme.accentSubtle,
       review: theme.orangeSubtle,

--- a/ui/src/constants.js
+++ b/ui/src/constants.js
@@ -19,7 +19,7 @@ export const MAX_EVENTS = 5000
  * Components derive their own views (uppercase labels, filtered subsets, etc.) from this array.
  */
 export const PIPELINE_STAGES = [
-  { key: 'triage',    label: 'Triage',    color: theme.triageGreen, subtleColor: theme.greenSubtle,  role: 'triage',      configKey: null },
+  { key: 'triage',    label: 'Triage',    color: theme.yellow,      subtleColor: theme.yellowSubtle,  role: 'triage',      configKey: null },
   { key: 'plan',      label: 'Plan',      color: theme.purple,      subtleColor: theme.purpleSubtle, role: 'planner',     configKey: 'max_planners' },
   { key: 'implement', label: 'Implement', color: theme.accent,      subtleColor: theme.accentSubtle, role: 'implementer', configKey: 'max_workers' },
   { key: 'review',    label: 'Review',    color: theme.orange,      subtleColor: theme.orangeSubtle, role: 'reviewer',    configKey: 'max_reviewers' },
@@ -33,7 +33,7 @@ export const STREAM_CARD_STATUSES = ['active', 'queued', 'done', 'failed', 'hitl
  * Pipeline loop definitions — core processing loops that can be toggled on/off.
  */
 export const PIPELINE_LOOPS = [
-  { key: 'triage',    label: 'Triage',    color: theme.triageGreen, dimColor: theme.greenSubtle  },
+  { key: 'triage',    label: 'Triage',    color: theme.yellow,      dimColor: theme.yellowSubtle  },
   { key: 'plan',      label: 'Plan',      color: theme.purple,      dimColor: theme.purpleSubtle },
   { key: 'implement', label: 'Implement', color: theme.accent,      dimColor: theme.accentSubtle },
   { key: 'review',    label: 'Review',    color: theme.orange,      dimColor: theme.orangeSubtle },


### PR DESCRIPTION
Closes #1208

## Summary
- change triage stage color from green to yellow in pipeline stage metadata
- keep merged stage as green success state
- update constants test expectations for triage color/subtle color
- add explicit guidance in `CLAUDE.md` to always implement issue work on dedicated git worktrees

## Validation
- `npm --prefix ui test -- --run src/components/__tests__/constants.test.js src/components/__tests__/StreamView.test.jsx`
- pre-push `make quality-lite` passed
