### PR TITLE
Fix milestones API defaulting to POST instead of GET

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1723,6 +1723,8 @@ class PRManager:
             "gh",
             "api",
             f"repos/{self._repo}/milestones",
+            "--method",
+            "GET",
             "-f",
             f"state={state}",
             "-f",


### PR DESCRIPTION
## Summary
- The `list_milestones` method uses `gh api` with `-f` flags, which causes it to default to POST (create milestone endpoint) instead of GET (list milestones endpoint)
- Added `--method GET` so `-f` params become query string parameters and `state=all` / `per_page=100` work correctly

## Test plan
- [x] Verified `gh api repos/T-rav/hyrda/milestones --method GET -f state=all -f per_page=100 --paginate` returns successfully
- [ ] Confirm dashboard crate fetching no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)