### PR TITLE
fix(hooks): portability, efficiency, and wiring fixes from audit

### DIFF
--- a/.claude/hooks/hf.check-cross-service-impact.sh
+++ b/.claude/hooks/hf.check-cross-service-impact.sh
@@ -24,14 +24,15 @@ if ! echo "$FILE_PATH" | grep -qE '\.py$'; then
 fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 
-# Check if already warned this session (within last 4 hours)
+# Check if already warned this session (within last 4 hours) — before mkdir
 WARNED_MARKER="$MARKER_DIR/warned-cross-service"
 if [ -f "$WARNED_MARKER" ] && [ -n "$(find "$WARNED_MARKER" -mmin -240 2>/dev/null)" ]; then
   exit 0
 fi
+
+mkdir -p "$MARKER_DIR"
 
 # Find which services import from shared/
 SHARED_MODULE=$(echo "$FILE_PATH" | sed -n 's|.*/shared/\(.*\)\.py$|\1|p' | tr '/' '.')

--- a/.claude/hooks/hf.check-reindex-needed.sh
+++ b/.claude/hooks/hf.check-reindex-needed.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 
 REINDEX_MARKER="$MARKER_DIR/needs-reindex"
 INDEXED_MARKER="$MARKER_DIR/last-indexed"

--- a/.claude/hooks/hf.check-test-counterpart.sh
+++ b/.claude/hooks/hf.check-test-counterpart.sh
@@ -44,3 +44,5 @@ echo "Reminder: New source file being created without a test counterpart." >&2
 echo "  Source: $FILE_PATH" >&2
 echo "  Expected: test_${FILENAME}.py" >&2
 echo "  Per CLAUDE.md: Every new function/class MUST include tests." >&2
+
+exit 0

--- a/.claude/hooks/hf.cleanup-code-change-marker.sh
+++ b/.claude/hooks/hf.cleanup-code-change-marker.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 rm -f "$MARKER_DIR/code-changed"
 
 exit 0

--- a/.claude/hooks/hf.enforce-plan-and-explore.sh
+++ b/.claude/hooks/hf.enforce-plan-and-explore.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Hook: Warn if editing source code without prior exploration or planning.
-# Fires on PreToolUse for Edit tool.
+# Fires on PreToolUse for Edit and Write tools.
 # Warns ONCE per session (4-hour window), does not block.
 # Only checks Python source files (skips tests, configs, __init__).
 
@@ -20,14 +20,15 @@ if echo "$FILE_PATH" | grep -qE '(test_|_test\.py|conftest\.py|/tests/|__init__\
 fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 
-# Check if already warned this session (within last 4 hours)
+# Check if already warned this session (within last 4 hours) — before mkdir
 WARNED_MARKER="$MARKER_DIR/warned"
 if [ -f "$WARNED_MARKER" ] && [ -n "$(find "$WARNED_MARKER" -mmin -240 2>/dev/null)" ]; then
   exit 0
 fi
+
+mkdir -p "$MARKER_DIR"
 
 WARNINGS=""
 

--- a/.claude/hooks/hf.gate-stop-agents.sh
+++ b/.claude/hooks/hf.gate-stop-agents.sh
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 
 if [ ! -f "$MARKER_DIR/code-changed" ]; then
   exit 2

--- a/.claude/hooks/hf.observe-session.sh
+++ b/.claude/hooks/hf.observe-session.sh
@@ -15,7 +15,7 @@ ARCHIVE_DIR="${STATE_DIR}/archive"
 OBS_FILE="${STATE_DIR}/observations.jsonl"
 MAX_BYTES=$((5 * 1024 * 1024))
 
-mkdir -p "${STATE_DIR}" "${ARCHIVE_DIR}"
+[ -d "${ARCHIVE_DIR}" ] || mkdir -p "${STATE_DIR}" "${ARCHIVE_DIR}"
 
 tool_name=$(echo "${INPUT}" | jq -r '.tool_name // .tool // "unknown"')
 session_id=$(echo "${INPUT}" | jq -r '.session_id // empty')
