### PR TITLE
Make Add Repo flow folder-picker only

### DIFF
--- a/src/dashboard_routes.py
+++ b/src/dashboard_routes.py
@@ -7,6 +7,7 @@ import contextlib
 import importlib
 import logging
 import os
+import sys
 import tempfile
 import time
 from collections import Counter
@@ -102,6 +103,80 @@ _INFERENCE_COUNTER_KEYS: tuple[str, ...] = (
     "cache_hits",
     "cache_misses",
 )
+
+
+async def _run_dialog_command(*cmd: str, timeout_seconds: float = 30.0) -> str | None:
+    """Run a folder-picker shell command and return trimmed stdout on success."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
+    except (FileNotFoundError, OSError, TimeoutError):
+        return None
+    if proc.returncode != 0:
+        return None
+    selected = (stdout or b"").decode().strip()
+    return selected or None
+
+
+async def _pick_folder_with_dialog() -> str | None:
+    """Open a best-effort native folder picker and return the selected path."""
+    try:
+        import tkinter as tk  # noqa: PLC0415
+        from tkinter import filedialog  # noqa: PLC0415
+
+        def _choose_dir() -> str | None:
+            root = tk.Tk()
+            root.withdraw()
+            with contextlib.suppress(Exception):
+                root.wm_attributes("-topmost", 1)
+            try:
+                selected = filedialog.askdirectory(title="Select repository folder")
+                return selected or None
+            finally:
+                root.destroy()
+
+        selected = await asyncio.to_thread(_choose_dir)
+        if selected:
+            return selected
+    except Exception:
+        logger.debug("Tk folder picker unavailable", exc_info=True)
+
+    if sys.platform == "darwin":
+        selected = await _run_dialog_command(
+            "osascript",
+            "-e",
+            'POSIX path of (choose folder with prompt "Select repository folder")',
+        )
+        if selected:
+            return selected
+    elif sys.platform.startswith("linux"):
+        selected = await _run_dialog_command(
+            "zenity",
+            "--file-selection",
+            "--directory",
+            "--title=Select repository folder",
+        )
+        if selected:
+            return selected
+    elif sys.platform.startswith("win"):
+        selected = await _run_dialog_command(
+            "powershell",
+            "-NoProfile",
+            "-Command",
+            (
+                "[System.Reflection.Assembly]::LoadWithPartialName"
+                "('System.Windows.Forms') | Out-Null; "
+                "$d = New-Object System.Windows.Forms.FolderBrowserDialog; "
+                "if ($d.ShowDialog() -eq 'OK') { Write-Output $d.SelectedPath }"
+            ),
+        )
+        if selected:
+            return selected
+    return None
 
 
 def _parse_iso_or_none(raw: str | None) -> datetime | None:
@@ -2848,6 +2923,19 @@ def create_router(
                 "labels_created": labels_created,
             }
         )
+
+    @router.post("/api/repos/pick-folder")
+    async def pick_repo_folder() -> JSONResponse:
+        """Open a native folder picker and return the selected path."""
+        selected = await _pick_folder_with_dialog()
+        if not selected:
+            return JSONResponse({"error": "No folder selected"}, status_code=400)
+        path = Path(os.path.realpath(os.path.expanduser(selected)))
+        if not path.is_dir():
+            return JSONResponse(
+                {"error": "Selected path is not a directory"}, status_code=400
+            )
+        return JSONResponse({"path": str(path)})
 
     @router.post("/api/intent")
     async def submit_intent(request: IntentRequest) -> JSONResponse:

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from 'react'
+import React, { useState, useMemo } from 'react'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { theme } from '../theme'
 import { PULSE_ANIMATION } from '../constants'
@@ -22,17 +22,15 @@ export function SessionSidebar() {
     runtimes = [],
     startRuntime = () => {},
     stopRuntime = () => {},
-    addRepoShortcut,
+    addRepoFromPicker,
     removeRepoShortcut,
   } = useHydraFlow()
   const [expandedRepos, setExpandedRepos] = useState({})
   const [hoveredSession, setHoveredSession] = useState(null)
   const [hoveredDeleteId, setHoveredDeleteId] = useState(null)
   const [showAddRepo, setShowAddRepo] = useState(false)
-  const [addRepoValue, setAddRepoValue] = useState('')
   const [addRepoError, setAddRepoError] = useState('')
   const [isAddRepoSubmitting, setIsAddRepoSubmitting] = useState(false)
-  const addRepoInputRef = useRef(null)
 
   const repoEntries = useMemo(() => {
     const entries = new Map()
@@ -97,41 +95,26 @@ export function SessionSidebar() {
     deleteSession(sessionId)
   }
 
-  useEffect(() => {
-    if (showAddRepo && addRepoInputRef.current) {
-      addRepoInputRef.current.focus()
+  const handlePickRepoFolder = async () => {
+    if (isAddRepoSubmitting) return
+    if (!addRepoFromPicker) {
+      setAddRepoError('Folder picker is unavailable')
+      return
     }
-  }, [showAddRepo])
-
-  const handleAddRepoSubmit = async () => {
-    const trimmed = addRepoValue.trim()
-    if (!trimmed || isAddRepoSubmitting) return
     setIsAddRepoSubmitting(true)
+    setAddRepoError('')
     try {
-      if (addRepoShortcut) {
-        const result = await addRepoShortcut(trimmed)
-        if (result && !result.ok) {
-          setAddRepoError(result.error || 'Failed to add repo')
-          return
-        }
+      const result = await addRepoFromPicker()
+      if (result && !result.ok) {
+        setAddRepoError(result.error || 'Failed to add repo')
+        return
       }
       setAddRepoError('')
-      setAddRepoValue('')
       setShowAddRepo(false)
     } catch {
       setAddRepoError('Failed to add repo')
     } finally {
       setIsAddRepoSubmitting(false)
-    }
-  }
-
-  const handleAddRepoKeyDown = (e) => {
-    if (e.key === 'Enter') {
-      handleAddRepoSubmit()
-    } else if (e.key === 'Escape') {
-      setAddRepoError('')
-      setAddRepoValue('')
-      setShowAddRepo(false)
     }
   }
 
@@ -165,7 +148,7 @@ export function SessionSidebar() {
           onClick={(e) => {
             e.stopPropagation()
             setShowAddRepo(prev => {
-              if (prev) { setAddRepoError(''); setAddRepoValue('') }
+              if (prev) setAddRepoError('')
               return !prev
             })
           }}
@@ -178,17 +161,14 @@ export function SessionSidebar() {
       </div>
       {showAddRepo && (
         <div style={styles.addRepoRow}>
-          <input
-            ref={addRepoInputRef}
-            type="text"
-            value={addRepoValue}
-            onChange={(e) => { setAddRepoError(''); setAddRepoValue(e.target.value) }}
-            onKeyDown={handleAddRepoKeyDown}
-            placeholder="owner/repo or /path/to/repo"
+          <button
+            onClick={handlePickRepoFolder}
             disabled={isAddRepoSubmitting}
-            aria-invalid={addRepoError ? 'true' : undefined}
-            style={addRepoError ? addRepoInputError : styles.addRepoInput}
-          />
+            style={styles.pickFolderBtn}
+            title="Pick a local repo folder"
+          >
+            Pick Folder
+          </button>
           {addRepoError && (
             <div style={styles.addRepoErrorMsg} role="alert">{addRepoError}</div>
           )}
@@ -379,16 +359,16 @@ const styles = {
     padding: '4px 12px 8px',
     borderBottom: `1px solid ${theme.border}`,
   },
-  addRepoInput: {
-    width: '100%',
-    padding: '4px 8px',
-    fontSize: 11,
-    background: theme.bg,
+  pickFolderBtn: {
+    background: 'none',
     border: `1px solid ${theme.border}`,
     borderRadius: 4,
-    color: theme.text,
-    outline: 'none',
-    boxSizing: 'border-box',
+    color: theme.textMuted,
+    fontSize: 11,
+    fontWeight: 600,
+    cursor: 'pointer',
+    padding: '4px 8px',
+    whiteSpace: 'nowrap',
   },
   addRepoErrorMsg: {
     fontSize: 10,
@@ -586,5 +566,4 @@ const repoHeaderSelected = { ...styles.repoHeader, background: theme.accentSubtl
 const sessionRowSelected = { ...styles.sessionRow, background: theme.accentSubtle }
 const sessionRowCurrent = { ...styles.sessionRow, borderLeft: `3px solid ${theme.accent}` }
 const sessionRowCurrentSelected = { ...sessionRowCurrent, background: theme.accentSubtle }
-const addRepoInputError = { ...styles.addRepoInput, border: `1px solid ${theme.red}` }
 const deleteButtonHovered = { ...styles.deleteButton, color: theme.red, background: theme.redSubtle }

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -23,6 +23,7 @@ function defaultContext(overrides = {}) {
     runtimes: [],
     startRuntime: vi.fn(),
     stopRuntime: vi.fn(),
+    addRepoFromPicker: vi.fn(),
     addRepoShortcut: vi.fn(),
     removeRepoShortcut: vi.fn(),
     ...overrides,
@@ -433,399 +434,45 @@ describe('SessionSidebar add repo button', () => {
     expect(screen.getByLabelText('Add repo')).toBeDefined()
   })
 
-  it('shows input field when "+" is clicked', () => {
+  it('shows picker button when "+" is clicked', () => {
     render(<SessionSidebar />)
     fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
+    expect(screen.getByText('Pick Folder')).toBeDefined()
   })
 
-  it('calls addRepoShortcut when input is submitted via Enter', () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
+  it('calls addRepoFromPicker when "Pick Folder" is clicked', async () => {
+    const addRepoFromPicker = vi.fn().mockResolvedValue({ ok: true })
+    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoFromPicker }))
+    render(<SessionSidebar />)
+    fireEvent.click(screen.getByLabelText('Add repo'))
+    fireEvent.click(screen.getByText('Pick Folder'))
+    await vi.waitFor(() => {
+      expect(addRepoFromPicker).toHaveBeenCalledTimes(1)
+      expect(screen.queryByText('Pick Folder')).toBeNull()
+    })
+  })
+
+  it('shows error and keeps picker open when picker action fails', async () => {
+    const addRepoFromPicker = vi.fn().mockResolvedValue({ ok: false, error: 'No folder selected' })
     mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
+      defaultContext({ addRepoFromPicker })
     )
     render(<SessionSidebar />)
     fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'my-org/my-repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(addRepoShortcut).toHaveBeenCalledWith('my-org/my-repo')
-  })
-
-  it('hides input and clears value after submitting', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
-    )
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'my-org/my-repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
+    fireEvent.click(screen.getByText('Pick Folder'))
     await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
+      expect(screen.getByText('No folder selected')).toBeDefined()
+      expect(screen.getByText('Pick Folder')).toBeDefined()
     })
   })
 
-  it('hides input on Escape without calling addRepoShortcut', () => {
-    const addRepoShortcut = vi.fn()
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
-    )
+  it('shows fallback error when picker callback is missing', async () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoFromPicker: undefined }))
     render(<SessionSidebar />)
     fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.keyDown(input, { key: 'Escape' })
-    expect(addRepoShortcut).not.toHaveBeenCalled()
-    expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-  })
-
-  it('does not submit empty input', () => {
-    const addRepoShortcut = vi.fn()
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
-    )
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(addRepoShortcut).not.toHaveBeenCalled()
-  })
-
-  it('closes input when "+" is clicked again while input is visible (toggle off)', () => {
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-  })
-
-  it('keeps panel open on empty Enter', () => {
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    // Press Enter with empty input — panel should stay open
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-
-  it('shows error message when addRepoShortcut returns failure', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: "slug 'bad' not registered" })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    // Wait for async handler
+    fireEvent.click(screen.getByText('Pick Folder'))
     await vi.waitFor(() => {
-      expect(screen.getByText("slug 'bad' not registered")).toBeDefined()
-    })
-  })
-
-  it('keeps input open when addRepoShortcut returns failure', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'not found' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad-repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('not found')).toBeDefined()
-    })
-    // Input should still be visible
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-
-  it('clears error when user types in input', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'some error' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('some error')).toBeDefined()
-    })
-    // Start typing — error should disappear
-    fireEvent.change(input, { target: { value: 'fix' } })
-    expect(screen.queryByText('some error')).toBeNull()
-  })
-
-  it('clears error on Escape', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'err' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('err')).toBeDefined()
-    })
-    fireEvent.keyDown(input, { key: 'Escape' })
-    // Input should be hidden and error gone
-    expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    expect(screen.queryByText('err')).toBeNull()
-  })
-
-  it('closes input on successful addRepoShortcut', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('clears error and value when "+" toggle closes the input', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'stale error' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    // Open, trigger error
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('stale error')).toBeDefined()
-    })
-    // Close via "+" toggle
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.queryByText('stale error')).toBeNull()
-    // Reopen — error and value should be gone
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.queryByText('stale error')).toBeNull()
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo').value).toBe('')
-  })
-
-  it('handles rejected addRepoShortcut gracefully', async () => {
-    const addRepoShortcut = vi.fn().mockRejectedValue(new Error('Network error'))
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('Failed to add repo')).toBeDefined()
-    })
-    // Input should stay open
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-
-  it('succeeds when addRepoShortcut returns undefined', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue(undefined)
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('disables input while submitting', async () => {
-    let resolvePromise
-    const addRepoShortcut = vi.fn().mockImplementation(() =>
-      new Promise(resolve => { resolvePromise = resolve })
-    )
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    // Input should be disabled while request is in-flight
-    await vi.waitFor(() => {
-      expect(input.disabled).toBe(true)
-    })
-    // Resolve the promise
-    resolvePromise({ ok: true })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('error message has role="alert" for accessibility', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'a11y test' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      const alert = screen.getByRole('alert')
-      expect(alert.textContent).toBe('a11y test')
-    })
-  })
-
-  it('shows error message when addRepoShortcut returns failure', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: "slug 'bad' not registered" })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    // Wait for async handler
-    await vi.waitFor(() => {
-      expect(screen.getByText("slug 'bad' not registered")).toBeDefined()
-    })
-  })
-
-  it('keeps input open when addRepoShortcut returns failure', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'not found' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad-repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('not found')).toBeDefined()
-    })
-    // Input should still be visible
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-
-  it('clears error when user types in input', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'some error' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('some error')).toBeDefined()
-    })
-    // Start typing — error should disappear
-    fireEvent.change(input, { target: { value: 'fix' } })
-    expect(screen.queryByText('some error')).toBeNull()
-  })
-
-  it('clears error on Escape', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'err' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('err')).toBeDefined()
-    })
-    fireEvent.keyDown(input, { key: 'Escape' })
-    // Input should be hidden and error gone
-    expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    expect(screen.queryByText('err')).toBeNull()
-  })
-
-  it('closes input on successful addRepoShortcut', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('clears error and value when "+" toggle closes the input', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'stale error' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    // Open, trigger error
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('stale error')).toBeDefined()
-    })
-    // Close via "+" toggle
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.queryByText('stale error')).toBeNull()
-    // Reopen — error and value should be gone
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.queryByText('stale error')).toBeNull()
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo').value).toBe('')
-  })
-
-  it('handles rejected addRepoShortcut gracefully', async () => {
-    const addRepoShortcut = vi.fn().mockRejectedValue(new Error('Network error'))
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('Failed to add repo')).toBeDefined()
-    })
-    // Input should stay open
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-
-  it('succeeds when addRepoShortcut returns undefined', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue(undefined)
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('disables input while submitting', async () => {
-    let resolvePromise
-    const addRepoShortcut = vi.fn().mockImplementation(() =>
-      new Promise(resolve => { resolvePromise = resolve })
-    )
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'org/repo' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    // Input should be disabled while request is in-flight
-    await vi.waitFor(() => {
-      expect(input.disabled).toBe(true)
-    })
-    // Resolve the promise
-    resolvePromise({ ok: true })
-    await vi.waitFor(() => {
-      expect(screen.queryByPlaceholderText('owner/repo or /path/to/repo')).toBeNull()
-    })
-  })
-
-  it('error message has role="alert" for accessibility', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'a11y test' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: 'bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      const alert = screen.getByRole('alert')
-      expect(alert.textContent).toBe('a11y test')
+      expect(screen.getByText('Folder picker is unavailable')).toBeDefined()
     })
   })
 })
@@ -1054,50 +701,3 @@ describe('SessionSidebar per-repo Start/Stop', () => {
 // ---------------------------------------------------------------------------
 // Path-based repo input
 // ---------------------------------------------------------------------------
-
-describe('SessionSidebar path-based repo input', () => {
-  it('calls addRepoShortcut with full path when input starts with /', () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
-    )
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: '/home/user/repos/myproject' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(addRepoShortcut).toHaveBeenCalledWith('/home/user/repos/myproject')
-  })
-
-  it('calls addRepoShortcut with tilde path', () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: true })
-    mockUseHydraFlow.mockReturnValue(
-      defaultContext({ addRepoShortcut })
-    )
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: '~/repos/insightmesh' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    expect(addRepoShortcut).toHaveBeenCalledWith('~/repos/insightmesh')
-  })
-
-  it('shows error on invalid path from addRepoShortcut', async () => {
-    const addRepoShortcut = vi.fn().mockResolvedValue({ ok: false, error: 'path does not exist: /bad' })
-    mockUseHydraFlow.mockReturnValue(defaultContext({ addRepoShortcut }))
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    const input = screen.getByPlaceholderText('owner/repo or /path/to/repo')
-    fireEvent.change(input, { target: { value: '/bad' } })
-    fireEvent.keyDown(input, { key: 'Enter' })
-    await vi.waitFor(() => {
-      expect(screen.getByText('path does not exist: /bad')).toBeDefined()
-    })
-  })
-
-  it('shows updated placeholder text', () => {
-    render(<SessionSidebar />)
-    fireEvent.click(screen.getByLabelText('Add repo'))
-    expect(screen.getByPlaceholderText('owner/repo or /path/to/repo')).toBeDefined()
-  })
-})

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -921,6 +921,29 @@ export function HydraFlowProvider({ children }) {
     }
   }, [fetchRepos])
 
+  const pickRepoFolder = useCallback(async () => {
+    try {
+      const res = await fetch('/api/repos/pick-folder', { method: 'POST' })
+      if (!res.ok) {
+        let errorMsg = `status ${res.status}`
+        try { const body = await res.json(); if (body.error) errorMsg = body.error } catch { /* ignore */ }
+        return { ok: false, error: errorMsg }
+      }
+      const body = await res.json()
+      const path = (body?.path || '').trim()
+      if (!path) return { ok: false, error: 'No folder selected' }
+      return { ok: true, path }
+    } catch (err) {
+      return { ok: false, error: err.message || 'Network error' }
+    }
+  }, [])
+
+  const addRepoFromPicker = useCallback(async () => {
+    const picked = await pickRepoFolder()
+    if (!picked.ok) return picked
+    return addRepoByPath(picked.path)
+  }, [pickRepoFolder, addRepoByPath])
+
   const addRepoShortcut = useCallback(async (input) => {
     if (input.startsWith('/') || input.startsWith('~') || input.startsWith('.'))
       return addRepoByPath(input)
@@ -1279,6 +1302,7 @@ export function HydraFlowProvider({ children }) {
     selectRepo,
     deleteSession,
     addRepoByPath,
+    addRepoFromPicker,
     addRepoShortcut,
     removeRepoShortcut,
     startRuntime,

--- a/tests/test_dashboard_routes.py
+++ b/tests/test_dashboard_routes.py
@@ -6982,3 +6982,85 @@ class TestAddRepoByPath:
         assert resp.status_code == 200
         assert data["status"] == "ok"
         assert data["labels_created"] is False
+
+
+class TestPickRepoFolder:
+    """Tests for POST /api/repos/pick-folder endpoint."""
+
+    def _make_router(self, config, event_bus, state, tmp_path):
+        from dashboard_routes import create_router
+        from pr_manager import PRManager
+
+        pr_mgr = PRManager(config, event_bus)
+        return create_router(
+            config=config,
+            event_bus=event_bus,
+            state=state,
+            pr_manager=pr_mgr,
+            get_orchestrator=lambda: None,
+            set_orchestrator=lambda o: None,
+            set_run_task=lambda t: None,
+            ui_dist_dir=tmp_path / "no-dist",
+            template_dir=tmp_path / "no-templates",
+        )
+
+    def _get_endpoint(self, router):
+        for route in router.routes:
+            if (
+                hasattr(route, "path")
+                and route.path == "/api/repos/pick-folder"
+                and hasattr(route, "endpoint")
+            ):
+                return route.endpoint
+        msg = "pick_repo_folder endpoint not found"
+        raise AssertionError(msg)
+
+    @pytest.mark.asyncio
+    async def test_no_selection_returns_400(
+        self,
+        config,
+        event_bus: EventBus,
+        state,
+        tmp_path: Path,
+    ) -> None:
+        import json as json_mod
+
+        router = self._make_router(config, event_bus, state, tmp_path)
+        endpoint = self._get_endpoint(router)
+
+        with patch(
+            "dashboard_routes._pick_folder_with_dialog",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            resp = await endpoint()
+
+        data = json_mod.loads(resp.body)
+        assert resp.status_code == 400
+        assert data["error"] == "No folder selected"
+
+    @pytest.mark.asyncio
+    async def test_selected_folder_returns_path(
+        self,
+        config,
+        event_bus: EventBus,
+        state,
+        tmp_path: Path,
+    ) -> None:
+        import json as json_mod
+
+        repo_dir = tmp_path / "picked-repo"
+        repo_dir.mkdir()
+        router = self._make_router(config, event_bus, state, tmp_path)
+        endpoint = self._get_endpoint(router)
+
+        with patch(
+            "dashboard_routes._pick_folder_with_dialog",
+            new_callable=AsyncMock,
+            return_value=str(repo_dir),
+        ):
+            resp = await endpoint()
+
+        data = json_mod.loads(resp.body)
+        assert resp.status_code == 200
+        assert data["path"] == str(repo_dir.resolve())


### PR DESCRIPTION
## Summary
- add native backend endpoint `POST /api/repos/pick-folder` to choose a local repo directory
- wire picker flow in UI context and submit selected path through existing `/api/repos/add`
- remove manual text input from SessionSidebar add-repo panel (picker-only UX)
- update backend and UI tests for the new picker-only behavior

## Validation
- `pytest -q tests/test_dashboard_routes.py -k "AddRepoByPath or PickRepoFolder"`
- `cd src/ui && npm run -s test -- src/components/__tests__/SessionSidebar.test.jsx`
