### PR TITLE
feat: add worktree GC background loop

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -42,6 +42,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("pr_unstick_interval", "HYDRAFLOW_PR_UNSTICK_INTERVAL", 3600),
     ("report_issue_interval", "HYDRAFLOW_REPORT_ISSUE_INTERVAL", 30),
     ("epic_monitor_interval", "HYDRAFLOW_EPIC_MONITOR_INTERVAL", 1800),
+    ("worktree_gc_interval", "HYDRAFLOW_WORKTREE_GC_INTERVAL", 1800),
     ("pr_unstick_batch_size", "HYDRAFLOW_PR_UNSTICK_BATCH_SIZE", 10),
     ("max_subskill_attempts", "HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS", 0),
     ("max_debug_attempts", "HYDRAFLOW_MAX_DEBUG_ATTEMPTS", 1),
@@ -360,6 +361,12 @@ class HydraFlowConfig(BaseModel):
     epic_monitor_interval: int = Field(
         default=1800,
         description="Epic monitor loop interval in seconds (default 30 min)",
+    )
+    worktree_gc_interval: int = Field(
+        default=1800,
+        ge=300,
+        le=86400,
+        description="Worktree GC loop interval in seconds (default 30 min)",
     )
     epic_stale_days: int = Field(
         default=7,

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -137,6 +137,7 @@ class HydraFlowOrchestrator:
         self._report_issue_loop = svc.report_issue_loop
         self._epic_manager = svc.epic_manager
         self._epic_monitor_loop = svc.epic_monitor_loop
+        self._worktree_gc_loop = svc.worktree_gc_loop
 
     @property
     def event_bus(self) -> EventBus:
@@ -799,6 +800,7 @@ class HydraFlowOrchestrator:
             ("manifest_refresh", self._manifest_refresh_bg_loop),
             ("report_issue", self._report_issue_loop.run),
             ("epic_monitor", self._epic_monitor_loop.run),
+            ("worktree_gc", self._worktree_gc_loop.run),
             ("pipeline_stats", self._pipeline_stats_loop),
         ]
         tasks: dict[str, asyncio.Task[None]] = {}

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -47,6 +47,7 @@ from triage_phase import TriagePhase
 from troubleshooting_store import TroubleshootingPatternStore
 from verification_judge import VerificationJudge
 from worktree import WorktreeManager
+from worktree_gc_loop import WorktreeGCLoop
 
 if TYPE_CHECKING:
     from metrics_manager import MetricsManager
@@ -96,6 +97,7 @@ class ServiceRegistry:
     manifest_refresh_loop: ManifestRefreshLoop
     report_issue_loop: ReportIssueLoop
     epic_monitor_loop: EpicMonitorLoop
+    worktree_gc_loop: WorktreeGCLoop
 
 
 @dataclass
@@ -332,6 +334,19 @@ def build_services(
         interval_cb=callbacks.get_bg_worker_interval,
     )
 
