### PR TITLE
feat: isolate worktree and container lifecycle per repo runtime

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -943,13 +943,18 @@ class HydraFlowConfig(BaseModel):
                 return str(path.relative_to(base))
         return str(path)
 
+    @property
+    def repo_slug(self) -> str:
+        """Normalized repo identifier for path namespacing (e.g. ``org-repo``)."""
+        return self.repo.replace("/", "-") if self.repo else self.repo_root.name
+
     def branch_for_issue(self, issue_number: int) -> str:
         """Return the canonical branch name for a given issue number."""
         return f"agent/issue-{issue_number}"
 
     def worktree_path_for_issue(self, issue_number: int) -> Path:
-        """Return the worktree directory path for a given issue number."""
-        return self.worktree_base / f"issue-{issue_number}"
+        """Return the repo-scoped worktree directory path for a given issue number."""
+        return self.worktree_base / self.repo_slug / f"issue-{issue_number}"
 
     @model_validator(mode="after")
     def resolve_defaults(self) -> HydraFlowConfig:

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -242,7 +242,7 @@ class ImplementPhase:
 
     async def _setup_worktree_and_branch(self, issue: Task, branch: str) -> Path:
         """Ensure worktree exists/resumed and branch is pushed."""
-        wt_path = self._config.worktree_base / f"issue-{issue.id}"
+        wt_path = self._config.worktree_path_for_issue(issue.id)
         if wt_path.is_dir():
             logger.info("Resuming existing worktree for issue #%d", issue.id)
         else:

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -114,7 +114,7 @@ class PostMergeHandler:
             should_merge = await ci_gate_fn(
                 pr,
                 issue,
-                self._config.worktree_base / f"issue-{pr.issue_number}",
+                self._config.worktree_path_for_issue(pr.issue_number),
                 result,
                 worker_id,
             )

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -256,7 +256,7 @@ class ReviewPhase:
         self, pr: PRInfo, task: Task, idx: int
     ) -> Path | None:
         """Ensure worktree exists and main is merged. Returns path or None on conflict."""
-        wt_path = self._config.worktree_base / f"issue-{pr.issue_number}"
+        wt_path = self._config.worktree_path_for_issue(pr.issue_number)
         if not wt_path.exists():
             wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
         merged = await self._merge_with_main(pr, task, wt_path, idx)

--- a/src/worktree.py
+++ b/src/worktree.py
@@ -16,6 +16,7 @@ from subprocess_util import run_subprocess
 logger = logging.getLogger("hydraflow.worktree")
 
 _FETCH_LOCKS: dict[str, asyncio.Lock] = {}
+_WORKTREE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 class WorktreeManager:
@@ -65,6 +66,15 @@ class WorktreeManager:
         if lock is None:
             lock = asyncio.Lock()
             _FETCH_LOCKS[key] = lock
+        return lock
+
+    def _repo_worktree_lock(self) -> asyncio.Lock:
+        """Return a per-repo lock for worktree create/destroy operations."""
+        key = f"wt:{self._config.repo_slug}"
+        lock = _WORKTREE_LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _WORKTREE_LOCKS[key] = lock
         return lock
 
     def _is_main_ref_lock_error(self, message: str) -> bool:
@@ -142,6 +152,11 @@ class WorktreeManager:
 
         Returns the absolute path to the new worktree.
         """
+        async with self._repo_worktree_lock():
+            return await self._create_unlocked(issue_number, branch)
+
+    async def _create_unlocked(self, issue_number: int, branch: str) -> Path:
+        """Inner create logic — must be called under ``_repo_worktree_lock``."""
         wt_path = self._config.worktree_path_for_issue(issue_number)
         logger.info(
             "Creating worktree %s on branch %s",
@@ -154,8 +169,8 @@ class WorktreeManager:
             logger.info("[dry-run] Would create worktree at %s", wt_path)
             return wt_path
 
-        # Ensure base directory exists
-        self._base.mkdir(parents=True, exist_ok=True)
+        # Ensure repo-scoped base directory exists
+        wt_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Clean up any stale local branch (from previous runs) to avoid
         # fetch conflicts and worktree checkout errors
@@ -245,6 +260,11 @@ class WorktreeManager:
 
     async def destroy(self, issue_number: int) -> None:
         """Remove the worktree for *issue_number*."""
+        async with self._repo_worktree_lock():
+            await self._destroy_unlocked(issue_number)
+
+    async def _destroy_unlocked(self, issue_number: int) -> None:
+        """Inner destroy logic — must be called under ``_repo_worktree_lock``."""
         wt_path = self._config.worktree_path_for_issue(issue_number)
         if self._config.dry_run:
             logger.info("[dry-run] Would destroy worktree %s", wt_path)
@@ -279,16 +299,21 @@ class WorktreeManager:
             )
 
     async def destroy_all(self) -> None:
-        """Remove every worktree under the base directory."""
+        """Remove every worktree under this repo's scoped base directory."""
         if not self._base.exists():
             return
