### PR TITLE
Add hydraflow-hitl-autofix label for auto-fix visibility

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -196,6 +196,7 @@ _ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
     "HYDRAFLOW_LABEL_REVIEW": ("review_label", ["hydraflow-review"]),
     "HYDRAFLOW_LABEL_HITL": ("hitl_label", ["hydraflow-hitl"]),
     "HYDRAFLOW_LABEL_HITL_ACTIVE": ("hitl_active_label", ["hydraflow-hitl-active"]),
+    "HYDRAFLOW_LABEL_HITL_AUTOFIX": ("hitl_autofix_label", ["hydraflow-hitl-autofix"]),
     "HYDRAFLOW_LABEL_FIXED": ("fixed_label", ["hydraflow-fixed"]),
     "HYDRAFLOW_LABEL_IMPROVE": ("improve_label", ["hydraflow-improve"]),
     "HYDRAFLOW_LABEL_MEMORY": ("memory_label", ["hydraflow-memory"]),
@@ -364,6 +365,10 @@ class HydraFlowConfig(BaseModel):
     hitl_active_label: list[str] = Field(
         default=["hydraflow-hitl-active"],
         description="Labels for HITL items being actively processed (OR logic)",
+    )
+    hitl_autofix_label: list[str] = Field(
+        default=["hydraflow-hitl-autofix"],
+        description="Labels for HITL items undergoing automatic fix attempt (OR logic)",
     )
     fixed_label: list[str] = Field(
         default=["hydraflow-fixed"],
@@ -1166,6 +1171,7 @@ class HydraFlowConfig(BaseModel):
         "review_label",
         "hitl_label",
         "hitl_active_label",
+        "hitl_autofix_label",
         "fixed_label",
         "improve_label",
         "memory_label",
@@ -1220,6 +1226,7 @@ class HydraFlowConfig(BaseModel):
             self.review_label,
             self.hitl_label,
             self.hitl_active_label,
+            self.hitl_autofix_label,
             self.fixed_label,
             self.improve_label,
             self.transcript_label,
@@ -1309,7 +1316,8 @@ class HydraFlowConfig(BaseModel):
             HYDRAFLOW_LABEL_READY       → ready_label  (implement stage)
             HYDRAFLOW_LABEL_REVIEW      → review_label
             HYDRAFLOW_LABEL_HITL        → hitl_label
-            HYDRAFLOW_LABEL_HITL_ACTIVE → hitl_active_label
+            HYDRAFLOW_LABEL_HITL_ACTIVE  → hitl_active_label
+            HYDRAFLOW_LABEL_HITL_AUTOFIX → hitl_autofix_label
             HYDRAFLOW_LABEL_FIXED       → fixed_label
             HYDRAFLOW_LABEL_IMPROVE     → improve_label
             HYDRAFLOW_LABEL_MEMORY      → memory_label

--- a/src/hitl_phase.py
+++ b/src/hitl_phase.py
@@ -125,6 +125,12 @@ class HITLPhase:
                 "Issue #%d: attempting auto-fix before human correction",
                 issue_number,
             )
+
+            # Swap label so the issue leaves the HITL dashboard immediately
+            await self._prs.swap_pipeline_labels(
+                issue_number, self._config.hitl_autofix_label[0]
+            )
+
             await self._prs.post_comment(
                 issue_number,
                 "**Auto-fix attempt** — trying automated correction "

--- a/tests/test_hitl_phase.py
+++ b/tests/test_hitl_phase.py
@@ -835,6 +835,9 @@ class TestHITLAutoFix:
         assert 42 in phase._hitl_corrections
         assert "AUTOMATIC FIX ATTEMPT" in phase._hitl_corrections[42]
         assert "CI failed" in phase._hitl_corrections[42]
+        prs.swap_pipeline_labels.assert_awaited_once_with(
+            42, config.hitl_autofix_label[0]
+        )
         prs.post_comment.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds configurable `hitl_autofix_label` (default `hydraflow-hitl-autofix`) to swap issues off the HITL dashboard immediately when auto-fix begins
- Label is swapped in `attempt_auto_fixes` before queuing the correction, so issues don't linger on the HITL dashboard during automated fix attempts
- Configurable via `HYDRAFLOW_LABEL_HITL_AUTOFIX` env var

## Test plan
- [x] Existing HITL phase tests pass (38/38)
- [x] Updated test verifies `swap_pipeline_labels` called with autofix label
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)