### PR TITLE
Add global GitHub API concurrency limiter

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -29,6 +29,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("max_issue_body_chars", "HYDRAFLOW_MAX_ISSUE_BODY_CHARS", 10_000),
     ("max_review_diff_chars", "HYDRAFLOW_MAX_REVIEW_DIFF_CHARS", 15_000),
     ("gh_max_retries", "HYDRAFLOW_GH_MAX_RETRIES", 3),
+    ("gh_api_concurrency", "HYDRAFLOW_GH_API_CONCURRENCY", 5),
     ("max_issue_attempts", "HYDRAFLOW_MAX_ISSUE_ATTEMPTS", 3),
     ("memory_sync_interval", "HYDRAFLOW_MEMORY_SYNC_INTERVAL", 3600),
     ("metrics_sync_interval", "HYDRAFLOW_METRICS_SYNC_INTERVAL", 7200),
@@ -323,6 +324,12 @@ class HydraFlowConfig(BaseModel):
         ge=0,
         le=10,
         description="Max retry attempts for gh CLI calls",
+    )
+    gh_api_concurrency: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="Max concurrent gh/git subprocess calls (prevents API rate limiting)",
     )
 
     # Task source

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -29,7 +29,11 @@ from phase_utils import (
 )
 from service_registry import OrchestratorCallbacks, build_services
 from state import StateTracker
-from subprocess_util import AuthenticationError, CreditExhaustedError
+from subprocess_util import (
+    AuthenticationError,
+    CreditExhaustedError,
+    configure_gh_concurrency,
+)
 
 if TYPE_CHECKING:
     from crate_manager import CrateManager
@@ -90,6 +94,9 @@ class HydraFlowOrchestrator:
         self._session_issue_results: dict[int, bool] = {}
         # Loop tasks (set by _supervise_loops for stop() to cancel)
         self._loop_tasks: dict[str, asyncio.Task[None]] = {}
