### PR TITLE
Fixes #2540: Bump version from 0.9.0 to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["ui*", "templates*", "tests*"]
 
 [project]
 name = "hydraflow"
-version = "0.9.0"
+version = "0.9.1"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "pydantic>=2.0.0",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@
 Canonical repository slug: ``T-rav/hyrdaflow``.
 """
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"

--- a/src/app_version.py
+++ b/src/app_version.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from importlib.metadata import PackageNotFoundError, version
 
 _PACKAGE_NAME = "hydraflow"
-_FALLBACK_VERSION = "0.9.0+dev"
+_FALLBACK_VERSION = "0.9.1+dev"
 
 
 def get_app_version() -> str:

--- a/src/ui/e2e/fixtures/seed-state.js
+++ b/src/ui/e2e/fixtures/seed-state.js
@@ -202,7 +202,7 @@ export const seedConfig = {
   batch_size: 15,
   ready_label: 'hydraflow-ready',
   planner_label: 'hydraflow-plan',
-  app_version: '0.9.0',
+  app_version: '0.9.1',
 }
 
 export const seedSupervisedRepos = [

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hydraflow-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hydraflow-ui",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.263.1",
@@ -1165,11 +1165,10 @@
         "arm64"
       ],
       "license": "MIT",
+      "optional": true,
       "os": [
         "linux"
-      ],
-      "optional": true,
-      "dev": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydraflow-ui",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "HydraFlow dashboard — Intent in. Software out.",
   "private": true,
   "engines": {

--- a/src/ui/src/components/__tests__/Header.test.jsx
+++ b/src/ui/src/components/__tests__/Header.test.jsx
@@ -169,17 +169,17 @@ describe('Header component', () => {
   it('renders app version when available in config', () => {
     mockUseHydraFlow.mockReturnValue({
       stageStatus: mockStageStatus(),
-      config: { app_version: '0.9.0' },
+      config: { app_version: '0.9.1' },
     })
     render(<Header {...defaultProps} />)
-    expect(screen.getByText('v0.9.0')).toBeInTheDocument()
+    expect(screen.getByText('v0.9.1')).toBeInTheDocument()
   })
 
   it('renders update notice with command when update is available', () => {
     mockUseHydraFlow.mockReturnValue({
       stageStatus: mockStageStatus(),
       config: {
-        app_version: '0.9.0',
+        app_version: '0.9.1',
         latest_version: '0.9.2',
         update_available: true,
       },

--- a/tests/test_dashboard_routes_control.py
+++ b/tests/test_dashboard_routes_control.py
@@ -163,7 +163,7 @@ class TestControlStatusAppVersion:
         monkeypatch.setattr(
             "dashboard_routes.load_cached_update_result",
             lambda **_kwargs: UpdateCheckResult(
-                current_version="0.9.0",
+                current_version="0.9.1",
                 latest_version="0.9.2",
                 update_available=True,
                 error=None,

--- a/uv.lock
+++ b/uv.lock
@@ -210,7 +210,7 @@ wheels = [
 
 [[package]]
 name = "hydraflow"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary

Closes #2540.

## Issue

Bump version from 0.9.0 to 0.9.1

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow