### PR TITLE
Auto-fix merge conflicts in standard review merge path

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2041,6 +2041,20 @@ class VisualGateFn(Protocol):
     ) -> bool: ...
 
 
+class MergeConflictFixFn(Protocol):
+    """Async callback for post-merge conflict recovery attempts.
+
+    Returns ``True`` when the conflict was resolved and branch updates were pushed.
+    """
+
+    async def __call__(
+        self,
+        pr: PRInfo,
+        issue: Task,
+        worker_id: int,
+    ) -> bool: ...
+
+
 class StatusCallback(Protocol):
     """Sync callback for background worker status updates.
 

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -23,6 +23,7 @@ from models import (
     IssueOutcomeType,
     JudgeResult,
     JudgeVerdict,
+    MergeConflictFixFn,
     PRInfo,
     PublishFn,
     ReviewResult,
@@ -145,6 +146,7 @@ class PostMergeHandler:
         code_scanning_alerts: list[dict] | None = None,
         visual_gate_fn: VisualGateFn | None = None,
         visual_decision: VisualValidationDecision | None = None,
+        merge_conflict_fix_fn: MergeConflictFixFn | None = None,
     ) -> None:
         """Attempt merge for an approved PR (with optional CI gate).
 
@@ -205,6 +207,20 @@ class PostMergeHandler:
 
         await publish_fn(pr, worker_id, "merging")
         success = await self._prs.merge_pr(pr.number)
+        mergeable: bool | None = None
+        if not success:
+            mergeable = await self._prs.get_pr_mergeable(pr.number)
+            if mergeable is False and merge_conflict_fix_fn is not None:
+                logger.info(
+                    "PR #%d merge failed due to conflict — attempting standard review auto-fix",
+                    pr.number,
+                )
+                await publish_fn(pr, worker_id, "merge_fix")
+                recovered = await merge_conflict_fix_fn(pr, issue, worker_id)
+                if recovered:
+                    await publish_fn(pr, worker_id, "merging")
+                    success = await self._prs.merge_pr(pr.number)
+
         if success:
             result.merged = True
             self._state.mark_issue(pr.issue_number, "merged")
@@ -264,7 +280,8 @@ class PostMergeHandler:
         else:
             logger.warning("PR #%d merge failed — escalating to HITL", pr.number)
             await publish_fn(pr, worker_id, "escalating")
-            mergeable = await self._prs.get_pr_mergeable(pr.number)
+            if mergeable is None:
+                mergeable = await self._prs.get_pr_mergeable(pr.number)
             cause = "PR merge failed on GitHub"
             comment = (
                 "**Merge failed** — PR could not be merged. Escalating to human review."

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -823,7 +823,42 @@ class ReviewPhase:
             code_scanning_alerts=code_scanning_alerts,
             visual_gate_fn=self.check_visual_gate,
             visual_decision=visual_decision,
+            merge_conflict_fix_fn=self._attempt_post_merge_conflict_fix,
         )
+
+    async def _attempt_post_merge_conflict_fix(
+        self,
+        pr: PRInfo,
+        issue: Task,
+        worker_id: int,
+    ) -> bool:
+        """Attempt conflict resolution after a failed GitHub merge.
+
+        This keeps the standard review path aligned with unsticker behavior:
+        resolve merge conflicts on the branch, push updates, then retry merge.
+        """
+        wt_path = self._config.worktree_path_for_issue(pr.issue_number)
+        if not wt_path.exists():
+            wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
+
+        resolution = await self._conflict_resolver.resolve_merge_conflicts(
+            pr,
+            issue,
+            wt_path,
+            worker_id=worker_id,
+            source="post_merge",
+        )
+        if not resolution.success:
+            return False
+
+        if resolution.used_rebuild:
+            await self._prs.force_push_branch(
+                self._config.worktree_path_for_issue(pr.issue_number),
+                pr.branch,
+            )
+        else:
+            await self._prs.push_branch(wt_path, pr.branch)
+        return True
 
     async def check_visual_gate(
         self,

--- a/tests/test_post_merge_handler.py
+++ b/tests/test_post_merge_handler.py
@@ -263,6 +263,70 @@ class TestPostMergeHandler:
         )
 
     @pytest.mark.asyncio
+    async def test_handle_approved_merge_conflict_attempts_auto_fix_and_retries_merge(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """On merge conflict, standard review path should attempt auto-fix before HITL."""
+        handler = _make_handler(config)
+        pr = PRInfoFactory.create()
+        issue = TaskFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(side_effect=[False, True])
+        handler._prs.get_pr_mergeable = AsyncMock(return_value=False)
+        publish_fn = AsyncMock()
+        escalate_fn = AsyncMock()
+        merge_conflict_fix_fn = AsyncMock(return_value=True)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=AsyncMock(return_value=True),
+            escalate_fn=escalate_fn,
+            publish_fn=publish_fn,
+            merge_conflict_fix_fn=merge_conflict_fix_fn,
+        )
+
+        merge_conflict_fix_fn.assert_awaited_once_with(pr, issue, 0)
+        assert handler._prs.merge_pr.await_count == 2
+        escalate_fn.assert_not_awaited()
+        assert result.merged is True
+
+    @pytest.mark.asyncio
+    async def test_handle_approved_merge_conflict_fix_failure_escalates(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """If standard auto-fix fails, merge conflict should still escalate to HITL."""
+        handler = _make_handler(config)
+        pr = PRInfoFactory.create()
+        issue = TaskFactory.create()
+        result = ReviewResultFactory.create()
+
+        handler._prs.merge_pr = AsyncMock(return_value=False)
+        handler._prs.get_pr_mergeable = AsyncMock(return_value=False)
+        escalate_fn = AsyncMock()
+        merge_conflict_fix_fn = AsyncMock(return_value=False)
+
+        await handler.handle_approved(
+            pr,
+            issue,
+            result,
+            "diff",
+            0,
+            ci_gate_fn=AsyncMock(return_value=True),
+            escalate_fn=escalate_fn,
+            publish_fn=AsyncMock(),
+            merge_conflict_fix_fn=merge_conflict_fix_fn,
+        )
+
+        merge_conflict_fix_fn.assert_awaited_once_with(pr, issue, 0)
+        kwargs = escalate_fn.await_args.kwargs
+        assert kwargs["cause"] == "PR merge failed on GitHub: merge conflict"
+
+    @pytest.mark.asyncio
     async def test_get_judge_result_none(self, config: HydraFlowConfig) -> None:
         """When verdict is None, should return None."""
         handler = _make_handler(config)

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 from events import EventType
 from models import (
+    ConflictResolutionResult,
     CriterionResult,
     CriterionVerdict,
     JudgeVerdict,
@@ -111,6 +112,50 @@ class TestReviewPRs:
         await phase.review_prs(prs, issues)
 
         assert concurrency_counter["peak"] <= config.max_reviewers
+
+
+class TestPostMergeConflictFix:
+    """Tests for post-merge conflict recovery helper."""
+
+    @pytest.mark.asyncio
+    async def test_attempt_post_merge_conflict_fix_pushes_branch_on_success(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create(number=101, issue_number=42, branch="agent/issue-42")
+        issue = TaskFactory.create(id=42)
+        wt = config.worktree_path_for_issue(42)
+        wt.mkdir(parents=True, exist_ok=True)
+
+        phase._conflict_resolver.resolve_merge_conflicts = AsyncMock(
+            return_value=ConflictResolutionResult(success=True, used_rebuild=False)
+        )
+
+        ok = await phase._attempt_post_merge_conflict_fix(pr, issue, worker_id=7)
+
+        assert ok is True
+        phase._prs.push_branch.assert_awaited_once_with(wt, pr.branch)
+        phase._prs.force_push_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_attempt_post_merge_conflict_fix_force_pushes_on_rebuild(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase = make_review_phase(config)
+        pr = PRInfoFactory.create(number=101, issue_number=42, branch="agent/issue-42")
+        issue = TaskFactory.create(id=42)
+        wt = config.worktree_path_for_issue(42)
+        wt.mkdir(parents=True, exist_ok=True)
+
+        phase._conflict_resolver.resolve_merge_conflicts = AsyncMock(
+            return_value=ConflictResolutionResult(success=True, used_rebuild=True)
+        )
+
+        ok = await phase._attempt_post_merge_conflict_fix(pr, issue, worker_id=7)
+
+        assert ok is True
+        phase._prs.force_push_branch.assert_awaited_once_with(wt, pr.branch)
+        phase._prs.push_branch.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_comment_verdict_when_issue_missing(


### PR DESCRIPTION
## Summary
- add a post-merge conflict recovery hook to PostMergeHandler
- when GitHub merge fails with mergeable=false, standard review now attempts automatic conflict resolution (same resolver flow used by unsticker)
- on successful recovery, push/force-push as needed and retry merge before escalating to HITL

## Tests
- pytest -q tests/test_post_merge_handler.py tests/test_review_phase_core.py
- added coverage for:
  - conflict auto-fix + retry merge success
  - conflict auto-fix failure still escalating with conflict cause
  - review-phase helper push vs force-push behavior
