### PR TITLE
Fix Docker core.worktree corruption on host

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -12,7 +12,7 @@ import contextlib
 import logging
 import os
 import struct
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
@@ -248,10 +248,12 @@ class DockerProcess:
         container: ContainerLike,
         socket: DockerSocket,
         loop: asyncio.AbstractEventLoop,
+        on_exit: Callable[[], None] | None = None,
     ) -> None:
         self._container = container
         self._socket = socket
         self._loop = loop
+        self._on_exit = on_exit
         stdout_reader = DockerStdoutReader(socket, loop)
         self.stdin = DockerStdinWriter(socket)
         self.stdout = stdout_reader
@@ -267,6 +269,8 @@ class DockerProcess:
         result = await self._loop.run_in_executor(None, self._container.wait)
         code = int(result.get("StatusCode", 1))
         self.returncode = code
+        if self._on_exit is not None:
+            self._on_exit()
         return code
 
 
@@ -557,6 +561,7 @@ class DockerRunner:
                     cast(ContainerLike, container),
                     cast(DockerSocket, socket),
                     loop,
+                    on_exit=lambda: self._fix_core_worktree(cwd),
                 ),
             )
         except Exception:
@@ -646,6 +651,30 @@ class DockerRunner:
             with contextlib.suppress(Exception):
                 await loop.run_in_executor(None, lambda: container.remove(force=True))
             self._containers.discard(container)
+            self._fix_core_worktree(cwd)
+
+    def _fix_core_worktree(self, cwd: str | None) -> None:
+        """Unset ``core.worktree`` on the worktree and main repo after container exit.
+
+        Docker containers set ``GIT_WORK_TREE=/workspace`` which can cause git
+        to persist ``core.worktree=/workspace`` into the local git config.
+        This breaks all host-side git operations since ``/workspace`` doesn't
+        exist on the host.
+        """
+        import subprocess  # noqa: PLC0415
+
+        targets = [str(self._repo_root)]
+        if cwd and cwd != str(self._repo_root):
+            targets.append(cwd)
+        for path in targets:
+            with contextlib.suppress(Exception):
+                subprocess.run(
+                    ["git", "config", "--unset", "core.worktree"],
+                    cwd=path,
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
 
     async def cleanup(self) -> None:
         """Remove all tracked containers."""

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -1456,3 +1456,112 @@ class TestBuildMountsGitDir:
         mounts = runner._build_mounts(None)
 
         assert not any(v["bind"] == "/dot-git" for v in mounts.values())
+
+
+# ---------------------------------------------------------------------------
+# _fix_core_worktree
+# ---------------------------------------------------------------------------
+
+
+class TestFixCoreWorktree:
+    """Verify _fix_core_worktree unsets core.worktree on the right paths."""
+
+    @patch("subprocess.run")
+    def test_unsets_repo_root_only_when_cwd_is_none(self, mock_run: MagicMock) -> None:
+        runner, _ = _make_runner(repo_root=Path("/fake/repo"))
+        runner._fix_core_worktree(None)
+        assert mock_run.call_count == 1
+        assert mock_run.call_args_list[0][1]["cwd"] == "/fake/repo"
+
+    @patch("subprocess.run")
+    def test_unsets_both_repo_root_and_cwd(self, mock_run: MagicMock) -> None:
+        runner, _ = _make_runner(repo_root=Path("/fake/repo"))
+        runner._fix_core_worktree("/fake/worktree")
+        assert mock_run.call_count == 2
+        cwds = [c[1]["cwd"] for c in mock_run.call_args_list]
+        assert "/fake/repo" in cwds
+        assert "/fake/worktree" in cwds
+
+    @patch("subprocess.run")
+    def test_skips_duplicate_when_cwd_equals_repo_root(
+        self, mock_run: MagicMock
+    ) -> None:
+        runner, _ = _make_runner(repo_root=Path("/fake/repo"))
+        runner._fix_core_worktree("/fake/repo")
+        assert mock_run.call_count == 1
+
+    @patch("subprocess.run", side_effect=Exception("boom"))
+    def test_suppresses_errors(self, mock_run: MagicMock) -> None:
+        runner, _ = _make_runner(repo_root=Path("/fake/repo"))
+        runner._fix_core_worktree("/fake/worktree")
+
+
+# ---------------------------------------------------------------------------
+# DockerProcess on_exit callback
+# ---------------------------------------------------------------------------
+
+
+class TestDockerProcessOnExit:
+    """Verify the on_exit callback fires after wait() completes."""
+
+    @pytest.mark.asyncio
+    async def test_on_exit_called_after_wait(self) -> None:
+        container = MagicMock()
+        container.wait.return_value = {"StatusCode": 0}
+        socket = MagicMock()
+        socket.recv.return_value = b""
+        callback = MagicMock()
+
+        proc = DockerProcess(
+            container, socket, asyncio.get_event_loop(), on_exit=callback
+        )
+        code = await proc.wait()
+
+        assert code == 0
+        callback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_callback_when_none(self) -> None:
+        container = MagicMock()
+        container.wait.return_value = {"StatusCode": 0}
+        socket = MagicMock()
+        socket.recv.return_value = b""
+
+        proc = DockerProcess(container, socket, asyncio.get_event_loop(), on_exit=None)
+        code = await proc.wait()
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# run_simple calls _fix_core_worktree in finally
+# ---------------------------------------------------------------------------
+
+
+class TestRunSimpleFixCoreWorktree:
+    """Verify run_simple invokes _fix_core_worktree after container exit."""
+
+    @pytest.mark.asyncio
+    async def test_called_after_successful_run(self) -> None:
+        runner, client = _make_runner()
+        container = client.containers.create.return_value
+        container.wait.return_value = {"StatusCode": 0}
+        container.logs.return_value = b"output"
+
+        with patch.object(runner, "_fix_core_worktree") as mock_fix:
+            result = await runner.run_simple(["echo", "hi"], cwd="/fake/worktree")
+
+        assert result.returncode == 0
+        mock_fix.assert_called_once_with("/fake/worktree")
+
+    @pytest.mark.asyncio
+    async def test_called_even_on_error(self) -> None:
+        runner, client = _make_runner()
+        container = client.containers.create.return_value
+        container.wait.return_value = {"StatusCode": 1}
+        container.logs.return_value = b"error"
+
+        with patch.object(runner, "_fix_core_worktree") as mock_fix:
+            result = await runner.run_simple(["false"], cwd="/fake/wt")
+
+        assert result.returncode == 1
+        mock_fix.assert_called_once_with("/fake/wt")


### PR DESCRIPTION
## Summary
- Docker containers set `GIT_WORK_TREE=/workspace` which persists `core.worktree=/workspace` into git config of both the worktree and main repo, breaking all host-side git operations
- Added `_fix_core_worktree()` method that unsets `core.worktree` on both the worktree and main repo after every container exit
- Wired cleanup into `run_simple`'s `finally` block and `DockerProcess.wait()` via `on_exit` callback for streaming processes

## Test plan
- [x] Unit tests for `_fix_core_worktree` (4 tests: repo-only, both paths, dedup, error suppression)
- [x] Unit tests for `DockerProcess.on_exit` callback (2 tests: fires after wait, no-op when None)
- [x] Integration tests for `run_simple` cleanup (2 tests: success path, error path)
- [x] All 8 new tests passing
- [x] Lint + typecheck + security clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)