### PR TITLE
Retry transient auth failures with exponential backoff

### DIFF
--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -18,7 +18,11 @@ from manifest import load_project_manifest
 from memory import load_memory_digest
 from models import TranscriptEventData
 from prompt_telemetry import PromptTelemetry, parse_command_tool_model
-from runner_utils import stream_claude_process, terminate_processes
+from runner_utils import (
+    AuthenticationRetryError,
+    stream_claude_process,
+    terminate_processes,
+)
 
 if TYPE_CHECKING:
     from execution import SubprocessRunner
@@ -53,6 +57,9 @@ class BaseRunner:
         """Kill all active subprocesses."""
         terminate_processes(self._active_procs)
 
+    _AUTH_RETRY_MAX = 3
+    _AUTH_RETRY_BASE_DELAY = 5.0  # seconds
+
     async def _execute(
         self,
         cmd: list[str],
@@ -63,28 +70,54 @@ class BaseRunner:
         on_output: Callable[[str], bool] | None = None,
         telemetry_stats: Mapping[str, object] | None = None,
     ) -> str:
-        """Run a claude subprocess and stream its output."""
+        """Run a claude subprocess and stream its output.
+
+        Retries up to ``_AUTH_RETRY_MAX`` times on transient authentication
+        failures (OAuth token refresh blips) with exponential backoff.
+        """
         start = time.monotonic()
         transcript = ""
         succeeded = False
         usage_stats: dict[str, object] = {}
         try:
