### PR TITLE
Fixes #2945: [Memory] ADR supersession must be bidirectional and st...

### DIFF
--- a/src/adr_pre_validator.py
+++ b/src/adr_pre_validator.py
@@ -165,9 +165,13 @@ class ADRPreValidator:
         supersedes_refs = _SUPERSEDE_RE.findall(content)
         superseded_by_refs = _SUPERSEDED_BY_RE.findall(content)
 
-        # Remove "superseded by" matches from the general supersede matches
-        # because _SUPERSEDE_RE also matches "superseded" (without "by")
-        supersedes_only = [r for r in supersedes_refs if r not in superseded_by_refs]
+        # De-conflict: if the same number appears in both directions (circular reference),
+        # only process it via the "superseded by" path to avoid double-reporting.
+        # Deduplicate both lists so repeated mentions don't generate duplicate issues.
+        superseded_by_refs = list(dict.fromkeys(superseded_by_refs))
+        supersedes_only = list(
+            dict.fromkeys(r for r in supersedes_refs if r not in superseded_by_refs)
+        )
 
         if not supersedes_only and not superseded_by_refs:
             return

--- a/tests/test_adr_pre_validator.py
+++ b/tests/test_adr_pre_validator.py
@@ -363,6 +363,37 @@ class TestCheckSupersession:
         assert "Accepted" in issue.message
         assert issue.fixable is True
 
+    def test_duplicate_supersedes_ref_produces_single_issue(self) -> None:
+        """Same ADR number mentioned twice in 'supersedes' should not double-report."""
+        content = _adr_with_number(
+            2, decision="This supersedes ADR-0001 and also supersedes ADR-0001."
+        )
+        target = _adr_with_number(1, decision="No back-reference here.")
+        all_adrs = [(1, "Test ADR 1", target, "0001-old-adr.md")]
+        validator = ADRPreValidator()
+        result = validator.validate(content, all_adrs)
+        issues = [
+            i for i in result.issues if i.code == "missing_reciprocal_supersession"
+        ]
+        assert len(issues) == 1
+
+    def test_bidirectional_check_skipped_when_no_heading(self) -> None:
+        """When ADR has no standard heading, self_number is None and reciprocity checks are skipped."""
+        content = (
+            "**Status:** Accepted\n\n"
+            "## Context\n\nSome context.\n\n"
+            "## Decision\n\nThis supersedes ADR-0001.\n\n"
+            "## Consequences\n\nSome consequences.\n"
+        )
+        target = _adr_with_number(1, decision="No back-reference here.")
+        all_adrs = [(1, "Test ADR 1", target, "0001-old-adr.md")]
+        validator = ADRPreValidator()
+        result = validator.validate(content, all_adrs)
+        # Existence check still runs; reciprocity check is silently skipped (self_number=None)
+        codes = [i.code for i in result.issues]
+        assert "invalid_supersession" not in codes
+        assert "missing_reciprocal_supersession" not in codes
+
     def test_proposed_can_supersede_proposed(self) -> None:
         """A Proposed ADR can supersede another Proposed ADR (neither is settled)."""
         content = _adr_with_number(


### PR DESCRIPTION
## Summary

Closes #2945.

## Issue

[Memory] ADR supersession must be bidirectional and status-coherent

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow