### PR TITLE
Fixes #3101: Fix phantom function references in ADRs 0009, 0010, 0021

### DIFF
--- a/docs/adr/0009-multi-repo-process-per-repo-model.md
+++ b/docs/adr/0009-multi-repo-process-per-repo-model.md
@@ -22,7 +22,7 @@ Runtime state for each managed repo lives under `.hydraflow/` in the repo
 directory (or under `$HYDRAFLOW_HOME/<repo_slug>/` when the supervisor sets
 `HYDRAFLOW_HOME`). Worktree paths are scoped via
 `config.worktree_path_for_issue()` which resolves to
-`<worktree_base>/<repo_slug>/issue-<num>`. The `_namespace_repo_paths()` helper
+`<worktree_base>/<repo_slug>/issue-<num>`. The `_resolve_repo_scoped_paths()` helper
 in `config.py` ensures state files (`state.json`, `events.jsonl`,
 `sessions.jsonl`, `config.json`) are placed under the repo slug subdirectory,
 with automatic migration of legacy flat files.
@@ -42,7 +42,7 @@ Adopt the **process-per-repo** model as the canonical multi-repo architecture:
 
 2. **Environment-driven isolation.** The supervisor sets `HYDRAFLOW_HOME` to a
    repo-scoped directory (`STATE_DIR / slug`). Config resolution in
-   `_resolve_paths()` reads this environment variable to set `data_root`,
+   `_resolve_base_paths()` reads this environment variable to set `data_root`,
    ensuring all state files, event logs, and session logs are isolated per repo.
 
 3. **Repo-scoped worktrees.** `WorktreeManager` resolves worktree paths under
@@ -115,7 +115,7 @@ Adopt the **process-per-repo** model as the canonical multi-repo architecture:
 - ADR-0006 (RepoRuntime Isolation Architecture) — superseded by this ADR
 - ADR-0008 (Multi-Repo Dashboard Architecture)
 - `src/hf_cli/supervisor_service.py` (`_start_repo`, `RUNNERS`, TCP protocol)
-- `src/config.py` (`_resolve_paths`, `_namespace_repo_paths`, `worktree_path_for_issue`)
+- `src/config.py` (`_resolve_base_paths`, `_resolve_repo_scoped_paths`, `worktree_path_for_issue`)
 - `src/orchestrator.py` (`HydraFlowOrchestrator.__init__`)
 - `src/worktree.py` (`WorktreeManager`, `_WORKTREE_LOCKS`)
 - `src/state.py` (`StateTracker`)

--- a/docs/adr/0010-worktree-and-path-isolation.md
+++ b/docs/adr/0010-worktree-and-path-isolation.md
@@ -8,7 +8,7 @@
 HydraFlow's supervisor spawns separate `cli.py` processes per repository, each
 with an isolated `HYDRAFLOW_HOME` environment variable. This provides
 process-level `data_root` isolation: state files, event logs, and session data
-are scoped under `data_root/<repo_slug>/` via `_namespace_repo_paths` in
+are scoped under `data_root/<repo_slug>/` via `_resolve_repo_scoped_paths` in
 `config.py`.
 
 However, not all filesystem paths follow the same scoping discipline:
@@ -47,7 +47,7 @@ artifacts:
    resolves to `worktree_base / repo_slug / issue-{N}/`, preventing cross-repo
    worktree collisions. This is the correct behavior and must be preserved.
 
-2. **State, events, and session files are repo-scoped.** `_namespace_repo_paths`
+2. **State, events, and session files are repo-scoped.** `_resolve_repo_scoped_paths`
    moves `state.json`, `events.jsonl`, and `sessions.jsonl` under
    `data_root/<repo_slug>/`. This is correct and must be preserved.
 
@@ -117,7 +117,7 @@ artifacts:
   the current flat layout (`log_dir = data_root / "logs"`, etc.).
   Accepting ADR-0010 requires amending that ADR's derived-paths table and layout
   diagram to reflect repo-scoped paths for `log_dir`, `plans_dir`, and `memory_dir`.
-- `src/config.py:HydraFlowConfig` — `_resolve_paths`, `worktree_path_for_issue`,
+- `src/config.py:HydraFlowConfig` — `_resolve_base_paths`, `worktree_path_for_issue`,
   `log_dir`, `plans_dir`, `memory_dir` properties
 - `src/worktree.py:WorktreeManager` — worktree lifecycle and cleanup
 - `src/docker_runner.py:DockerRunner._build_mounts` — container mount strategy

