### PR TITLE
File memory suggestions on implement and review failure escalations

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -18,6 +18,7 @@ from phase_utils import (
     record_harness_failure,
     release_batch_in_flight,
     run_refilling_pool,
+    safe_file_memory_suggestion,
     store_lifecycle,
 )
 from pr_manager import PRManager
@@ -351,6 +352,15 @@ class ImplementPhase:
                 hitl_label=self._config.hitl_label[0],
             )
             self._store.enqueue_transition(issue, "hitl")
+            if result.transcript:
+                await safe_file_memory_suggestion(
+                    result.transcript,
+                    "implement_zero_commits",
+                    f"issue #{issue.id}",
+                    self._config,
+                    self._prs,
+                    self._state,
+                )
             return result
 
         # Push final commits and create PR
@@ -400,6 +410,15 @@ class ImplementPhase:
                             hitl_label=self._config.hitl_label[0],
                         )
                         self._store.enqueue_transition(issue, "hitl")
+                        if result.transcript:
+                            await safe_file_memory_suggestion(
+                                result.transcript,
+                                "implement_zero_diff",
+                                f"issue #{issue.id}",
+                                self._config,
+                                self._prs,
+                                self._state,
+                            )
                         return result
                     logger.warning(
                         "Implementation succeeded for issue #%d but no open PR exists for branch %s",

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -43,6 +43,7 @@ from phase_utils import (
     record_harness_failure,
     release_batch_in_flight,
     run_concurrent_batch,
+    safe_file_memory_suggestion,
     store_lifecycle,
 )
 from post_merge_handler import PostMergeHandler
@@ -1201,6 +1202,15 @@ class ReviewPhase:
                 break
 
         result.ci_passed = False
+        if result.transcript:
+            await safe_file_memory_suggestion(
+                result.transcript,
+                "ci_fix_failure",
+                f"PR #{pr.number}",
+                self._config,
+                self._prs,
+                self._state,
+            )
         await self._publish_review_status(pr, worker_id, "escalating")
         await self._escalate_ci_failure(pr, issue, summary, result.ci_fix_attempts)
         return False
@@ -1533,6 +1543,15 @@ class ReviewPhase:
                 event_cause="review_fix_cap_exceeded",
                 task=task,
             )
+            if result.transcript:
+                await safe_file_memory_suggestion(
+                    result.transcript,
+                    "review_fix_cap_exceeded",
+                    f"PR #{pr.number}",
+                    self._config,
+                    self._prs,
+                    self._state,
+                )
             return False  # Destroy worktree
 
     def _record_harness_failure(

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -1027,6 +1027,121 @@ class TestZeroCommitEscalation:
 
 
 # ---------------------------------------------------------------------------
+# Post-mortem memory filing
+# ---------------------------------------------------------------------------
+
+
+class TestPostMortemMemoryFiling:
+    """Failure escalations file memory suggestions from agent transcripts."""
+
+    @pytest.mark.asyncio
+    async def test_zero_commit_files_memory_from_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Zero-commit failure should attempt to file a memory suggestion."""
+        issue = TaskFactory.create()
+
+        async def zero_commit_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+        ) -> WorkerResult:
+            return WorkerResult(
+                issue_number=issue.id,
+                branch=branch,
+                success=False,
+                error="No commits found on branch",
+                commits=0,
+                worktree_path=str(wt_path),
+                transcript="MEMORY_SUGGESTION_START\ntitle: test\nlearning: learned\nMEMORY_SUGGESTION_END",
+            )
+
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], agent_run=zero_commit_agent
+        )
+
+        await phase.run_batch()
+
+        # Memory suggestion should be filed as an issue
+        create_calls = mock_prs.create_issue.call_args_list
+        assert any("[Memory]" in str(c) for c in create_calls)
+
+    @pytest.mark.asyncio
+    async def test_zero_commit_no_memory_when_no_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Zero-commit with empty transcript should not attempt memory filing."""
+        issue = TaskFactory.create()
+
+        async def zero_commit_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+        ) -> WorkerResult:
+            return WorkerResult(
+                issue_number=issue.id,
+                branch=branch,
+                success=False,
+                error="No commits found on branch",
+                commits=0,
+                worktree_path=str(wt_path),
+                transcript="",
+            )
+
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], agent_run=zero_commit_agent
+        )
+
+        await phase.run_batch()
+
+        # No memory issue should be created
+        create_calls = mock_prs.create_issue.call_args_list
+        assert not any("[Memory]" in str(c) for c in create_calls)
+
+    @pytest.mark.asyncio
+    async def test_zero_diff_files_memory_from_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Zero-diff failure should attempt to file a memory suggestion."""
+        issue = TaskFactory.create()
+
+        async def zero_diff_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+        ) -> WorkerResult:
+            return WorkerResult(
+                issue_number=issue.id,
+                branch=branch,
+                success=True,
+                commits=1,
+                worktree_path=str(wt_path),
+                transcript="MEMORY_SUGGESTION_START\ntitle: zero diff\nlearning: no changes\nMEMORY_SUGGESTION_END",
+            )
+
+        from tests.conftest import PRInfoFactory
+
+        # create_pr returns a PR with number=0 to trigger the zero-diff check
+        null_pr = PRInfoFactory.create(number=0)
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], agent_run=zero_diff_agent, create_pr_return=null_pr
+        )
+        # Make branch_has_diff_from_main return False to trigger zero-diff path
+        mock_prs.branch_has_diff_from_main = AsyncMock(return_value=False)
+
+        await phase.run_batch()
+
+        create_calls = mock_prs.create_issue.call_args_list
+        assert any("[Memory]" in str(c) for c in create_calls)
+
+
+# ---------------------------------------------------------------------------
 # Retry cap escalation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_review_phase.py
+++ b/tests/test_review_phase.py
@@ -1265,6 +1265,143 @@ class TestWaitAndFixCI:
 
 
 # ---------------------------------------------------------------------------
+# Post-mortem memory filing
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPostMortemMemoryFiling:
+    """CI and review-fix failures file memory suggestions from transcripts."""
+
+    @pytest.mark.asyncio
+    async def test_ci_failure_files_memory_from_review_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """CI failure escalation should file memory from review transcript."""
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            max_ci_fix_attempts=1,
+            repo_root=config.repo_root,
+            worktree_base=config.worktree_base,
+            state_file=config.state_file,
+        )
+        phase = make_review_phase(cfg)
+        issue = TaskFactory.create()
+        pr = PRInfoFactory.create()
+
+        review_result = ReviewResultFactory.create(
+            transcript="MEMORY_SUGGESTION_START\ntitle: CI insight\nlearning: check imports\nMEMORY_SUGGESTION_END",
+        )
+        fix_result = ReviewResult(
+            pr_number=101,
+            issue_number=42,
+            verdict=ReviewVerdict.REQUEST_CHANGES,
+            fixes_made=True,
+        )
+
+        phase._reviewers.review = AsyncMock(return_value=review_result)
+        phase._reviewers.fix_ci = AsyncMock(return_value=fix_result)
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.wait_for_ci = AsyncMock(return_value=(False, "Failed checks: ci"))
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_path_for_issue(42)
+        wt.mkdir(parents=True, exist_ok=True)
+
+        await phase.review_prs([pr], [issue])
+
+        create_calls = phase._prs.create_issue.call_args_list
+        assert any("[Memory]" in str(c) for c in create_calls)
+
+    @pytest.mark.asyncio
+    async def test_ci_failure_no_memory_when_no_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """CI failure with empty transcript should not attempt memory filing."""
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            max_ci_fix_attempts=1,
+            repo_root=config.repo_root,
+            worktree_base=config.worktree_base,
+            state_file=config.state_file,
+        )
+        phase = make_review_phase(cfg)
+        issue = TaskFactory.create()
+        pr = PRInfoFactory.create()
+
+        review_result = ReviewResultFactory.create(transcript="")
+        fix_result = ReviewResult(
+            pr_number=101,
+            issue_number=42,
+            verdict=ReviewVerdict.REQUEST_CHANGES,
+            fixes_made=True,
+        )
+
+        phase._reviewers.review = AsyncMock(return_value=review_result)
+        phase._reviewers.fix_ci = AsyncMock(return_value=fix_result)
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.merge_pr = AsyncMock(return_value=True)
+        phase._prs.wait_for_ci = AsyncMock(return_value=(False, "Failed checks: ci"))
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_path_for_issue(42)
+        wt.mkdir(parents=True, exist_ok=True)
+
+        await phase.review_prs([pr], [issue])
+
+        create_calls = phase._prs.create_issue.call_args_list
+        assert not any("[Memory]" in str(c) for c in create_calls)
+
+    @pytest.mark.asyncio
+    async def test_review_fix_cap_files_memory_from_transcript(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Review fix cap exceeded should file memory from review transcript."""
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            max_review_fix_attempts=1,
+            repo_root=config.repo_root,
+            worktree_base=config.worktree_base,
+            state_file=config.state_file,
+        )
+        phase = make_review_phase(cfg)
+        issue = TaskFactory.create()
+        pr = PRInfoFactory.create()
+
+        review_result = ReviewResultFactory.create(
+            verdict=ReviewVerdict.REQUEST_CHANGES,
+            transcript="MEMORY_SUGGESTION_START\ntitle: Review insight\nlearning: check tests\nMEMORY_SUGGESTION_END",
+        )
+
+        phase._reviewers.review = AsyncMock(return_value=review_result)
+        phase._prs.get_pr_diff = AsyncMock(return_value="diff")
+        phase._prs.push_branch = AsyncMock(return_value=True)
+        phase._prs.post_pr_comment = AsyncMock()
+        phase._prs.remove_label = AsyncMock()
+        phase._prs.add_labels = AsyncMock()
+
+        wt = config.worktree_path_for_issue(42)
+        wt.mkdir(parents=True, exist_ok=True)
+
+        # Set review attempts to cap so next review triggers escalation
+        phase._state.increment_review_attempts(42)
+
+        await phase.review_prs([pr], [issue])
+
+        create_calls = phase._prs.create_issue.call_args_list
+        assert any("[Memory]" in str(c) for c in create_calls)
+
+
+# ---------------------------------------------------------------------------
 # _resolve_merge_conflicts
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add `safe_file_memory_suggestion()` calls at 4 failure escalation points that were missing them:
  - **Implement phase**: zero commits, zero diff → HITL
  - **Review phase**: CI fix failure, review fix cap exceeded → HITL
- Ensures any `MEMORY_SUGGESTION_START` block the agent emitted gets captured even when the overall run fails
- Closes the gap where agent learnings were lost on failed runs — plan, HITL, conflict resolution, and unsticker already had this

## Test plan
- [x] 3 new tests in `test_implement_phase.py` (zero commits with/without transcript, zero diff)
- [x] 3 new tests in `test_review_phase.py` (CI failure with/without transcript, review fix cap)
- [x] All 260 existing tests in both files still pass
- [x] `make quality-lite` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)