### PR TITLE
Remove TDD approach — implement first, then write tests

### DIFF
--- a/.claude/agents/hf.test-audit.md
+++ b/.claude/agents/hf.test-audit.md
@@ -944,7 +944,7 @@ Create structured report:
 ### P1 - High Priority (Fix ASAP)
 - **Critical violations** - Tests that don't work correctly, brittle tests, false positives/negatives
 - **Warning violations** - Test quality issues that impact maintainability, readability, and developer productivity
-- **Impact:** Blocks effective testing, slows TDD workflow, reduces confidence in test suite
+- **Impact:** Blocks effective testing, slows development workflow, reduces confidence in test suite
 - **Timeline:** Address immediately in current sprint/iteration
 
 **Examples:**

--- a/.claude/commands/hf.test-adequacy.md
+++ b/.claude/commands/hf.test-adequacy.md
@@ -5,7 +5,7 @@ Assess whether changed production code has adequate test coverage. This is a rea
 ## When to Use
 
 - After implementing changes, before committing
-- To verify test coverage fills gaps left by removed TDD enforcement
+- To verify test coverage is adequate for the changes
 - When reviewing a branch for test completeness
 
 ## Instructions

--- a/.codex/skills/hf.test-audit/SKILL.md
+++ b/.codex/skills/hf.test-audit/SKILL.md
@@ -944,7 +944,7 @@ Create structured report:
 ### P1 - High Priority (Fix ASAP)
 - **Critical violations** - Tests that don't work correctly, brittle tests, false positives/negatives
 - **Warning violations** - Test quality issues that impact maintainability, readability, and developer productivity
-- **Impact:** Blocks effective testing, slows TDD workflow, reduces confidence in test suite
+- **Impact:** Blocks effective testing, slows development workflow, reduces confidence in test suite
 - **Timeline:** Address immediately in current sprint/iteration
 
 **Examples:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ Plans are rejected (and retried once) if any gate fails:
 - `## Implementation Steps` has fewer than 3 numbered steps
 - Word count below `min_plan_words` (full plans only)
 - ≥4 `[NEEDS CLARIFICATION]` markers
-- `## Testing Strategy` is empty or deferred (test-first gate)
+- `## Testing Strategy` is empty or deferred (testing gate)
 - `constitution.md` principles violated (constitution gate)
 
 ### Retry behaviour
@@ -161,7 +161,7 @@ Commits changes but never pushes or creates PRs.
 6. **Common review feedback** — aggregated patterns from recent review history (via `ReviewInsightStore`), summarized to `_MAX_COMMON_FEEDBACK_CHARS` (2 000).
 7. **Manifest + memory injection**.
 8. **Runtime logs** (opt-in via `inject_runtime_logs`).
-9. **Instructions** — 5 numbered steps: understand → TDD → pre-quality review → run quality gate → commit.
+9. **Instructions** — 7 numbered steps: understand → implement → write tests → diff sanity → pre-quality review → run quality gate → commit.
 10. **UI guidelines** — component reuse, centralized constants/theme, responsive design, spacing.
 11. **Rules** — mandatory tests, no push/PR, quality gate must pass before commit.
 12. **Memory suggestion**.
@@ -192,7 +192,7 @@ quality-fix: <description> (#<issue>)
 
 ### Rules enforced by prompt
 
-- Write tests before implementing (TDD).
+- Write tests for all new code — tests are mandatory.
 - Never push to remote.
 - Never create PRs (`git push`, `gh pr create` are explicitly prohibited).
 - `make quality` must pass before committing.
@@ -313,7 +313,7 @@ The escalation `cause` string is classified into a prompt template:
 |-----------|------------------|--------------------|
 | `ci` | "ci", "check", "test fail" | `make quality` → fix root causes → rerun |
 | `merge_conflict` | "merge" + "conflict" | `git status` → resolve → quality check |
-| `needs_info` | "insufficient", "needs", "detail" | Read guidance → TDD → implement → quality |
+| `needs_info` | "insufficient", "needs", "detail" | Read guidance → implement → test → quality |
 | `default` | (anything else) | Read guidance → fix → quality |
 
 Note: `needs_info` is checked before `ci` because "insufficient" contains "ci".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ HydraFlow runs five concurrent async loops from `orchestrator.py`:
 
 1. **Triage loop**: Fetches new issues, scores complexity, classifies type, and applies the `hydraflow-plan` label.
 2. **Plan loop**: Fetches issues labeled `hydraflow-plan`, runs a read-only Claude agent to explore the codebase and produce an implementation plan, posts the plan as a comment, then swaps the label to `hydraflow-ready`.
-3. **Implement loop**: Fetches issues labeled `hydraflow-ready`, creates git worktrees, runs implementation agents with TDD prompts, pushes branches, creates PRs, then swaps to `hydraflow-review`.
+3. **Implement loop**: Fetches issues labeled `hydraflow-ready`, creates git worktrees, runs implementation agents, pushes branches, creates PRs, then swaps to `hydraflow-review`.
 4. **Review loop**: Fetches issues labeled `hydraflow-review`, runs a review agent to check quality and optionally fix issues, submits a formal PR review, waits for CI, and auto-merges approved PRs. CI failures escalate to `hydraflow-hitl` for human intervention.
 5. **HITL loop**: Processes issues labeled `hydraflow-hitl` that need human-in-the-loop correction.
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -507,11 +507,12 @@ Run through this checklist before your final commit:
 ## Instructions
 
 1. Understand the issue and relevant code paths.
-2. Write tests to ensure functionality, prevent regressions, and catch bugs.
-3. Diff Sanity Check and Test Adequacy Check run automatically after your implementation.
-4. Run Pre-Quality Review Skill for correctness, plan adherence, and missing tests.
-5. Run Run-Tool Skill: `make lint` → `{test_cmd}` → `make quality-lite`; fix and rerun.
-5. Commit with: "Fixes #{issue.id}: <concise summary>"
+2. Implement the solution — write the code changes first.
+3. Write tests to ensure functionality, prevent regressions, and catch bugs.
+4. Diff Sanity Check and Test Adequacy Check run automatically after your implementation.
+5. Run Pre-Quality Review Skill for correctness, plan adherence, and missing tests.
+6. Run Run-Tool Skill: `make lint` → `{test_cmd}` → `make quality-lite`; fix and rerun.
+7. Commit with: "Fixes #{issue.id}: <concise summary>"
 {feedback_section}{escalation_section}
 {self._build_self_check_checklist(escalations)}
 ## UI Guidelines

--- a/src/planner.py
+++ b/src/planner.py
@@ -556,7 +556,7 @@ This closes the issue automatically. False positives waste significant human tim
         {"fix", "typo", "correct", "patch", "update", "rename", "bump", "tweak"}
     )
 
