### PR TITLE
Fixes #1944: Integration Tests: Add coverage for file I/O operations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,8 @@ def dry_config(tmp_path: Path) -> HydraFlowConfig:
 @pytest.fixture
 def readonly_dir(tmp_path: Path) -> Iterator[Path]:
     """Create a read-only directory for permission error simulations."""
+    if os.getuid() == 0:
+        pytest.skip("read-only directory tests are unreliable when running as root")
     target = tmp_path / "readonly"
     target.mkdir()
     (target / "sentinel.txt").write_text("locked")

--- a/tests/test_integration_file_io.py
+++ b/tests/test_integration_file_io.py
@@ -205,6 +205,9 @@ def test_worktree_env_setup_docker_copies_and_updates_gitignore(tmp_path: Path) 
     assert not env_dst.is_symlink()
     assert env_dst.read_text() == "TOKEN=abc"
 
+    settings_dst = wt_path / ".claude" / "settings.local.json"
+    assert settings_dst.read_text() == "{}"
+
     node_modules_dst = wt_path / "ui" / "node_modules"
     assert node_modules_dst.is_dir()
     assert not node_modules_dst.is_symlink()


### PR DESCRIPTION
## Summary

Closes #1944.

## Issue

Integration Tests: Add coverage for file I/O operations

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow