### PR TITLE
Fix repo selector: wire RepoStore into dashboard server

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import signal
+from pathlib import Path
 
 from config import HydraFlowConfig
 from log import setup_logging
@@ -16,6 +17,8 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     from dashboard import HydraFlowDashboard  # noqa: PLC0415
     from events import EventBus, EventLog, EventType, HydraFlowEvent  # noqa: PLC0415
     from models import Phase  # noqa: PLC0415
+    from repo_runtime import RepoRuntimeRegistry  # noqa: PLC0415
+    from repo_store import RepoRecord, RepoRegistryStore  # noqa: PLC0415
     from state import StateTracker  # noqa: PLC0415
 
     event_log = EventLog(config.event_log_path)
@@ -27,10 +30,39 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     await bus.load_history_from_disk()
     state = StateTracker(config.state_file)
 
+    repo_store = RepoRegistryStore(config.data_root)
+    registry = RepoRuntimeRegistry()
+
+    async def _register_repo(
+        repo_path: Path, slug: str | None
+    ) -> tuple[RepoRecord, HydraFlowConfig]:
+        from runtime_config import load_runtime_config  # noqa: PLC0415
+
+        repo_cfg = load_runtime_config(
+            overrides={
+                "repo_root": str(repo_path),
+                **({"repo": slug} if slug else {}),
+            }
+        )
+        record = repo_store.upsert(
+            RepoRecord(
+                slug=repo_cfg.repo_slug,
+                repo=repo_cfg.repo_slug,
+                path=str(repo_path),
+            )
+        )
+        if record.slug not in registry:
+            await registry.register(repo_cfg)
+        return record, repo_cfg
+
     dashboard = HydraFlowDashboard(
         config=config,
         event_bus=bus,
         state=state,
+        registry=registry,
+        repo_store=repo_store,
+        register_repo_cb=_register_repo,
+        list_repos_cb=repo_store.list,
     )
     await dashboard.start()
 


### PR DESCRIPTION
## Summary
- Dashboard repo registration was broken — `_run_with_dashboard` created `HydraFlowDashboard` without `repo_store`, `register_repo_cb`, or `list_repos_cb`
- The `/api/repos` endpoint returned `can_register: false`, disabling the "Register repo" button in the UI
- Wire up `RepoRegistryStore`, `RepoRuntimeRegistry`, and a registration callback in `server.py`

## Test plan
- [x] All 8224 unit tests pass
- [x] Lint, typecheck, security checks pass
- [ ] Manual: `make run`, verify repo selector allows registering new repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)