### PR TITLE
System: auto-apply reviewer label on PR creation

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -245,6 +245,9 @@ class PRManager:
         ]
         if draft:
             cmd.append("--draft")
+        review_labels = self._config.review_label or ["hydraflow-review"]
+        for label in review_labels:
+            cmd.extend(["--label", label])
 
         try:
             output = await self._run_with_body_file(

--- a/tests/test_pr_manager.py
+++ b/tests/test_pr_manager.py
@@ -887,6 +887,20 @@ async def test_create_pr_includes_required_flags(config, event_bus, issue):
 
 
 @pytest.mark.asyncio
+async def test_create_pr_includes_review_label(config, event_bus, issue):
+    manager = _make_manager(config, event_bus)
+    pr_url = "https://github.com/test-org/test-repo/pull/55"
+    mock_create = SubprocessMockBuilder().with_stdout(pr_url).build()
+
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        await manager.create_pr(issue, "agent/issue-42")
+
+    args = mock_create.call_args[0]
+    assert "--label" in args
+    assert config.review_label[0] in args
+
+
+@pytest.mark.asyncio
 async def test_create_pr_parses_pr_number_from_url(config, event_bus, issue):
     manager = _make_manager(config, event_bus)
     pr_url = "https://github.com/test-org/test-repo/pull/123"


### PR DESCRIPTION
## Summary
- make HydraFlow system apply reviewer labels when creating PRs
- pass review labels directly to gh pr create via --label
- add test coverage for reviewer label injection in PR creation

## Why
- keeps PRs labeled by system behavior, without relying on CI gate workflows
- aligns with requirement that PRs should not be unlabeled in pipeline flow

## Testing
- pytest -q tests/test_pr_manager.py -k "create_pr"