### PR TITLE
Protect pipeline-queued issues from worktree GC

### DIFF
--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -470,6 +470,12 @@ class IssueStore:
         """Return True if the task is currently being processed."""
         return task_id in self._active
 
+    def is_in_pipeline(self, issue_number: int) -> bool:
+        """Return True if the issue is queued, in-flight, or active."""
+        if issue_number in self._active or issue_number in self._in_flight:
+            return True
+        return any(any(t.id == issue_number for t in q) for q in self._queues.values())
+
     def get_active_issues(self) -> dict[int, str]:
         """Return a copy of the active issue tracking dict."""
         return dict(self._active)

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -363,6 +363,7 @@ def build_services(
         enabled_cb=callbacks.is_bg_worker_enabled,
         sleep_fn=callbacks.sleep_or_stop,
         interval_cb=callbacks.get_bg_worker_interval,
+        is_in_pipeline_cb=store.is_in_pipeline,
     )
 
     runs_gc_loop = RunsGCLoop(

--- a/src/worktree_gc_loop.py
+++ b/src/worktree_gc_loop.py
@@ -42,6 +42,7 @@ class WorktreeGCLoop(BaseBackgroundLoop):
         enabled_cb: Callable[[str], bool],
         sleep_fn: Callable[[int | float], Coroutine[Any, Any, None]],
         interval_cb: Callable[[str], int] | None = None,
+        is_in_pipeline_cb: Callable[[int], bool] | None = None,
     ) -> None:
         super().__init__(
             worker_name="worktree_gc",
@@ -56,6 +57,7 @@ class WorktreeGCLoop(BaseBackgroundLoop):
         self._worktrees = worktrees
         self._prs = prs
         self._state = state
+        self._is_in_pipeline = is_in_pipeline_cb
 
     def _get_default_interval(self) -> int:
         return self._config.worktree_gc_interval
@@ -114,11 +116,15 @@ class WorktreeGCLoop(BaseBackgroundLoop):
 
         Returns False (skip) on any uncertainty.
         """
-        # Skip if currently being processed or HITL in progress
+        # Skip if active, HITL, or anywhere in the IssueStore pipeline
+        # (queued, in-flight, or being processed).
+        in_pipeline = self._is_in_pipeline and self._is_in_pipeline(issue_number)
         if (
             issue_number in self._state.get_active_issue_numbers()
             or self._state.get_hitl_cause(issue_number) is not None
+            or in_pipeline
         ):
+            logger.debug("GC: #%d is active/HITL/pipeline — skipping", issue_number)
             return False
 
         # Check issue state via GitHub API
@@ -267,8 +273,10 @@ class WorktreeGCLoop(BaseBackgroundLoop):
             if not match:
                 continue
             issue_num = int(match.group(1))
-            # Skip if worktree exists or issue is active
+            # Skip if worktree exists, issue is active, or in pipeline
             if issue_num in active_worktrees or issue_num in active_issues:
+                continue
+            if self._is_in_pipeline and self._is_in_pipeline(issue_num):
                 continue
             try:
                 await run_subprocess(

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -953,6 +953,43 @@ class TestInFlightProtection:
         assert store._eagerly_transitioned == {}
 
 
+# ── Pipeline Membership Check ──────────────────────────────────────
+
+
+class TestIsInPipeline:
+    """Tests for is_in_pipeline() used by worktree GC safety checks."""
+
+    def test_queued_issue_is_in_pipeline(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        assert store.is_in_pipeline(1) is True
+
+    def test_in_flight_issue_is_in_pipeline(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)  # dequeues → in-flight
+        assert store.is_in_pipeline(1) is True
+
+    def test_active_issue_is_in_pipeline(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+        store.mark_active(1, STAGE_PLAN)
+        assert store.is_in_pipeline(1) is True
+
+    def test_completed_issue_not_in_pipeline(self) -> None:
+        store = _make_store()
+        store._route_issues([TaskFactory.create(id=1, tags=["hydraflow-plan"])])
+        store.get_plannable(1)
+        store.mark_active(1, STAGE_PLAN)
+        store.mark_complete(1)
+        assert store.is_in_pipeline(1) is False
+
+    def test_unknown_issue_not_in_pipeline(self) -> None:
+        store = _make_store()
+        assert store.is_in_pipeline(999) is False
+
+
 # ── Eager Transition Protection ─────────────────────────────────────
 
 

--- a/tests/test_worktree_gc_loop.py
+++ b/tests/test_worktree_gc_loop.py
@@ -28,6 +28,7 @@ def _make_loop(
     active_worktrees: dict[int, str] | None = None,
     active_issue_numbers: list[int] | None = None,
     hitl_causes: dict[int, str] | None = None,
+    pipeline_issues: set[int] | None = None,
 ) -> tuple[WorktreeGCLoop, StateTracker, asyncio.Event]:
     """Build a WorktreeGCLoop with test-friendly defaults."""
     deps = make_bg_loop_deps(tmp_path, enabled=enabled, worktree_gc_interval=interval)
@@ -39,6 +40,8 @@ def _make_loop(
         state.set_active_issue_numbers(active_issue_numbers)
     for num, cause in (hitl_causes or {}).items():
         state.set_hitl_cause(num, cause)
+
+    in_pipeline = pipeline_issues or set()
 
     worktrees = MagicMock()
     worktrees.destroy = AsyncMock()
@@ -55,6 +58,7 @@ def _make_loop(
         enabled_cb=deps.enabled_cb,
         sleep_fn=deps.sleep_fn,
         interval_cb=None,
+        is_in_pipeline_cb=lambda n: n in in_pipeline,
     )
     loop._git_worktree_prune = AsyncMock()  # type: ignore[method-assign]
     loop._collect_orphaned_branches = AsyncMock(return_value=0)  # type: ignore[method-assign]
@@ -564,3 +568,65 @@ class TestIsSafeToGCDirect:
         loop._get_issue_state = AsyncMock(return_value="open")
         loop._has_open_pr = AsyncMock(side_effect=RuntimeError("PR check error"))
         assert await loop._is_safe_to_gc(42) is False
+
+    @pytest.mark.asyncio
+    async def test_unsafe_when_issue_in_pipeline(self, tmp_path: Path) -> None:
+        """Issues queued/in-flight/active in IssueStore must not be GC'd."""
+        loop, _s, _e = _make_loop(tmp_path, pipeline_issues={42})
+        assert await loop._is_safe_to_gc(42) is False
+
+    @pytest.mark.asyncio
+    async def test_safe_when_issue_not_in_pipeline(self, tmp_path: Path) -> None:
+        """Issues not in the pipeline can be GC'd if other checks pass."""
+        loop, _s, _e = _make_loop(tmp_path, pipeline_issues={99})
+        loop._get_issue_state = AsyncMock(return_value="closed")
+        assert await loop._is_safe_to_gc(42) is True
+
+
+class TestWorktreeGCPipelineProtection:
+    """Tests for pipeline-aware GC protection."""
+
+    @pytest.mark.asyncio
+    async def test_skips_worktree_for_queued_issue(self, tmp_path: Path) -> None:
+        """Worktrees for issues still in the pipeline queue are not collected."""
+        loop, state, _e = _make_loop(
+            tmp_path, active_worktrees={42: "/p/42"}, pipeline_issues={42}
+        )
+        result = await loop._do_work()
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["skipped"] == 1
+        assert 42 in state.get_active_worktrees()
+
+    @pytest.mark.asyncio
+    async def test_collects_worktree_not_in_pipeline(self, tmp_path: Path) -> None:
+        """Worktrees for issues no longer in the pipeline are collected normally."""
+        loop, _s, _e = _make_loop(
+            tmp_path, active_worktrees={42: "/p/42"}, pipeline_issues=set()
+        )
+        loop._get_issue_state = AsyncMock(return_value="closed")
+        result = await loop._do_work()
+        loop._worktrees.destroy.assert_awaited_once_with(42)
+        assert result["collected"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_skips_orphaned_dir_for_pipeline_issue(self, tmp_path: Path) -> None:
+        """Orphaned filesystem dirs for pipeline issues are not collected."""
+        loop, _s, _e = _make_loop(tmp_path, pipeline_issues={99})
+        orphan = loop._config.worktree_base / loop._config.repo_slug / "issue-99"
+        orphan.mkdir(parents=True)
+        result = await loop._do_work()
+        loop._worktrees.destroy.assert_not_awaited()
+        assert result["collected"] == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_branch_for_pipeline_issue(self, tmp_path: Path) -> None:
+        """Branches for issues in the pipeline are not deleted."""
+        loop, _s, _e = _make_loop(tmp_path, pipeline_issues={99})
+        loop._collect_orphaned_branches = (
+            WorktreeGCLoop._collect_orphaned_branches.__get__(loop)
+        )  # type: ignore[attr-defined]
+        with patch("worktree_gc_loop.run_subprocess", new_callable=AsyncMock) as m:
+            m.return_value = "  agent/issue-99\n"
+            count = await loop._collect_orphaned_branches()
+        assert count == 0
+        assert m.await_count == 1


### PR DESCRIPTION
## Summary
- Add `is_in_pipeline()` to `IssueStore` — checks if an issue is in any queue, in-flight, or active
- Wire it into `WorktreeGCLoop` via `is_in_pipeline_cb` callback
- GC now skips issues that are queued, in-flight, or actively being processed
- Same protection applied to orphaned branch cleanup

Fixes the zero-commit bug where the GC loop destroyed worktrees for issues that were queued for implementation but not yet in `active_issue_numbers`.

Fixes #1982

## Test plan
- [x] 5 new `TestIsInPipeline` tests (queued, in-flight, active, completed, unknown)
- [x] 6 new `TestWorktreeGCPipelineProtection` + `TestIsSafeToGCDirect` tests
- [x] All 143 existing + new tests pass
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)