### PR TITLE
Fix screenshot decode and downscale for report issue (#2189)

### DIFF
--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -211,7 +211,7 @@ class ReportIssueLoop(BaseBackgroundLoop):
             body += (
                 "### Screenshot\n\n"
                 f"Base64 screenshot attached ({len(report.screenshot_base64)} chars). "
-                "Could not be decoded during processing.\n"
+                "Too large to include in this issue.\n"
             )
 
         labels = list(self._config.hitl_label)
@@ -227,6 +227,8 @@ class ReportIssueLoop(BaseBackgroundLoop):
         payload = b64_data
         if payload.startswith("data:"):
             _, _, payload = payload.partition(",")
+        # Strip whitespace that may be introduced during transport
+        payload = payload.translate({ord(c): None for c in " \t\n\r"})
         raw = base64.b64decode(payload, validate=True)
         fd, path = tempfile.mkstemp(suffix=".png", prefix="hydraflow-report-")
         Path(path).write_bytes(raw)

--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -78,6 +78,27 @@ function sanitizeClonedDocumentForHtml2Canvas(clonedDoc) {
     })
   })
 }
+const MAX_SCREENSHOT_WIDTH = 1280
+
+/**
+ * Downscale a canvas to MAX_SCREENSHOT_WIDTH if it exceeds that width.
+ * Returns a data URL of the (possibly resized) image.
+ */
+function downscaleCanvas(source) {
+  if (source.width <= MAX_SCREENSHOT_WIDTH) {
+    return source.toDataURL('image/png')
+  }
+  const ratio = MAX_SCREENSHOT_WIDTH / source.width
+  const w = MAX_SCREENSHOT_WIDTH
+  const h = Math.round(source.height * ratio)
+  const offscreen = document.createElement('canvas')
+  offscreen.width = w
+  offscreen.height = h
+  const ctx = offscreen.getContext('2d')
+  ctx.drawImage(source, 0, 0, w, h)
+  return offscreen.toDataURL('image/png')
+}
+
 async function captureDashboardScreenshot(root, html2canvas) {
   if (!root) return null
   const STYLE_PROPS = [
@@ -117,7 +138,7 @@ async function captureDashboardScreenshot(root, html2canvas) {
         })
       },
     })
-    return first.toDataURL('image/png')
+    return downscaleCanvas(first)
   } catch (firstErr) {
     console.warn('Primary screenshot capture failed, retrying with safe mode.', firstErr)
   }
@@ -134,7 +155,7 @@ async function captureDashboardScreenshot(root, html2canvas) {
         redactSensitiveElements(clonedEl)
       },
     })
-    return second.toDataURL('image/png')
+    return downscaleCanvas(second)
   } catch (secondErr) {
     console.warn('Safe-mode screenshot capture failed, retrying with sanitized clone.', secondErr)
   }
@@ -153,7 +174,7 @@ async function captureDashboardScreenshot(root, html2canvas) {
         sanitizeClonedDocumentForHtml2Canvas(clonedDoc)
       },
     })
-    return third.toDataURL('image/png')
+    return downscaleCanvas(third)
   } catch (thirdErr) {
     console.error('Sanitized screenshot capture failed:', thirdErr)
     return null

--- a/src/ui/src/components/__tests__/Header.test.jsx
+++ b/src/ui/src/components/__tests__/Header.test.jsx
@@ -356,6 +356,7 @@ describe('Header component', () => {
 
     it('opens modal with screenshot thumbnail after capture', async () => {
       html2canvasFn.mockResolvedValue({
+        width: 800,
         toDataURL: () => 'data:image/png;base64,header-screenshot',
       })
 
@@ -375,6 +376,7 @@ describe('Header component', () => {
       html2canvasFn
         .mockRejectedValueOnce(new Error('primary failed'))
         .mockResolvedValueOnce({
+          width: 800,
           toDataURL: () => 'data:image/png;base64,safe-mode-screenshot',
         })
 

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -281,6 +281,32 @@ class TestReportIssueLoopDoWork:
         assert ".png" in prompt
 
     @pytest.mark.asyncio
+    async def test_base64_with_whitespace_decoded_successfully(
+        self, tmp_path: Path
+    ) -> None:
+        """Base64 with embedded newlines/spaces is stripped and decoded."""
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        raw_png = base64.b64encode(b"\x89PNG\r\n").decode()
+        # Insert newlines and spaces to simulate transport corruption
+        corrupted = "\n".join(raw_png[i : i + 4] for i in range(0, len(raw_png), 4))
+        report = PendingReport(
+            description="Whitespace in base64",
+            screenshot_base64=f"data:image/png;base64,{corrupted}",
+        )
+        state.enqueue_report(report)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "https://github.com/acme/repo/issues/99"
+            result = await loop._do_work()
+
+        assert result is not None
+        assert result["processed"] == 1
+        prompt = mock_stream.call_args.kwargs.get("prompt", "")
+        assert ".png" in prompt
+
+    @pytest.mark.asyncio
     async def test_invalid_screenshot_payload_continues_without_attachment(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

- Downscale screenshots to max 1280px on the frontend before sending (Retina 2x/3x captures were too large for agent context)
- Strip whitespace from base64 before decoding (defensive)
- Fix misleading "Could not be decoded" escalation message

Fixes #2189

## Test plan

- [x] `test_base64_with_whitespace_decoded_successfully` — whitespace in base64 is stripped
- [x] All 27 report_issue_loop tests pass
- [x] All 40 Header tests pass
- [x] UI build succeeds
- [x] quality-lite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)