### PR TITLE
feat: add collaborator check to issue pipeline

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -43,6 +43,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("report_issue_interval", "HYDRAFLOW_REPORT_ISSUE_INTERVAL", 30),
     ("epic_monitor_interval", "HYDRAFLOW_EPIC_MONITOR_INTERVAL", 1800),
     ("worktree_gc_interval", "HYDRAFLOW_WORKTREE_GC_INTERVAL", 1800),
+    ("collaborator_cache_ttl", "HYDRAFLOW_COLLABORATOR_CACHE_TTL", 600),
     ("pr_unstick_batch_size", "HYDRAFLOW_PR_UNSTICK_BATCH_SIZE", 10),
     ("max_subskill_attempts", "HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS", 0),
     ("max_debug_attempts", "HYDRAFLOW_MAX_DEBUG_ATTEMPTS", 1),
@@ -108,6 +109,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ),
     ("auto_process_epics", "HYDRAFLOW_AUTO_PROCESS_EPICS", False),
     ("auto_process_bug_reports", "HYDRAFLOW_AUTO_PROCESS_BUG_REPORTS", False),
+    ("collaborator_check_enabled", "HYDRAFLOW_COLLABORATOR_CHECK_ENABLED", True),
 ]
 
 # Literal-typed env-var overrides.
@@ -367,6 +369,16 @@ class HydraFlowConfig(BaseModel):
         ge=300,
         le=86400,
         description="Worktree GC loop interval in seconds (default 30 min)",
+    )
+    collaborator_check_enabled: bool = Field(
+        default=True,
+        description="When True, skip issues from non-collaborators at fetch time",
+    )
+    collaborator_cache_ttl: int = Field(
+        default=600,
+        ge=60,
+        le=7200,
+        description="Collaborator list cache TTL in seconds (default 10 min)",
     )
     epic_stale_days: int = Field(
         default=7,

--- a/src/issue_fetcher.py
+++ b/src/issue_fetcher.py
@@ -28,12 +28,16 @@ class IssueFetcher:
         self._rate_limited_until: datetime | None = None
         self._rate_limit_recovery_attempts = 0
         self._rate_limit_lock = asyncio.Lock()
+        self._collaborators: set[str] | None = None
+        self._collaborators_fetched_at: datetime | None = None
 
     @staticmethod
     def _normalize_issue_payload(item: dict) -> dict:
         """Map REST/CLI issue shapes to the GitHubIssue-compatible payload."""
         comments_raw = item.get("comments", [])
         comments: list = comments_raw if isinstance(comments_raw, list) else []
+        user = item.get("user")
+        author = user.get("login", "") if isinstance(user, dict) else ""
         return {
             "number": item.get("number"),
             "title": item.get("title", ""),
@@ -42,7 +46,65 @@ class IssueFetcher:
             "comments": comments,
             "url": item.get("html_url", item.get("url", "")),
             "createdAt": item.get("createdAt", item.get("created_at", "")),
+            "author": author,
         }
+
+    async def _get_collaborators(self) -> set[str] | None:
+        """Fetch and cache the repo's collaborator logins.
+
+        Returns ``None`` on API failure (fail-open).  The cache is
+        refreshed after ``collaborator_cache_ttl`` seconds.
+        """
+        now = datetime.now(UTC)
+        if (
+            self._collaborators is not None
+            and self._collaborators_fetched_at is not None
+            and (now - self._collaborators_fetched_at).total_seconds()
+            < self._config.collaborator_cache_ttl
+        ):
+            return self._collaborators
+
+        try:
+            raw = await run_subprocess(
+                "gh",
+                "api",
+                f"repos/{self._config.repo}/collaborators",
+                "--paginate",
+                "--jq",
+                ".[].login",
+                gh_token=self._config.gh_token,
+            )
+            logins = {line.strip() for line in raw.strip().splitlines() if line.strip()}
+            self._collaborators = logins
+            self._collaborators_fetched_at = now
+            return logins
+        except (RuntimeError, json.JSONDecodeError, FileNotFoundError) as exc:
+            logger.warning("Could not fetch collaborators (fail-open): %s", exc)
+            return None
+
+    def _filter_non_collaborators(
+        self,
+        issues: list[GitHubIssue],
+        collaborators: set[str] | None,
+    ) -> list[GitHubIssue]:
+        """Remove issues authored by non-collaborators.
+
+        Issues with an empty author pass through.  If *collaborators* is
+        ``None`` (API failure), all issues pass through (fail-open).
+        """
+        if collaborators is None:
+            return issues
+        result: list[GitHubIssue] = []
+        for issue in issues:
+            if not issue.author or issue.author in collaborators:
+                result.append(issue)
+            else:
+                logger.warning(
+                    "Skipping issue #%d from non-collaborator %s",
+                    issue.number,
+                    issue.author,
+                )
+        return result
 
     async def fetch_issues_by_labels(
         self,
@@ -150,6 +212,9 @@ class IssueFetcher:
             )
 
         issues = [GitHubIssue.model_validate(raw) for raw in seen.values()]
+        if self._config.collaborator_check_enabled:
+            collaborators = await self._get_collaborators()
+            issues = self._filter_non_collaborators(issues, collaborators)
         return issues[:limit]
 
     def _is_rate_limited_now(self) -> bool:
@@ -251,7 +316,7 @@ class IssueFetcher:
                 "api",
                 f"repos/{self._config.repo}/issues/{issue_number}",
                 "--jq",
-                "{number, title, body, labels, url: .html_url, createdAt: .created_at}",
+                '{number, title, body, labels, url: .html_url, createdAt: .created_at, author: (.user.login // "")}',
                 gh_token=self._config.gh_token,
             )
             data = json.loads(raw)

