### PR TITLE
Accept ADR-0009 and supersede ADR-0006

### DIFF
--- a/docs/adr/0006-repo-runtime-isolation.md
+++ b/docs/adr/0006-repo-runtime-isolation.md
@@ -1,6 +1,6 @@
 # ADR-0006: RepoRuntime Isolation Architecture
 
-**Status:** Accepted
+**Status:** Superseded by ADR-0009
 **Date:** 2026-02-28
 
 ## Context

--- a/docs/adr/0009-multi-repo-process-per-repo-model.md
+++ b/docs/adr/0009-multi-repo-process-per-repo-model.md
@@ -1,6 +1,6 @@
 # ADR-0009: Multi-Repo Process-Per-Repo Model
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-02-28
 
 ## Context
@@ -106,9 +106,13 @@ Adopt the **process-per-repo** model as the canonical multi-repo architecture:
 
 ## Related
 
+- **Supersedes ADR-0006** — ADR-0006 proposed in-process `RepoRuntime` isolation
+  with the supervisor using `RepoRuntime` as the unit of start/stop. This ADR
+  adopts `subprocess.Popen` process-per-repo instead, making ADR-0006's
+  supervisor integration decision obsolete.
 - Source memory: #1627
 - ADR-0001 (Five concurrent async loops — per-process architecture)
-- ADR-0006 (RepoRuntime isolation — in-process alternative)
+- ADR-0006 (RepoRuntime isolation — superseded by this ADR)
 - ADR-0008 (Multi-repo dashboard — supervisor-proxied aggregation)
 - `src/hf_cli/supervisor_service.py` (`_start_repo`, `RUNNERS`, TCP protocol)
 - `src/config.py` (`_resolve_paths`, `_namespace_repo_paths`, `worktree_path_for_issue`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,20 +16,20 @@ and optionally **Alternatives considered** and **Related** links.
 | [0003](0003-git-worktrees-for-isolation.md) | Git Worktrees for Issue Isolation | Accepted |
 | [0004](0004-agent-cli-as-runtime.md) | CLI-based Agent Runtime (Claude / Codex / Pi.dev) | Accepted |
 | [0005](0005-pr-recovery-and-zero-diff-branch-handling.md) | PR Recovery and Zero-Diff Branch Handling in Implement Phase | Accepted |
-| [0006](0006-repo-runtime-isolation.md) | RepoRuntime Isolation Architecture | Proposed |
-| [0007](0007-dashboard-api-multi-repo-scoping.md) | Dashboard API Architecture for Multi-Repo Scoping | Proposed |
+| [0006](0006-repo-runtime-isolation.md) | RepoRuntime Isolation Architecture | Superseded by ADR-0009 |
+| [0007](0007-dashboard-api-multi-repo-scoping.md) | Dashboard API Architecture for Multi-Repo Scoping | Accepted |
 | [0008](0008-multi-repo-dashboard-architecture.md) | Multi-Repo Dashboard Architecture | Proposed |
-| [0009](0009-multi-repo-process-per-repo-model.md) | Multi-Repo Process-Per-Repo Model | Proposed |
+| [0009](0009-multi-repo-process-per-repo-model.md) | Multi-Repo Process-Per-Repo Model | Accepted |
 | [0010](0010-worktree-and-path-isolation.md) | Worktree and Path Isolation Architecture | Proposed |
 | [0011](0011-epic-release-creation-architecture.md) | Epic Release Creation Architecture | Proposed |
 | [0012](0012-epic-merge-coordination-architecture.md) | Epic Merge Coordination Architecture | Proposed |
 | [0013](0013-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Proposed |
-| [0014](0014-session-counter-forward-progression-semantics.md) | Session Counter Forward-Progression Semantics | Proposed |
+| [0014](0014-session-counter-forward-progression-semantics.md) | Session Counter Forward-Progression Semantics | Accepted |
 | [0015](0015-protocol-callback-gate-pattern.md) | Protocol-Based Callback Injection Gate Pattern | Proposed |
-| [0016](0016-visual-validation-skipped-override-semantics.md) | VisualValidation SKIPPED Override Semantics | Proposed |
-| [0017](0017-auto-decompose-triage-counter-exclusion.md) | Auto-Decompose Triage Counter Exclusion | Proposed |
+| [0016](0016-visual-validation-skipped-override-semantics.md) | VisualValidation SKIPPED Override Semantics | Accepted |
+| [0017](0017-auto-decompose-triage-counter-exclusion.md) | Auto-Decompose Triage Counter Exclusion | Accepted |
 | [0018](0018-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Proposed |
-| [0019](0019-background-task-delegation-abstraction-layer.md) | Background Task Delegation Abstraction Layer | Proposed |
+| [0019](0019-background-task-delegation-abstraction-layer.md) | Background Task Delegation Abstraction Layer | Accepted |
 | [0020](0020-autoApproveRow-border-context-awareness.md) | autoApproveRow Border Context Awareness | Proposed |
 | [0021](0021-persistence-architecture-and-data-layout.md) | Persistence Architecture and Data Layout | Proposed |
 


### PR DESCRIPTION
## Summary
- Update ADR-0006 status from "Accepted" to "Superseded by ADR-0009"
- Update ADR-0009 status from "Proposed" to "Accepted" with supersession notice
- Sync README.md index with correct statuses for ADRs 0006, 0007, 0009, 0014, 0016, 0017, 0019

## Test plan
- [x] Verify ADR-0006 shows "Superseded by ADR-0009"
- [x] Verify ADR-0009 shows "Accepted" with Related section referencing ADR-0006
- [x] Verify README index matches individual ADR statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
