### PR TITLE
Fix missing sessions for owner/repo sidebar entries

### DIFF
--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -40,16 +40,17 @@ export function SessionSidebar() {
     const entries = new Map()
     const slugIndex = new Map()
 
-    const ensureEntry = (key, slug, displayName) => {
+    const ensureEntry = (key, slug, filterSlug, displayName) => {
       if (!entries.has(key)) {
         entries.set(key, {
           key,
           slug,
+          filterSlug,
           displayName,
           sessions: [],
           info: null,
         })
-        if (slug) slugIndex.set(slug, key)
+        if (filterSlug) slugIndex.set(filterSlug, key)
       }
       return entries.get(key)
     }
@@ -57,22 +58,34 @@ export function SessionSidebar() {
     for (const session of sessions) {
       const slug = canonicalRepoSlug(session.repo) || shortRepo(session.repo)
       const key = slug || session.repo
-      const entry = ensureEntry(key, slug, session.repo)
+      const entry = ensureEntry(key, slug, slug, session.repo)
       entry.sessions.push(session)
     }
 
     for (const repo of supervisedRepos || []) {
       if (!repo) continue
-      const slug = repo.slug || canonicalRepoSlug(repo.path || '') || shortRepo(repo.path || '')
-      let entryKey = (slug && slugIndex.get(slug)) || slug
+      const rawSlug = repo.slug || canonicalRepoSlug(repo.path || '') || shortRepo(repo.path || '')
+      const filterSlug = canonicalRepoSlug(rawSlug)
+      let entryKey = (filterSlug && slugIndex.get(filterSlug)) || filterSlug
       let entry = entryKey ? entries.get(entryKey) : undefined
       if (!entry) {
-        entryKey = slug || repo.path || repo.slug || `repo-${entries.size + 1}`
-        entry = ensureEntry(entryKey, slug, repo.slug || slug || repo.path || entryKey)
+        entryKey = filterSlug || repo.path || repo.slug || `repo-${entries.size + 1}`
+        entry = ensureEntry(
+          entryKey,
+          rawSlug,
+          filterSlug,
+          repo.slug || rawSlug || repo.path || entryKey,
+        )
+      }
+      if (repo.slug) {
+        entry.slug = repo.slug
+      }
+      if (!entry.filterSlug) {
+        entry.filterSlug = filterSlug
       }
       entry.info = repo
-      if (slug && !slugIndex.has(slug)) {
-        slugIndex.set(slug, entry.key)
+      if (filterSlug && !slugIndex.has(filterSlug)) {
+        slugIndex.set(filterSlug, entry.key)
       }
       if (!entry.displayName && (repo.slug || repo.path)) {
         entry.displayName = repo.slug || repo.path
@@ -80,9 +93,11 @@ export function SessionSidebar() {
     }
 
     // Merge runtime status into entries
-    const runtimeMap = new Map((runtimes || []).map(rt => [rt.slug, rt]))
+    const runtimeMap = new Map(
+      (runtimes || []).map((rt) => [canonicalRepoSlug(rt.slug), rt]),
+    )
     for (const entry of entries.values()) {
-      entry.runtime = runtimeMap.get(entry.slug) || null
+      entry.runtime = runtimeMap.get(entry.filterSlug) || null
     }
 
     return Array.from(entries.values()).sort((a, b) =>
@@ -186,7 +201,7 @@ export function SessionSidebar() {
         {repoEntries.map(entry => {
           const repoSessions = entry.sessions
           const isExpanded = expandedRepos[entry.key] !== false
-          const isRepoSelected = selectedRepoSlug === entry.slug
+          const isRepoSelected = selectedRepoSlug === entry.filterSlug
           const rt = entry.runtime
           const isRunning = rt?.running ?? entry.info?.running ?? false
 

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -177,6 +177,29 @@ describe('SessionSidebar with multiple repos', () => {
     expect(screen.getByLabelText('Add repo')).toBeDefined()
     expect(screen.queryByLabelText('Disconnect repo')).toBeNull()
   })
+
+  it('merges session and supervised repo groups for owner/repo slugs', () => {
+    mockUseHydraFlow.mockReturnValue(
+      defaultContext({
+        sessions: [
+          {
+            ...SESSION_A,
+            repo: '8thlight/insightmesh',
+            id: '8thlight-insightmesh-20260303T120000',
+          },
+        ],
+        supervisedRepos: [
+          {
+            slug: '8thlight/insightmesh',
+            path: '/Users/travisf/Documents/projects/insightmesh',
+            running: true,
+          },
+        ],
+      }),
+    )
+    render(<SessionSidebar />)
+    expect(screen.getAllByText('8thlight/insightmesh')).toHaveLength(1)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -52,6 +52,10 @@ export const initialState = {
   runtimes: [],
 }
 
+function normalizeRepoSlug(value) {
+  return String(value || '').trim().replace(/[\\/]+/g, '-')
+}
+
 function isDuplicate(state, action) {
   const eventId = action.id ?? -1
   return eventId !== -1 && eventId <= state.lastSeenId
@@ -701,7 +705,11 @@ export function reducer(state, action) {
       return { ...state, selectedSessionId: action.data.sessionId }
 
     case 'SELECT_REPO':
-      return { ...state, selectedRepoSlug: action.data.slug, selectedSessionId: null }
+      return {
+        ...state,
+        selectedRepoSlug: normalizeRepoSlug(action.data.slug),
+        selectedSessionId: null,
+      }
 
     case 'SET_RUNTIMES':
       return {
@@ -1356,8 +1364,7 @@ export function HydraFlowProvider({ children }) {
   const repoFilteredSessions = useMemo(() => {
     if (!state.selectedRepoSlug) return state.sessions
     return state.sessions.filter(s => {
-      const slug = String(s.repo || '').replace(/[\\/]+/g, '-')
-      return slug === state.selectedRepoSlug
+      return normalizeRepoSlug(s.repo) === state.selectedRepoSlug
     })
   }, [state.sessions, state.selectedRepoSlug])
 

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -1409,6 +1409,17 @@ describe('SELECT_SESSION reducer', () => {
   })
 })
 
+describe('SELECT_REPO reducer', () => {
+  it('normalizes owner/repo slugs for filtering', () => {
+    const result = reducer(initialState, {
+      type: 'SELECT_REPO',
+      data: { slug: '8thlight/insightmesh' },
+    })
+    expect(result.selectedRepoSlug).toBe('8thlight-insightmesh')
+    expect(result.selectedSessionId).toBeNull()
+  })
+})
+
 describe('hitl_escalation reducer', () => {
   it('marks review worker as escalated when pr is present (automated escalation)', () => {
     const state = {


### PR DESCRIPTION
## Root cause
Session filtering/grouping used mixed slug formats:
- sessions normalized repo as `owner-repo`
- supervised repo selection/grouping could keep raw `owner/repo`

That mismatch caused sessions to disappear in the UI when selecting repos like `8thlight/insightmesh`.

## Fix
- normalize selected repo slug in context reducer (`SELECT_REPO`)
- normalize repo filtering in `repoFilteredSessions`
- normalize/merge sidebar grouping keys so session + supervised entry for the same repo collapse into one group
- normalize runtime lookup keys for sidebar entry runtime matching

## Tests
- add reducer test for `SELECT_REPO` owner/repo normalization
- add sidebar regression test to ensure session + supervised owner/repo entries merge
- ran:
  - `npm test -- src/context/__tests__/HydraFlowContext.test.jsx src/components/__tests__/SessionSidebar.test.jsx`
