### PR TITLE
Fix queue eviction: two-strike policy (#2095)

### DIFF
--- a/src/issue_fetcher.py
+++ b/src/issue_fetcher.py
@@ -136,12 +136,12 @@ class IssueFetcher:
             return []
 
         seen: dict[int, dict] = {}
-        rate_limited = False
+        incomplete = False
 
         async def _query_label(label: str | None) -> None:
-            nonlocal rate_limited
+            nonlocal incomplete
             if self._is_rate_limited_now():
-                rate_limited = True
+                incomplete = True
                 return
             page = 1
             remaining = max(0, limit)
@@ -188,9 +188,11 @@ class IssueFetcher:
                 except (RuntimeError, json.JSONDecodeError, FileNotFoundError) as exc:
                     if isinstance(exc, RuntimeError) and self._is_rate_limit_error(exc):
                         await self._set_rate_limit_backoff(exc)
-                        rate_limited = True
-                        return
-                    logger.error("gh issue list failed for label=%r: %s", label, exc)
+                    else:
+                        logger.error(
+                            "gh issue list failed for label=%r: %s", label, exc
+                        )
+                    incomplete = True
                     return
 
         if labels:
@@ -212,9 +214,9 @@ class IssueFetcher:
         else:
             return []
 
-        if require_complete and rate_limited:
+        if require_complete and incomplete:
             raise IncompleteIssueFetchError(
-                "GitHub issue fetch incomplete due to rate limiting"
+                "GitHub issue fetch incomplete due to rate limiting or API errors"
             )
 
         issues = [GitHubIssue.model_validate(raw) for raw in seen.values()]
@@ -304,7 +306,7 @@ class IssueFetcher:
             return []
         return await self.fetch_issues_by_labels(
             all_labels,
-            limit=100,
+            limit=500,
             require_complete=True,
         )
 

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -123,6 +123,10 @@ class IssueStore:
         self._lock = asyncio.Lock()
         self._crate_manager: CrateManager | None = None
 
+        # Two-strike eviction: items must be missing from two consecutive
+        # fetches before being removed from queues.
+        self._eviction_candidates: set[int] = set()
+
     def set_crate_manager(self, cm: CrateManager) -> None:
         """Inject the crate manager after construction (avoids circular init)."""
         self._crate_manager = cm
@@ -227,25 +231,40 @@ class IssueStore:
             )
         return unique
 
-    def _evict_stale_tasks(self, incoming_ids: set[int]) -> None:
-        """Remove tasks no longer present in the pipeline from all queues.
+    def _evict_confirmed_closed(self, incoming_ids: set[int]) -> None:
+        """Remove only issues confirmed absent from *two consecutive* fetches.
 
-        Items that are in-flight (taken from queue, not yet marked active)
-        or eagerly transitioned (label swap pending) are protected from
-        eviction.
+        Instead of evicting everything missing from a single poll,
+        we track candidates and only evict on the second miss.  This
+        prevents partial or degraded fetches from nuking the queue.
         """
         protected = (
             set(self._active.keys())
             | set(self._in_flight)
             | set(self._eagerly_transitioned)
         )
+        all_queued = set()
+        for members in self._queue_members.values():
+            all_queued |= members
+        all_queued |= self._hitl_numbers
+
+        missing = all_queued - incoming_ids - protected
+
+        # Items missing for the first time become candidates.
+        # Items that were already candidates (missed twice) get evicted.
+        confirmed = missing & self._eviction_candidates
+        self._eviction_candidates = missing - confirmed
+
+        if not confirmed:
+            return
+
         for stage, q in self._queues.items():
             members = self._queue_members[stage]
-            stale = members - incoming_ids - protected
+            stale = members & confirmed
             if stale:
                 self._queues[stage] = deque(t for t in q if t.id not in stale)
                 members -= stale
-        self._hitl_numbers &= incoming_ids | protected
+        self._hitl_numbers -= confirmed
 
     def _route_incoming_tasks(
         self, stage_map: dict[int, tuple[IssueStoreStage, Task]]
@@ -291,11 +310,11 @@ class IssueStore:
         - Each task goes to the most advanced stage matching its tags.
         - Tasks already active are not re-queued.
         - Tasks that changed tags are moved between queues.
-        - Tasks no longer returned by the fetcher are removed from queues.
+        - Tasks missing from two consecutive fetches are evicted.
         """
         stage_map = self._compute_stage_map(tasks)
         incoming_ids = set(stage_map.keys())
-        self._evict_stale_tasks(incoming_ids)
+        self._evict_confirmed_closed(incoming_ids)
         self._route_incoming_tasks(stage_map)
 
         # Prune eagerly-transitioned entries for issues that vanished

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -153,7 +153,11 @@ class TestRouting:
         store._route_issues([issue1, issue2])
         assert len(store._queues[STAGE_FIND]) == 2
 
-        # On next refresh, only issue 41 comes back (40 was closed)
+        # First miss: issue 40 becomes an eviction candidate but stays
+        store._route_issues([issue2])
+        assert store._queue_members[STAGE_FIND] == {40, 41}
+
+        # Second consecutive miss: issue 40 is confirmed gone
         store._route_issues([issue2])
         assert store._queue_members[STAGE_FIND] == {41}
         assert len(store._queues[STAGE_FIND]) == 1
