### PR TITLE
Fix report processing and plan comment enrichment on startup

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -379,6 +379,11 @@ class ImplementPhase:
             issue, branch, reset_for_retry=reset_for_retry
         )
 
+        # Enrich the task with comments so the agent can find the plan
+        # comment posted by the planner.  The IssueStore bulk fetch
+        # does not include comment bodies.
+        issue = await self._store.enrich_with_comments(issue)
+
         result = await self._agents.run(
             issue,
             wt_path,

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -382,6 +382,34 @@ class IssueStore:
         """Return up to *max_count* issues from the plan queue."""
         return self._take_from_queue(STAGE_PLAN, max_count)
 
+    async def enrich_with_comments(self, task: Task) -> Task:
+        """Fetch issue comments from GitHub and return an enriched copy.
+
+        The bulk ``refresh()`` fetch does not include comment bodies
+        (the REST list endpoint returns a count, not content).  Call
+        this before handing a task to an agent that needs the plan
+        comment or discussion history.
+        """
+        # Try the fetcher directly first; if it's a wrapper (e.g.
+        # GitHubTaskFetcher), reach through to the inner IssueFetcher.
+        fetch_fn = getattr(self._fetcher, "fetch_issue_comments", None)
+        if fetch_fn is None or not callable(fetch_fn):
+            inner = getattr(self._fetcher, "_fetcher", None)
+            fetch_fn = getattr(inner, "fetch_issue_comments", None) if inner else None
+        if fetch_fn is None or not callable(fetch_fn):
+            return task
+        try:
+            comments = await fetch_fn(task.id)
+        except Exception:
+            logger.warning(
+                "Could not fetch comments for issue #%d — proceeding without",
+                task.id,
+            )
+            return task
+        if comments:
+            return task.model_copy(update={"comments": comments})
+        return task
+
     def get_implementable(self, max_count: int) -> list[Task]:
         """Return up to *max_count* issues from the ready queue."""
         return self._take_from_queue(STAGE_READY, max_count)

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -189,8 +189,14 @@ class ReportIssueLoop(BaseBackgroundLoop):
             # Verify the agent applied the correct label and screenshot
             await self._verify_issue(issue_number, ready_label, screenshot_url)
 
-            # Success — remove from queue
+            # Success — remove from queue and update tracked report
             self._state.remove_report(report.id)
+            self._state.update_tracked_report(
+                report.id,
+                status="fixed",
+                detail=f"Created issue #{issue_number}",
+                action_label="processed",
+            )
             logger.info(
                 "Processed report %s as issue #%d: %s",
                 report.id,
@@ -207,6 +213,12 @@ class ReportIssueLoop(BaseBackgroundLoop):
         attempt_count = self._state.fail_report(report.id)
         if attempt_count >= _MAX_REPORT_ATTEMPTS:
             self._state.remove_report(report.id)
+            self._state.update_tracked_report(
+                report.id,
+                status="closed",
+                detail=f"Failed {attempt_count} times — escalated to HITL",
+                action_label="escalated",
+            )
             await self._escalate_failed_report(report)
             logger.error(
                 "Report %s failed %d times — escalated to HITL",
@@ -220,6 +232,11 @@ class ReportIssueLoop(BaseBackgroundLoop):
                 "escalated": True,
             }
 
+        self._state.update_tracked_report(
+            report.id,
+            detail=f"Attempt {attempt_count}/{_MAX_REPORT_ATTEMPTS} failed — retrying",
+            action_label="retry",
+        )
         logger.warning(
             "Report %s failed (attempt %d/%d) — will retry next cycle",
             report.id,

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -62,6 +62,7 @@ class ReportIssueLoop(BaseBackgroundLoop):
             enabled_cb=enabled_cb,
             sleep_fn=sleep_fn,
             interval_cb=interval_cb,
+            run_on_startup=True,
         )
         self._state = state
         self._pr_manager = pr_manager

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -1300,3 +1300,81 @@ class TestAdditiveOnlyQueue:
         await store.refresh()
         assert len(store._queues[STAGE_FIND]) == 2
         assert store._queue_members[STAGE_FIND] == {1, 2}
+
+
+# ── Comment Enrichment ───────────────────────────────────────────────
+
+
+class TestEnrichWithComments:
+    """IssueStore.enrich_with_comments fetches and attaches comments."""
+
+    @pytest.mark.asyncio
+    async def test_enriches_task_with_fetched_comments(self) -> None:
+        fetcher = AsyncMock()
+        fetcher.fetch_all = AsyncMock(return_value=[])
+        fetcher.fetch_issue_comments = AsyncMock(
+            return_value=["## Implementation Plan\nDo the thing"]
+        )
+        store = _make_store(fetcher=fetcher)
+        task = TaskFactory.create(id=42, tags=["hydraflow-ready"])
+
+        enriched = await store.enrich_with_comments(task)
+
+        assert enriched.comments == ["## Implementation Plan\nDo the thing"]
+        fetcher.fetch_issue_comments.assert_awaited_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_no_comments(self) -> None:
+        fetcher = AsyncMock()
+        fetcher.fetch_all = AsyncMock(return_value=[])
+        fetcher.fetch_issue_comments = AsyncMock(return_value=[])
+        store = _make_store(fetcher=fetcher)
+        task = TaskFactory.create(id=10, tags=["hydraflow-ready"])
+
+        enriched = await store.enrich_with_comments(task)
+
+        assert enriched.comments == []
+
+    @pytest.mark.asyncio
+    async def test_returns_original_on_fetch_failure(self) -> None:
+        fetcher = AsyncMock()
+        fetcher.fetch_all = AsyncMock(return_value=[])
+        fetcher.fetch_issue_comments = AsyncMock(side_effect=RuntimeError("API error"))
+        store = _make_store(fetcher=fetcher)
+        task = TaskFactory.create(id=10, tags=["hydraflow-ready"])
+
+        enriched = await store.enrich_with_comments(task)
+
+        assert enriched is task  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_works_with_wrapped_fetcher(self) -> None:
+        """When the fetcher is a GitHubTaskFetcher wrapper, reach through."""
+        inner = AsyncMock()
+        inner.fetch_issue_comments = AsyncMock(return_value=["plan text"])
+        wrapper = AsyncMock()
+        wrapper._fetcher = inner
+        del wrapper.fetch_issue_comments
+        wrapper.fetch_all = AsyncMock(return_value=[])
+        store = _make_store(fetcher=wrapper)
+        task = TaskFactory.create(id=5, tags=["hydraflow-ready"])
+
+        enriched = await store.enrich_with_comments(task)
+
+        assert enriched.comments == ["plan text"]
+        inner.fetch_issue_comments.assert_awaited_once_with(5)
+
+    @pytest.mark.asyncio
+    async def test_returns_original_when_fetcher_has_no_comment_method(self) -> None:
+        """Gracefully handles fetchers that don't support comment fetching."""
+
+        class BareTaskFetcher:
+            async def fetch_all(self) -> list:
+                return []
+
+        store = _make_store(fetcher=BareTaskFetcher())  # type: ignore[arg-type]
+        task = TaskFactory.create(id=10, tags=["hydraflow-ready"])
+
+        enriched = await store.enrich_with_comments(task)
+
+        assert enriched is task

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -61,6 +61,15 @@ def _make_loop(
     return loop, deps.stop_event, state, pr_manager
 
 
+class TestReportIssueLoopStartup:
+    """Tests for ReportIssueLoop startup behaviour."""
+
+    def test_run_on_startup_enabled(self, tmp_path: Path) -> None:
+        """ReportIssueLoop should process queued reports immediately on startup."""
+        loop, _stop, _state, _pr = _make_loop(tmp_path)
+        assert loop._run_on_startup is True
+
+
 class TestReportIssueLoopDoWork:
     """Tests for ReportIssueLoop._do_work."""
 

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -15,8 +15,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from models import PendingReport
-from report_issue_loop import ReportIssueLoop
+from models import PendingReport, TrackedReport
+from report_issue_loop import ReportIssueLoop, _MAX_REPORT_ATTEMPTS
 from state import StateTracker
 from tests.helpers import make_bg_loop_deps
 
@@ -726,3 +726,82 @@ class TestSaveScreenshotResourceManagement:
 
         fd_after = len(os.listdir(f"/proc/{pid}/fd"))
         assert fd_after <= fd_before, "FD leaked after _save_screenshot"
+
+
+class TestTrackedReportStatusUpdates:
+    """Tracked report status is updated after processing."""
+
+    @pytest.mark.asyncio
+    async def test_success_updates_tracked_report_to_fixed(self, tmp_path: Path) -> None:
+        """A successfully processed report updates the tracked report to 'fixed'."""
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        report = PendingReport(description="Button is broken")
+        state.enqueue_report(report)
+
+        tracked = TrackedReport(
+            id=report.id, reporter_id="user-1", description=report.description
+        )
+        state.add_tracked_report(tracked)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "https://github.com/acme/repo/issues/77"
+            await loop._do_work()
+
+        updated = state.get_tracked_report(report.id)
+        assert updated is not None
+        assert updated.status == "fixed"
+        assert any("issue #77" in h.detail.lower() for h in updated.history)
+
+    @pytest.mark.asyncio
+    async def test_escalation_updates_tracked_report_to_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """A report that exhausts retries updates the tracked report to 'closed'."""
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        report = PendingReport(description="Persistent failure")
+        state.enqueue_report(report)
+
+        tracked = TrackedReport(
+            id=report.id, reporter_id="user-1", description=report.description
+        )
+        state.add_tracked_report(tracked)
+
+        # Exhaust all attempts
+        for _ in range(_MAX_REPORT_ATTEMPTS - 1):
+            state.fail_report(report.id)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = ""  # No issue URL — failure
+            await loop._do_work()
+
+        updated = state.get_tracked_report(report.id)
+        assert updated is not None
+        assert updated.status == "closed"
+        assert any("escalated" in h.action for h in updated.history)
+
+    @pytest.mark.asyncio
+    async def test_retry_adds_history_entry(self, tmp_path: Path) -> None:
+        """A failed attempt that will be retried adds a history entry."""
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        report = PendingReport(description="Intermittent failure")
+        state.enqueue_report(report)
+
+        tracked = TrackedReport(
+            id=report.id, reporter_id="user-1", description=report.description
+        )
+        state.add_tracked_report(tracked)
+
+        with patch(
+            "report_issue_loop.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = ""  # No issue URL — failure
+            await loop._do_work()
+
+        updated = state.get_tracked_report(report.id)
+        assert updated is not None
+        assert updated.status == "queued"  # Not changed on retry
+        assert any("retry" in h.action for h in updated.history)


### PR DESCRIPTION
## Summary

- **Process queued reports on startup:** `ReportIssueLoop` now sets `run_on_startup=True` so bug reports submitted while the orchestrator was stopped are processed immediately when it starts, instead of waiting for the next poll interval.
- **Update tracked report status:** `ReportIssueLoop._do_work()` now calls `state.update_tracked_report()` on success (→ "fixed"), max-retry escalation (→ "closed"), and retry (→ history entry). Previously, processed reports stayed as "Queued" in the Bug Report Tracker UI forever.
- **Fetch issue comments before implementation:** Added `IssueStore.enrich_with_comments()` which fetches full comment bodies for a task. Called in the implement phase before handing the task to the agent, so it can find the `## Implementation Plan` comment posted by the planner instead of falling back to a local plan file.

## Test plan

- [x] `tests/test_report_issue_loop.py` — 34 passed (3 new: startup flag, tracked report status updates)
- [x] `tests/test_issue_store.py` — 102 passed (5 new: comment enrichment scenarios)
- [ ] Manual: submit a bug report, stop orchestrator, restart, verify report is processed immediately
- [ ] Manual: verify Bug Report Tracker shows "fixed" after successful processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)