### PR TITLE
fix: harden already-satisfied guards to prevent false positives

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -431,6 +431,9 @@ Run through this checklist before your final commit:
 - Do NOT run `git push` or `gh pr create`.
 - Ensure `make quality` passes before committing.
 - If you encounter issues, commit what works with a descriptive message.
+- NEVER conclude that the issue is "already satisfied" or that no work is needed.
+  The planner already verified this issue requires implementation. Your job is to
+  write the code, not to second-guess the plan. Always produce commits.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="implementation")}"""
         stats = {

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -71,7 +71,9 @@ class PlanPhase:
         failed (caller should fall through to plan failure handling).
         """
         validation_errors = PlannerRunner.validate_already_satisfied_evidence(
-            result.summary
+            result.summary,
+            issue_body=issue.body,
+            repo_root=self._config.repo_root,
         )
         if validation_errors:
             error_list = "\n".join(f"- {e}" for e in validation_errors)

--- a/src/planner.py
+++ b/src/planner.py
@@ -920,10 +920,19 @@ This closes the issue automatically. False positives waste significant human tim
         return lines[-1][:200] if lines else "No summary provided"
 
     @staticmethod
-    def validate_already_satisfied_evidence(summary: str) -> list[str]:
+    def validate_already_satisfied_evidence(
+        summary: str,
+        issue_body: str = "",
+        repo_root: Path | None = None,
+    ) -> list[str]:
         """Validate that an already-satisfied summary contains required evidence.
 
         Returns a list of error strings.  An empty list means the evidence is valid.
+
+        When *issue_body* and *repo_root* are provided, the validator also
+        checks for new files mentioned in the issue (``ADDED:`` lines in a
+        File Delta section, or items under a ``## New Files`` heading).
+        If any referenced file does not exist on disk, the claim is rejected.
         """
         errors: list[str] = []
         if not summary or not summary.strip():
@@ -950,7 +959,74 @@ This closes the issue automatically. False positives waste significant human tim
         if not criteria_match or not criteria_match.group(1).strip():
             errors.append("Missing or empty 'Criteria:' field")
 
+        # Reject when issue describes many acceptance criteria — complex
+        # issues are almost never "already satisfied"
+        if issue_body:
+            criteria_count = len(re.findall(r"^- \[ \]", issue_body, re.MULTILINE))
+            if criteria_count >= 5:
+                errors.append(
+                    f"Issue has {criteria_count} unchecked acceptance criteria "
+                    f"— too complex to be already satisfied"
+                )
+
+        # Check for new files described in the issue that don't exist yet
+        if issue_body and repo_root:
+            missing = PlannerRunner._check_new_files_exist(issue_body, repo_root)
+            if missing:
+                files_list = ", ".join(missing[:5])
+                errors.append(
+                    f"Issue describes new files that do not exist: {files_list}"
+                )
+
         return errors
+
+    @staticmethod
+    def _check_new_files_exist(issue_body: str, repo_root: Path) -> list[str]:
+        """Extract new file paths from an issue body and check existence.
+
+        Looks for ``ADDED: path/to/file`` lines in a File Delta section
+        and bare file paths under ``## New Files`` headings.
+
+        Returns a list of file paths that do not exist on disk.
+        """
+        new_files: list[str] = []
+
+        # Match "ADDED: path/to/file.ext" lines
+        for match in re.finditer(r"^ADDED:\s*(\S+\.\w+)", issue_body, re.MULTILINE):
+            new_files.append(match.group(1))
+
+        # Match file paths under "## New Files" section
+        in_new_files = False
+        for line in issue_body.splitlines():
+            stripped = line.strip()
+            if re.match(r"^##\s+New Files", stripped):
+                in_new_files = True
+                continue
+            if in_new_files and re.match(r"^##\s+", stripped):
+                break
+            if in_new_files:
+                # Extract backtick-delimited paths
+                for m in re.findall(r"`([^`]+\.\w+)`", stripped):
+                    new_files.append(m)
+                # Extract bold paths
+                for m in re.findall(r"\*\*([^*]+\.\w+)\*\*", stripped):
+                    new_files.append(m)
+                # Extract bare list-item paths: - path/to/file.ext
+                bare = re.match(r"^[-*]\s+(\S+\.\w+)", stripped)
+                if bare and not bare.group(1).startswith("`"):
+                    new_files.append(bare.group(1))
+
+        # Deduplicate and check existence
+        seen: set[str] = set()
+        missing: list[str] = []
+        for fp in new_files:
+            if fp in seen:
+                continue
+            seen.add(fp)
+            if not (repo_root / fp).exists():
+                missing.append(fp)
+
+        return missing
 
     @staticmethod
     def _extract_already_satisfied(transcript: str) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -436,6 +436,16 @@ class TestBuildPrompt:
         assert "edge cases" in prompt
         assert "empty inputs" in prompt
 
