### PR TITLE
Enable git rerere and simplify conflict resolution prompts

### DIFF
--- a/src/conflict_prompt.py
+++ b/src/conflict_prompt.py
@@ -41,18 +41,12 @@ def build_conflict_prompt(
     """
     sections: list[str] = []
 
-    # --- Header ---
+    # --- Goal ---
     sections.append(
-        "There are merge conflicts on this branch.\n\n"
+        "Merge conflicts exist on this branch. Resolve them so `make quality` passes.\n\n"
         f"- Issue: {issue_url}\n"
         f"- PR: {pr_url}\n\n"
-        "Plan your approach before editing anything. Understand both sides "
-        "of each conflict — read the conflicted files, check git log to see "
-        "what changed on main vs the branch, and use `gh` CLI or read any "
-        "repo file if you need more context.\n\n"
-        "Then resolve all conflicts and run `make quality`. Before "
-        "committing, review your own diff — you may catch things "
-        "`make quality` won't. Do not push."
+        "Commit when done. Do not push."
     )
 
     # --- Project manifest & memory digest ---
@@ -64,24 +58,6 @@ def build_conflict_prompt(
         if digest:
             sections.append(f"## Accumulated Learnings\n\n{digest}")
 
-    # --- Post-merge checklist ---
-    sections.append(
-        "## Post-Merge Checklist\n\n"
-        "After resolving conflict markers, check for these common merge artifacts:\n\n"
-        "1. **Duplicate definitions**: Two PRs may add the same Pydantic Field, "
-        "function parameter, or env-override tuple. Pydantic silently uses the "
-        "last Field — remove the earlier duplicate and verify cross-field "
-        "validators still hold with the surviving default.\n"
-        "2. **Duplicate keyword arguments**: If a function signature had duplicate "
-        "params, the constructor call likely has duplicate kwargs too — remove them.\n"
-        "3. **Sequential numbering**: Files like `docs/adr/README.md` use "
-        "auto-incrementing IDs. When both sides added the same number, "
-        "keep main's entry and renumber the PR's entry to the next available.\n"
-        "4. **Stale assertions**: If source text changed on main "
-        '(e.g. "completed" → "resolved"), grep tests for the old string '
-        "and update assertions to match."
-    )
-
     # --- Previous attempt error ---
     if last_error and attempt > 1:
         max_chars = (
@@ -91,11 +67,8 @@ def build_conflict_prompt(
         )
         sections.append(
             f"## Previous Attempt Failed\n\n"
-            f"Attempt {attempt - 1} resolved the conflicts but "
-            f"failed verification:\n"
-            f"```\n{last_error[-max_chars:]}\n```\n"
-            f"Please resolve the conflicts again, paying attention "
-            f"to the above errors."
+            f"Attempt {attempt - 1} failed verification:\n"
+            f"```\n{last_error[-max_chars:]}\n```"
         )
 
     # --- Optional memory suggestion ---
@@ -134,13 +107,10 @@ def build_rebuild_prompt(
 
     sections: list[str] = []
 
-    # --- Header ---
+    # --- Goal ---
     sections.append(
-        "You are re-applying changes from a pull request onto a fresh branch "
-        "from main.\n\n"
-        "The original PR had merge conflicts that could not be resolved "
-        "automatically. You are now on a **clean branch from current main** "
-        "— no conflicts.\n\n"
+        "Re-apply this PR's changes onto a clean branch from main. "
+        "The original branch had unresolvable merge conflicts.\n\n"
         f"- Issue: {issue_url}\n"
         f"- PR: {pr_url}"
     )
@@ -157,33 +127,15 @@ def build_rebuild_prompt(
     # --- Original PR diff ---
     sections.append(
         "## Original PR Diff\n\n"
-        "Below is the diff of what the PR changed. Re-apply these logical "
-        "changes to the current codebase. The code on main may have evolved, "
-        "so adapt accordingly — do NOT blindly paste.\n\n"
+        "Adapt these changes to the current codebase — main may have evolved.\n\n"
         f"```diff\n{truncated_diff}\n```"
     )
 
     # --- Instructions ---
     sections.append(
-        "## Instructions\n\n"
-        "Plan before coding. Read the diff, the issue, and the current "
-        "codebase to understand what changed and what the PR intended. "
-        "Use `gh` CLI or read any file you need for context.\n\n"
-        "Then re-apply the same logical changes. If the diff adds a "
-        "numbered file (ADR, migration, etc.), check the directory for "
-        "existing numbers — do not reuse one that already exists.\n\n"
-        "Write or update tests and run `make quality`. Before committing, "
-        "review your own diff — you may catch things `make quality` won't. "
-        f'Commit with message: "Rebuild: Fixes #{issue_number}"'
-    )
-
-    # --- Rules ---
-    sections.append(
-        "## Rules\n\n"
-        "- Follow CLAUDE.md strictly.\n"
-        "- Tests are mandatory.\n"
-        "- Do NOT push or create PRs.\n"
-        "- Ensure `make quality` passes."
+        f"Ensure `make quality` passes. "
+        f'Commit with message: "Rebuild: Fixes #{issue_number}"\n'
+        f"Do not push."
     )
 
     # --- Optional memory suggestion ---

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -34,6 +34,7 @@ from subprocess_util import (
     AuthenticationError,
     CreditExhaustedError,
     configure_gh_concurrency,
+    run_subprocess,
 )
 
 if TYPE_CHECKING:
@@ -762,6 +763,7 @@ class HydraFlowOrchestrator:
         )
 
         await self._prs.ensure_labels_exist()
+        await self._enable_rerere()
         self._warn_if_agents_md_missing()
         await self._start_session()
 
@@ -777,6 +779,21 @@ class HydraFlowOrchestrator:
             self._running = False
             await self._publish_status()
             logger.info("HydraFlow stopped")
+
+    async def _enable_rerere(self) -> None:
+        """Enable git rerere so resolved conflicts are remembered for next time."""
+        try:
+            await run_subprocess(
+                "git",
+                "config",
+                "rerere.enabled",
+                "true",
+                cwd=self._config.repo_root,
+                gh_token=self._config.gh_token,
+            )
+            logger.info("git rerere enabled")
+        except (RuntimeError, FileNotFoundError):
+            logger.debug("Could not enable git rerere", exc_info=True)
 
     def _warn_if_agents_md_missing(self) -> None:
         """Log a warning if AGENTS.md is absent from the repo root.

--- a/tests/test_conflict_prompt.py
+++ b/tests/test_conflict_prompt.py
@@ -32,14 +32,6 @@ class TestBuildConflictPrompt:
         prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1)
         assert "Do not push" in prompt
 
-    def test_includes_post_merge_checklist(self) -> None:
-        prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1)
-        assert "Post-Merge Checklist" in prompt
-        assert "Duplicate definitions" in prompt
-        assert "Duplicate keyword arguments" in prompt
-        assert "Sequential numbering" in prompt
-        assert "Stale assertions" in prompt
-
     def test_no_previous_error_on_first_attempt(self) -> None:
         prompt = build_conflict_prompt(ISSUE_URL, PR_URL, None, 1)
         assert "Previous Attempt Failed" not in prompt
@@ -54,7 +46,6 @@ class TestBuildConflictPrompt:
         )
         assert "## Previous Attempt Failed" in prompt
         assert "ruff error" in prompt
-        assert "Attempt 1" in prompt
 
     def test_truncates_long_error(self) -> None:
         long_error = "x" * 5000
@@ -142,12 +133,11 @@ class TestBuildRebuildPrompt:
         assert ISSUE_URL in prompt
         assert PR_URL in prompt
 
-    def test_includes_fresh_branch_instructions(self) -> None:
+    def test_includes_re_apply_header(self) -> None:
         prompt = build_rebuild_prompt(
             ISSUE_URL, PR_URL, issue_number=42, pr_diff=PR_DIFF
         )
-        assert "fresh branch" in prompt.lower()
-        assert "re-applying" in prompt.lower()
+        assert "re-apply" in prompt.lower()
 
     def test_includes_pr_diff(self) -> None:
         prompt = build_rebuild_prompt(
@@ -157,11 +147,10 @@ class TestBuildRebuildPrompt:
         assert "-old" in prompt
         assert "+new" in prompt
 
-    def test_includes_instructions_section(self) -> None:
+    def test_includes_make_quality(self) -> None:
         prompt = build_rebuild_prompt(
             ISSUE_URL, PR_URL, issue_number=42, pr_diff=PR_DIFF
         )
-        assert "## Instructions" in prompt
         assert "make quality" in prompt
 
     def test_includes_commit_message_with_issue_number(self) -> None:
@@ -170,28 +159,18 @@ class TestBuildRebuildPrompt:
         )
         assert "Fixes #42" in prompt
 
-    def test_includes_numbered_file_instruction(self) -> None:
+    def test_includes_do_not_push(self) -> None:
         prompt = build_rebuild_prompt(
             ISSUE_URL, PR_URL, issue_number=42, pr_diff=PR_DIFF
         )
-        assert "numbered file" in prompt.lower()
-        assert "already exists" in prompt
-
-    def test_includes_rules_section(self) -> None:
-        prompt = build_rebuild_prompt(
-            ISSUE_URL, PR_URL, issue_number=42, pr_diff=PR_DIFF
-        )
-        assert "## Rules" in prompt
-        assert "Do NOT push" in prompt
+        assert "Do not push" in prompt
 
     def test_truncates_long_diff(self) -> None:
         long_diff = "+" + "x" * 20_000
         prompt = build_rebuild_prompt(
             ISSUE_URL, PR_URL, issue_number=42, pr_diff=long_diff
         )
-        diff_section = prompt.split("## Original PR Diff")[1].split("## Instructions")[
-            0
-        ]
+        diff_section = prompt.split("## Original PR Diff")[1].split("## Optional:")[0]
         assert diff_section.count("x") <= 15_000
 
     def test_truncates_diff_using_config_max_chars(self, tmp_path: Path) -> None:
@@ -202,9 +181,7 @@ class TestBuildRebuildPrompt:
         prompt = build_rebuild_prompt(
             ISSUE_URL, PR_URL, issue_number=42, pr_diff=long_diff, config=config
         )
-        diff_section = prompt.split("## Original PR Diff")[1].split("## Instructions")[
-            0
-        ]
+        diff_section = prompt.split("## Original PR Diff")[1].split("## Optional:")[0]
         assert diff_section.count("Q") <= 2000
 
     def test_includes_project_context_when_config_provided(

--- a/tests/test_credit_pause.py
+++ b/tests/test_credit_pause.py
@@ -88,6 +88,7 @@ def _mock_fetcher_noop(orch: HydraFlowOrchestrator) -> None:
     orch._store.get_active_issues = lambda: {}  # type: ignore[method-assign]
     orch._fetcher.fetch_issue_by_number = AsyncMock(return_value=None)  # type: ignore[method-assign]
     orch._fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+    orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
 
 # ===========================================================================

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -50,6 +50,7 @@ def _mock_fetcher_noop(orch: HydraFlowOrchestrator) -> None:
     orch._store.get_active_issues = lambda: {}  # type: ignore[method-assign]
     orch._fetcher.fetch_issue_by_number = AsyncMock(return_value=None)  # type: ignore[method-assign]
     orch._fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
+    orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
 
 def make_worker_result(
@@ -1427,6 +1428,7 @@ class TestSupervisorLoops:
         """If one loop crashes despite try/except, others should keep running."""
         orch = HydraFlowOrchestrator(config)
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
         implement_calls = 0
 
@@ -1708,6 +1710,7 @@ class TestAuthFailure:
         """An AuthenticationError in any loop should stop the orchestrator."""
         orch = HydraFlowOrchestrator(config)
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_triage() -> None:
             raise AuthenticationError("401 Unauthorized")
@@ -1734,6 +1737,7 @@ class TestAuthFailure:
         """Auth failure should publish a SYSTEM_ALERT event."""
         orch = HydraFlowOrchestrator(config, event_bus=event_bus)
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_plan() -> list[PlanResult]:
             raise AuthenticationError("401 Unauthorized")
@@ -1764,6 +1768,7 @@ class TestAuthFailure:
         """Auth failure should set the _auth_failed flag."""
         orch = HydraFlowOrchestrator(config)
         orch._prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
+        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_implement() -> tuple[list[WorkerResult], list[Task]]:
             raise AuthenticationError("401 Unauthorized")


### PR DESCRIPTION
## Summary
- **git rerere**: Enabled on orchestrator startup so Git remembers how conflicts were resolved — subsequent merges with the same conflicts resolve automatically
- **Goal-driven prompts**: Replaced verbose checklist-style conflict/rebuild prompts with concise goal statements — the agent has full context via CLAUDE.md and filesystem access, so inline instructions were redundant noise

## Test plan
- [x] `tests/test_conflict_prompt.py` — updated for simplified prompts (25 tests pass)
- [x] `tests/test_orchestrator.py` — added rerere mock to affected tests (190 tests pass)
- [x] `tests/test_credit_pause.py` — added rerere mock (40 tests pass)
- [x] `make quality-lite` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)