### PR TITLE
Fixes #2210: Sync ADR README index statuses with ADR file statuses

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,10 +18,10 @@ and optionally **Alternatives considered** and **Related** links.
 | [0005](0005-pr-recovery-and-zero-diff-branch-handling.md) | PR Recovery and Zero-Diff Branch Handling in Implement Phase | Accepted |
 | [0006](0006-repo-runtime-isolation.md) | RepoRuntime Isolation Architecture | Superseded |
 | [0007](0007-dashboard-api-multi-repo-scoping.md) | Dashboard API Architecture for Multi-Repo Scoping | Accepted |
-| [0008](0008-multi-repo-dashboard-architecture.md) | Multi-Repo Dashboard Architecture | Proposed |
+| [0008](0008-multi-repo-dashboard-architecture.md) | Multi-Repo Dashboard Architecture | Accepted |
 | [0009](0009-multi-repo-process-per-repo-model.md) | Multi-Repo Process-Per-Repo Model | Accepted |
 | [0010](0010-worktree-and-path-isolation.md) | Worktree and Path Isolation Architecture | Proposed |
-| [0011](0011-epic-release-creation-architecture.md) | Epic Release Creation Architecture | Proposed |
+| [0011](0011-epic-release-creation-architecture.md) | Epic Release Creation Architecture | Accepted |
 | [0012](0012-epic-merge-coordination-architecture.md) | Epic Merge Coordination Architecture | Proposed |
 | [0013](0013-screenshot-capture-pipeline.md) | Screenshot Capture Pipeline Architecture | Superseded |
 | [0014](0014-session-counter-forward-progression-semantics.md) | Session Counter Forward-Progression Semantics | Accepted |


### PR DESCRIPTION
## Summary

Closes #2210.

## Issue

Sync ADR README index statuses with ADR file statuses

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow