### PR TITLE
Skip CI jobs for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,33 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      ui: ${{ steps.filter.outputs.ui }}
+      ci: ${{ steps.filter.outputs.ci }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'src/**/*.py'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+            ui:
+              - 'src/ui/**'
+            ci:
+              - '.github/workflows/**'
+
   lint:
     name: Lint & Format
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -31,6 +56,8 @@ jobs:
 
   typecheck:
     name: Type Check
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -48,6 +75,8 @@ jobs:
 
   security:
     name: Security Scan
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -65,6 +94,8 @@ jobs:
 
   test:
     name: Tests
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -91,6 +122,8 @@ jobs:
 
   smoke:
     name: Smoke Tests
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -116,6 +149,8 @@ jobs:
 
   ui-build:
     name: Dashboard Build
+    needs: changes
+    if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -137,6 +172,8 @@ jobs:
 
   visual-capture:
     name: Visual Capture
+    needs: changes
+    if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,6 +11,25 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Makefile'
+              - '.github/workflows/**'
+
   discover-projects:
     runs-on: ubuntu-latest
     outputs:
@@ -75,7 +94,8 @@ jobs:
 
   quality:
     runs-on: ubuntu-latest
-    needs: discover-projects
+    needs: [changes, discover-projects]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover-projects.outputs.matrix) }}


### PR DESCRIPTION
## Summary
- Add `dorny/paths-filter` to both `ci.yml` and `quality.yml` to detect what files changed
- Python jobs (lint, typecheck, security, tests) only run when `src/**/*.py`, `tests/**`, `pyproject.toml`, or `uv.lock` change
- UI jobs (dashboard build, visual capture) only run when `src/ui/**` changes
- Smoke tests run when either Python or UI code changes
- All jobs still run on workflow file changes for safety
- A README-only PR no longer triggers 8000+ tests

## Test plan
- [ ] Open a docs-only PR and verify skipped jobs show as "skipped" not "failed"
- [ ] Open a Python code PR and verify all Python jobs still run
- [ ] Open a UI code PR and verify UI + smoke jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)