### PR TITLE
Fix .git file corruption on ungraceful Docker container exit

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -242,10 +242,13 @@ class DockerProcess:
         container: ContainerLike,
         socket: DockerSocket,
         loop: asyncio.AbstractEventLoop,
+        *,
+        git_restore: tuple[Path, str] | None = None,
     ) -> None:
         self._container = container
         self._socket = socket
         self._loop = loop
+        self._git_restore = git_restore
         stdout_reader = DockerStdoutReader(socket, loop)
         self.stdin = DockerStdinWriter(socket)
         self.stdout = stdout_reader
@@ -261,6 +264,9 @@ class DockerProcess:
         result = await self._loop.run_in_executor(None, self._container.wait)
         code = int(result.get("StatusCode", 1))
         self.returncode = code
+        if self._git_restore:
+            git_file, original = self._git_restore
+            DockerRunner._restore_host_git_file(git_file, original)
         return code
 
 
@@ -363,25 +369,45 @@ class DockerRunner:
                 mounts[parts[0]] = {"bind": parts[1], "mode": mode}
         return mounts
 
+    @staticmethod
+    def _restore_host_git_file(git_file: Path, original: str) -> None:
+        """Restore a worktree ``.git`` file on the host after container exit.
+
+        The in-container shell script tries to restore it, but if the
+        container is killed (OOM, timeout, force-stop) the restore never
+        runs.  This host-side fallback guarantees the file is correct.
+        """
+        if not original or not git_file.parent.exists():
+            return
+        try:
+            current = git_file.read_text().strip()
+        except OSError:
+            return
+        if current != original:
+            logger.info("Restoring host .git file: %s", git_file)
+            git_file.write_text(original + "\n")
+
     def _wrap_cmd_for_worktree(
         self,
         cmd: Sequence[str],
         cwd: str | None,
-    ) -> Sequence[str]:
+    ) -> tuple[Sequence[str], Path | None, str]:
         """Wrap *cmd* with a git-fixup preamble when *cwd* is a worktree.
 
         Inside the container the worktree's ``.git`` file still references a
         host-absolute path.  We rewrite it to ``/dot-git/worktrees/<name>``
         before exec-ing the real command so that git operations work.
+
+        Returns ``(wrapped_cmd, git_file_path, original_content)`` so that
+        callers can restore the ``.git`` file on the host after the container
+        exits — even when the container is killed ungracefully.
         """
         if not cwd:
-            return cmd
+            return cmd, None, ""
         wt_name = self._detect_worktree(cwd)
         if not wt_name:
-            return cmd
+            return cmd, None, ""
         # Read the original .git content so we can restore it on exit.
-        # This prevents the container from permanently overwriting the host
-        # worktree's .git file with the container-internal path.
         git_file = Path(cwd) / ".git"
         try:
             original = git_file.read_text().strip()
@@ -398,7 +424,7 @@ class DockerRunner:
             f"printf {shlex.quote(original + chr(10))} > /workspace/.git; "
             f"exit $RC"
         )
-        return ["sh", "-c", script]
+        return ["sh", "-c", script], git_file, original
 
     def _get_user_tool_mounts(self) -> dict[str, dict[str, str]]:
         """Return cached user-tool mounts, refreshing when env/home selection changes."""
@@ -526,7 +552,8 @@ class DockerRunner:
         mounts = self._build_mounts(cwd)
         container_env = self._build_env()
         working_dir = "/workspace" if cwd else None
-        actual_cmd = self._wrap_cmd_for_worktree(cmd, cwd)
+        actual_cmd, git_file, git_original = self._wrap_cmd_for_worktree(cmd, cwd)
+        git_restore = (git_file, git_original) if git_file else None
 
         needs_stdin = stdin is None or stdin == asyncio.subprocess.PIPE
 
@@ -564,10 +591,15 @@ class DockerRunner:
             return cast(
                 asyncio.subprocess.Process,
                 DockerProcess(
-                    cast(ContainerLike, container), cast(DockerSocket, socket), loop
+                    cast(ContainerLike, container),
+                    cast(DockerSocket, socket),
+                    loop,
+                    git_restore=git_restore,
                 ),
             )
         except Exception:
+            if git_file:
+                self._restore_host_git_file(git_file, git_original)
             with contextlib.suppress(Exception):
                 await loop.run_in_executor(None, lambda: container.remove(force=True))
             self._containers.discard(container)
@@ -597,7 +629,7 @@ class DockerRunner:
         mounts = self._build_mounts(cwd)
         container_env = self._build_env()
         working_dir = "/workspace" if cwd else None
-        actual_cmd = self._wrap_cmd_for_worktree(cmd, cwd)
+        actual_cmd, git_file, git_original = self._wrap_cmd_for_worktree(cmd, cwd)
 
         container_kwargs: dict[str, Any] = {
             "image": self._image,
@@ -651,6 +683,8 @@ class DockerRunner:
                 await loop.run_in_executor(None, container.kill)
             raise
         finally:
+            if git_file:
+                self._restore_host_git_file(git_file, git_original)
             with contextlib.suppress(Exception):
                 await loop.run_in_executor(None, lambda: container.remove(force=True))
             self._containers.discard(container)

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -1384,12 +1384,16 @@ class TestWrapCmdForWorktree:
         runner, _ = _make_runner(log_dir=tmp_path / "logs")
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
-        result = runner._wrap_cmd_for_worktree(["claude", "-p", "hello"], str(tmp_path))
+        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(
+            ["claude", "-p", "hello"], str(tmp_path)
+        )
 
-        assert result[0] == "sh"
-        assert result[1] == "-c"
-        assert "/dot-git/worktrees/issue-99" in result[2]
-        assert "claude" in result[2]
+        assert wrapped[0] == "sh"
+        assert wrapped[1] == "-c"
+        assert "/dot-git/worktrees/issue-99" in wrapped[2]
+        assert "claude" in wrapped[2]
+        assert git_file == tmp_path / ".git"
+        assert "gitdir: /repo/.git/worktrees/issue-99" in git_original
 
     def test_no_wrap_for_non_worktree(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
@@ -1397,16 +1401,58 @@ class TestWrapCmdForWorktree:
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
         cmd = ["claude", "-p", "hello"]
-        result = runner._wrap_cmd_for_worktree(cmd, str(tmp_path))
-        assert list(result) == cmd
+        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(
+            cmd, str(tmp_path)
+        )
+        assert list(wrapped) == cmd
+        assert git_file is None
+        assert git_original == ""
 
     def test_no_wrap_when_cwd_none(self, tmp_path: Path) -> None:
         runner, _ = _make_runner(log_dir=tmp_path / "logs")
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
         cmd = ["claude", "-p", "hello"]
-        result = runner._wrap_cmd_for_worktree(cmd, None)
-        assert list(result) == cmd
+        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(cmd, None)
+        assert list(wrapped) == cmd
+        assert git_file is None
+        assert git_original == ""
+
+
+class TestRestoreHostGitFile:
+    """Tests for DockerRunner._restore_host_git_file."""
+
+    def test_restores_corrupted_git_file(self, tmp_path: Path) -> None:
+        git_file = tmp_path / ".git"
+        original = "gitdir: /home/user/repo/.git/worktrees/issue-99"
+        git_file.write_text("gitdir: /dot-git/worktrees/issue-99\n")
+
+        DockerRunner._restore_host_git_file(git_file, original)
+
+        assert git_file.read_text() == original + "\n"
+
+    def test_no_op_when_already_correct(self, tmp_path: Path) -> None:
+        git_file = tmp_path / ".git"
+        original = "gitdir: /home/user/repo/.git/worktrees/issue-99"
+        git_file.write_text(original + "\n")
+
+        DockerRunner._restore_host_git_file(git_file, original)
+
+        assert git_file.read_text() == original + "\n"
+
+    def test_no_op_when_original_empty(self, tmp_path: Path) -> None:
+        git_file = tmp_path / ".git"
+        git_file.write_text("gitdir: /dot-git/worktrees/issue-99\n")
+
+        DockerRunner._restore_host_git_file(git_file, "")
+
+        # Should not modify — empty original means we don't know what to restore
+        assert "dot-git" in git_file.read_text()
+
+    def test_no_op_when_parent_missing(self, tmp_path: Path) -> None:
+        git_file = tmp_path / "nonexistent" / ".git"
+        # Should not raise
+        DockerRunner._restore_host_git_file(git_file, "gitdir: something")
 
 
 class TestBuildMountsGitDir:


### PR DESCRIPTION
## Summary
- When Docker containers are killed (OOM, timeout, force-stop), the in-container shell script that restores the worktree `.git` file never runs, leaving it pointing to `/dot-git/worktrees/<name>` — a container-internal path that doesn't exist on the host
- Added host-side `.git` file restore in `run_simple` (finally block) and `DockerProcess.wait()` so the file is always correct regardless of how the container exits
- `_wrap_cmd_for_worktree` now returns `(cmd, git_file, original_content)` tuple so callers have the info needed for host-side restore

## Test plan
- [x] New `TestRestoreHostGitFile` tests: corrupted restore, no-op when correct, no-op when empty original, no-op when parent missing
- [x] Updated `TestWrapCmdForWorktree` tests for new tuple return type
- [x] Full suite: 6990 passed, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)