### PR TITLE
Fix supervisor start for owner/repo slugs

### DIFF
--- a/src/hf_cli/supervisor_service.py
+++ b/src/hf_cli/supervisor_service.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -31,6 +32,20 @@ class RepoProcess:
 RUNNERS: dict[str, RepoProcess] = {}
 
 
+def _slug_for_log_filename(slug: str) -> str:
+    cleaned = slug.strip().replace("/", "-").replace("\\", "-")
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", cleaned)
+    cleaned = cleaned.strip("-").lstrip(".")
+    return cleaned or "repo"
+
+
+def _repo_log_file(slug: str, port: int) -> Path:
+    log_dir = STATE_DIR / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    safe_slug = _slug_for_log_filename(slug)
+    return (log_dir / f"{safe_slug}-{port}.log").resolve()
+
+
 def _is_repo_running(slug: str) -> bool:
     proc = RUNNERS.get(slug)
     return proc is not None and proc.proc.poll() is None
@@ -54,9 +69,7 @@ def _start_repo(path: str, *, slug: str | None = None) -> tuple[int, str, str, s
     slug = slug or _slug_for_repo(repo_path)
     existing = RUNNERS.get(slug)
     if existing and existing.proc.poll() is None:
-        log_dir = STATE_DIR / "logs"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        log_file = (log_dir / f"{existing.slug}-{existing.port}.log").resolve()
+        log_file = _repo_log_file(existing.slug, existing.port)
         return (
             existing.port,
             existing.slug,
@@ -66,9 +79,7 @@ def _start_repo(path: str, *, slug: str | None = None) -> tuple[int, str, str, s
     state_root = STATE_DIR / slug
     state_root.mkdir(parents=True, exist_ok=True)
     port = _find_free_port()
-    log_dir = STATE_DIR / "logs"
-    log_dir.mkdir(parents=True, exist_ok=True)
-    log_file = (log_dir / f"{slug}-{port}.log").resolve()
+    log_file = _repo_log_file(slug, port)
     env = os.environ.copy()
     env.setdefault("HYDRAFLOW_HOME", str(state_root))
     src_path = str((repo_path / "src").resolve())

--- a/tests/hf_cli/test_supervisor_service.py
+++ b/tests/hf_cli/test_supervisor_service.py
@@ -20,6 +20,23 @@ def test_find_free_port_returns_positive_int() -> None:
     assert supervisor_service._find_free_port() > 0
 
 
+def test_slug_for_log_filename_sanitizes_owner_repo() -> None:
+    assert (
+        supervisor_service._slug_for_log_filename("8thlight/insightmesh")
+        == "8thlight-insightmesh"
+    )
+
+
+def test_repo_log_file_flattens_slug_and_creates_logs_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(supervisor_service, "STATE_DIR", tmp_path)
+    log_file = supervisor_service._repo_log_file("8thlight/insightmesh", 57475)
+
+    assert log_file == (tmp_path / "logs" / "8thlight-insightmesh-57475.log").resolve()
+    assert log_file.parent.exists()
+
+
 def test_build_repo_status_payload_marks_running(monkeypatch) -> None:
     monkeypatch.setattr(
         supervisor_service.supervisor_state,


### PR DESCRIPTION
## Summary
- fix supervisor log-file path generation for repo slugs that include `/` (for example `8thlight/insightmesh`)
- sanitize slug for log filenames and centralize path creation
- ensure log directory exists before opening log file

## Why
Clicking **Start** for repos with owner/repo slugs could fail with:
`No such file or directory: ~/.hydraflow/logs/8thlight/insightmesh-<port>.log`

## Testing
- `pytest -q tests/hf_cli/test_supervisor_service.py`
- `make quality-lite`
