### PR TITLE
Fixes #1623: "config.py resolve_defaults validator order creates ci...

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1323,6 +1323,9 @@ def _resolve_repo_scoped_paths(config: HydraFlowConfig) -> None:
     explicit = config.__pydantic_fields_set__
 
     # Target directory: repo-scoped when a slug is available, flat otherwise.
+    # NOTE: repo_slug never returns "" for a non-root repo_root, so the `else
+    # data_root` branch below and the `if slug` migration guards are only
+    # reached when repo_root is the filesystem root ("/").
     repo_dir = data_root / slug if slug else data_root
 
     # --- state_file ---

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4750,6 +4750,21 @@ class TestNamespaceRepoPaths:
         cfg = HydraFlowConfig(repo_root=tmp_path, repo="acme/widgets")
         assert cfg.state_file.read_text() == '{"new": true}'
 
+    def test_no_migration_when_scoped_event_log_already_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """If scoped events.jsonl already exists, legacy file should not overwrite it."""
+        data_root = tmp_path / ".hydraflow"
+        data_root.mkdir()
+        legacy_events = data_root / "events.jsonl"
+        legacy_events.write_text('{"event":"old"}\n')
+        scoped_dir = data_root / "acme-widgets"
+        scoped_dir.mkdir(parents=True)
+        (scoped_dir / "events.jsonl").write_text('{"event":"new"}\n')
+
+        cfg = HydraFlowConfig(repo_root=tmp_path, repo="acme/widgets")
+        assert cfg.event_log_path.read_text() == '{"event":"new"}\n'
+
 
 # ---------------------------------------------------------------------------
 # Two-phase path resolution order (base paths → repo → repo-scoped paths)


### PR DESCRIPTION
## Summary

Closes #1623.

## Issue

"config.py resolve_defaults validator order creates circular dependency for repo-namespaced paths"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow