### PR TITLE
Fix memory sync issue processing and label-removal noise

### DIFF
--- a/src/memory.py
+++ b/src/memory.py
@@ -26,6 +26,7 @@ from state import StateTracker
 from subprocess_util import make_clean_env
 
 if TYPE_CHECKING:
+    from ports import PRPort
     from pr_manager import PRManager
 
 logger = logging.getLogger("hydraflow.memory")
@@ -187,6 +188,7 @@ class MemorySyncWorker:
         state: StateTracker,
         event_bus: EventBus,
         runner: SubprocessRunner | None = None,
+        prs: PRPort | None = None,
         *,
         manifest_store: CuratedManifestStore | None = None,
         manifest_manager: ProjectManifestManager | None = None,
@@ -196,6 +198,7 @@ class MemorySyncWorker:
         self._state = state
         self._bus = event_bus
         self._runner = runner or get_default_runner()
+        self._prs = prs
         self._manifest_store = manifest_store or CuratedManifestStore(config)
         self._manifest_manager = manifest_manager or ProjectManifestManager(
             config, curator=self._manifest_store
@@ -288,6 +291,7 @@ class MemorySyncWorker:
         self._state.update_memory_state(current_ids, digest_hash)
         self._manifest_store.update_from_learnings(learnings)
         await self._refresh_manifest("memory-sync")
+        await self._close_synced_issues(issues)
 
         return {
             "action": "synced",
@@ -295,6 +299,43 @@ class MemorySyncWorker:
             "compacted": compacted,
             "digest_chars": len(digest),
         }
+
+    def _should_auto_close_issue(self, issue: MemoryIssueData) -> bool:
+        """Return True only for canonical memory suggestion issues."""
+        title = str(issue.get("title", "")).strip()
+        labels = issue.get("labels", [])
+        if not isinstance(labels, list):
+            return False
+        has_memory_label = any(lbl in self._config.memory_label for lbl in labels)
+        return title.startswith("[Memory]") and has_memory_label
+
+    async def _close_synced_issues(self, issues: list[MemoryIssueData]) -> None:
+        """Close synced memory issues when a PR port is available."""
+        if self._prs is None:
+            return
+        closed = 0
+        failed = 0
+        for issue in issues:
+            if not self._should_auto_close_issue(issue):
+                continue
+            issue_number = int(issue.get("number", 0))
+            if issue_number <= 0:
+                continue
+            try:
+                await self._prs.close_issue(issue_number)
+                closed += 1
+            except Exception as exc:  # noqa: BLE001
+                failed += 1
+                logger.warning(
+                    "Could not close synced memory issue #%d: %s",
+                    issue_number,
+                    exc,
+                )
+        logger.info(
+            "Memory sync auto-close summary: closed=%d failed=%d",
+            closed,
+            failed,
+        )
 
     async def _refresh_manifest(self, source: str) -> None:
         """Regenerate the manifest and optionally sync it upstream."""

--- a/src/memory_sync_loop.py
+++ b/src/memory_sync_loop.py
@@ -58,6 +58,7 @@ class MemorySyncLoop(BaseBackgroundLoop):
                 title=i.title,
                 body=i.body,
                 createdAt=i.created_at,
+                labels=list(i.labels),
             )
             for i in issues
         ]

--- a/src/models.py
+++ b/src/models.py
@@ -960,6 +960,7 @@ class MemoryIssueData(TypedDict):
     title: str
     body: str
     createdAt: str
+    labels: NotRequired[list[str]]
 
 
 class MemorySyncResult(TypedDict):

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -32,6 +32,12 @@ logger = logging.getLogger("hydraflow.pr_manager")
 _LABEL_CACHE_TTL: int = 30
 
 
+def _is_missing_label_404(exc: RuntimeError) -> bool:
+    """Return True when gh reports a missing label during label removal."""
+    msg = str(exc).lower()
+    return "label does not exist" in msg and "http 404" in msg
+
+
 class SelfReviewError(RuntimeError):
     """Raised when a formal review fails due to the 'own pull request' restriction."""
 
@@ -452,6 +458,14 @@ class PRManager:
                 "DELETE",
             )
         except RuntimeError as exc:
