### PR TITLE
Fix multi-repo Start reliability for session-only repos

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -142,17 +142,39 @@ class HydraFlowDashboard:
             return
 
         if _auto_start_supervisor_enabled():
+            supervisor_manager = None
             try:
                 supervisor_manager = importlib.import_module(
                     "hf_cli.supervisor_manager"
                 )
-                await asyncio.to_thread(supervisor_manager.ensure_running)
             except ImportError:
                 logger.debug(
                     "hf_cli.supervisor_manager not importable; skipping supervisor auto-start"
                 )
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("Supervisor auto-start failed: %s", exc)
+            if supervisor_manager is not None:
+                try:
+                    await asyncio.to_thread(supervisor_manager.ensure_running)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Supervisor auto-start failed: %s", exc)
+
+            # Keep the current dashboard repo discoverable in /api/repos so Start works
+            # even for session-only sidebar entries after restart.
+            try:
+                supervisor_client = importlib.import_module("hf_cli.supervisor_client")
+            except ImportError:
+                supervisor_client = None
+            if supervisor_client is not None:
+                try:
+                    slug = self._config.repo or None
+                    await asyncio.to_thread(
+                        supervisor_client.register_repo,
+                        self._config.repo_root,
+                        slug,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "Supervisor auto-register current repo failed: %s", exc
+                    )
 
         app = self.create_app()
         config = uvicorn.Config(

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -877,6 +877,29 @@ export function HydraFlowProvider({ children }) {
     return String(value || '').trim().replace(/[\\/]+/g, '-').toLowerCase()
   }, [])
 
