### PR TITLE
Fix 5 ADR council HITL issues

### DIFF
--- a/docs/adr/0010-worktree-and-path-isolation.md
+++ b/docs/adr/0010-worktree-and-path-isolation.md
@@ -85,7 +85,12 @@ artifacts:
   `<repo_root>/.hydraflow/`) gain an extra directory level with no functional
   benefit, since isolation is already implicit.
 - The metrics cache path becomes triple-nested
-  (`data_root/<slug>/metrics/<slug>/`) which is redundant but harmless.
+  (`data_root/<slug>/metrics/<slug>/`) which is redundant but harmless. This is
+  a known consequence of applying repo-slug scoping at both the `data_root` level
+  (via `_resolve_repo_scoped_paths`) and the metrics level (via
+  `get_metrics_cache_dir`). Fixing this requires changing `get_metrics_cache_dir`
+  to use `data_root` directly instead of `state_file.parent`, but is deferred as
+  the duplication has no functional impact.
 
 ## Alternatives considered
 
@@ -108,6 +113,10 @@ artifacts:
 - Implementation: #1677
 - ADR-0003 — Git Worktrees for Issue Isolation (original worktree decision)
 - ADR-0006 — RepoRuntime Isolation Architecture (broader isolation abstraction)
+- **ADR-0021** — Persistence Architecture and Data Layout. ADR-0021's derived-paths
+  table documents the current flat layout (`log_dir = data_root / "logs"`, etc.).
+  Accepting ADR-0010 requires amending ADR-0021's derived-paths table and layout
+  diagram to reflect repo-scoped paths for `log_dir`, `plans_dir`, and `memory_dir`.
 - `src/config.py:HydraFlowConfig` — `_resolve_paths`, `worktree_path_for_issue`,
   `log_dir`, `plans_dir`, `memory_dir` properties
 - `src/worktree.py:WorktreeManager` — worktree lifecycle and cleanup

--- a/docs/adr/0012-epic-merge-coordination-architecture.md
+++ b/docs/adr/0012-epic-merge-coordination-architecture.md
@@ -29,8 +29,9 @@ conflated into a single step.
 
 ## Decision
 
-Introduce an **EpicMergeCoordinator** that intercepts the merge path in
-`PostMergeHandler.handle_approved()` to support four merge strategies:
+Intercept the merge path in `PostMergeHandler.handle_approved()` to support
+four merge strategies, coordinated between `PostMergeHandler._should_defer_merge()`
+and `EpicManager.on_child_approved()`:
 
 1. **`independent`** (default): No coordination — PRs merge immediately on
    approval. This preserves current behavior and requires no configuration.
@@ -44,25 +45,27 @@ Introduce an **EpicMergeCoordinator** that intercepts the merge path in
    bundle is ready, escalate to HITL for human sign-off before the merge batch
    executes.
 
-4. **`ordered`**: Dependency-aware merge ordering. Children specify merge order
-   or dependencies, and the coordinator merges them sequentially in the correct
-   order once all are approved.
+4. **`ordered`**: Registration-order merge sequencing. Children are merged in
+   the order they were registered in `EpicState.child_issues`. Explicit
+   dependency metadata (BLOCKS/BLOCKED_BY) is not yet implemented; callers
+   must register children in the correct order at epic creation time.
 
 ### Merge flow
 
 ```
 Review approves PR
   → PostMergeHandler.handle_approved()
-    → EpicMergeCoordinator.should_hold_merge(issue)
-      → If independent: proceed to merge (no change)
-      → If bundled/bundled_hitl/ordered:
-        1. Apply `hydraflow-approved` label
-        2. Record in EpicState.approved_children
+    → _should_defer_merge(issue_number)
+      → Checks parent epics via EpicManager.find_parent_epics()
+      → If all parents use "independent": proceed to merge
+      → If any parent uses bundled/bundled_hitl/ordered:
+        1. Record in EpicState.approved_children
+        2. Call EpicManager.on_child_approved()
         3. Check bundle readiness (all children approved?)
         4. If ready:
-           - bundled: auto-merge all approved children
+           - bundled: auto-merge all via release_epic()
            - bundled_hitl: escalate to HITL with merge instructions
-           - ordered: merge in dependency order
+           - ordered: merge in registration order via release_epic()
         5. If not ready: hold (do not merge), log status
 ```
 
@@ -76,11 +79,21 @@ Extend `EpicState` with:
 
 ### Integration point
 
-`EpicMergeCoordinator` is injected into `PostMergeHandler` alongside the existing
-`EpicManager`. The coordinator's `should_hold_merge()` is called before the
-`merge_pr()` call. When the coordinator holds a merge, it returns `False` and
-the handler skips the merge without escalating to HITL (the PR remains open and
-approved).
+`PostMergeHandler._should_defer_merge()` is called before the `merge_pr()` call.
+It queries `EpicManager.find_parent_epics()` to discover whether the issue belongs
+to a coordinated epic. When a defer is indicated, `handle_approved()` calls
+`EpicManager.on_child_approved()` which records the approval, checks bundle
+readiness, and dispatches to the appropriate strategy handler (`_handle_bundled_ready`,
+`_handle_bundled_hitl_ready`, or `_handle_ordered_ready`). The PR remains open and
+approved until the bundle is ready.
+
+### Failure path
+
+When a held child PR fails review while siblings remain approved-but-held, the
+`failed_children` list in `EpicState` is updated. The bundle readiness check
+(`EpicProgress.ready_to_merge`) requires `failed == 0`, so a single failure
+blocks the entire bundle. Recovery requires manual intervention: re-trigger
+review on the failed child, or remove it from the epic's `child_issues` list.
 
 ### Configuration
 
@@ -106,11 +119,11 @@ an epic body directive parsed during registration.
   interception point that must be tested for all four strategies.
 - Held PRs may become stale if the bundle takes a long time to complete. Needs a
   staleness timeout or periodic rebase mechanism.
-- `ordered` strategy requires dependency metadata (merge order or explicit
-  dependency graph) that must be authored and maintained in epic bodies.
-- Bundle failures are harder to reason about — if one child fails review, the
-  entire bundle is blocked. Clear status reporting and HITL escalation paths are
-  needed.
+- `ordered` strategy currently uses registration order only; explicit dependency
+  metadata (BLOCKS/BLOCKED_BY graphs) is not yet implemented.
+- Bundle failures block all siblings — if one child fails review, approved
+  siblings remain held indefinitely until the failure is resolved or the child
+  is removed from the epic.
 - Merge conflicts become more likely when multiple PRs are held open
   simultaneously. A conflict resolution strategy (sequential rebase before merge)
   is needed for `bundled` and `ordered`.
@@ -135,8 +148,8 @@ an epic body directive parsed during registration.
 
 - Source memory: #1684
 - ADR issue: #1702
-- `src/post_merge_handler.py` (`handle_approved` — merge interception point)
-- `src/epic.py` (`EpicManager`, `EpicCompletionChecker`)
+- `src/post_merge_handler.py` (`handle_approved`, `_should_defer_merge` — merge interception)
+- `src/epic.py` (`EpicManager.on_child_approved`, `_handle_bundled_ready`, `_handle_ordered_ready`, `_get_merge_order`)
 - `src/models.py` (`EpicState` — model to extend)
 - `src/review_phase.py` (`_handle_approved_merge` — review-to-merge flow)
 - `src/epic_monitor_loop.py` (stale epic detection — relevant for held bundles)

--- a/docs/adr/0013-screenshot-capture-pipeline.md
+++ b/docs/adr/0013-screenshot-capture-pipeline.md
@@ -1,6 +1,6 @@
 # ADR-0013: Screenshot Capture Pipeline Architecture
 
-**Status:** Proposed
+**Status:** Superseded by ADR-0018
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0015-protocol-callback-gate-pattern.md
+++ b/docs/adr/0015-protocol-callback-gate-pattern.md
@@ -64,10 +64,19 @@ for all merge-phase gates in HydraFlow. Specifically:
 | Gate | Type | Protocol / Decision | Config Guard |
 |------|------|---------------------|--------------|
 | CI gate | Async callback | `CiGateFn` | `max_ci_fix_attempts > 0` |
-| Visual validation | Sync decision | `VisualValidationDecision` | `visual_validation_enabled` |
+| Visual validation decision | Sync decision object | `VisualValidationDecision` | `visual_validation_enabled` |
+| Visual gate | Async callback | `VisualGateFn` | `visual_gate_enabled` |
+| Merge conflict fix | Async callback | `MergeConflictFixFn` | Triggered on merge conflict |
 | Escalation | Async callback | `EscalateFn` | `debug_escalation_enabled` |
 | Status publishing | Async callback | `PublishFn` | Always active |
-| Adversarial threshold | Async method | Returns `ReviewResult` | `min_review_findings > 0` |
+| Adversarial threshold | Async method (not yet injected) | Returns `ReviewResult` | `min_review_findings > 0` |
+
+**Note:** The visual validation row represents the pre-gate decision object that
+determines *whether* validation is required. The visual gate row (`VisualGateFn`)
+is the actual async callback that enforces the gate at merge time. The adversarial
+threshold is currently an embedded async method on `ReviewPhase` rather than an
+injected Protocol callback — it follows the four-phase protocol pattern but does
+not yet conform to Rule 2 (injection as a parameter).
 
 ## Consequences
 
@@ -104,7 +113,7 @@ for all merge-phase gates in HydraFlow. Specifically:
 
 - Source memory: #1720
 - Issue: #1746
-- `src/models.py` — `CiGateFn`, `EscalateFn`, `PublishFn`, `VisualValidationDecision`
+- `src/models.py` — `CiGateFn`, `VisualGateFn`, `MergeConflictFixFn`, `EscalateFn`, `PublishFn`, `VisualValidationDecision`
 - `src/post_merge_handler.py` — `handle_approved()` callback injection
 - `src/review_phase.py` — `check_visual_gate()`, `_fetch_code_scanning_alerts()`
 - `src/visual_validation.py` — `compute_visual_validation()`

--- a/docs/adr/0018-screenshot-capture-pipeline.md
+++ b/docs/adr/0018-screenshot-capture-pipeline.md
@@ -1,6 +1,6 @@
 # ADR-0018: Screenshot Capture Pipeline Architecture
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-01
 
 ## Context
@@ -128,6 +128,10 @@ inadvertently contains sensitive information.
 
 ## Related
 
+- **Supersedes ADR-0013** — ADR-0013 documented the original screenshot pipeline
+  with hardcoded `--public` gists and no DOM redaction. This ADR adds defense-in-depth
+  security (DOM redaction, backend secret scanning, configurable gist visibility),
+  making ADR-0013's public-gist-only design obsolete.
 - Source memory: #1734
 - ADR issue: #1749
 - `src/ui/src/components/Header.jsx` — `captureDashboardScreenshot()`, `redactSensitiveElements()`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,12 +23,12 @@ and optionally **Alternatives considered** and **Related** links.
 | [0010](0010-worktree-and-path-isolation.md) | Worktree and Path Isolation Architecture | Proposed |
 | [0011](0011-epic-release-creation-architecture.md) | Epic Release Creation Architecture | Proposed |
 | [0012](0012-epic-merge-coordination-architecture.md) | Epic Merge Coordination Architecture | Proposed |
-| [0013](0013-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Proposed |
+| [0013](0013-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Superseded by ADR-0018 |
 | [0014](0014-session-counter-forward-progression-semantics.md) | Session Counter Forward-Progression Semantics | Accepted |
 | [0015](0015-protocol-callback-gate-pattern.md) | Protocol-Based Callback Injection Gate Pattern | Proposed |
 | [0016](0016-visual-validation-skipped-override-semantics.md) | VisualValidation SKIPPED Override Semantics | Accepted |
 | [0017](0017-auto-decompose-triage-counter-exclusion.md) | Auto-Decompose Triage Counter Exclusion | Accepted |
-| [0018](0018-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Proposed |
+| [0018](0018-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Accepted |
 | [0019](0019-background-task-delegation-abstraction-layer.md) | Background Task Delegation Abstraction Layer | Accepted |
 | [0020](0020-autoApproveRow-border-context-awareness.md) | autoApproveRow Border Context Awareness | Proposed |
 | [0021](0021-persistence-architecture-and-data-layout.md) | Persistence Architecture and Data Layout | Proposed |


### PR DESCRIPTION
## Summary
- **ADR-0013/0018** (#2019, #2021): Mark ADR-0013 as Superseded by ADR-0018, accept ADR-0018 with supersession notice
- **ADR-0015** (#2020): Fix gate table — add missing VisualGateFn and MergeConflictFixFn rows, distinguish decision object from gate callback, note adversarial threshold is not yet an injected callback
- **ADR-0012** (#2018): Replace fictional EpicMergeCoordinator with actual implementation (PostMergeHandler._should_defer_merge + EpicManager.on_child_approved), document failure path, note ordered strategy limitation
- **ADR-0010** (#2017): Add ADR-0021 cross-reference for flat-path contradiction, add metrics triple-nesting disposition

## Test plan
- [x] All existing ADR tests pass (status assertions unchanged — ADR-0010/0012/0015 remain Proposed)
- [x] quality-lite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