+            if _is_missing_label_404(exc):
+                logger.debug(
+                    "Label %r not present on %s #%d; skipping remove",
+                    label,
+                    target,
+                    number,
+                )
+                return
             logger.warning(
                 "Could not remove label %r from %s #%d: %s",
                 label,

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -201,6 +201,7 @@ def build_services(
         state,
         event_bus,
         runner=subprocess_runner,
+        prs=prs,
         manifest_syncer=manifest_syncer,
     )
     retrospective = RetrospectiveCollector(config, state, prs)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -725,6 +725,99 @@ class TestMemorySyncWorkerSync:
         assert isinstance(call_args[1], str)  # digest hash
 
     @pytest.mark.asyncio
+    async def test_sync_auto_closes_processed_memory_issues(
+        self, tmp_path: Path
+    ) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+        prs = MagicMock()
+        prs.close_issue = AsyncMock()
+
+        worker = MemorySyncWorker(config, state, bus, prs=prs)
+        issues = [
+            {
+                "number": 5,
+                "title": "[Memory] T",
+                "body": "**Learning:** Something",
+                "createdAt": "",
+                "labels": ["hydraflow-memory"],
+            },
+            {
+                "number": 6,
+                "title": "[Memory] U",
+                "body": "**Learning:** Else",
+                "createdAt": "",
+                "labels": ["hydraflow-memory"],
+            },
+        ]
+        await worker.sync(issues)
+
+        assert prs.close_issue.await_count == 2
+        prs.close_issue.assert_any_await(5)
+        prs.close_issue.assert_any_await(6)
+
+    @pytest.mark.asyncio
+    async def test_sync_close_issue_failure_does_not_fail_sync(
+        self, tmp_path: Path
+    ) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+        prs = MagicMock()
+        prs.close_issue = AsyncMock(side_effect=RuntimeError("close failed"))
+
+        worker = MemorySyncWorker(config, state, bus, prs=prs)
+        issues = [
+            {
+                "number": 5,
+                "title": "[Memory] T",
+                "body": "**Learning:** Something",
+                "createdAt": "",
+                "labels": ["hydraflow-memory"],
+            },
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["item_count"] == 1
+        prs.close_issue.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_sync_does_not_close_non_memory_style_issues(
+        self, tmp_path: Path
+    ) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+        prs = MagicMock()
+        prs.close_issue = AsyncMock()
+
+        worker = MemorySyncWorker(config, state, bus, prs=prs)
+        issues = [
+            {
+                "number": 5,
+                "title": "Feature issue that mentions memory",
+                "body": "**Learning:** Something",
+                "createdAt": "",
+                "labels": ["hydraflow-memory"],
+            },
+            {
+                "number": 6,
+                "title": "[Memory] Missing memory label",
+                "body": "**Learning:** Else",
+                "createdAt": "",
+                "labels": ["hydraflow-plan"],
+            },
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["item_count"] == 2
+        prs.close_issue.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sync_refreshes_manifest_and_syncer(self, tmp_path: Path) -> None:
         config = ConfigFactory.create(repo_root=tmp_path)
         state = MagicMock()

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -2732,6 +2732,28 @@ class TestRemoveLabelHelper:
             # Should not raise even on subprocess failure
             await mgr._remove_label("issue", 42, "missing-label")
 
+    @pytest.mark.asyncio
+    async def test_remove_label_missing_label_404_is_noop(
+        self, config, event_bus, caplog
+    ):
+        """Missing-label 404 should be treated as expected no-op (not warning)."""
+        mgr = _make_manager(config, event_bus)
+        mock_create = (
+            SubprocessMockBuilder()
+            .with_returncode(1)
+            .with_stderr("gh: Label does not exist (HTTP 404)")
+            .build()
+        )
+
+        with (
+            patch("asyncio.create_subprocess_exec", mock_create),
+            caplog.at_level(logging.DEBUG, logger="hydraflow.pr_manager"),
+        ):
+            await mgr._remove_label("issue", 42, "missing-label")
+
+        assert "Could not remove label" not in caplog.text
+        assert "skipping remove" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Decomposed get_label_counts helpers


### PR DESCRIPTION
## Summary
- treat missing-label remove failures (`Label does not exist (HTTP 404)`) as expected no-op to avoid warning spam
- wire memory sync to auto-close only canonical memory suggestion issues after successful sync
- add strict close guard so only issues with both `[Memory]` title prefix and `hydraflow-memory` label are auto-closed
- pass labels through memory sync payload for guard checks

## Why
- memory sync was processing issues but leaving them open
- workflow noise from expected missing-label deletes obscured real warnings
- guard ensures related feature issues are never auto-closed by memory sync

## Validation
- `PYTHONPATH=src uv run --active pytest tests/test_pr_manager.py -k "TestRemoveLabelHelper" -q`
- `PYTHONPATH=src uv run --active pytest tests/test_memory.py -k "TestMemorySyncWorkerSync and (auto_closes or close_issue_failure or does_not_close_non_memory_style_issues or updates_state or no_issues_returns_zero_count)" -q`
- `PYTHONPATH=src uv run --active pytest tests/test_memory_sync_loop.py -q`
- pre-push `make quality-lite` hook passed
