### PR TITLE
Fixes #3131: [Memory] Multi-item continuance tests for per-item iso...

### DIFF
--- a/tests/test_epic.py
+++ b/tests/test_epic.py
@@ -1604,7 +1604,7 @@ class TestNarrowedExceptionHandling:
             for c in manager._bus.publish.call_args_list
             if c.args[0].type == EventType.SYSTEM_ALERT
         ]
-        assert len(alert_events) >= 2
+        assert len(alert_events) == 2
 
     @pytest.mark.asyncio
     async def test_release_epic_merge_loop_catches_runtime_error(


### PR DESCRIPTION
## Summary

Closes #3131.

## Issue

[Memory] Multi-item continuance tests for per-item isolation

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow