### PR TITLE
feat: add managed model-pricing JSON asset and cost estimation

### DIFF
--- a/src/assets/model_pricing.json
+++ b/src/assets/model_pricing.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "currency": "USD",
+  "updated_at": "2026-02-28",
+  "source": "https://docs.anthropic.com/en/docs/about-claude/models",
+  "models": {
+    "claude-3-5-haiku-20241022": {
+      "provider": "anthropic",
+      "aliases": ["haiku", "claude-3-5-haiku", "claude-3.5-haiku"],
+      "input_cost_per_million": 0.80,
+      "output_cost_per_million": 4.00,
+      "cache_write_cost_per_million": 1.00,
+      "cache_read_cost_per_million": 0.08
+    },
+    "claude-sonnet-4-20250514": {
+      "provider": "anthropic",
+      "aliases": ["sonnet", "claude-4-sonnet", "claude-sonnet-4"],
+      "input_cost_per_million": 3.00,
+      "output_cost_per_million": 15.00,
+      "cache_write_cost_per_million": 3.75,
+      "cache_read_cost_per_million": 0.30
+    },
+    "claude-opus-4-20250514": {
+      "provider": "anthropic",
+      "aliases": ["opus", "claude-4-opus", "claude-opus-4"],
+      "input_cost_per_million": 15.00,
+      "output_cost_per_million": 75.00,
+      "cache_write_cost_per_million": 18.75,
+      "cache_read_cost_per_million": 1.50
+    }
+  }
+}

--- a/src/model_pricing.py
+++ b/src/model_pricing.py
@@ -1,0 +1,171 @@
+"""Model pricing loader — reads per-model token costs from a managed JSON asset."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("hydraflow.model_pricing")
+
+_ASSET_PATH = Path(__file__).parent / "assets" / "model_pricing.json"
+
+_REQUIRED_COST_FIELDS = frozenset({"input_cost_per_million", "output_cost_per_million"})
+
+
+@dataclass(frozen=True, slots=True)
+class ModelRate:
+    """Per-model token pricing rates (USD per million tokens)."""
+
+    input_cost_per_million: float
+    output_cost_per_million: float
+    cache_write_cost_per_million: float
+    cache_read_cost_per_million: float
+
+    def estimate_cost(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cache_write_tokens: int = 0,
+        cache_read_tokens: int = 0,
+    ) -> float:
+        """Return estimated cost in USD for the given token counts."""
+        return (
+            self.input_cost_per_million * input_tokens
+            + self.output_cost_per_million * output_tokens
+            + self.cache_write_cost_per_million * cache_write_tokens
+            + self.cache_read_cost_per_million * cache_read_tokens
+        ) / 1_000_000
+
+
+class ModelPricingTable:
+    """Loads and resolves model pricing from the managed JSON asset."""
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or _ASSET_PATH
+        self._rates: dict[str, ModelRate] = {}
+        self._aliases: dict[str, str] = {}
+        self._loaded = False
+
+    def _load(self) -> None:
+        """Parse the pricing JSON and build lookup tables."""
+        if self._loaded:
+            return
+        self._loaded = True
+        if not self._path.is_file():
+            logger.warning("Model pricing asset not found: %s", self._path)
+            return
+        try:
+            raw = json.loads(self._path.read_text())
+        except (json.JSONDecodeError, OSError):
+            logger.warning(
+                "Failed to load model pricing from %s", self._path, exc_info=True
+            )
+            return
+        if not isinstance(raw, dict):
+            return
+        models = raw.get("models", {})
+        if not isinstance(models, dict):
+            return
+        for model_id, entry in models.items():
+            if not isinstance(entry, dict):
+                continue
+            if not _REQUIRED_COST_FIELDS.issubset(entry):
+                logger.warning(
+                    "Skipping model %r — missing required cost fields", model_id
+                )
+                continue
+            rate = ModelRate(
+                input_cost_per_million=float(entry["input_cost_per_million"]),
+                output_cost_per_million=float(entry["output_cost_per_million"]),
+                cache_write_cost_per_million=float(
+                    entry.get("cache_write_cost_per_million", 0.0)
+                ),
+                cache_read_cost_per_million=float(
+                    entry.get("cache_read_cost_per_million", 0.0)
+                ),
+            )
+            self._rates[model_id] = rate
+            for alias in entry.get("aliases", []):
+                if isinstance(alias, str):
+                    self._aliases[alias.lower()] = model_id
+
+    def get_rate(self, model: str) -> ModelRate | None:
+        """Look up pricing for *model* by exact ID or alias."""
+        self._load()
+        model_l = model.lower().strip()
+        if model_l in self._rates:
+            return self._rates[model_l]
+        canonical = self._aliases.get(model_l)
+        if canonical:
+            return self._rates.get(canonical)
+        # Fuzzy match: check if any alias is a substring of the model string
+        for alias, canonical_id in self._aliases.items():
+            if alias in model_l:
+                return self._rates.get(canonical_id)
+        return None
+
+    def estimate_cost(
+        self,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cache_write_tokens: int = 0,
+        cache_read_tokens: int = 0,
+    ) -> float | None:
+        """Return estimated cost in USD, or None if model is unknown."""
+        rate = self.get_rate(model)
+        if rate is None:
+            return None
+        return rate.estimate_cost(
+            input_tokens, output_tokens, cache_write_tokens, cache_read_tokens
+        )
+
+    @property
+    def model_ids(self) -> list[str]:
+        """Return all loaded model IDs."""
+        self._load()
+        return list(self._rates)
+
+    def validate(self) -> list[str]:
+        """Return a list of validation errors (empty if valid)."""
+        self._load()
+        errors: list[str] = []
+        if not self._rates:
+            errors.append("No models loaded from pricing asset")
+        for model_id, rate in self._rates.items():
+            if rate.input_cost_per_million < 0:
+                errors.append(f"{model_id}: negative input cost")
+            if rate.output_cost_per_million < 0:
+                errors.append(f"{model_id}: negative output cost")
+        return errors
+
+
+def load_pricing(path: Path | None = None) -> ModelPricingTable:
+    """Load the model pricing table from the default or given path."""
+    return ModelPricingTable(path)
+
+
+def validate_pricing_asset(raw: dict[str, Any]) -> list[str]:
+    """Validate raw pricing JSON structure without loading from disk."""
+    errors: list[str] = []
+    if not isinstance(raw, dict):
+        return ["Root must be a JSON object"]
+    if "schema_version" not in raw:
+        errors.append("Missing schema_version")
+    models = raw.get("models")
+    if not isinstance(models, dict):
+        errors.append("Missing or invalid 'models' key")
+        return errors
+    for model_id, entry in models.items():
+        if not isinstance(entry, dict):
+            errors.append(f"{model_id}: entry must be an object")
+            continue
+        for field in _REQUIRED_COST_FIELDS:
+            if field not in entry:
+                errors.append(f"{model_id}: missing {field}")
+            elif not isinstance(entry[field], int | float):
+                errors.append(f"{model_id}: {field} must be numeric")
+    return errors

--- a/src/prompt_telemetry.py
+++ b/src/prompt_telemetry.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from config import HydraFlowConfig
 from file_util import atomic_write, file_lock
+from model_pricing import ModelPricingTable, load_pricing
 
 logger = logging.getLogger("hydraflow.prompt_telemetry")
 
@@ -37,12 +38,17 @@ def _estimate_tokens(chars: int, model: str) -> tuple[int, float, str]:
 class PromptTelemetry:
     """Writes prompt/inference metrics to filesystem-backed JSON artifacts."""
 
-    def __init__(self, config: HydraFlowConfig) -> None:
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        pricing: ModelPricingTable | None = None,
+    ) -> None:
         self._config = config
         self._dir = config.data_path("metrics", "prompt")
         self._inferences_file = self._dir / "inferences.jsonl"
         self._pr_stats_file = self._dir / "pr_stats.json"
         self._lock_file = self._dir / ".lock"
+        self._pricing = pricing or load_pricing()
 
     def record(
         self,
@@ -154,6 +160,15 @@ class PromptTelemetry:
                 else max(0, history_saved + context_saved)
             ),
         }
+        # Estimate cost from pricing table
+        cost = self._pricing.estimate_cost(
+            model,
+            input_tokens=actual_input_tokens or prompt_tokens,
+            output_tokens=actual_output_tokens or transcript_tokens,
+            cache_write_tokens=actual_cache_creation_tokens,
+            cache_read_tokens=actual_cache_read_tokens,
+        )
+        record["estimated_cost_usd"] = round(cost, 6) if cost is not None else None
         section_chars = st.get("section_chars")
         if isinstance(section_chars, dict):
             clean_sections: dict[str, int] = {}
@@ -344,6 +359,12 @@ class PromptTelemetry:
         target["pruned_chars_total"] = _as_int(
             target.get("pruned_chars_total", 0)
         ) + _as_int(record.get("pruned_chars_total", 0))
+        record_cost = record.get("estimated_cost_usd")
+        if isinstance(record_cost, int | float) and record_cost > 0:
+            target["estimated_cost_usd"] = round(
+                _as_float(target.get("estimated_cost_usd", 0.0)) + float(record_cost),
+                6,
+            )
         target["last_updated"] = str(record.get("timestamp", ""))
 
     def get_pr_totals(self, pr_number: int) -> dict[str, int] | None:
@@ -457,6 +478,20 @@ def _as_int(value: object) -> int:
         except ValueError:
             return 0
     return 0
+
+
+def _as_float(value: object) -> float:
+    """Best-effort float conversion for telemetry cost accumulators."""
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
 
 
 def _get_or_init_dict(

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -1,0 +1,380 @@
+"""Tests for model_pricing.py."""
+
+from __future__ import annotations
+
+import json
+
+from model_pricing import (
+    ModelPricingTable,
+    ModelRate,
+    load_pricing,
+    validate_pricing_asset,
+)
+
+
+class TestModelRate:
+    def test_estimate_cost_input_only(self):
+        rate = ModelRate(
+            input_cost_per_million=3.0,
+            output_cost_per_million=15.0,
+            cache_write_cost_per_million=0.0,
+            cache_read_cost_per_million=0.0,
+        )
+        cost = rate.estimate_cost(input_tokens=1_000_000, output_tokens=0)
+        assert cost == 3.0
+
+    def test_estimate_cost_output_only(self):
+        rate = ModelRate(
+            input_cost_per_million=3.0,
+            output_cost_per_million=15.0,
+            cache_write_cost_per_million=0.0,
+            cache_read_cost_per_million=0.0,
+        )
+        cost = rate.estimate_cost(input_tokens=0, output_tokens=1_000_000)
+        assert cost == 15.0
+
+    def test_estimate_cost_with_cache(self):
+        rate = ModelRate(
+            input_cost_per_million=3.0,
+            output_cost_per_million=15.0,
+            cache_write_cost_per_million=3.75,
+            cache_read_cost_per_million=0.30,
+        )
+        cost = rate.estimate_cost(
+            input_tokens=500_000,
+            output_tokens=100_000,
+            cache_write_tokens=200_000,
+            cache_read_tokens=300_000,
+        )
+        expected = (
+            3.0 * 500_000 + 15.0 * 100_000 + 3.75 * 200_000 + 0.30 * 300_000
+        ) / 1_000_000
+        assert abs(cost - expected) < 1e-9
+
+    def test_frozen_dataclass(self):
+        rate = ModelRate(
+            input_cost_per_million=3.0,
+            output_cost_per_million=15.0,
+            cache_write_cost_per_million=0.0,
+            cache_read_cost_per_million=0.0,
+        )
+        try:
+            rate.input_cost_per_million = 999  # type: ignore[misc]
+            raise AssertionError("Should be frozen")
+        except AttributeError:
+            pass
+
+
+class TestModelPricingTable:
+    def _write_asset(self, tmp_path, data):
+        path = tmp_path / "pricing.json"
+        path.write_text(json.dumps(data))
+        return path
+
+    def test_load_and_get_rate_by_exact_id(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "claude-sonnet-4-20250514": {
+                        "input_cost_per_million": 3.0,
+                        "output_cost_per_million": 15.0,
+                        "aliases": ["sonnet"],
+                    }
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        rate = table.get_rate("claude-sonnet-4-20250514")
+        assert rate is not None
+        assert rate.input_cost_per_million == 3.0
+        assert rate.output_cost_per_million == 15.0
+        assert rate.cache_write_cost_per_million == 0.0
+
+    def test_get_rate_by_alias(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "claude-opus-4-20250514": {
+                        "input_cost_per_million": 15.0,
+                        "output_cost_per_million": 75.0,
+                        "aliases": ["opus", "claude-4-opus"],
+                    }
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        rate = table.get_rate("opus")
+        assert rate is not None
+        assert rate.output_cost_per_million == 75.0
+
+    def test_get_rate_case_insensitive(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "claude-3-5-haiku-20241022": {
+                        "input_cost_per_million": 0.8,
+                        "output_cost_per_million": 4.0,
+                        "aliases": ["haiku"],
+                    }
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        assert table.get_rate("HAIKU") is not None
+        assert table.get_rate("Haiku") is not None
+
+    def test_get_rate_fuzzy_substring_match(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "claude-sonnet-4-20250514": {
+                        "input_cost_per_million": 3.0,
+                        "output_cost_per_million": 15.0,
+                        "aliases": ["sonnet"],
+                    }
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        rate = table.get_rate("claude-sonnet-4-20250514-extended")
+        assert rate is not None
+        assert rate.input_cost_per_million == 3.0
+
+    def test_get_rate_unknown_returns_none(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {},
+            },
+        )
+        table = ModelPricingTable(path)
+        assert table.get_rate("unknown-model") is None
+
+    def test_estimate_cost_delegates_to_rate(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "claude-sonnet-4-20250514": {
+                        "input_cost_per_million": 3.0,
+                        "output_cost_per_million": 15.0,
+                        "aliases": ["sonnet"],
+                    }
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        cost = table.estimate_cost("sonnet", input_tokens=1000, output_tokens=500)
+        expected = (3.0 * 1000 + 15.0 * 500) / 1_000_000
+        assert abs(cost - expected) < 1e-9
+
+    def test_estimate_cost_unknown_returns_none(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {},
+            },
+        )
+        table = ModelPricingTable(path)
+        assert (
+            table.estimate_cost("unknown", input_tokens=100, output_tokens=50) is None
+        )
+
+    def test_model_ids_property(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "model-a": {
+                        "input_cost_per_million": 1.0,
+                        "output_cost_per_million": 2.0,
+                    },
+                    "model-b": {
+                        "input_cost_per_million": 3.0,
+                        "output_cost_per_million": 4.0,
+                    },
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        ids = table.model_ids
+        assert "model-a" in ids
+        assert "model-b" in ids
+        assert len(ids) == 2
+
+    def test_validate_reports_no_errors_for_valid_asset(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "model-a": {
+                        "input_cost_per_million": 1.0,
+                        "output_cost_per_million": 2.0,
+                    },
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        assert table.validate() == []
+
+    def test_validate_reports_empty_models(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {},
+            },
+        )
+        table = ModelPricingTable(path)
+        errors = table.validate()
+        assert any("No models" in e for e in errors)
+
+    def test_validate_reports_negative_cost(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "bad-model": {
+                        "input_cost_per_million": -1.0,
+                        "output_cost_per_million": 2.0,
+                    },
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        errors = table.validate()
+        assert any("negative input cost" in e for e in errors)
+
+    def test_missing_file_returns_none(self, tmp_path):
+        path = tmp_path / "nonexistent.json"
+        table = ModelPricingTable(path)
+        assert table.get_rate("anything") is None
+        assert table.model_ids == []
+
+    def test_corrupt_json_handled_gracefully(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+        table = ModelPricingTable(path)
+        assert table.get_rate("anything") is None
+
+    def test_skips_entry_missing_required_fields(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "incomplete": {"input_cost_per_million": 1.0},
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        assert table.get_rate("incomplete") is None
+        assert table.model_ids == []
+
+    def test_lazy_loading(self, tmp_path):
+        path = self._write_asset(
+            tmp_path,
+            {
+                "schema_version": 1,
+                "models": {
+                    "model-a": {
+                        "input_cost_per_million": 1.0,
+                        "output_cost_per_million": 2.0,
+                    },
+                },
+            },
+        )
+        table = ModelPricingTable(path)
+        assert not table._loaded
+        table.get_rate("model-a")
+        assert table._loaded
+
+
+class TestLoadPricing:
+    def test_returns_table_instance(self, tmp_path):
+        path = tmp_path / "pricing.json"
+        path.write_text(json.dumps({"schema_version": 1, "models": {}}))
+        table = load_pricing(path)
+        assert isinstance(table, ModelPricingTable)
+
+
+class TestValidatePricingAsset:
+    def test_valid_asset_returns_no_errors(self):
+        raw = {
+            "schema_version": 1,
+            "models": {
+                "model-a": {
+                    "input_cost_per_million": 1.0,
+                    "output_cost_per_million": 2.0,
+                },
+            },
+        }
+        assert validate_pricing_asset(raw) == []
+
+    def test_missing_schema_version(self):
+        raw = {
+            "models": {
+                "model-a": {
+                    "input_cost_per_million": 1.0,
+                    "output_cost_per_million": 2.0,
+                },
+            },
+        }
+        errors = validate_pricing_asset(raw)
+        assert any("schema_version" in e for e in errors)
+
+    def test_missing_models_key(self):
+        raw = {"schema_version": 1}
+        errors = validate_pricing_asset(raw)
+        assert any("models" in e for e in errors)
+
+    def test_missing_required_cost_field(self):
+        raw = {
+            "schema_version": 1,
+            "models": {
+                "model-a": {"input_cost_per_million": 1.0},
+            },
+        }
+        errors = validate_pricing_asset(raw)
+        assert any("output_cost_per_million" in e for e in errors)
+
+    def test_non_numeric_cost_field(self):
+        raw = {
+            "schema_version": 1,
+            "models": {
+                "model-a": {
+                    "input_cost_per_million": "not_a_number",
+                    "output_cost_per_million": 2.0,
+                },
+            },
+        }
+        errors = validate_pricing_asset(raw)
+        assert any("must be numeric" in e for e in errors)
+
+    def test_non_dict_root(self):
+        errors = validate_pricing_asset([])  # type: ignore[arg-type]
+        assert errors == ["Root must be a JSON object"]
+
+    def test_non_dict_entry(self):
+        raw = {
+            "schema_version": 1,
+            "models": {
+                "model-a": "not_a_dict",
+            },
+        }
+        errors = validate_pricing_asset(raw)
+        assert any("must be an object" in e for e in errors)

--- a/tests/test_prompt_telemetry.py
+++ b/tests/test_prompt_telemetry.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 
-from prompt_telemetry import PromptTelemetry, parse_command_tool_model
+from model_pricing import ModelPricingTable
+from prompt_telemetry import PromptTelemetry, _as_float, parse_command_tool_model
 from tests.helpers import ConfigFactory
 
 
@@ -334,3 +335,131 @@ class TestPromptTelemetry:
         )
         mtime = telemetry.get_mtime()
         assert mtime > 0.0
+
+    def test_record_includes_estimated_cost_for_known_model(self, tmp_path):
+        pricing_path = tmp_path / "pricing.json"
+        pricing_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "models": {
+                        "claude-sonnet-4-20250514": {
+                            "input_cost_per_million": 3.0,
+                            "output_cost_per_million": 15.0,
+                            "aliases": ["sonnet"],
+                        }
+                    },
+                }
+            )
+        )
+        config = ConfigFactory.create(repo_root=tmp_path)
+        pricing = ModelPricingTable(pricing_path)
+        telemetry = PromptTelemetry(config, pricing=pricing)
+        telemetry.record(
+            source="reviewer",
+            tool="claude",
+            model="sonnet",
+            issue_number=50,
+            pr_number=600,
+            session_id="sess-cost",
+            prompt_chars=800,
+            transcript_chars=400,
+            duration_seconds=1.0,
+            success=True,
+            stats={"input_tokens": 1000, "output_tokens": 500},
+        )
+        inf_file = config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(inf_file.read_text().strip())
+        assert row["estimated_cost_usd"] is not None
+        assert row["estimated_cost_usd"] > 0
+        expected = (3.0 * 1000 + 15.0 * 500) / 1_000_000
+        assert abs(row["estimated_cost_usd"] - expected) < 1e-6
+
+    def test_record_cost_none_for_unknown_model(self, tmp_path):
+        pricing_path = tmp_path / "pricing.json"
+        pricing_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "models": {},
+                }
+            )
+        )
+        config = ConfigFactory.create(repo_root=tmp_path)
+        pricing = ModelPricingTable(pricing_path)
+        telemetry = PromptTelemetry(config, pricing=pricing)
+        telemetry.record(
+            source="reviewer",
+            tool="claude",
+            model="unknown-model",
+            issue_number=51,
+            pr_number=601,
+            session_id="sess-nocost",
+            prompt_chars=100,
+            transcript_chars=50,
+            duration_seconds=0.5,
+            success=True,
+            stats={},
+        )
+        inf_file = config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(inf_file.read_text().strip())
+        assert row["estimated_cost_usd"] is None
+
+    def test_cost_accumulates_across_records(self, tmp_path):
+        pricing_path = tmp_path / "pricing.json"
+        pricing_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "models": {
+                        "claude-opus-4-20250514": {
+                            "input_cost_per_million": 15.0,
+                            "output_cost_per_million": 75.0,
+                            "aliases": ["opus"],
+                        }
+                    },
+                }
+            )
+        )
+        config = ConfigFactory.create(repo_root=tmp_path)
+        pricing = ModelPricingTable(pricing_path)
+        telemetry = PromptTelemetry(config, pricing=pricing)
+        for _ in range(3):
+            telemetry.record(
+                source="implementer",
+                tool="claude",
+                model="opus",
+                issue_number=52,
+                pr_number=700,
+                session_id="sess-accum",
+                prompt_chars=100,
+                transcript_chars=50,
+                duration_seconds=0.1,
+                success=True,
+                stats={"input_tokens": 1000, "output_tokens": 200},
+            )
+        pr_file = config.data_path("metrics", "prompt", "pr_stats.json")
+        rollup = json.loads(pr_file.read_text())
+        pr_cost = rollup["prs"]["700"]["estimated_cost_usd"]
+        single_cost = (15.0 * 1000 + 75.0 * 200) / 1_000_000
+        assert abs(pr_cost - round(single_cost * 3, 6)) < 1e-6
+
+
+class TestAsFloat:
+    def test_int_value(self):
+        assert _as_float(42) == 42.0
+
+    def test_float_value(self):
+        assert _as_float(3.14) == 3.14
+
+    def test_string_value(self):
+        assert _as_float("2.5") == 2.5
+
+    def test_invalid_string(self):
+        assert _as_float("not_a_number") == 0.0
+
+    def test_bool_value(self):
+        assert _as_float(True) == 1.0
+
+    def test_none_value(self):
+        assert _as_float(None) == 0.0


### PR DESCRIPTION
## Summary
- Adds `src/assets/model_pricing.json` with versioned pricing for Claude Haiku, Sonnet, and Opus models
- Adds `src/model_pricing.py` with `ModelPricingTable` loader supporting exact ID, alias, and fuzzy substring model lookup
- Integrates cost estimation into `PromptTelemetry` — each inference record now includes `estimated_cost_usd`, accumulated across PR/session/lifetime rollups
- Adds `_as_float` helper for safe float accumulation in telemetry counters

## Test plan
- [x] 27 new tests for `model_pricing.py` (rate calculation, alias resolution, fuzzy match, validation, error handling)
- [x] 9 new tests for cost integration in `prompt_telemetry.py` (known model cost, unknown model null, accumulation, `_as_float` helper)
- [x] Full test suite passes (5542 passed)

Closes #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)