### PR TITLE
Fixes #2718: Deduplicate _ADR_FILE_RE regex between phase_utils.py ...

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from adr_pre_validator import ADRPreValidator, ADRValidationResult
 from agent_cli import build_lightweight_command
 from models import ADRCouncilResult, CouncilVerdict, CouncilVote
-from phase_utils import _ADR_FILE_RE, is_likely_bug
+from phase_utils import ADR_FILE_RE, is_likely_bug
 from subprocess_util import make_clean_env, run_subprocess
 
 if TYPE_CHECKING:
@@ -113,7 +113,7 @@ class ADRCouncilReviewer:
         """Find ADR files with Status: Proposed."""
         results: list[tuple[int, Path, str]] = []
         for path in sorted(adr_dir.glob("*.md")):
-            match = _ADR_FILE_RE.match(path.name)
+            match = ADR_FILE_RE.match(path.name)
             if not match:
                 continue
             adr_number = int(match.group(1))
@@ -131,7 +131,7 @@ class ADRCouncilReviewer:
         """Load all ADR files as (number, title, content)."""
         results: list[tuple[int, str, str]] = []
         for path in sorted(adr_dir.glob("*.md")):
-            match = _ADR_FILE_RE.match(path.name)
+            match = ADR_FILE_RE.match(path.name)
             if not match:
                 continue
             adr_number = int(match.group(1))

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -316,7 +316,7 @@ def load_existing_adr_topics(repo_root: Path) -> set[str]:
     return topics
 
 
-_ADR_FILE_RE = re.compile(r"^(\d{4})-.*\.md$")
+ADR_FILE_RE = re.compile(r"^(\d{4})-.*\.md$")
 
 
 # ---------------------------------------------------------------------------
@@ -539,7 +539,7 @@ def next_adr_number(
     for d in (adr_dir, primary_adr_dir):
         if d is not None and d.is_dir():
             for f in d.iterdir():
-                m = _ADR_FILE_RE.match(f.name)
+                m = ADR_FILE_RE.match(f.name)
                 if m:
                     highest = max(highest, int(m.group(1)))
 

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -65,20 +65,20 @@ Some consequences.
 
 
 class TestADRFileREShared:
-    """Verify _ADR_FILE_RE is shared between adr_reviewer and phase_utils."""
+    """Verify ADR_FILE_RE is shared between adr_reviewer and phase_utils."""
 
     def test_adr_reviewer_uses_phase_utils_regex(self) -> None:
-        """adr_reviewer._ADR_FILE_RE must be the exact same object as phase_utils._ADR_FILE_RE."""
+        """adr_reviewer.ADR_FILE_RE must be the exact same object as phase_utils.ADR_FILE_RE."""
         import adr_reviewer
         import phase_utils
 
-        assert adr_reviewer._ADR_FILE_RE is phase_utils._ADR_FILE_RE
+        assert adr_reviewer.ADR_FILE_RE is phase_utils.ADR_FILE_RE
 
     def test_shared_regex_matches_adr_filenames(self) -> None:
         """The shared regex correctly matches NNNN-*.md and captures the number."""
         import adr_reviewer
 
-        m = adr_reviewer._ADR_FILE_RE.match("0023-some-title.md")
+        m = adr_reviewer.ADR_FILE_RE.match("0023-some-title.md")
         assert m is not None
         assert m.group(1) == "0023"
 
@@ -86,9 +86,10 @@ class TestADRFileREShared:
         """The shared regex rejects files that don't match the ADR naming pattern."""
         import adr_reviewer
 
-        assert adr_reviewer._ADR_FILE_RE.match("README.md") is None
-        assert adr_reviewer._ADR_FILE_RE.match("abc-title.md") is None
-        assert adr_reviewer._ADR_FILE_RE.match("00-short.md") is None
+        assert adr_reviewer.ADR_FILE_RE.match("README.md") is None
+        assert adr_reviewer.ADR_FILE_RE.match("abc-title.md") is None
+        assert adr_reviewer.ADR_FILE_RE.match("00-short.md") is None
+        assert adr_reviewer.ADR_FILE_RE.match("023-title.md") is None
 
 
 class TestFindProposedADRs:


### PR DESCRIPTION
## Summary

Closes #2718.

## Issue

Deduplicate _ADR_FILE_RE regex between phase_utils.py and adr_reviewer.py

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow