### PR TITLE
Skip implementation when non-draft PR already exists

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -154,6 +154,37 @@ class ImplementPhase:
     async def _worker_inner(self, idx: int, issue: Task, branch: str) -> WorkerResult:
         """Core implementation logic — called inside the semaphore."""
         self._prepare_adr_plan(issue)
+
+        # If a non-draft PR already exists and this is NOT a review-feedback
+        # retry, skip implementation and transition directly to review.
+        # This handles issues requeued to hydraflow-ready that already have
+        # completed PRs from a prior run.
+        review_feedback = self._state.get_review_feedback(issue.id) or ""
+        if not review_feedback:
+            existing_pr = await self._prs.find_open_pr_for_branch(
+                branch, issue_number=issue.id
+            )
+            if existing_pr and existing_pr.number > 0 and not existing_pr.draft:
+                logger.info(
+                    "Issue #%d already has open PR #%d — skipping to review",
+                    issue.id,
+                    existing_pr.number,
+                )
+                await self._transitioner.transition(
+                    issue.id,
+                    "review",
+                    pr_number=existing_pr.number,
+                )
+                self._store.enqueue_transition(issue, "review")
+                self._state.increment_session_counter("implemented")
+                self._state.mark_issue(issue.id, "success")
+                return WorkerResult(
+                    issue_number=issue.id,
+                    branch=branch,
+                    success=True,
+                    pr_info=existing_pr,
+                )
+
         cap_result = await self._check_attempt_cap(issue, branch)
         if cap_result is not None:
             return cap_result
@@ -171,7 +202,6 @@ class ImplementPhase:
                 logger.debug("Run recording setup failed", exc_info=True)
                 ctx = None
 
-        review_feedback = self._state.get_review_feedback(issue.id) or ""
         result = await self._run_implementation(issue, branch, idx, review_feedback)
 
         # Finalize the recording

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1041,7 +1041,7 @@ def make_implement_phase(
         if create_pr_return is not None
         else PRInfoFactory.create()
     )
-    mock_prs.find_open_pr_for_branch = AsyncMock(return_value=PRInfoFactory.create())
+    mock_prs.find_open_pr_for_branch = AsyncMock(return_value=None)
     mock_prs.branch_has_diff_from_main = AsyncMock(return_value=True)
     mock_prs.add_labels = AsyncMock()
     mock_prs.remove_label = AsyncMock()

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -760,6 +760,9 @@ class TestReviewFeedbackPassing:
             agent_run=simple_agent,
             create_pr_return=PRInfoFactory.create(),
         )
+        # On retry, find_open_pr_for_branch returns the existing PR (used by
+        # _handle_implementation_result to recover the PR on the retry path)
+        mock_prs.find_open_pr_for_branch.return_value = PRInfoFactory.create()
         # Set review feedback to simulate a retry cycle
         phase._state.set_review_feedback(42, "Fix error handling")
 
@@ -1482,6 +1485,7 @@ class TestHandleImplementationResult:
         )
 
         phase, _, mock_prs = make_implement_phase(config, [issue])
+        mock_prs.find_open_pr_for_branch.return_value = PRInfoFactory.create()
 
         returned = await phase._handle_implementation_result(issue, result, True)
 
@@ -1631,6 +1635,60 @@ class TestWorkerInner:
         result = await phase._worker_inner(0, issue, "agent/issue-42")
 
         assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_existing_non_draft_pr_skips_to_review(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Issue with existing open non-draft PR should skip implementation."""
+        issue = TaskFactory.create()
+        existing_pr = PRInfoFactory.create(number=99, draft=False)
+
+        agent_called = False
+
+        async def tracking_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+        ) -> WorkerResult:
+            nonlocal agent_called
+            agent_called = True
+            return WorkerResultFactory.create(
+                issue_number=issue.id, worktree_path=str(wt_path)
+            )
+
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], agent_run=tracking_agent
+        )
+        mock_prs.find_open_pr_for_branch.return_value = existing_pr
+
+        result = await phase._worker_inner(0, issue, "agent/issue-42")
+
+        assert result.success is True
+        assert result.pr_info == existing_pr
+        assert not agent_called
+        mock_prs.transition.assert_awaited_once_with(issue.id, "review", pr_number=99)
+
+    @pytest.mark.asyncio
+    async def test_existing_draft_pr_does_not_skip(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Issue with a draft PR should proceed with normal implementation."""
+        issue = TaskFactory.create()
+        draft_pr = PRInfoFactory.create(number=99, draft=True)
+
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+        mock_prs.find_open_pr_for_branch.return_value = draft_pr
+
+        result = await phase._worker_inner(0, issue, "agent/issue-42")
+
+        assert result.success is True
+        # transition should be called from _handle_implementation_result, not the skip path
+        mock_prs.transition.assert_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When an issue labeled `hydraflow-ready` already has an open, non-draft PR from a prior run, the implement phase now skips the agent and transitions directly to `hydraflow-review`
- Prevents issues from getting stuck in the implement queue when they've already been implemented but their labels were reset (e.g., after HITL requeue)
- The skip is bypassed when review feedback is present, since those issues need re-implementation

## Test plan
- [x] New test: existing non-draft PR skips to review without running agent
- [x] New test: existing draft PR proceeds with normal implementation
- [x] All 67 existing implement phase tests pass
- [x] Lint, typecheck, and security checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)