### PR TITLE
Fix UI repo selector bugs and deploy script Bash 3 compat

### DIFF
--- a/deploy/ec2/deploy-hydraflow.sh
+++ b/deploy/ec2/deploy-hydraflow.sh
@@ -266,7 +266,8 @@ health_probe() {
   if [[ ${quiet} -eq 0 ]]; then
     printf '%s\n' "${response}"
   fi
-  local require_ready="${HEALTHCHECK_REQUIRE_READY,,}"
+  local require_ready
+  require_ready="$(printf '%s' "${HEALTHCHECK_REQUIRE_READY:-}" | tr '[:upper:]' '[:lower:]')"
   if [[ "${require_ready}" =~ ^(1|true|yes)$ && "${ready}" != "true" ]]; then
     HEALTH_PROBE_LAST_CODE="not_ready"
     HEALTH_PROBE_LAST_MESSAGE="Service is not ready (ready=${ready:-unset})"
@@ -308,7 +309,8 @@ wait_for_health_ready() {
 }
 
 maybe_wait_for_ready() {
-  local wait_flag="${HEALTHCHECK_WAIT_FOR_READY,,}"
+  local wait_flag
+  wait_flag="$(printf '%s' "${HEALTHCHECK_WAIT_FOR_READY:-}" | tr '[:upper:]' '[:lower:]')"
   if [[ "${wait_flag}" =~ ^(1|true|yes)$ ]]; then
     wait_for_health_ready
   fi

--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -250,8 +250,8 @@ export function OutcomesPanel() {
       if ((item.epic || '').toLowerCase().includes(q)) return true
       if ((item.crate_title || '').toLowerCase().includes(q)) return true
       if (item.crate_number != null && String(item.crate_number).includes(q)) return true
-      const slug = extractRepoSlug(item.issue_url)
-      if (slug && slug.toLowerCase().includes(q)) return true
+      const repoSlug = extractRepoSlug(item.issue_url)
+      if (repoSlug && repoSlug.toLowerCase().includes(q)) return true
       if ((item.outcome?.reason || '').toLowerCase().includes(q)) return true
       return false
     })

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -43,6 +43,7 @@ export const initialState = {
   currentSessionId: null,
   selectedSessionId: null,
   selectedRepoSlug: null,
+  selectedRepoSlugRaw: null,
   supervisedRepos: [],
   runtimes: [],
   issueHistory: null,
@@ -54,7 +55,8 @@ export const initialState = {
 }
 
 function normalizeRepoSlug(value) {
-  return String(value || '').trim().replace(/[\\/]+/g, '-')
+  if (value == null) return null
+  return String(value).trim().replace(/[\\/]+/g, '-') || null
 }
 
 function isDuplicate(state, action) {
@@ -669,12 +671,25 @@ export function reducer(state, action) {
     case 'SELECT_SESSION':
       return { ...state, selectedSessionId: action.data.sessionId }
 
-    case 'SELECT_REPO':
+    case 'SELECT_REPO': {
+      const newSlug = normalizeRepoSlug(action.data.slug)
+      const changed = newSlug !== state.selectedRepoSlug
       return {
         ...state,
-        selectedRepoSlug: normalizeRepoSlug(action.data.slug),
+        selectedRepoSlug: newSlug,
+        selectedRepoSlugRaw: action.data.slug ?? null,
         selectedSessionId: null,
+        ...(changed && {
+          pipelineIssues: { ...emptyPipeline },
+          hitlItems: [],
+          workers: {},
+          prs: [],
+          reviews: [],
+          sessionPrsCount: 0,
+          events: [],
+        }),
       }
+    }
 
     case 'SET_RUNTIMES':
       return {

--- a/tests/test_deploy_ec2_script.py
+++ b/tests/test_deploy_ec2_script.py
@@ -97,8 +97,10 @@ def _write_sequence_curl(
         'if [[ -f "${counter_file}" ]]; then\n'
         '  count="$(<"${counter_file}")"\n'
         "fi\n"
-        'mapfile -t responses < "${responses_file}"\n'
-        'total="${#responses[@]}"\n'
+        "total=0\n"
+        'while IFS= read -r _line || [[ -n "$_line" ]]; do\n'
+        "  total=$((total + 1))\n"
+        'done < "${responses_file}"\n'
         "if (( total == 0 )); then\n"
         "  printf '{}'\n"
         "  exit 0\n"
@@ -106,7 +108,14 @@ def _write_sequence_curl(
         "if (( count >= total )); then\n"
         "  count=$((total - 1))\n"
         "fi\n"
-        'printf "%s\\n" "${responses[count]}"\n'
+        "line_no=0\n"
+        'while IFS= read -r line || [[ -n "$line" ]]; do\n'
+        "  if (( line_no == count )); then\n"
+        '    printf "%s\\n" "$line"\n'
+        "    break\n"
+        "  fi\n"
+        "  line_no=$((line_no + 1))\n"
+        'done < "${responses_file}"\n'
         'echo $((count + 1)) > "${counter_file}"\n'
     )
     script_path.chmod(0o755)


### PR DESCRIPTION
## Summary
- Fix `normalizeRepoSlug(null)` returning `''` instead of `null` (broke SELECT_REPO reducer tests)
- Add missing `selectedRepoSlugRaw` field and pipeline reset on repo switch
- Fix variable shadowing TDZ crash in IssueHistoryPanel (`const slug` declared twice in nested scope)
- Replace Bash 4+ `${,,}` lowercase syntax with `tr` for macOS Bash 3.2 compatibility
- Replace `mapfile` (Bash 4+) in test helper with POSIX while-read loop

## Test plan
- [x] All 851 UI tests pass
- [x] All backend tests pass (including deploy script tests)
- [x] `make test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)