### PR TITLE
Replace worktree .git sharing with standalone clones for Docker

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -370,32 +370,35 @@ class DockerRunner:
 
         # Determine the current branch
         try:
-            branch = subprocess.run(
+            branch: str | None = subprocess.run(
                 ["git", "rev-parse", "--abbrev-ref", "HEAD"],
                 cwd=cwd,
                 capture_output=True,
                 text=True,
                 check=True,
             ).stdout.strip()
+            if branch == "HEAD":
+                # Detached HEAD — can't use --branch with "HEAD"
+                branch = None
         except (subprocess.CalledProcessError, OSError):
-            branch = "HEAD"
+            branch = None
 
         # Clone the repo locally, then swap .git/ into the workspace
         import shutil  # noqa: PLC0415
 
         clone_tmp = Path(cwd) / ".git-clone-tmp"
         try:
+            clone_cmd = [
+                "git",
+                "clone",
+                "--local",
+                "--no-checkout",
+            ]
+            if branch:
+                clone_cmd += ["--branch", branch]
+            clone_cmd += [str(self._repo_root), str(clone_tmp)]
             subprocess.run(
-                [
-                    "git",
-                    "clone",
-                    "--local",
-                    "--no-checkout",
-                    "--branch",
-                    branch,
-                    str(self._repo_root),
-                    str(clone_tmp),
-                ],
+                clone_cmd,
                 check=True,
                 capture_output=True,
             )

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -1408,6 +1408,170 @@ class TestPrepareWorkspace:
         runner.prepare_workspace(str(tmp_path))
         assert (tmp_path / ".git").is_file()
 
+    def test_converts_worktree_to_standalone(self, tmp_path: Path) -> None:
+        """Happy path: a worktree .git file is replaced with a real .git dir."""
+        # Set up a real git repo to clone from
+        import subprocess
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=str(repo),
+            check=True,
+            capture_output=True,
+            env={
+                **__import__("os").environ,
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "t@t",
+            },
+        )
+
+        # Create a worktree
+        wt = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "worktree", "add", str(wt), "-b", "test-branch"],
+            cwd=str(repo),
+            check=True,
+            capture_output=True,
+        )
+
+        # Verify it starts as a .git file (worktree pointer)
+        assert (wt / ".git").is_file()
+
+        runner, _ = _make_runner(repo_root=repo, log_dir=tmp_path / "logs")
+        (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+        runner.prepare_workspace(str(wt))
+
+        # After conversion it should be a standalone .git directory
+        assert (wt / ".git").is_dir()
+        # Should be a functional git repo
+        result = subprocess.run(
+            ["git", "status"],
+            cwd=str(wt),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0
+
+    def test_converts_worktree_cleanup_on_failure(self, tmp_path: Path) -> None:
+        """If git clone fails, cleanup runs and exception re-raised."""
+        import subprocess as sp
+
+        wt = tmp_path / "worktree"
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /nonexistent/path\n")
+
+        runner, _ = _make_runner(
+            repo_root=tmp_path / "nonexistent-repo",
+            log_dir=tmp_path / "logs",
+        )
+        (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+
+        with pytest.raises((sp.CalledProcessError, OSError)):
+            runner.prepare_workspace(str(wt))
+
+        # .git file should still be gone (unlinked before clone fails)
+        # but .git-clone-tmp should be cleaned up
+        assert not (wt / ".git-clone-tmp").exists()
+
+    def test_branch_none_skips_branch_flag(self, tmp_path: Path) -> None:
+        """When branch detection fails, clone proceeds without --branch."""
+        import subprocess
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=str(repo),
+            check=True,
+            capture_output=True,
+            env={
+                **__import__("os").environ,
+                "GIT_AUTHOR_NAME": "test",
+                "GIT_AUTHOR_EMAIL": "t@t",
+                "GIT_COMMITTER_NAME": "test",
+                "GIT_COMMITTER_EMAIL": "t@t",
+            },
+        )
+
+        wt = tmp_path / "worktree"
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(wt)],
+            cwd=str(repo),
+            check=True,
+            capture_output=True,
+        )
+        assert (wt / ".git").is_file()
+
+        runner, _ = _make_runner(repo_root=repo, log_dir=tmp_path / "logs")
+        (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+        runner.prepare_workspace(str(wt))
+
+        # Should still convert successfully (detached HEAD → no --branch flag)
+        assert (wt / ".git").is_dir()
+
+
+class TestPrepareWorkspaceCalledFromEntryPoints:
+    """Verify prepare_workspace is invoked from create_streaming_process and run_simple."""
+
+    @pytest.mark.asyncio
+    async def test_create_streaming_process_calls_prepare(self) -> None:
+        runner, mock_client = _make_runner()
+        mock_container = MagicMock()
+        mock_container.wait.return_value = {"StatusCode": 0}
+        mock_socket = _MockSocketBuffer(b"")
+        mock_socket._sock = mock_socket
+        mock_container.attach_socket.return_value = mock_socket
+        mock_client.containers.create.return_value = mock_container
+
+        with patch.object(runner, "prepare_workspace") as mock_prep:
+            await runner.create_streaming_process(["echo", "hi"], cwd="/some/path")
+            mock_prep.assert_called_once_with("/some/path")
+
+    @pytest.mark.asyncio
+    async def test_create_streaming_process_skips_prepare_no_cwd(self) -> None:
+        runner, mock_client = _make_runner()
+        mock_container = MagicMock()
+        mock_container.wait.return_value = {"StatusCode": 0}
+        mock_socket = _MockSocketBuffer(b"")
+        mock_socket._sock = mock_socket
+        mock_container.attach_socket.return_value = mock_socket
+        mock_client.containers.create.return_value = mock_container
+
+        with patch.object(runner, "prepare_workspace") as mock_prep:
+            await runner.create_streaming_process(["echo", "hi"])
+            mock_prep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_simple_calls_prepare(self) -> None:
+        runner, mock_client = _make_runner()
+        mock_container = MagicMock()
+        mock_container.wait.return_value = {"StatusCode": 0}
+        mock_container.logs.return_value = b""
+        mock_client.containers.create.return_value = mock_container
+
+        with patch.object(runner, "prepare_workspace") as mock_prep:
+            await runner.run_simple(["echo", "hi"], cwd="/some/path")
+            mock_prep.assert_called_once_with("/some/path")
+
+    @pytest.mark.asyncio
+    async def test_run_simple_skips_prepare_no_cwd(self) -> None:
+        runner, mock_client = _make_runner()
+        mock_container = MagicMock()
+        mock_container.wait.return_value = {"StatusCode": 0}
+        mock_container.logs.return_value = b""
+        mock_client.containers.create.return_value = mock_container
+
+        with patch.object(runner, "prepare_workspace") as mock_prep:
+            await runner.run_simple(["echo", "hi"])
+            mock_prep.assert_not_called()
+
 
 class TestBuildMountsNoGitDir:
     """Tests verifying .git is NOT mounted into Docker containers."""


### PR DESCRIPTION
## Summary
- **Fixes Docker git corruption** (`core.bare=true`) caused by multiple containers concurrently writing to the host `.git/config` via rw mount
- Adds `prepare_workspace()` which converts worktree `.git` file pointers to standalone repos using `git clone --local` (hardlinked objects, no extra disk) before container start
- Removes all worktree jank: `_detect_worktree`, `_worktree_git_env`, `_patch_worktree_config`, `_unpatch_worktree_config`, and the patch/unpatch lifecycle in `DockerProcess.wait`
- `.git` directory is **no longer mounted** into containers — standalone clones have their own `.git`

## Test plan
- [x] `tests/test_docker_runner.py` — 85 tests pass (replaced old worktree tests with `TestPrepareWorkspace` and `TestBuildMountsNoGitDir`)
- [x] `tests/test_orchestrator.py` + `tests/test_credit_pause.py` — 313 tests pass
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] End-to-end: run HydraFlow with Docker runner on real issues to confirm no git corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)