### PR TITLE
Strengthen quality gates: blocking diff sanity, worktree reset, scope review

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -132,16 +132,22 @@ Run through this checklist before your final commit:
             )
             result.transcript = transcript
 
-            # Diff sanity + test adequacy skills (read-only checks)
+            # Diff sanity check (blocking — agent must fix flagged issues)
             sanity_ok, sanity_msg = await self._run_diff_sanity_loop(
                 task, worktree_path, branch, worker_id
             )
             if not sanity_ok:
                 logger.warning(
-                    "Diff sanity flagged issues for #%d: %s (non-blocking)",
+                    "Diff sanity flagged issues for #%d: %s",
                     task.id,
                     sanity_msg,
                 )
+                result.success = False
+                result.error = f"Diff sanity check failed: {sanity_msg}"
+                result.commits = await self._count_commits(worktree_path, branch)
+                await self._emit_status(task.id, worker_id, WorkerStatus.FAILED)
+                result.duration_seconds = time.monotonic() - start
+                return result
 
             adequacy_ok, adequacy_msg = await self._run_test_adequacy_loop(
                 task, worktree_path, branch, worker_id

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -24,7 +24,7 @@ from phase_utils import (
 from pr_manager import PRManager
 from run_recorder import RunRecorder
 from state import StateTracker
-from subprocess_util import AuthenticationError, CreditExhaustedError
+from subprocess_util import AuthenticationError, CreditExhaustedError, run_subprocess
 from task_source import TaskTransitioner
 from worktree import WorktreeManager
 
@@ -279,11 +279,38 @@ class ImplementPhase:
             error=f"Implementation attempt cap exceeded ({attempts - 1} attempts)",
         )
 
-    async def _setup_worktree_and_branch(self, issue: Task, branch: str) -> Path:
-        """Ensure worktree exists/resumed and branch is pushed."""
+    async def _setup_worktree_and_branch(
+        self, issue: Task, branch: str, *, reset_to_main: bool = False
+    ) -> Path:
+        """Ensure worktree exists/resumed and branch is pushed.
+
+        When *reset_to_main* is True (review-feedback retry), hard-reset the
+        branch to ``origin/main`` so the agent starts fresh instead of
+        re-implementing on top of previously rejected code.
+        """
         wt_path = self._config.worktree_path_for_issue(issue.id)
         if wt_path.is_dir():
-            logger.info("Resuming existing worktree for issue #%d", issue.id)
+            if reset_to_main:
+                logger.info(
+                    "Resetting worktree for issue #%d to main (review retry)",
+                    issue.id,
+                )
+                await run_subprocess(
+                    "git",
+                    "fetch",
+                    "origin",
+                    "main",
+                    cwd=wt_path,
+                )
+                await run_subprocess(
+                    "git",
+                    "reset",
+                    "--hard",
+                    "origin/main",
+                    cwd=wt_path,
+                )
+            else:
+                logger.info("Resuming existing worktree for issue #%d", issue.id)
         else:
             wt_path = await self._worktrees.create(issue.id, branch)
         self._state.set_worktree(issue.id, str(wt_path))
@@ -332,7 +359,9 @@ class ImplementPhase:
         review_feedback: str,
     ) -> WorkerResult:
         """Set up worktree, push branch, run agent, record metrics."""
