### PR TITLE
Fix default repo sidebar controls and blank screen on select

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -379,6 +379,14 @@ class RouteContext:
 
     # -- Dependency resolution helpers ------------------------------------------
 
+    def _is_default_repo(self, slug: str) -> bool:
+        """Check if *slug* refers to the default (host) repo."""
+        default = self.config.repo
+        if not default:
+            return False
+        normalized = default.replace("/", "-")
+        return slug in (default, normalized)
+
     def resolve_runtime(
         self,
         slug: str | None,
@@ -390,10 +398,12 @@ class RouteContext:
     ]:
         """Resolve per-repo dependencies from the registry.
 
-        When *slug* is ``None`` or no registry is configured, returns the
-        single-repo defaults for backward compatibility.
+        When *slug* is ``None``, matches the default repo, or no registry is
+        configured, returns the single-repo defaults for backward compatibility.
         """
         if self.registry is not None and slug is not None:
+            if self._is_default_repo(slug):
+                return self.config, self.state, self.event_bus, self.get_orchestrator
             rt: RepoRuntime | None = self.registry.get(slug)
             if rt is None:
                 raise HTTPException(status_code=404, detail=f"Unknown repo: {slug}")
@@ -3034,29 +3044,57 @@ def create_router(
 
     # --- Repo runtime lifecycle endpoints ---
 
+    def _is_default_repo(slug: str) -> bool:
+        """Check if *slug* refers to the default (host) repo."""
+        return ctx._is_default_repo(slug)
+
     @router.get("/api/runtimes")
     async def list_runtimes() -> JSONResponse:
         """List all registered repo runtimes with status."""
 
-        if registry is None:
-            return JSONResponse({"runtimes": []})
-        infos = []
-        for rt in registry.all:
+        infos: list[dict[str, Any]] = []
+
+        # Always include the default (host) repo.
+        orch = get_orchestrator()
+        if config.repo:
             infos.append(
                 RepoRuntimeInfo(
-                    slug=rt.slug,
-                    repo=rt.config.repo,
-                    running=rt.running,
-                    session_id=rt.orchestrator.current_session_id
-                    if rt.running
+                    slug=config.repo,
+                    repo=config.repo,
+                    running=bool(orch and orch.running),
+                    session_id=orch.current_session_id
+                    if orch and orch.running
                     else None,
                 ).model_dump()
             )
+
+        if registry is not None:
+            for rt in registry.all:
+                infos.append(
+                    RepoRuntimeInfo(
+                        slug=rt.slug,
+                        repo=rt.config.repo,
+                        running=rt.running,
+                        session_id=rt.orchestrator.current_session_id
+                        if rt.running
+                        else None,
+                    ).model_dump()
+                )
         return JSONResponse({"runtimes": infos})
 
     @router.get("/api/runtimes/{slug}")
     async def get_runtime_status(slug: str) -> JSONResponse:
         """Get status of a specific repo runtime."""
+
+        if _is_default_repo(slug):
+            orch = get_orchestrator()
+            info = RepoRuntimeInfo(
+                slug=config.repo,
+                repo=config.repo,
+                running=bool(orch and orch.running),
+                session_id=orch.current_session_id if orch and orch.running else None,
+            )
+            return JSONResponse(info.model_dump())
 
         if registry is None:
             return JSONResponse(
@@ -3076,6 +3114,27 @@ def create_router(
     @router.post("/api/runtimes/{slug}/start")
     async def start_runtime(slug: str) -> JSONResponse:
         """Start a specific repo runtime."""
+        if _is_default_repo(slug):
+            orch = get_orchestrator()
+            if orch and orch.running:
+                return JSONResponse({"error": "Already running"}, status_code=409)
+            from orchestrator import HydraFlowOrchestrator
+
+            new_orch = HydraFlowOrchestrator(
+                config,
+                event_bus=event_bus,
+                state=state,
+            )
+            set_orchestrator(new_orch)
+            set_run_task(asyncio.create_task(new_orch.run()))
+            await event_bus.publish(
+                HydraFlowEvent(
+                    type=EventType.ORCHESTRATOR_STATUS,
+                    data=OrchestratorStatusPayload(status="running", reset=True),
+                )
+            )
+            return JSONResponse({"status": "started", "slug": slug})
+
         if registry is None:
             return JSONResponse(
                 {"error": "No runtime registry configured"}, status_code=501
@@ -3091,6 +3150,13 @@ def create_router(
     @router.post("/api/runtimes/{slug}/stop")
     async def stop_runtime(slug: str) -> JSONResponse:
         """Stop a specific repo runtime."""
+        if _is_default_repo(slug):
+            orch = get_orchestrator()
+            if not orch or not orch.running:
+                return JSONResponse({"error": "Not running"}, status_code=400)
+            await orch.request_stop()
+            return JSONResponse({"status": "stopped", "slug": slug})
+
         if registry is None:
             return JSONResponse(
                 {"error": "No runtime registry configured"}, status_code=501

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -186,20 +186,6 @@ export function SessionSidebar() {
                   )}
                   {entry.info && (
                     <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        const slug = entry.repoSlug || entry.displayName
-                        if (isRunning) { stopRuntime(slug) } else { startRuntime(slug) }
-                      }}
-                      style={isRunning ? styles.runtimeStopBtn : styles.runtimeStartBtn}
-                      aria-label={isRunning ? 'Stop repo' : 'Start repo'}
-                      title={isRunning ? 'Stop processing' : 'Start processing'}
-                    >
-                      {isRunning ? '■' : '▶'}
-                    </button>
-                  )}
-                  {entry.info && (
-                    <button
                       onClick={(e) => handleDisconnect(e, entry.repoSlug || entry.displayName, isRunning)}
                       style={styles.disconnectBtn}
                       aria-label="Disconnect repo"

--- a/tests/test_dashboard_routes_core.py
+++ b/tests/test_dashboard_routes_core.py
@@ -472,9 +472,10 @@ class TestRuntimeLifecycleEndpoints:
         import json
 
         data = json.loads(resp.body)
-        assert len(data["runtimes"]) == 1
-        assert data["runtimes"][0]["slug"] == "org-repo"
-        assert data["runtimes"][0]["running"] is True
+        # First entry is the default (host) repo, subsequent are registered runtimes
+        registered = [r for r in data["runtimes"] if r["slug"] == "org-repo"]
+        assert len(registered) == 1
+        assert registered[0]["running"] is True
 
     @pytest.mark.asyncio
     async def test_get_runtime_status_not_found(

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -1736,7 +1736,11 @@ class TestRuntimeEndpointsWithRegistry:
         import json as json_mod
 
         data = json_mod.loads(resp.body)
-        assert data == {"runtimes": []}
+        # Default (host) repo is always included; no additional registered runtimes
+        default_entries = [r for r in data["runtimes"] if r["slug"] == config.repo]
+        assert len(default_entries) == 1
+        registered = [r for r in data["runtimes"] if r["slug"] != config.repo]
+        assert registered == []
 
     @pytest.mark.asyncio
     async def test_list_runtimes_with_registered_runtime(
@@ -1759,9 +1763,9 @@ class TestRuntimeEndpointsWithRegistry:
         import json as json_mod
 
         data = json_mod.loads(resp.body)
-        assert len(data["runtimes"]) == 1
-        assert data["runtimes"][0]["slug"] == "owner-repo"
-        assert data["runtimes"][0]["running"] is False
+        registered = [r for r in data["runtimes"] if r["slug"] == "owner-repo"]
+        assert len(registered) == 1
+        assert registered[0]["running"] is False
 
     @pytest.mark.asyncio
     async def test_get_runtime_status_found(


### PR DESCRIPTION
## Summary
- The default (host) repo appeared in the sidebar but had no start/stop button and caused a blank screen when clicked
- `resolve_runtime()` didn't recognise the host repo slug, so all `?repo=slug` API calls returned 404 and the WebSocket closed with code 1008
- Added `_is_default_repo()` to `RouteContext` so the host repo resolves to the orchestrator's single-repo defaults
- Included the default repo in `/api/runtimes` and delegated its start/stop to the orchestrator endpoints
- Removed a duplicate start/stop button that was rendering twice for supervised repos

## Test plan
- [x] All 354 dashboard route tests pass
- [x] Lint clean
- [ ] Verify default repo shows start/stop button in sidebar
- [ ] Verify clicking default repo no longer causes blank screen
- [ ] Verify start/stop on default repo starts/stops the orchestrator
- [ ] Verify added repos still work as before (start/stop/disconnect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)