### PR TITLE
Fix credit exhaustion detection for usage limit message

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -106,6 +106,7 @@ _CREDIT_PATTERNS = (
     "usage limit reached",
     "credit balance is too low",
     "you've hit your limit",
+    "hit your usage limit",
 )
 
 # Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",

--- a/tests/test_credit_pause.py
+++ b/tests/test_credit_pause.py
@@ -119,6 +119,16 @@ class TestIsCreditExhaustion:
         assert is_credit_exhaustion("Credit Balance Is Too Low") is True
         assert is_credit_exhaustion("YOU'VE HIT YOUR LIMIT") is True
 
+    def test_detects_hit_your_usage_limit(self) -> None:
+        """Exact message from Claude CLI when quota is exhausted."""
+        assert (
+            is_credit_exhaustion(
+                "You've hit your usage limit. To get more access now, "
+                "send a request to your admin or try again at 3:29 PM."
+            )
+            is True
+        )
+
 
 # ===========================================================================
 # subprocess_util — parse_credit_resume_time


### PR DESCRIPTION
## Summary
- The Claude CLI returns "You've hit your usage limit" when quota is exhausted
- The credit exhaustion pattern matcher only checked for "you've hit your limit" (without "usage"), missing the actual message
- This caused agents to silently fail, cycle through all queued issues, and attempt PR creation with no commits ("No commits between main and agent/issue-XXXX")
- Added the pattern "hit your usage limit" to catch this variant

## Test plan
- [x] New test with exact Claude CLI message
- [x] All 39 credit pause tests pass
- [x] Quality-lite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)