+    def test_prompt_forbids_already_satisfied(
+        self, config, event_bus: EventBus, issue
+    ) -> None:
+        """Prompt must instruct agent to never claim issue is already satisfied."""
+        runner = AgentRunner(config, event_bus)
+        prompt = runner._build_prompt(issue)
+        assert "NEVER conclude that the issue is" in prompt
+        assert "already satisfied" in prompt.lower()
+        assert "Always produce commits" in prompt
+
 
 # ---------------------------------------------------------------------------
 # AgentRunner.run — success path

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2026,3 +2026,88 @@ class TestValidateAlreadySatisfiedEvidence:
         )
         errors = PlannerRunner.validate_already_satisfied_evidence(summary)
         assert errors == []
+
+    def test_rejects_when_issue_has_many_acceptance_criteria(self) -> None:
+        """Issues with 5+ unchecked criteria are too complex for 'already satisfied'."""
+        summary = (
+            "Feature: MyClass at src/models.py:42\n"
+            "Tests: test_my_class\n"
+            "Criteria: All criteria met"
+        )
+        issue_body = (
+            "## Acceptance Criteria\n\n"
+            "- [ ] First criterion\n"
+            "- [ ] Second criterion\n"
+            "- [ ] Third criterion\n"
+            "- [ ] Fourth criterion\n"
+            "- [ ] Fifth criterion\n"
+        )
+        errors = PlannerRunner.validate_already_satisfied_evidence(
+            summary, issue_body=issue_body
+        )
+        assert any("acceptance criteria" in e.lower() for e in errors)
+
+    def test_accepts_when_few_acceptance_criteria(self) -> None:
+        """Issues with <5 criteria should pass the criteria count check."""
+        summary = (
+            "Feature: MyClass at src/models.py:42\n"
+            "Tests: test_my_class\n"
+            "Criteria: All criteria met"
+        )
+        issue_body = (
+            "## Acceptance Criteria\n\n- [ ] First criterion\n- [ ] Second criterion\n"
+        )
+        errors = PlannerRunner.validate_already_satisfied_evidence(
+            summary, issue_body=issue_body
+        )
+        assert errors == []
+
+    def test_rejects_when_new_files_do_not_exist(self, tmp_path) -> None:
+        """Already-satisfied claim is invalid when issue describes new files that don't exist."""
+        summary = (
+            "Feature: MyClass at src/models.py:42\n"
+            "Tests: test_my_class\n"
+            "Criteria: All criteria met"
+        )
+        issue_body = (
+            "## New Files\n\n- `src/new_feature.py`\n- `tests/test_new_feature.py`\n"
+        )
+        errors = PlannerRunner.validate_already_satisfied_evidence(
+            summary, issue_body=issue_body, repo_root=tmp_path
+        )
+        assert any("do not exist" in e for e in errors)
+
+    def test_accepts_when_new_files_exist(self, tmp_path) -> None:
+        """No error when described new files actually exist on disk."""
+        summary = (
+            "Feature: MyClass at src/models.py:42\n"
+            "Tests: test_my_class\n"
+            "Criteria: All criteria met"
+        )
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "existing.py").write_text("# exists")
+        issue_body = "## New Files\n\n- `src/existing.py`\n"
+        errors = PlannerRunner.validate_already_satisfied_evidence(
+            summary, issue_body=issue_body, repo_root=tmp_path
+        )
+        assert errors == []
+
+    def test_rejects_file_delta_added_lines(self, tmp_path) -> None:
+        """ADDED: lines in File Delta should be checked for existence."""
+        summary = (
+            "Feature: MyClass at src/models.py:42\n"
+            "Tests: test_my_class\n"
+            "Criteria: All criteria met"
+        )
+        issue_body = (
+            "## File Delta\n\n"
+            "```\n"
+            "MODIFIED: src/config.py\n"
+            "ADDED: src/brand_new.py\n"
+            "ADDED: tests/test_brand_new.py\n"
+            "```\n"
+        )
+        errors = PlannerRunner.validate_already_satisfied_evidence(
+            summary, issue_body=issue_body, repo_root=tmp_path
+        )
+        assert any("do not exist" in e for e in errors)


### PR DESCRIPTION
## Summary
- Adds a prompt-level guard in `agent.py` telling the implementation agent to never claim an issue is "already satisfied" — that determination belongs to the planner only
- Adds an acceptance criteria count guard in `planner.py` that rejects already-satisfied claims when the issue has 5+ unchecked `- [ ]` items
- Adds a new-file existence check in `planner.py` that rejects claims when the issue describes new files (`ADDED:` lines or `## New Files` sections) that don't exist on disk

Addresses root cause from #1547 where the implementation agent falsely claimed a massive feature request was already satisfied without producing any code.

## Test plan
- [x] Unit tests for acceptance criteria count guard (5+ rejects, <5 passes)
- [x] Unit tests for new-file existence check (missing files reject, existing files pass)
- [x] Unit test for ADDED: lines in File Delta sections
- [x] Unit test for agent prompt containing "never already satisfied" rule
- [x] `make lint` passes
- [x] `make test-fast` passes (planner, agent, plan_phase tests all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)