### PR TITLE
Fix PipelineIssueStatus missing 'processing' value

### DIFF
--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
-from models import PipelineSnapshotEntry, QueueStats, Task
+from models import PipelineIssueStatus, PipelineSnapshotEntry, QueueStats, Task
 from subprocess_util import AuthenticationError
 from task_source import TaskFetcher
 
@@ -610,7 +610,7 @@ class IssueStore:
                 issue_number=task_id,
                 title=cached.title if cached else f"Issue #{task_id}",
                 url=cached.source_url if cached else "",
-                status="processing",
+                status=PipelineIssueStatus.PROCESSING,
             )
             if cached:
                 epic_meta = self._epic_metadata(cached)

--- a/src/models.py
+++ b/src/models.py
@@ -1133,6 +1133,7 @@ class PipelineIssueStatus(StrEnum):
 
     QUEUED = "queued"
     ACTIVE = "active"
+    PROCESSING = "processing"
     HITL = "hitl"
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2522,6 +2522,7 @@ class TestPipelineIssueStatusEnum:
         [
             (PipelineIssueStatus.QUEUED, "queued"),
             (PipelineIssueStatus.ACTIVE, "active"),
+            (PipelineIssueStatus.PROCESSING, "processing"),
             (PipelineIssueStatus.HITL, "hitl"),
         ],
         ids=[m.name for m in PipelineIssueStatus],
@@ -2530,7 +2531,7 @@ class TestPipelineIssueStatusEnum:
         assert member == expected
 
     def test_member_count(self) -> None:
-        assert len(PipelineIssueStatus) == 3
+        assert len(PipelineIssueStatus) == 4
 
 
 class TestBGWorkerHealthEnum:


### PR DESCRIPTION
## Summary
- Add `PROCESSING = "processing"` to `PipelineIssueStatus` enum
- Use `PipelineIssueStatus.PROCESSING` instead of raw string in `issue_store.py`
- Update tests for new enum member count (3 → 4)

Fixes the Pydantic `ValidationError` on `/api/pipeline` endpoint caused by in-flight snapshot items (PR #1894) using `status="processing"` which wasn't in the enum.

## Test plan
- [x] `TestPipelineSnapshot` — 10 tests pass (including in-flight snapshot tests)
- [x] `TestPipelineIssueStatusEnum` — 5 tests pass (includes new PROCESSING member)
- [x] Dashboard pipeline endpoint tests — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)