### PR TITLE
Accept ADR-0007: dashboard api multi repo scoping

### DIFF
--- a/docs/adr/0007-dashboard-api-multi-repo-scoping.md
+++ b/docs/adr/0007-dashboard-api-multi-repo-scoping.md
@@ -1,6 +1,6 @@
 # ADR-0007: Dashboard API Architecture for Multi-Repo Scoping
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-02-28
 
 ## Context
@@ -78,3 +78,12 @@ Extend the dashboard API to support multi-repo scoping through two mechanisms:
 - `src/hf_cli/supervisor_service.py`, `src/hf_cli/supervisor_client.py`
 - `src/ui/src/context/HydraFlowContext.jsx`
 - ADR-0006 (RepoRuntime isolation)
+## Council Amendment Notes
+
+The following amendments were generated from council feedback:
+
+- Architect: The ADR is structurally sound and complementary to ADR-0008 (not superseded by it), but
+- Pragmatist: ADR-0007 defines the API contract layer (query-param scoping, endpoint signatures, WebSocket
+- Editor: The Architect's evidence that ADR-0008 explicitly references ADR-0007 as a prerequisite settles
+
+These notes are intended to be incorporated before final acceptance.


### PR DESCRIPTION
## ADR Council Review

The ADR review council has voted to **accept** ADR-0007.

**Final decision:** ACCEPT
**Rounds needed:** 3

### Final Votes
- **Architect:** approve — ADR-0007 defines the API contract layer (query-param scoping, endpoint signatures, WebSocket parameterization) that ADR-0008 (Accepted) explicitly depends on as a prerequisite, so blocking acceptance perpetuates an inconsistency in the ADR index where an Accepted ADR references a Proposed one. The Pragmatist's implementation-completeness concern conflates the purpose of an ADR with a delivery tracker; partial implementation of a Proposed ADR being accepted to guide remaining work is standard practice. The editorial concerns (truncated amendment notes, missing back-reference) are correctable in a follow-up edit and do not obscure the decision's structural soundness. Accepting closes the index inconsistency; advisory issues should be resolved via a post-acceptance amendment.
- **Pragmatist:** approve — The ADR-0008 back-reference and removal of truncated amendment notes address the most concrete editorial gaps, and the remaining implementation-completeness concern is advisory rather than blocking — ADRs capture intended decisions, not delivery checklists. The Accepted ADR-0008 referencing this one as a prerequisite creates a concrete index inconsistency that favors resolution over continued blocking. The partial implementation of scoping mechanisms is expected for a Proposed ADR being elevated to guide remaining work.
- **Editor:** approve — The truncated amendment notes, missing ADR-0008 back-reference, and "proxies or filters" ambiguity are real but correctable editorial defects that do not obscure the core decision. An Accepted ADR (ADR-0008) referencing this one as a prerequisite creates a worse index inconsistency than the document's imperfections. The amendment notes are clearly labeled for post-acceptance incorporation rather than embedded in the decision body. A follow-up editorial pass should clean up the Related section and remove or integrate the amendment notes.

### Summary

The council reached unanimous approval in Round 3 after two deliberation rounds surfaced that the Pragmatist and Editor's concerns — truncated amendment notes, missing ADR-0008 back-reference, and ambiguous proxy language — are mechanical editorial defects rather than structural blockers, and that continuing to hold ADR-0007 at Proposed while the Accepted ADR-0008 explicitly depends on it as a prerequisite creates a worse ADR index inconsistency than the document's correctable imperfections.

---
Generated by HydraFlow ADR Council