### PR TITLE
Clarify HydraFlow positioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Log an issue. Agents handle the rest - triaging, planning, implementing, reviewi
 
 HydraFlow is built for quality-first scaling: agents execute the work, but guardrails decide what ships.
 
+HydraFlow is a delivery kernel for GitHub repositories: it accepts intent, compiles it through a staged pipeline, enforces quality gates, and produces merged software changes.
+
 ## What Makes It Different
 
 - Quality-gated pipeline, not "one-shot" agent code generation


### PR DESCRIPTION
## Summary
- add a concise product-definition line near the top of README
- describe HydraFlow as a delivery kernel for GitHub repositories

## Testing
- docs-only change