### PR TITLE
Fixes #2688: "WS pipeline handler missing triage_update.failed and ...

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -755,6 +755,31 @@ function getReporterId() {
   return id
 }
 
+/** Maps a WebSocket event to a WS_PIPELINE_UPDATE action, or null if not applicable. */
+export function getPipelineAction(event) {
+  const issueNum = event.data?.issue != null ? Number(event.data.issue) : null
+  if (issueNum == null) return null
+  const s = event.data?.status
+  if (event.type === 'triage_update') {
+    if (s === 'done') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'triage', toStage: 'plan', status: 'queued' } }
+    if (s === 'failed') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'failed' } }
+    if (s) return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } }
+  } else if (event.type === 'planner_update') {
+    if (s === 'done') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'plan', toStage: 'implement', status: 'queued' } }
+    if (s === 'failed') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'failed' } }
+    if (s) return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } }
+  } else if (event.type === 'worker_update') {
+    if (s === 'done') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'implement', toStage: 'review', status: 'queued' } }
+    if (s) return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } }
+  } else if (event.type === 'review_update') {
+    if (s === 'done') return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'done' } }
+    if (s) return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } }
+  } else if (event.type === 'merge_update' && s === 'merged') {
+    return { type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'review', toStage: 'merged', status: 'done' } }
+  }
+  return null
+}
+
 export function HydraFlowProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, undefined, getInitialState)
   const isSeeded = typeof window !== 'undefined' && !!window.__HYDRAFLOW_SEED_STATE__
@@ -1383,32 +1408,8 @@ export function HydraFlowProvider({ children }) {
           lastEventTsRef.current = event.timestamp
         }
         // Dispatch WS pipeline updates for stage transitions
-        const issueNum = event.data?.issue != null ? Number(event.data.issue) : null
-        if (issueNum != null) {
-          if (event.type === 'triage_update' && event.data?.status === 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'triage', toStage: 'plan', status: 'queued' } })
-          } else if (event.type === 'triage_update' && event.data?.status === 'failed') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'failed' } })
-          } else if (event.type === 'triage_update' && event.data?.status && event.data.status !== 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } })
-          } else if (event.type === 'planner_update' && event.data?.status === 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'plan', toStage: 'implement', status: 'queued' } })
-          } else if (event.type === 'planner_update' && event.data?.status === 'failed') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'failed' } })
-          } else if (event.type === 'planner_update' && event.data?.status && event.data.status !== 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } })
-          } else if (event.type === 'worker_update' && event.data?.status === 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'implement', toStage: 'review', status: 'queued' } })
-          } else if (event.type === 'worker_update' && event.data?.status && event.data.status !== 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } })
-          } else if (event.type === 'review_update' && event.data?.status === 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'done' } })
-          } else if (event.type === 'review_update' && event.data?.status && event.data.status !== 'done') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: null, toStage: null, status: 'active' } })
-          } else if (event.type === 'merge_update' && event.data?.status === 'merged') {
-            dispatch({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: issueNum, fromStage: 'review', toStage: 'merged', status: 'done' } })
-          }
-        }
+        const pipelineAction = getPipelineAction(event)
+        if (pipelineAction) dispatch(pipelineAction)
 
         if (event.type === 'metrics_update') {
           fetchLifetimeStats()

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, act } from '@testing-library/react'
-import { reducer } from '../HydraFlowContext'
+import { reducer, getPipelineAction } from '../HydraFlowContext'
 
 const emptyPipeline = {
   triage: [],
@@ -418,6 +418,46 @@ describe('WS_PIPELINE_UPDATE reducer', () => {
     expect(next.pipelineIssues.plan).toHaveLength(1)
     expect(next.pipelineIssues.plan[0].status).toBe('failed')
     expect(next.pipelineIssues.implement).toHaveLength(0)
+  })
+})
+
+describe('getPipelineAction', () => {
+  it('triage_update done → move triage→plan as queued', () => {
+    const action = getPipelineAction({ type: 'triage_update', data: { issue: 5, status: 'done' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 5, fromStage: 'triage', toStage: 'plan', status: 'queued' } })
+  })
+
+  it('triage_update failed → mark failed in-place', () => {
+    const action = getPipelineAction({ type: 'triage_update', data: { issue: 5, status: 'failed' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 5, fromStage: null, toStage: null, status: 'failed' } })
+  })
+
+  it('triage_update active status → mark active in-place', () => {
+    const action = getPipelineAction({ type: 'triage_update', data: { issue: 5, status: 'evaluating' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 5, fromStage: null, toStage: null, status: 'active' } })
+  })
+
+  it('planner_update done → move plan→implement as queued', () => {
+    const action = getPipelineAction({ type: 'planner_update', data: { issue: 7, status: 'done' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 7, fromStage: 'plan', toStage: 'implement', status: 'queued' } })
+  })
+
+  it('planner_update failed → mark failed in-place', () => {
+    const action = getPipelineAction({ type: 'planner_update', data: { issue: 7, status: 'failed' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 7, fromStage: null, toStage: null, status: 'failed' } })
+  })
+
+  it('planner_update planning status → mark active in-place', () => {
+    const action = getPipelineAction({ type: 'planner_update', data: { issue: 7, status: 'planning' } })
+    expect(action).toEqual({ type: 'WS_PIPELINE_UPDATE', data: { issueNumber: 7, fromStage: null, toStage: null, status: 'active' } })
+  })
+
+  it('event with no issue number → returns null', () => {
+    expect(getPipelineAction({ type: 'triage_update', data: { status: 'failed' } })).toBeNull()
+  })
+
+  it('unrecognised event type → returns null', () => {
+    expect(getPipelineAction({ type: 'metrics_update', data: { issue: 1 } })).toBeNull()
   })
 })
 


### PR DESCRIPTION
## Summary

Closes #2688.

## Issue

"WS pipeline handler missing triage_update.failed and planner_update.failed branches"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow