### PR TITLE
fix: prevent IssueStore queue race conditions with in-flight protection

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -15,6 +15,7 @@ from phase_utils import (
     escalate_to_hitl,
     is_adr_issue_title,
     record_harness_failure,
+    release_batch_in_flight,
     run_concurrent_batch,
     store_lifecycle,
 )
@@ -143,7 +144,10 @@ class ImplementPhase:
                                 list(self._active_issues)
                             )
 
-        all_results = await run_concurrent_batch(issues, _worker, self._stop_event)
+        try:
+            all_results = await run_concurrent_batch(issues, _worker, self._stop_event)
+        finally:
+            release_batch_in_flight(self._store, {i.id for i in issues})
         return all_results, issues
 
     async def _worker_inner(self, idx: int, issue: Task, branch: str) -> WorkerResult:

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -87,6 +87,17 @@ class IssueStore:
         # Active issue tracking: issue_number → stage
         self._active: dict[int, str] = {}
 
+        # In-flight protection: items between _take_from_queue and mark_active.
+        # Prevents refresh() from re-queuing or evicting items that a phase
+        # has dequeued but hasn't yet marked active (semaphore wait gap).
+        self._in_flight: set[int] = set()
+
+        # Eager transition protection: items placed by enqueue_transition
+        # before GitHub labels have caught up.  Keyed by target stage so
+        # _route_incoming_tasks can detect when labels match or exceed the
+        # target and clear protection automatically.
+        self._eagerly_transitioned: dict[int, IssueStoreStage] = {}
+
         # Session throughput counters
         self._processed_count: dict[str, int] = {
             STAGE_FIND: 0,
@@ -197,22 +208,48 @@ class IssueStore:
         return unique
 
     def _evict_stale_tasks(self, incoming_ids: set[int]) -> None:
-        """Remove tasks no longer present in the pipeline from all queues."""
+        """Remove tasks no longer present in the pipeline from all queues.
+
+        Items that are in-flight (taken from queue, not yet marked active)
+        or eagerly transitioned (label swap pending) are protected from
+        eviction.
+        """
+        protected = (
+            set(self._active.keys()) | self._in_flight | set(self._eagerly_transitioned)
+        )
         for stage, q in self._queues.items():
             members = self._queue_members[stage]
-            stale = members - incoming_ids - set(self._active.keys())
+            stale = members - incoming_ids - protected
             if stale:
                 self._queues[stage] = deque(t for t in q if t.id not in stale)
                 members -= stale
-        self._hitl_numbers &= incoming_ids | set(self._active.keys())
+        self._hitl_numbers &= incoming_ids | protected
 
     def _route_incoming_tasks(
         self, stage_map: dict[int, tuple[IssueStoreStage, Task]]
     ) -> None:
-        """Move each task to its target queue if it isn't already there."""
+        """Move each task to its target queue if it isn't already there.
+
+        Items that are in-flight or eagerly transitioned are protected:
+        - In-flight items are never re-routed.
+        - Eagerly-transitioned items have their protection cleared once
+          incoming labels match or exceed the target stage (labels caught up).
+          Until then, stale labels are ignored to prevent backward movement.
+        """
         for task_id, (stage, task) in stage_map.items():
-            if task_id in self._active:
+            if task_id in self._active or task_id in self._in_flight:
                 continue
+
+            # Handle eagerly-transitioned items
+            eager_stage = self._eagerly_transitioned.get(task_id)
+            if eager_stage is not None:
+                if _STAGE_PRIORITY.get(stage, -1) >= _STAGE_PRIORITY.get(
+                    eager_stage, -1
+                ):
+                    del self._eagerly_transitioned[task_id]  # labels caught up
+                else:
+                    continue  # stale labels, skip
+
             if stage == STAGE_HITL:
                 self._hitl_numbers.add(task_id)
                 self._remove_from_all_queues(task_id)
@@ -235,8 +272,20 @@ class IssueStore:
         - Tasks no longer returned by the fetcher are removed from queues.
         """
         stage_map = self._compute_stage_map(tasks)
-        self._evict_stale_tasks(set(stage_map.keys()))
+        incoming_ids = set(stage_map.keys())
+        self._evict_stale_tasks(incoming_ids)
         self._route_incoming_tasks(stage_map)
+
+        # Prune eagerly-transitioned entries for issues that vanished
+        # entirely (e.g. closed issues no longer returned by the fetcher).
+        vanished = (
+            set(self._eagerly_transitioned)
+            - incoming_ids
+            - set(self._active.keys())
+            - self._in_flight
+        )
+        for tid in vanished:
+            del self._eagerly_transitioned[tid]
 
     def _build_label_map(self) -> dict[str, IssueStoreStage]:
         """Build a mapping from label name → pipeline stage."""
@@ -280,7 +329,8 @@ class IssueStore:
 
         This provides an eager handoff between phases so downstream workers
         can pick up transitioned issues without waiting for the next GitHub
-        polling cycle.
+        polling cycle.  The item is protected from ``refresh()`` eviction /
+        re-routing until GitHub labels catch up to the target stage.
         """
         stage_alias: dict[str, IssueStoreStage] = {
             "find": STAGE_FIND,
@@ -293,21 +343,25 @@ class IssueStore:
         if stage is None:
             return
 
+        self._in_flight.discard(task.id)
         self._issue_cache[task.id] = task
         self._remove_from_all_queues(task.id)
         self._hitl_numbers.discard(task.id)
 
         if stage == STAGE_HITL:
             self._hitl_numbers.add(task.id)
+            self._eagerly_transitioned[task.id] = stage
             self._publish_queue_update_nowait()
             return
 
         if task.id in self._queue_members[stage]:
             self._dedup_stats["queued_entries"] += 1
+            self._eagerly_transitioned[task.id] = stage
             self._publish_queue_update_nowait()
             return
         self._queues[stage].append(task)
         self._queue_members[stage].add(task.id)
+        self._eagerly_transitioned[task.id] = stage
         self._publish_queue_update_nowait()
 
     # ------------------------------------------------------------------
@@ -362,6 +416,7 @@ class IssueStore:
             self._queue_members[stage].add(task.id)
 
         if result:
+            self._in_flight.update(t.id for t in result)
             self._publish_queue_update_nowait()
         return result
 
@@ -371,11 +426,13 @@ class IssueStore:
 
     def mark_active(self, task_id: int, stage: str) -> None:
         """Mark a task as actively being processed in *stage*."""
+        self._in_flight.discard(task_id)
         self._active[task_id] = stage
         self._publish_queue_update_nowait()
 
     def mark_complete(self, task_id: int) -> None:
         """Mark a task as done processing; increment throughput counter."""
+        self._in_flight.discard(task_id)
         stage = self._active.pop(task_id, None)
         if stage and stage in self._processed_count:
             self._processed_count[stage] += 1
@@ -389,9 +446,20 @@ class IssueStore:
         """Return a copy of the active issue tracking dict."""
         return dict(self._active)
 
+    def release_in_flight(self, task_ids: set[int]) -> None:
+        """Remove *task_ids* from the in-flight protection set.
+
+        Called after a batch completes (in a ``finally`` block) to ensure
+        no orphaned in-flight entries survive if a worker exits without
+        reaching ``mark_active`` or ``mark_complete``.
+        """
+        self._in_flight -= task_ids
+
     def clear_active(self) -> None:
         """Clear all active issue tracking (used during reset)."""
         self._active.clear()
+        self._in_flight.clear()
+        self._eagerly_transitioned.clear()
         self._publish_queue_update_nowait()
 
     def _publish_queue_update_nowait(self) -> None:
@@ -503,4 +571,5 @@ class IssueStore:
             total_processed=dict(self._processed_count),
             last_poll_timestamp=self._last_poll_ts,
             dedup_stats=dict(self._dedup_stats),
+            in_flight_count=len(self._in_flight),
         )

--- a/src/models.py
+++ b/src/models.py
@@ -539,6 +539,7 @@ class QueueStats(BaseModel):
     total_processed: dict[str, int] = Field(default_factory=dict)
     last_poll_timestamp: str | None = None
     dedup_stats: dict[str, int] = Field(default_factory=dict)
+    in_flight_count: int = 0
 
 
 class SessionStatus(StrEnum):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -19,7 +19,11 @@ from models import (
     SessionStatus,
     WorkFn,
 )
-from phase_utils import is_adr_issue_title, safe_file_memory_suggestion
+from phase_utils import (
+    is_adr_issue_title,
+    release_batch_in_flight,
+    safe_file_memory_suggestion,
+)
 from service_registry import OrchestratorCallbacks, build_services
 from state import StateTracker
 from subprocess_util import AuthenticationError, CreditExhaustedError
@@ -820,68 +824,73 @@ class HydraFlowOrchestrator:
             review_issues = self._store.get_reviewable(self._config.batch_size)
             if not review_issues:
                 break
-            cycle_did_work = False
-            adr_issues = [
-                issue for issue in review_issues if is_adr_issue_title(issue.title)
-            ]
-            normal_review_issues = [
-                issue
-                for issue in review_issues
-                if issue.id not in {a.id for a in adr_issues}
-            ]
+            try:
+                cycle_did_work = False
+                adr_issues = [
+                    issue for issue in review_issues if is_adr_issue_title(issue.title)
+                ]
+                normal_review_issues = [
+                    issue
+                    for issue in review_issues
+                    if issue.id not in {a.id for a in adr_issues}
+                ]
 
-            if adr_issues:
+                if adr_issues:
+                    cycle_did_work = True
+                    await self._reviewer.review_adrs(adr_issues)
+
+                if not normal_review_issues:
+                    did_work = did_work or cycle_did_work
+                    continue
+
+                active_in_store = set(self._store.get_active_issues().keys())
+                gh_review_issues = [
+                    GitHubIssue.from_task(t) for t in normal_review_issues
+                ]
+                prs, gh_issues = await self._fetcher.fetch_reviewable_prs(
+                    active_in_store, prefetched_issues=gh_review_issues
+                )
+                if not prs:
+                    # Keep review tasks in queue memory when PR visibility lags labels.
+                    for issue in normal_review_issues:
+                        self._store.enqueue_transition(issue, "review")
+                    # Treat as idle so the polling loop applies its normal backoff.
+                    did_work = did_work or cycle_did_work
+                    break
                 cycle_did_work = True
-                await self._reviewer.review_adrs(adr_issues)
-
-            if not normal_review_issues:
-                did_work = did_work or cycle_did_work
-                continue
-
-            active_in_store = set(self._store.get_active_issues().keys())
-            gh_review_issues = [GitHubIssue.from_task(t) for t in normal_review_issues]
-            prs, gh_issues = await self._fetcher.fetch_reviewable_prs(
-                active_in_store, prefetched_issues=gh_review_issues
-            )
-            if not prs:
-                # Keep review tasks in queue memory when PR visibility lags labels.
+                review_results = await self._reviewer.review_prs(
+                    prs, [i.to_task() for i in gh_issues]
+                )
+                reviewed_issue_numbers = {pr.issue_number for pr in prs}
                 for issue in normal_review_issues:
-                    self._store.enqueue_transition(issue, "review")
-                # Treat as idle so the polling loop applies its normal backoff.
+                    if issue.id not in reviewed_issue_numbers:
+                        self._store.enqueue_transition(issue, "review")
+                for result in review_results:
+                    if result.transcript:
+                        if result.merged:
+                            review_status = "success"
+                        elif result.ci_passed is False:
+                            review_status = "failed"
+                        else:
+                            review_status = "completed"
+                        await self._post_run_hooks(
+                            transcript=result.transcript,
+                            source="reviewer",
+                            reference=f"PR #{result.pr_number}",
+                            issue_number=result.issue_number,
+                            phase="review",
+                            status=review_status,
+                            duration_seconds=result.duration_seconds,
+                            log_file=self._log_reference(
+                                f"review-pr-{result.pr_number}.txt"
+                            ),
+                        )
+                if any(r.merged for r in review_results):
+                    await asyncio.sleep(_POST_MERGE_DELAY)
+                    await self._prs.pull_main()
                 did_work = did_work or cycle_did_work
-                break
-            cycle_did_work = True
-            review_results = await self._reviewer.review_prs(
-                prs, [i.to_task() for i in gh_issues]
-            )
-            reviewed_issue_numbers = {pr.issue_number for pr in prs}
-            for issue in normal_review_issues:
-                if issue.id not in reviewed_issue_numbers:
-                    self._store.enqueue_transition(issue, "review")
-            for result in review_results:
-                if result.transcript:
-                    if result.merged:
-                        review_status = "success"
-                    elif result.ci_passed is False:
-                        review_status = "failed"
-                    else:
-                        review_status = "completed"
-                    await self._post_run_hooks(
-                        transcript=result.transcript,
-                        source="reviewer",
-                        reference=f"PR #{result.pr_number}",
-                        issue_number=result.issue_number,
-                        phase="review",
-                        status=review_status,
-                        duration_seconds=result.duration_seconds,
-                        log_file=self._log_reference(
-                            f"review-pr-{result.pr_number}.txt"
-                        ),
-                    )
-            if any(r.merged for r in review_results):
-                await asyncio.sleep(_POST_MERGE_DELAY)
-                await self._prs.pull_main()
-            did_work = did_work or cycle_did_work
+            finally:
+                release_batch_in_flight(self._store, {i.id for i in review_issues})
         return did_work
 
     async def _sleep_or_stop(self, seconds: int | float) -> None:

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -56,6 +56,16 @@ async def run_concurrent_batch(
     return results
 
 
+def release_batch_in_flight(store: IssueStore, task_ids: set[int]) -> None:
+    """Release in-flight protection for a batch of issues.
+
+    Should be called in a ``finally`` block after ``run_concurrent_batch``
+    to ensure no orphaned in-flight entries survive if a worker exits
+    without reaching ``mark_active`` / ``mark_complete``.
+    """
+    store.release_in_flight(task_ids)
+
+
 async def escalate_to_hitl(
     state: StateTracker,
     prs: PRManager,

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -14,6 +14,7 @@ from models import PipelineStage, PlanResult, Task
 from phase_utils import (
     escalate_to_hitl,
     record_harness_failure,
+    release_batch_in_flight,
     run_concurrent_batch,
     safe_file_memory_suggestion,
     store_lifecycle,
@@ -242,7 +243,10 @@ class PlanPhase:
                     await self._post_plan_transcript(issue, result, status=ts_status)
                     return result
 
-        return await run_concurrent_batch(issues, _plan_one, self._stop_event)
+        try:
+            return await run_concurrent_batch(issues, _plan_one, self._stop_event)
+        finally:
+            release_batch_in_flight(self._store, {i.id for i in issues})
 
     def _record_harness_failure(
         self,

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -30,6 +30,7 @@ from phase_utils import (
     is_adr_issue_title,
     publish_review_status,
     record_harness_failure,
+    release_batch_in_flight,
     run_concurrent_batch,
     store_lifecycle,
 )
@@ -157,7 +158,10 @@ class ReviewPhase:
                                 list(self._active_issues)
                             )
 
-        return await run_concurrent_batch(prs, _review_one, self._stop_event)
+        try:
+            return await run_concurrent_batch(prs, _review_one, self._stop_event)
+        finally:
+            release_batch_in_flight(self._store, {pr.issue_number for pr in prs})
 
     async def review_adrs(self, issues: list[Task]) -> list[ReviewResult]:
         """Review ADR issues that intentionally have no PR."""

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -12,6 +12,7 @@ from phase_utils import (
     adr_validation_reasons,
     escalate_to_hitl,
     is_adr_issue_title,
+    release_batch_in_flight,
     store_lifecycle,
 )
 from pr_manager import PRManager
@@ -58,69 +59,72 @@ class TriagePhase:
 
         logger.info("Triaging %d found issues", len(issues))
         processed = 0
-        for issue in issues:
-            if self._stop_event.is_set():
-                logger.info("Stop requested — aborting triage loop")
-                return processed
+        try:
+            for issue in issues:
+                if self._stop_event.is_set():
+                    logger.info("Stop requested — aborting triage loop")
+                    return processed
 
-            async with store_lifecycle(self._store, issue.id, "find"):
-                # ADR draft issues are already scoped/planned; validate shape and
-                # route directly to implementation (ready queue).
-                if is_adr_issue_title(issue.title):
+                async with store_lifecycle(self._store, issue.id, "find"):
+                    # ADR draft issues are already scoped/planned; validate shape and
+                    # route directly to implementation (ready queue).
+                    if is_adr_issue_title(issue.title):
+                        processed += 1
+                        if self._config.dry_run:
+                            continue
+                        reasons = adr_validation_reasons(issue.body)
+                        if reasons:
+                            await self._escalate_triage_issue(issue.id, reasons)
+                            logger.info(
+                                "Issue #%d ADR triage → %s (invalid ADR shape: %s)",
+                                issue.id,
+                                self._config.hitl_label[0],
+                                "; ".join(reasons),
+                            )
+                        else:
+                            await self._transitioner.transition(issue.id, "ready")
+                            self._store.enqueue_transition(issue, "ready")
+                            logger.info(
+                                "Issue #%d ADR triage → %s (validated ADR shape)",
+                                issue.id,
+                                self._config.ready_label[0],
+                            )
+                        continue
+
+                    result = await self._triage.evaluate(issue)
                     processed += 1
+
                     if self._config.dry_run:
                         continue
-                    reasons = adr_validation_reasons(issue.body)
-                    if reasons:
-                        await self._escalate_triage_issue(issue.id, reasons)
+
+                    if result.ready:
+                        await self._transitioner.transition(issue.id, "plan")
+                        self._store.enqueue_transition(issue, "plan")
                         logger.info(
-                            "Issue #%d ADR triage → %s (invalid ADR shape: %s)",
+                            "Issue #%d triaged → %s (ready for planning)",
                             issue.id,
-                            self._config.hitl_label[0],
-                            "; ".join(reasons),
+                            self._config.planner_label[0],
                         )
                     else:
-                        await self._transitioner.transition(issue.id, "ready")
-                        self._store.enqueue_transition(issue, "ready")
+                        await self._escalate_triage_issue(issue.id, result.reasons)
+                        self._store.enqueue_transition(issue, "hitl")
+                        await self._bus.publish(
+                            HydraFlowEvent(
+                                type=EventType.HITL_UPDATE,
+                                data={
+                                    "issue": issue.id,
+                                    "action": "escalated",
+                                },
+                            )
+                        )
                         logger.info(
-                            "Issue #%d ADR triage → %s (validated ADR shape)",
+                            "Issue #%d triaged → %s (needs attention: %s)",
                             issue.id,
-                            self._config.ready_label[0],
+                            self._config.hitl_label[0],
+                            "; ".join(result.reasons),
                         )
-                    continue
-
-                result = await self._triage.evaluate(issue)
-                processed += 1
-
-                if self._config.dry_run:
-                    continue
-
-                if result.ready:
-                    await self._transitioner.transition(issue.id, "plan")
-                    self._store.enqueue_transition(issue, "plan")
-                    logger.info(
-                        "Issue #%d triaged → %s (ready for planning)",
-                        issue.id,
-                        self._config.planner_label[0],
-                    )
-                else:
-                    await self._escalate_triage_issue(issue.id, result.reasons)
-                    self._store.enqueue_transition(issue, "hitl")
-                    await self._bus.publish(
-                        HydraFlowEvent(
-                            type=EventType.HITL_UPDATE,
-                            data={
-                                "issue": issue.id,
-                                "action": "escalated",
-                            },
-                        )
-                    )
-                    logger.info(
-                        "Issue #%d triaged → %s (needs attention: %s)",
-                        issue.id,
-                        self._config.hitl_label[0],
-                        "; ".join(result.reasons),
-                    )
+        finally:
+            release_batch_in_flight(self._store, {i.id for i in issues})
         return processed
 
     async def _escalate_triage_issue(self, issue_id: int, reasons: list[str]) -> None:

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -795,3 +795,249 @@ class TestPipelineSnapshot:
         assert len(plan_issues) == 1
         assert plan_issues[0]["title"] == "Issue #999"
         assert plan_issues[0]["url"] == ""
+
+
+# ── In-Flight Protection ────────────────────────────────────────────
+
+
+class TestInFlightProtection:
+    """Items between _take_from_queue and mark_active are protected."""
+
+    def test_taken_items_added_to_in_flight(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+
+        assert 1 in store._in_flight
+
+    def test_mark_active_clears_in_flight(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+        assert 1 in store._in_flight
+
+        store.mark_active(1, STAGE_PLAN)
+        assert 1 not in store._in_flight
+
+    def test_mark_complete_clears_in_flight(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+        # Skip mark_active — simulate a worker that crashes before mark_active
+        store.mark_complete(1)
+        assert 1 not in store._in_flight
+
+    def test_in_flight_items_not_rerouted_by_refresh(self) -> None:
+        """Core regression test: items taken from queue must not be
+        re-queued by refresh() during the semaphore wait gap."""
+        fetcher = AsyncMock()
+        store = _make_store(fetcher=fetcher)
+
+        # Initial refresh: issue 1 in plan queue
+        fetcher.fetch_all = AsyncMock(
+            return_value=[TaskFactory.create(id=1, tags=["hydraflow-plan"])]
+        )
+        store._route_issues(fetcher.fetch_all.return_value)
+
+        # Simulate phase taking the issue (dequeue → in-flight)
+        taken = store.get_plannable(1)
+        assert len(taken) == 1
+        assert 1 in store._in_flight
+
+        # Refresh again — same issue still has plan label on GitHub
+        store._route_issues(fetcher.fetch_all.return_value)
+
+        # Issue must NOT be re-queued (it's in-flight)
+        assert 1 not in store._queue_members[STAGE_PLAN]
+        assert len(store._queues[STAGE_PLAN]) == 0
+
+    def test_batch_of_40_items_all_protected(self) -> None:
+        """Reproduces the '38 drop out and reappear' bug.
+        All 40 taken items must stay in-flight across a refresh."""
+        fetcher = AsyncMock()
+        store = _make_store(fetcher=fetcher)
+
+        issues = [
+            TaskFactory.create(id=i, tags=["hydraflow-plan"]) for i in range(1, 41)
+        ]
+        store._route_issues(issues)
+
+        # Phase takes all 40
+        taken = store.get_plannable(40)
+        assert len(taken) == 40
+        assert len(store._in_flight) == 40
+
+        # Refresh with same issues — none should reappear in queue
+        store._route_issues(issues)
+        assert len(store._queues[STAGE_PLAN]) == 0
+        assert store._queue_members[STAGE_PLAN] == set()
+
+    def test_in_flight_items_not_evicted_when_absent_from_refresh(self) -> None:
+        """In-flight items must survive eviction even if the fetcher
+        temporarily doesn't return them (e.g. label swap in progress)."""
+        store = _make_store()
+
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        assert 1 in store._in_flight
+
+        # Refresh with empty list — issue 1 not returned
+        store._route_issues([])
+
+        # Should NOT have been evicted
+        assert 1 in store._in_flight
+
+    def test_release_in_flight_clears_protection(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+        assert 1 in store._in_flight
+
+        store.release_in_flight({1})
+        assert 1 not in store._in_flight
+
+    def test_clear_active_also_clears_in_flight_and_eager(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        store.clear_active()
+
+        assert store._in_flight == set()
+        assert store._eagerly_transitioned == {}
+
+
+# ── Eager Transition Protection ─────────────────────────────────────
+
+
+class TestEagerTransitionProtection:
+    """Items placed by enqueue_transition are protected from stale-label re-routing."""
+
+    def test_enqueue_transition_clears_in_flight(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        assert 1 in store._in_flight
+
+        store.enqueue_transition(issue, "ready")
+        assert 1 not in store._in_flight
+        assert 1 in store._eagerly_transitioned
+
+    def test_eager_transition_not_evicted_when_absent_from_refresh(self) -> None:
+        """Eagerly transitioned items must survive eviction even when
+        the fetcher doesn't return them (label swap in progress)."""
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        assert 1 in store._queue_members[STAGE_READY]
+
+        # Refresh with empty results — issue vanished temporarily
+        store._route_issues([])
+
+        # Item must still be in the ready queue (protected by eager transition)
+        assert 1 in store._queue_members[STAGE_READY]
+
+    def test_eager_transition_not_moved_backward_by_stale_labels(self) -> None:
+        """If GitHub still shows old labels, refresh must not move
+        the issue backward from its eagerly-transitioned stage."""
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        assert 1 in store._queue_members[STAGE_READY]
+
+        # Refresh with stale plan label — should NOT move back to plan
+        stale_issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([stale_issue])
+
+        assert 1 in store._queue_members[STAGE_READY]
+        assert 1 not in store._queue_members[STAGE_PLAN]
+
+    def test_eager_protection_cleared_when_labels_catch_up(self) -> None:
+        """Once GitHub labels match or exceed the target stage,
+        eager protection is cleared and normal routing resumes."""
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        assert 1 in store._eagerly_transitioned
+
+        # Refresh with ready label (matches target) — protection clears
+        caught_up = TaskFactory.create(id=1, tags=["test-label"])  # ready
+        store._route_issues([caught_up])
+
+        assert 1 not in store._eagerly_transitioned
+        # Still in ready queue (label matches target, no move needed)
+        assert 1 in store._queue_members[STAGE_READY]
+
+    def test_eager_protection_cleared_when_labels_exceed_target(self) -> None:
+        """Labels that exceed the target stage also clear protection."""
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        # Refresh with review label (exceeds ready target)
+        advanced = TaskFactory.create(id=1, tags=["hydraflow-review"])
+        store._route_issues([advanced])
+
+        assert 1 not in store._eagerly_transitioned
+        # Moved to review (more advanced stage)
+        assert 1 in store._queue_members[STAGE_REVIEW]
+        assert 1 not in store._queue_members[STAGE_READY]
+
+    def test_eager_transition_vanished_issues_pruned(self) -> None:
+        """Eagerly transitioned items for issues that vanish entirely
+        (closed) should be pruned from the protection dict."""
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-plan"])
+        store._route_issues([issue])
+        store.get_plannable(1)
+        store.enqueue_transition(issue, "ready")
+
+        assert 1 in store._eagerly_transitioned
+
+        # Issue 1 completely vanished (closed), only issue 2 returned
+        other = TaskFactory.create(id=2, tags=["hydraflow-find"])
+        store._route_issues([other])
+
+        # Eager protection for vanished issue should be pruned
+        assert 1 not in store._eagerly_transitioned
+
+    def test_eager_transition_to_hitl_is_protected(self) -> None:
+        store = _make_store()
+        issue = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        store._route_issues([issue])
+        store.get_triageable(1)
+        store.enqueue_transition(issue, "hitl")
+
+        assert 1 in store._hitl_numbers
+        assert 1 in store._eagerly_transitioned
+
+        # Refresh with stale find label — should NOT evict from HITL
+        stale = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        store._route_issues([stale])
+
+        assert 1 in store._hitl_numbers
+
+    def test_in_flight_count_in_queue_stats(self) -> None:
+        store = _make_store()
+        store._route_issues(
+            [TaskFactory.create(id=i, tags=["hydraflow-plan"]) for i in range(1, 4)]
+        )
+        store.get_plannable(3)
+
+        stats = store.get_queue_stats()
+        assert stats.in_flight_count == 3


### PR DESCRIPTION
## Summary
- Adds `_in_flight` set and `_eagerly_transitioned` dict to `IssueStore` to protect items in transitional states from being re-queued or evicted by `refresh()`
- Wraps all phase batch callers (`plan`, `implement`, `review`, `triage`, orchestrator review loop) in `try/finally` to release in-flight protection on exit
- Adds `in_flight_count` to `QueueStats` for dashboard visibility
- 15 new tests covering both race condition scenarios and eager transition protection

## Context
Items oscillate in/out of queues ("40 items, 38 drop out and reappear every other cycle"). Root cause: when a phase calls `get_plannable(N)`, items are popped from the queue but not marked active until each worker acquires its semaphore inside `store_lifecycle`. During this gap, `refresh()` sees them as untracked and re-queues them. A secondary race exists where `enqueue_transition` places items in a downstream queue but `refresh()` evicts/re-routes them during the GitHub label swap window.

## Test plan
- [x] All 15 new tests pass including core regression test (`test_batch_of_40_items_all_protected`)
- [x] Full test suite passes (5353 tests)
- [x] `make quality` green (lint + typecheck + security + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)