### PR TITLE
Add --no-cache to docker-build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -460,7 +460,7 @@ screenshot-update:
 
 docker-build:
 	@echo "$(BLUE)Building Hydra agent Docker image...$(RESET)"
-	docker build --platform linux/amd64 -f Dockerfile.agent -t $(DOCKER_IMAGE) .
+	docker build --no-cache --platform linux/amd64 -f Dockerfile.agent -t $(DOCKER_IMAGE) .
 	@echo "$(GREEN)Image built: $(DOCKER_IMAGE)$(RESET)"
 
 docker-test: docker-build


### PR DESCRIPTION
## Summary
- update `make docker-build` to pass `--no-cache`
- ensures image rebuilds from fresh layers by default

## Change
- `docker build --platform linux/amd64 ...` -> `docker build --no-cache --platform linux/amd64 ...`
