### PR TITLE
Fix queue handoff lag by enqueueing stage transitions in-memory

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -213,6 +213,7 @@ class ImplementPhase:
             origin_label=self._config.ready_label[0],
             hitl_label=self._config.hitl_label[0],
         )
+        self._store.enqueue_transition(issue, "hitl")
         record_harness_failure(
             self._harness_insights,
             issue.id,
@@ -367,6 +368,7 @@ class ImplementPhase:
                         "review",
                         pr_number=pr.number if pr and pr.number > 0 else None,
                     )
+                    self._store.enqueue_transition(issue, "review")
 
         status = "success" if result.success else "failed"
         self._state.mark_issue(issue.id, status)

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -249,6 +249,35 @@ class IssueStore:
         for stage in self._queues:
             self._remove_from_queue(stage, issue_number)
 
+    def enqueue_transition(self, task: Task, next_stage: str) -> None:
+        """Immediately route *task* into *next_stage* in-memory.
+
+        This provides an eager handoff between phases so downstream workers
+        can pick up transitioned issues without waiting for the next GitHub
+        polling cycle.
+        """
+        stage_alias: dict[str, IssueStoreStage] = {
+            "find": STAGE_FIND,
+            "plan": STAGE_PLAN,
+            "ready": STAGE_READY,
+            "review": STAGE_REVIEW,
+            "hitl": STAGE_HITL,
+        }
+        stage = stage_alias.get(next_stage)
+        if stage is None:
+            return
+
+        self._issue_cache[task.id] = task
+        self._remove_from_all_queues(task.id)
+        self._hitl_numbers.discard(task.id)
+
+        if stage == STAGE_HITL:
+            self._hitl_numbers.add(task.id)
+            return
+
+        self._queues[stage].append(task)
+        self._queue_members[stage].add(task.id)
+
     # ------------------------------------------------------------------
     # Queue accessors (non-blocking, return available issues)
     # ------------------------------------------------------------------

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -102,6 +102,7 @@ class PlanPhase:
         analysis = analyzer.analyze(result.plan, issue.id)
         await self._transitioner.post_comment(issue.id, analysis.format_comment())
         await self._transitioner.transition(issue.id, "ready")
+        self._store.enqueue_transition(issue, "ready")
 
         for new_issue in result.new_issues:
             if len(new_issue.body) < _MIN_ISSUE_BODY_CHARS:
@@ -141,6 +142,7 @@ class PlanPhase:
             origin_label=self._config.planner_label[0],
             hitl_label=self._config.hitl_label[0],
         )
+        self._store.enqueue_transition(issue, "hitl")
         record_harness_failure(
             self._harness_insights,
             issue.id,

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -79,6 +79,7 @@ class TriagePhase:
                         )
                     else:
                         await self._transitioner.transition(issue.id, "review")
+                        self._store.enqueue_transition(issue, "review")
                         logger.info(
                             "Issue #%d ADR triage → %s (validated ADR shape)",
                             issue.id,
@@ -93,6 +94,7 @@ class TriagePhase:
 
                 if result.ready:
                     await self._transitioner.transition(issue.id, "plan")
+                    self._store.enqueue_transition(issue, "plan")
                     logger.info(
                         "Issue #%d triaged → %s (ready for planning)",
                         issue.id,
@@ -100,6 +102,7 @@ class TriagePhase:
                     )
                 else:
                     await self._escalate_triage_issue(issue.id, result.reasons)
+                    self._store.enqueue_transition(issue, "hitl")
                     await self._bus.publish(
                         HydraFlowEvent(
                             type=EventType.HITL_UPDATE,

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -165,6 +165,29 @@ class TestRouting:
 
         assert 50 in store._hitl_numbers
 
+    def test_enqueue_transition_moves_issue_to_next_stage_immediately(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=60, tags=["hydraflow-find"])
+        store._route_issues([issue])
+        assert 60 in store._queue_members[STAGE_FIND]
+
+        store.enqueue_transition(issue, "plan")
+
+        assert 60 not in store._queue_members[STAGE_FIND]
+        assert 60 in store._queue_members[STAGE_PLAN]
+        assert 60 not in store._hitl_numbers
+
+    def test_enqueue_transition_routes_to_hitl_set(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=61, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        assert 61 in store._queue_members[STAGE_PLAN]
+
+        store.enqueue_transition(issue, "hitl")
+
+        assert 61 not in store._queue_members[STAGE_PLAN]
+        assert 61 in store._hitl_numbers
+
 
 # ── Queue Accessors ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add `IssueStore.enqueue_transition(task, next_stage)` for eager in-memory stage routing
- call eager handoff on successful transitions:
  - triage -> plan/review/hitl
  - plan -> ready/hitl
  - implement -> review/hitl (attempt cap path)
- add IssueStore tests for immediate move and hitl routing

## Why
Addresses issue #1306 where stage handoffs could appear incomplete until the next fetch poll cycle.

## Validation
- `uv run pytest tests/test_issue_store.py tests/test_triage_phase.py tests/test_plan_phase.py tests/test_implement_phase.py -q`
