### PR TITLE
Add ETag caching to GitHub issue polling

### DIFF
--- a/src/issue_fetcher.py
+++ b/src/issue_fetcher.py
@@ -30,6 +30,7 @@ class IssueFetcher:
         self._rate_limit_lock = asyncio.Lock()
         self._collaborators: set[str] | None = None
         self._collaborators_fetched_at: datetime | None = None
+        self._api_cache_ttl = f"{config.data_poll_interval}s"
 
     @staticmethod
     def _normalize_issue_payload(item: dict) -> dict:
@@ -153,6 +154,8 @@ class IssueFetcher:
                     f"repos/{self._config.repo}/issues",
                     "--method",
                     "GET",
+                    "--cache",
+                    self._api_cache_ttl,
                     "--field",
                     "state=open",
                     "--field",

--- a/tests/test_issue_fetcher.py
+++ b/tests/test_issue_fetcher.py
@@ -1025,6 +1025,40 @@ class TestFetchIssuesByLabels:
         assert issues[0].number == 1
         assert issues[-1].number == 150
 
+    @pytest.mark.asyncio
+    async def test_gh_api_calls_include_cache_flag(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """The gh api calls should include --cache to enable ETag caching."""
+        fetcher = IssueFetcher(config)
+        raw = json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "Test",
+                    "body": "",
+                    "labels": [{"name": "ready"}],
+                    "comments": [],
+                    "url": "https://github.com/test-org/test-repo/issues/1",
+                }
+            ]
+        )
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.communicate = AsyncMock(return_value=(raw.encode(), b""))
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_exec:
+            await fetcher.fetch_issues_by_labels(["ready"], limit=10)
+
+        # Verify --cache flag was passed to gh api
+        call_args = mock_exec.call_args_list[0]
+        cmd = list(call_args.args)
+        assert "--cache" in cmd
+        cache_idx = cmd.index("--cache")
+        assert cmd[cache_idx + 1] == f"{config.data_poll_interval}s"
+
 
 # ---------------------------------------------------------------------------
 # fetch_all_hydraflow_issues


### PR DESCRIPTION
## Summary
- Add `--cache` flag to `gh api` calls in the issue polling path, using `data_poll_interval` as TTL
- After TTL expires, `gh` makes conditional requests with `If-None-Match` headers
- 304 responses are free (don't count against GitHub rate limits) and return cached data
- Saves API queries on every poll cycle when issues haven't changed

## Test plan
- [x] All 7017 existing tests pass
- [x] New test verifies `--cache` flag is present in `gh api` commands with correct TTL

🤖 Generated with [Claude Code](https://claude.com/claude-code)