-        wt_path = await self._setup_worktree_and_branch(issue, branch)
+        wt_path = await self._setup_worktree_and_branch(
+            issue, branch, reset_to_main=bool(review_feedback)
+        )
 
         result = await self._agents.run(
             issue,

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -1223,15 +1223,8 @@ class ReviewPhase:
                 body = build_insight_issue_body(category, count, len(recent), evidence)
                 desc = CATEGORY_DESCRIPTIONS.get(category, category)
                 title = f"[Review Insight] Recurring feedback: {desc}"
-                labels = self._config.improve_label[:1] + self._config.hitl_label[:1]
-                issue_num = await self._transitioner.create_task(title, body, labels)
-                if issue_num:
-                    self._state.set_hitl_origin(
-                        issue_num, self._config.improve_label[0]
-                    )
-                    self._state.set_hitl_cause(
-                        issue_num, f"Recurring review pattern: {desc}"
-                    )
+                labels = self._config.improve_label[:1]
+                await self._transitioner.create_task(title, body, labels)
                 self._insights.mark_category_proposed(category)
         except Exception:  # noqa: BLE001
             status = "error"

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -590,18 +590,20 @@ Then a brief summary on the next line starting with "SUMMARY: ".
 
 ## Review Instructions
 
-1. Evaluate three dimensions: correctness, completeness, and quality.
-2. Look for edge cases, missing error handling, security risks, test gaps, and style violations.
-3. You MUST find at least {min_findings} issues across all categories. If you find fewer, re-examine the code more carefully.
-4. If you genuinely find fewer than {min_findings} issues, include THOROUGH_REVIEW_COMPLETE:
+1. Evaluate four dimensions: **scope**, correctness, completeness, and quality.
+2. **Scope check (mandatory first step):** Compare every changed file against the issue title and description. Flag any file or change that is unrelated to the stated goal. Unrelated test files, docs, or config changes are scope creep — reject them. Follow CLAUDE.md rules strictly (e.g., never add tests for ADR markdown content).
+3. Look for edge cases, missing error handling, security risks, test gaps, and style violations.
+4. You MUST find at least {min_findings} issues across all categories. If you find fewer, re-examine the code more carefully.
+5. If you genuinely find fewer than {min_findings} issues, include THOROUGH_REVIEW_COMPLETE:
 ```
 THOROUGH_REVIEW_COMPLETE
+Scope: No issues — <justification>
 Correctness: No issues — <justification>
 Completeness: No issues — <justification>
 Quality: No issues — <justification>
 ```
 {verify_step}
-6. Run project audits on changed code:
+7. Run project audits on changed code:
    - Review code quality patterns (SRP, type hints, naming, complexity)
    - Review test quality (3As structure, factories, edge cases)
    - Check for security issues (injection, crypto, auth)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -690,6 +690,40 @@ class TestDiffSanityLoop:
         assert ok is False
         assert "debug code" in msg
 
+    @pytest.mark.asyncio
+    async def test_run_fails_when_diff_sanity_fails(
+        self, config, event_bus: EventBus, issue, tmp_path: Path
+    ) -> None:
+        """AgentRunner.run should return success=False when diff sanity fails."""
+        config.max_diff_sanity_attempts = 1
+        runner = AgentRunner(config, event_bus)
+        with (
+            patch.object(
+                runner, "_execute", new_callable=AsyncMock, return_value="transcript"
+            ),
+            patch.object(
+                runner, "_count_commits", new_callable=AsyncMock, return_value=1
+            ),
+            patch.object(
+                runner,
+                "_get_branch_diff",
+                new_callable=AsyncMock,
+                return_value="+print('debug')\n",
+            ),
+            patch.object(runner, "_save_transcript"),
+        ):
+            # Mock _execute to return RETRY for diff sanity (second call)
+            runner._execute = AsyncMock(
+                side_effect=[
+                    "transcript",  # implementation run
+                    "DIFF_SANITY_RESULT: RETRY\nSUMMARY: scope creep",
+                ]
+            )
+            result = await runner.run(issue, tmp_path, "agent/issue-42")
+
+        assert result.success is False
+        assert "Diff sanity" in (result.error or "")
+
 
 class TestTestAdequacyLoop:
     """Tests for the test adequacy check skill integration."""

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -450,6 +450,42 @@ class TestWorktreeCreationFailure:
         assert result_map[2].success is True
 
     @pytest.mark.asyncio
+    async def test_review_retry_resets_worktree_to_main(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When review feedback exists, worktree branch should reset to origin/main."""
+        from state import StateTracker
+
+        issue = TaskFactory.create(id=99)
+        state = StateTracker(config.state_file)
+        state.set_review_feedback(99, "Fix the scope creep")
+
+        phase, mock_wt, _ = make_implement_phase(config, [issue])
+
+        # Simulate existing worktree directory
+        wt_path = config.worktree_path_for_issue(99)
+        wt_path.mkdir(parents=True, exist_ok=True)
+        phase._state = state
+
+        # Mock run_subprocess to track git reset calls
+        from unittest.mock import patch
+
+        with patch(
+            "implement_phase.run_subprocess", new_callable=AsyncMock
+        ) as mock_run:
+            results, _ = await phase.run_batch()
+
+        # Verify git fetch + reset --hard were called
+        fetch_calls = [c for c in mock_run.call_args_list if "fetch" in c.args]
+        reset_calls = [
+            c
+            for c in mock_run.call_args_list
+            if "reset" in c.args and "--hard" in c.args
+        ]
+        assert len(fetch_calls) >= 1, "Should fetch origin main"
+        assert len(reset_calls) >= 1, "Should reset --hard to origin/main"
+
+    @pytest.mark.asyncio
     async def test_stop_event_cancels_remaining_workers(
         self, config: HydraFlowConfig
     ) -> None:

--- a/tests/test_review_phase.py
+++ b/tests/test_review_phase.py
@@ -2559,7 +2559,7 @@ class TestReviewInsightIntegration:
         call_args = phase._prs.create_task.call_args
         assert "[Review Insight]" in call_args.args[0]
         assert "hydraflow-improve" in call_args.args[2]
-        assert "hydraflow-hitl" in call_args.args[2]
+        assert "hydraflow-hitl" not in call_args.args[2]
 
     @pytest.mark.asyncio
     async def test_review_insight_does_not_refile_proposed_category(

--- a/tests/test_review_phase_metrics.py
+++ b/tests/test_review_phase_metrics.py
@@ -414,7 +414,7 @@ class TestReviewInsightIntegration:
         call_args = phase._prs.create_task.call_args
         assert "[Review Insight]" in call_args.args[0]
         assert "hydraflow-improve" in call_args.args[2]
-        assert "hydraflow-hitl" in call_args.args[2]
+        assert "hydraflow-hitl" not in call_args.args[2]
 
     @pytest.mark.asyncio
     async def test_review_insight_does_not_refile_proposed_category(
@@ -1546,45 +1546,6 @@ class TestRecordReviewInsight:
             await phase._record_review_insight(result)
 
         phase._prs.create_task.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_sets_hitl_state_when_issue_created(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """When an insight issue is created, HITL origin and cause are recorded in state."""
-        phase = make_review_phase(config)
-        result = ReviewResultFactory.create(
-            issue_number=42, verdict=ReviewVerdict.REQUEST_CHANGES
-        )
-        phase._prs.create_task = AsyncMock(return_value=99)
-
-        mock_insights = MagicMock()
-        mock_insights.load_recent.return_value = [MagicMock()] * 5
-        mock_insights.get_proposed_categories.return_value = set()
-        phase._insights = mock_insights
-
-        from review_insights import ReviewRecord
-
-        mock_evidence = [
-            ReviewRecord(
-                pr_number=10,
-                issue_number=42,
-                timestamp="2026-01-01T00:00:00",
-                verdict="request-changes",
-                summary="Type errors found",
-                fixes_made=False,
-                categories=["type_errors"],
-            ),
-        ]
-        with patch(
-            "review_phase.analyze_patterns",
-            return_value=[("type_errors", 3, mock_evidence)],
-        ):
-            await phase._record_review_insight(result)
-
-        assert phase._state.get_hitl_origin(99) == config.improve_label[0]
-        cause = phase._state.get_hitl_cause(99)
-        assert cause is not None and "Recurring review pattern" in cause
 
     @pytest.mark.asyncio
     async def test_exception_does_not_propagate(self, config: HydraFlowConfig) -> None:


### PR DESCRIPTION
## Summary

Four changes to reduce bad PRs reaching merge:

1. **Make diff sanity check blocking** — `agent.run()` now fails when diff sanity detects scope creep, debug code, or logic errors. Previously it only logged a warning and continued, allowing PRs like #2157 (164 lines of forbidden ADR tests on top of a 2-line fix) through.

2. **Reset worktree to origin/main on review retry** — When a PR is rejected and re-queued for implementation, the branch is hard-reset so the agent starts fresh with clean code + feedback, instead of building on top of previously rejected code (the root cause of HITL cycling).

3. **Stop filing review insights as HITL** — Insight issues now only get `hydraflow-improve` label, not `hydraflow-hitl`. This prevents auto-generated noise (#2176, #2212) from flooding the HITL queue.

4. **Add scope validation to reviewer prompt** — Reviewer now checks every changed file against the issue description as a mandatory first step, with explicit instructions to reject unrelated changes and follow CLAUDE.md rules.

## Test plan

- [x] 7006 tests pass, 0 failures
- [x] Full `make quality` green (lint, typecheck, security, tests)
- [x] New test: `test_run_fails_when_diff_sanity_fails` — verifies agent fails on RETRY result
- [x] New test: `test_review_retry_resets_worktree_to_main` — verifies git reset on retry
- [x] Updated test: insight issues no longer get `hydraflow-hitl` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)