@@ -25,11 +25,12 @@ fi
 
 file_path=$(echo "${INPUT}" | jq -r '.tool_input.file_path // empty')
 bash_command=$(echo "${INPUT}" | jq -r '.tool_input.command // empty')
-bash_verb=$(printf '%s' "${bash_command}" | awk '{print $1}')
+bash_verb="${bash_command%% *}"
 if [ -z "${bash_verb}" ]; then
   bash_verb="n/a"
 fi
 
+# Rotate log only when file exists and exceeds threshold
 if [ -f "${OBS_FILE}" ]; then
   current_size=$(wc -c < "${OBS_FILE}" | tr -d ' ')
   if [ "${current_size}" -ge "${MAX_BYTES}" ]; then

--- a/.claude/hooks/hf.scan-secrets-before-commit.sh
+++ b/.claude/hooks/hf.scan-secrets-before-commit.sh
@@ -54,14 +54,16 @@ MATCHES=$(echo "$ADDED_LINES" | grep -oEn "$COMBINED_PATTERN" 2>/dev/null || tru
 if [ -n "$MATCHES" ]; then
   echo "BLOCKED: Potential secrets detected in staged changes:" >&2
   echo "" >&2
-  # Show which files contain the matches
-  while IFS= read -r file; do
-    [ -f "$file" ] || continue
-    FILE_DIFF=$(git diff --cached -U0 -- "$file" 2>/dev/null | grep -E '^\+[^+]' || true)
-    if echo "$FILE_DIFF" | grep -qE "$COMBINED_PATTERN" 2>/dev/null; then
-      echo "  - $file" >&2
-    fi
-  done <<< "$STAGED_FILES"
+  # Single-pass: parse file headers from the full staged diff to attribute matches
+  FULL_DIFF=$(git diff --cached -U0 2>/dev/null || true)
+  AFFECTED_FILES=$(echo "$FULL_DIFF" | awk -v pat="$COMBINED_PATTERN" '
+    /^diff --git/ { file = $NF; sub(/^b\//, "", file) }
+    /^\+[^+]/ && match($0, pat) { files[file] = 1 }
+    END { for (f in files) print f }
+  ' 2>/dev/null || true)
+  if [ -n "$AFFECTED_FILES" ]; then
+    echo "$AFFECTED_FILES" | sed 's/^/  - /' >&2
+  fi
   echo "" >&2
   echo "Remove secrets and use environment variables instead." >&2
   echo "If this is a false positive (e.g., test fixtures), ask the user to confirm." >&2

--- a/.claude/hooks/hf.session-retro.sh
+++ b/.claude/hooks/hf.session-retro.sh
@@ -5,6 +5,13 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Skip retro if no code was changed this session
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+if [ ! -f "$MARKER_DIR/code-changed" ]; then
+  exit 0
+fi
+
 STATE_DIR="${PROJECT_DIR}/.claude/state/self-improve"
 OBS_FILE="${STATE_DIR}/observations.jsonl"
 RETRO_DIR="${STATE_DIR}/session-retros"
@@ -33,13 +40,14 @@ if [ "${event_count}" -eq 0 ]; then
   exit 0
 fi
 
-write_count=$(jq -s '[.[] | select(.tool == "Write")] | length' "${SESSION_EVENTS_FILE}")
-edit_count=$(jq -s '[.[] | select(.tool == "Edit")] | length' "${SESSION_EVENTS_FILE}")
-read_count=$(jq -s '[.[] | select(.tool == "Read")] | length' "${SESSION_EVENTS_FILE}")
-bash_count=$(jq -s '[.[] | select(.tool == "Bash")] | length' "${SESSION_EVENTS_FILE}")
-task_count=$(jq -s '[.[] | select(.tool == "TaskCreate")] | length' "${SESSION_EVENTS_FILE}")
-
-unique_files=$(jq -s '[.[] | select(.file_path != "") | .file_path] | unique | length' "${SESSION_EVENTS_FILE}")
+eval $(jq -s '{
+  write_count: [.[] | select(.tool == "Write")] | length,
+  edit_count: [.[] | select(.tool == "Edit")] | length,
+  read_count: [.[] | select(.tool == "Read")] | length,
+  bash_count: [.[] | select(.tool == "Bash")] | length,
+  task_count: [.[] | select(.tool == "TaskCreate")] | length,
+  unique_files: [.[] | select(.file_path != "") | .file_path] | unique | length
+} | to_entries | .[] | "\(.key)=\(.value)"' "${SESSION_EVENTS_FILE}")
 top_bash_verbs=$(jq -r 'select(.bash_verb != "n/a") | .bash_verb' "${SESSION_EVENTS_FILE}" | sort | uniq -c | sort -nr | head -n 5 || true)
 
 ts_slug=$(date -u +"%Y%m%dT%H%M%SZ")

--- a/.claude/hooks/hf.track-code-changes.sh
+++ b/.claude/hooks/hf.track-code-changes.sh
@@ -26,8 +26,8 @@ if echo "$FILE_PATH" | grep -qE '\.claude/'; then
 fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+[ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
 touch "$MARKER_DIR/code-changed"
 
 exit 0

--- a/.claude/hooks/hf.track-exploration.sh
+++ b/.claude/hooks/hf.track-exploration.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
-# Hook: Track that code exploration (Read/Grep) has occurred in this session.
-# Fires on PostToolUse for Read and Grep tools.
+# Hook: Track that code exploration (Read/Grep/Glob) has occurred in this session.
+# Fires on PostToolUse for Read, Grep, Glob, claude-context, and cclsp tools.
 # Touches a marker file so the edit guard can verify exploration happened.
+# Filters out non-code files to avoid false "explored" markers.
 
 set -euo pipefail
 
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+
+# If a file path is present, only count code files as exploration
+if [ -n "$FILE_PATH" ]; then
+  if ! echo "$FILE_PATH" | grep -qE '\.(py|ts|tsx|js|jsx|rs|go|java|rb|sh|yml|yaml)$'; then
+    exit 0
+  fi
+fi
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+[ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
 touch "$MARKER_DIR/explored"

--- a/.claude/hooks/hf.track-indexed.sh
+++ b/.claude/hooks/hf.track-indexed.sh
@@ -6,8 +6,8 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+[ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
 
 touch "$MARKER_DIR/last-indexed"
 rm -f "$MARKER_DIR/needs-reindex"

--- a/.claude/hooks/hf.track-planning.sh
+++ b/.claude/hooks/hf.track-planning.sh
@@ -6,6 +6,6 @@
 set -euo pipefail
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+[ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
 touch "$MARKER_DIR/planned"

--- a/.claude/hooks/hf.track-reindex-needed.sh
+++ b/.claude/hooks/hf.track-reindex-needed.sh
@@ -15,7 +15,7 @@ fi
 # Detect git operations that change the working tree
 if echo "$COMMAND" | grep -qE 'git\s+(pull|merge|checkout|switch|rebase|cherry-pick|stash\s+pop|stash\s+apply)'; then
   PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-  MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-  mkdir -p "$MARKER_DIR"
+  MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+  [ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
   touch "$MARKER_DIR/needs-reindex"
 fi

--- a/.claude/hooks/hf.validate-tests-before-commit.sh
+++ b/.claude/hooks/hf.validate-tests-before-commit.sh
@@ -92,9 +92,14 @@ for dir in $TOP_DIRS; do
   fi
 done
 
-# Also check root-level test directory
-if echo "$STAGED_FILES" | grep -q "^tests/"; then
-  SERVICES_TO_TEST="$SERVICES_TO_TEST root"
+# Check for root-level source files (e.g., src/orchestrator.py, cli.py)
+# or staged test files in tests/
+ROOT_SOURCE=$(echo "$STAGED_FILES" | grep -E '^(src/)?[^/]*\.py$' || true)
+ROOT_TESTS=$(echo "$STAGED_FILES" | grep -q "^tests/" && echo "yes" || true)
+if [ -n "$ROOT_SOURCE" ] || [ -n "$ROOT_TESTS" ]; then
+  if [ -d "$PROJECT_ROOT/tests" ]; then
+    SERVICES_TO_TEST="$SERVICES_TO_TEST root"
+  fi
 fi
 
 if [ -z "$SERVICES_TO_TEST" ]; then

--- a/.claude/hooks/hf.warn-new-file-creation.sh
+++ b/.claude/hooks/hf.warn-new-file-creation.sh
@@ -26,9 +26,9 @@ if git -C "$PROJECT_DIR" ls-files --error-unmatch "$FILE_PATH" > /dev/null 2>&1;
 fi
 
 # File is new (untracked) — soft warning
-MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | md5)"
-mkdir -p "$MARKER_DIR"
-WARNED_MARKER="$MARKER_DIR/warned-newfile-$(echo -n "$FILE_PATH" | md5)"
+MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_DIR" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+[ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
+WARNED_MARKER="$MARKER_DIR/warned-newfile-$(echo -n "$FILE_PATH" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
 
 if [ -f "$WARNED_MARKER" ]; then
   exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,6 +47,12 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.check-cross-service-impact.sh",
+            "timeout": 15,
+            "statusMessage": "Checking cross-service impact for shared/ changes..."
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.codex/skills/strategic-compact/suggest-compact.sh",
             "timeout": 5,
             "statusMessage": "Checking if strategic compaction checkpoint is due..."
@@ -101,14 +107,12 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.track-reindex-needed.sh",
-            "timeout": 5,
-            "statusMessage": "Tracking reindex state..."
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.observe-session.sh",
-            "timeout": 5,
-            "statusMessage": "Capturing self-improvement observation..."
+            "timeout": 5
           }
         ]
       },
@@ -168,13 +172,32 @@
         ]
       },
       {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.track-exploration.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Glob",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.track-exploration.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write",
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.warn-new-file-creation.sh",
-            "timeout": 10,
-            "statusMessage": "Checking if file is new..."
+            "timeout": 10
           },
           {
             "type": "command",

--- a/.codex/skills/strategic-compact/suggest-compact.sh
+++ b/.codex/skills/strategic-compact/suggest-compact.sh
@@ -33,15 +33,15 @@ SESSION_ID="${CLAUDE_SESSION_ID:-${PPID:-default}}"
 COUNTER_FILE="/tmp/claude-tool-count-${SESSION_ID}"
 THRESHOLD=${COMPACT_THRESHOLD:-50}
 
-# Initialize or increment counter
+# Initialize or increment counter (atomic write via temp file)
 if [ -f "$COUNTER_FILE" ]; then
-  count=$(cat "$COUNTER_FILE")
+  count=$(cat "$COUNTER_FILE" 2>/dev/null || echo 0)
   count=$((count + 1))
-  echo "$count" > "$COUNTER_FILE"
 else
-  echo "1" > "$COUNTER_FILE"
   count=1
 fi
+TMP_COUNTER="${COUNTER_FILE}.$$"
+echo "$count" > "$TMP_COUNTER" && mv "$TMP_COUNTER" "$COUNTER_FILE"
 
 # Suggest compact after threshold tool calls
 if [ "$count" -eq "$THRESHOLD" ]; then


### PR DESCRIPTION
## Summary
- Fix Linux portability: replace macOS-only `md5` with `(md5sum || md5)` across all 12 marker-based hook scripts
- Fix Stop hook gating: move code-changed check into session-retro.sh directly (Stop hooks don't support exit-2 chaining)
- Fix settings.json wiring: add Grep/Glob exploration tracking, cross-service impact on Write, remove PostToolUse statusMessages
- Optimize: consolidate 5 jq calls → 1 in session-retro, single-pass secret scan, bash builtins over forks, guarded mkdir

## Test plan
- [x] All 19 hook scripts pass `bash -n` syntax check
- [x] `settings.json` validates as correct JSON
- [x] No bare `md5` calls remain in any `.sh` file
- [x] `make quality-lite` passes (lint, typecheck, security)
- [ ] Verify exploration marker is set after Grep/Glob usage
- [ ] Verify session retro skips on read-only sessions
- [ ] Verify cross-service impact warning fires on Write to `shared/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
