### PR TITLE
Fixes #2543: Make Outcomes table columns moveable and sortable

### DIFF
--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -271,7 +271,6 @@ export function OutcomesPanel() {
   const handleDragStart = useCallback((e, key) => {
     dragColumnRef.current = key
     e.dataTransfer.effectAllowed = 'move'
-    e.dataTransfer.setData('text/plain', key)
   }, [])
 
   const handleDragOver = useCallback((e, targetKey) => {
@@ -295,6 +294,10 @@ export function OutcomesPanel() {
       next.splice(tgtIdx, 0, sourceKey)
       return next
     })
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverColumn(null)
   }, [])
 
   const handleDragEnd = useCallback(() => {
@@ -724,6 +727,7 @@ export function OutcomesPanel() {
                 onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleHeaderClick(key) } }}
                 onDragStart={(e) => handleDragStart(e, key)}
                 onDragOver={(e) => handleDragOver(e, key)}
+                onDragLeave={handleDragLeave}
                 onDrop={(e) => handleDrop(e, key)}
                 onDragEnd={handleDragEnd}
                 role="columnheader"

--- a/src/ui/src/components/__tests__/IssueHistoryPanel.test.jsx
+++ b/src/ui/src/components/__tests__/IssueHistoryPanel.test.jsx
@@ -428,7 +428,7 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
         effectAllowed: '',
         dropEffect: '',
         setData: vi.fn(),
-        getData: vi.fn(() => 'title'),
+        getData: vi.fn(),
       }
 
       fireEvent.dragStart(titleHeader, { dataTransfer })
@@ -450,7 +450,7 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
         effectAllowed: '',
         dropEffect: '',
         setData: vi.fn(),
-        getData: vi.fn(() => 'title'),
+        getData: vi.fn(),
       }
 
       fireEvent.dragStart(titleHeader, { dataTransfer })
@@ -472,7 +472,7 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
         effectAllowed: '',
         dropEffect: '',
         setData: vi.fn(),
-        getData: vi.fn(() => 'title'),
+        getData: vi.fn(),
       }
       fireEvent.dragStart(headers[1], { dataTransfer })
       fireEvent.drop(headers[0], { dataTransfer })
@@ -499,7 +499,7 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
         effectAllowed: '',
         dropEffect: '',
         setData: vi.fn(),
-        getData: vi.fn(() => 'number'),
+        getData: vi.fn(),
       }
 
       fireEvent.dragStart(numHeader, { dataTransfer })


### PR DESCRIPTION
## Summary

Closes #2543.

## Issue

Make Outcomes table columns moveable and sortable

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow