### PR TITLE
feat: add RepoRuntime isolation boundary and registry

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -17,7 +17,6 @@ from typing import Any
 from config import HydraFlowConfig, load_config_file
 from file_util import atomic_write
 from log import setup_logging
-from orchestrator import HydraFlowOrchestrator
 
 _PREP_COVERAGE_MIN_REQUIRED = 20.0
 _PREP_COVERAGE_TARGET = 70.0
@@ -1316,24 +1315,15 @@ async def _run_main(config: HydraFlowConfig) -> None:
                 await dashboard._orchestrator.stop()
             await dashboard.stop()
     else:
-        from events import EventBus, EventLog
+        from repo_runtime import RepoRuntime
 
-        event_log = EventLog(config.event_log_path)
-        bus = EventBus(event_log=event_log)
-        await bus.rotate_log(
-            config.event_log_max_size_mb * 1024 * 1024,
-            config.event_log_retention_days,
-        )
-        await bus.load_history_from_disk()
-        orchestrator = HydraFlowOrchestrator(config, event_bus=bus)
+        runtime = await RepoRuntime.create(config)
 
         loop = asyncio.get_running_loop()
         for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(
-                sig, lambda: asyncio.create_task(orchestrator.stop())
-            )
+            loop.add_signal_handler(sig, lambda: asyncio.create_task(runtime.stop()))
 
-        await orchestrator.run()
+        await runtime.run()
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/src/models.py
+++ b/src/models.py
@@ -584,6 +584,16 @@ class PipelineStats(BaseModel):
     uptime_seconds: float = 0.0
 
 
+class RepoRuntimeInfo(BaseModel):
+    """Snapshot of a single repo runtime for API/dashboard consumption."""
+
+    slug: str
+    repo: str = ""
+    running: bool = False
+    session_id: str | None = None
+    uptime_seconds: float = 0.0
+
+
 class IssueOutcomeType(StrEnum):
     """How an issue was ultimately resolved."""
 

--- a/src/repo_runtime.py
+++ b/src/repo_runtime.py
@@ -1,0 +1,174 @@
+"""RepoRuntime — per-repo lifecycle boundary for orchestrator + state + events.
+
+Each ``RepoRuntime`` encapsulates the full mutable runtime for a single
+repository: config, event bus, state tracker, and orchestrator.  The
+``RepoRuntimeRegistry`` manages multiple runtimes by slug.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from config import HydraFlowConfig
+from events import EventBus, EventLog
+from orchestrator import HydraFlowOrchestrator
+from state import StateTracker
+
+logger = logging.getLogger("hydraflow.repo_runtime")
+
+
+class RepoRuntime:
+    """Isolated runtime boundary for a single repository.
+
+    Owns the event bus, state tracker, and orchestrator.  Call
+    :meth:`start` to begin the orchestrator loop and :meth:`stop` to
+    shut it down gracefully.
+    """
+
+    def __init__(self, config: HydraFlowConfig) -> None:
+        self._config = config
+        self._slug = config.repo.replace("/", "-") or config.repo_root.name
+        event_log = EventLog(config.event_log_path)
+        self._event_bus = EventBus(event_log=event_log)
+        self._state = StateTracker(config.state_file)
+        self._orchestrator = HydraFlowOrchestrator(
+            config,
+            event_bus=self._event_bus,
+            state=self._state,
+        )
+        self._task: asyncio.Task[None] | None = None
+
+    @classmethod
+    async def create(cls, config: HydraFlowConfig) -> RepoRuntime:
+        """Construct a runtime and perform async initialization.
+
+        Rotates the event log and loads persisted event history before
+        returning the ready-to-start runtime.
+        """
+        runtime = cls(config)
+        await runtime._event_bus.rotate_log(
+            config.event_log_max_size_mb * 1024 * 1024,
+            config.event_log_retention_days,
+        )
+        await runtime._event_bus.load_history_from_disk()
+        return runtime
+
+    # --- Properties ---
+
+    @property
+    def slug(self) -> str:
+        """Repo slug derived from config (e.g. ``owner-repo``)."""
+        return self._slug
+
+    @property
+    def config(self) -> HydraFlowConfig:
+        return self._config
+
+    @property
+    def event_bus(self) -> EventBus:
+        return self._event_bus
+
+    @property
+    def state(self) -> StateTracker:
+        return self._state
+
+    @property
+    def orchestrator(self) -> HydraFlowOrchestrator:
+        return self._orchestrator
+
+    @property
+    def running(self) -> bool:
+        return self._orchestrator.running
+
+    # --- Lifecycle ---
+
+    async def start(self) -> None:
+        """Start the orchestrator loop as a background task."""
+        if self._task and not self._task.done():
+            logger.warning("Runtime %r already running", self._slug)
+            return
+        logger.info("Starting runtime for %r", self._slug)
+        self._task = asyncio.create_task(
+            self._orchestrator.run(), name=f"runtime-{self._slug}"
+        )
+
+    async def run(self) -> None:
+        """Run the orchestrator loop in the foreground (blocks until stopped)."""
+        logger.info("Running runtime for %r", self._slug)
+        await self._orchestrator.run()
+
+    async def stop(self) -> None:
+        """Stop the orchestrator and wait for the loop task to complete."""
+        logger.info("Stopping runtime for %r", self._slug)
+        await self._orchestrator.stop()
+        if self._task and not self._task.done():
+            try:
+                await asyncio.wait_for(self._task, timeout=30)
+            except (TimeoutError, asyncio.CancelledError):
+                logger.warning("Runtime %r did not stop within timeout", self._slug)
+
+    def __repr__(self) -> str:
+        status = "running" if self.running else "stopped"
+        return f"<RepoRuntime slug={self._slug!r} status={status}>"
+
+
+class RepoRuntimeRegistry:
+    """Manages multiple :class:`RepoRuntime` instances by slug.
+
+    Provides lookup, lifecycle management, and graceful shutdown ordering.
+    """
+
+    def __init__(self) -> None:
+        self._runtimes: dict[str, RepoRuntime] = {}
+
+    async def register(self, config: HydraFlowConfig) -> RepoRuntime:
+        """Create and register a runtime for the given config.
+
+        Raises ``ValueError`` if a runtime with the same slug already exists.
+        """
+        runtime = await RepoRuntime.create(config)
+        if runtime.slug in self._runtimes:
+            msg = f"Runtime already registered for slug {runtime.slug!r}"
+            raise ValueError(msg)
+        self._runtimes[runtime.slug] = runtime
+        logger.info("Registered runtime %r", runtime.slug)
+        return runtime
+
+    def get(self, slug: str) -> RepoRuntime | None:
+        """Look up a runtime by slug."""
+        return self._runtimes.get(slug)
+
+    def remove(self, slug: str) -> RepoRuntime | None:
+        """Remove and return a runtime (does not stop it)."""
+        return self._runtimes.pop(slug, None)
+
+    @property
+    def slugs(self) -> list[str]:
+        """Return all registered slug names."""
+        return list(self._runtimes)
+
+    @property
+    def all(self) -> list[RepoRuntime]:
+        """Return all registered runtimes."""
+        return list(self._runtimes.values())
+
+    async def start_all(self) -> None:
+        """Start all registered runtimes as background tasks."""
+        for runtime in self._runtimes.values():
+            await runtime.start()
+
+    async def stop_all(self) -> None:
+        """Stop all registered runtimes gracefully."""
+        tasks = [runtime.stop() for runtime in self._runtimes.values()]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def __len__(self) -> int:
+        return len(self._runtimes)
+
+    def __contains__(self, slug: str) -> bool:
+        return slug in self._runtimes
+
+    def __repr__(self) -> str:
+        return f"<RepoRuntimeRegistry runtimes={len(self._runtimes)}>"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -718,12 +718,16 @@ class TestRunMainSignalHandlers:
             side_effect=lambda sig, cb: registered_signals.append(sig)
         )
 
-        mock_orch = AsyncMock()
-        mock_orch.run = AsyncMock()
-        mock_orch.stop = AsyncMock()
+        mock_runtime = AsyncMock()
+        mock_runtime.run = AsyncMock()
+        mock_runtime.stop = AsyncMock()
 
         with (
-            patch("cli.HydraFlowOrchestrator", return_value=mock_orch),
+            patch(
+                "repo_runtime.RepoRuntime.create",
+                new_callable=AsyncMock,
+                return_value=mock_runtime,
+            ),
             patch("asyncio.get_running_loop", return_value=mock_loop),
         ):
             await _run_main(config)
@@ -733,7 +737,7 @@ class TestRunMainSignalHandlers:
 
     @pytest.mark.asyncio
     async def test_headless_sigint_calls_orchestrator_stop(self) -> None:
-        """Simulating SIGINT callback should trigger orchestrator.stop()."""
+        """Simulating SIGINT callback should trigger runtime.stop()."""
         from tests.helpers import ConfigFactory
 
         config = ConfigFactory.create(dashboard_enabled=False)
@@ -746,8 +750,8 @@ class TestRunMainSignalHandlers:
         mock_loop = MagicMock()
         mock_loop.add_signal_handler = MagicMock(side_effect=capture_handler)
 
-        mock_orch = AsyncMock()
-        mock_orch.stop = AsyncMock()
+        mock_runtime = AsyncMock()
+        mock_runtime.stop = AsyncMock()
 
         async def fake_run() -> None:
             # Simulate signal arriving during run
@@ -757,15 +761,19 @@ class TestRunMainSignalHandlers:
             # Give the stop task a chance to run
             await asyncio.sleep(0)
 
-        mock_orch.run = fake_run
+        mock_runtime.run = fake_run
 
         with (
-            patch("cli.HydraFlowOrchestrator", return_value=mock_orch),
+            patch(
+                "repo_runtime.RepoRuntime.create",
+                new_callable=AsyncMock,
+                return_value=mock_runtime,
+            ),
             patch("asyncio.get_running_loop", return_value=mock_loop),
         ):
             await _run_main(config)
 
-        mock_orch.stop.assert_called_once()
+        mock_runtime.stop.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_dashboard_registers_signal_handlers(self) -> None:

--- a/tests/test_repo_runtime.py
+++ b/tests/test_repo_runtime.py
@@ -1,0 +1,284 @@
+"""Tests for repo_runtime.py — RepoRuntime and RepoRuntimeRegistry."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models import RepoRuntimeInfo
+from repo_runtime import RepoRuntime, RepoRuntimeRegistry
+from tests.helpers import ConfigFactory
+
+
+class TestRepoRuntimeInfo:
+    def test_defaults(self):
+        info = RepoRuntimeInfo(slug="owner-repo")
+        assert info.slug == "owner-repo"
+        assert info.running is False
+        assert info.session_id is None
+        assert info.uptime_seconds == 0.0
+
+    def test_with_values(self):
+        info = RepoRuntimeInfo(
+            slug="org-proj",
+            repo="org/proj",
+            running=True,
+            session_id="sess-1",
+            uptime_seconds=123.4,
+        )
+        assert info.running is True
+        assert info.session_id == "sess-1"
+
+
+class TestRepoRuntime:
+    def test_slug_from_repo(self, tmp_path):
+        config = ConfigFactory.create(repo="acme/widgets", repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = RepoRuntime(config)
+        assert runtime.slug == "acme-widgets"
+
+    def test_slug_fallback_to_dir_name(self, tmp_path):
+        config = ConfigFactory.create(repo="", repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = RepoRuntime(config)
+        assert runtime.slug == tmp_path.name
+
+    def test_properties_expose_internals(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus") as mock_bus_cls,
+            patch("repo_runtime.StateTracker") as mock_state_cls,
+            patch("repo_runtime.HydraFlowOrchestrator") as mock_orch_cls,
+        ):
+            runtime = RepoRuntime(config)
+        assert runtime.config is config
+        assert runtime.event_bus is mock_bus_cls.return_value
+        assert runtime.state is mock_state_cls.return_value
+        assert runtime.orchestrator is mock_orch_cls.return_value
+
+    def test_running_delegates_to_orchestrator(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator") as mock_orch_cls,
+        ):
+            mock_orch_cls.return_value.running = True
+            runtime = RepoRuntime(config)
+        assert runtime.running is True
+
+    @pytest.mark.asyncio
+    async def test_create_initializes_event_log(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_bus = MagicMock()
+        mock_bus.rotate_log = AsyncMock()
+        mock_bus.load_history_from_disk = AsyncMock()
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", return_value=mock_bus),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = await RepoRuntime.create(config)
+        mock_bus.rotate_log.assert_awaited_once()
+        mock_bus.load_history_from_disk.assert_awaited_once()
+        assert runtime.slug
+
+    @pytest.mark.asyncio
+    async def test_start_creates_background_task(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock()
+        mock_orch.running = False
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", return_value=mock_orch),
+        ):
+            runtime = RepoRuntime(config)
+        await runtime.start()
+        assert runtime._task is not None
+        # Let the event loop tick so the task runs
+        await asyncio.sleep(0)
+        mock_orch.run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stop_stops_orchestrator(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_orch = MagicMock()
+        mock_orch.stop = AsyncMock()
+        mock_orch.running = False
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", return_value=mock_orch),
+        ):
+            runtime = RepoRuntime(config)
+        await runtime.stop()
+        mock_orch.stop.assert_awaited_once()
+
+    def test_repr(self, tmp_path):
+        config = ConfigFactory.create(repo="org/proj", repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator") as mock_orch_cls,
+        ):
+            mock_orch_cls.return_value.running = False
+            runtime = RepoRuntime(config)
+        r = repr(runtime)
+        assert "org-proj" in r
+        assert "stopped" in r
+
+
+class TestRepoRuntimeRegistry:
+    @pytest.mark.asyncio
+    async def test_register_and_get(self, tmp_path):
+        config = ConfigFactory.create(repo="org/alpha", repo_root=tmp_path)
+        registry = RepoRuntimeRegistry()
+        mock_bus = MagicMock()
+        mock_bus.rotate_log = AsyncMock()
+        mock_bus.load_history_from_disk = AsyncMock()
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", return_value=mock_bus),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = await registry.register(config)
+        assert registry.get("org-alpha") is runtime
+        assert "org-alpha" in registry
+        assert len(registry) == 1
+        assert registry.slugs == ["org-alpha"]
+
+    @pytest.mark.asyncio
+    async def test_register_duplicate_raises(self, tmp_path):
+        config = ConfigFactory.create(repo="org/beta", repo_root=tmp_path)
+        registry = RepoRuntimeRegistry()
+        mock_bus = MagicMock()
+        mock_bus.rotate_log = AsyncMock()
+        mock_bus.load_history_from_disk = AsyncMock()
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", return_value=mock_bus),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            await registry.register(config)
+            with pytest.raises(ValueError, match="already registered"):
+                await registry.register(config)
+
+    @pytest.mark.asyncio
+    async def test_remove(self, tmp_path):
+        config = ConfigFactory.create(repo="org/gamma", repo_root=tmp_path)
+        registry = RepoRuntimeRegistry()
+        mock_bus = MagicMock()
+        mock_bus.rotate_log = AsyncMock()
+        mock_bus.load_history_from_disk = AsyncMock()
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", return_value=mock_bus),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            await registry.register(config)
+        removed = registry.remove("org-gamma")
+        assert removed is not None
+        assert registry.get("org-gamma") is None
+        assert len(registry) == 0
+
+    @pytest.mark.asyncio
+    async def test_stop_all(self, tmp_path):
+        registry = RepoRuntimeRegistry()
+        configs = [
+            ConfigFactory.create(repo=f"org/repo-{i}", repo_root=tmp_path / f"r{i}")
+            for i in range(2)
+        ]
+        for c in configs:
+            c.repo_root.mkdir(parents=True, exist_ok=True)
+        runtimes = []
+
+        def _make_orch(*_a, **_kw):
+            m = MagicMock()
+            m.stop = AsyncMock()
+            m.running = False
+            return m
+
+        def _make_bus(*_a, **_kw):
+            m = MagicMock()
+            m.rotate_log = AsyncMock()
+            m.load_history_from_disk = AsyncMock()
+            return m
+
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", side_effect=_make_bus),
+            patch("repo_runtime.StateTracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", side_effect=_make_orch),
+        ):
+            for c in configs:
+                rt = await registry.register(c)
+                runtimes.append(rt)
+        await registry.stop_all()
+        for rt in runtimes:
+            rt.orchestrator.stop.assert_awaited_once()
+
+    def test_get_missing_returns_none(self):
+        registry = RepoRuntimeRegistry()
+        assert registry.get("nonexistent") is None
+
+    def test_remove_missing_returns_none(self):
+        registry = RepoRuntimeRegistry()
+        assert registry.remove("nonexistent") is None
+
+    def test_repr(self):
+        registry = RepoRuntimeRegistry()
+        assert "runtimes=0" in repr(registry)
+
+    @pytest.mark.asyncio
+    async def test_two_runtimes_isolated(self, tmp_path):
+        """Two runtimes for different repos have independent state."""
+        registry = RepoRuntimeRegistry()
+        config_a = ConfigFactory.create(repo="org/repo-a", repo_root=tmp_path / "a")
+        config_b = ConfigFactory.create(repo="org/repo-b", repo_root=tmp_path / "b")
+        config_a.repo_root.mkdir(parents=True, exist_ok=True)
+        config_b.repo_root.mkdir(parents=True, exist_ok=True)
+
+        def _make_bus(*_a, **_kw):
+            m = MagicMock()
+            m.rotate_log = AsyncMock()
+            m.load_history_from_disk = AsyncMock()
+            return m
+
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus", side_effect=_make_bus),
+            patch("repo_runtime.StateTracker"),
+            patch(
+                "repo_runtime.HydraFlowOrchestrator",
+                side_effect=lambda *a, **kw: MagicMock(),
+            ),
+        ):
+            rt_a = await registry.register(config_a)
+            rt_b = await registry.register(config_b)
+        assert rt_a.slug != rt_b.slug
+        assert rt_a.orchestrator is not rt_b.orchestrator
+        assert rt_a.event_bus is not rt_b.event_bus
+        assert len(registry) == 2


### PR DESCRIPTION
## Summary
- Adds `src/repo_runtime.py` with `RepoRuntime` class that wraps orchestrator + state tracker + event bus + event log into a formal per-repo lifecycle boundary
- Adds `RepoRuntimeRegistry` for managing multiple runtimes by slug with start/stop/lookup operations
- Adds `RepoRuntimeInfo` Pydantic model to `models.py` for API/dashboard consumption
- Refactors CLI headless path to use `RepoRuntime.create()` instead of manually constructing services
- Updates CLI signal handler tests to match new `RepoRuntime` pattern

## Test plan
- [x] 18 new tests for `RepoRuntime` and `RepoRuntimeRegistry` covering construction, slug derivation, lifecycle, isolation between two runtimes, and registry operations
- [x] Updated 2 existing CLI signal handler tests for new code path
- [x] Full test suite passes (5585 passed, 0 failed)

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)