### PR TITLE
Fix UI: persist Harness Insights cache across server restarts

### DIFF
--- a/src/ui/src/components/HarnessInsightsPanel.jsx
+++ b/src/ui/src/components/HarnessInsightsPanel.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { theme } from '../theme'
+import { useHydraFlow } from '../context/HydraFlowContext'
 
 const CATEGORY_LABELS = {
   plan_validation: 'Plan Validation',
@@ -75,21 +76,48 @@ function SuggestionCard({ suggestion }) {
 }
 
 export function HarnessInsightsPanel() {
+  const { config } = useHydraFlow()
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(true)
+  const [usingCachedData, setUsingCachedData] = useState(false)
+  const cacheKey = `hydraflow:harness-insights:${config?.repo || 'default'}`
 
   useEffect(() => {
     let cancelled = false
+    let hasCachedData = false
+
+    try {
+      const raw = localStorage.getItem(cacheKey)
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (parsed && typeof parsed === 'object') {
+          hasCachedData = true
+          setData(parsed)
+          setUsingCachedData(true)
+          setLoading(false)
+        }
+      }
+    } catch {
+      // Ignore malformed cache; fetch fresh from API
+    }
+
     async function fetchData() {
       try {
         const resp = await fetch('/api/harness-insights')
         if (resp.ok && !cancelled) {
-          setData(await resp.json())
+          const payload = await resp.json()
+          setData(payload)
+          setUsingCachedData(false)
+          try {
+            localStorage.setItem(cacheKey, JSON.stringify(payload))
+          } catch {
+            // Ignore storage write errors
+          }
         }
       } catch {
         // Silently fail — panel just shows empty state
       } finally {
-        if (!cancelled) setLoading(false)
+        if (!cancelled && !hasCachedData) setLoading(false)
       }
     }
     fetchData()
@@ -98,7 +126,7 @@ export function HarnessInsightsPanel() {
       cancelled = true
       clearInterval(interval)
     }
-  }, [])
+  }, [cacheKey])
 
   if (loading) {
     return <div style={styles.empty}>Loading harness insights...</div>
@@ -117,6 +145,9 @@ export function HarnessInsightsPanel() {
       <div style={styles.header}>
         <span style={styles.totalBadge}>{data.total_failures}</span>
         <span style={styles.headerText}>failures tracked</span>
+        {usingCachedData && (
+          <span style={styles.cachedHint}>cached</span>
+        )}
       </div>
 
       <div style={styles.section}>
@@ -199,6 +230,15 @@ const styles = {
   headerText: {
     fontSize: 13,
     color: theme.textMuted,
+  },
+  cachedHint: {
+    fontSize: 11,
+    color: theme.yellow,
+    border: `1px solid ${theme.yellow}`,
+    borderRadius: 6,
+    padding: '1px 6px',
+    textTransform: 'uppercase',
+    letterSpacing: '0.4px',
   },
   section: {
     display: 'flex',

--- a/src/ui/src/components/__tests__/HarnessInsightsPanel.test.jsx
+++ b/src/ui/src/components/__tests__/HarnessInsightsPanel.test.jsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { HarnessInsightsPanel } = await import('../HarnessInsightsPanel')
+
+function insightsPayload(overrides = {}) {
+  return {
+    total_failures: 3,
+    category_counts: {
+      quality_gate: 2,
+      review_rejection: 1,
+    },
+    subcategory_counts: {},
+    suggestions: [],
+    proposed_patterns: [],
+    ...overrides,
+  }
+}
+
+describe('HarnessInsightsPanel cache', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mockUseHydraFlow.mockReturnValue({
+      config: { repo: 'T-rav/hyrda' },
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('loads cached data when API fetch fails', async () => {
+    localStorage.setItem(
+      'hydraflow:harness-insights:T-rav/hyrda',
+      JSON.stringify(insightsPayload({ total_failures: 7 })),
+    )
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+
+    render(<HarnessInsightsPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failure Categories')).toBeInTheDocument()
+      expect(screen.getByText('cached')).toBeInTheDocument()
+      expect(screen.getByText('7')).toBeInTheDocument()
+    })
+  })
+
+  it('writes fresh API payload to localStorage', async () => {
+    const payload = insightsPayload({ total_failures: 5 })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => payload,
+      }),
+    )
+
+    render(<HarnessInsightsPanel />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Failure Categories')).toBeInTheDocument()
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+
+    const raw = localStorage.getItem('hydraflow:harness-insights:T-rav/hyrda')
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw).total_failures).toBe(5)
+  })
+})


### PR DESCRIPTION
## Summary
- Cache Harness Insights payload in browser `localStorage` (repo-keyed).
- Load cached payload on mount so Insights survive temporary backend/server downtime.
- Continue background refresh from `/api/harness-insights` and update cache on successful fetch.
- Show a small `cached` badge when displaying fallback cached data.

## Tests
- Added `HarnessInsightsPanel` tests for:
  - cached fallback when API fetch fails
  - cache write on successful API fetch

## Validation
- `make lint-check`
- `cd src/ui && npm test -- HarnessInsightsPanel.test.jsx`
