### PR TITLE
Use REST endpoints for hot GitHub paths to avoid GraphQL exhaustion

### DIFF
--- a/src/issue_fetcher.py
+++ b/src/issue_fetcher.py
@@ -18,6 +18,22 @@ class IssueFetcher:
 
     def __init__(self, config: HydraFlowConfig) -> None:
         self._config = config
+        self._repo_owner = config.repo.split("/", 1)[0] if "/" in config.repo else ""
+
+    @staticmethod
+    def _normalize_issue_payload(item: dict) -> dict:
+        """Map REST/CLI issue shapes to the GitHubIssue-compatible payload."""
+        comments_raw = item.get("comments", [])
+        comments: list = comments_raw if isinstance(comments_raw, list) else []
+        return {
+            "number": item.get("number"),
+            "title": item.get("title", ""),
+            "body": item.get("body", ""),
+            "labels": item.get("labels", []),
+            "comments": comments,
+            "url": item.get("html_url", item.get("url", "")),
+            "createdAt": item.get("createdAt", item.get("created_at", "")),
+        }
 
     async def fetch_issues_by_labels(
         self,
@@ -43,23 +59,30 @@ class IssueFetcher:
         async def _query_label(label: str | None) -> None:
             cmd = [
                 "gh",
-                "issue",
-                "list",
-                "--repo",
-                self._config.repo,
-                "--limit",
-                str(limit),
-                "--json",
-                "number,title,body,labels,comments,url,createdAt",
-                "--search",
-                "sort:created-asc",
+                "api",
+                f"repos/{self._config.repo}/issues",
+                "--field",
+                "state=open",
+                "--field",
+                "sort=created",
+                "--field",
+                "direction=asc",
+                "--field",
+                f"per_page={limit}",
             ]
             if label is not None:
-                cmd += ["--label", label]
+                cmd += ["--field", f"labels={label}"]
             try:
                 raw = await run_subprocess(*cmd, gh_token=self._config.gh_token)
                 for item in json.loads(raw):
-                    seen.setdefault(item["number"], item)
+                    if not isinstance(item, dict):
+                        continue
+                    if "pull_request" in item:
+                        continue
+                    normalized = self._normalize_issue_payload(item)
+                    number = normalized.get("number")
+                    if isinstance(number, int):
+                        seen.setdefault(number, normalized)
             except (RuntimeError, json.JSONDecodeError, FileNotFoundError) as exc:
                 logger.error("gh issue list failed for label=%r: %s", label, exc)
 
@@ -189,21 +212,20 @@ class IssueFetcher:
         pr_infos: list[PRInfo] = []
         for issue in issues:
             branch = f"agent/issue-{issue.number}"
+            head_filter = f"{self._repo_owner}:{branch}" if self._repo_owner else branch
             try:
                 raw = await run_subprocess(
                     "gh",
-                    "pr",
-                    "list",
-                    "--repo",
-                    self._config.repo,
-                    "--head",
-                    branch,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number,url,isDraft",
-                    "--limit",
-                    "1",
+                    "api",
+                    f"repos/{self._config.repo}/pulls",
+                    "--field",
+                    "state=open",
+                    "--field",
+                    f"head={head_filter}",
+                    "--field",
+                    "per_page=1",
+                    "--jq",
+                    "[.[] | {number, url: .html_url, isDraft: .draft}]",
                     gh_token=self._config.gh_token,
                 )
                 prs_json = json.loads(raw)

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -11,6 +11,7 @@ import re
 import tempfile
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import quote
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
@@ -89,6 +90,7 @@ class PRManager:
         self._config = config
         self._bus = event_bus
         self._repo = config.repo
+        self._repo_owner = config.repo.split("/", 1)[0] if "/" in config.repo else ""
         self._max_retries = config.gh_max_retries
         self._label_counts_cache: LabelCounts | None = None
         self._label_counts_ts: float = 0.0
@@ -414,13 +416,12 @@ class PRManager:
             try:
                 await self._run_gh(
                     "gh",
-                    target,
-                    "edit",
-                    str(number),
-                    "--repo",
-                    self._repo,
-                    "--add-label",
-                    label,
+                    "api",
+                    f"repos/{self._repo}/issues/{number}/labels",
+                    "-X",
+                    "POST",
+                    "--raw-field",
+                    f"labels[]={label}",
                 )
             except RuntimeError as exc:
                 logger.warning(
@@ -442,15 +443,13 @@ class PRManager:
         if self._config.dry_run:
             return
         try:
+            encoded_label = quote(label, safe="")
             await self._run_gh(
                 "gh",
-                target,
-                "edit",
-                str(number),
-                "--repo",
-                self._repo,
-                "--remove-label",
-                label,
+                "api",
+                f"repos/{self._repo}/issues/{number}/labels/{encoded_label}",
+                "-X",
+                "DELETE",
             )
         except RuntimeError as exc:
             logger.warning(
@@ -939,18 +938,16 @@ class PRManager:
             try:
                 raw = await self._run_gh(
                     "gh",
-                    "pr",
-                    "list",
-                    "--repo",
-                    self._repo,
-                    "--label",
-                    label,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number,url,headRefName,isDraft,title",
-                    "--limit",
-                    "50",
+                    "api",
+                    f"repos/{self._repo}/issues",
+                    "--field",
+                    "state=open",
+                    "--field",
+                    f"labels={label}",
+                    "--field",
+                    "per_page=50",
+                    "--jq",
+                    "[.[] | select(.pull_request) | {number, url: .html_url, title}]",
                 )
                 for p in json.loads(raw):
                     pr_num = p.get("number")
@@ -962,21 +959,22 @@ class PRManager:
                     if pr_num in seen:
                         continue
                     seen.add(pr_num)
-                    branch = p.get("headRefName", "")
-                    issue_num = 0
-                    if branch.startswith("agent/issue-"):
-                        with contextlib.suppress(ValueError):
-                            issue_num = int(branch.split("-")[-1])
-                    prs.append(
-                        PRListItem(
-                            pr=pr_num,
-                            issue=issue_num,
-                            branch=branch,
-                            url=p.get("url", ""),
-                            draft=p.get("isDraft", False),
-                            title=p.get("title", ""),
+                    try:
+                        branch, draft = await self._get_pr_branch_and_draft(pr_num)
+                        issue_num = self._issue_number_from_branch(branch)
+                        prs.append(
+                            PRListItem(
+                                pr=pr_num,
+                                issue=issue_num,
+                                branch=branch,
+                                url=p.get("url", ""),
+                                draft=draft,
+                                title=p.get("title", ""),
+                            )
                         )
-                    )
+                    except (RuntimeError, json.JSONDecodeError, KeyError, TypeError):
+                        logger.debug("Skipping PR in list_open_prs", exc_info=True)
+                        continue
             except (RuntimeError, json.JSONDecodeError, KeyError, TypeError):
                 logger.debug("Skipping PR in list_open_prs", exc_info=True)
                 continue
@@ -993,18 +991,16 @@ class PRManager:
             try:
                 raw = await self._run_gh(
                     "gh",
-                    "issue",
-                    "list",
-                    "--repo",
-                    self._repo,
-                    "--label",
-                    label,
-                    "--state",
-                    "open",
-                    "--json",
-                    "number,title,url",
-                    "--limit",
-                    "50",
+                    "api",
+                    f"repos/{self._repo}/issues",
+                    "--field",
+                    "state=open",
+                    "--field",
+                    f"labels={label}",
+                    "--field",
+                    "per_page=50",
+                    "--jq",
+                    "[.[] | select(.pull_request | not) | {number, title, url: .html_url}]",
                 )
                 for issue in json.loads(raw):
                     if issue["number"] not in seen_issues:
@@ -1023,20 +1019,19 @@ class PRManager:
         pr_number = 0
         pr_url = ""
         try:
+            head_filter = f"{self._repo_owner}:{branch}" if self._repo_owner else branch
             pr_raw = await self._run_gh(
                 "gh",
-                "pr",
-                "list",
-                "--repo",
-                self._repo,
-                "--head",
-                branch,
-                "--state",
-                "open",
-                "--json",
-                "number,url",
-                "--limit",
-                "1",
+                "api",
+                f"repos/{self._repo}/pulls",
+                "--field",
+                "state=open",
+                "--field",
+                f"head={head_filter}",
+                "--field",
+                "per_page=1",
+                "--jq",
+                "[.[] | {number, url: .html_url}]",
             )
             pr_data = json.loads(pr_raw)
             if pr_data:
@@ -1056,6 +1051,30 @@ class PRManager:
             prUrl=pr_url,
             branch=branch,
         )
+
+    @staticmethod
+    def _issue_number_from_branch(branch: str) -> int:
+        issue_num = 0
+        if branch.startswith("agent/issue-"):
+            with contextlib.suppress(ValueError):
+                issue_num = int(branch.rsplit("-", maxsplit=1)[-1])
+        return issue_num
+
+    async def _get_pr_branch_and_draft(self, pr_number: int) -> tuple[str, bool]:
+        """Resolve branch + draft status for a PR via REST API."""
+        raw = await self._run_gh(
+            "gh",
+            "api",
+            f"repos/{self._repo}/pulls/{pr_number}",
+            "--jq",
+            "{headRefName: .head.ref, isDraft: .draft}",
+        )
+        data = json.loads(raw)
+        if isinstance(data, list):
+            data = data[0] if data else {}
+        if not isinstance(data, dict):
+            return "", False
+        return str(data.get("headRefName", "")), bool(data.get("isDraft", False))
 
     async def list_hitl_items(self, hitl_labels: list[str]) -> list[HITLItem]:
         """Fetch HITL issues and look up their associated PRs.

--- a/tests/test_issue_fetcher.py
+++ b/tests/test_issue_fetcher.py
@@ -231,10 +231,10 @@ class TestFetchReadyIssues:
         mock_exec.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_query_label_includes_created_asc_sort(
+    async def test_query_label_uses_rest_issue_sort_fields(
         self, config: HydraFlowConfig
     ) -> None:
-        """_query_label passes --search sort:created-asc to gh issue list."""
+        """_query_label uses REST sort fields to fetch oldest-first."""
         fetcher = IssueFetcher(config)
         mock_proc = AsyncMock()
         mock_proc.returncode = 0
@@ -246,9 +246,12 @@ class TestFetchReadyIssues:
             await fetcher.fetch_ready_issues(set())
 
         cmd = list(mock_exec.call_args_list[0].args)
-        assert "--search" in cmd
-        search_idx = cmd.index("--search")
-        assert cmd[search_idx + 1] == "sort:created-asc"
+        assert "api" in cmd
+        assert any(
+            token.startswith("repos/") and token.endswith("/issues") for token in cmd
+        )
+        assert "sort=created" in cmd
+        assert "direction=asc" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -294,7 +297,7 @@ class TestFetchReviewablePrs:
         )
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return pr_json
 
@@ -320,7 +323,7 @@ class TestFetchReviewablePrs:
         )
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return pr_json
 
@@ -344,7 +347,7 @@ class TestFetchReviewablePrs:
         fetcher = IssueFetcher(config)
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             raise RuntimeError("Command failed (rc=1): some error")
 
@@ -363,7 +366,7 @@ class TestFetchReviewablePrs:
         fetcher = IssueFetcher(config)
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return "not-valid-json"
 
@@ -392,7 +395,7 @@ class TestFetchReviewablePrs:
         )
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return pr_json
 
@@ -411,7 +414,7 @@ class TestFetchReviewablePrs:
         fetcher = IssueFetcher(config)
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return "[]"
 
@@ -455,7 +458,7 @@ class TestFetchReviewablePrs:
         )
 
         async def fake_run(*args: str, **kwargs: Any) -> str:
-            if "issue" in args:
+            if any("issues" in arg for arg in args):
                 return RAW_ISSUE_JSON
             return pr_json_missing_number
 

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -896,7 +896,7 @@ async def test_merge_pr_dry_run_skips_command(dry_config, event_bus):
 
 
 @pytest.mark.asyncio
-async def test_add_labels_calls_gh_issue_edit_for_each_label(config, event_bus):
+async def test_add_labels_calls_issue_labels_api_for_each_label(config, event_bus):
     manager = _make_manager(config, event_bus)
     mock_create = SubprocessMockBuilder().with_stdout("").build()
 
@@ -907,12 +907,13 @@ async def test_add_labels_calls_gh_issue_edit_for_each_label(config, event_bus):
 
     first_args = mock_create.call_args_list[0][0]
     assert first_args[0] == "gh"
-    assert "issue" in first_args
-    assert "edit" in first_args
-    assert "--add-label" in first_args
+    assert "api" in first_args
+    assert "repos/test-org/test-repo/issues/42/labels" in first_args
+    assert "POST" in first_args
+    assert "labels[]=bug" in first_args
 
     second_args = mock_create.call_args_list[1][0]
-    assert "--add-label" in second_args
+    assert "labels[]=enhancement" in second_args
 
 
 @pytest.mark.asyncio
@@ -943,7 +944,7 @@ async def test_add_labels_empty_list_skips_command(config, event_bus):
 
 
 @pytest.mark.asyncio
-async def test_remove_label_calls_gh_issue_edit(config, event_bus):
+async def test_remove_label_calls_issue_labels_api(config, event_bus):
     manager = _make_manager(config, event_bus)
     mock_create = SubprocessMockBuilder().with_stdout("").build()
 
@@ -953,11 +954,9 @@ async def test_remove_label_calls_gh_issue_edit(config, event_bus):
     assert mock_create.call_count == 1
     args = mock_create.call_args[0]
     assert args[0] == "gh"
-    assert "issue" in args
-    assert "edit" in args
-    assert "42" in args
-    assert "--remove-label" in args
-    assert "ready" in args
+    assert "api" in args
+    assert "repos/test-org/test-repo/issues/42/labels/ready" in args
+    assert "DELETE" in args
 
 
 @pytest.mark.asyncio
@@ -977,7 +976,7 @@ async def test_remove_label_dry_run_skips_command(dry_config, event_bus):
 
 
 @pytest.mark.asyncio
-async def test_add_pr_labels_calls_gh_pr_edit_for_each_label(config, event_bus):
+async def test_add_pr_labels_calls_issue_labels_api_for_each_label(config, event_bus):
     manager = _make_manager(config, event_bus)
     mock_create = SubprocessMockBuilder().with_stdout("").build()
 
@@ -988,12 +987,13 @@ async def test_add_pr_labels_calls_gh_pr_edit_for_each_label(config, event_bus):
 
     first_args = mock_create.call_args_list[0][0]
     assert first_args[0] == "gh"
-    assert "pr" in first_args
-    assert "edit" in first_args
-    assert "--add-label" in first_args
+    assert "api" in first_args
+    assert "repos/test-org/test-repo/issues/101/labels" in first_args
+    assert "POST" in first_args
+    assert "labels[]=bug" in first_args
 
     second_args = mock_create.call_args_list[1][0]
-    assert "--add-label" in second_args
+    assert "labels[]=enhancement" in second_args
 
 
 @pytest.mark.asyncio
@@ -1036,7 +1036,7 @@ async def test_add_pr_labels_subprocess_error_does_not_raise(config, event_bus):
 
 
 @pytest.mark.asyncio
-async def test_remove_pr_label_calls_gh_pr_edit(config, event_bus):
+async def test_remove_pr_label_calls_issue_labels_api(config, event_bus):
     manager = _make_manager(config, event_bus)
     mock_create = SubprocessMockBuilder().with_stdout("").build()
 
@@ -1044,10 +1044,9 @@ async def test_remove_pr_label_calls_gh_pr_edit(config, event_bus):
         await manager.remove_pr_label(101, "hydraflow-review")
 
     args = mock_create.call_args[0]
-    assert "pr" in args
-    assert "edit" in args
-    assert "--remove-label" in args
-    assert "hydraflow-review" in args
+    assert "api" in args
+    assert "repos/test-org/test-repo/issues/101/labels/hydraflow-review" in args
+    assert "DELETE" in args
 
 
 @pytest.mark.asyncio
@@ -2591,9 +2590,10 @@ class TestAddLabelsHelper:
             await mgr._add_labels("issue", 42, ["bug"])
 
         cmd = mock_create.call_args[0]
-        assert "issue" in cmd
-        assert "edit" in cmd
-        assert "--add-label" in cmd
+        assert "api" in cmd
+        assert "repos/test-org/test-repo/issues/42/labels" in cmd
+        assert "POST" in cmd
+        assert "labels[]=bug" in cmd
 
     @pytest.mark.asyncio
     async def test_add_labels_pr_target(self, config, event_bus):
@@ -2604,9 +2604,10 @@ class TestAddLabelsHelper:
             await mgr._add_labels("pr", 101, ["enhancement"])
 
         cmd = mock_create.call_args[0]
-        assert "pr" in cmd
-        assert "edit" in cmd
-        assert "--add-label" in cmd
+        assert "api" in cmd
+        assert "repos/test-org/test-repo/issues/101/labels" in cmd
+        assert "POST" in cmd
+        assert "labels[]=enhancement" in cmd
 
     @pytest.mark.asyncio
     async def test_add_labels_dry_run(self, dry_config, event_bus):
@@ -2661,10 +2662,9 @@ class TestRemoveLabelHelper:
             await mgr._remove_label("issue", 42, "ready")
 
         cmd = mock_create.call_args[0]
-        assert "issue" in cmd
-        assert "edit" in cmd
-        assert "--remove-label" in cmd
-        assert "ready" in cmd
+        assert "api" in cmd
+        assert "repos/test-org/test-repo/issues/42/labels/ready" in cmd
+        assert "DELETE" in cmd
 
     @pytest.mark.asyncio
     async def test_remove_label_pr_target(self, config, event_bus):
@@ -2675,10 +2675,9 @@ class TestRemoveLabelHelper:
             await mgr._remove_label("pr", 101, "hydraflow-review")
 
         cmd = mock_create.call_args[0]
-        assert "pr" in cmd
-        assert "edit" in cmd
-        assert "--remove-label" in cmd
-        assert "hydraflow-review" in cmd
+        assert "api" in cmd
+        assert "repos/test-org/test-repo/issues/101/labels/hydraflow-review" in cmd
+        assert "DELETE" in cmd
 
     @pytest.mark.asyncio
     async def test_remove_label_dry_run(self, dry_config, event_bus):


### PR DESCRIPTION
## Summary
- switch hot polling/listing paths from GraphQL-backed `gh ... list --json` calls to REST `gh api` endpoints
- replace branch PR lookups with `GET /repos/{repo}/pulls?head=owner:branch`
- replace repeated issue/PR label mutations with REST issue-label endpoints
- keep behavior-compatible payload normalization and update tests

## Why
During sustained runs, GraphQL quota can hit zero while core quota remains available. These hot loops were causing repeated retries and log storms.

## Validation
- `pytest -q tests/test_issue_fetcher.py tests/test_pr_manager.py`
- pre-commit hooks (lint-check auto-fix) passed on commit
- pre-push `make quality-lite` passed