+  const slugTail = useCallback((value) => {
+    const normalized = canonicalSlug(value)
+    if (!normalized) return ''
+    const parts = normalized.split('-').filter(Boolean)
+    return parts.length > 0 ? parts[parts.length - 1] : normalized
+  }, [canonicalSlug])
+
+  const isAdjacentSwap = useCallback((a, b) => {
+    if (a === b || a.length !== b.length || a.length < 2) return false
+    let first = -1
+    let second = -1
+    for (let i = 0; i < a.length; i += 1) {
+      if (a[i] !== b[i]) {
+        if (first === -1) first = i
+        else if (second === -1) second = i
+        else return false
+      }
+    }
+    if (first === -1 || second === -1) return false
+    if (second !== first + 1) return false
+    return a[first] === b[second] && a[second] === b[first]
+  }, [])
+
   const postCompat = useCallback(async (url, options) => {
     const payloads = Array.isArray(options?.payloads) ? options.payloads : []
     const queryPayloads = Array.isArray(options?.queryPayloads) ? options.queryPayloads : []
@@ -948,10 +971,20 @@ export function HydraFlowProvider({ children }) {
             const payload = await listRes.json()
             const repos = Array.isArray(payload?.repos) ? payload.repos : []
             const targetSlug = canonicalSlug(slug)
+            const targetTail = slugTail(slug)
             const match = repos.find((repo) => {
               const repoSlug = canonicalSlug(repo?.slug)
               const repoPathSlug = canonicalSlug(repo?.path)
-              return repoSlug === targetSlug || repoPathSlug.endsWith(`-${targetSlug}`)
+              const repoPathTail = slugTail(repo?.path)
+              const repoSlugTail = slugTail(repo?.slug)
+              return (
+                repoSlug === targetSlug
+                || repoPathSlug.endsWith(`-${targetSlug}`)
+                || (targetTail && repoPathTail === targetTail)
+                || (targetTail && repoSlugTail === targetTail)
+                || (targetTail && repoPathTail && isAdjacentSwap(repoPathTail, targetTail))
+                || (targetTail && repoSlugTail && isAdjacentSwap(repoSlugTail, targetTail))
+              )
             })
             path = String(match?.path || '').trim()
           }
@@ -990,7 +1023,7 @@ export function HydraFlowProvider({ children }) {
       console.warn('Failed to start runtime', slug, err)
       return { ok: false, error: err?.message || 'Failed to start runtime' }
     }
-  }, [fetchRuntimes, fetchRepos, parseApiError, canonicalSlug, postCompat])
+  }, [fetchRuntimes, fetchRepos, parseApiError, canonicalSlug, slugTail, isAdjacentSwap, postCompat])
 
   const stopRuntime = useCallback(async (slug) => {
     try {

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -928,6 +928,95 @@ describe('startRuntime compatibility flow', () => {
     })
   })
 
+  it('resolves repo path by slug tail when canonical slug forms differ', async () => {
+    window.__HYDRAFLOW_SEED_STATE__ = { connected: true, phase: 'idle' }
+    vi.resetModules()
+
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/runtimes/T-rav-hyrda/start') {
+        return Promise.resolve({
+          ok: false,
+          status: 405,
+          json: async () => ({ error: 'Method Not Allowed' }),
+        })
+      }
+      if (url === '/api/repos' && init?.method === 'POST') {
+        return Promise.resolve({
+          ok: false,
+          status: 422,
+          json: async () => ({ detail: [{ msg: 'Field required' }] }),
+        })
+      }
+      if (url.startsWith('/api/repos?')) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: async () => ({ error: 'Internal Server Error' }),
+        })
+      }
+      if (url === '/api/repos') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            repos: [
+              {
+                slug: 'T-rav/hydra',
+                path: '/Users/travisf/Documents/projects/hydra',
+                running: false,
+              },
+            ],
+          }),
+        })
+      }
+      if (url === '/api/repos/add') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ status: 'ok', slug: 'T-rav/hydra' }),
+        })
+      }
+      if (url === '/api/runtimes') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ runtimes: [] }),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    await act(async () => {
+      await capturedState.startRuntime('T-rav-hyrda')
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/repos/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path: '/Users/travisf/Documents/projects/hydra' }),
+    })
+  })
+
   it('retries POST /api/repos/add with wrapped req payload on 422', async () => {
     window.__HYDRAFLOW_SEED_STATE__ = { connected: true, phase: 'idle' }
     vi.resetModules()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -827,16 +827,69 @@ class TestStartStop:
         mock_server.serve = AsyncMock(return_value=None)
         mock_manager = MagicMock()
         mock_manager.ensure_running = MagicMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.register_repo = MagicMock(return_value={"status": "ok"})
+        import importlib as _stdlib_importlib  # noqa: PLC0415
+
+        real_import_module = _stdlib_importlib.import_module
+
+        def _import_module(name: str):
+            if name == "hf_cli.supervisor_manager":
+                return mock_manager
+            if name == "hf_cli.supervisor_client":
+                return mock_client
+            return real_import_module(name)
 
         with (
             patch("dashboard._auto_start_supervisor_enabled", return_value=True),
-            patch("dashboard.importlib.import_module", return_value=mock_manager),
+            patch("dashboard.importlib.import_module", side_effect=_import_module),
             patch("uvicorn.Config"),
             patch("uvicorn.Server", return_value=mock_server),
         ):
             await dashboard.start()
 
         mock_manager.ensure_running.assert_called_once()
+        mock_client.register_repo.assert_called_once_with(config.repo_root, config.repo)
+
+        if dashboard._server_task and not dashboard._server_task.done():
+            dashboard._server_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await dashboard._server_task
+
+    @pytest.mark.asyncio
+    async def test_start_tolerates_supervisor_register_repo_failure(
+        self, config: HydraFlowConfig, event_bus: EventBus, state
+    ) -> None:
+        from dashboard import HydraFlowDashboard
+
+        dashboard = HydraFlowDashboard(config, event_bus, state)
+        mock_server = AsyncMock()
+        mock_server.serve = AsyncMock(return_value=None)
+        mock_manager = MagicMock()
+        mock_manager.ensure_running = MagicMock(return_value=None)
+        mock_client = MagicMock()
+        mock_client.register_repo = MagicMock(side_effect=RuntimeError("boom"))
+        import importlib as _stdlib_importlib  # noqa: PLC0415
+
+        real_import_module = _stdlib_importlib.import_module
+
+        def _import_module(name: str):
+            if name == "hf_cli.supervisor_manager":
+                return mock_manager
+            if name == "hf_cli.supervisor_client":
+                return mock_client
+            return real_import_module(name)
+
+        with (
+            patch("dashboard._auto_start_supervisor_enabled", return_value=True),
+            patch("dashboard.importlib.import_module", side_effect=_import_module),
+            patch("uvicorn.Config"),
+            patch("uvicorn.Server", return_value=mock_server),
+        ):
+            await dashboard.start()
+
+        mock_manager.ensure_running.assert_called_once()
+        mock_client.register_repo.assert_called_once_with(config.repo_root, config.repo)
 
         if dashboard._server_task and not dashboard._server_task.done():
             dashboard._server_task.cancel()


### PR DESCRIPTION
## What this fixes
- fixes Start failures like `Repo not found for slug: T-rav-hyrda`
- makes dashboard auto-register the current repo with supervisor at startup
- hardens frontend slug->path fallback matching for mixed slug formats and adjacent transposition typos (for example `hyrda` vs `hydra`)

## Why it was failing
- session-only sidebar entries can lack a supervisor path, so Start must resolve path via `/api/repos`
- if slug formats differ (or include a minor transposition typo), the old matcher failed and returned `Repo not found`

## Changes
- `src/dashboard.py`
  - after supervisor auto-start, auto-register current dashboard repo with supervisor (`register_repo(repo_root, repo)`), non-fatal on errors
- `src/ui/src/context/HydraFlowContext.jsx`
  - stronger fallback matching in `startRuntime` when selecting path from `/api/repos`
  - adds adjacent-swap tolerance for tail slug matching
- tests:
  - `tests/test_dashboard.py`
  - `src/ui/src/context/__tests__/HydraFlowContext.test.jsx`

## Validation run
- `pytest -q tests/test_dashboard.py -k "auto_starts_supervisor_when_enabled or tolerates_supervisor_register_repo_failure"`
- `npm test -- src/context/__tests__/HydraFlowContext.test.jsx src/components/__tests__/SessionSidebar.test.jsx`
- `make quality-lite`
- Docker rebuild from this branch:
  - `docker build --no-cache --pull --platform linux/amd64 -f Dockerfile.agent -t ghcr.io/t-rav/hydraflow-agent:latest .`
