### PR TITLE
Block interactive git and remove TDD approach from agent prompts

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -529,8 +529,10 @@ Run through this checklist before your final commit:
 - Do NOT run `git push` or `gh pr create`.
 - Run `make quality-lite` (lint + typecheck + security, no tests) as a sense check.
   CI runs the full test suite — you do not need to run `make quality` or `make test`.
-- ALWAYS commit your work with `git add` and `git commit`.
+- ALWAYS commit your work with `git add <file>` and `git commit`.
   The system runs its own quality gate after you finish — your job is to produce commits.
+- NEVER use interactive git commands (`git add -i`, `git add -p`, `git rebase -i`).
+  There is no TTY — interactive commands will hang. Use `git add <file>` or `git add -A`.
 - NEVER conclude that the issue is "already satisfied" or that no work is needed.
   The planner already verified this issue requires implementation. Your job is to
   write the code, not to second-guess the plan. Always produce commits.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -293,6 +293,16 @@ class TestBuildPrompt:
         assert "push" in prompt.lower() or "Do NOT push" in prompt
         assert "pull request" in prompt.lower() or "pr create" in prompt.lower()
 
+    def test_prompt_forbids_interactive_git(
+        self, config, event_bus: EventBus, issue
+    ) -> None:
+        """Prompt should forbid interactive git commands (no TTY in Docker)."""
+        runner = AgentRunner(config, event_bus)
+        prompt = runner._build_prompt(issue)
+        assert "git add -i" in prompt
+        assert "git add -p" in prompt
+        assert "git rebase -i" in prompt
+
     def test_prompt_includes_common_feedback_when_reviews_exist(
         self, config, event_bus: EventBus, issue
     ) -> None:


### PR DESCRIPTION
## Summary
- Block interactive git commands (`git add -i`, `-p`, `git rebase -i`) in agent prompt — no TTY in Docker, these hang and waste tokens
- Remove TDD approach — agents now implement first, then write tests (prevents agents from trying to isolate test-only commits with interactive staging)
- Renamed "Test-first gate" to "Testing gate" in planner (still requires a testing strategy, just not test-first)
- Purged all TDD references from AGENTS.md, CLAUDE.md, skill docs

## Test plan
- [x] `test_prompt_forbids_interactive_git` passes
- [x] All agent tests pass (134)
- [x] All planner tests pass
- [x] `make quality-lite` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)