### PR TITLE
fix: add missing name field to skill-stocktake frontmatter

### DIFF
--- a/.codex/skills/skill-stocktake/SKILL.md
+++ b/.codex/skills/skill-stocktake/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: skill-stocktake
 description: "Use when auditing Claude skills and commands for quality. Supports Quick Scan (changed skills only) and Full Stocktake modes with sequential subagent batch evaluation."
 origin: ECC
 ---


### PR DESCRIPTION
## Summary
- add missing `name` field to `.codex/skills/skill-stocktake/SKILL.md` frontmatter
- resolves skill loader warning about invalid SKILL.md YAML

## Validation
- local skill frontmatter check confirms `name` present
- pre-push quality-lite checks passed
