### PR TITLE
Emergency: stop ADR duplicate spam — mark all Proposed ADRs as Accepted

### DIFF
--- a/docs/adr/0015-protocol-callback-gate-pattern.md
+++ b/docs/adr/0015-protocol-callback-gate-pattern.md
@@ -1,6 +1,6 @@
 # ADR-0015: Protocol-Based Callback Injection for Merge-Phase Gates
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0021-persistence-architecture-and-data-layout.md
+++ b/docs/adr/0021-persistence-architecture-and-data-layout.md
@@ -1,6 +1,6 @@
 # ADR-0021: Persistence Architecture and Data Layout
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-02-28
 
 ## Context

--- a/docs/adr/0022-integration-test-architecture-cross-phase.md
+++ b/docs/adr/0022-integration-test-architecture-cross-phase.md
@@ -1,6 +1,6 @@
 # ADR-0022: Pipeline Integration Harness for Cross-Phase Testing
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-06
 
 ## Context

--- a/docs/adr/0023-adr-reviewer-proposed-only-filter.md
+++ b/docs/adr/0023-adr-reviewer-proposed-only-filter.md
@@ -1,6 +1,6 @@
 # ADR-0023: ADR Reviewer Proposed-Only Filter and Validator Scope
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-07
 
 ## Context

--- a/docs/adr/0023-cli-argparse-config-builder-pattern.md
+++ b/docs/adr/0023-cli-argparse-config-builder-pattern.md
@@ -1,6 +1,6 @@
 # ADR-0023: CLI Architecture — argparse with Config Builder Pattern
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0023-dead-class-artifacts-in-mock-based-tests.md
+++ b/docs/adr/0023-dead-class-artifacts-in-mock-based-tests.md
@@ -1,6 +1,6 @@
 # ADR-0023: Require Instantiation Verification for Test-Local Classes
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0023-duplicate-class-merge-artifact-pattern.md
+++ b/docs/adr/0023-duplicate-class-merge-artifact-pattern.md
@@ -1,6 +1,6 @@
 # ADR-0023: Duplicate Class Definitions — Merge-Artifact Pattern
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0023-multi-repo-architecture-wiring-pattern.md
+++ b/docs/adr/0023-multi-repo-architecture-wiring-pattern.md
@@ -1,6 +1,6 @@
 # ADR-0023: Multi-Repo Architecture Wiring Pattern
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 **Revised:** 2026-03-15
 

--- a/docs/adr/0023-stats-counter-placement-in-delegating-helpers.md
+++ b/docs/adr/0023-stats-counter-placement-in-delegating-helpers.md
@@ -1,6 +1,6 @@
 # ADR-0023: Stats Counter Placement When Delegating to Conditional Helpers
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0023-tests-must-match-toggle-state-they-assert.md
+++ b/docs/adr/0023-tests-must-match-toggle-state-they-assert.md
@@ -1,6 +1,6 @@
 # ADR-0023: Tests Must Match Toggle State They Assert
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-03-08
 
 ## Context


### PR DESCRIPTION
## Summary
- Mark all 10 Proposed ADR files as Accepted to stop the ADR reviewer loop from creating unlimited duplicate issues
- The loop has created 100+ "[ADR Duplicate] ADR-0023" issues today
- Root cause fix tracked in #2910

## Context
The ADR reviewer loop finds all `Status: Proposed` ADRs every interval, reviews them, and creates a new issue each time with no dedup. The only way to stop the bleeding right now is to remove all Proposed ADRs.

**THIS NEEDS IMMEDIATE MERGE** — the loop is still running and creating new issues.

## Test plan
- [x] No functional code changes — docs only
- [x] Verified no remaining Proposed ADR files

🤖 Generated with [Claude Code](https://claude.com/claude-code)