### PR TITLE
Fixes #2913: [Memory] ADR cross-reference notes should use full tit...

### DIFF
--- a/src/adr_pre_validator.py
+++ b/src/adr_pre_validator.py
@@ -278,6 +278,29 @@ class ADRPreValidator:
             )
 
     @staticmethod
+    def _word_prefix_overlap(cited: str, real: str, min_words: int = 3) -> bool:
+        """Check if *cited* and *real* share a significant word-prefix.
+
+        Strips trailing punctuation from each word so that ``"routing"``
+        matches ``"routing,"`` — this handles em-dash titles where the regex
+        captures trailing prose (e.g. ``"Title for details."``) while the real
+        title continues with different words (e.g. ``"Title, Not Just X"``).
+
+        Returns True when the shared word-prefix is at least *min_words* long
+        and shorter than the real title (i.e. the cited text is an abbreviation).
+        """
+        strip = str.maketrans("", "", ".,;:!?")
+        cited_words = [w.translate(strip) for w in cited.lower().split()]
+        real_words = [w.translate(strip) for w in real.lower().split()]
+        common = 0
+        for cw, rw in zip(cited_words, real_words, strict=False):
+            if cw == rw:
+                common += 1
+            else:
+                break
+        return common >= min_words and common < len(real_words)
+
+    @staticmethod
     def _extract_cited_title(text: str) -> str | None:
         """Extract the cited title from parenthesized or em-dash annotation."""
         paren_match = _ADR_PAREN_TITLE_RE.match(text)
@@ -322,6 +345,10 @@ class ADRPreValidator:
             # Let _check_cross_reference_titles flag it as abbreviated_cross_ref_title
             # to avoid double-flagging with mismatched_adr_title.
             if real_lower.startswith(cited_lower):
+                return
+            # Em-dash form may capture trailing prose (e.g. "Title for details.")
+            # so the simple prefix check fails.  Fall back to word-prefix overlap.
+            if ADRPreValidator._word_prefix_overlap(cited_lower, real_lower):
                 return
         # No match against any title for this number
         mismatched[ref_num] = (cited_title, titles[0])
@@ -370,9 +397,13 @@ class ADRPreValidator:
                 if any(cited_lower == t.lower() for t in titles):
                     continue
 
-                # Abbreviated: cited is a prefix of a real title
+                # Abbreviated: cited is a prefix of a real title, or shares
+                # a significant word-prefix (handles em-dash trailing prose)
                 abbreviated_of = [
-                    t for t in titles if t.lower().startswith(cited_lower)
+                    t
+                    for t in titles
+                    if t.lower().startswith(cited_lower)
+                    or ADRPreValidator._word_prefix_overlap(cited_lower, t)
                 ]
                 if abbreviated_of:
                     result.issues.append(

--- a/tests/test_adr_pre_validator.py
+++ b/tests/test_adr_pre_validator.py
@@ -693,6 +693,73 @@ class TestCheckCrossReferenceTitles:
         assert "abbreviated_cross_ref_title" not in codes
 
 
+class TestWordPrefixOverlap:
+    """Tests for _word_prefix_overlap — handles em-dash trailing prose."""
+
+    def test_matching_prefix_returns_true(self) -> None:
+        """Strings sharing a word-prefix longer than the real title are detected."""
+        assert ADRPreValidator._word_prefix_overlap(
+            "auto-triage toggle must gate routing for details.",
+            "Auto-Triage Toggle Must Gate Routing, Not Just Stat Tracking",
+        )
+
+    def test_exact_match_returns_false(self) -> None:
+        """Exact match is not an abbreviation."""
+        assert not ADRPreValidator._word_prefix_overlap(
+            "auto-triage toggle must gate routing",
+            "Auto-Triage Toggle Must Gate Routing",
+        )
+
+    def test_too_few_common_words_returns_false(self) -> None:
+        """Fewer than min_words shared words returns False."""
+        assert not ADRPreValidator._word_prefix_overlap(
+            "auto-triage toggle different words",
+            "Auto-Triage Toggle Must Gate Routing",
+        )
+
+    def test_no_overlap_returns_false(self) -> None:
+        """Completely different strings return False."""
+        assert not ADRPreValidator._word_prefix_overlap(
+            "completely different title here",
+            "Auto-Triage Toggle Must Gate Routing",
+        )
+
+    def test_custom_min_words(self) -> None:
+        """Custom min_words threshold is respected."""
+        # 3 common words, but min_words=4
+        assert not ADRPreValidator._word_prefix_overlap(
+            "alpha beta gamma different",
+            "Alpha Beta Gamma Delta Epsilon",
+            min_words=4,
+        )
+        # 3 common words, min_words=3
+        assert ADRPreValidator._word_prefix_overlap(
+            "alpha beta gamma different",
+            "Alpha Beta Gamma Delta Epsilon",
+            min_words=3,
+        )
+
+    def test_emdash_abbreviated_not_double_flagged(self) -> None:
+        """Em-dash abbreviated title with trailing prose is not flagged as mismatched."""
+        content = _valid_adr(
+            decision="See ADR-0023 \u2014 Auto-Triage Toggle Must Gate Routing for details."
+        )
+        all_adrs = [
+            (1, "Test ADR", "content", "0001-test.md"),
+            (
+                23,
+                "Auto-Triage Toggle Must Gate Routing, Not Just Stat Tracking",
+                "c",
+                "0023-gate.md",
+            ),
+        ]
+        validator = ADRPreValidator()
+        result = validator.validate(content, all_adrs)
+        codes = [i.code for i in result.issues]
+        assert "abbreviated_cross_ref_title" in codes
+        assert "mismatched_adr_title" not in codes
+
+
 class TestDictCollisionSharedNumbers:
     """Tests that title checking handles multiple ADRs sharing the same number."""
 


### PR DESCRIPTION
## Summary

Closes #2913.

## Issue

[Memory] ADR cross-reference notes should use full titles when multiple entries share a number

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow