### PR TITLE
Fixes #1464: Remove +/- controls from session sidebar

### DIFF
--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -11,8 +11,6 @@ export function SessionSidebar() {
     stageStatus,
     selectSession,
     deleteSession,
-    addRepoShortcut,
-    removeRepoShortcut,
     supervisedRepos = [],
   } = useHydraFlow()
   const [expandedRepos, setExpandedRepos] = useState({})
@@ -81,21 +79,6 @@ export function SessionSidebar() {
     deleteSession(sessionId)
   }
 
-  const repoIdentifier = (entry) => {
-    if (entry.sessions.length > 0) return entry.displayName
-    return entry.slug || entry.displayName
-  }
-
-  const handleAddRepo = (e, entry) => {
-    e.stopPropagation()
-    addRepoShortcut?.(repoIdentifier(entry))
-  }
-
-  const handleRemoveRepo = (e, entry) => {
-    e.stopPropagation()
-    removeRepoShortcut?.(repoIdentifier(entry))
-  }
-
   return (
     <div style={styles.sidebar}>
       <div style={styles.header}>
@@ -142,26 +125,6 @@ export function SessionSidebar() {
                     </span>
                   )}
                   <span style={styles.repoCount}>{repoSessions.length}</span>
-                </div>
-                <div style={styles.repoActions}>
-                  <button
-                    type="button"
-                    aria-label={`Add repo ${entry.displayName}`}
-                    title="Add repo"
-                    onClick={(e) => handleAddRepo(e, entry)}
-                    style={styles.repoActionButton}
-                  >
-                    +
-                  </button>
-                  <button
-                    type="button"
-                    aria-label={`Remove repo ${entry.displayName}`}
-                    title="Remove repo"
-                    onClick={(e) => handleRemoveRepo(e, entry)}
-                    style={styles.repoActionButton}
-                  >
-                    −
-                  </button>
                 </div>
               </div>
 
@@ -297,7 +260,7 @@ const styles = {
   },
   repoHeader: {
     display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) auto auto',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
     alignItems: 'flex-start',
     gap: 6,
     padding: '8px 12px',
@@ -316,22 +279,6 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     minWidth: 0,
-  },
-  repoActions: {
-    display: 'flex',
-    gap: 4,
-    justifyContent: 'flex-end',
-  },
-  repoActionButton: {
-    border: `1px solid ${theme.border}`,
-    borderRadius: 4,
-    width: 20,
-    height: 20,
-    fontSize: 12,
-    fontWeight: 700,
-    background: theme.surfaceAlt ?? theme.surface,
-    color: theme.text,
-    cursor: 'pointer',
   },
   arrow: {
     fontSize: 9,

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -17,8 +17,6 @@ function defaultContext(overrides = {}) {
     stageStatus: { workload: { total: 0, active: 0, done: 0, failed: 0 } },
     selectSession: vi.fn(),
     deleteSession: vi.fn(),
-    addRepoShortcut: vi.fn(),
-    removeRepoShortcut: vi.fn(),
     supervisedRepos: [],
     ...overrides,
   }
@@ -152,24 +150,13 @@ describe('SessionSidebar with multiple repos', () => {
     expect(screen.getByText('other-org/other-repo')).toBeDefined()
   })
 
-  it('fires addRepoShortcut when clicking the add button', () => {
-    const addRepoShortcut = vi.fn()
+  it('does not render add/remove repo action buttons', () => {
     mockUseHydraFlow.mockReturnValue(
-      defaultContext({ sessions: [SESSION_A], addRepoShortcut })
+      defaultContext({ sessions: [SESSION_A] })
     )
     render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo org/repo'))
-    expect(addRepoShortcut).toHaveBeenCalledWith('org/repo')
-  })
-
-  it('fires removeRepoShortcut when clicking the remove button', () => {
-    const removeRepoShortcut = vi.fn()
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ sessions: [SESSION_A], removeRepoShortcut })
-    )
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Remove repo org/repo'))
-    expect(removeRepoShortcut).toHaveBeenCalledWith('org/repo')
+    expect(screen.queryByLabelText(/Add repo/)).toBeNull()
+    expect(screen.queryByLabelText(/Remove repo/)).toBeNull()
   })
 })
 
@@ -188,22 +175,16 @@ describe('SessionSidebar supervised repo state', () => {
     expect(screen.getByText('RUNNING')).toBeDefined()
   })
 
-  it('uses slug when firing add/remove shortcuts for supervised-only repo', () => {
-    const addRepoShortcut = vi.fn()
-    const removeRepoShortcut = vi.fn()
+  it('shows STOPPED status for non-running supervised repo', () => {
     mockUseHydraFlow.mockReturnValue(
       defaultContext({
         supervisedRepos: [{ ...SUPERVISED_REPO, running: false }],
-        addRepoShortcut,
-        removeRepoShortcut,
       })
     )
     render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo demo'))
-    fireEvent.click(screen.getByLabelText('Remove repo demo'))
-    expect(addRepoShortcut).toHaveBeenCalledWith('demo')
-    expect(removeRepoShortcut).toHaveBeenCalledWith('demo')
     expect(screen.getByText('STOPPED')).toBeDefined()
+    expect(screen.queryByLabelText(/Add repo/)).toBeNull()
+    expect(screen.queryByLabelText(/Remove repo/)).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary
- Removed Add (+) and Remove (-) repo action buttons from `SessionSidebar.jsx`
- Removed associated `handleAddRepo`/`handleRemoveRepo` handlers and `repoIdentifier` helper
- Reduced CSS grid from 3 columns to 2 columns
- Removed unused `repoActions` and `repoActionButton` styles
- Updated tests to verify buttons are absent

## Test plan
- [x] All 28 SessionSidebar tests pass
- [x] Verified no add/remove buttons render
- [x] Sidebar still shows repo counts and RUNNING/STOPPED status correctly
- [x] quality-lite checks pass (lint, typecheck, security)

Fixes #1464

🤖 Generated with [Claude Code](https://claude.com/claude-code)