### PR TITLE
Fix Start button 422 regressions for mixed backend payload shapes

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -856,6 +856,26 @@ export function HydraFlowProvider({ children }) {
   const canonicalSlug = useCallback((value) => {
     return String(value || '').trim().replace(/[\\/]+/g, '-').toLowerCase()
   }, [])
+
+  const postJsonCompat = useCallback(async (url, payload) => {
+    const baseInit = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    }
+    let res = await fetch(url, {
+      ...baseInit,
+      body: JSON.stringify(payload),
+    })
+    if (res.status === 422) {
+      // Some dashboard backends expect wrapped payloads: { req: { ... } }.
+      res = await fetch(url, {
+        ...baseInit,
+        body: JSON.stringify({ req: payload }),
+      })
+    }
+    return res
+  }, [])
+
   const startRuntime = useCallback(async (slug, repoPath = null) => {
     try {
       const encodedSlug = encodeURIComponent(slug)
@@ -869,11 +889,7 @@ export function HydraFlowProvider({ children }) {
 
       // Compatibility mode: when runtime registry route is unavailable, start via supervisor.
       if (runtimeRes.status === 404 || runtimeRes.status === 405 || runtimeRes.status === 501) {
-        const repoRes = await fetch('/api/repos', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ slug }),
-        })
+        const repoRes = await postJsonCompat('/api/repos', { slug })
         // Older backends may not support POST /api/repos; fallback to /api/repos/add by path.
         if (repoRes.status === 404 || repoRes.status === 405) {
           let path = String(repoPath || '').trim()
@@ -899,11 +915,7 @@ export function HydraFlowProvider({ children }) {
           if (!path) {
             return { ok: false, error: `Repo not found for slug: ${slug}` }
           }
-          const addRes = await fetch('/api/repos/add', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ path }),
-          })
+          const addRes = await postJsonCompat('/api/repos/add', { path })
           if (!addRes.ok) {
             const message = await parseApiError(
               addRes,
@@ -934,7 +946,7 @@ export function HydraFlowProvider({ children }) {
       console.warn('Failed to start runtime', slug, err)
       return { ok: false, error: err?.message || 'Failed to start runtime' }
     }
-  }, [fetchRuntimes, fetchRepos, parseApiError, canonicalSlug])
+  }, [fetchRuntimes, fetchRepos, parseApiError, canonicalSlug, postJsonCompat])
 
   const stopRuntime = useCallback(async (slug) => {
     try {

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -699,6 +699,171 @@ describe('startRuntime compatibility flow', () => {
       expect(firstAddIndex).toBeLessThan(firstListIndex)
     }
   })
+
+  it('retries POST /api/repos with wrapped req payload when backend returns 422', async () => {
+    window.__HYDRAFLOW_SEED_STATE__ = { connected: true, phase: 'idle' }
+    vi.resetModules()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/runtimes/demo/start') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos' && init?.method === 'POST' && init?.body === JSON.stringify({ slug: 'demo' })) {
+        return Promise.resolve({
+          ok: false,
+          status: 422,
+          json: async () => ({ detail: 'invalid body' }),
+        })
+      }
+      if (url === '/api/repos' && init?.method === 'POST' && init?.body === JSON.stringify({ req: { slug: 'demo' } })) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok' }),
+        })
+      }
+      if (url === '/api/repos') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ repos: [] }),
+        })
+      }
+      if (url === '/api/runtimes') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ runtimes: [] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    await act(async () => {
+      await capturedState.startRuntime('demo')
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug: 'demo' }),
+    })
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ req: { slug: 'demo' } }),
+    })
+  })
+
+  it('retries POST /api/repos/add with wrapped req payload on 422', async () => {
+    window.__HYDRAFLOW_SEED_STATE__ = { connected: true, phase: 'idle' }
+    vi.resetModules()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/runtimes/demo/start') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos/add' && init?.body === JSON.stringify({ path: '/tmp/from-sidebar' })) {
+        return Promise.resolve({
+          ok: false,
+          status: 422,
+          json: async () => ({ detail: 'invalid body' }),
+        })
+      }
+      if (url === '/api/repos/add' && init?.body === JSON.stringify({ req: { path: '/tmp/from-sidebar' } })) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok', slug: 'demo' }),
+        })
+      }
+      if (url === '/api/repos') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ repos: [] }),
+        })
+      }
+      if (url === '/api/runtimes') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ runtimes: [] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    await act(async () => {
+      await capturedState.startRuntime('demo', '/tmp/from-sidebar')
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: '/tmp/from-sidebar' }),
+    })
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ req: { path: '/tmp/from-sidebar' } }),
+    })
+  })
 })
 
 describe('seed state injection via __HYDRAFLOW_SEED_STATE__', () => {


### PR DESCRIPTION
## Summary
- add `postJsonCompat` helper for runtime start compatibility POSTs
- on `422`, retry with wrapped payload shape: `{ req: payload }`
- apply compatibility retry to both:
  - `POST /api/repos`
  - `POST /api/repos/add`
- keep existing 404/405/501 fallback flow and sidebar error surfacing

## Why
Some deployed dashboard/backend variants expect wrapped request bodies and return `422` for flat payloads. Start appeared broken even though fallback endpoints existed. This patch makes Start robust across both payload contracts.

## Validation
- `cd src/ui && npm run -s test -- src/context/__tests__/HydraFlowContext.test.jsx`
- `cd src/ui && npm run -s test -- src/components/__tests__/SessionSidebar.test.jsx`
- `make quality-lite`
