### PR TITLE
Add global rate-limit cooldown to prevent retry amplification

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -22,6 +22,11 @@ logger = logging.getLogger("hydraflow.subprocess")
 _gh_semaphore: asyncio.Semaphore | None = None
 _GH_DEFAULT_CONCURRENCY = 5
 
+# Global rate-limit cooldown: when ANY call gets a 403 rate limit,
+# ALL callers pause until this timestamp (UTC).
+_rate_limit_until: datetime | None = None
+_RATE_LIMIT_COOLDOWN_SECONDS = 60
+
 
 def configure_gh_concurrency(limit: int) -> None:
     """Set the global GitHub API concurrency limit.
@@ -39,6 +44,37 @@ def _get_gh_semaphore() -> asyncio.Semaphore:
     if _gh_semaphore is None:
         _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
     return _gh_semaphore
+
+
+def _is_rate_limited(stderr: str) -> bool:
+    """Check if stderr indicates a GitHub API rate limit (403)."""
+    lower = stderr.lower()
+    return "rate limit" in lower and ("403" in lower or "http 403" in lower)
+
+
+def _trigger_rate_limit_cooldown() -> None:
+    """Set the global cooldown so all callers pause."""
+    global _rate_limit_until  # noqa: PLW0603
+    _rate_limit_until = datetime.now(tz=UTC) + timedelta(
+        seconds=_RATE_LIMIT_COOLDOWN_SECONDS
+    )
+    logger.warning(
+        "GitHub API rate limit hit — pausing ALL gh/git calls for %ds",
+        _RATE_LIMIT_COOLDOWN_SECONDS,
+    )
+
+
+async def _wait_for_rate_limit_cooldown() -> None:
+    """If a global rate-limit cooldown is active, sleep until it expires."""
+    if _rate_limit_until is None:
+        return
+    remaining = (_rate_limit_until - datetime.now(tz=UTC)).total_seconds()
+    if remaining > 0:
+        logger.info(
+            "Rate-limit cooldown active — waiting %.0fs before gh/git call",
+            remaining,
+        )
+        await asyncio.sleep(remaining)
 
 
 class AuthenticationError(RuntimeError):
@@ -261,17 +297,19 @@ async def run_subprocess(
             msg = f"Command {cmd!r} failed (rc={result.returncode}): {result.stderr}"
             if _is_auth_error(result.stderr):
                 raise AuthenticationError(msg)
+            if _is_rate_limited(result.stderr):
+                _trigger_rate_limit_cooldown()
             raise RuntimeError(msg)
         return result.stdout
 
     if use_semaphore:
+        await _wait_for_rate_limit_cooldown()
         async with _get_gh_semaphore():
             return await _exec()
     return await _exec()
 
 
 _RETRYABLE_PATTERNS = (
-    "rate limit",
     "timeout",
     "timed out",
     "connection",
@@ -279,17 +317,20 @@ _RETRYABLE_PATTERNS = (
     "503",
     "504",
 )
+# Rate-limit errors are handled by the global cooldown in run_subprocess(),
+# not by per-call retries which would just amplify the problem.
 _NON_RETRYABLE_PATTERNS = ("401", "403", "404")
 
 
 def _is_retryable_error(stderr: str) -> bool:
-    """Check if a subprocess error indicates a transient/retryable condition."""
+    """Check if a subprocess error indicates a transient/retryable condition.
+
+    Rate-limit errors (403 + "rate limit") are NOT retried per-call;
+    they trigger a global cooldown in :func:`run_subprocess` instead.
+    """
     stderr_lower = stderr.lower()
     for pattern in _NON_RETRYABLE_PATTERNS:
         if pattern in stderr_lower:
-            # 403 with "rate limit" IS retryable
-            if pattern == "403" and "rate limit" in stderr_lower:
-                continue
             return False
     return any(p in stderr_lower for p in _RETRYABLE_PATTERNS)
 

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -193,8 +193,9 @@ def test_make_clean_env_does_not_mutate_os_environ() -> None:
 class TestIsRetryableError:
     """Tests for the _is_retryable_error helper."""
 
-    def test_retryable_on_rate_limit(self) -> None:
-        assert _is_retryable_error("API rate limit exceeded") is True
+    def test_not_retryable_on_rate_limit(self) -> None:
+        """Rate limits are handled by the global cooldown, not per-call retry."""
+        assert _is_retryable_error("API rate limit exceeded") is False
 
     def test_retryable_on_timeout(self) -> None:
         assert _is_retryable_error("connection timeout") is True
@@ -217,8 +218,9 @@ class TestIsRetryableError:
     def test_not_retryable_on_403_without_rate_limit(self) -> None:
         assert _is_retryable_error("403 Forbidden") is False
 
-    def test_retryable_on_403_with_rate_limit(self) -> None:
-        assert _is_retryable_error("403 rate limit exceeded") is True
+    def test_not_retryable_on_403_with_rate_limit(self) -> None:
+        """403 rate limits are handled by the global cooldown, not per-call retry."""
+        assert _is_retryable_error("403 rate limit exceeded") is False
 
     def test_not_retryable_on_404(self) -> None:
         assert _is_retryable_error("404 Not Found") is False
@@ -303,18 +305,17 @@ class TestRunSubprocessWithRetry:
         mock_run.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_retry_on_403_rate_limit(self) -> None:
-        with (
-            patch("subprocess_util.run_subprocess", new_callable=AsyncMock) as mock_run,
-            patch("asyncio.sleep", new_callable=AsyncMock),
-        ):
-            mock_run.side_effect = [
-                RuntimeError("Command failed (rc=1): 403 rate limit exceeded"),
-                "ok",
-            ]
-            result = await run_subprocess_with_retry("gh", "pr", "list", max_retries=3)
-        assert result == "ok"
-        assert mock_run.await_count == 2
+    async def test_no_retry_on_403_rate_limit(self) -> None:
+        """403 rate limits trigger global cooldown, not per-call retry."""
+        with patch(
+            "subprocess_util.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            mock_run.side_effect = RuntimeError(
+                "Command failed (rc=1): 403 rate limit exceeded"
+            )
+            with pytest.raises(RuntimeError, match="rate limit"):
+                await run_subprocess_with_retry("gh", "pr", "list", max_retries=3)
+        mock_run.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_backoff_increases_exponentially(self) -> None:
@@ -789,9 +790,105 @@ class TestGhApiSemaphore:
         configure_gh_concurrency(5)
 
         async def fail_run_simple(cmd: list[str], **_kwargs: object) -> SimpleResult:
-            return SimpleResult(stdout="", stderr="rate limit exceeded", returncode=1)
+            return SimpleResult(stdout="", stderr="some error", returncode=1)
 
         runner = MagicMock()
         runner.run_simple = fail_run_simple
+        with pytest.raises(RuntimeError, match="some error"):
+            await run_subprocess("gh", "api", "test", runner=runner)
+
+
+class TestRateLimitCooldown:
+    """Tests for the global rate-limit cooldown."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self) -> None:
+        """Reset global state before each test."""
+        import subprocess_util
+
+        subprocess_util._gh_semaphore = None
+        subprocess_util._rate_limit_until = None
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_triggers_global_cooldown(self) -> None:
+        """A 403 rate-limit response should set _rate_limit_until."""
+        import subprocess_util
+        from execution import SimpleResult
+
+        configure_gh_concurrency(5)
+
+        async def rate_limit_response(
+            cmd: list[str], **_kwargs: object
+        ) -> SimpleResult:
+            return SimpleResult(
+                stdout="",
+                stderr="gh: API rate limit exceeded (HTTP 403)",
+                returncode=1,
+            )
+
+        runner = MagicMock()
+        runner.run_simple = rate_limit_response
+
         with pytest.raises(RuntimeError, match="rate limit"):
             await run_subprocess("gh", "api", "test", runner=runner)
