### PR TITLE
Fix Docker worktree: use GIT_DIR env var instead of rewriting .git file

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -11,7 +11,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import shlex
 import struct
 from collections.abc import Sequence
 from pathlib import Path
@@ -249,13 +248,10 @@ class DockerProcess:
         container: ContainerLike,
         socket: DockerSocket,
         loop: asyncio.AbstractEventLoop,
-        *,
-        git_restore: tuple[Path, str] | None = None,
     ) -> None:
         self._container = container
         self._socket = socket
         self._loop = loop
-        self._git_restore = git_restore
         stdout_reader = DockerStdoutReader(socket, loop)
         self.stdin = DockerStdinWriter(socket)
         self.stdout = stdout_reader
@@ -271,9 +267,6 @@ class DockerProcess:
         result = await self._loop.run_in_executor(None, self._container.wait)
         code = int(result.get("StatusCode", 1))
         self.returncode = code
-        if self._git_restore:
-            git_file, original = self._git_restore
-            DockerRunner._restore_host_git_file(git_file, original)
         return code
 
 
@@ -376,62 +369,23 @@ class DockerRunner:
                 mounts[parts[0]] = {"bind": parts[1], "mode": mode}
         return mounts
 
-    @staticmethod
-    def _restore_host_git_file(git_file: Path, original: str) -> None:
-        """Restore a worktree ``.git`` file on the host after container exit.
+    def _worktree_git_env(self, cwd: str | None) -> dict[str, str]:
+        """Return ``GIT_DIR`` / ``GIT_WORK_TREE`` env vars when *cwd* is a worktree.
 
-        The in-container shell script tries to restore it, but if the
-        container is killed (OOM, timeout, force-stop) the restore never
-        runs.  This host-side fallback guarantees the file is correct.
-        """
-        if not original or not git_file.parent.exists():
-            return
-        try:
-            current = git_file.read_text().strip()
-        except OSError:
-            return
-        if current != original:
-            logger.info("Restoring host .git file: %s", git_file)
-            git_file.write_text(original + "\n")
-
-    def _wrap_cmd_for_worktree(
-        self,
-        cmd: Sequence[str],
-        cwd: str | None,
-    ) -> tuple[Sequence[str], Path | None, str]:
-        """Wrap *cmd* with a git-fixup preamble when *cwd* is a worktree.
-
-        Inside the container the worktree's ``.git`` file still references a
-        host-absolute path.  We rewrite it to ``/dot-git/worktrees/<name>``
-        before exec-ing the real command so that git operations work.
-
-        Returns ``(wrapped_cmd, git_file_path, original_content)`` so that
-        callers can restore the ``.git`` file on the host after the container
-        exits — even when the container is killed ungracefully.
+        Instead of rewriting the ``.git`` file inside the container (which
+        corrupts the host worktree when the container is killed), we set
+        environment variables that tell git where the gitdir lives.  This is
+        safe regardless of how the container exits.
         """
         if not cwd:
-            return cmd, None, ""
+            return {}
         wt_name = self._detect_worktree(cwd)
         if not wt_name:
-            return cmd, None, ""
-        # Read the original .git content so we can restore it on exit.
-        git_file = Path(cwd) / ".git"
-        try:
-            original = git_file.read_text().strip()
-        except OSError:
-            original = ""
-
-        escaped = " ".join(shlex.quote(a) for a in cmd)
-        # Shell wrapper: rewrite .git → container path, run the command,
-        # then restore the original .git content regardless of exit code.
-        script = (
-            f'printf "gitdir: /dot-git/worktrees/{wt_name}\\n" > /workspace/.git; '
-            f"{escaped}; "
-            f"RC=$?; "
-            f"printf {shlex.quote(original + chr(10))} > /workspace/.git; "
-            f"exit $RC"
-        )
-        return ["sh", "-c", script], git_file, original
+            return {}
+        return {
+            "GIT_DIR": f"/dot-git/worktrees/{wt_name}",
+            "GIT_WORK_TREE": "/workspace",
+        }
 
     def _get_user_tool_mounts(self) -> dict[str, dict[str, str]]:
         """Return cached user-tool mounts, refreshing when env/home selection changes."""
@@ -561,15 +515,14 @@ class DockerRunner:
         loop = asyncio.get_running_loop()
         mounts = self._build_mounts(cwd)
         container_env = self._build_env()
+        container_env.update(self._worktree_git_env(cwd))
         working_dir = "/workspace" if cwd else None
-        actual_cmd, git_file, git_original = self._wrap_cmd_for_worktree(cmd, cwd)
-        git_restore = (git_file, git_original) if git_file else None
 
         needs_stdin = stdin is None or stdin == asyncio.subprocess.PIPE
 
         container_kwargs: dict[str, Any] = {
             "image": self._image,
-            "command": actual_cmd,
+            "command": list(cmd),
             "environment": container_env,
             "volumes": mounts,
             "stdin_open": needs_stdin,
@@ -604,12 +557,9 @@ class DockerRunner:
                     cast(ContainerLike, container),
                     cast(DockerSocket, socket),
                     loop,
-                    git_restore=git_restore,
                 ),
             )
         except Exception:
-            if git_file:
-                self._restore_host_git_file(git_file, git_original)
             with contextlib.suppress(Exception):
                 await loop.run_in_executor(None, lambda: container.remove(force=True))
             self._containers.discard(container)
@@ -638,12 +588,12 @@ class DockerRunner:
         loop = asyncio.get_running_loop()
         mounts = self._build_mounts(cwd)
         container_env = self._build_env()
+        container_env.update(self._worktree_git_env(cwd))
         working_dir = "/workspace" if cwd else None
-        actual_cmd, git_file, git_original = self._wrap_cmd_for_worktree(cmd, cwd)
 
         container_kwargs: dict[str, Any] = {
             "image": self._image,
-            "command": actual_cmd,
+            "command": list(cmd),
             "environment": container_env,
             "volumes": mounts,
             "detach": True,
@@ -693,8 +643,6 @@ class DockerRunner:
                 await loop.run_in_executor(None, container.kill)
             raise
         finally:
-            if git_file:
-                self._restore_host_git_file(git_file, git_original)
             with contextlib.suppress(Exception):
                 await loop.run_in_executor(None, lambda: container.remove(force=True))
             self._containers.discard(container)

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -1392,83 +1392,33 @@ class TestDetectWorktree:
         assert DockerRunner._detect_worktree(str(tmp_path)) is None
 
 
-class TestWrapCmdForWorktree:
-    """Tests for DockerRunner._wrap_cmd_for_worktree."""
+class TestWorktreeGitEnv:
+    """Tests for DockerRunner._worktree_git_env."""
 
-    def test_wraps_command_for_worktree(self, tmp_path: Path) -> None:
+    def test_returns_git_env_for_worktree(self, tmp_path: Path) -> None:
         (tmp_path / ".git").write_text("gitdir: /repo/.git/worktrees/issue-99\n")
         runner, _ = _make_runner(log_dir=tmp_path / "logs")
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
-        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(
-            ["claude", "-p", "hello"], str(tmp_path)
-        )
+        env = runner._worktree_git_env(str(tmp_path))
 
-        assert wrapped[0] == "sh"
-        assert wrapped[1] == "-c"
-        assert "/dot-git/worktrees/issue-99" in wrapped[2]
-        assert "claude" in wrapped[2]
-        assert git_file == tmp_path / ".git"
-        assert "gitdir: /repo/.git/worktrees/issue-99" in git_original
+        assert env["GIT_DIR"] == "/dot-git/worktrees/issue-99"
+        assert env["GIT_WORK_TREE"] == "/workspace"
 
-    def test_no_wrap_for_non_worktree(self, tmp_path: Path) -> None:
+    def test_empty_for_non_worktree(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()
         runner, _ = _make_runner(log_dir=tmp_path / "logs")
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
-        cmd = ["claude", "-p", "hello"]
-        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(
-            cmd, str(tmp_path)
-        )
-        assert list(wrapped) == cmd
-        assert git_file is None
-        assert git_original == ""
+        env = runner._worktree_git_env(str(tmp_path))
+        assert env == {}
 
-    def test_no_wrap_when_cwd_none(self, tmp_path: Path) -> None:
+    def test_empty_when_cwd_none(self, tmp_path: Path) -> None:
         runner, _ = _make_runner(log_dir=tmp_path / "logs")
         (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
 
-        cmd = ["claude", "-p", "hello"]
-        wrapped, git_file, git_original = runner._wrap_cmd_for_worktree(cmd, None)
-        assert list(wrapped) == cmd
-        assert git_file is None
-        assert git_original == ""
-
-
-class TestRestoreHostGitFile:
-    """Tests for DockerRunner._restore_host_git_file."""
-
-    def test_restores_corrupted_git_file(self, tmp_path: Path) -> None:
-        git_file = tmp_path / ".git"
-        original = "gitdir: /home/user/repo/.git/worktrees/issue-99"
-        git_file.write_text("gitdir: /dot-git/worktrees/issue-99\n")
-
-        DockerRunner._restore_host_git_file(git_file, original)
-
-        assert git_file.read_text() == original + "\n"
-
-    def test_no_op_when_already_correct(self, tmp_path: Path) -> None:
-        git_file = tmp_path / ".git"
-        original = "gitdir: /home/user/repo/.git/worktrees/issue-99"
-        git_file.write_text(original + "\n")
-
-        DockerRunner._restore_host_git_file(git_file, original)
-
-        assert git_file.read_text() == original + "\n"
-
-    def test_no_op_when_original_empty(self, tmp_path: Path) -> None:
-        git_file = tmp_path / ".git"
-        git_file.write_text("gitdir: /dot-git/worktrees/issue-99\n")
-
-        DockerRunner._restore_host_git_file(git_file, "")
-
-        # Should not modify — empty original means we don't know what to restore
-        assert "dot-git" in git_file.read_text()
-
-    def test_no_op_when_parent_missing(self, tmp_path: Path) -> None:
-        git_file = tmp_path / "nonexistent" / ".git"
-        # Should not raise
-        DockerRunner._restore_host_git_file(git_file, "gitdir: something")
+        env = runner._worktree_git_env(None)
+        assert env == {}
 
 
 class TestBuildMountsGitDir:


### PR DESCRIPTION
## Summary

- **Root cause of zero-commit failures**: Docker containers were rewriting the worktree `.git` file to point to container paths (`/dot-git/worktrees/<name>`). When containers were killed (exit 137), the restore script never ran, leaving `.git` corrupted on the host. `_count_commits` then failed → "zero commits" → HITL escalation, even though the agent DID commit.
- **Fix**: Replace `.git` file rewriting with `GIT_DIR` and `GIT_WORK_TREE` environment variables on the container. Git respects these over the `.git` file, so the host file is never touched and can never be corrupted.
- **Removed**: `_wrap_cmd_for_worktree`, `_restore_host_git_file`, and all `git_restore` plumbing from `DockerProcess` — 130 lines of fragile code replaced by 2 env vars.

## Test plan

- [x] 89 docker runner tests pass
- [x] Verified in real Docker container: git log, status, commit all work with GIT_DIR
- [x] Verified commits persist on host after container exits
- [x] Verified `.git` file survives container kill (exit 137)
- [x] Lint, typecheck, security clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)