-        for child in self._base.iterdir():
-            if child.is_dir() and child.name.startswith("issue-"):
-                try:
-                    num = int(child.name.split("-", 1)[1])
-                    await self.destroy(num)
-                except (ValueError, RuntimeError) as exc:
-                    logger.warning("Could not destroy %s: %s", child, exc)
+        repo_base = self._base / self._config.repo_slug
+        # Also scan the flat (legacy) layout for backward compatibility
+        for scan_dir in (repo_base, self._base):
+            if not scan_dir.exists():
+                continue
+            for child in scan_dir.iterdir():
+                if child.is_dir() and child.name.startswith("issue-"):
+                    try:
+                        num = int(child.name.split("-", 1)[1])
+                        await self.destroy(num)
+                    except (ValueError, RuntimeError) as exc:
+                        logger.warning("Could not destroy %s: %s", child, exc)
 
         # Final prune
         with contextlib.suppress(RuntimeError):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2107,28 +2107,55 @@ class TestWorktreePathForIssue:
 
     def test_returns_path_under_worktree_base(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
+            repo="org/my-repo",
             repo_root=tmp_path,
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.worktree_path_for_issue(42) == tmp_path / "wt" / "issue-42"
+        assert (
+            cfg.worktree_path_for_issue(42)
+            == tmp_path / "wt" / "org-my-repo" / "issue-42"
+        )
 
     def test_single_digit_issue(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
+            repo="org/my-repo",
             repo_root=tmp_path,
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.worktree_path_for_issue(1) == tmp_path / "wt" / "issue-1"
+        assert (
+            cfg.worktree_path_for_issue(1)
+            == tmp_path / "wt" / "org-my-repo" / "issue-1"
+        )
 
     def test_uses_configured_worktree_base(self, tmp_path: Path) -> None:
         custom_base = tmp_path / "custom-worktrees"
         cfg = HydraFlowConfig(
+            repo="org/proj",
             repo_root=tmp_path,
             worktree_base=custom_base,
             state_file=tmp_path / "s.json",
         )
-        assert cfg.worktree_path_for_issue(7) == custom_base / "issue-7"
+        assert cfg.worktree_path_for_issue(7) == custom_base / "org-proj" / "issue-7"
+
+    def test_repo_slug_from_repo(self, tmp_path: Path) -> None:
+        cfg = HydraFlowConfig(
+            repo="acme/widgets",
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.repo_slug == "acme-widgets"
+
+    def test_repo_slug_fallback_to_dir_name(self, tmp_path: Path) -> None:
+        cfg = HydraFlowConfig(
+            repo="",
+            repo_root=tmp_path,
+            worktree_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert cfg.repo_slug == tmp_path.name
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hitl_phase.py
+++ b/tests/test_hitl_phase.py
@@ -43,7 +43,7 @@ def _make_phase(
     fetcher_store = AsyncMock()
     store = IssueStore(config, fetcher_store, bus)
     worktrees = AsyncMock()
-    worktrees.create = AsyncMock(return_value=config.worktree_base / "issue-42")
+    worktrees.create = AsyncMock(return_value=config.worktree_path_for_issue(42))
     worktrees.destroy = AsyncMock()
     hitl_runner = AsyncMock()
     prs = AsyncMock()
@@ -458,7 +458,7 @@ class TestHITLResetsAttempts:
         )
 
         # Create worktree directory
-        wt_path = config.worktree_base / "issue-42"
+        wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
         wt.create = AsyncMock(return_value=wt_path)
 

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -132,11 +132,11 @@ class TestImplementBatch:
         expected = [
             WorkerResultFactory.create(
                 issue_number=1,
-                worktree_path=str(config.worktree_base / "issue-1"),
+                worktree_path=str(config.worktree_path_for_issue(1)),
             ),
             WorkerResultFactory.create(
                 issue_number=2,
-                worktree_path=str(config.worktree_base / "issue-2"),
+                worktree_path=str(config.worktree_path_for_issue(2)),
             ),
         ]
 
@@ -230,7 +230,7 @@ class TestImplementBatch:
         issue = TaskFactory.create(id=77)
 
         # Pre-create worktree directory to simulate resume
-        wt_path = config.worktree_base / "issue-77"
+        wt_path = config.worktree_path_for_issue(77)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = _make_phase(
@@ -1407,7 +1407,7 @@ class TestRunImplementation:
         """When worktree dir exists, should reuse it."""
         issue = TaskFactory.create()
 
-        wt_path = config.worktree_base / "issue-42"
+        wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = _make_phase(config, [issue])
@@ -1503,7 +1503,7 @@ class TestHandleImplementationResult:
             success=False,
             error="No commits found on branch",
             commits=0,
-            worktree_path=str(config.worktree_base / "issue-42"),
+            worktree_path=str(config.worktree_path_for_issue(42)),
         )
 
         phase, _, mock_prs = _make_phase(config, [issue])
@@ -1524,7 +1524,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_base / "issue-42"),
+            worktree_path=str(config.worktree_path_for_issue(42)),
         )
 
         phase, _, mock_prs = _make_phase(
@@ -1546,7 +1546,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_base / "issue-42"),
+            worktree_path=str(config.worktree_path_for_issue(42)),
         )
 
         phase, _, mock_prs = _make_phase(config, [issue])
@@ -1567,7 +1567,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_base / "issue-42"),
+            worktree_path=str(config.worktree_path_for_issue(42)),
         )
 
         phase, _, mock_prs = _make_phase(
@@ -1594,7 +1594,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_base / "issue-42"),
+            worktree_path=str(config.worktree_path_for_issue(42)),
         )
 
         phase, _, mock_prs = _make_phase(

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -55,7 +55,7 @@ class TestMergeConflictResolver:
         result = await resolver.merge_with_main(
             pr,
             issue,
-            config.worktree_base / "issue-42",
+            config.worktree_path_for_issue(42),
             0,
             escalate_fn=escalate_fn,
             publish_fn=publish_fn,
@@ -80,7 +80,7 @@ class TestMergeConflictResolver:
         result = await resolver.merge_with_main(
             pr,
             issue,
-            config.worktree_base / "issue-42",
+            config.worktree_path_for_issue(42),
             0,
             escalate_fn=escalate_fn,
             publish_fn=publish_fn,
@@ -99,7 +99,7 @@ class TestMergeConflictResolver:
         issue = TaskFactory.create()
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -117,7 +117,7 @@ class TestMergeConflictResolver:
         resolver._worktrees.start_merge_main = AsyncMock(return_value=True)
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -138,7 +138,7 @@ class TestMergeConflictResolver:
         resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -160,7 +160,7 @@ class TestMergeConflictResolver:
         resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
@@ -187,7 +187,7 @@ class TestSourceParameter:
         await resolver.resolve_merge_conflicts(
             pr,
             issue,
-            config.worktree_base / "issue-42",
+            config.worktree_path_for_issue(42),
             worker_id=0,
             source="pr_unsticker",
         )
@@ -218,7 +218,7 @@ class TestSourceParameter:
             await resolver.resolve_merge_conflicts(
                 pr,
                 issue,
-                config.worktree_base / "issue-42",
+                config.worktree_path_for_issue(42),
                 worker_id=0,
                 source="test_source",
             )
@@ -255,7 +255,7 @@ class TestWorkerIdNone:
         resolver._bus.publish = track_publish
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=None
+            pr, issue, config.worktree_path_for_issue(42), worker_id=None
         )
 
         # No REVIEW_UPDATE events should have been published
@@ -290,7 +290,7 @@ class TestWorkerIdNone:
         resolver._bus.publish = track_publish
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=1
+            pr, issue, config.worktree_path_for_issue(42), worker_id=1
         )
 
         # Should have published at least one REVIEW_UPDATE event

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -258,7 +258,7 @@ class TestCleanMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
@@ -295,7 +295,7 @@ class TestSuccessfulResolution:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
@@ -334,7 +334,7 @@ class TestFailedResolution:
             return_value=ConflictResolutionResult(success=False, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
@@ -409,7 +409,7 @@ class TestCIFailureResolution:
 
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -454,7 +454,7 @@ class TestGenericResolution:
         wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
@@ -485,7 +485,7 @@ class TestGenericResolution:
         fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
         wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
@@ -522,7 +522,7 @@ class TestAutoMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -562,7 +562,7 @@ class TestAutoMergeDisabled:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -585,9 +585,11 @@ class TestCascadingRebase:
             tmp_path
         )
 
-        # Create worktree dirs
+        # Create worktree dirs (repo-scoped path)
         for i in [1, 2]:
-            (tmp_path / "worktrees" / f"issue-{i}").mkdir(parents=True)
+            unsticker._config.worktree_path_for_issue(i).mkdir(
+                parents=True, exist_ok=True
+            )
 
         remaining = [_make_hitl_item(issue=1), _make_hitl_item(issue=2)]
 
@@ -742,7 +744,9 @@ class TestGoalDrivenLoop:
         )
 
         for i in [1, 2]:
