### PR TITLE
Fix bug report status, credit banner, and issue extraction

### DIFF
--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -194,22 +194,14 @@ class ReportIssueLoop(BaseBackgroundLoop):
             if tracked:
                 tracked.linked_issue_url = issue_url
 
-            # Mark tracked report as fixed (also saves state)
+            # Success — mark tracked report and remove from queue
             self._state.update_tracked_report(
                 report.id,
                 status="fixed",
                 action_label="fixed",
                 detail=f"Created issue #{issue_number}",
             )
-
-            # Success — remove from queue
             self._state.remove_report(report.id)
-            self._state.update_tracked_report(
-                report.id,
-                status="fixed",
-                detail=f"Created issue #{issue_number}",
-                action_label="processed",
-            )
             logger.info(
                 "Processed report %s as issue #%d: %s",
                 report.id,
@@ -226,15 +218,7 @@ class ReportIssueLoop(BaseBackgroundLoop):
         attempt_count = self._state.fail_report(report.id)
         if attempt_count >= _MAX_REPORT_ATTEMPTS:
             self._state.remove_report(report.id)
-            self._state.update_tracked_report(
-                report.id,
-                status="closed",
-                detail=f"Failed {attempt_count} times — escalated to HITL",
-                action_label="escalated",
-            )
             await self._escalate_failed_report(report)
-
-            # Mark tracked report as closed after escalation
             self._state.update_tracked_report(
                 report.id,
                 status="closed",
@@ -383,11 +367,36 @@ class ReportIssueLoop(BaseBackgroundLoop):
 
     @classmethod
     def _extract_issue_number_from_transcript(cls, transcript: str) -> int:
-        """Return issue number parsed from transcript output, or 0 when absent."""
-        match = cls._ISSUE_URL_RE.search(transcript or "")
-        if not match:
+        """Return issue number parsed from transcript output, or 0 when absent.
+
+        Only matches issue URLs that appear near creation context (e.g.,
+        ``gh issue create`` output or "Created issue" text) to avoid
+        false positives from URLs mentioned in agent reasoning.
+        """
+        if not transcript:
             return 0
-        try:
-            return int(match.group(1))
-        except ValueError:
-            return 0
+
+        # Strategy 1: look for `gh issue create` output which prints the URL
+        # on its own line (the most reliable signal)
+        for line in reversed(transcript.splitlines()):
+            stripped = line.strip()
+            match = cls._ISSUE_URL_RE.fullmatch(stripped)
+            if match:
+                try:
+                    return int(match.group(1))
+                except ValueError:
+                    continue
+
+        # Strategy 2: look for "created" context near an issue URL
+        created_re = re.compile(
+            r"(?:creat|open|filed|submitt)\w*\s+.*?" + cls._ISSUE_URL_RE.pattern,
+            re.IGNORECASE,
+        )
+        match = created_re.search(transcript)
+        if match:
+            try:
+                return int(match.group(1))
+            except ValueError:
+                pass
+
+        return 0

--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -18,13 +18,24 @@ const TAB_LABELS = {
   system: 'System',
 }
 
-function SystemAlertBanner({ alert }) {
+function SystemAlertBanner({ alert, onDismiss }) {
   if (!alert) return null
   return (
     <div style={styles.alertBanner}>
       <span style={styles.alertIcon}>!</span>
       <span>{alert.message}</span>
       {alert.source && <span style={styles.alertSource}>Source: {alert.source}</span>}
+      {onDismiss && (
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={onDismiss}
+          onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onDismiss() } }}
+          style={styles.alertDismiss}
+        >
+          ✕
+        </span>
+      )}
     </div>
   )
 }
@@ -92,7 +103,7 @@ function AppContent() {
   const {
     connected, orchestratorStatus, workers, prs,
     hitlItems, humanInputRequests, submitHumanInput, refreshHitl,
-    backgroundWorkers, systemAlert, intents, toggleBgWorker, triggerBgWorker, updateBgWorkerInterval,
+    backgroundWorkers, systemAlert, dismissSystemAlert, intents, toggleBgWorker, triggerBgWorker, updateBgWorkerInterval,
     selectedSession, selectSession,
     currentSessionId,
     stageStatus,
@@ -140,7 +151,7 @@ function AppContent() {
           onClear={() => selectSession(null)}
           liveStats={selectedSessionLiveStats}
         />
-        <SystemAlertBanner alert={systemAlert} />
+        <SystemAlertBanner alert={systemAlert} onDismiss={dismissSystemAlert} />
         <ConfigWarningBanner warning={configWarning} />
         <HumanInputBanner requests={humanInputRequests} onSubmit={submitHumanInput} />
 
@@ -274,10 +285,18 @@ const styles = {
     flexShrink: 0,
   },
   alertSource: {
-    marginLeft: 'auto',
     fontSize: 11,
     fontWeight: 400,
     opacity: 0.8,
+  },
+  alertDismiss: {
+    marginLeft: 'auto',
+    cursor: 'pointer',
+    fontSize: 14,
+    fontWeight: 700,
+    opacity: 0.7,
+    padding: '0 4px',
+    transition: 'opacity 0.15s',
   },
   configWarningBanner: {
     display: 'flex',

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -124,10 +124,14 @@ export function reducer(state, action) {
       const newStatus = action.data.status
       const isStopped = newStatus === 'idle' || newStatus === 'done' || newStatus === 'stopping'
       const isSessionStart = newStatus === 'running' && action.data.reset === true
+      const creditsPaused = action.data.credits_paused_until || null
+      // Clear the system alert banner when credits are no longer paused
+      const clearAlert = !creditsPaused && state.systemAlert?.message?.includes('Credit limit')
       return {
         ...addEvent(state, action),
         orchestratorStatus: newStatus,
-        creditsPausedUntil: action.data.credits_paused_until || null,
+        creditsPausedUntil: creditsPaused,
+        ...(clearAlert ? { systemAlert: null } : {}),
         ...(isStopped ? {
           workers: {},
           sessionPrsCount: 0,
@@ -480,6 +484,9 @@ export function reducer(state, action) {
 
     case 'system_alert':
       return { ...addEvent(state, action), systemAlert: action.data }
+
+    case 'CLEAR_SYSTEM_ALERT':
+      return { ...state, systemAlert: null }
 
     case 'error':
       return addEvent(state, action)
@@ -1569,6 +1576,7 @@ export function HydraFlowProvider({ children }) {
     toggleBgWorker,
     triggerBgWorker,
     updateBgWorkerInterval,
+    dismissSystemAlert: useCallback(() => dispatch({ type: 'CLEAR_SYSTEM_ALERT' }), [dispatch]),
     refreshHitl: fetchHitlItems,
     selectSession,
     selectRepo,


### PR DESCRIPTION
## Summary
- **Old bug reports stuck as Queued**: Removed duplicate `update_tracked_report()` calls on success and escalation paths introduced by cherry-pick conflict
- **New bugs marked Fixed without processing**: `_extract_issue_number_from_transcript()` now only matches standalone URLs (gh CLI output) or URLs near creation context, not URLs in agent reasoning
- **Credit banner persists after resume**: `systemAlert` auto-clears when `orchestrator_status` reports `creditsPausedUntil: null`. Added dismiss button

## Beads tracking
5 bugs tracked via beads with dependency ordering — all closed.

## Test plan
- [x] `tests/test_report_issue_loop.py` — all pass
- [x] `make lint` clean
- [ ] Manual: verify bug report status transitions
- [ ] Manual: verify credit banner auto-clears + dismiss button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)