+
+        # Configure global GitHub API concurrency limiter
+        configure_gh_concurrency(config.gh_api_concurrency)
 
         # Build all services via the factory
         svc = build_services(

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -17,6 +17,29 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.subprocess")
 
+# Global semaphore to limit concurrent gh/git subprocess calls and prevent
+# GitHub API rate limiting when multiple async loops poll simultaneously.
+_gh_semaphore: asyncio.Semaphore | None = None
+_GH_DEFAULT_CONCURRENCY = 5
+
+
+def configure_gh_concurrency(limit: int) -> None:
+    """Set the global GitHub API concurrency limit.
+
+    Must be called once during startup before any subprocess calls.
+    """
+    global _gh_semaphore  # noqa: PLW0603
+    _gh_semaphore = asyncio.Semaphore(limit)
+    logger.info("GitHub API concurrency limit set to %d", limit)
+
+
+def _get_gh_semaphore() -> asyncio.Semaphore:
+    """Return the global semaphore, creating with defaults if not configured."""
+    global _gh_semaphore  # noqa: PLW0603
+    if _gh_semaphore is None:
+        _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
+    return _gh_semaphore
+
 
 class AuthenticationError(RuntimeError):
     """Raised when a subprocess fails due to GitHub authentication issues."""
@@ -192,6 +215,9 @@ def make_docker_env(
     return env
 
 
+_GH_COMMANDS = frozenset({"gh", "git"})
+
+
 async def run_subprocess(
     *cmd: str,
     cwd: Path | None = None,
@@ -205,6 +231,9 @@ async def run_subprocess(
     nesting detection.  When *gh_token* is non-empty it is injected
     as ``GH_TOKEN``.
 
+    For ``gh`` and ``git`` commands, execution is gated through a global
+    semaphore to prevent GitHub API rate limiting from concurrent calls.
+
     Raises :class:`SubprocessTimeoutError` if the command exceeds *timeout* seconds.
     Raises :class:`RuntimeError` on non-zero exit.
     """
@@ -212,25 +241,33 @@ async def run_subprocess(
 
     env = make_clean_env(gh_token)
 
-    if runner is None:
-        runner = get_default_runner()
-    try:
-        result = await runner.run_simple(
-            list(cmd),
-            cwd=str(cwd) if cwd is not None else None,
-            env=env,
-            timeout=timeout,
-        )
-    except TimeoutError:
-        raise SubprocessTimeoutError(
-            f"Command {cmd!r} timed out after {timeout}s"
-        ) from None
-    if result.returncode != 0:
-        msg = f"Command {cmd!r} failed (rc={result.returncode}): {result.stderr}"
-        if _is_auth_error(result.stderr):
-            raise AuthenticationError(msg)
-        raise RuntimeError(msg)
-    return result.stdout
+    resolved_runner = runner if runner is not None else get_default_runner()
+
+    use_semaphore = bool(cmd) and cmd[0] in _GH_COMMANDS
+
+    async def _exec() -> str:
+        try:
+            result = await resolved_runner.run_simple(
+                list(cmd),
+                cwd=str(cwd) if cwd is not None else None,
+                env=env,
+                timeout=timeout,
+            )
+        except TimeoutError:
+            raise SubprocessTimeoutError(
+                f"Command {cmd!r} timed out after {timeout}s"
+            ) from None
+        if result.returncode != 0:
+            msg = f"Command {cmd!r} failed (rc={result.returncode}): {result.stderr}"
+            if _is_auth_error(result.stderr):
+                raise AuthenticationError(msg)
+            raise RuntimeError(msg)
+        return result.stdout
+
+    if use_semaphore:
+        async with _get_gh_semaphore():
+            return await _exec()
+    return await _exec()
 
 
 _RETRYABLE_PATTERNS = (

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -14,6 +14,7 @@ from subprocess_util import (
     SubprocessTimeoutError,
     _is_auth_error,
     _is_retryable_error,
+    configure_gh_concurrency,
     make_clean_env,
     make_docker_env,
     run_subprocess,
@@ -698,3 +699,99 @@ class TestMakeDockerEnv:
             "GIT_COMMITTER_EMAIL",
         }
         assert set(env.keys()) == expected_keys
+
+
+# --- GitHub API concurrency semaphore ---
+
+
+class TestGhApiSemaphore:
+    """Tests for the global GitHub API concurrency limiter."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_semaphore(self) -> None:
+        """Reset the global semaphore before each test."""
+        import subprocess_util
+
+        subprocess_util._gh_semaphore = None
+
+    @staticmethod
+    def _make_tracking_runner(
+        delay: float = 0.05,
+    ) -> tuple[MagicMock, dict[str, int]]:
+        """Create a mock runner that tracks concurrency."""
+        from execution import SimpleResult
+
+        stats: dict[str, int] = {"calls": 0, "max_concurrent": 0, "current": 0}
+
+        async def fake_run_simple(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            stats["current"] += 1
+            stats["calls"] += 1
+            stats["max_concurrent"] = max(stats["max_concurrent"], stats["current"])
+            await asyncio.sleep(delay)
+            stats["current"] -= 1
+            return SimpleResult(stdout="ok", stderr="", returncode=0)
+
+        runner = MagicMock()
+        runner.run_simple = fake_run_simple
+        return runner, stats
+
+    @pytest.mark.asyncio
+    async def test_gh_commands_use_semaphore(self) -> None:
+        """gh and git commands should be gated by the semaphore."""
+        configure_gh_concurrency(2)
+        runner, stats = self._make_tracking_runner()
+
+        tasks = [run_subprocess("gh", "api", "test", runner=runner) for _ in range(5)]
+        await asyncio.gather(*tasks)
+
+        assert stats["calls"] == 5
+        assert stats["max_concurrent"] <= 2
+
+    @pytest.mark.asyncio
+    async def test_non_gh_commands_bypass_semaphore(self) -> None:
+        """Non-gh/git commands should not use the semaphore."""
+        configure_gh_concurrency(1)
+        runner, stats = self._make_tracking_runner()
+
+        tasks = [run_subprocess("echo", "hello", runner=runner) for _ in range(3)]
+        await asyncio.gather(*tasks)
+
+        # With semaphore(1), if it were used, max_concurrent would be 1
+        # Non-gh commands bypass it, so all 3 run concurrently
+        assert stats["max_concurrent"] == 3
+
+    @pytest.mark.asyncio
+    async def test_configure_gh_concurrency_sets_limit(self) -> None:
+        """configure_gh_concurrency should set the semaphore limit."""
+        import subprocess_util
+
+        configure_gh_concurrency(7)
+        sem = subprocess_util._gh_semaphore
+        assert sem is not None
+        assert sem._value == 7
+
+    @pytest.mark.asyncio
+    async def test_default_semaphore_created_lazily(self) -> None:
+        """If not configured, a default semaphore is created on first use."""
+        import subprocess_util
+
+        assert subprocess_util._gh_semaphore is None
+        runner, _ = self._make_tracking_runner(delay=0)
+        await run_subprocess("gh", "pr", "list", runner=runner)
+        assert subprocess_util._gh_semaphore is not None
+        assert subprocess_util._gh_semaphore._value == 5
+
+    @pytest.mark.asyncio
+    async def test_semaphore_does_not_block_errors(self) -> None:
+        """Errors should propagate normally through the semaphore."""
+        from execution import SimpleResult
+
+        configure_gh_concurrency(5)
+
+        async def fail_run_simple(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            return SimpleResult(stdout="", stderr="rate limit exceeded", returncode=1)
+
+        runner = MagicMock()
+        runner.run_simple = fail_run_simple
+        with pytest.raises(RuntimeError, match="rate limit"):
+            await run_subprocess("gh", "api", "test", runner=runner)


### PR DESCRIPTION
## Summary
- Adds a global `asyncio.Semaphore` in `subprocess_util.py` that gates all `gh`/`git` subprocess calls through a shared concurrency limit (default 5)
- Configurable via `HYDRAFLOW_GH_API_CONCURRENCY` env var / `gh_api_concurrency` config field
- Prevents GitHub API rate limiting when multiple async loops (review, GC, unsticker, dashboard, metrics) all poll simultaneously at scale (15+ concurrent issues)

Fixes #1986

## Test plan
- [x] 5 new tests in `TestGhApiSemaphore`: semaphore limits gh commands, non-gh bypasses, configure sets limit, lazy default creation, errors propagate
- [x] All 73 existing subprocess_util tests pass
- [x] Lint + typecheck + security clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)