### PR TITLE
Improve Claude Code workflow from insights analysis

### DIFF
--- a/.claude/commands/hf.quality-gate.md
+++ b/.claude/commands/hf.quality-gate.md
@@ -1,0 +1,74 @@
+# Quality Gate
+
+Run a comprehensive quality check before declaring work complete or committing. This catches lint errors, type issues, and test failures BEFORE they accumulate.
+
+## When to Use
+
+- After finishing implementation, before committing
+- Anytime you want to verify the codebase is clean
+- Before presenting work as "done" to the user
+
+## Instructions
+
+Run these checks **sequentially** (each depends on the prior passing):
+
+### Step 1: Lint (auto-fix)
+
+```bash
+make lint
+```
+
+If ruff fixes anything, report which files were modified. Re-stage those files if they were already staged.
+
+### Step 2: Type Check
+
+```bash
+make typecheck
+```
+
+If pyright reports errors, fix them immediately. Common issues:
+- Missing imports after ruff auto-removed unused ones
+- Type narrowing needed after refactoring
+- New function missing return type annotation
+
+### Step 3: Security Scan
+
+```bash
+make security
+```
+
+Fix any Medium+ findings from bandit.
+
+### Step 4: Tests
+
+```bash
+make test-fast
+```
+
+If tests fail:
+1. Read the failure output carefully
+2. Determine if it's a test bug or implementation bug
+3. Fix the root cause (not the symptom)
+4. Re-run only the failing test file to verify the fix
+5. Run the full suite again
+
+### Step 5: Report
+
+Produce a summary:
+
+```
+QUALITY GATE: PASS/FAIL
+- Lint: ✓/✗ (N files auto-fixed)
+- Types: ✓/✗ (N errors)
+- Security: ✓/✗ (N findings)
+- Tests: ✓/✗ (N passed, N failed)
+```
+
+If any step fails and you cannot auto-fix it, stop and report the issue clearly.
+
+## Important
+
+- Do NOT skip steps or declare early success
+- Do NOT use `--no-verify` to work around failures
+- If lint auto-fixes create type errors, fix the type errors too
+- This is the minimum bar — run `make quality` for the full parallel check

--- a/.claude/hooks/hf.auto-lint-after-edit.sh
+++ b/.claude/hooks/hf.auto-lint-after-edit.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Hook: Auto-fix lint issues on Python files immediately after edits.
+# Fires on PostToolUse for Edit and Write tools.
+# Runs ruff check --fix on the specific file changed (fast, targeted).
+# Does NOT block — silently fixes lint issues to prevent accumulation.
+
+set -euo pipefail
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Only lint Python files
+if ! echo "$FILE_PATH" | grep -qE '\.py$'; then
+  exit 0
+fi
+
+# Skip .claude/ config files
+if echo "$FILE_PATH" | grep -qE '\.claude/'; then
+  exit 0
+fi
+
+# File must exist (might have been a failed write)
+if [ ! -f "$FILE_PATH" ]; then
+  exit 0
+fi
+
+# Auto-fix lint issues on this file only (fast, ~200ms)
+if command -v ruff &>/dev/null; then
+  ISSUES=$(ruff check "$FILE_PATH" 2>/dev/null || true)
+  if [ -n "$ISSUES" ]; then
+    ruff check --fix --unsafe-fixes "$FILE_PATH" > /dev/null 2>&1 || true
+    ruff format "$FILE_PATH" > /dev/null 2>&1 || true
+    REMAINING=$(ruff check "$FILE_PATH" 2>/dev/null || true)
+    if [ -n "$REMAINING" ]; then
+      echo "LINT: Auto-fixed some issues in $(basename "$FILE_PATH"), but these remain:" >&2
+      echo "$REMAINING" | head -5 >&2
+      echo "Fix these manually before committing." >&2
+    fi
+  fi
+elif command -v uv &>/dev/null; then
+  ISSUES=$(uv run ruff check "$FILE_PATH" 2>/dev/null || true)
+  if [ -n "$ISSUES" ]; then
+    uv run ruff check --fix --unsafe-fixes "$FILE_PATH" > /dev/null 2>&1 || true
+    uv run ruff format "$FILE_PATH" > /dev/null 2>&1 || true
+    REMAINING=$(uv run ruff check "$FILE_PATH" 2>/dev/null || true)
+    if [ -n "$REMAINING" ]; then
+      echo "LINT: Auto-fixed some issues in $(basename "$FILE_PATH"), but these remain:" >&2
+      echo "$REMAINING" | head -5 >&2
+      echo "Fix these manually before committing." >&2
+    fi
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/hf.check-test-counterpart.sh
+++ b/.claude/hooks/hf.check-test-counterpart.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# Hook: Nudge when creating new Python source files without a test counterpart.
-# Fires on PreToolUse for Write tool.
+# Hook: Nudge when editing or creating Python source files without a test counterpart.
+# Fires on PreToolUse for Write and Edit tools.
 # Does NOT block (exit 0) - only shows a reminder.
+# For edits: warns once per file per session (4-hour window).
+# For new files: always warns.
 
 set -euo pipefail
 
@@ -22,27 +24,38 @@ if echo "$FILE_PATH" | grep -qE '(test_|_test\.py|conftest\.py|/tests/|__init__\
   exit 0
 fi
 
-# Only warn for NEW files (not edits to existing files)
-if [ -f "$FILE_PATH" ]; then
-  exit 0
-fi
-
 FILENAME=$(basename "$FILE_PATH" .py)
 
 # Look for existing test counterpart in common locations
 DIR=$(dirname "$FILE_PATH")
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
 for test_path in \
   "${DIR}/tests/test_${FILENAME}.py" \
   "${DIR}/test_${FILENAME}.py" \
-  "${DIR}/../tests/test_${FILENAME}.py"; do
+  "${DIR}/../tests/test_${FILENAME}.py" \
+  "${PROJECT_ROOT}/tests/test_${FILENAME}.py"; do
   if [ -f "$test_path" ]; then
     exit 0  # Test file already exists
   fi
 done
 
-echo "Reminder: New source file being created without a test counterpart." >&2
+# For existing files (edits), only warn once per file per session
+if [ -f "$FILE_PATH" ]; then
+  MARKER_DIR="/tmp/claude-code-markers/$(echo -n "$PROJECT_ROOT" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+  [ -d "$MARKER_DIR" ] || mkdir -p "$MARKER_DIR"
+  WARNED_MARKER="$MARKER_DIR/warned-test-$(echo -n "$FILE_PATH" | (md5sum 2>/dev/null || md5) | cut -d' ' -f1)"
+  if [ -f "$WARNED_MARKER" ] && [ -n "$(find "$WARNED_MARKER" -mmin -240 2>/dev/null)" ]; then
+    exit 0
+  fi
+  touch "$WARNED_MARKER"
+  echo "Reminder: Editing source file without a test counterpart." >&2
+else
+  echo "Reminder: New source file being created without a test counterpart." >&2
+fi
+
 echo "  Source: $FILE_PATH" >&2
 echo "  Expected: test_${FILENAME}.py" >&2
-echo "  Per CLAUDE.md: Every new function/class MUST include tests." >&2
+echo "  Per CLAUDE.md: Every new function/class/feature MUST include tests." >&2
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,6 +64,12 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.check-test-counterpart.sh",
+            "timeout": 10,
+            "statusMessage": "Checking for test counterpart..."
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.enforce-migrations.sh",
             "timeout": 10,
             "statusMessage": "Checking for direct DB schema changes..."
@@ -140,6 +146,12 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.track-code-changes.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.auto-lint-after-edit.sh",
+            "timeout": 15,
+            "statusMessage": "Auto-fixing lint issues..."
           }
         ]
       },
@@ -150,6 +162,12 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.track-code-changes.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.auto-lint-after-edit.sh",
+            "timeout": 15,
+            "statusMessage": "Auto-fixing lint issues..."
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,17 @@ HydraFlow creates isolated git worktrees for each issue. **Always clean up workt
 - Coverage threshold: 70%
 - **Never write tests for ADR markdown content.** ADRs are documentation, not code. Do not create `test_adr_NNNN_*.py` files that assert on markdown headings, status fields, or prose content — these break whenever the document is edited and provide no value. Only test ADR-related *code* (e.g., `test_adr_reviewer.py` tests the reviewer logic).
 
+## Quality Before Completion
+
+**Always run lint and tests before declaring work complete or committing.** Do not present implementation as "done" until quality checks pass.
+
+1. After each significant code change: `make lint` (auto-fixes formatting and imports)
+2. Before committing: `make quality` (lint + typecheck + security + tests in parallel)
+3. If lint auto-fixes files, re-check for type errors introduced by removed imports
+4. Track your edits across files — avoid creating duplicate helpers or inconsistent naming when refactoring multiple test files
+
+The `/hf.quality-gate` command runs a structured quality check sequence. Use it before presenting work as complete.
+
 ## Never Skip Commit Hooks
 
 **NEVER** use `git commit --no-verify` or `--no-hooks` flags. Always fix code issues first.


### PR DESCRIPTION
## Summary

Addresses the top friction points identified by Claude Code Insights — buggy first-pass code, lint errors accumulating until commit time, and missing test reminders during edits.

- **New hook: `hf.auto-lint-after-edit.sh`** — PostToolUse hook that auto-runs `ruff check --fix` + `ruff format` on every Python file after Edit/Write. Catches unused imports, formatting issues, and fixable lint errors immediately instead of letting them pile up until commit time.
- **Updated hook: `hf.check-test-counterpart.sh`** — Now fires on Edit (was Write-only). Reminds about missing test counterparts when editing source files, not just when creating new ones. Uses per-file 4-hour dedup to avoid spam.
- **New command: `/hf.quality-gate`** — Mid-session quality validation skill that runs lint → typecheck → security → tests sequentially, reporting structured pass/fail results.
- **Updated `CLAUDE.md`** — New "Quality Before Completion" section requiring lint and tests before presenting work as done, plus guidance on tracking edits across files to avoid duplicate helpers.
- **Updated `settings.json`** — Wires auto-lint hook into both Edit and Write PostToolUse matchers, adds test counterpart check to Edit PreToolUse matcher.

## Test plan

- [ ] Edit a Python file → verify auto-lint hook fires and fixes formatting
- [ ] Edit a source file without test counterpart → verify reminder appears
- [ ] Edit same file again → verify dedup suppresses second warning
- [ ] Run `/hf.quality-gate` → verify structured output
- [ ] Commit with lint errors → verify pre-commit hook still blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)