### PR TITLE
Fix triage verdict parsing and enhance audit issue templates

### DIFF
--- a/.claude/commands/hf.audit-code.md
+++ b/.claude/commands/hf.audit-code.md
@@ -73,6 +73,12 @@ You are a code quality auditor focused on dead code detection for the project at
 ## Context
 <1-2 sentences on why this cleanup matters>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Dead Code Found
 | Type | File:Line | Name | Reason |
 |------|-----------|------|--------|
@@ -81,6 +87,12 @@ You are a code quality auditor focused on dead code detection for the project at
 ## Suggested Actions
 - [ ] Remove <item> — unused since <reason>
 - [ ] Remove <item> — only referenced by other dead code
+
+## Acceptance Criteria
+- [ ] All identified dead code items are removed
+- [ ] No remaining references to removed symbols
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Impact
 - Lines removable: ~<N>
@@ -165,6 +177,12 @@ You are a code quality auditor focused on method size, class cohesion, and dupli
 ## Context
 <1-2 sentences on why small methods and focused classes matter here>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Long Methods
 | File:Line | Method | Lines | Issue |
 |-----------|--------|-------|-------|
@@ -185,6 +203,13 @@ You are a code quality auditor focused on method size, class cohesion, and dupli
 - [ ] Split `<GodClass>` into `<ClassA>` (methods a,b,c) + `<ClassB>` (methods d,e,f)
 - [ ] Replace magic value `<value>` with named constant
 - [ ] Deduplicate <pattern> into shared `<helper>()`
+
+## Acceptance Criteria
+- [ ] No method exceeds 50 lines of logic
+- [ ] No class exceeds 200 lines or 7 public methods
+- [ ] Duplicated patterns are extracted into shared helpers
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Code Example (Before/After)
 <Show a concrete before/after for the highest-impact item>
@@ -264,6 +289,12 @@ You are a code quality auditor focused on error handling and robustness for the 
 ## Context
 <1-2 sentences on the robustness risk>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Findings
 | Severity | File:Line | Issue | Risk |
 |----------|-----------|-------|------|
@@ -273,6 +304,13 @@ You are a code quality auditor focused on error handling and robustness for the 
 - [ ] <file:line> — Add error handling for <operation>
 - [ ] <file:line> — Replace bare except with specific exception type
 - [ ] <file:line> — Add timeout to subprocess call
+
+## Acceptance Criteria
+- [ ] All bare/broad excepts are replaced with specific exception types
+- [ ] All subprocess/external calls have timeouts and error handling
+- [ ] Resource management uses context managers or proper cleanup
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Impact
 - Blast radius: <what breaks if this isn't fixed>
@@ -344,6 +382,12 @@ You are a code quality auditor focused on type safety and API consistency for th
 ## Context
 <1-2 sentences on why type safety/consistency matters here>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Findings
 | Issue | File:Line | Current | Suggested |
 |-------|-----------|---------|-----------|
@@ -353,6 +397,13 @@ You are a code quality auditor focused on type safety and API consistency for th
 - [ ] <file:line> — Add return type annotation `-> X`
 - [ ] <file:line> — Replace `Any` with `SpecificType`
 - [ ] <file:line> — Rename `issue_num` to `issue_number` for consistency
+
+## Acceptance Criteria
+- [ ] All public functions have complete type annotations
+- [ ] No unnecessary `Any` types remain
+- [ ] Parameter naming is consistent across modules
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Impact
 - Type checker improvements: <N> new errors caught

--- a/.claude/commands/hf.audit-tests.md
+++ b/.claude/commands/hf.audit-tests.md
@@ -84,6 +84,12 @@ You are a test quality auditor focused on naming, structure, and method size for
 ## Context
 <1-2 sentences on why this test quality issue matters>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Findings
 | Severity | File:Line | Test Name | Issue |
 |----------|-----------|-----------|-------|
@@ -94,6 +100,13 @@ You are a test quality auditor focused on naming, structure, and method size for
 - [ ] <file:line> — Split test with 6 assertions into 3 focused tests
 - [ ] <file:line> — Extract 12-line setup into `make_<object>()` factory
 - [ ] <file:line> — Test is 35 lines — extract arrange into fixture, split act steps
+
+## Acceptance Criteria
+- [ ] All test methods follow `test_<method>_<scenario>` naming convention
+- [ ] No test method exceeds 20 lines of logic
+- [ ] Each test has exactly one act step
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Impact
 - Tests affected: <N>
@@ -186,6 +199,12 @@ You are a test quality auditor focused on anti-patterns, hygiene, and flakiness 
 ## Context
 <1-2 sentences on the anti-pattern risk>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Duplicate Helpers (if found)
 | Helper | Location 1 | Location 2 | Suggested Home |
 |--------|-----------|-----------|----------------|
@@ -206,6 +225,14 @@ You are a test quality auditor focused on anti-patterns, hygiene, and flakiness 
 - [ ] <file:line> — Replace `patch.object(x, '_method')` with behavior test
 - [ ] <file:line> — Add cleanup for temp directory created at line N
 - [ ] <file:line> — Replace `time.sleep(1)` with async await
+
+## Acceptance Criteria
+- [ ] Duplicate helpers are consolidated into a single shared location
+- [ ] No over-mocking of private methods remains
+- [ ] All tests have proper cleanup/teardown for resources
+- [ ] No flaky patterns (sleep, random without seed, order dependency)
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Impact
 - Flaky test risk: <high/medium/low>
@@ -311,6 +338,12 @@ You are a test quality auditor focused on test infrastructure and coverage gaps 
 ## Context
 <1-2 sentences on the test infrastructure gap>
 
+**Type:** chore
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
 ## Missing Factories
 | Object | Used In | Times Repeated | Suggested Factory |
 |--------|---------|---------------|-------------------|
@@ -332,6 +365,13 @@ You are a test quality auditor focused on test infrastructure and coverage gaps 
 - [ ] Convert `make_<object>(**overrides)` to fluent `<Object>Builder` class
 - [ ] Add tests for <untested_function> in <source_file>
 - [ ] Add edge case tests for <function>: empty input, None, error path
+
+## Acceptance Criteria
+- [ ] Repeated object construction patterns use shared factories
+- [ ] Factories with 3+ optional fields use fluent builder pattern
+- [ ] All identified coverage gaps have corresponding tests
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
 
 ## Builder Skeleton
 ```python

--- a/src/triage.py
+++ b/src/triage.py
@@ -281,7 +281,7 @@ or for truly insufficient issues:
         """Build a TriageResult from a parsed JSON dict."""
         raw = data.get("reasons", [])
         complexity = data.get("complexity_score", 0)
-        score = int(complexity) if isinstance(complexity, (int, float)) else 0
+        score = int(complexity) if isinstance(complexity, int | float) else 0
         issue_type_raw = data.get("issue_type", IssueType.FEATURE)
         if isinstance(issue_type_raw, IssueType):
             issue_type = issue_type_raw
@@ -306,6 +306,30 @@ or for truly insufficient issues:
         )
 
     @staticmethod
+    def _strip_system_lines(transcript: str) -> str:
+        """Remove Claude Code system/init JSON lines from the transcript.
+
+        The subprocess transcript may include session initialization lines
+        like ``{"type":"system","subtype":"init",...}`` before the actual
+        LLM response.  These confuse the JSON parsing strategies, so we
+        strip them out first.
+        """
+        filtered: list[str] = []
+        for line in transcript.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                filtered.append(line)
+                continue
+            try:
+                obj = json.loads(stripped)
+                if isinstance(obj, dict) and obj.get("type") == "system":
+                    continue
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
+            filtered.append(line)
+        return "\n".join(filtered)
+
+    @staticmethod
     def _parse_verdict(transcript: str, issue_number: int) -> TriageResult | None:
         """Extract a JSON verdict from the LLM transcript.
 
@@ -314,6 +338,9 @@ or for truly insufficient issues:
         2. Extract JSON from markdown code fences
         3. Regex to find a JSON object with ``"ready"`` key
         """
+        # Pre-process: strip Claude Code system/init lines
+        transcript = TriageRunner._strip_system_lines(transcript)
+
         # Strategy 1: direct parse
         try:
             data = json.loads(transcript.strip())

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -431,6 +431,78 @@ class TestParseVerdict:
         assert result is not None
         assert result.ready is True
 
+    def test_system_init_lines_stripped_before_parsing(self) -> None:
+        """Claude Code system/init JSON lines should be filtered out."""
+        system_line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "cwd": "/workspace",
+                "session_id": "abc-123",
+                "tools": ["Read", "Write"],
+            }
+        )
+        verdict = '{"ready": true, "reasons": []}'
+        transcript = f"{system_line}\n{verdict}"
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is not None
+        assert result.ready is True
+
+    def test_multiple_system_lines_stripped(self) -> None:
+        """Multiple system lines before the verdict should all be stripped."""
+        sys1 = json.dumps({"type": "system", "subtype": "init", "cwd": "/workspace"})
+        sys2 = json.dumps({"type": "system", "subtype": "config", "key": "val"})
+        verdict = '{"ready": false, "reasons": ["Vague description"]}'
+        transcript = f"{sys1}\n{sys2}\n{verdict}"
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is not None
+        assert result.ready is False
+        assert result.reasons == ["Vague description"]
+
+    def test_system_lines_with_code_fence_verdict(self) -> None:
+        """System lines + markdown code-fenced verdict should parse correctly."""
+        system_line = json.dumps({"type": "system", "subtype": "init"})
+        fenced = '```json\n{"ready": true, "reasons": []}\n```'
+        transcript = f"{system_line}\n{fenced}"
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is not None
+        assert result.ready is True
+
+    def test_non_system_json_lines_preserved(self) -> None:
+        """JSON lines with type != 'system' should not be stripped."""
+        assistant_line = json.dumps({"type": "assistant", "text": "hello"})
+        # This transcript has no "ready" key, so parsing should return None
+        transcript = assistant_line
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _strip_system_lines unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestStripSystemLines:
+    """Direct tests for TriageRunner._strip_system_lines."""
+
+    def test_removes_system_lines(self) -> None:
+        system_line = json.dumps({"type": "system", "subtype": "init"})
+        normal = "some normal text"
+        result = TriageRunner._strip_system_lines(f"{system_line}\n{normal}")
+        assert result.strip() == normal
+
+    def test_preserves_empty_lines(self) -> None:
+        result = TriageRunner._strip_system_lines("line1\n\nline2")
+        assert result == "line1\n\nline2"
+
+    def test_preserves_non_json_lines(self) -> None:
+        text = "This is plain text\nAnother line"
+        assert TriageRunner._strip_system_lines(text) == text
+
+    def test_preserves_non_system_json(self) -> None:
+        line = json.dumps({"type": "result", "data": "value"})
+        assert TriageRunner._strip_system_lines(line) == line
+
 
 # ---------------------------------------------------------------------------
 # Command and prompt building


### PR DESCRIPTION
## Summary
- Fix triage agent failing on all audit-created issues — Claude Code system init JSON (`{"type":"system",...}`) in subprocess transcripts was unparseable by the verdict parser
- Added `_strip_system_lines()` preprocessing step to filter system init lines before the 3 parsing strategies
- Updated `/hf.audit-code` and `/hf.audit-tests` command templates to produce triage-friendly issue bodies with `**Type:** chore`, `## Scope`, and `## Acceptance Criteria` sections

## Test plan
- [x] 8 new tests for system line stripping (4 via `_parse_verdict`, 4 direct unit tests for `_strip_system_lines`)
- [x] All 49 existing triage tests pass
- [x] `make lint` clean
- [x] `make typecheck` clean
- [ ] Re-triage a HITL issue to verify the fix end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)