### PR TITLE
Revert #3223: remove duplicate start/stop button

### DIFF
--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -8,7 +8,6 @@
       "name": "hydraflow-ui",
       "version": "0.9.1",
       "dependencies": {
-        "@rollup/rollup-linux-arm64-gnu": "^4.59.0",
         "html2canvas": "^1.4.1",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -170,20 +170,6 @@ export function SessionSidebar() {
                 </div>
                 <div style={styles.repoMeta}>
                   <span style={styles.repoCount}>{repoSessions.length}</span>
-                  {(entry.info || entry.runtime) && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        const slug = entry.repoSlug || entry.displayName
-                        if (isRunning) { stopRuntime(slug) } else { startRuntime(slug) }
-                      }}
-                      style={isRunning ? styles.runtimeStopBtn : styles.runtimeStartBtn}
-                      aria-label={isRunning ? 'Stop repo' : 'Start repo'}
-                      title={isRunning ? 'Stop processing' : 'Start processing'}
-                    >
-                      {isRunning ? '■' : '▶'}
-                    </button>
-                  )}
                   {entry.info && (
                     <button
                       onClick={(e) => {


### PR DESCRIPTION
## Summary
- Reverts #3223 which added `|| entry.runtime` guard causing duplicate play buttons on registered repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)