### PR TITLE
Fixes #2587: Test Quality: Vague single-word test names in event_pa...

### DIFF
--- a/tests/test_event_payloads.py
+++ b/tests/test_event_payloads.py
@@ -260,12 +260,12 @@ class TestReviewerStatusFixingReviewFindings:
 
         assert hasattr(ReviewerStatus, "FIXING_REVIEW_FINDINGS")
 
-    def test_value(self) -> None:
+    def test_fixing_review_findings_has_expected_string_value(self) -> None:
         from models import ReviewerStatus
 
         assert ReviewerStatus.FIXING_REVIEW_FINDINGS == "fixing_review_findings"
 
-    def test_roundtrip(self) -> None:
+    def test_fixing_review_findings_roundtrips_from_string(self) -> None:
         from models import ReviewerStatus
 
         assert (
@@ -361,7 +361,7 @@ class TestTranscriptLinePayload:
 
 
 class TestSystemAlertPayload:
-    def test_construct(self) -> None:
+    def test_system_alert_payload_accepts_required_keys(self) -> None:
         from models import SystemAlertPayload
 
         p: SystemAlertPayload = {"message": "alert", "source": "loop"}
@@ -401,7 +401,7 @@ class TestTranscriptSummaryPayload:
 
 
 class TestVerificationJudgePayload:
-    def test_construct(self) -> None:
+    def test_verification_judge_payload_accepts_required_keys(self) -> None:
         from models import VerificationJudgePayload
 
         p: VerificationJudgePayload = {
@@ -415,7 +415,7 @@ class TestVerificationJudgePayload:
 
 
 class TestVisualGatePayload:
-    def test_construct(self) -> None:
+    def test_visual_gate_payload_accepts_required_keys(self) -> None:
         from models import VisualGatePayload
 
         p: VisualGatePayload = {
@@ -443,7 +443,7 @@ class TestVisualGatePayload:
 
 
 class TestBaselineUpdatePayload:
-    def test_approved(self) -> None:
+    def test_baseline_update_payload_sets_approved_flag(self) -> None:
         from models import BaselineUpdatePayload
 
         p: BaselineUpdatePayload = {
@@ -455,7 +455,7 @@ class TestBaselineUpdatePayload:
         }
         assert p["approved"] is True
 
-    def test_rollback(self) -> None:
+    def test_baseline_update_payload_includes_rollback_reason(self) -> None:
         from models import BaselineUpdatePayload
 
         p: BaselineUpdatePayload = {
@@ -471,7 +471,7 @@ class TestBaselineUpdatePayload:
 
 
 class TestEpicPayloads:
-    def test_progress(self) -> None:
+    def test_epic_progress_payload_carries_epic_number(self) -> None:
         from models import EpicProgressPayload
 
         p: EpicProgressPayload = {
@@ -480,7 +480,7 @@ class TestEpicPayloads:
         }
         assert p["epic_number"] == 1
 
-    def test_ready(self) -> None:
+    def test_epic_ready_payload_carries_readiness(self) -> None:
         from models import EpicReadyPayload
 
         p: EpicReadyPayload = {
@@ -489,7 +489,7 @@ class TestEpicPayloads:
         }
         assert p["readiness"]["ready"] is True
 
-    def test_releasing(self) -> None:
+    def test_epic_releasing_payload_carries_job_id(self) -> None:
         from models import EpicReleasingPayload
 
         p: EpicReleasingPayload = {"epic_number": 1, "job_id": "j-1"}
@@ -516,7 +516,7 @@ class TestEpicPayloads:
         }
         assert p["error"] == "merge conflict"
 
-    def test_update(self) -> None:
+    def test_epic_update_payload_carries_action(self) -> None:
         from models import EpicUpdatePayload
 
         p: EpicUpdatePayload = {"epic_number": 1, "action": "released"}
@@ -524,13 +524,13 @@ class TestEpicPayloads:
 
 
 class TestCratePayloads:
-    def test_activated(self) -> None:
+    def test_crate_activated_payload_carries_crate_number(self) -> None:
         from models import CrateActivatedPayload
 
         p: CrateActivatedPayload = {"crate_number": 1}
         assert p["crate_number"] == 1
 
-    def test_completed(self) -> None:
+    def test_crate_completed_payload_carries_crate_number(self) -> None:
         from models import CrateCompletedPayload
 
         p: CrateCompletedPayload = {"crate_number": 1}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3130,7 +3130,7 @@ class TestPRInfoDescriptions:
 class TestLoopResult:
     """Tests for the LoopResult dataclass."""
 
-    def test_defaults(self) -> None:
+    def test_loop_result_defaults_attempts_to_zero(self) -> None:
         result = LoopResult(passed=True, summary="OK")
         assert result.passed is True
         assert result.summary == "OK"
@@ -3142,17 +3142,17 @@ class TestLoopResult:
         assert result.summary == "failed"
         assert result.attempts == 3
 
-    def test_frozen(self) -> None:
+    def test_loop_result_is_immutable(self) -> None:
         result = LoopResult(passed=True, summary="OK")
         with pytest.raises(AttributeError):
             result.passed = False  # type: ignore[misc]
 
-    def test_equality(self) -> None:
+    def test_loop_result_equal_when_fields_match(self) -> None:
         a = LoopResult(passed=True, summary="OK", attempts=1)
         b = LoopResult(passed=True, summary="OK", attempts=1)
         assert a == b
 
-    def test_inequality(self) -> None:
+    def test_loop_result_not_equal_when_passed_differs(self) -> None:
         a = LoopResult(passed=True, summary="OK")
         b = LoopResult(passed=False, summary="OK")
         assert a != b

--- a/tests/test_review_phase_complexity.py
+++ b/tests/test_review_phase_complexity.py
@@ -61,7 +61,7 @@ class TestHitlEscalation:
         assert esc.origin_label == "hydraflow-review"
         assert esc.comment == "Escalation comment"
 
-    def test_defaults(self) -> None:
+    def test_hitl_escalation_defaults_post_on_pr_true(self) -> None:
         """Optional fields should have sensible defaults."""
         esc = HitlEscalation(
             issue_number=1,


### PR DESCRIPTION
## Summary

Closes #2587.

## Issue

Test Quality: Vague single-word test names in event_payloads and models

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow