### PR TITLE
Fix StreamView queued count to use pipelineStats

### DIFF
--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -98,10 +98,9 @@ function EpicContainer({ epicNumber, issues, children }) {
   )
 }
 
-function StageSection({ stage, issues, workerCount, workerCap, intentMap, onRequestChanges, open, onToggle, enabled, dotColor, workers, prs }) {
+function StageSection({ stage, issues, workerCount, workerCap, queuedCount, intentMap, onRequestChanges, open, onToggle, enabled, dotColor, workers, prs }) {
   const failedCount = issues.filter(i => i.overallStatus === 'failed').length
   const hitlCount = issues.filter(i => i.overallStatus === 'hitl').length
-  const queuedCount = issues.filter(i => i.overallStatus === 'queued').length
   const hasRole = !!stage.role
 
   return (
@@ -492,6 +491,7 @@ export function StreamView({ intents, expandedStages, onToggleStage, onRequestCh
             issues={stageIssues}
             workerCount={workerCount}
             workerCap={workerCap}
+            queuedCount={status.queuedCount || 0}
             intentMap={intentMap}
             onRequestChanges={stage.role ? onRequestChanges : undefined}
             open={!!expandedStages[stage.key]}

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -655,6 +655,9 @@ describe('Merged stage count display', () => {
           { issue_number: 2, title: 'Queued issue', status: 'queued' },
         ],
       },
+      pipelineStats: {
+        stages: { implement: { queued: 1, active: 1, completed_session: 0, worker_count: 0 } },
+      },
     }))
     render(<StreamView {...defaultProps} />)
     const section = screen.getByTestId('stage-section-implement')


### PR DESCRIPTION
## Summary

- StreamView `StageSection` was deriving `queuedCount` by filtering `pipelineIssues` cards (`status === 'queued'`), which dropped to 0 when the pipeline snapshot returned stale/empty data
- Now receives `queuedCount` from `stageStatus` (backed by `pipelineStats.stages[key].queued` from the backend) — the single source of truth
- This is the root cause of the "30 implement items then 0" dashboard bug

## Test plan

- [x] StreamView tests pass (73/73)
- [x] UI build succeeds
- [x] quality-lite passes
- [ ] Verify dashboard queued counts stay stable when snapshot polling returns empty data

🤖 Generated with [Claude Code](https://claude.com/claude-code)