### PR TITLE
Retain failed bug reports with retry counter and HITL escalation

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1313,6 +1313,7 @@ class PendingReport(BaseModel):
     screenshot_base64: str = ""
     environment: dict[str, Any] = Field(default_factory=dict)
     created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    attempts: int = 0
 
 
 class PRListItem(BaseModel):

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -22,13 +22,15 @@ from base_background_loop import BaseBackgroundLoop
 from config import HydraFlowConfig
 from events import EventBus
 from execution import SubprocessRunner
-from models import StatusCallback, TranscriptEventData
+from models import PendingReport, StatusCallback, TranscriptEventData
 from pr_manager import PRManager
 from runner_utils import stream_claude_process
 from screenshot_scanner import scan_base64_for_secrets
 from state import StateTracker
 
 logger = logging.getLogger("hydraflow.report_issue_loop")
+
+_MAX_REPORT_ATTEMPTS = 5
 
 
 class ReportIssueLoop(BaseBackgroundLoop):
@@ -71,7 +73,7 @@ class ReportIssueLoop(BaseBackgroundLoop):
         if self._config.dry_run:
             return None
 
-        report = self._state.dequeue_report()
+        report = self._state.peek_report()
         if report is None:
             return None
 
@@ -158,20 +160,78 @@ class ReportIssueLoop(BaseBackgroundLoop):
             issue_number = await self._pr_manager.create_issue(
                 fallback_title, fallback_body, labels_list
             )
-        if issue_number <= 0:
-            logger.error(
-                "Report %s failed: issue was not created via agent or fallback",
-                report.id,
-            )
-            return {"processed": 0, "report_id": report.id, "error": True}
 
-        logger.info(
-            "Processed report %s as issue #%d: %s",
+        if issue_number > 0:
+            # Success — remove from queue
+            self._state.remove_report(report.id)
+            logger.info(
+                "Processed report %s as issue #%d: %s",
+                report.id,
+                issue_number,
+                fallback_title,
+            )
+            return {
+                "processed": 1,
+                "report_id": report.id,
+                "issue_number": issue_number,
+            }
+
+        # Failed — increment attempts and check cap
+        attempt_count = self._state.fail_report(report.id)
+        if attempt_count >= _MAX_REPORT_ATTEMPTS:
+            self._state.remove_report(report.id)
+            await self._escalate_failed_report(report)
+            logger.error(
+                "Report %s failed %d times — escalated to HITL",
+                report.id,
+                attempt_count,
+            )
+            return {
+                "processed": 0,
+                "report_id": report.id,
+                "error": True,
+                "escalated": True,
+            }
+
+        logger.warning(
+            "Report %s failed (attempt %d/%d) — will retry next cycle",
             report.id,
-            issue_number,
-            fallback_title,
+            attempt_count,
+            _MAX_REPORT_ATTEMPTS,
         )
-        return {"processed": 1, "report_id": report.id, "issue_number": issue_number}
+        return {"processed": 0, "report_id": report.id, "error": True}
+
+    async def _escalate_failed_report(self, report: PendingReport) -> None:
+        """Create a HITL issue with the raw report content for manual review."""
+        body = (
+            "## Bug Report — Processing Failed\n\n"
+            "This bug report could not be processed automatically after "
+            f"{_MAX_REPORT_ATTEMPTS} attempts. The raw input is preserved "
+            "below for manual review.\n\n"
+            f"**Report ID:** {report.id}\n"
+            f"**Created:** {report.created_at}\n\n"
+            "### Description\n\n"
+            f"{report.description}\n\n"
+        )
+        if report.environment:
+            body += "### Environment\n\n"
+            for key, value in report.environment.items():
+                body += f"- **{key}:** {value}\n"
+            body += "\n"
+        if report.screenshot_base64:
+            # Include a truncated indicator — the full base64 is too large for an issue
+            body += (
+                "### Screenshot\n\n"
+                f"Base64 screenshot attached ({len(report.screenshot_base64)} chars). "
+                "Could not be decoded during processing.\n"
+            )
+
+        labels = list(self._config.hitl_label)
+        await self._pr_manager.create_issue(
+            f"[Bug Report] Failed to process: {report.description[:80]}",
+            body,
+            labels,
+        )
 
     @staticmethod
     def _save_screenshot(b64_data: str) -> Path:

--- a/src/state.py
+++ b/src/state.py
@@ -861,6 +861,12 @@ class StateTracker:
         self._data.pending_reports.append(report)
         self.save()
 
+    def peek_report(self) -> PendingReport | None:
+        """Return the first pending report without removing it, or None."""
+        if not self._data.pending_reports:
+            return None
+        return self._data.pending_reports[0]
+
     def dequeue_report(self) -> PendingReport | None:
         """Pop the first pending report (FIFO) and persist, or return None."""
         if not self._data.pending_reports:
@@ -868,6 +874,22 @@ class StateTracker:
         report = self._data.pending_reports.pop(0)
         self.save()
         return report
+
+    def remove_report(self, report_id: str) -> None:
+        """Remove a report by ID and persist."""
+        self._data.pending_reports = [
+            r for r in self._data.pending_reports if r.id != report_id
+        ]
+        self.save()
+
+    def fail_report(self, report_id: str) -> int:
+        """Increment attempt count for a report. Returns the new count."""
+        for r in self._data.pending_reports:
+            if r.id == report_id:
+                r.attempts += 1
+                self.save()
+                return r.attempts
+        return 0
 
     def get_pending_reports(self) -> list[PendingReport]:
         """Return a copy of the pending reports list."""

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -85,8 +85,8 @@ class TestReportIssueLoopDoWork:
         mock_stream.assert_awaited_once()
         _pr.create_issue.assert_not_awaited()
         assert mock_stream.call_args[1]["gh_token"] == loop._config.gh_token
-        # Queue should be empty after processing
-        assert state.dequeue_report() is None
+        # Queue should be empty after successful processing
+        assert state.peek_report() is None
 
     @pytest.mark.asyncio
     async def test_screenshot_uploaded_before_agent(self, tmp_path: Path) -> None:
@@ -146,7 +146,7 @@ class TestReportIssueLoopDoWork:
     async def test_returns_error_when_agent_and_fallback_both_fail(
         self, tmp_path: Path
     ) -> None:
-        """When neither agent nor fallback creates an issue, report stays failed."""
+        """When neither agent nor fallback creates an issue, report stays in queue."""
         loop, _stop, state, pr_mgr = _make_loop(tmp_path)
         pr_mgr.create_issue.return_value = 0
         report = PendingReport(description="Still broken")
@@ -163,6 +163,10 @@ class TestReportIssueLoopDoWork:
         assert result["processed"] == 0
         assert result["report_id"] == report.id
         pr_mgr.create_issue.assert_awaited_once()
+        # Report should still be in the queue with incremented attempts
+        pending = state.get_pending_reports()
+        assert len(pending) == 1
+        assert pending[0].attempts == 1
 
     @pytest.mark.asyncio
     async def test_dry_run_returns_none(self, tmp_path: Path) -> None:
@@ -174,7 +178,7 @@ class TestReportIssueLoopDoWork:
         result = await loop._do_work()
         assert result is None
         # Report should still be in the queue
-        assert state.dequeue_report() is not None
+        assert state.peek_report() is not None
 
     @pytest.mark.asyncio
     async def test_prompt_includes_description(self, tmp_path: Path) -> None:
@@ -346,6 +350,129 @@ class TestReportIssueLoopDoWork:
         # Scan is disabled — screenshot should still be referenced in prompt
         prompt = mock_stream.call_args.kwargs.get("prompt", "")
         assert ".png" in prompt
+
+
+class TestReportRetryAndEscalation:
+    """Tests for report retry counting and HITL escalation."""
+
+    @pytest.mark.asyncio
+    async def test_failed_report_stays_in_queue(self, tmp_path: Path) -> None:
+        """A failed report remains in the queue for retry."""
+        loop, _stop, state, pr_mgr = _make_loop(tmp_path)
+        pr_mgr.create_issue.return_value = 0
+        report = PendingReport(description="Retry me")
+        state.enqueue_report(report)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "no url"
+            await loop._do_work()
+
+        pending = state.get_pending_reports()
+        assert len(pending) == 1
+        assert pending[0].id == report.id
+        assert pending[0].attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_attempt_counter_increments(self, tmp_path: Path) -> None:
+        """Each failure increments the attempt counter."""
+        loop, _stop, state, pr_mgr = _make_loop(tmp_path)
+        pr_mgr.create_issue.return_value = 0
+        report = PendingReport(description="Keep trying")
+        state.enqueue_report(report)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "no url"
+            await loop._do_work()
+            await loop._do_work()
+            await loop._do_work()
+
+        pending = state.get_pending_reports()
+        assert len(pending) == 1
+        assert pending[0].attempts == 3
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_hitl_after_max_attempts(self, tmp_path: Path) -> None:
+        """After 5 failures, report is removed and escalated to HITL."""
+        loop, _stop, state, pr_mgr = _make_loop(tmp_path)
+        pr_mgr.create_issue.return_value = 0
+        report = PendingReport(
+            description="Persistent failure",
+            environment={"browser": "Chrome"},
+        )
+        state.enqueue_report(report)
+        # Pre-set to 4 attempts so next failure is the 5th
+        for _ in range(4):
+            state.fail_report(report.id)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "no url"
+            result = await loop._do_work()
+
+        assert result is not None
+        assert result["escalated"] is True
+        # Report should be removed from queue
+        assert state.peek_report() is None
+        # HITL issue should have been created with raw content
+        hitl_call = pr_mgr.create_issue.call_args_list[-1]
+        title = hitl_call[0][0]
+        body = hitl_call[0][1]
+        assert "[Bug Report]" in title
+        assert "Persistent failure" in body
+        assert "Chrome" in body
+
+    @pytest.mark.asyncio
+    async def test_success_after_retries_removes_from_queue(
+        self, tmp_path: Path
+    ) -> None:
+        """A report that succeeds after previous failures is removed from queue."""
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        report = PendingReport(description="Eventually works")
+        state.enqueue_report(report)
+        # Pre-set 2 failed attempts
+        state.fail_report(report.id)
+        state.fail_report(report.id)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "https://github.com/acme/repo/issues/99"
+            result = await loop._do_work()
+
+        assert result is not None
+        assert result["processed"] == 1
+        assert state.peek_report() is None
+
+    @pytest.mark.asyncio
+    async def test_escalated_report_includes_screenshot_indicator(
+        self, tmp_path: Path
+    ) -> None:
+        """Escalated HITL issue mentions the screenshot when present."""
+        loop, _stop, state, pr_mgr = _make_loop(tmp_path)
+        pr_mgr.create_issue.return_value = 0
+        report = PendingReport(
+            description="Screenshot bug",
+            screenshot_base64="abc123" * 100,
+        )
+        state.enqueue_report(report)
+        for _ in range(4):
+            state.fail_report(report.id)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "no url"
+            await loop._do_work()
+
+        hitl_call = pr_mgr.create_issue.call_args_list[-1]
+        body = hitl_call[0][1]
+        assert "screenshot" in body.lower()
+        assert "600 chars" in body
 
 
 class TestReportIssueLoopInterval:


### PR DESCRIPTION
## Summary
- Reports now **stay on disk** until successfully processed — no more lost reports
- Each failure increments an `attempts` counter on the `PendingReport` model
- After **5 failed attempts**, the report is removed and escalated as a HITL GitHub issue with the raw description, environment data, and screenshot indicator preserved
- Changed `dequeue_report()` to `peek_report()` + `remove_report()` pattern so the report is only removed on success or final escalation

## Changes
- `src/models.py` — Added `attempts: int = 0` field to `PendingReport`
- `src/state.py` — Added `peek_report()`, `remove_report()`, `fail_report()` methods
- `src/report_issue_loop.py` — Peek/remove pattern, retry counting, `_escalate_failed_report()` for HITL
- `tests/test_report_issue_loop.py` — 6 new tests for retry/escalation, updated existing tests

## Test plan
- [x] Failed report stays in queue with incremented counter
- [x] Counter increments on each failure
- [x] Escalates to HITL after 5 failures with raw content preserved
- [x] Success after retries removes from queue
- [x] Escalated issue includes screenshot indicator
- [x] All 27 report issue loop tests pass
- [x] All state tests pass
- [x] `make quality-lite` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)