### PR TITLE
Fix Docker stdin incompatibility in model calls

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -403,8 +403,8 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             ]
             cmd_input = None
         else:
-            cmd = [tool, "-p", "--model", model]
-            cmd_input = prompt.encode()
+            cmd = [tool, "-p", "--model", model, prompt]
+            cmd_input = None
 
         env = make_clean_env(self._config.gh_token)
         try:

--- a/src/memory.py
+++ b/src/memory.py
@@ -753,8 +753,8 @@ class MemorySyncWorker:
             ]
             cmd_input = None
         else:
-            cmd = ["claude", "-p", "--model", model]
-            cmd_input = prompt.encode()
+            cmd = ["claude", "-p", "--model", model, prompt]
+            cmd_input = None
         env = make_clean_env(self._config.gh_token)
 
         try:

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -768,8 +768,8 @@ If nothing novel, output exactly: NO_NEW_PATTERN"""
             ]
             cmd_input = None
         else:
-            cmd = [tool, "-p", "--model", model]
-            cmd_input = prompt.encode()
+            cmd = [tool, "-p", "--model", model, prompt]
+            cmd_input = None
 
         env = make_clean_env(self._config.gh_token)
 

--- a/src/transcript_summarizer.py
+++ b/src/transcript_summarizer.py
@@ -341,8 +341,8 @@ class TranscriptSummarizer:
             ]
             cmd_input = None
         else:
-            cmd = ["claude", "-p", "--model", model]
-            cmd_input = prompt.encode()
+            cmd = ["claude", "-p", "--model", model, prompt]
+            cmd_input = None
         env = make_clean_env(self._config.gh_token)
 
         try:

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1472,7 +1472,7 @@ class TestSummariseWithModel:
 
     @pytest.mark.asyncio
     async def test_calls_run_simple_not_raw_subprocess(self, tmp_path: Path) -> None:
-        """Verify run_simple is used (not asyncio.create_subprocess_exec)."""
+        """Verify run_simple is used and prompt is passed as CLI arg (not stdin)."""
         config = ConfigFactory.create(repo_root=tmp_path)
         runner = AsyncMock()
         runner.run_simple = AsyncMock(
@@ -1482,9 +1482,11 @@ class TestSummariseWithModel:
         await worker._summarise_with_model("content", 4000)
 
         runner.run_simple.assert_awaited_once()
-        call_kwargs = runner.run_simple.call_args[1]
-        assert call_kwargs["input"] is not None
-        assert isinstance(call_kwargs["input"], bytes)
+        call_args = runner.run_simple.call_args
+        cmd = call_args[0][0]
+        assert cmd[0] == "claude"
+        assert cmd[1] == "-p"
+        assert call_args[1].get("input") is None
 
     @pytest.mark.asyncio
     async def test_codex_tool_passes_prompt_as_cli_arg(self, tmp_path: Path) -> None:

--- a/tests/test_transcript_summarizer.py
+++ b/tests/test_transcript_summarizer.py
@@ -375,7 +375,7 @@ class TestSummarizeAndComment:
 
     @pytest.mark.asyncio
     async def test_calls_run_simple_not_raw_subprocess(self, tmp_path: Path) -> None:
-        """Verify run_simple is used (not asyncio.create_subprocess_exec)."""
+        """Verify run_simple is used and prompt is passed as CLI arg (not stdin)."""
         config = ConfigFactory.create(repo_root=tmp_path)
         prs = MagicMock()
         prs.post_comment = AsyncMock()
@@ -390,9 +390,12 @@ class TestSummarizeAndComment:
         )
 
         runner.run_simple.assert_awaited_once()
-        call_kwargs = runner.run_simple.call_args[1]
-        assert call_kwargs["input"] is not None
-        assert isinstance(call_kwargs["input"], bytes)
+        call_args = runner.run_simple.call_args
+        cmd = call_args[0][0]
+        assert cmd[0] == "claude"
+        assert cmd[1] == "-p"
+        # Prompt is the last CLI arg, not stdin
+        assert call_args[1].get("input") is None
 
     @pytest.mark.asyncio
     async def test_codex_tool_passes_prompt_as_cli_arg(self, tmp_path: Path) -> None:
@@ -597,12 +600,12 @@ class TestSummarizeAndPublish:
             transcript="x" * 50_000, issue_number=42, phase="implement"
         )
 
-        # Verify the input passed to run_simple was truncated
-        call_kwargs = runner.run_simple.call_args[1]
-        stdin_data = call_kwargs["input"]
-        assert stdin_data is not None
-        # The prompt includes the transcript, check it's capped
-        assert len(stdin_data) < 50_000
+        # Verify the prompt passed as CLI arg was truncated
+        call_args = runner.run_simple.call_args
+        cmd = call_args[0][0]
+        # Prompt is the last CLI arg
+        prompt_arg = cmd[-1]
+        assert len(prompt_arg) < 50_000
 
     @pytest.mark.asyncio
     async def test_handles_model_failure(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Transcript summarizer, PR unsticker, ADR reviewer, and memory compaction all passed prompts via stdin to `claude -p`, which fails in Docker mode (`NotImplementedError: stdin input not supported`)
- Changed all 4 callers to pass the prompt as the last CLI argument instead
- Updated tests to match

## Test plan
- [x] `test_transcript_summarizer.py` — 24 tests pass
- [x] `test_memory.py` — all tests pass  
- [x] `test_adr_reviewer.py` — all tests pass
- [x] `test_pr_unsticker.py` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)