### PR TITLE
Fixes #830: Add self-check checklist to implementation agent

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -36,6 +36,21 @@ class AgentRunner(BaseRunner):
     _MAX_IMPL_PLAN_CHARS = 6_000
     _MAX_REVIEW_FEEDBACK_CHARS = 2_000
 
+    _SELF_CHECK_CHECKLIST = """
+## Self-Check Before Committing
+
+Run through this checklist before your final commit:
+
+- [ ] **Tests cover all new/changed code** — every new function, branch, and edge case has a test
+- [ ] **No missing imports** — all new symbols are imported; removed code has imports cleaned up
+- [ ] **Type hints are correct** — function signatures match actual usage; no `Any` where a concrete type exists
+- [ ] **Edge cases handled** — empty inputs, None values, boundary conditions are addressed
+- [ ] **No leftover debug code** — no print(), console.log(), or commented-out code
+- [ ] **Error messages are clear** — exceptions include context (what failed, what was expected)
+- [ ] **Existing tests still pass** — your changes don't break unrelated tests
+- [ ] **Commit message matches changes** — "Fixes #N: <summary>" accurately describes what changed
+"""
+
     def __init__(
         self,
         config: HydraFlowConfig,
@@ -400,6 +415,7 @@ class AgentRunner(BaseRunner):
 4. Run Run-Tool Skill: `make lint` → `{test_cmd}` → `make quality`; fix and rerun.
 5. Commit with: "Fixes #{issue.id}: <concise summary>"
 {feedback_section}
+{self._SELF_CHECK_CHECKLIST}
 ## UI Guidelines
 
 - Before creating UI components, search `src/ui/src/components/` for existing patterns to reuse.
@@ -484,6 +500,8 @@ Attempt: {attempt}
 Scope:
 - review current branch changes for correctness and plan adherence
 - add/fix tests for missing coverage and edge cases
+- verify all new functions have type hints and all imports are correct
+- check edge cases: empty inputs, None values, missing keys, boundary conditions
 - apply code fixes directly in this working tree
 
 Constraints:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -397,6 +397,45 @@ class TestBuildPrompt:
 
         assert plan_pos < feedback_pos < instructions_pos
 
+    def test_prompt_includes_self_check_checklist(
+        self, config, event_bus: EventBus, issue
+    ) -> None:
+        """Prompt should include the self-check checklist section."""
+        runner = AgentRunner(config, event_bus)
+        prompt = runner._build_prompt(issue)
+        assert "## Self-Check Before Committing" in prompt
+        assert "Tests cover all new/changed code" in prompt
+        assert "No missing imports" in prompt
+        assert "Type hints are correct" in prompt
+        assert "Edge cases handled" in prompt
+        assert "No leftover debug code" in prompt
+
+    def test_self_check_appears_after_instructions(
+        self, config, event_bus: EventBus, issue
+    ) -> None:
+        """Self-check should appear after Instructions and before UI Guidelines."""
+        runner = AgentRunner(config, event_bus)
+        prompt = runner._build_prompt(issue)
+        instructions_pos = prompt.index("## Instructions")
+        self_check_pos = prompt.index("## Self-Check Before Committing")
+        ui_pos = prompt.index("## UI Guidelines")
+        assert instructions_pos < self_check_pos < ui_pos
+
+    def test_self_check_is_class_constant(self) -> None:
+        """_SELF_CHECK_CHECKLIST should be a non-empty class attribute."""
+        assert hasattr(AgentRunner, "_SELF_CHECK_CHECKLIST")
+        assert len(AgentRunner._SELF_CHECK_CHECKLIST) > 100
+
+    def test_pre_quality_review_includes_edge_case_checks(
+        self, config, event_bus: EventBus, issue
+    ) -> None:
+        """Pre-quality review prompt should include expanded scope items."""
+        runner = AgentRunner(config, event_bus)
+        prompt = runner._build_pre_quality_review_prompt(issue, attempt=1)
+        assert "type hints" in prompt
+        assert "edge cases" in prompt
+        assert "empty inputs" in prompt
+
 
 # ---------------------------------------------------------------------------
 # AgentRunner.run — success path


### PR DESCRIPTION
## Summary
- Added `_SELF_CHECK_CHECKLIST` class constant to `AgentRunner` covering top reviewer fix categories (tests, imports, types, edge cases, debug code)
- Injected checklist into implementation prompt between Instructions and UI Guidelines
- Expanded pre-quality review scope with type hint and edge case verification items

## Test plan
- [x] 4 new tests verify checklist presence, positioning, and expanded review scope
- [x] All 109 agent tests pass
- [x] quality-lite checks pass

Fixes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)