--- a/src/models.py
+++ b/src/models.py
@@ -140,6 +140,7 @@ class GitHubIssue(BaseModel):
     labels: list[str] = Field(default_factory=list)
     comments: list[str] = Field(default_factory=list)
     url: HttpUrl = ""
+    author: str = ""
     created_at: str = Field(
         default="",
         validation_alias=AliasChoices("createdAt", "created_at"),
@@ -163,6 +164,9 @@ class GitHubIssue(BaseModel):
 
     def to_task(self) -> Task:
         """Convert to a source-agnostic :class:`Task`."""
+        metadata: dict[str, Any] = {}
+        if self.author:
+            metadata["author"] = self.author
         return Task(
             id=self.number,
             title=self.title,
@@ -172,6 +176,7 @@ class GitHubIssue(BaseModel):
             source_url=self.url,
             created_at=self.created_at,
             links=parse_task_links(self.body),
+            metadata=metadata,
         )
 
     @classmethod
@@ -185,6 +190,7 @@ class GitHubIssue(BaseModel):
             comments=list(task.comments),
             url=task.source_url,
             created_at=task.created_at,
+            author=task.metadata.get("author", ""),
         )
 
 
@@ -818,6 +824,43 @@ class EpicDetail(BaseModel):
     created_at: str = ""
     auto_decomposed: bool = False
     children: list[EpicChildInfo] = Field(default_factory=list)
+
+
+class Crate(BaseModel):
+    """A GitHub milestone used as a delivery work package (crate)."""
+
+    number: int
+    title: str
+    description: str = ""
+    due_on: str | None = None
+    state: str = "open"
+    open_issues: int = 0
+    closed_issues: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class CrateCreateRequest(BaseModel):
+    """Request body for POST /api/crates."""
+
+    title: str
+    description: str = ""
+    due_on: str | None = None
+
+
+class CrateUpdateRequest(BaseModel):
+    """Request body for PATCH /api/crates/{number}."""
+
+    title: str | None = None
+    description: str | None = None
+    due_on: str | None = None
+    state: str | None = None
+
+
+class CrateItemsRequest(BaseModel):
+    """Request body for POST/DELETE /api/crates/{number}/items."""
+
+    issue_numbers: list[int] = Field(default_factory=list)
 
 
 class PipelineIssueStatus(StrEnum):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -273,6 +273,8 @@ class ConfigFactory:
         epic_monitor_interval: int = 1800,
         worktree_gc_interval: int = 1800,
         epic_stale_days: int = 7,
