### PR TITLE
Fixes #2592: Test Quality: time.sleep and potential flaky patterns ...

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,10 +45,11 @@ if TYPE_CHECKING:
 #
 # - ``setup_test_environment`` removes HYDRAFLOW_*/HYDRA_*/GIT_* env vars so
 #   that tests don't accidentally read the host's configuration.  A
-#   ``finally`` block restores original values, but an abnormal termination
-#   (SIGKILL, segfault) would leave the environment corrupted for any
-#   subsequent in-process test run.  This is an acceptable trade-off because
-#   pytest does not survive such terminations anyway.
+#   ``finally`` block restores original values after all tests in the session
+#   complete.  An abnormal process termination (SIGKILL, segfault) will kill
+#   the pytest process before the ``finally`` runs, but since the environment
+#   is process-local, it cannot affect any other process — this is an
+#   acceptable trade-off.
 #
 # - ``_reset_gh_semaphore`` clears module-level private state in
 #   subprocess_util to prevent cross-test leakage of semaphore/rate-limit

--- a/tests/test_integration_file_io.py
+++ b/tests/test_integration_file_io.py
@@ -154,7 +154,9 @@ class TestFileLock:
                     # Non-atomic read-modify-write: without mutual exclusion
                     # another thread could read the same value before we write.
                     current = int(counter_path.read_text())
-                    yield_point.wait(timeout=0)  # yield CPU without wall-clock delay
+                    yield_point.wait(
+                        timeout=0
+                    )  # no wall-clock delay; no CPU yield guaranteed
                     counter_path.write_text(str(current + 1))
 
         threads = [threading.Thread(target=worker) for _ in range(3)]


### PR DESCRIPTION
## Summary

Closes #2592.

## Issue

Test Quality: time.sleep and potential flaky patterns in test suite

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow