### PR TITLE
Fixes #3173: [Memory] Reviewer scope-creep removal commits need sta...

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -760,7 +760,7 @@ class ReviewResult(BaseModel):
     )
     commit_stat: str = Field(
         default="",
-        description="Output of git diff --stat HEAD~1 after fixes, for audit trail",
+        description="Output of git diff --stat covering all reviewer commits, for audit trail",
     )
     visual_passed: bool | None = Field(
         default=None,

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -169,7 +169,9 @@ class ReviewRunner(BaseRunner):
             )
             result.fixes_made = await self._has_changes(worktree_path, before_sha)
             if result.fixes_made and result.files_changed:
-                result.commit_stat = await self._get_commit_stat(worktree_path)
+                result.commit_stat = await self._get_commit_stat(
+                    worktree_path, before_sha
+                )
                 logger.info(
                     "Review fix for PR #%d changed files: %s",
                     pr.number,
@@ -178,7 +180,7 @@ class ReviewRunner(BaseRunner):
             elif result.fixes_made and not result.files_changed:
                 logger.warning(
                     "PR #%d: fixes_made is True but no committed file changes detected "
-                    "— review commit may not have persisted all intended changes",
+                    "— agent may have left uncommitted changes or the commit was empty",
                     pr.number,
                 )
 
@@ -279,7 +281,9 @@ class ReviewRunner(BaseRunner):
             )
             result.fixes_made = await self._has_changes(worktree_path, before_sha)
             if result.fixes_made and result.files_changed:
-                result.commit_stat = await self._get_commit_stat(worktree_path)
+                result.commit_stat = await self._get_commit_stat(
+                    worktree_path, before_sha
+                )
                 logger.info(
                     "CI fix for PR #%d changed files: %s",
                     pr.number,
@@ -288,7 +292,7 @@ class ReviewRunner(BaseRunner):
             elif result.fixes_made and not result.files_changed:
                 logger.warning(
                     "PR #%d: fixes_made is True but no committed file changes detected "
-                    "— CI fix commit may not have persisted all intended changes",
+                    "— agent may have left uncommitted changes or the commit was empty",
                     pr.number,
                 )
             self._save_transcript("review-pr", pr.number, transcript)
@@ -372,7 +376,9 @@ class ReviewRunner(BaseRunner):
             )
             result.fixes_made = await self._has_changes(worktree_path, before_sha)
             if result.fixes_made and result.files_changed:
-                result.commit_stat = await self._get_commit_stat(worktree_path)
+                result.commit_stat = await self._get_commit_stat(
+                    worktree_path, before_sha
+                )
                 logger.info(
                     "Review-fix for PR #%d changed files: %s",
                     pr.number,
@@ -381,7 +387,7 @@ class ReviewRunner(BaseRunner):
             elif result.fixes_made and not result.files_changed:
                 logger.warning(
                     "PR #%d: fixes_made is True but no committed file changes detected "
-                    "— review-fix commit may not have persisted all intended changes",
+                    "— agent may have left uncommitted changes or the commit was empty",
                     pr.number,
                 )
 
@@ -900,11 +906,20 @@ Diff snippet:
             return result.stdout
         return None
 
-    async def _get_commit_stat(self, worktree_path: Path) -> str:
-        """Run ``git diff --stat HEAD~1`` and return the output for audit trail."""
+    async def _get_commit_stat(
+        self, worktree_path: Path, before_sha: str | None = None
+    ) -> str:
+        """Return ``git diff --stat`` covering all reviewer commits for audit trail.
+
+        When *before_sha* is supplied the range ``<before_sha>..HEAD`` is used so
+        that multi-commit sessions are fully captured.  Falls back to ``HEAD~1``
+        when *before_sha* is unavailable (e.g. the repo had no commits before the
+        agent ran).
+        """
+        ref = f"{before_sha}..HEAD" if before_sha else "HEAD~1"
         try:
             result = await self._runner.run_simple(
-                ["git", "diff", "--stat", "HEAD~1"],
+                ["git", "diff", "--stat", ref],
                 cwd=str(worktree_path),
                 timeout=self._config.git_command_timeout,
             )

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -952,6 +952,73 @@ async def test_get_commit_stat_returns_empty_when_no_stdout(
     assert result == ""
 
 
+@pytest.mark.asyncio
+async def test_get_commit_stat_uses_before_sha_range(config, event_bus, tmp_path):
+    """_get_commit_stat passes 'before_sha..HEAD' when before_sha is provided."""
+    runner = _make_runner(config, event_bus)
+    stat_output = " src/foo.py | 2 +-\n 1 file changed"
+
+    mock_result = AsyncMock()
+    mock_result.returncode = 0
+    mock_result.stdout = stat_output
+
+    mock_run_simple = AsyncMock(return_value=mock_result)
+    with patch.object(runner._runner, "run_simple", mock_run_simple):
+        result = await runner._get_commit_stat(tmp_path, before_sha="abc123")
+
+    assert result == stat_output.strip()
+    called_args = mock_run_simple.call_args[0][0]
+    assert "abc123..HEAD" in called_args
+
+
+@pytest.mark.asyncio
+async def test_get_commit_stat_falls_back_to_head1_without_before_sha(
+    config, event_bus, tmp_path
+):
+    """_get_commit_stat uses HEAD~1 when before_sha is not provided."""
+    runner = _make_runner(config, event_bus)
+
+    mock_result = AsyncMock()
+    mock_result.returncode = 0
+    mock_result.stdout = " src/foo.py | 1 +\n 1 file changed"
+
+    mock_run_simple = AsyncMock(return_value=mock_result)
+    with patch.object(runner._runner, "run_simple", mock_run_simple):
+        await runner._get_commit_stat(tmp_path)
+
+    called_args = mock_run_simple.call_args[0][0]
+    assert "HEAD~1" in called_args
+
+
+# ---------------------------------------------------------------------------
+# Warning path: fixes_made=True but files_changed=[]
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_review_logs_warning_when_fixes_made_but_no_committed_files(
+    config, event_bus, pr_info, task, tmp_path
+):
+    """review() warns when fixes_made is True but no committed file changes are detected."""
+    runner = _make_runner(config, event_bus)
+    transcript = "Fixed.\nVERDICT: APPROVE\nSUMMARY: Fixed it"
+
+    with (
+        patch.object(runner, "_get_head_sha", AsyncMock(return_value="abc123")),
+        patch.object(runner, "_execute", AsyncMock(return_value=transcript)),
+        patch.object(runner, "_get_changed_files", AsyncMock(return_value=[])),
+        patch.object(runner, "_has_changes", AsyncMock(return_value=True)),
+        patch.object(runner, "_save_transcript"),
+        patch("reviewer.logger") as mock_logger,
+    ):
+        result = await runner.review(pr_info, task, tmp_path, "diff")
+
+    mock_logger.warning.assert_called_once()
+    assert result.fixes_made is True
+    assert result.files_changed == []
+    assert result.commit_stat == ""
+
+
 # ---------------------------------------------------------------------------
 # commit_stat populated in review/fix_ci/fix_review_findings
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #3173.

## Issue

[Memory] Reviewer scope-creep removal commits need stat verification

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow