### PR TITLE
Make Work Stream pipeline snapshot ingest additive

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -39,7 +39,6 @@ export const initialState = {
   githubMetrics: null,
   metricsHistory: null,
   pipelineIssues: { ...emptyPipeline },
-  emptyPipelineSnapshotStreak: 0,
   pipelinePollerLastRun: null,
   sessions: [],
   currentSessionId: null,
@@ -61,6 +60,30 @@ function addEvent(state, action) {
     lastSeenId: eventId !== -1 ? eventId : state.lastSeenId,
     events: [event, ...state.events].slice(0, MAX_EVENTS),
   }
+}
+
+function mergeStageIssues(existingIssues, incomingIssues) {
+  const next = [...(existingIssues || [])]
+  const idxByIssue = new Map()
+  next.forEach((item, idx) => {
+    if (item?.issue_number != null && !idxByIssue.has(item.issue_number)) {
+      idxByIssue.set(item.issue_number, idx)
+    }
+  })
+  for (const item of (incomingIssues || [])) {
+    if (item?.issue_number == null) {
+      next.push(item)
+      continue
+    }
+    const existingIdx = idxByIssue.get(item.issue_number)
+    if (existingIdx != null) {
+      next[existingIdx] = { ...next[existingIdx], ...item }
+    } else {
+      idxByIssue.set(item.issue_number, next.length)
+      next.push(item)
+    }
+  }
+  return next
 }
 
 export function reducer(state, action) {
@@ -125,7 +148,6 @@ export function reducer(state, action) {
           hitlEscalation: null,
           lastSeenId: -1,
           pipelineIssues: { ...emptyPipeline },
-          emptyPipelineSnapshotStreak: 0,
           intents: [],
           humanInputRequests: {},
         } : {}),
@@ -444,33 +466,14 @@ export function reducer(state, action) {
     case 'PIPELINE_SNAPSHOT': {
       const incoming = action.data || {}
       const openStages = ['triage', 'plan', 'implement', 'review', 'hitl']
-      const incomingOpenCount = openStages.reduce(
-        (sum, key) => sum + ((incoming[key] || []).length),
-        0,
-      )
-      const existingOpenCount = openStages.reduce(
-        (sum, key) => sum + ((state.pipelineIssues[key] || []).length),
-        0,
-      )
-      const nextEmptyStreak = incomingOpenCount === 0
-        ? (state.emptyPipelineSnapshotStreak || 0) + 1
-        : 0
-
-      // Guard against transient empty snapshots: require 3 consecutive empty
-      // polls before clearing non-empty open queues.
-      const preserveExistingOpen = (state.emptyPipelineSnapshotStreak || 0) < 2
-        && incomingOpenCount === 0
-        && existingOpenCount > 0
 
       const nextOpen = Object.fromEntries(openStages.map((key) => {
-        if (preserveExistingOpen) {
-          return [key, state.pipelineIssues[key] || []]
-        }
-        // Partial payloads should not clear stages omitted by backend.
         if (!Object.prototype.hasOwnProperty.call(incoming, key)) {
           return [key, state.pipelineIssues[key] || []]
         }
-        return [key, incoming[key] || []]
+        // Snapshot payloads are additive: upsert known issues by id and keep
+        // existing queue members until an explicit transition/reset removes them.
+        return [key, mergeStageIssues(state.pipelineIssues[key], incoming[key] || [])]
       }))
 
       return {
@@ -480,7 +483,6 @@ export function reducer(state, action) {
           // Server never sends merged — preserve session-accumulated merged items
           merged: state.pipelineIssues.merged || [],
         },
-        emptyPipelineSnapshotStreak: nextEmptyStreak,
         pipelinePollerLastRun: new Date().toISOString(),
       }
     }
@@ -524,11 +526,7 @@ export function reducer(state, action) {
         }
       }
 
-      return {
-        ...state,
-        pipelineIssues: next,
-        emptyPipelineSnapshotStreak: 0,
-      }
+      return { ...state, pipelineIssues: next }
     }
 
     case 'SESSION_RESET': {
@@ -548,7 +546,6 @@ export function reducer(state, action) {
         humanInputRequests: {},
         lastSeenId: -1,
         pipelineIssues: { ...emptyPipeline },
-        emptyPipelineSnapshotStreak: 0,
         intents: [],
       }
     }

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -133,17 +133,28 @@ describe('HydraFlowContext reducer', () => {
 })
 
 describe('PIPELINE_SNAPSHOT reducer', () => {
-  it('replaces provided stages with server data', () => {
+  it('additively upserts provided stages with server data', () => {
+    const state = {
+      ...initialState,
+      pipelineIssues: {
+        ...emptyPipeline,
+        triage: [{ issue_number: 1, title: 'Old title', url: '/old', status: 'active' }],
+      },
+    }
     const data = {
-      triage: [{ issue_number: 1, title: 'Bug', url: '', status: 'queued' }],
+      triage: [
+        { issue_number: 1, title: 'Bug', url: '', status: 'queued' },
+        { issue_number: 9, title: 'New', url: '', status: 'queued' },
+      ],
       plan: [],
       implement: [{ issue_number: 2, title: 'Feature', url: '', status: 'active' }],
       review: [],
       hitl: [],
     }
-    const next = reducer(initialState, { type: 'PIPELINE_SNAPSHOT', data })
-    expect(next.pipelineIssues.triage).toHaveLength(1)
-    expect(next.pipelineIssues.triage[0].issue_number).toBe(1)
+    const next = reducer(state, { type: 'PIPELINE_SNAPSHOT', data })
+    expect(next.pipelineIssues.triage).toHaveLength(2)
+    expect(next.pipelineIssues.triage.find(i => i.issue_number === 1)?.title).toBe('Bug')
+    expect(next.pipelineIssues.triage.find(i => i.issue_number === 9)).toBeTruthy()
     expect(next.pipelineIssues.implement).toHaveLength(1)
     expect(next.pipelineIssues.implement[0].status).toBe('active')
   })
@@ -168,7 +179,7 @@ describe('PIPELINE_SNAPSHOT reducer', () => {
     expect(next.pipelineIssues.hitl).toEqual([])
   })
 
-  it('ignores transient empty snapshots', () => {
+  it('does not clear existing queues on empty snapshots', () => {
     const state = {
       ...initialState,
       pipelineIssues: {
@@ -183,23 +194,6 @@ describe('PIPELINE_SNAPSHOT reducer', () => {
     })
     expect(next.pipelineIssues.triage).toHaveLength(1)
     expect(next.pipelineIssues.implement).toHaveLength(1)
-  })
-
-  it('clears open queues after 3 consecutive empty snapshots', () => {
-    const state = {
-      ...initialState,
-      pipelineIssues: {
-        ...emptyPipeline,
-        triage: [{ issue_number: 10, title: 'Queued', url: '', status: 'queued' }],
-      },
-    }
-    const emptyData = { triage: [], plan: [], implement: [], review: [], hitl: [] }
-    const after1 = reducer(state, { type: 'PIPELINE_SNAPSHOT', data: emptyData })
-    const after2 = reducer(after1, { type: 'PIPELINE_SNAPSHOT', data: emptyData })
-    const after3 = reducer(after2, { type: 'PIPELINE_SNAPSHOT', data: emptyData })
-    expect(after1.pipelineIssues.triage).toHaveLength(1)
-    expect(after2.pipelineIssues.triage).toHaveLength(1)
-    expect(after3.pipelineIssues.triage).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
## Summary\n- stop destructive queue replacement from pipeline snapshots\n- make snapshot ingestion additive by upserting per-stage items keyed by issue_number\n- keep stage removals transition-driven (WS pipeline updates/session reset)\n\n## Why\nWork Stream queue was dropping to zero when snapshots arrived with missing/empty stage payloads.\n\n## Testing\n- npm test -- --run src/context/__tests__/HydraFlowContext.test.jsx\n- npm test -- --run src/components/__tests__/StreamView.test.jsx