--- a/docs/adr/0021-persistence-architecture-and-data-layout.md
+++ b/docs/adr/0021-persistence-architecture-and-data-layout.md
@@ -159,5 +159,5 @@ but the defaults ensure a single `data_root` change relocates everything.
 - `src/file_util.py:atomic_write` — atomic file write helper
 - ADR-0003 (Git Worktrees for Issue Isolation) — worktree isolation (complementary filesystem layout)
 - ADR-0006 (RepoRuntime Isolation Architecture, superseded by ADR-0009 Multi-Repo Process-Per-Repo Model) — RepoRuntime isolation (per-repo process boundaries)
-- ADR-0009 (Multi-Repo Process-Per-Repo Model) — `_namespace_repo_paths()` scoping that places state files under `data_root/<repo_slug>/`
+- ADR-0009 (Multi-Repo Process-Per-Repo Model) — `_resolve_repo_scoped_paths()` scoping that places state files under `data_root/<repo_slug>/`
 - ADR-0010 (Worktree and Path Isolation Architecture) — mandates repo-slug scoping for `log_dir`, `plans_dir`, `memory_dir` to `data_root/<repo_slug>/`

--- a/tests/test_adr_pre_validator.py
+++ b/tests/test_adr_pre_validator.py
@@ -516,3 +516,73 @@ class TestMultipleIssues:
         assert "missing_status" in codes
         assert "missing_section_context" in codes
         assert "missing_section_consequences" in codes
+
+
+import re
+
+
+class TestAdrFunctionReferences:
+    """Validate that function names referenced in ADRs 0009, 0010, 0021 exist in config.py."""
+
+    _ADR_DIR = Path(__file__).parent.parent / "docs" / "adr"
+    _CONFIG_PATH = Path(__file__).parent.parent / "src" / "config.py"
+    _FUNCTION_PATTERN = re.compile(r"`(_resolve_\w+|_namespace_\w+)`")
+
+    def _defined_functions(self) -> set[str]:
+        """Extract all function names defined in config.py."""
+        source = self._CONFIG_PATH.read_text()
+        return set(re.findall(r"def (\w+)\(", source))
+
+    def test_adr_function_references_exist_in_config(self) -> None:
+        """Function names cited in ADRs 0009, 0010, 0021 must exist as defs in config.py."""
+        defined = self._defined_functions()
+        adr_files = [
+            "0009-multi-repo-process-per-repo-model.md",
+            "0010-worktree-and-path-isolation.md",
+            "0021-persistence-architecture-and-data-layout.md",
+        ]
+        missing: list[str] = []
+        for filename in adr_files:
+            content = (self._ADR_DIR / filename).read_text()
+            refs = self._FUNCTION_PATTERN.findall(content)
+            for ref in refs:
+                # Strip trailing parens if captured
+                func_name = ref.rstrip("()")
+                if func_name not in defined:
+                    missing.append(f"{filename}: `{func_name}` not found in config.py")
+        assert not missing, "Phantom function references in ADRs:\n" + "\n".join(
+            missing
+        )
+
+    def test_no_phantom_resolve_paths_reference(self) -> None:
+        """Ensure the old phantom name `_resolve_paths` does not appear in the three ADRs."""
+        adr_files = [
+            "0009-multi-repo-process-per-repo-model.md",
+            "0010-worktree-and-path-isolation.md",
+            "0021-persistence-architecture-and-data-layout.md",
+        ]
+        found: list[str] = []
+        for filename in adr_files:
+            content = (self._ADR_DIR / filename).read_text()
+            if "`_resolve_paths`" in content or "`_resolve_paths()`" in content:
+                found.append(filename)
+        assert not found, f"Phantom `_resolve_paths` still referenced in: {found}"
+
+    def test_no_phantom_namespace_repo_paths_reference(self) -> None:
+        """Ensure the old phantom name `_namespace_repo_paths` does not appear in the three ADRs."""
+        adr_files = [
+            "0009-multi-repo-process-per-repo-model.md",
+            "0010-worktree-and-path-isolation.md",
+            "0021-persistence-architecture-and-data-layout.md",
+        ]
+        found: list[str] = []
+        for filename in adr_files:
+            content = (self._ADR_DIR / filename).read_text()
+            if (
+                "`_namespace_repo_paths`" in content
+                or "`_namespace_repo_paths()`" in content
+            ):
+                found.append(filename)
+        assert not found, (
+            f"Phantom `_namespace_repo_paths` still referenced in: {found}"
+        )


### PR DESCRIPTION
## Summary

Closes #3101.

## Issue

Fix phantom function references in ADRs 0009, 0010, 0021

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow