### PR TITLE
Fix Docker streaming hang: disable stdin when prompt is CLI arg

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -422,7 +422,7 @@ class DockerRunner:
         *,
         cwd: str | None = None,
         env: dict[str, str] | None = None,  # noqa: ARG002
-        stdin: int | None = None,  # noqa: ARG002
+        stdin: int | None = None,
         stdout: int | None = None,  # noqa: ARG002
         stderr: int | None = None,  # noqa: ARG002
         limit: int = 1024 * 1024,  # noqa: ARG002
@@ -449,12 +449,14 @@ class DockerRunner:
         container_env = self._build_env()
         working_dir = "/workspace" if cwd else None
 
+        needs_stdin = stdin is None or stdin == asyncio.subprocess.PIPE
+
         container_kwargs: dict[str, Any] = {
             "image": self._image,
             "command": cmd,
             "environment": container_env,
             "volumes": mounts,
-            "stdin_open": True,
+            "stdin_open": needs_stdin,
             "detach": True,
         }
         if working_dir:
@@ -473,11 +475,12 @@ class DockerRunner:
 
         try:
             await loop.run_in_executor(None, container.start)
+            attach_params = {"stdout": 1, "stderr": 1, "stream": 1}
+            if needs_stdin:
+                attach_params["stdin"] = 1
             socket = await loop.run_in_executor(
                 None,
-                lambda: container.attach_socket(
-                    params={"stdin": 1, "stdout": 1, "stderr": 1, "stream": 1}
-                ),
+                lambda: container.attach_socket(params=attach_params),
             )
             return cast(
                 asyncio.subprocess.Process,


### PR DESCRIPTION
## Summary
- `DockerRunner.create_streaming_process` always set `stdin_open=True` and attached stdin on the socket, even when the prompt was passed as a CLI argument (stdin=DEVNULL)
- The multiplexed Docker socket blocked stdout reads when stdin was attached but unused
- Fix: respect the `stdin` parameter — only open stdin when `PIPE` is requested

## Root cause
After PR #2075 moved prompts to CLI args, `stream_claude_process` set `stdin=DEVNULL` but `DockerRunner` ignored it and still attached stdin on the socket. The blocking `sock.recv()` in `DockerStdoutReader` never got data because the multiplexed stream was waiting on the stdin channel.

## Tested
- Docker image built locally, smoke test 17/17 pass
- Live tested: `stream_claude_process` → `DockerRunner` → Claude CLI returned `TRIAGE_WORKS` successfully
- All `test_docker_runner.py` tests pass (78/78)

🤖 Generated with [Claude Code](https://claude.com/claude-code)