+        collaborator_check_enabled: bool = False,
+        collaborator_cache_ttl: int = 600,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -433,6 +435,8 @@ class ConfigFactory:
             epic_stale_days=epic_stale_days,
             auto_process_epics=auto_process_epics,
             auto_process_bug_reports=auto_process_bug_reports,
+            collaborator_check_enabled=collaborator_check_enabled,
+            collaborator_cache_ttl=collaborator_cache_ttl,
         )
 
 

--- a/tests/test_issue_fetcher.py
+++ b/tests/test_issue_fetcher.py
@@ -1086,3 +1086,228 @@ class TestFetchAllHydraFlowIssues:
             pytest.raises(IncompleteIssueFetchError),
         ):
             await fetcher.fetch_all_hydraflow_issues()
+
+
+# ---------------------------------------------------------------------------
+# Collaborator check
+# ---------------------------------------------------------------------------
+
+RAW_COLLAB_ISSUES = json.dumps(
+    [
+        {
+            "number": 1,
+            "title": "From collaborator",
+            "body": "",
+            "labels": [{"name": "ready"}],
+            "comments": [],
+            "url": "",
+            "user": {"login": "alice"},
+        },
+        {
+            "number": 2,
+            "title": "From outsider",
+            "body": "",
+            "labels": [{"name": "ready"}],
+            "comments": [],
+            "url": "",
+            "user": {"login": "mallory"},
+        },
+    ]
+)
+
+
+def _collab_config(tmp_path: Path, *, enabled: bool = True) -> HydraFlowConfig:
+    """Build a config with collaborator check toggled."""
+    from tests.helpers import ConfigFactory
+
+    return ConfigFactory.create(
+        repo_root=tmp_path / "repo",
+        worktree_base=tmp_path / "worktrees",
+        state_file=tmp_path / "state.json",
+        collaborator_check_enabled=enabled,
+    )
+
+
+class TestCollaboratorCheck:
+    """Tests for the collaborator filtering in IssueFetcher."""
+
+    @pytest.mark.asyncio
+    async def test_non_collaborator_issues_skipped(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=True)
+        fetcher = IssueFetcher(cfg)
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                return "alice\nbob\n"
+            return RAW_COLLAB_ISSUES
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            issues = await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert len(issues) == 1
+        assert issues[0].number == 1
+        assert issues[0].author == "alice"
+
+    @pytest.mark.asyncio
+    async def test_all_issues_allowed_when_disabled(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=False)
+        fetcher = IssueFetcher(cfg)
+        collab_called = False
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            nonlocal collab_called
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                collab_called = True
+                return "alice\n"
+            return RAW_COLLAB_ISSUES
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            issues = await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert len(issues) == 2
+        assert not collab_called, "collaborator API should not be called when disabled"
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_api_error(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=True)
+        fetcher = IssueFetcher(cfg)
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                raise RuntimeError("API error")
+            return RAW_COLLAB_ISSUES
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            issues = await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert len(issues) == 2
+
+    @pytest.mark.asyncio
+    async def test_cache_reused_within_ttl(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=True)
+        fetcher = IssueFetcher(cfg)
+        call_count = 0
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            nonlocal call_count
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                call_count += 1
+                return "alice\n"
+            return RAW_COLLAB_ISSUES
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+            await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_issues_without_author_pass_through(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=True)
+        fetcher = IssueFetcher(cfg)
+
+        no_author_issues = json.dumps(
+            [
+                {
+                    "number": 99,
+                    "title": "No author",
+                    "body": "",
+                    "labels": [{"name": "ready"}],
+                    "comments": [],
+                    "url": "",
+                }
+            ]
+        )
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                return "alice\n"
+            return no_author_issues
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            issues = await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert len(issues) == 1
+        assert issues[0].number == 99
+
+    @pytest.mark.asyncio
+    async def test_cache_expires_after_ttl(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=True)
+        fetcher = IssueFetcher(cfg)
+        call_count = 0
+
+        async def fake_run(*args: str, **kwargs: Any) -> str:
+            nonlocal call_count
+            joined = " ".join(str(a) for a in args)
+            if "/collaborators" in joined:
+                call_count += 1
+                return "alice\n"
+            return RAW_COLLAB_ISSUES
+
+        with patch("issue_fetcher.run_subprocess", side_effect=fake_run):
+            await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+            assert call_count == 1
+
+            # Expire the cache by backdating the fetch timestamp
+            fetcher._collaborators_fetched_at = datetime.now(UTC) - timedelta(
+                seconds=cfg.collaborator_cache_ttl + 1
+            )
+            await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fetch_issue_by_number_extracts_author(self, tmp_path: Path) -> None:
+        cfg = _collab_config(tmp_path, enabled=False)
+        fetcher = IssueFetcher(cfg)
+
+        issue_json = json.dumps(
+            {
+                "number": 42,
+                "title": "Test",
+                "body": "",
+                "labels": [],
+                "url": "https://github.com/test-org/test-repo/issues/42",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "author": "alice",
+            }
+        )
+        comments_json = json.dumps([])
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(
+            side_effect=[
+                (issue_json.encode(), b""),
+                (comments_json.encode(), b""),
+            ]
+        )
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            issue = await fetcher.fetch_issue_by_number(42)
+
+        assert issue is not None
+        assert issue.author == "alice"
+
+    def test_normalize_extracts_user_login(self) -> None:
+        payload = {
+            "number": 1,
+            "title": "Test",
+            "user": {"login": "alice"},
+        }
+        result = IssueFetcher._normalize_issue_payload(payload)
+        assert result["author"] == "alice"
+
+    def test_normalize_handles_missing_user(self) -> None:
+        payload = {"number": 1, "title": "Test"}
+        result = IssueFetcher._normalize_issue_payload(payload)
+        assert result["author"] == ""
+
+    def test_normalize_handles_null_user(self) -> None:
+        payload = {"number": 1, "title": "Test", "user": None}
+        result = IssueFetcher._normalize_issue_payload(payload)
+        assert result["author"] == ""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -248,6 +248,28 @@ class TestGitHubIssue:
         assert issue.comments == ["LGTM", "Needs tests"]
         assert issue.url == "https://github.com/org/repo/issues/42"
 
+    # -- Author field ----------------------------------------------------------
+
+    def test_author_defaults_to_empty_string(self) -> None:
+        issue = GitHubIssue(number=1, title="t")
+        assert issue.author == ""
+
+    def test_author_propagated_to_task_metadata(self) -> None:
+        issue = GitHubIssue(number=1, title="t", author="alice")
+        task = issue.to_task()
+        assert task.metadata["author"] == "alice"
+
+    def test_empty_author_not_in_metadata(self) -> None:
+        issue = GitHubIssue(number=1, title="t", author="")
+        task = issue.to_task()
+        assert "author" not in task.metadata
+
+    def test_from_task_round_trips_author(self) -> None:
+        issue = GitHubIssue(number=1, title="t", author="bob")
+        task = issue.to_task()
+        restored = GitHubIssue.from_task(task)
+        assert restored.author == "bob"
+
 
 # ---------------------------------------------------------------------------
 # Task


### PR DESCRIPTION
## Summary

- Adds defense-in-depth collaborator filtering at the `IssueFetcher` level to complement the GitHub Actions auto-close workflow (#1671)
- Extracts issue author from the GitHub API response, caches the repo's collaborator list (10 min TTL), and silently skips non-collaborator issues before they enter any pipeline queue
- **Fail-open**: API errors fetching collaborators allow all issues through so transient GitHub outages don't block legitimate work

## Test plan

- [x] 10 new tests covering filtering, disabled mode, fail-open, cache reuse/expiry, empty-author passthrough, normalize extraction, null user handling, and `fetch_issue_by_number` author extraction
- [x] Existing 5850+ tests unaffected (ConfigFactory defaults `collaborator_check_enabled=False`)
- [x] `make lint`, `make typecheck`, `make test-fast` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)