### PR TITLE
Fix false-positive auth errors on early-killed processes

### DIFF
--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -185,8 +185,10 @@ async def stream_claude_process(
             # Claude CLI emits '"error":"authentication_failed"' when it
             # cannot authenticate — this can be a transient OAuth token
             # refresh failure, so the caller retries with backoff.
+            # Skip when early_killed=True — killing the process can cause
+            # in-flight API requests to fail with auth errors as a side effect.
             raw_output = "\n".join(raw_lines)
-            if "authentication_failed" in raw_output:
+            if not early_killed and "authentication_failed" in raw_output:
                 raise AuthenticationRetryError(
                     "Agent CLI authentication failed — check "
                     "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -342,6 +342,27 @@ class TestStreamClaudeProcessExitHandling:
 
         mock_logger.warning.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_early_kill_ignores_auth_failed_in_output(self, event_bus) -> None:
+        """When on_output kills the process, auth_failed in output should not raise."""
+        import json
+
+        auth_line = json.dumps({"error": "authentication_failed"})
+        mock_create = make_streaming_proc(
+            returncode=0, stdout=f"good output\n{auth_line}"
+        )
+
+        with patch("asyncio.create_subprocess_exec", mock_create):
+            result = await stream_claude_process(
+                **_default_kwargs(
+                    event_bus,
+                    on_output=lambda _: True,  # Kill immediately
+                )
+            )
+
+        # Should NOT raise AuthenticationRetryError
+        assert "good output" in result
+
 
 # ---------------------------------------------------------------------------
 # stream_claude_process — on_output callback


### PR DESCRIPTION
## Summary
- When `on_output` kills the Claude process early (e.g. planner found `PLAN_END` markers), in-flight API requests can fail with `authentication_failed` as a side effect
- The auth check in `stream_claude_process` ran unconditionally on raw output, causing completed plans to be discarded after 3 false retry attempts
- Added `not early_killed` guard to the auth check, matching the existing credit-exhaustion guard pattern

## Test plan
- [x] Added `test_early_kill_ignores_auth_failed_in_output` — verifies no `AuthenticationRetryError` when process is killed via `on_output` callback
- [x] All 35 `test_runner_utils.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)