-            transcript = await stream_claude_process(
-                cmd=cmd,
-                prompt=prompt,
-                cwd=cwd,
-                active_procs=self._active_procs,
-                event_bus=self._bus,
-                event_data=event_data,
-                logger=self._log,
-                on_output=on_output,
-                timeout=self._config.agent_timeout,
-                runner=self._runner,
-                usage_stats=usage_stats,
-                gh_token=self._config.gh_token,
-            )
-            succeeded = True
-            return transcript
+            last_auth_error: AuthenticationRetryError | None = None
+            for attempt in range(1, self._AUTH_RETRY_MAX + 1):
+                try:
+                    transcript = await stream_claude_process(
+                        cmd=cmd,
+                        prompt=prompt,
+                        cwd=cwd,
+                        active_procs=self._active_procs,
+                        event_bus=self._bus,
+                        event_data=event_data,
+                        logger=self._log,
+                        on_output=on_output,
+                        timeout=self._config.agent_timeout,
+                        runner=self._runner,
+                        usage_stats=usage_stats,
+                        gh_token=self._config.gh_token,
+                    )
+                    succeeded = True
+                    return transcript
+                except AuthenticationRetryError as exc:
+                    last_auth_error = exc
+                    if attempt < self._AUTH_RETRY_MAX:
+                        delay = self._AUTH_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                        self._log.warning(
+                            "Auth failed (attempt %d/%d), retrying in %.0fs: %s",
+                            attempt,
+                            self._AUTH_RETRY_MAX,
+                            delay,
+                            exc,
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        self._log.error(
+                            "Auth failed after %d attempts: %s",
+                            self._AUTH_RETRY_MAX,
+                            exc,
+                        )
+            raise last_auth_error  # type: ignore[misc]
         finally:
             duration = time.monotonic() - start
             source = str(event_data.get("source", "unknown"))

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -21,6 +21,15 @@ from subprocess_util import (
     parse_credit_resume_time,
 )
 
+logger = logging.getLogger("hydraflow.runner_utils")
+
+
+class AuthenticationRetryError(RuntimeError):
+    """Raised when the agent CLI reports authentication_failed.
+
+    Treated as retryable — OAuth token refresh can fail transiently.
+    """
+
 
 async def stream_claude_process(
     *,
@@ -173,13 +182,13 @@ async def stream_claude_process(
 
             # Detect authentication failures from stream-json output.
             # Claude CLI emits '"error":"authentication_failed"' when it
-            # has no valid API key or OAuth session (common in Docker
-            # containers without ANTHROPIC_API_KEY).
+            # cannot authenticate — this can be a transient OAuth token
+            # refresh failure, so the caller retries with backoff.
             raw_output = "\n".join(raw_lines)
             if "authentication_failed" in raw_output:
-                raise RuntimeError(
-                    "Agent CLI authentication failed — set ANTHROPIC_API_KEY "
-                    "in .env for Docker execution mode"
+                raise AuthenticationRetryError(
+                    "Agent CLI authentication failed — check "
+                    "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
                 )
 
             # Check for credit exhaustion in both stderr and transcript.

--- a/tests/test_base_runner.py
+++ b/tests/test_base_runner.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from base_runner import BaseRunner
 from events import EventBus
+from runner_utils import AuthenticationRetryError
 
 # ---------------------------------------------------------------------------
 # Concrete subclass for testing (BaseRunner has abstract _log ClassVar)
@@ -188,6 +189,56 @@ class TestExecute:
 
         call_kwargs = mock.call_args[1]
         assert call_kwargs["on_output"] is callback
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_retries_with_backoff(
+        self, config, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """Auth failures are retried 3 times before raising."""
+        runner = _TestRunner(config, event_bus)
+
+        with (
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                side_effect=AuthenticationRetryError("auth failed"),
+            ) as mock,
+            patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+            pytest.raises(AuthenticationRetryError),
+        ):
+            await runner._execute(["claude", "-p"], "prompt", tmp_path, {"issue": 42})
+
+        assert mock.await_count == 3
+        # 2 sleeps: 5s after attempt 1, 10s after attempt 2
+        assert sleep_mock.await_count == 2
+        sleep_mock.assert_any_await(5.0)
+        sleep_mock.assert_any_await(10.0)
+
+    @pytest.mark.asyncio
+    async def test_auth_failure_succeeds_on_retry(
+        self, config, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """Auth succeeds on second attempt after transient failure."""
+        runner = _TestRunner(config, event_bus)
+
+        with (
+            patch(
+                "base_runner.stream_claude_process",
+                new_callable=AsyncMock,
+                side_effect=[
+                    AuthenticationRetryError("auth failed"),
+                    "transcript output",
+                ],
+            ) as mock,
+            patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock,
+        ):
+            result = await runner._execute(
+                ["claude", "-p"], "prompt", tmp_path, {"issue": 42}
+            )
+
+        assert result == "transcript output"
+        assert mock.await_count == 2
+        assert sleep_mock.await_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from base_runner import BaseRunner
 from events import EventBus, EventType
 from models import TriageResult
+from runner_utils import AuthenticationRetryError
 from subprocess_util import CreditExhaustedError
 from tests.conftest import TaskFactory
 from tests.helpers import ConfigFactory, make_streaming_proc
@@ -251,10 +252,10 @@ class TestLLMEvaluation:
         assert any("error" in r.lower() for r in result.reasons)
 
     @pytest.mark.asyncio
-    async def test_auth_failure_raises_runtime_error(
+    async def test_auth_failure_retries_then_raises(
         self, runner: TriageRunner, mock_runner: AsyncMock
     ) -> None:
-        """Docker containers without API key produce auth_failed stream events."""
+        """Auth failures retry 3 times with backoff, then raise."""
         issue = TaskFactory.create(
             id=4,
             title="Implement feature X for module Y",
@@ -281,10 +282,22 @@ class TestLLMEvaluation:
             }
         )
         stdout = f"{auth_failed}\n{result_event}"
-        mock_runner.create_streaming_process = make_streaming_proc(stdout=stdout)
+        # Each retry needs a fresh proc (AsyncLineIter exhausts after one use)
+        mock_runner.create_streaming_process = AsyncMock(
+            side_effect=[
+                make_streaming_proc(stdout=stdout).return_value,
+                make_streaming_proc(stdout=stdout).return_value,
+                make_streaming_proc(stdout=stdout).return_value,
+            ]
+        )
 
-        with pytest.raises(RuntimeError, match="authentication failed"):
+        with (
+            unittest.mock.patch("asyncio.sleep", new_callable=AsyncMock),
+            pytest.raises(AuthenticationRetryError, match="authentication failed"),
+        ):
             await runner.evaluate(issue)
+        # Should have been called 3 times (initial + 2 retries)
+        assert mock_runner.create_streaming_process.call_count == 3
 
     @pytest.mark.asyncio
     async def test_credit_exhausted_propagates(


### PR DESCRIPTION
## Summary
- OAuth token refresh can fail transiently, causing the Claude CLI to emit `authentication_failed` — previously treated as fatal, now retried 3 times with exponential backoff (5s, 10s)
- Added `AuthenticationRetryError` as a distinct retryable error class
- Fixed misleading error message that only mentioned `ANTHROPIC_API_KEY` — now also mentions `CLAUDE_CODE_OAUTH_TOKEN`
- Retry logic lives in `BaseRunner._execute()` so all agents (implement, plan, review, triage, conflict resolver) benefit

## Test plan
- [x] Auth retry exhaustion: 3 attempts, correct backoff delays (5s, 10s)
- [x] Auth retry success: recovers on second attempt
- [x] Triage auth failure: retries 3 times then raises
- [x] Full test suite: 6997 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)