### PR TITLE
Add YAML frontmatter to skill SKILL.md files

### DIFF
--- a/.codex/skills/hf.audit-code/SKILL.md
+++ b/.codex/skills/hf.audit-code/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.audit-code
+description: Code Quality Audit
+---
+
 # Code Quality Audit
 
 Run a comprehensive code quality audit across the entire repo. Dynamically analyzes source code for dead code, complexity, duplication, error handling gaps, type safety issues, and architectural problems. Creates GitHub issues for findings so HydraFlow can process them.

--- a/.codex/skills/hf.audit-hooks/SKILL.md
+++ b/.codex/skills/hf.audit-hooks/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.audit-hooks
+description: Hooks & Workflow Audit
+---
+
 # Hooks & Workflow Audit
 
 Audit all Claude Code hooks (`.claude/settings.json` and `.claude/hooks/*.sh`) for correctness, efficiency, and gating opportunities. Launch a single agent that reads everything and reports findings.

--- a/.codex/skills/hf.audit-integration-tests/SKILL.md
+++ b/.codex/skills/hf.audit-integration-tests/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.audit-integration-tests
+description: Integration Test Audit
+---
+
 # Integration Test Audit
 
 Run a comprehensive integration test audit across the entire repo. Dynamically discovers external dependencies in source code, inventories existing integration tests, identifies coverage gaps, flags ugly/outdated tests, and creates GitHub issues for findings.

--- a/.codex/skills/hf.audit-tests/SKILL.md
+++ b/.codex/skills/hf.audit-tests/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.audit-tests
+description: Test Audit
+---
+
 # Test Audit
 
 Run a comprehensive test quality audit across the entire repo. Analyzes test naming, structure, factory usage, anti-patterns, coverage gaps, and flaky patterns. Creates GitHub issues for findings so HydraFlow can process them.

--- a/.codex/skills/hf.block-destructive-git/SKILL.md
+++ b/.codex/skills/hf.block-destructive-git/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.block-destructive-git
+description: hf.block-destructive-git
+---
+
 # hf.block-destructive-git
 
 ```bash

--- a/.codex/skills/hf.check-cross-service-impact/SKILL.md
+++ b/.codex/skills/hf.check-cross-service-impact/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.check-cross-service-impact
+description: hf.check-cross-service-impact
+---
+
 # hf.check-cross-service-impact
 
 ```bash

--- a/.codex/skills/hf.check-reindex-needed/SKILL.md
+++ b/.codex/skills/hf.check-reindex-needed/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.check-reindex-needed
+description: hf.check-reindex-needed
+---
+
 # hf.check-reindex-needed
 
 ```bash

--- a/.codex/skills/hf.check-test-counterpart/SKILL.md
+++ b/.codex/skills/hf.check-test-counterpart/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.check-test-counterpart
+description: hf.check-test-counterpart
+---
+
 # hf.check-test-counterpart
 
 ```bash

--- a/.codex/skills/hf.cleanup-code-change-marker/SKILL.md
+++ b/.codex/skills/hf.cleanup-code-change-marker/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.cleanup-code-change-marker
+description: hf.cleanup-code-change-marker
+---
+
 # hf.cleanup-code-change-marker
 
 ```bash

--- a/.codex/skills/hf.enforce-migrations/SKILL.md
+++ b/.codex/skills/hf.enforce-migrations/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.enforce-migrations
+description: hf.enforce-migrations
+---
+
 # hf.enforce-migrations
 
 ```bash

--- a/.codex/skills/hf.enforce-plan-and-explore/SKILL.md
+++ b/.codex/skills/hf.enforce-plan-and-explore/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.enforce-plan-and-explore
+description: hf.enforce-plan-and-explore
+---
+
 # hf.enforce-plan-and-explore
 
 ```bash

--- a/.codex/skills/hf.gate-stop-agents/SKILL.md
+++ b/.codex/skills/hf.gate-stop-agents/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.gate-stop-agents
+description: hf.gate-stop-agents
+---
+
 # hf.gate-stop-agents
 
 ```bash

--- a/.codex/skills/hf.issue/SKILL.md
+++ b/.codex/skills/hf.issue/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.issue
+description: Create a GitHub Issue
+---
+
 # Create a GitHub Issue
 
 Take a rough description from the user, research the relevant codebase, and create a well-structured GitHub issue with full context, file references, and acceptance criteria.

--- a/.codex/skills/hf.memory/SKILL.md
+++ b/.codex/skills/hf.memory/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.memory
+description: Capture Session Learnings as Memory Suggestions
+---
+
 # Capture Session Learnings as Memory Suggestions
 
 Scan the current conversation for architectural decisions, bug root causes, configuration choices, codebase patterns, and workflow preferences. File each as a memory suggestion issue that enters the HITL review pipeline and eventually syncs into the agent memory digest.

--- a/.codex/skills/hf.scan-secrets-before-commit/SKILL.md
+++ b/.codex/skills/hf.scan-secrets-before-commit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.scan-secrets-before-commit
+description: hf.scan-secrets-before-commit
+---
+
 # hf.scan-secrets-before-commit
 
 ```bash

--- a/.codex/skills/hf.track-code-changes/SKILL.md
+++ b/.codex/skills/hf.track-code-changes/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.track-code-changes
+description: hf.track-code-changes
+---
+
 # hf.track-code-changes
 
 ```bash

--- a/.codex/skills/hf.track-exploration/SKILL.md
+++ b/.codex/skills/hf.track-exploration/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.track-exploration
+description: hf.track-exploration
+---
+
 # hf.track-exploration
 
 ```bash

--- a/.codex/skills/hf.track-indexed/SKILL.md
+++ b/.codex/skills/hf.track-indexed/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.track-indexed
+description: hf.track-indexed
+---
+
 # hf.track-indexed
 
 ```bash

--- a/.codex/skills/hf.track-planning/SKILL.md
+++ b/.codex/skills/hf.track-planning/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.track-planning
+description: hf.track-planning
+---
+
 # hf.track-planning
 
 ```bash

--- a/.codex/skills/hf.track-reindex-needed/SKILL.md
+++ b/.codex/skills/hf.track-reindex-needed/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.track-reindex-needed
+description: hf.track-reindex-needed
+---
+
 # hf.track-reindex-needed
 
 ```bash

--- a/.codex/skills/hf.validate-tests-before-commit/SKILL.md
+++ b/.codex/skills/hf.validate-tests-before-commit/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.validate-tests-before-commit
+description: hf.validate-tests-before-commit
+---
+
 # hf.validate-tests-before-commit
 
 ```bash

--- a/.codex/skills/hf.warn-new-file-creation/SKILL.md
+++ b/.codex/skills/hf.warn-new-file-creation/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: hf.warn-new-file-creation
+description: hf.warn-new-file-creation
+---
+
 # hf.warn-new-file-creation
 
 ```bash


### PR DESCRIPTION
## Summary
- add missing YAML frontmatter delimiters to skill SKILL.md files under .codex/skills
- include name and description keys in each affected file
- resolve all reported "missing YAML frontmatter delimited by ---" warnings

## Validation
- scanned all SKILL.md files in project and user skill roots
- confirmed frontmatter issues count is 0 for current project files
