### PR TITLE
Fix Claude CLI Grep tool in Docker: symlink ripgrep to expected path

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -82,8 +82,15 @@ RUN groupadd --gid 1000 hydraflow \
 ENV PATH="/opt/hydraflow-venv/bin:${PATH}"
 ENV VIRTUAL_ENV=/opt/hydraflow-venv
 
-# Configure git safe directory for mounted worktrees
+# Configure git safe directory for mounted workspaces
 RUN git config --system --add safe.directory /workspace
+
+# Symlink system ripgrep to where Claude CLI expects its bundled binary.
+# Claude CLI looks for rg at /usr/bin/vendor/ripgrep/<arch>-linux/rg but
+# the apt-installed ripgrep lives at /usr/bin/rg.
+RUN ARCH=$(dpkg --print-architecture) \
+    && mkdir -p /usr/bin/vendor/ripgrep/${ARCH}-linux \
+    && ln -s /usr/bin/rg /usr/bin/vendor/ripgrep/${ARCH}-linux/rg
 
 WORKDIR /workspace
 USER hydraflow


### PR DESCRIPTION
## Summary
- Claude CLI's Grep tool looks for rg at `/usr/bin/vendor/ripgrep/<arch>-linux/rg` but the apt-installed ripgrep is at `/usr/bin/rg`
- Creates a symlink so Claude CLI finds rg where it expects it
- Fixes planner agent failures caused by "rg binary not found" errors

## Test plan
- [ ] Rebuild Docker image: `docker build -f Dockerfile.agent -t hydraflow-agent:latest .`
- [ ] Verify symlink: `docker run --rm hydraflow-agent:latest ls -la /usr/bin/vendor/ripgrep/*/rg`
- [ ] Verify rg works: `docker run --rm hydraflow-agent:latest rg --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)