### PR TITLE
Fix missing-PR branch recovery and requeue stale ready issues

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -333,6 +333,33 @@ class ImplementPhase:
                     gh_issue = GitHubIssue.from_task(issue)
                     pr = await self._prs.create_pr(gh_issue, result.branch, draft=draft)
                     result.pr_info = pr
+                else:
+                    pr = await self._prs.find_open_pr_for_branch(
+                        result.branch, issue_number=issue.id
+                    )
+                    result.pr_info = pr
+
+                if result.success and (pr is None or pr.number <= 0):
+                    has_diff = await self._prs.branch_has_diff_from_main(result.branch)
+                    if not has_diff:
+                        await self._close_as_already_satisfied(issue)
+                        self._state.mark_issue(issue.id, "already_satisfied")
+                        return result
+                    logger.warning(
+                        "Implementation succeeded for issue #%d but no open PR exists for branch %s",
+                        issue.id,
+                        result.branch,
+                    )
+                    await self._transitioner.post_comment(
+                        issue.id,
+                        "PR creation/recovery failed after successful implementation. "
+                        "Keeping issue in ready queue for retry.",
+                    )
+                    self._state.mark_issue(issue.id, "failed")
+                    result.success = False
+                    if not result.error:
+                        result.error = "PR creation failed"
+                    return result
 
                 if result.success:
                     await self._transitioner.transition(

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -272,12 +272,87 @@ class PRManager:
 
         except (RuntimeError, ValueError) as exc:
             logger.error("PR creation failed for issue #%d: %s", issue.number, exc)
+            existing = await self.find_open_pr_for_branch(
+                branch, issue_number=issue.number
+            )
+            if existing is not None:
+                logger.info(
+                    "Using existing PR #%d for issue #%d on branch %s after create failure",
+                    existing.number,
+                    issue.number,
+                    branch,
+                )
+                return existing
             return PRInfo(
                 number=0,
                 issue_number=issue.number,
                 branch=branch,
                 draft=draft,
             )
+
+    async def find_open_pr_for_branch(
+        self, branch: str, *, issue_number: int = 0
+    ) -> PRInfo | None:
+        """Return the open PR for *branch*, or ``None`` when absent/unreadable."""
+        if self._config.dry_run:
+            return None
+        head_filter = f"{self._repo_owner}:{branch}" if self._repo_owner else branch
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "api",
+                f"repos/{self._repo}/pulls",
+                "--method",
+                "GET",
+                "--field",
+                "state=open",
+                "--field",
+                f"head={head_filter}",
+                "--field",
+                "per_page=1",
+                "--jq",
+                "[.[] | {number, url: .html_url, isDraft: .draft}]",
+            )
+            prs = json.loads(raw)
+            if not prs:
+                return None
+            pr_data = prs[0]
+            return PRInfo(
+                number=int(pr_data["number"]),
+                issue_number=issue_number,
+                branch=branch,
+                url=str(pr_data.get("url", "")),
+                draft=bool(pr_data.get("isDraft", False)),
+            )
+        except (RuntimeError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+            logger.debug(
+                "Could not resolve open PR for branch %s", branch, exc_info=True
+            )
+            return None
+
+    async def branch_has_diff_from_main(self, branch: str) -> bool:
+        """Return whether *branch* has commits ahead of configured main branch."""
+        if self._config.dry_run:
+            return True
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "api",
+                f"repos/{self._repo}/compare/{self._config.main_branch}...{branch}",
+                "--jq",
+                "{ahead_by}",
+            )
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                ahead_by = int(data.get("ahead_by", 0) or 0)
+                return ahead_by > 0
+        except (RuntimeError, ValueError, TypeError, json.JSONDecodeError):
+            logger.warning(
+                "Could not determine branch diff for %s; assuming diff exists",
+                branch,
+                exc_info=True,
+            )
+        return True
 
     async def merge_pr(self, pr_number: int) -> bool:
         """Merge PR immediately via squash merge with branch deletion.

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -92,6 +92,8 @@ def _make_phase(
         if create_pr_return is not None
         else PRInfoFactory.create()
     )
+    mock_prs.find_open_pr_for_branch = AsyncMock(return_value=PRInfoFactory.create())
+    mock_prs.branch_has_diff_from_main = AsyncMock(return_value=True)
     mock_prs.add_labels = AsyncMock()
     mock_prs.remove_label = AsyncMock()
     mock_prs.swap_pipeline_labels = AsyncMock()
@@ -849,8 +851,9 @@ class TestReviewFeedbackPassing:
         mock_prs.create_pr.assert_not_awaited()
         # But result should still be successful
         assert results[0].success is True
-        # pr_info should be None since PR creation was skipped
-        assert results[0].pr_info is None
+        # Existing PR should be recovered from branch lookup
+        assert results[0].pr_info is not None
+        assert results[0].pr_info.number == 101
 
     @pytest.mark.asyncio
     async def test_creates_pr_on_first_run(self, config: HydraFlowConfig) -> None:
@@ -1563,7 +1566,62 @@ class TestHandleImplementationResult:
         returned = await phase._handle_implementation_result(issue, result, True)
 
         mock_prs.create_pr.assert_not_awaited()
-        assert returned.pr_info is None
+        assert returned.pr_info is not None
+        assert returned.pr_info.number == 101
+        mock_prs.transition.assert_awaited_once_with(42, "review", pr_number=101)
+
+    @pytest.mark.asyncio
+    async def test_success_without_pr_and_no_branch_diff_closes_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """No PR + no branch diff should close issue as already satisfied."""
+        issue = TaskFactory.create()
+        result = WorkerResultFactory.create(
+            issue_number=42,
+            success=True,
+            worktree_path=str(config.worktree_base / "issue-42"),
+        )
+
+        phase, _, mock_prs = _make_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create(number=0)
+        )
+        mock_prs.find_open_pr_for_branch.return_value = None
+        mock_prs.branch_has_diff_from_main.return_value = False
+
+        returned = await phase._handle_implementation_result(issue, result, False)
+
+        assert returned.success is True
+        assert (
+            phase._state.to_dict()["processed_issues"].get(str(42))
+            == "already_satisfied"
+        )
+        mock_prs.transition.assert_not_awaited()
+        mock_prs.close_task.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_success_without_pr_and_with_diff_stays_ready_as_failed(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """No PR + branch diff should avoid review transition and mark failed."""
+        issue = TaskFactory.create()
+        result = WorkerResultFactory.create(
+            issue_number=42,
+            success=True,
+            worktree_path=str(config.worktree_base / "issue-42"),
+        )
+
+        phase, _, mock_prs = _make_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create(number=0)
+        )
+        mock_prs.find_open_pr_for_branch.return_value = None
+        mock_prs.branch_has_diff_from_main.return_value = True
+
+        returned = await phase._handle_implementation_result(issue, result, False)
+
+        assert returned.success is False
+        assert returned.error == "PR creation failed"
+        assert phase._state.to_dict()["processed_issues"].get(str(42)) == "failed"
+        mock_prs.transition.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_failure_marks_issue_failed(self, config: HydraFlowConfig) -> None:

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -17,7 +17,7 @@ import pytest
 from events import EventType
 from models import ReviewVerdict
 from pr_manager import PRManager
-from tests.conftest import SubprocessMockBuilder
+from tests.conftest import PRInfoFactory, SubprocessMockBuilder
 from tests.helpers import ConfigFactory
 
 # ---------------------------------------------------------------------------
@@ -796,6 +796,52 @@ async def test_create_pr_failure_returns_pr_info_with_number_zero(
     assert pr_info.number == 0
     assert pr_info.issue_number == issue.number
     assert pr_info.branch == "agent/issue-42"
+
+
+@pytest.mark.asyncio
+async def test_create_pr_failure_recovers_existing_open_pr(config, event_bus, issue):
+    manager = _make_manager(config, event_bus)
+    manager.find_open_pr_for_branch = AsyncMock(
+        return_value=PRInfoFactory.create(
+            number=222,
+            issue_number=issue.number,
+            branch="agent/issue-42",
+            url="https://github.com/test-org/test-repo/pull/222",
+        )
+    )
+    mock_create = (
+        SubprocessMockBuilder().with_returncode(1).with_stderr("gh: error").build()
+    )
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        pr_info = await manager.create_pr(issue, "agent/issue-42")
+
+    assert pr_info.number == 222
+    manager.find_open_pr_for_branch.assert_awaited_once_with(
+        "agent/issue-42", issue_number=issue.number
+    )
+
+
+@pytest.mark.asyncio
+async def test_branch_has_diff_from_main_false_when_not_ahead(config, event_bus):
+    manager = _make_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout('{"ahead_by":0}').build()
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        has_diff = await manager.branch_has_diff_from_main("agent/issue-42")
+
+    assert has_diff is False
+
+
+@pytest.mark.asyncio
+async def test_branch_has_diff_from_main_true_when_ahead(config, event_bus):
+    manager = _make_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout('{"ahead_by":3}').build()
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        has_diff = await manager.branch_has_diff_from_main("agent/issue-42")
+
+    assert has_diff is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- recover existing open PR by branch when PR creation command fails
- add branch diff check (`main...agent/issue-N`) to detect no-diff branches
- in implement phase, avoid sending successful issues to review without a PR
- auto-close as already satisfied when branch has no diff and no PR can be created

## Why
Open `hydraflow-ready` issues could get stuck when an `agent/issue-N` branch existed but had zero diff from `main` and no PR, leading to repeated attempts and no review intake.

## Validation
- `uv run pytest tests/test_implement_phase.py tests/test_pr_manager.py -q`

## Live repair performed
- deleted stale zero-diff remote branches and local worktrees for `#861`, `#987`, `#1285`
- normalized those issues to `hydraflow-ready` so implement can re-run cleanly