+
+        assert subprocess_util._rate_limit_until is not None
+
+    @pytest.mark.asyncio
+    async def test_cooldown_delays_subsequent_calls(self) -> None:
+        """When cooldown is active, gh calls should wait before executing."""
+        from datetime import UTC, datetime, timedelta
+
+        import subprocess_util
+
+        configure_gh_concurrency(5)
+        # Set cooldown to expire in 0.1s
+        subprocess_util._rate_limit_until = datetime.now(tz=UTC) + timedelta(
+            seconds=0.1
+        )
+
+        runner, stats = TestGhApiSemaphore._make_tracking_runner(delay=0)
+        start = asyncio.get_event_loop().time()
+        await run_subprocess("gh", "api", "test", runner=runner)
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert stats["calls"] == 1
+        assert elapsed >= 0.08  # Should have waited ~0.1s
+
+    @pytest.mark.asyncio
+    async def test_expired_cooldown_does_not_delay(self) -> None:
+        """An expired cooldown should not delay calls."""
+        from datetime import UTC, datetime, timedelta
+
+        import subprocess_util
+
+        configure_gh_concurrency(5)
+        # Set cooldown in the past
+        subprocess_util._rate_limit_until = datetime.now(tz=UTC) - timedelta(seconds=5)
+
+        runner, stats = TestGhApiSemaphore._make_tracking_runner(delay=0)
+        start = asyncio.get_event_loop().time()
+        await run_subprocess("gh", "api", "test", runner=runner)
+        elapsed = asyncio.get_event_loop().time() - start
+
+        assert stats["calls"] == 1
+        assert elapsed < 0.05  # Should not have waited
+
+    @pytest.mark.asyncio
+    async def test_non_rate_limit_error_does_not_trigger_cooldown(self) -> None:
+        """Non-rate-limit errors should not set the global cooldown."""
+        import subprocess_util
+        from execution import SimpleResult
+
+        configure_gh_concurrency(5)
+
+        async def normal_error(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            return SimpleResult(stdout="", stderr="404 not found", returncode=1)
+
+        runner = MagicMock()
+        runner.run_simple = normal_error
+
+        with pytest.raises(RuntimeError):
+            await run_subprocess("gh", "api", "test", runner=runner)
+
+        assert subprocess_util._rate_limit_until is None


### PR DESCRIPTION
## Summary
- When ANY `gh`/`git` call gets a 403 rate-limit response, ALL callers now pause for 60 seconds
- Rate-limit errors are no longer retried per-call (which was amplifying the problem — each failed retry triggered 3 more retries across all concurrent callers)
- Builds on #1987's semaphore — semaphore limits concurrency, cooldown handles rate-limit recovery

## What changed
- `subprocess_util.py`: Added `_rate_limit_until` global timestamp, `_is_rate_limited()` detection, `_trigger_rate_limit_cooldown()`, and `_wait_for_rate_limit_cooldown()` 
- `run_subprocess()`: Detects 403 rate-limit in responses → triggers global cooldown; waits for cooldown before `gh`/`git` calls
- `_is_retryable_error()`: Removed "rate limit" from retryable patterns — no more per-call retry amplification
- 4 new tests for cooldown behavior, updated 3 existing tests for new rate-limit handling

Fixes #1986

## Test plan
- [x] 77 tests pass in test_subprocess_util.py (4 new cooldown tests)
- [x] Lint + typecheck + security clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)