### PR TITLE
Fixes #1102: Add memory manager stale item cleanup

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -544,6 +544,11 @@ class HydraFlowConfig(BaseModel):
         description="When True, memory suggestions skip HITL and go directly to the sync queue",
     )
 
+    memory_prune_stale_items: bool = Field(
+        default=True,
+        description="Remove local memory item files whose source issue is no longer active",
+    )
+
     # Observability context injection
     inject_runtime_logs: bool = Field(
         default=False,

--- a/src/memory.py
+++ b/src/memory.py
@@ -253,6 +253,9 @@ class MemorySyncWorker:
         prev_ids, prev_hash, _ = self._state.get_memory_state()
 
         if not issues:
+            pruned = 0
+            if self._config.memory_prune_stale_items:
+                pruned = self._prune_stale_items([])
             self._state.update_memory_state([], prev_hash)
             self._manifest_store.update_from_learnings([])
             await self._refresh_manifest("memory-sync-empty")
@@ -261,6 +264,8 @@ class MemorySyncWorker:
                 "item_count": 0,
                 "compacted": False,
                 "digest_chars": 0,
+                "pruned": pruned,
+                "issues_closed": 0,
             }
 
         # Extract learnings (now typed) and build digest
@@ -301,6 +306,11 @@ class MemorySyncWorker:
             item_path = items_dir / f"{num}.md"
             item_path.write_text(learning)
 
+        # Prune stale item files
+        pruned = 0
+        if self._config.memory_prune_stale_items:
+            pruned = self._prune_stale_items(current_ids)
+
         # Atomic write of digest
         self._write_digest(digest)
 
@@ -310,13 +320,15 @@ class MemorySyncWorker:
         self._manifest_store.update_from_learnings(learnings)
         await self._refresh_manifest("memory-sync")
         await self._route_adr_candidates(issues)
-        await self._close_synced_issues(issues)
+        closed, _close_failed = await self._close_synced_issues(issues)
 
         return {
             "action": "synced",
             "item_count": len(learnings),
             "compacted": compacted,
             "digest_chars": len(digest),
+            "pruned": pruned,
+            "issues_closed": closed,
         }
 
     def _should_auto_close_issue(self, issue: MemoryIssueData) -> bool:
@@ -335,10 +347,37 @@ class MemorySyncWorker:
         )
         return is_memory or is_transcript
 
-    async def _close_synced_issues(self, issues: list[MemoryIssueData]) -> None:
-        """Close synced memory issues when a PR port is available."""
+    def _prune_stale_items(self, current_ids: list[int]) -> int:
+        """Remove item files whose source issue is no longer active.
+
+        Returns the number of pruned files.
+        """
+        items_dir = self._config.data_path("memory", "items")
+        if not items_dir.is_dir():
+            return 0
+        active = set(current_ids)
+        pruned = 0
+        for path in items_dir.glob("*.md"):
+            try:
+                file_id = int(path.stem)
+            except ValueError:
+                continue
+            if file_id not in active:
+                path.unlink()
+                pruned += 1
+        if pruned:
+            logger.info("Pruned %d stale memory item files", pruned)
+        return pruned
+
+    async def _close_synced_issues(
+        self, issues: list[MemoryIssueData]
+    ) -> tuple[int, int]:
+        """Close synced memory issues when a PR port is available.
+
+        Returns ``(closed, failed)`` counts.
+        """
         if self._prs is None:
-            return
+            return 0, 0
         closed = 0
         failed = 0
         for issue in issues:
@@ -362,6 +401,7 @@ class MemorySyncWorker:
             closed,
             failed,
         )
+        return closed, failed
 
     async def _route_adr_candidates(self, issues: list[MemoryIssueData]) -> None:
         """Create ADR draft tasks from architecture-shift memory issues."""

--- a/src/models.py
+++ b/src/models.py
@@ -1100,6 +1100,8 @@ class MemorySyncResult(TypedDict):
     item_count: int
     compacted: bool
     digest_chars: int
+    pruned: NotRequired[int]
+    issues_closed: NotRequired[int]
 
 
 class UnstickResult(TypedDict):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -248,6 +248,7 @@ class ConfigFactory:
         docker_network: str = "",
         docker_extra_mounts: list[str] | None = None,
         memory_auto_approve: bool = False,
+        memory_prune_stale_items: bool = True,
         transcript_summary_as_issue: bool = False,
         harness_insight_window: int = 20,
         harness_pattern_threshold: int = 3,
@@ -400,6 +401,7 @@ class ConfigFactory:
             if docker_extra_mounts is not None
             else [],
             memory_auto_approve=memory_auto_approve,
+            memory_prune_stale_items=memory_prune_stale_items,
             transcript_summary_as_issue=transcript_summary_as_issue,
             harness_insight_window=harness_insight_window,
             harness_pattern_threshold=harness_pattern_threshold,

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1044,6 +1044,102 @@ class TestMemorySyncWorkerSync:
         for r in results:
             assert not isinstance(r, Exception), f"sync() raised: {r}"
 
+    @pytest.mark.asyncio
+    async def test_sync_prunes_stale_item_files(self, tmp_path: Path) -> None:
+        """Stale .md files in items/ should be removed when their issue is gone."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([10, 20, 30], "oldhash", "")
+        bus = MagicMock()
+
+        # Pre-populate items dir with files for issues 10, 20, 30
+        items_dir = tmp_path / ".hydraflow" / "memory" / "items"
+        items_dir.mkdir(parents=True)
+        for n in [10, 20, 30]:
+            (items_dir / f"{n}.md").write_text(f"learning for {n}")
+
+        worker = MemorySyncWorker(config, state, bus)
+        # Only issue 10 is still active
+        issues = [
+            {"number": 10, "title": "A", "body": "B", "createdAt": ""},
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["pruned"] == 2
+        assert (items_dir / "10.md").exists()
+        assert not (items_dir / "20.md").exists()
+        assert not (items_dir / "30.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_sync_prune_disabled_by_config(self, tmp_path: Path) -> None:
+        """When memory_prune_stale_items is False, no files should be removed."""
+        config = ConfigFactory.create(
+            repo_root=tmp_path, memory_prune_stale_items=False
+        )
+        state = MagicMock()
+        state.get_memory_state.return_value = ([10, 20], "oldhash", "")
+        bus = MagicMock()
+
+        items_dir = tmp_path / ".hydraflow" / "memory" / "items"
+        items_dir.mkdir(parents=True)
+        (items_dir / "10.md").write_text("active")
+        (items_dir / "99.md").write_text("stale")
+
+        worker = MemorySyncWorker(config, state, bus)
+        issues = [
+            {"number": 10, "title": "A", "body": "B", "createdAt": ""},
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats.get("pruned", 0) == 0
+        assert (items_dir / "99.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_sync_returns_issues_closed_count(self, tmp_path: Path) -> None:
+        """Sync result should include issues_closed count."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([], "", None)
+        bus = MagicMock()
+        prs = AsyncMock()
+        prs.close_issue = AsyncMock()
+
+        worker = MemorySyncWorker(config, state, bus, prs=prs)
+        issues = [
+            {
+                "number": 10,
+                "title": "[Memory] Test",
+                "body": "## Memory Suggestion\n\n**Learning:** Test\n\n**Context:** Test",
+                "createdAt": "",
+                "labels": ["hydraflow-memory"],
+            },
+        ]
+        stats = await worker.sync(issues)
+
+        assert stats["issues_closed"] == 1
+        prs.close_issue.assert_awaited_once_with(10)
+
+    @pytest.mark.asyncio
+    async def test_sync_empty_issues_prunes_all_stale_files(
+        self, tmp_path: Path
+    ) -> None:
+        """When no issues remain, all item files should be pruned."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        state = MagicMock()
+        state.get_memory_state.return_value = ([10], "hash", "")
+        bus = MagicMock()
+
+        items_dir = tmp_path / ".hydraflow" / "memory" / "items"
+        items_dir.mkdir(parents=True)
+        (items_dir / "10.md").write_text("stale")
+
+        worker = MemorySyncWorker(config, state, bus)
+        stats = await worker.sync([])
+
+        assert stats["pruned"] == 1
+        assert stats["issues_closed"] == 0
+        assert not (items_dir / "10.md").exists()
+
 
 # --- State tracking tests ---
 


### PR DESCRIPTION
## Summary
- Added `_prune_stale_items()` to `MemorySyncWorker` — removes `.md` files from `items/` when source issue is no longer active
- `_close_synced_issues` now returns `(closed, failed)` counts instead of void
- `MemorySyncResult` includes `pruned` and `issues_closed` fields for dashboard visibility
- New `memory_prune_stale_items` config flag (default `True`) to control pruning behavior
- Both empty-issues and active-issues sync paths include cleanup stats

## Test plan
- [x] 4 new tests: prune stale files, prune disabled by config, issues_closed count, empty-issues prune
- [x] All 140 memory tests pass
- [x] quality-lite checks pass

Fixes #1102

🤖 Generated with [Claude Code](https://claude.com/claude-code)