### PR TITLE
Fix runtime Start regression for 405 fallback path

### DIFF
--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -138,11 +138,12 @@ export function SessionSidebar() {
     }
   }
 
-  const handleRuntimeToggle = async (e, slug, isRunning) => {
+  const handleRuntimeToggle = async (e, slug, isRunning, repoPath = null) => {
     e.stopPropagation()
     setRuntimeError('')
-    const action = isRunning ? stopRuntime : startRuntime
-    const result = await action(slug)
+    const result = isRunning
+      ? await stopRuntime(slug)
+      : await startRuntime(slug, repoPath)
     if (result && result.ok === false) {
       setRuntimeError(result.error || `Failed to ${isRunning ? 'stop' : 'start'} repo runtime`)
     }
@@ -211,7 +212,7 @@ export function SessionSidebar() {
                 </div>
                 <div style={styles.repoMeta}>
                   <button
-                    onClick={(e) => { handleRuntimeToggle(e, entry.slug, isRunning) }}
+                    onClick={(e) => { handleRuntimeToggle(e, entry.slug, isRunning, entry.info?.path || null) }}
                     style={isRunning ? styles.repoStopBtn : styles.repoStartBtn}
                     title={isRunning ? 'Stop this repo runtime' : 'Start this repo runtime'}
                   >

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -649,7 +649,7 @@ describe('SessionSidebar per-repo Start/Stop', () => {
     )
     render(<SessionSidebar />)
     fireEvent.click(screen.getByText('Start'))
-    expect(startRuntime).toHaveBeenCalledWith('demo')
+    expect(startRuntime).toHaveBeenCalledWith('demo', '/repos/demo')
   })
 
   it('calls stopRuntime when Stop button is clicked', () => {
@@ -724,7 +724,7 @@ describe('SessionSidebar per-repo Start/Stop', () => {
     )
     render(<SessionSidebar />)
     fireEvent.click(screen.getByText('Start'))
-    expect(startRuntime).toHaveBeenCalledWith('org-repo')
+    expect(startRuntime).toHaveBeenCalledWith('org-repo', null)
   })
 })
 

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -856,7 +856,7 @@ export function HydraFlowProvider({ children }) {
   const canonicalSlug = useCallback((value) => {
     return String(value || '').trim().replace(/[\\/]+/g, '-').toLowerCase()
   }, [])
-  const startRuntime = useCallback(async (slug) => {
+  const startRuntime = useCallback(async (slug, repoPath = null) => {
     try {
       const encodedSlug = encodeURIComponent(slug)
       const runtimeRes = await fetch(`/api/runtimes/${encodedSlug}/start`, {
@@ -876,23 +876,26 @@ export function HydraFlowProvider({ children }) {
         })
         // Older backends may not support POST /api/repos; fallback to /api/repos/add by path.
         if (repoRes.status === 404 || repoRes.status === 405) {
-          const listRes = await fetch('/api/repos')
-          if (!listRes.ok) {
-            const message = await parseApiError(
-              listRes,
-              `Failed to list repos (${listRes.status})`,
-            )
-            return { ok: false, error: message }
+          let path = String(repoPath || '').trim()
+          if (!path) {
+            const listRes = await fetch('/api/repos')
+            if (!listRes.ok) {
+              const message = await parseApiError(
+                listRes,
+                `Failed to list repos (${listRes.status})`,
+              )
+              return { ok: false, error: message }
+            }
+            const payload = await listRes.json()
+            const repos = Array.isArray(payload?.repos) ? payload.repos : []
+            const targetSlug = canonicalSlug(slug)
+            const match = repos.find((repo) => {
+              const repoSlug = canonicalSlug(repo?.slug)
+              const repoPathSlug = canonicalSlug(repo?.path)
+              return repoSlug === targetSlug || repoPathSlug.endsWith(`-${targetSlug}`)
+            })
+            path = String(match?.path || '').trim()
           }
-          const payload = await listRes.json()
-          const repos = Array.isArray(payload?.repos) ? payload.repos : []
-          const targetSlug = canonicalSlug(slug)
-          const match = repos.find((repo) => {
-            const repoSlug = canonicalSlug(repo?.slug)
-            const repoPath = canonicalSlug(repo?.path)
-            return repoSlug === targetSlug || repoPath.endsWith(`-${targetSlug}`)
-          })
-          const path = String(match?.path || '').trim()
           if (!path) {
             return { ok: false, error: `Repo not found for slug: ${slug}` }
           }

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -615,6 +615,90 @@ describe('startRuntime compatibility flow', () => {
       body: JSON.stringify({ path: '/tmp/demo' }),
     })
   })
+
+  it('uses provided repo path for /api/repos/add fallback without listing repos', async () => {
+    window.__HYDRAFLOW_SEED_STATE__ = { connected: true, phase: 'idle' }
+    vi.resetModules()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/runtimes/demo/start') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos/add') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok', slug: 'demo' }),
+        })
+      }
+      if (url === '/api/repos') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ repos: [] }),
+        })
+      }
+      if (url === '/api/runtimes') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ runtimes: [] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    await act(async () => {
+      await capturedState.startRuntime('demo', '/tmp/from-sidebar')
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: '/tmp/from-sidebar' }),
+    })
+    const firstAddIndex = fetchSpy.mock.calls.findIndex(
+      (args) => args[0] === '/api/repos/add',
+    )
+    const firstListIndex = fetchSpy.mock.calls.findIndex(
+      (args) => args[0] === '/api/repos' && args.length === 1,
+    )
+    expect(firstAddIndex).toBeGreaterThan(-1)
+    if (firstListIndex !== -1) {
+      expect(firstAddIndex).toBeLessThan(firstListIndex)
+    }
+  })
 })
 
 describe('seed state injection via __HYDRAFLOW_SEED_STATE__', () => {


### PR DESCRIPTION
## Summary
- pass selected repo path from SessionSidebar into runtime start flow
- when `/api/runtimes/{slug}/start` and `POST /api/repos` are unavailable (405), start via `/api/repos/add` using the known selected path
- keep slug-based lookup as a fallback when path is not available
- keep runtime error surfacing in sidebar

## Why
Some environments return `405 Method Not Allowed` for runtime/supervisor start endpoints.
Even with fallback enabled, slug->path inference can miss, causing false 'Failed to start runtime' for valid repos.
Using the selected repo path is deterministic and avoids that miss.

## Validation
- `cd src/ui && npm run -s test -- src/context/__tests__/HydraFlowContext.test.jsx`
- `cd src/ui && npm run -s test -- src/components/__tests__/SessionSidebar.test.jsx`
- `make quality-lite`