-            (tmp_path / "worktrees" / f"issue-{i}").mkdir(parents=True)
+            unsticker._config.worktree_path_for_issue(i).mkdir(
+                parents=True, exist_ok=True
+            )
 
         items = [
             _make_hitl_item(issue=1, pr=101),
@@ -786,7 +790,7 @@ class TestMergeConflictDelegation:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         pr_url = "https://github.com/test-org/test-repo/pull/100"
@@ -825,7 +829,7 @@ class TestMergeConflictDelegation:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+        unsticker._config.worktree_path_for_issue(42).mkdir(parents=True, exist_ok=True)
 
         await unsticker.unstick([_make_hitl_item(42)])
 
@@ -864,7 +868,7 @@ class TestFreshBranchRebuild:
         )
         prs.force_push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         pr_url = "https://github.com/test-org/test-repo/pull/100"
@@ -895,7 +899,7 @@ class TestFreshBranchRebuild:
             return_value=ConflictResolutionResult(success=False, used_rebuild=False)
         )
 
-        (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+        unsticker._config.worktree_path_for_issue(42).mkdir(parents=True, exist_ok=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
 
@@ -928,7 +932,7 @@ class TestResolverNoneEdgeCases:
         fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
         wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
-        (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+        unsticker._config.worktree_path_for_issue(42).mkdir(parents=True, exist_ok=True)
 
         stats = await unsticker.unstick([_make_hitl_item(42)])
 
@@ -963,7 +967,7 @@ def _setup_ci_fix_memory_test(tmp_path: Path, *, transcript: str = "transcript")
 
     prs.push_branch = AsyncMock(return_value=True)
 
-    (tmp_path / "worktrees" / "issue-42").mkdir(parents=True)
+    unsticker._config.worktree_path_for_issue(42).mkdir(parents=True, exist_ok=True)
     (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
     return unsticker, state, prs, agents, wt, fetcher, bus
@@ -1035,7 +1039,7 @@ class TestCITimeoutResolution:
 
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1124,7 +1128,7 @@ class TestCITimeoutResolution:
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1170,7 +1174,7 @@ class TestCITimeoutResolution:
         agents._verify_result = AsyncMock(return_value=(False, "tests still hang"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1250,7 +1254,7 @@ class TestCITimeoutResolution:
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1313,7 +1317,7 @@ Done."""
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1363,7 +1367,7 @@ Done."""
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1437,7 +1441,7 @@ Done."""
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1510,7 +1514,7 @@ TROUBLESHOOTING_PATTERN_END
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1571,7 +1575,7 @@ TROUBLESHOOTING_PATTERN_END
         agents._verify_result = AsyncMock(return_value=(True, "OK"))
         prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = tmp_path / "worktrees" / "issue-42"
+        wt_dir = unsticker._config.worktree_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 

--- a/tests/test_review_phase.py
+++ b/tests/test_review_phase.py
@@ -67,7 +67,7 @@ class TestReviewPRs:
         phase._prs.add_labels = AsyncMock()
 
         # Ensure worktree path exists
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -88,7 +88,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -147,7 +147,7 @@ class TestReviewPRs:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
 
         # Worktree for issue-999 exists
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -170,7 +170,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -196,7 +196,7 @@ class TestReviewPRs:
         phase._prs.push_branch = AsyncMock(return_value=True)
         phase._prs.merge_pr = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -221,7 +221,7 @@ class TestReviewPRs:
         phase._prs.add_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -252,7 +252,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -285,7 +285,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -313,7 +313,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -342,7 +342,7 @@ class TestReviewPRs:
         # But agent resolves them
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -367,7 +367,7 @@ class TestReviewPRs:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -396,7 +396,7 @@ class TestReviewPRs:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -430,7 +430,7 @@ class TestReviewPRs:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -457,7 +457,7 @@ class TestReviewPRs:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -481,7 +481,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -506,7 +506,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -528,7 +528,7 @@ class TestReviewPRs:
         phase._prs.push_branch = AsyncMock(return_value=True)
         phase._prs.merge_pr = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -553,7 +553,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -574,7 +574,7 @@ class TestReviewPRs:
         phase._prs.push_branch = AsyncMock(return_value=True)
         phase._prs.merge_pr = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -601,7 +601,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -628,7 +628,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -659,7 +659,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -689,7 +689,7 @@ class TestReviewPRs:
             )
         )
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -779,7 +779,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -816,7 +816,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -844,7 +844,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -889,7 +889,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -932,7 +932,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -966,7 +966,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1002,7 +1002,7 @@ class TestWaitAndFixCI:
         phase._prs.merge_pr = AsyncMock(return_value=True)
         phase._prs.wait_for_ci = AsyncMock(return_value=(True, "passed"))
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1057,7 +1057,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1101,7 +1101,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1147,7 +1147,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1193,7 +1193,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1236,7 +1236,7 @@ class TestWaitAndFixCI:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1260,7 +1260,7 @@ class TestResolveMergeConflicts:
         issue = TaskFactory.create()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -1278,7 +1278,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.start_merge_main = AsyncMock(return_value=True)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -1300,7 +1300,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -1323,7 +1323,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result.success is False
@@ -1346,7 +1346,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -1401,7 +1401,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         # Second call to _execute should have received a prompt with the error
@@ -1426,7 +1426,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         # abort_merge called once before attempt 2
@@ -1448,7 +1448,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
@@ -1532,7 +1532,7 @@ class TestResolveMergeConflicts:
             new_callable=AsyncMock,
         ) as mock_fms:
             await phase._resolve_merge_conflicts(
-                pr, issue, config.worktree_base / "issue-42", worker_id=0
+                pr, issue, config.worktree_path_for_issue(42), worker_id=0
             )
 
             mock_fms.assert_awaited_once_with(
@@ -1564,7 +1564,7 @@ class TestResolveMergeConflicts:
             side_effect=RuntimeError("network error"),
         ):
             result = await phase._resolve_merge_conflicts(
-                pr, issue, config.worktree_base / "issue-42", worker_id=0
+                pr, issue, config.worktree_path_for_issue(42), worker_id=0
             )
 
             assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -1593,7 +1593,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1617,7 +1617,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1691,7 +1691,7 @@ class TestActiveIssuesCleanup:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -1713,7 +1713,7 @@ class TestActiveIssuesCleanup:
             side_effect=RuntimeError("merge exploded")
         )
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -1736,7 +1736,7 @@ class TestActiveIssuesCleanup:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -1783,7 +1783,7 @@ class TestActiveIssuesCleanup:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1815,7 +1815,7 @@ class TestReviewUpdateStartEvent:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1840,7 +1840,7 @@ class TestReviewUpdateStartEvent:
         phase = make_review_phase(config, event_bus=event_bus)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [])
@@ -1871,7 +1871,7 @@ class TestReviewUpdateStartEvent:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1910,7 +1910,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1939,7 +1939,7 @@ class TestLifecycleMetricRecording:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1969,7 +1969,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1998,7 +1998,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2029,7 +2029,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2057,7 +2057,7 @@ class TestLifecycleMetricRecording:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2085,7 +2085,7 @@ class TestLifecycleMetricRecording:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2127,7 +2127,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2181,7 +2181,7 @@ class TestLifecycleMetricRecording:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -2219,7 +2219,7 @@ class TestRetrospectiveIntegration:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2254,7 +2254,7 @@ class TestRetrospectiveIntegration:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2282,7 +2282,7 @@ class TestRetrospectiveIntegration:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Should not raise despite retro failure
@@ -2308,7 +2308,7 @@ class TestRetrospectiveIntegration:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -2340,7 +2340,7 @@ class TestReviewInsightIntegration:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2391,7 +2391,7 @@ class TestReviewInsightIntegration:
         phase._prs.create_task = AsyncMock(return_value=999)
         phase._prs.submit_review = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2443,7 +2443,7 @@ class TestReviewInsightIntegration:
         phase._prs.create_task = AsyncMock(return_value=999)
         phase._prs.submit_review = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2469,7 +2469,7 @@ class TestReviewInsightIntegration:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Make the insight store raise
@@ -2507,7 +2507,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2543,7 +2543,7 @@ class TestGranularReviewStatusEvents:
         phase._worktrees.merge_main = AsyncMock(return_value=False)
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2579,7 +2579,7 @@ class TestGranularReviewStatusEvents:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2610,7 +2610,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2643,7 +2643,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.add_labels = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2683,7 +2683,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2742,7 +2742,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2790,7 +2790,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2821,7 +2821,7 @@ class TestGranularReviewStatusEvents:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2859,7 +2859,7 @@ class TestHITLEscalationEvents:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2895,7 +2895,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2948,7 +2948,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -2982,7 +2982,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3021,7 +3021,7 @@ class TestHITLEscalationEvents:
         phase._prs.submit_review = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3070,7 +3070,7 @@ class TestRequestChangesRetry:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         return phase, pr, issue
@@ -3172,7 +3172,7 @@ class TestRequestChangesRetry:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3201,7 +3201,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3227,7 +3227,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3267,7 +3267,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3299,7 +3299,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3341,7 +3341,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -3414,7 +3414,7 @@ class TestSelfFixReReview:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         return phase, pr, issue
@@ -4100,7 +4100,7 @@ class TestMergeWithMain:
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is True
@@ -4123,7 +4123,7 @@ class TestMergeWithMain:
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is True
@@ -4146,7 +4146,7 @@ class TestMergeWithMain:
         phase._prs.add_pr_labels = AsyncMock()
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is False
@@ -4177,7 +4177,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         assert result.fixes_made is True
@@ -4196,7 +4196,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.post_pr_comment.assert_awaited_once_with(101, "Looks good.")
@@ -4217,7 +4217,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.submit_review.assert_not_awaited()
@@ -4238,7 +4238,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.submit_review.assert_awaited_once()
@@ -4261,7 +4261,7 @@ class TestRunAndPostReview:
         )
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         assert result.verdict == ReviewVerdict.REQUEST_CHANGES
@@ -4282,7 +4282,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -4307,7 +4307,7 @@ class TestHandleApprovedMerge:
         phase._prs.add_labels = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -4327,7 +4327,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -4513,7 +4513,7 @@ class TestReviewOneInner:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {})
@@ -4536,7 +4536,7 @@ class TestReviewOneInner:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -4561,7 +4561,7 @@ class TestReviewOneInner:
         phase._prs.add_labels = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -4851,7 +4851,7 @@ class TestWaitAndFixCIEdgeCases:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -4896,7 +4896,7 @@ class TestWaitAndFixCIEdgeCases:
         # Set stop_event before running
         phase._stop_event.set()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -123,7 +123,7 @@ class TestReviewPRs:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
 
         # Worktree for issue-999 exists
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -203,7 +203,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -236,7 +236,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -264,7 +264,7 @@ class TestReviewPRs:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -309,7 +309,7 @@ class TestReviewPRs:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=False)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -636,7 +636,7 @@ class TestReviewPRs:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -687,7 +687,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -711,7 +711,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -785,7 +785,7 @@ class TestActiveIssuesCleanup:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -807,7 +807,7 @@ class TestActiveIssuesCleanup:
             side_effect=RuntimeError("merge exploded")
         )
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -830,7 +830,7 @@ class TestActiveIssuesCleanup:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -914,7 +914,7 @@ class TestReviewUpdateStartEvent:
         phase = make_review_phase(config, event_bus=event_bus)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [])
@@ -973,7 +973,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         assert result.fixes_made is True
@@ -992,7 +992,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.post_pr_comment.assert_awaited_once_with(101, "Looks good.")
@@ -1013,7 +1013,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.submit_review.assert_not_awaited()
@@ -1034,7 +1034,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         phase._prs.submit_review.assert_awaited_once()
@@ -1057,7 +1057,7 @@ class TestRunAndPostReview:
         )
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_base / "issue-42", "diff", 0
+            pr, issue, config.worktree_path_for_issue(42), "diff", 0
         )
 
         assert result.verdict == ReviewVerdict.REQUEST_CHANGES
@@ -1078,7 +1078,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1103,7 +1103,7 @@ class TestHandleApprovedMerge:
         phase._prs.add_labels = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1123,7 +1123,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1304,7 +1304,7 @@ class TestReviewOneInner:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_base / "issue-999"
+        wt = config.worktree_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {})
@@ -1342,7 +1342,7 @@ class TestReviewOneInner:
         phase._prs.add_labels = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -1717,7 +1717,7 @@ class TestSkipGuardNoNewCommits:
         phase._state.set_last_reviewed_sha(42, "abc123def456")
         phase._prs.get_pr_head_sha = AsyncMock(return_value="abc123def456")
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -1819,7 +1819,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(AuthenticationError, match="401"):
@@ -1841,7 +1841,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(CreditExhaustedError, match="limit reached"):
@@ -1859,7 +1859,7 @@ class TestCriticalExceptionPropagation:
         phase._reviewers.review = AsyncMock(side_effect=MemoryError("OOM"))
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(MemoryError, match="OOM"):
@@ -1889,7 +1889,7 @@ class TestCriticalExceptionPropagation:
             await phase._handle_self_fix_re_review(
                 pr,
                 issue,
-                config.worktree_base / "issue-42",
+                config.worktree_path_for_issue(42),
                 original_result,
                 "diff",
                 worker_id=0,
@@ -1915,7 +1915,7 @@ class TestCriticalExceptionPropagation:
             await phase._handle_self_fix_re_review(
                 pr,
                 issue,
-                config.worktree_base / "issue-42",
+                config.worktree_path_for_issue(42),
                 original_result,
                 "diff",
                 worker_id=0,
@@ -1937,7 +1937,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(AuthenticationError):

--- a/tests/test_review_phase_hitl.py
+++ b/tests/test_review_phase_hitl.py
@@ -55,7 +55,7 @@ class TestHITLEscalationEvents:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
         phase._worktrees.abort_merge = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -91,7 +91,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -142,7 +142,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_pr_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -176,7 +176,7 @@ class TestHITLEscalationEvents:
         phase._prs.add_labels = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -215,7 +215,7 @@ class TestHITLEscalationEvents:
         phase._prs.submit_review = AsyncMock()
         phase._worktrees.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -264,7 +264,7 @@ class TestRequestChangesRetry:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         return phase, pr, issue
@@ -366,7 +366,7 @@ class TestRequestChangesRetry:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -395,7 +395,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -421,7 +421,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -461,7 +461,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -493,7 +493,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -535,7 +535,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -574,7 +574,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -615,7 +615,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -657,7 +657,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])

--- a/tests/test_review_phase_merge.py
+++ b/tests/test_review_phase_merge.py
@@ -38,7 +38,7 @@ class TestResolveMergeConflicts:
         issue = TaskFactory.create()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -57,7 +57,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.start_merge_main = AsyncMock(return_value=True)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -80,7 +80,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.start_merge_main = AsyncMock(return_value=False)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -104,7 +104,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result.success is False
@@ -128,7 +128,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -185,7 +185,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         # Second call to _execute should have received a prompt with the error
@@ -211,7 +211,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         # abort_merge called once before attempt 2
@@ -234,7 +234,7 @@ class TestResolveMergeConflicts:
         phase._worktrees.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_base / "issue-42", worker_id=0
+            pr, issue, config.worktree_path_for_issue(42), worker_id=0
         )
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
@@ -321,7 +321,7 @@ class TestResolveMergeConflicts:
             new_callable=AsyncMock,
         ) as mock_fms:
             await phase._resolve_merge_conflicts(
-                pr, issue, config.worktree_base / "issue-42", worker_id=0
+                pr, issue, config.worktree_path_for_issue(42), worker_id=0
             )
 
             mock_fms.assert_awaited_once_with(
@@ -354,7 +354,7 @@ class TestResolveMergeConflicts:
             side_effect=RuntimeError("network error"),
         ):
             result = await phase._resolve_merge_conflicts(
-                pr, issue, config.worktree_base / "issue-42", worker_id=0
+                pr, issue, config.worktree_path_for_issue(42), worker_id=0
             )
 
             assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -374,7 +374,7 @@ class TestMergeWithMain:
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is True
@@ -397,7 +397,7 @@ class TestMergeWithMain:
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is True
@@ -420,7 +420,7 @@ class TestMergeWithMain:
         phase._prs.add_pr_labels = AsyncMock()
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_base / "issue-42", 0
+            pr, issue, config.worktree_path_for_issue(42), 0
         )
 
         assert result is False

--- a/tests/test_stop_resume.py
+++ b/tests/test_stop_resume.py
@@ -455,7 +455,7 @@ class TestWorktreePreservation:
         phase._prs.pull_main = AsyncMock()
 
         # Create worktree path
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -498,7 +498,7 @@ class TestWorktreePreservation:
         phase._prs.swap_pipeline_labels = AsyncMock()
         phase._prs.pull_main = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -528,7 +528,7 @@ class TestWorktreePreservation:
         phase._prs.swap_pipeline_labels = AsyncMock()
         phase._prs.pull_main = AsyncMock()
 
-        wt = config.worktree_base / "issue-42"
+        wt = config.worktree_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Stop event is NOT set

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -1141,7 +1141,7 @@ class TestReviewPhaseWiring:
         mock_judge.judge = AsyncMock(return_value=JudgeVerdict(issue_number=42))
 
         # Create worktree dir
-        wt_path = config.worktree_base / "issue-42"
+        wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase = ReviewPhase(
@@ -1206,7 +1206,7 @@ class TestReviewPhaseWiring:
         mock_prs.post_pr_comment = AsyncMock()
         mock_prs.submit_review = AsyncMock()
 
-        wt_path = config.worktree_base / "issue-42"
+        wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase = ReviewPhase(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -147,7 +147,7 @@ class TestCreate:
         setup_env.assert_called_once()
         create_venv.assert_awaited_once()
         install_hooks.assert_awaited_once()
-        assert result == config.worktree_base / "issue-7"
+        assert result == config.worktree_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_returns_correct_path(self, config, tmp_path: Path) -> None:
@@ -167,7 +167,7 @@ class TestCreate:
         ):
             result = await manager.create(issue_number=99, branch="agent/issue-99")
 
-        assert result == config.worktree_base / "issue-99"
+        assert result == config.worktree_path_for_issue(99)
 
     @pytest.mark.asyncio
     async def test_create_dry_run_skips_git_commands(
@@ -180,7 +180,7 @@ class TestCreate:
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
         mock_exec.assert_not_called()
-        assert result == dry_config.worktree_base / "issue-7"
+        assert result == dry_config.worktree_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_raises_when_fetch_origin_main_fails(
@@ -238,7 +238,7 @@ class TestCreate:
         ):
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
-        assert result == config.worktree_base / "issue-7"
+        assert result == config.worktree_path_for_issue(7)
         assert call_count >= 4  # fetch (fail), fetch (retry), branch, worktree add
         sleep_mock.assert_awaited_once()
 
@@ -357,7 +357,7 @@ class TestCreate:
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
         # _create_venv catches RuntimeError internally, so create completes
-        assert result == config.worktree_base / "issue-7"
+        assert result == config.worktree_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_cleans_up_branch_when_worktree_add_fails(
@@ -449,7 +449,7 @@ class TestDestroy:
         manager = WorktreeManager(config)
 
         # Simulate existing worktree path
-        wt_path = config.worktree_base / "issue-7"
+        wt_path = config.worktree_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc()
@@ -492,7 +492,7 @@ class TestDestroy:
         """destroy should swallow RuntimeError from 'git branch -D' gracefully."""
         manager = WorktreeManager(config)
 
-        wt_path = config.worktree_base / "issue-7"
+        wt_path = config.worktree_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         remove_proc = make_proc(returncode=0)
@@ -518,7 +518,7 @@ class TestDestroy:
         """destroy should propagate RuntimeError when 'git worktree remove --force' fails."""
         manager = WorktreeManager(config)
 
-        wt_path = config.worktree_base / "issue-7"
+        wt_path = config.worktree_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         fail_proc = make_proc(returncode=1, stderr=b"fatal: dirty worktree")
@@ -557,9 +557,10 @@ class TestDestroyAll:
         """destroy_all should call destroy for each issue-N directory."""
         manager = WorktreeManager(config)
 
-        # Create two issue directories
-        (config.worktree_base / "issue-1").mkdir(parents=True, exist_ok=True)
-        (config.worktree_base / "issue-2").mkdir(parents=True, exist_ok=True)
+        # Create two issue directories in the repo-scoped subdirectory
+        repo_base = config.worktree_base / config.repo_slug
+        (repo_base / "issue-1").mkdir(parents=True, exist_ok=True)
+        (repo_base / "issue-2").mkdir(parents=True, exist_ok=True)
 
         destroyed: list[int] = []
 
@@ -593,8 +594,9 @@ class TestDestroyAll:
         """destroy_all should skip directories not named issue-N."""
         manager = WorktreeManager(config)
 
-        (config.worktree_base / "random-dir").mkdir(parents=True, exist_ok=True)
-        (config.worktree_base / "issue-5").mkdir(parents=True, exist_ok=True)
+        repo_base = config.worktree_base / config.repo_slug
+        (repo_base / "random-dir").mkdir(parents=True, exist_ok=True)
+        (repo_base / "issue-5").mkdir(parents=True, exist_ok=True)
 
         destroyed: list[int] = []
 
@@ -608,6 +610,124 @@ class TestDestroyAll:
             await manager.destroy_all()
 
         assert destroyed == [5]
+
+
+# ---------------------------------------------------------------------------
+# Repo-scoped isolation
+# ---------------------------------------------------------------------------
+
+
+class TestRepoScopedPaths:
+    """Verify worktree paths are namespaced by repo slug."""
+
+    def test_worktree_path_includes_repo_slug(self, config) -> None:
+        """worktree_path_for_issue should include repo_slug in the path."""
+        path = config.worktree_path_for_issue(42)
+        assert config.repo_slug in str(path)
+        assert path.name == "issue-42"
+        assert path.parent.name == config.repo_slug
+
+    def test_two_repos_have_distinct_paths(self, tmp_path: Path) -> None:
+        """Two different repos should have non-overlapping worktree paths."""
+        from tests.helpers import ConfigFactory
+
+        cfg_a = ConfigFactory.create(
+            repo="org/repo-a",
+            worktree_base=tmp_path / "worktrees",
+            repo_root=tmp_path / "a",
+        )
+        cfg_b = ConfigFactory.create(
+            repo="org/repo-b",
+            worktree_base=tmp_path / "worktrees",
+            repo_root=tmp_path / "b",
+        )
+        path_a = cfg_a.worktree_path_for_issue(10)
+        path_b = cfg_b.worktree_path_for_issue(10)
+        assert path_a != path_b
+        assert "org-repo-a" in str(path_a)
+        assert "org-repo-b" in str(path_b)
+
+
+class TestPerRepoWorktreeLock:
+    """Verify per-repo locking prevents concurrent worktree operations."""
+
+    @pytest.mark.asyncio
+    async def test_create_delegates_to_create_unlocked(self, config) -> None:
+        """create should delegate to _create_unlocked under the lock."""
+        manager = WorktreeManager(config)
+
+        mock_create = AsyncMock(return_value=config.worktree_path_for_issue(7))
+        with patch.object(manager, "_create_unlocked", mock_create):
+            result = await manager.create(7, "agent/issue-7")
+
+        mock_create.assert_awaited_once_with(7, "agent/issue-7")
+        assert result == config.worktree_path_for_issue(7)
+
+    def test_same_repo_gets_same_lock(self, config) -> None:
+        """Two managers for the same repo should share the same lock."""
+        manager_a = WorktreeManager(config)
+        manager_b = WorktreeManager(config)
+        assert manager_a._repo_worktree_lock() is manager_b._repo_worktree_lock()
+
+    def test_different_repos_get_different_locks(self, tmp_path: Path) -> None:
+        """Two managers for different repos should have independent locks."""
+        from tests.helpers import ConfigFactory
+
+        cfg_a = ConfigFactory.create(
+            repo="org/alpha",
+            worktree_base=tmp_path / "wt",
+            repo_root=tmp_path / "a",
+        )
+        cfg_b = ConfigFactory.create(
+            repo="org/beta",
+            worktree_base=tmp_path / "wt",
+            repo_root=tmp_path / "b",
+        )
+        lock_a = WorktreeManager(cfg_a)._repo_worktree_lock()
+        lock_b = WorktreeManager(cfg_b)._repo_worktree_lock()
+        assert lock_a is not lock_b
+
+
+class TestDestroyAllRepoScoped:
+    """Verify destroy_all only cleans the current repo's worktrees."""
+
+    @pytest.mark.asyncio
+    async def test_destroy_all_only_targets_repo_scoped_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """destroy_all should remove worktrees under the repo-scoped directory."""
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            repo="org/alpha",
+            worktree_base=tmp_path / "worktrees",
+            repo_root=tmp_path / "repo",
+        )
+        manager = WorktreeManager(cfg)
+
+        # Create repo-scoped worktree dirs
+        alpha_base = tmp_path / "worktrees" / "org-alpha"
+        (alpha_base / "issue-1").mkdir(parents=True)
+        (alpha_base / "issue-2").mkdir(parents=True)
+
+        # Create another repo's worktree (should NOT be destroyed)
+        beta_base = tmp_path / "worktrees" / "org-beta"
+        (beta_base / "issue-1").mkdir(parents=True)
+
+        destroyed: list[int] = []
+
+        async def fake_destroy(issue_number: int) -> None:
+            destroyed.append(issue_number)
+
+        with (
+            patch.object(manager, "destroy", side_effect=fake_destroy),
+            patch("worktree.run_subprocess", new_callable=AsyncMock),
+        ):
+            await manager.destroy_all()
+
+        assert sorted(destroyed) == [1, 2]
+        # Beta repo's worktree should still exist
+        assert (beta_base / "issue-1").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `repo_slug` property to `HydraFlowConfig` and namespaces all worktree paths by repo slug to prevent cross-repo collisions
- Adds per-repo `asyncio.Lock` for worktree create/destroy operations ensuring concurrent safety
- Fixes hardcoded `worktree_base / "issue-N"` paths in `implement_phase.py`, `review_phase.py`, and `post_merge_handler.py` to use the centralized `worktree_path_for_issue()` method
- Updates `destroy_all` to scan the repo-scoped subdirectory with legacy flat-layout fallback
- Adds 8 new tests covering repo-scoped paths, lock isolation, and cross-repo safety

## Test plan
- [x] All 5593 existing tests pass (0 failures)
- [x] New tests: `TestRepoScopedPaths`, `TestPerRepoWorktreeLock`, `TestDestroyAllRepoScoped`
- [x] Lint, typecheck, and security checks pass

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)