### PR TITLE
Skip circuit breaker alerts for transient Docker errors

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -845,8 +845,20 @@ class HydraFlowOrchestrator:
                 display = name.replace("_", " ").capitalize()
                 exc_type = type(exc)
 
+                # Docker/network transient errors should not count toward
+                # the circuit breaker — they resolve on their own when the
+                # daemon restarts or the network recovers.
+                is_transient = (
+                    isinstance(exc, ConnectionError | FileNotFoundError | OSError)
+                    or "closed pipe" in str(exc).lower()
+                )
+
                 # Track consecutive failures of the same type
-                if exc_type is last_exc_type:
+                if is_transient:
+                    # Don't escalate transient infra errors
+                    consecutive_failures = 0
+                    last_exc_type = None
+                elif exc_type is last_exc_type:
                     consecutive_failures += 1
                 else:
                     consecutive_failures = 1


### PR DESCRIPTION
## Summary
- Docker daemon restarts and container crashes (`ConnectionError`, `FileNotFoundError`, `OSError`, "closed pipe") no longer trigger `SYSTEM_ALERT`
- These transient errors reset the consecutive failure counter instead of incrementing it
- The circuit breaker still fires for real bugs (TypeError, KeyError, etc.)

## Test plan
- [x] Orchestrator tests pass
- [x] Lint clean
- [ ] Restart Docker Desktop mid-run → verify no system alert banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)