-    # Pattern for detecting test-first gate violations.
+    # Pattern for detecting deferred testing strategy.
     _TEST_LATER_RE = re.compile(
         r"\b(later|tbd|todo|to\s+be\s+determined|will\s+be\s+added\s+later)\b",
         re.IGNORECASE,
@@ -851,7 +851,7 @@ This closes the issue automatically. False positives waste significant human tim
                     f"(threshold is {threshold})"
                 )
 
-        # --- Test-first gate: reject if Testing Strategy is empty or deferred ---
+        # --- Testing gate: reject if Testing Strategy is empty or deferred ---
         ts_match = re.search(
             r"## Testing Strategy\s*\n(.*?)(?=\n## |\Z)",
             plan,
@@ -860,11 +860,10 @@ This closes the issue automatically. False positives waste significant human tim
         if ts_match:
             ts_body = ts_match.group(1).strip()
             if not ts_body or ts_body.lower() in ("none", "n/a", "-"):
-                blocking.append("Test-first gate: Testing Strategy section is empty")
+                blocking.append("Testing gate: Testing Strategy section is empty")
             elif self._TEST_LATER_RE.search(ts_body):
                 blocking.append(
-                    "Test-first gate: Testing Strategy defers tests "
-                    "(e.g. 'later', 'TBD')"
+                    "Testing gate: Testing Strategy defers tests (e.g. 'later', 'TBD')"
                 )
         else:
             # Section missing entirely — already caught by _validate_plan

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1328,7 +1328,7 @@ def test_phase_minus_one_simplicity_gate_warns_on_many_new_files(config, event_b
     assert any("Simplicity gate" in w for w in warnings)
 
 
-def test_phase_minus_one_test_first_gate_rejects_later(config, event_bus):
+def test_phase_minus_one_testing_gate_rejects_later(config, event_bus):
     """'tests will be added later' in Testing Strategy is rejected."""
     runner = _make_runner(config, event_bus)
     plan = _valid_plan().replace(
@@ -1337,10 +1337,10 @@ def test_phase_minus_one_test_first_gate_rejects_later(config, event_bus):
         "Tests will be added later after implementation is stable.",
     )
     blocking, _ = runner._run_phase_minus_one_gates(plan)
-    assert any("Test-first gate" in e for e in blocking)
+    assert any("Testing gate" in e for e in blocking)
 
 
-def test_phase_minus_one_test_first_gate_rejects_tbd(config, event_bus):
+def test_phase_minus_one_testing_gate_rejects_tbd(config, event_bus):
     """'TBD' in Testing Strategy is rejected."""
     runner = _make_runner(config, event_bus)
     plan = _valid_plan().replace(
@@ -1349,14 +1349,14 @@ def test_phase_minus_one_test_first_gate_rejects_tbd(config, event_bus):
         "TBD",
     )
     blocking, _ = runner._run_phase_minus_one_gates(plan)
-    assert any("Test-first gate" in e for e in blocking)
+    assert any("Testing gate" in e for e in blocking)
 
 
-def test_phase_minus_one_test_first_gate_accepts_valid(config, event_bus):
-    """A proper testing strategy passes the test-first gate."""
+def test_phase_minus_one_testing_gate_accepts_valid(config, event_bus):
+    """A proper testing strategy passes the testing gate."""
     runner = _make_runner(config, event_bus)
     blocking, _ = runner._run_phase_minus_one_gates(_valid_plan())
-    assert not any("Test-first gate" in e for e in blocking)
+    assert not any("Testing gate" in e for e in blocking)
 
 
 def test_phase_minus_one_constitution_gate_skipped_when_no_file(config, event_bus):


### PR DESCRIPTION
## Summary
- Reordered agent prompt: implement first, then write tests (not TDD test-first)
- Renamed "Test-first gate" to "Testing gate" in planner (still requires testing strategy)
- Purged all TDD references from AGENTS.md, CLAUDE.md, skill/audit docs

Agents were using TDD ordering which caused issues like attempting interactive git staging to separate test-only commits from implementation commits.

## Test plan
- [x] All planner tests pass (gate renamed)
- [x] All agent tests pass
- [x] `make quality-lite` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)