### PR TITLE
Scale batch fetch size with worker count across all phases

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1099,7 +1099,7 @@ class HydraFlowOrchestrator:
         """Work function for the review loop."""
         did_work = False
         while not self._stop_event.is_set():
-            review_issues = self._store.get_reviewable(self._config.batch_size)
+            review_issues = self._store.get_reviewable(2 * self._config.max_reviewers)
             if not review_issues:
                 break
             try:

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -570,7 +570,7 @@ class PlanPhase:
 
     async def plan_issues(self) -> list[PlanResult]:
         """Run planning agents on issues from the plan queue."""
-        issues = self._store.get_plannable(self._config.batch_size)
+        issues = self._store.get_plannable(2 * self._config.max_planners)
         if not issues:
             return []
 

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -69,7 +69,7 @@ class TriagePhase:
         comment explaining what is missing so the dashboard surfaces
         them as "needs attention".
         """
-        issues = self._store.get_triageable(self._config.batch_size)
+        issues = self._store.get_triageable(2 * self._config.max_triagers)
         if not issues:
             return 0
 

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -1015,3 +1015,40 @@ class TestPlanPhaseEvidenceValidation:
         assert len(plan_failure_comments) == 1
         assert "after planning attempts" in plan_failure_comments[0]
         assert "after two attempts" not in plan_failure_comments[0]
+
+
+class TestPlanPhaseBatchScaling:
+    """Batch fetch size must scale with max_planners, not use fixed batch_size."""
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_scales_with_max_planners(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """get_plannable should be called with 2 * max_planners."""
+        from unittest.mock import MagicMock
+
+        phase, _state, _planners, _prs, store, _stop = make_plan_phase(config)
+        store.get_plannable = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+        config.max_planners = 3  # type: ignore[assignment]
+        await phase.plan_issues()
+
+        store.get_plannable.assert_called_once_with(6)
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_reflects_updated_worker_count(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """After bumping max_planners, the next batch should fetch more."""
+        from unittest.mock import MagicMock
+
+        phase, _state, _planners, _prs, store, _stop = make_plan_phase(config)
+        store.get_plannable = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+        config.max_planners = 1  # type: ignore[assignment]
+        await phase.plan_issues()
+        store.get_plannable.assert_called_with(2)
+
+        config.max_planners = 5  # type: ignore[assignment]
+        await phase.plan_issues()
+        store.get_plannable.assert_called_with(10)

--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -268,3 +268,40 @@ class TestTriagePhase:
         comment = prs.post_comment.call_args.args[1]
         assert "Needs More Information" in comment
         assert "Missing required ADR sections" in comment
+
+
+class TestTriagePhaseBatchScaling:
+    """Batch fetch size must scale with max_triagers, not use fixed batch_size."""
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_scales_with_max_triagers(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """get_triageable should be called with 2 * max_triagers."""
+        from unittest.mock import MagicMock
+
+        phase, _state, _triage, _prs, store, _stop = make_triage_phase(config)
+        store.get_triageable = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+        config.max_triagers = 4  # type: ignore[assignment]
+        await phase.triage_issues()
+
+        store.get_triageable.assert_called_once_with(8)
+
+    @pytest.mark.asyncio
+    async def test_batch_fetch_reflects_updated_worker_count(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """After bumping max_triagers, the next batch should fetch more."""
+        from unittest.mock import MagicMock
+
+        phase, _state, _triage, _prs, store, _stop = make_triage_phase(config)
+        store.get_triageable = MagicMock(return_value=[])  # type: ignore[method-assign]
+
+        config.max_triagers = 1  # type: ignore[assignment]
+        await phase.triage_issues()
+        store.get_triageable.assert_called_with(2)
+
+        config.max_triagers = 5  # type: ignore[assignment]
+        await phase.triage_issues()
+        store.get_triageable.assert_called_with(10)


### PR DESCRIPTION
## Summary
- Plan, triage, and review phases used a fixed `batch_size` (default 15) to fetch work, regardless of worker count
- When workers were incremented at runtime (e.g., `max_planners` 1→5), the phase had to finish all 15 items one-at-a-time before the new concurrency took effect
- Now all phases fetch `2 * worker_count` items (matching the existing implement phase pattern), so batches are proportional to concurrency and config changes take effect on the next short cycle

## Files changed
- `src/plan_phase.py` — `get_plannable(2 * max_planners)` instead of `get_plannable(batch_size)`
- `src/triage_phase.py` — `get_triageable(2 * max_triagers)` instead of `get_triageable(batch_size)`
- `src/orchestrator.py` — `get_reviewable(2 * max_reviewers)` instead of `get_reviewable(batch_size)`
- `tests/test_plan_phase.py` — Tests verifying batch scales with worker count
- `tests/test_triage_phase.py` — Tests verifying batch scales with worker count

## Test plan
- [x] Plan phase tests pass (47 tests)
- [x] Orchestrator tests pass (185 tests)
- [x] Review phase tests pass (368 combined)
- [x] Lint check passes
- [x] Quality-lite passes (lint + typecheck + security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)