+    worktree_gc_loop = WorktreeGCLoop(
+        config=config,
+        worktrees=worktrees,
+        prs=prs,
+        state=state,
+        event_bus=event_bus,
+        stop_event=stop_event,
+        status_cb=callbacks.update_bg_worker_status,
+        enabled_cb=callbacks.is_bg_worker_enabled,
+        sleep_fn=callbacks.sleep_or_stop,
+        interval_cb=callbacks.get_bg_worker_interval,
+    )
+
     return ServiceRegistry(
         worktrees=worktrees,
         subprocess_runner=subprocess_runner,
@@ -364,4 +379,5 @@ def build_services(
         manifest_refresh_loop=manifest_refresh_loop,
         report_issue_loop=report_issue_loop,
         epic_monitor_loop=epic_monitor_loop,
+        worktree_gc_loop=worktree_gc_loop,
     )

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -107,7 +107,7 @@ export const PIPELINE_POLLER_PRESETS = [
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'metrics', 'pr_unsticker', 'pipeline_poller', 'report_issue'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'metrics', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -120,6 +120,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   memory_sync: 3600,
   metrics: 7200,
   report_issue: 30,
+  worktree_gc: 1800,
 }
 
 /**
@@ -147,4 +148,5 @@ export const BACKGROUND_WORKERS = [
   { key: 'metrics',         label: 'Metrics Munger', description: 'Updates operational and GitHub metrics used by the dashboard.', color: theme.yellow, system: true },
   { key: 'pr_unsticker',    label: 'PR Unsticker',   description: 'Requeues stalled HITL PRs once requirements are actionable.', color: theme.orange, system: true },
   { key: 'report_issue',   label: 'Report Issue',   description: 'Processes queued bug reports into GitHub issues.', color: theme.red },
+  { key: 'worktree_gc',    label: 'Worktree GC',    description: 'Garbage-collects stale worktrees and orphaned branches.', color: theme.textMuted, system: true },
 ]

--- a/src/worktree_gc_loop.py
+++ b/src/worktree_gc_loop.py
@@ -1,0 +1,275 @@
+"""Background worker loop — garbage-collect stale worktrees and branches."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+from base_background_loop import BaseBackgroundLoop
+from config import HydraFlowConfig
+from events import EventBus
+from models import StatusCallback
+from pr_manager import PRManager
+from state import StateTracker
+from subprocess_util import run_subprocess
+from worktree import WorktreeManager
+
+logger = logging.getLogger("hydraflow.worktree_gc_loop")
+
+# Maximum worktrees to GC per cycle to avoid long-running passes.
+_MAX_GC_PER_CYCLE = 20
+
+
+class WorktreeGCLoop(BaseBackgroundLoop):
+    """Periodically garbage-collects stale worktrees and orphaned branches.
+
+    Catches worktrees that leak when PRs are merged manually, via HITL,
+    or when implementations fail/crash.
+    """
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        worktrees: WorktreeManager,
+        prs: PRManager,
+        state: StateTracker,
+        event_bus: EventBus,
+        stop_event: asyncio.Event,
+        status_cb: StatusCallback,
+        enabled_cb: Callable[[str], bool],
+        sleep_fn: Callable[[int | float], Coroutine[Any, Any, None]],
+        interval_cb: Callable[[str], int] | None = None,
+    ) -> None:
+        super().__init__(
+            worker_name="worktree_gc",
+            config=config,
+            bus=event_bus,
+            stop_event=stop_event,
+            status_cb=status_cb,
+            enabled_cb=enabled_cb,
+            sleep_fn=sleep_fn,
+            interval_cb=interval_cb,
+        )
+        self._worktrees = worktrees
+        self._prs = prs
+        self._state = state
+
+    def _get_default_interval(self) -> int:
+        return self._config.worktree_gc_interval
+
+    async def _do_work(self) -> dict[str, Any] | None:
+        """Run one GC cycle: state worktrees, orphan dirs, prune, orphan branches."""
+        collected = 0
+        skipped = 0
+        errors = 0
+
+        # Phase 1: GC worktrees tracked in state
+        active_worktrees = self._state.get_active_worktrees()
+        for issue_number in list(active_worktrees.keys()):
+            if self._stop_event.is_set() or collected >= _MAX_GC_PER_CYCLE:
+                break
+            try:
+                if await self._is_safe_to_gc(issue_number):
+                    await self._worktrees.destroy(issue_number)
+                    self._state.remove_worktree(issue_number)
+                    collected += 1
+                    logger.info("GC: collected worktree for issue #%d", issue_number)
+                else:
+                    skipped += 1
+            except Exception:
+                logger.warning(
+                    "GC: failed to collect worktree for issue #%d",
+                    issue_number,
+                    exc_info=True,
+                )
+                errors += 1
+
+        # Phase 2: scan filesystem for orphaned issue-* dirs not in state
+        if not self._stop_event.is_set():
+            orphan_count = await self._collect_orphaned_dirs(
+                active_worktrees, _MAX_GC_PER_CYCLE - collected
+            )
+            collected += orphan_count
+
+        # Phase 3: run git worktree prune
+        if not self._stop_event.is_set():
+            await self._git_worktree_prune()
+
+        # Phase 4: delete orphaned agent/issue-* local branches
+        if not self._stop_event.is_set():
+            branch_count = await self._collect_orphaned_branches()
+            collected += branch_count
+
+        return {"collected": collected, "skipped": skipped, "errors": errors}
+
+    async def _is_safe_to_gc(self, issue_number: int) -> bool:
+        """Determine whether a worktree for *issue_number* can be safely GC'd.
+
+        Returns False (skip) on any uncertainty.
+        """
+        # Skip if currently being processed or HITL in progress
+        if (
+            issue_number in self._state.get_active_issue_numbers()
+            or self._state.get_hitl_cause(issue_number) is not None
+        ):
+            return False
+
+        # Check issue state via GitHub API
+        try:
+            issue_state = await self._get_issue_state(issue_number)
+        except Exception:
+            logger.debug(
+                "GC: could not fetch issue #%d state — skipping",
+                issue_number,
+                exc_info=True,
+            )
+            return False
+
+        if issue_state == "closed":
+            return True
+
+        # Issue is open — only GC if no open PR exists
+        if issue_state == "open":
+            try:
+                return not await self._has_open_pr(issue_number)
+            except Exception:
+                logger.debug(
+                    "GC: could not check PR for issue #%d — skipping",
+                    issue_number,
+                    exc_info=True,
+                )
+                return False
+
+        # Unknown state — don't GC
+        return False
+
+    async def _get_issue_state(self, issue_number: int) -> str:
+        """Query GitHub for the issue state ('open' or 'closed')."""
+        output = await run_subprocess(
+            "gh",
+            "api",
+            f"repos/{self._config.repo}/issues/{issue_number}",
+            "--jq",
+            ".state",
+            cwd=self._config.repo_root,
+            gh_token=self._config.gh_token,
+        )
+        return output.strip()
+
+    async def _has_open_pr(self, issue_number: int) -> bool:
+        """Check whether an open PR exists for the issue's branch."""
+        branch = self._config.branch_for_issue(issue_number)
+        try:
+            output = await run_subprocess(
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number",
+                "--jq",
+                "length",
+                cwd=self._config.repo_root,
+                gh_token=self._config.gh_token,
+            )
+            return int(output.strip() or "0") > 0
+        except (RuntimeError, ValueError):
+            return True  # Assume PR exists on error — don't GC
+
+    async def _collect_orphaned_dirs(self, tracked: dict[int, str], budget: int) -> int:
+        """Scan filesystem for orphaned issue-* dirs not tracked in state."""
+        collected = 0
+        repo_wt_base = self._config.worktree_base / self._config.repo_slug
+        if not repo_wt_base.exists():
+            return 0
+
+        tracked_issues = set(tracked.keys())
+        for child in sorted(repo_wt_base.iterdir()):
+            if collected >= budget or self._stop_event.is_set():
+                break
+            if not child.is_dir() or not child.name.startswith("issue-"):
+                continue
+            try:
+                issue_num = int(child.name.split("-", 1)[1])
+            except (ValueError, IndexError):
+                continue
+            if issue_num in tracked_issues:
+                continue
+            try:
+                if await self._is_safe_to_gc(issue_num):
+                    await self._worktrees.destroy(issue_num)
+                    collected += 1
+                    logger.info(
+                        "GC: collected orphaned worktree dir for issue #%d", issue_num
+                    )
+            except Exception:
+                logger.warning(
+                    "GC: failed to collect orphaned dir for issue #%d",
+                    issue_num,
+                    exc_info=True,
+                )
+        return collected
+
+    async def _git_worktree_prune(self) -> None:
+        """Run ``git worktree prune`` to clean up stale bookkeeping."""
+        try:
+            await run_subprocess(
+                "git",
+                "worktree",
+                "prune",
+                cwd=self._config.repo_root,
+                gh_token=self._config.gh_token,
+            )
+        except RuntimeError:
+            logger.warning("GC: git worktree prune failed", exc_info=True)
+
+    _AGENT_BRANCH_RE = re.compile(r"^agent/issue-(\d+)$")
+
+    async def _collect_orphaned_branches(self) -> int:
+        """Delete local ``agent/issue-*`` branches with no corresponding worktree."""
+        collected = 0
+        try:
+            output = await run_subprocess(
+                "git",
+                "branch",
+                "--list",
+                "agent/issue-*",
+                cwd=self._config.repo_root,
+                gh_token=self._config.gh_token,
+            )
+        except RuntimeError:
+            logger.warning("GC: could not list local branches", exc_info=True)
+            return 0
+
+        active_worktrees = self._state.get_active_worktrees()
+        active_issues = set(self._state.get_active_issue_numbers())
+
+        for line in output.strip().splitlines():
+            branch = line.strip().lstrip("* ")
+            match = self._AGENT_BRANCH_RE.match(branch)
+            if not match:
+                continue
+            issue_num = int(match.group(1))
+            # Skip if worktree exists or issue is active
+            if issue_num in active_worktrees or issue_num in active_issues:
+                continue
+            try:
+                await run_subprocess(
+                    "git",
+                    "branch",
+                    "-D",
+                    branch,
+                    cwd=self._config.repo_root,
+                    gh_token=self._config.gh_token,
+                )
+                collected += 1
+                logger.info("GC: deleted orphaned branch %s", branch)
+            except RuntimeError:
+                logger.debug("GC: could not delete branch %s", branch, exc_info=True)
+        return collected

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -271,6 +271,7 @@ class ConfigFactory:
         auto_process_epics: bool = False,
         auto_process_bug_reports: bool = False,
         epic_monitor_interval: int = 1800,
+        worktree_gc_interval: int = 1800,
         epic_stale_days: int = 7,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
@@ -428,6 +429,7 @@ class ConfigFactory:
             epic_auto_decompose=epic_auto_decompose,
             epic_decompose_complexity_threshold=epic_decompose_complexity_threshold,
             epic_monitor_interval=epic_monitor_interval,
+            worktree_gc_interval=worktree_gc_interval,
             epic_stale_days=epic_stale_days,
             auto_process_epics=auto_process_epics,
             auto_process_bug_reports=auto_process_bug_reports,

--- a/tests/test_worktree_gc_loop.py
+++ b/tests/test_worktree_gc_loop.py
@@ -1,0 +1,351 @@
+"""Tests for the WorktreeGCLoop background worker."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from events import EventType
+from state import StateTracker
+from tests.helpers import make_bg_loop_deps
+from worktree_gc_loop import WorktreeGCLoop
+
+
+def _make_loop(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+    interval: int = 600,
+    active_worktrees: dict[int, str] | None = None,
+    active_issue_numbers: list[int] | None = None,
+    hitl_causes: dict[int, str] | None = None,
+) -> tuple[WorktreeGCLoop, StateTracker, asyncio.Event]:
+    """Build a WorktreeGCLoop with test-friendly defaults."""
+    deps = make_bg_loop_deps(tmp_path, enabled=enabled, worktree_gc_interval=interval)
+
+    state = StateTracker(deps.config.state_file)
+    for num, path in (active_worktrees or {}).items():
+        state.set_worktree(num, path)
+    if active_issue_numbers:
+        state.set_active_issue_numbers(active_issue_numbers)
+    for num, cause in (hitl_causes or {}).items():
+        state.set_hitl_cause(num, cause)
+
+    worktrees = MagicMock()
+    worktrees.destroy = AsyncMock()
+
+    prs = MagicMock()
+
+    loop = WorktreeGCLoop(
+        config=deps.config,
+        worktrees=worktrees,
+        prs=prs,
+        state=state,
+        event_bus=deps.bus,
+        stop_event=deps.stop_event,
+        status_cb=deps.status_cb,
+        enabled_cb=deps.enabled_cb,
+        sleep_fn=deps.sleep_fn,
+        interval_cb=None,
+    )
+    # Stub out subprocess-calling methods by default so unit tests
+    # don't hit the real filesystem/git.  Individual tests override
+    # these when they want to verify prune/branch behaviour.
+    loop._git_worktree_prune = AsyncMock()  # type: ignore[method-assign]
+    loop._collect_orphaned_branches = AsyncMock(return_value=0)  # type: ignore[method-assign]
+    return loop, state, deps.stop_event
+
+
+class TestWorktreeGCLoopBasics:
+    """Basic loop lifecycle tests."""
+
+    def test_worker_name(self, tmp_path: Path) -> None:
+        """Worker name is 'worktree_gc'."""
+        loop, _state, _stop = _make_loop(tmp_path)
+        assert loop._worker_name == "worktree_gc"
+
+    def test_default_interval(self, tmp_path: Path) -> None:
+        """Default interval comes from config.worktree_gc_interval."""
+        loop, _state, _stop = _make_loop(tmp_path, interval=900)
+        assert loop._get_default_interval() == 900
+
+    @pytest.mark.asyncio
+    async def test_run__skips_when_disabled(self, tmp_path: Path) -> None:
+        """The loop skips work when the enabled callback returns False."""
+        loop, _state, _stop = _make_loop(tmp_path, enabled=False)
+
+        await loop.run()
+
+        loop._status_cb.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run__publishes_status_on_success(self, tmp_path: Path) -> None:
+        """The loop publishes a BACKGROUND_WORKER_STATUS event on success."""
+        loop, _state, _stop = _make_loop(tmp_path)
+
+        with patch.object(
+            loop,
+            "_do_work",
+            new_callable=AsyncMock,
+            return_value={"collected": 0, "skipped": 0, "errors": 0},
+        ):
+            await loop.run()
+
+        events = [
+            e
+            for e in loop._bus.get_history()
+            if e.type == EventType.BACKGROUND_WORKER_STATUS
+        ]
+        assert len(events) >= 1
+        assert events[0].data["worker"] == "worktree_gc"
+        assert events[0].data["status"] == "ok"
+
+
+class TestWorktreeGCCollectsClosedIssues:
+    """Tests for GC of worktrees whose issues are closed."""
+
+    @pytest.mark.asyncio
+    async def test_gc_closed_issue_worktree(self, tmp_path: Path) -> None:
+        """Worktrees for closed issues are destroyed and removed from state."""
+        loop, state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(return_value="closed")
+
+        await loop._do_work()
+
+        loop._worktrees.destroy.assert_awaited_once_with(42)
+        assert 42 not in state.get_active_worktrees()
+
+    @pytest.mark.asyncio
+    async def test_gc_returns_collected_count(self, tmp_path: Path) -> None:
+        """_do_work returns stats with collected count."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(return_value="closed")
+
+        result = await loop._do_work()
+
+        assert result["collected"] >= 1
+
+
+class TestWorktreeGCSkipsActive:
+    """Tests for skipping active worktrees."""
+
+    @pytest.mark.asyncio
+    async def test_skips_active_issue(self, tmp_path: Path) -> None:
+        """Worktrees for issues in active_issue_numbers are skipped."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+            active_issue_numbers=[42],
+        )
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_hitl_in_progress(self, tmp_path: Path) -> None:
+        """Worktrees for issues with HITL cause are skipped."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+            hitl_causes={42: "ci_failure"},
+        )
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_open_issue_with_pr(self, tmp_path: Path) -> None:
+        """Worktrees for open issues with an open PR are skipped."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(return_value="open")
+        loop._has_open_pr = AsyncMock(return_value=True)
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_gc_open_issue_without_pr(self, tmp_path: Path) -> None:
+        """Worktrees for open issues with no open PR are collected."""
+        loop, state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(return_value="open")
+        loop._has_open_pr = AsyncMock(return_value=False)
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_awaited_once_with(42)
+        assert result["collected"] >= 1
+
+
+class TestWorktreeGCOrphanedDirs:
+    """Tests for orphaned filesystem worktree cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_collects_orphaned_filesystem_dirs(self, tmp_path: Path) -> None:
+        """Orphaned issue-* dirs not in state are collected."""
+        loop, _state, _stop = _make_loop(tmp_path)
+
+        # Create orphaned dir on filesystem
+        repo_slug = loop._config.repo_slug
+        orphan_dir = loop._config.worktree_base / repo_slug / "issue-99"
+        orphan_dir.mkdir(parents=True)
+
+        loop._get_issue_state = AsyncMock(return_value="closed")
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_awaited_once_with(99)
+        assert result["collected"] >= 1
+
+
+class TestWorktreeGCPrune:
+    """Tests for git worktree prune."""
+
+    @pytest.mark.asyncio
+    async def test_git_worktree_prune_called(self, tmp_path: Path) -> None:
+        """git worktree prune is called each cycle."""
+        loop, _state, _stop = _make_loop(tmp_path)
+        # Restore real method for this test
+        loop._git_worktree_prune = WorktreeGCLoop._git_worktree_prune.__get__(loop)  # type: ignore[attr-defined]
+
+        with patch(
+            "worktree_gc_loop.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = ""
+            await loop._git_worktree_prune()
+
+        mock_run.assert_awaited_once()
+        args = mock_run.call_args[0]
+        assert args[:3] == ("git", "worktree", "prune")
+
+
+class TestWorktreeGCOrphanedBranches:
+    """Tests for orphaned branch cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_orphaned_branches(self, tmp_path: Path) -> None:
+        """Local agent/issue-* branches with no worktree are deleted."""
+        loop, _state, _stop = _make_loop(tmp_path)
+        # Restore real method for this test
+        loop._collect_orphaned_branches = (
+            WorktreeGCLoop._collect_orphaned_branches.__get__(loop)
+        )  # type: ignore[attr-defined]
+
+        with patch(
+            "worktree_gc_loop.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            # First call: git branch --list returns orphaned branch
+            # Second call: git branch -D deletes it
+            mock_run.side_effect = [
+                "  agent/issue-99\n",
+                "",
+            ]
+            count = await loop._collect_orphaned_branches()
+
+        assert count == 1
+        # Second call should be the delete
+        delete_call = mock_run.call_args_list[1]
+        assert delete_call[0] == ("git", "branch", "-D", "agent/issue-99")
+
+    @pytest.mark.asyncio
+    async def test_skips_branches_with_active_worktree(self, tmp_path: Path) -> None:
+        """Branches for issues with active worktrees are not deleted."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={99: "/some/path/issue-99"},
+        )
+        # Restore real method for this test
+        loop._collect_orphaned_branches = (
+            WorktreeGCLoop._collect_orphaned_branches.__get__(loop)
+        )  # type: ignore[attr-defined]
+
+        with patch(
+            "worktree_gc_loop.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.return_value = "  agent/issue-99\n"
+            count = await loop._collect_orphaned_branches()
+
+        assert count == 0
+        # Only one call (listing) — no delete
+        assert mock_run.await_count == 1
+
+
+class TestWorktreeGCErrorHandling:
+    """Tests for graceful error handling."""
+
+    @pytest.mark.asyncio
+    async def test_api_error_skips_worktree(self, tmp_path: Path) -> None:
+        """GitHub API errors cause the worktree to be skipped, not GC'd."""
+        loop, state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(side_effect=RuntimeError("API failure"))
+
+        result = await loop._do_work()
+
+        loop._worktrees.destroy.assert_not_awaited()
+        assert 42 in state.get_active_worktrees()
+        assert result["skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_destroy_error_increments_error_count(self, tmp_path: Path) -> None:
+        """Errors during worktree destroy are counted."""
+        loop, _state, _stop = _make_loop(
+            tmp_path,
+            active_worktrees={42: "/some/path/issue-42"},
+        )
+
+        loop._get_issue_state = AsyncMock(return_value="closed")
+        loop._worktrees.destroy = AsyncMock(side_effect=RuntimeError("destroy failed"))
+
+        result = await loop._do_work()
+
+        assert result["errors"] == 1
+
+
+class TestWorktreeGCStopEvent:
+    """Tests for early exit on stop event."""
+
+    @pytest.mark.asyncio
+    async def test_stop_event_halts_gc(self, tmp_path: Path) -> None:
+        """Setting the stop event mid-cycle halts GC processing."""
+        loop, _state, stop_event = _make_loop(
+            tmp_path,
+            active_worktrees={1: "/p/issue-1", 2: "/p/issue-2", 3: "/p/issue-3"},
+        )
+        stop_event.set()
+
+        result = await loop._do_work()
+
+        # With stop set, no worktrees should be processed
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["collected"] == 0


### PR DESCRIPTION
## Summary
  - Adds WorktreeGCLoop that periodically garbage-collects stale worktrees and orphaned branches
  - Runs 4 phases per cycle: state-tracked worktrees, orphaned dirs, git worktree prune, orphaned branches
  - Safety checks skip active issues, HITL-in-progress, issues with open PRs, and API errors
  - Configurable via HYDRAFLOW_WORKTREE_GC_INTERVAL (default 30min)
  - 17 unit tests, all quality gates pass