### PR TITLE
Fix lifetime metrics fallback when GitHub totals are unavailable

### DIFF
--- a/src/ui/src/components/MetricsPanel.jsx
+++ b/src/ui/src/components/MetricsPanel.jsx
@@ -105,6 +105,11 @@ export function MetricsPanel() {
   const github = githubMetrics || {}
   const openByLabel = github.open_by_label || {}
   const lifetime = metrics?.lifetime || lifetimeStats || {}
+  const lifetimeIssuesCompleted = Number(lifetime.issues_completed ?? 0)
+  const lifetimePrsMerged = Number(lifetime.prs_merged ?? 0)
+  const githubTotalClosed = Number(github.total_closed ?? 0)
+  const githubTotalMerged = Number(github.total_merged ?? 0)
+  const githubOpenIssueTotal = Object.values(openByLabel).reduce((a, b) => a + Number(b || 0), 0)
 
   const timeToMerge = metrics?.time_to_merge || {}
   const thresholds = metrics?.thresholds || []
@@ -112,10 +117,16 @@ export function MetricsPanel() {
   const inferenceSession = metrics?.inference_session || {}
 
   const hasGithub = githubMetrics !== null && githubMetrics !== undefined
+  const githubLooksUnavailable = hasGithub
+    && githubOpenIssueTotal === 0
+    && githubTotalClosed === 0
+    && githubTotalMerged === 0
+    && (lifetimeIssuesCompleted > 0 || lifetimePrsMerged > 0)
+  const useGithubTotals = hasGithub && !githubLooksUnavailable
   const hasSession = sessionTriaged > 0 || sessionPlanned > 0 ||
     sessionImplemented > 0 || sessionReviewed > 0 || mergedCount > 0
-  const hasLifetime = hasGithub || lifetime.issues_completed > 0 ||
-    lifetime.prs_merged > 0
+  const hasLifetime = useGithubTotals || lifetimeIssuesCompleted > 0 ||
+    lifetimePrsMerged > 0
 
   // Extract history data
   const historyData = metricsHistory || {}
@@ -139,7 +150,7 @@ export function MetricsPanel() {
         <div className="metrics-grid" data-testid="metrics-grid-lifetime">
           <StatCard
             label="Issues Completed"
-            value={github.total_closed ?? lifetime.issues_completed ?? 0}
+            value={useGithubTotals ? githubTotalClosed : lifetimeIssuesCompleted}
             trend={<TrendIndicator
               current={current?.issues_completed}
               previous={prev?.issues_completed}
@@ -147,16 +158,16 @@ export function MetricsPanel() {
           />
           <StatCard
             label="PRs Merged"
-            value={github.total_merged ?? lifetime.prs_merged ?? 0}
+            value={useGithubTotals ? githubTotalMerged : lifetimePrsMerged}
             trend={<TrendIndicator
               current={current?.prs_merged}
               previous={prev?.prs_merged}
             />}
           />
-          {hasGithub && (
+          {useGithubTotals && (
             <StatCard
               label="Open Issues"
-              value={Object.values(openByLabel).reduce((a, b) => a + b, 0)}
+              value={githubOpenIssueTotal}
             />
           )}
         </div>

--- a/src/ui/src/components/__tests__/MetricsPanel.test.jsx
+++ b/src/ui/src/components/__tests__/MetricsPanel.test.jsx
@@ -137,6 +137,24 @@ describe('MetricsPanel', () => {
     expect(screen.getByText('8')).toBeInTheDocument()
   })
 
+  it('prefers local lifetime when github metrics are all zeros', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      metrics: {
+        lifetime: { issues_completed: 12, prs_merged: 9, issues_created: 3 },
+        rates: {},
+      },
+      githubMetrics: {
+        open_by_label: {},
+        total_closed: 0,
+        total_merged: 0,
+      },
+    }))
+    render(<MetricsPanel />)
+    expect(screen.getByText('12')).toBeInTheDocument()
+    expect(screen.getByText('9')).toBeInTheDocument()
+    expect(screen.queryByText('Open Issues')).not.toBeInTheDocument()
+  })
+
   it('shows empty state when everything is null and session is empty', () => {
     render(<MetricsPanel />)
     expect(screen.getByText('No metrics data available yet.')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- prevent false-zero Lifetime metrics when GitHub metrics endpoint returns all-zero payloads due to fetch issues
- fall back to local persisted lifetime counters in that case
- keep Open Issues card hidden when GitHub metrics are unavailable

## Changes
- update MetricsPanel fallback selection logic
- add regression test for all-zero GitHub payload with non-zero local lifetime

## Validation
- npm test -- --run src/components/__tests__/MetricsPanel.test.jsx