@@ -437,10 +441,14 @@ class TestRefresh:
         await store.refresh()
         assert len(store._queues[STAGE_FIND]) == 2
 
-        # Second poll: only issue 2 remains (issue 1 was closed)
+        # Second poll: only issue 2 remains (issue 1 becomes candidate)
         fetcher.fetch_all = AsyncMock(
             return_value=[TaskFactory.create(id=2, tags=["hydraflow-find"])]
         )
+        await store.refresh()
+        assert store._queue_members[STAGE_FIND] == {1, 2}  # still present
+
+        # Third poll: issue 1 missing again — now confirmed gone
         await store.refresh()
         assert store._queue_members[STAGE_FIND] == {2}
         assert len(store._queues[STAGE_FIND]) == 1
@@ -1215,3 +1223,114 @@ class TestCrateGate:
         uncrated = store.get_uncrated_issues()
         assert len(uncrated) == 1
         assert uncrated[0].id == 2
+
+
+# ── Two-strike eviction ──────────────────────────────────────────────
+
+
+class TestTwoStrikeEviction:
+    """Issues are only evicted after missing from two consecutive fetches."""
+
+    def test_single_miss_does_not_evict(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        issue2 = TaskFactory.create(id=2, tags=["hydraflow-find"])
+        store._route_issues([issue1, issue2])
+
+        # Issue 1 missing from one fetch — should still be queued
+        store._route_issues([issue2])
+        assert 1 in store._queue_members[STAGE_FIND]
+        assert len(store._queues[STAGE_FIND]) == 2
+
+    def test_two_consecutive_misses_evicts(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        issue2 = TaskFactory.create(id=2, tags=["hydraflow-find"])
+        store._route_issues([issue1, issue2])
+
+        # First miss — candidate
+        store._route_issues([issue2])
+        # Second miss — evicted
+        store._route_issues([issue2])
+        assert 1 not in store._queue_members[STAGE_FIND]
+        assert len(store._queues[STAGE_FIND]) == 1
+
+    def test_candidate_cleared_if_item_reappears(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        issue2 = TaskFactory.create(id=2, tags=["hydraflow-find"])
+        store._route_issues([issue1, issue2])
+
+        # Miss once — becomes candidate
+        store._route_issues([issue2])
+        assert 1 in store._eviction_candidates
+
+        # Reappears — candidate cleared
+        store._route_issues([issue1, issue2])
+        assert 1 not in store._eviction_candidates
+
+        # Missing again — only a candidate, not evicted
+        store._route_issues([issue2])
+        assert 1 in store._queue_members[STAGE_FIND]
+
+    def test_active_issues_protected_from_eviction(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        store._route_issues([issue1])
+        store.get_triageable(1)
+        store.mark_active(1, STAGE_FIND)
+
+        # Two misses — still protected because active
+        store._route_issues([])
+        store._route_issues([])
+        assert store.is_active(1)
+
+    def test_in_flight_issues_protected_from_eviction(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-find"])
+        store._route_issues([issue1])
+        store._in_flight[1] = STAGE_FIND
+
+        # Two misses — protected
+        store._route_issues([])
+        store._route_issues([])
+        assert 1 in store._in_flight
+
+    def test_hitl_issues_evicted_after_two_misses(self) -> None:
+        store = _make_store()
+        issue1 = TaskFactory.create(id=1, tags=["hydraflow-hitl"])
+        store._route_issues([issue1])
+        assert 1 in store._hitl_numbers
+
+        # First miss — candidate
+        store._route_issues([])
+        assert 1 in store._hitl_numbers
+
+        # Second miss — evicted
+        store._route_issues([])
+        assert 1 not in store._hitl_numbers
+
+    @pytest.mark.asyncio
+    async def test_incomplete_fetch_does_not_evict(self) -> None:
+        from issue_fetcher import IncompleteIssueFetchError
+
+        fetcher = AsyncMock()
+        store = _make_store(fetcher=fetcher)
+
+        # Initial fetch populates queue
+        fetcher.fetch_all = AsyncMock(
+            return_value=[
+                TaskFactory.create(id=1, tags=["hydraflow-find"]),
+                TaskFactory.create(id=2, tags=["hydraflow-find"]),
+            ]
+        )
+        await store.refresh()
+        assert len(store._queues[STAGE_FIND]) == 2
+
+        # Fetcher raises IncompleteIssueFetchError — queue untouched
+        fetcher.fetch_all = AsyncMock(
+            side_effect=IncompleteIssueFetchError("rate limited")
+        )
+        await store.refresh()
+        assert len(store._queues[STAGE_FIND]) == 2
+        assert store._queue_members[STAGE_FIND] == {1, 2}


### PR DESCRIPTION
## Summary
- Replace aggressive single-miss eviction with two-consecutive-miss policy — items must be absent from two GitHub fetches before removal
- Track all API errors (not just rate limits) as incomplete fetches to prevent partial results from clearing the queue
- Bump `fetch_all_hydraflow_issues` limit from 100 to 500 for full pipeline coverage
- Add 7 dedicated regression tests for two-strike eviction behavior

Closes #2095

## Test plan
- [x] All 7023 existing tests pass
- [x] 7 new `TestTwoStrikeEviction` tests cover: single-miss retention, double-miss eviction, candidate clearing on reappearance, active/in-flight protection, HITL eviction, and incomplete fetch safety

🤖 Generated with [Claude Code](https://claude.com/claude-code)