### PR TITLE
Fixes #3246: [Memory] HITL scope-creep removal requires branch rese...

### DIFF
--- a/src/hitl_phase.py
+++ b/src/hitl_phase.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
-from hitl_runner import HITLRunner
+from hitl_runner import HITLRunner, classify_cause
 from issue_fetcher import IssueFetcher
 from issue_store import IssueStore
 from models import GitHubIssue, HITLUpdatePayload
@@ -213,6 +213,22 @@ class HITLPhase:
                 await self._prs.swap_pipeline_labels(
                     issue_number, self._config.hitl_active_label[0]
                 )
+
+                # Pre-run scope-creep cleanup: reset branch to main and
+                # let the HITL agent selectively re-apply in-scope changes.
+                if classify_cause(cause) == "scope_creep":
+                    try:
+                        await self._worktrees.soft_reset_to_main(wt_path)
+                        logger.info(
+                            "Scope-creep cleanup: soft-reset branch for issue #%d",
+                            issue_number,
+                        )
+                    except RuntimeError as exc:
+                        logger.warning(
+                            "Scope-creep cleanup failed for issue #%d: %s",
+                            issue_number,
+                            exc,
+                        )
 
                 result = await self._hitl_runner.run(issue, correction, cause, wt_path)
 

--- a/src/hitl_runner.py
+++ b/src/hitl_runner.py
@@ -17,7 +17,9 @@ from runner_constants import MEMORY_SUGGESTION_PROMPT
 
 logger = logging.getLogger("hydraflow.hitl_runner")
 
-HITLCauseKey = Literal["ci", "merge_conflict", "needs_info", "visual", "default"]
+HITLCauseKey = Literal[
+    "ci", "merge_conflict", "needs_info", "scope_creep", "visual", "default"
+]
 
 # Prompt instructions keyed by escalation cause category.
 _CAUSE_INSTRUCTIONS: dict[HITLCauseKey, str] = {
@@ -56,6 +58,17 @@ _CAUSE_INSTRUCTIONS: dict[HITLCauseKey, str] = {
         "5. Run `make quality` to verify.\n"
         '6. Commit with message: "hitl-fix: resolve visual regression (#{issue})".'
     ),
+    "scope_creep": (
+        "The branch has scope-creep from previous agent attempts.\n"
+        "Files unrelated to the issue were modified or committed.\n"
+        "1. Run `git diff main...HEAD --stat` to see all changed files.\n"
+        "2. Identify which files are relevant to the issue and which are not.\n"
+        "3. Run `git reset --soft main` to unstage everything.\n"
+        "4. Selectively `git add` only the files related to the issue.\n"
+        "5. Discard unrelated changes with `git checkout -- <file>`.\n"
+        "6. Run `make quality` to verify the in-scope changes pass.\n"
+        '7. Commit with message: "hitl-fix: remove scope-creep (#{issue})".'
+    ),
     "default": (
         "This issue was escalated to human review.\n"
         "The human operator has provided guidance below.\n"
@@ -67,13 +80,16 @@ _CAUSE_INSTRUCTIONS: dict[HITLCauseKey, str] = {
 }
 
 
-def _classify_cause(cause: str) -> HITLCauseKey:
+def classify_cause(cause: str) -> HITLCauseKey:
     """Map a free-text escalation cause to a prompt template key."""
     lower = cause.lower()
     # Check visual BEFORE needs_info — visual summaries can contain "needs"
     # (e.g. "login screen needs baseline update").
     if any(kw in lower for kw in ("visual", "screenshot", "diff image")):
         return "visual"
+    # Check scope_creep BEFORE needs_info/ci — "scope" is unambiguous.
+    if "scope" in lower and ("creep" in lower or "unrelated" in lower):
+        return "scope_creep"
     # Check needs_info BEFORE ci — "insufficient" contains the substring "ci".
     if "insufficient" in lower or "needs" in lower or "detail" in lower:
         return "needs_info"
@@ -82,6 +98,10 @@ def _classify_cause(cause: str) -> HITLCauseKey:
     if "merge" in lower and "conflict" in lower:
         return "merge_conflict"
     return "default"
+
+
+# Backward-compatible alias for internal callers.
+_classify_cause = classify_cause
 
 
 class HITLRunner(BaseRunner):
@@ -176,7 +196,7 @@ class HITLRunner(BaseRunner):
         self, issue: GitHubIssue, correction: str, cause: str
     ) -> tuple[str, dict[str, object]]:
         """Build the HITL prompt with pruning stats."""
-        cause_key = _classify_cause(cause)
+        cause_key = classify_cause(cause)
         instructions = _CAUSE_INSTRUCTIONS[cause_key].replace(
             "#{issue}", f"#{issue.number}"
         )

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -599,6 +599,76 @@ class WorkspaceManager:
             "Reset worktree %s to origin/%s", worktree_path, self._config.main_branch
         )
 
+    async def soft_reset_to_main(self, worktree_path: Path) -> None:
+        """Soft-reset worktree to ``origin/main`` and unstage all files.
+
+        Preserves the working-tree contents so that callers can selectively
+        re-stage only the in-scope changes.  Each git step has its own
+        try/except so failures are attributable (learning #3305).
+        """
+        try:
+            await self._fetch_origin_with_retry(worktree_path, self._config.main_branch)
+        except RuntimeError:
+            logger.error("soft_reset_to_main: fetch failed in %s", worktree_path)
+            raise
+
+        try:
+            await run_subprocess(
+                "git",
+                "reset",
+                "--soft",
+                f"origin/{self._config.main_branch}",
+                cwd=worktree_path,
+                gh_token=self._config.gh_token,
+            )
+        except RuntimeError:
+            logger.error(
+                "soft_reset_to_main: git reset --soft failed in %s",
+                worktree_path,
+            )
+            raise
+
+        try:
+            await run_subprocess(
+                "git",
+                "reset",
+                "HEAD",
+                cwd=worktree_path,
+                gh_token=self._config.gh_token,
+            )
+        except RuntimeError:
+            logger.error(
+                "soft_reset_to_main: git reset HEAD (unstage) failed in %s",
+                worktree_path,
+            )
+            raise
+
+        logger.info(
+            "Soft-reset worktree %s to origin/%s (unstaged)",
+            worktree_path,
+            self._config.main_branch,
+        )
+
+    async def get_branch_diff_stat(self, worktree_path: Path) -> list[str]:
+        """Return the list of files changed on the branch relative to main.
+
+        Runs ``git diff main...HEAD --stat --name-only`` in *worktree_path*.
+        Returns an empty list on failure.
+        """
+        try:
+            output = await run_subprocess(
+                "git",
+                "diff",
+                f"origin/{self._config.main_branch}...HEAD",
+                "--name-only",
+                cwd=worktree_path,
+                gh_token=self._config.gh_token,
+            )
+            return [f.strip() for f in output.strip().splitlines() if f.strip()]
+        except RuntimeError:
+            logger.warning("Could not get branch diff stat in %s", worktree_path)
+            return []
+
     async def merge_main(self, worktree_path: Path, branch: str) -> bool:
         """Merge latest main into *branch* inside *worktree_path*.
 

--- a/tests/test_hitl_phase.py
+++ b/tests/test_hitl_phase.py
@@ -847,3 +847,89 @@ class TestHITLAutoFix:
 
         assert 42 not in phase._hitl_corrections
         assert 43 not in phase._hitl_corrections
+
+
+# ---------------------------------------------------------------------------
+# HITL scope-creep branch cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestHITLScopeCreepCleanup:
+    """Tests for scope-creep branch reset in _process_one_hitl."""
+
+    @pytest.mark.asyncio
+    async def test_scope_creep_cause_triggers_soft_reset(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When cause classifies as scope_creep, soft_reset_to_main is called."""
+        phase, state, fetcher, prs, wt, runner, _bus = make_hitl_phase(config)
+        issue = TaskFactory.create(id=42, title="Fix scope creep")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        state.set_hitl_origin(42, "hydraflow-review")
+        state.set_hitl_cause(42, "scope creep from previous agent attempts")
+
+        runner.run = AsyncMock(return_value=HITLResultFactory.create())
+
+        semaphore = asyncio.Semaphore(1)
+        await phase._process_one_hitl(42, "Remove unrelated files", semaphore)
+
+        wt.soft_reset_to_main.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_scope_creep_cause_skips_soft_reset(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When cause is not scope_creep, soft_reset_to_main is not called."""
+        phase, state, fetcher, prs, wt, runner, _bus = make_hitl_phase(config)
+        issue = TaskFactory.create(id=42, title="Fix CI")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        state.set_hitl_origin(42, "hydraflow-review")
+        state.set_hitl_cause(42, "CI failed after 2 fix attempt(s)")
+
+        runner.run = AsyncMock(return_value=HITLResultFactory.create())
+
+        semaphore = asyncio.Semaphore(1)
+        await phase._process_one_hitl(42, "Fix the tests", semaphore)
+
+        wt.soft_reset_to_main.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_scope_creep_cleanup_failure_does_not_block_runner(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """If soft_reset_to_main fails, the HITL runner should still execute."""
+        phase, state, fetcher, prs, wt, runner, _bus = make_hitl_phase(config)
+        issue = TaskFactory.create(id=42, title="Fix scope creep")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        state.set_hitl_origin(42, "hydraflow-review")
+        state.set_hitl_cause(42, "scope creep from previous agent attempts")
+
+        wt.soft_reset_to_main = AsyncMock(side_effect=RuntimeError("reset failed"))
+        runner.run = AsyncMock(return_value=HITLResultFactory.create())
+
+        semaphore = asyncio.Semaphore(1)
+        await phase._process_one_hitl(42, "Remove unrelated files", semaphore)
+
+        # Runner still executed despite cleanup failure
+        runner.run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_scope_creep_with_no_cause_uses_default(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When no cause is stored, classify_cause('Unknown escalation') -> default."""
+        phase, state, fetcher, prs, wt, runner, _bus = make_hitl_phase(config)
+        issue = TaskFactory.create(id=42, title="Test")
+
+        fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        # No hitl_cause set — falls back to "Unknown escalation"
+
+        runner.run = AsyncMock(return_value=HITLResultFactory.create())
+
+        semaphore = asyncio.Semaphore(1)
+        await phase._process_one_hitl(42, "Fix it", semaphore)
+
+        wt.soft_reset_to_main.assert_not_awaited()

--- a/tests/test_hitl_runner.py
+++ b/tests/test_hitl_runner.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from base_runner import BaseRunner
 from config import HydraFlowConfig
 from events import EventBus, EventType
-from hitl_runner import HITLRunner, _classify_cause
+from hitl_runner import HITLRunner, _classify_cause, classify_cause
 from models import LoopResult
 from tests.conftest import HITLResultFactory, IssueFactory
 
@@ -100,6 +100,29 @@ class TestClassifyCause:
         # "deficit" contains "ci" as a substring — should not misclassify
         assert _classify_cause("deficit in implementation coverage") == "default"
 
+    def test_scope_creep_maps_correctly(self) -> None:
+        assert (
+            classify_cause("scope creep from previous agent attempts") == "scope_creep"
+        )
+
+    def test_scope_unrelated_maps_to_scope_creep(self) -> None:
+        assert classify_cause("scope: unrelated files changed") == "scope_creep"
+
+    def test_scope_creep_case_insensitive(self) -> None:
+        assert classify_cause("Scope Creep detected in branch") == "scope_creep"
+
+    def test_scope_creep_before_ci(self) -> None:
+        """scope_creep should match before ci when both keywords present."""
+        assert classify_cause("scope creep in CI branch") == "scope_creep"
+
+    def test_scope_without_creep_or_unrelated_is_default(self) -> None:
+        """'scope' alone (without 'creep' or 'unrelated') should not match."""
+        assert classify_cause("out of scope issue") == "default"
+
+    def test_classify_cause_is_public_alias(self) -> None:
+        """classify_cause and _classify_cause should be the same function."""
+        assert classify_cause is _classify_cause
+
 
 # ---------------------------------------------------------------------------
 # Prompt building
@@ -165,6 +188,14 @@ class TestBuildPrompt:
         assert "visual" in prompt.lower()
         assert "screenshot" in prompt.lower()
         assert "visual regression" in prompt.lower()
+
+    def test_prompt_uses_scope_creep_instructions(self, hitl_runner) -> None:
+        issue = IssueFactory.create(number=42)
+        prompt, _ = hitl_runner._build_prompt_with_stats(
+            issue, "Remove unrelated files", "scope creep from previous attempts"
+        )
+        assert "git reset --soft main" in prompt
+        assert "scope-creep" in prompt.lower()
 
     def test_prompt_includes_issue_number_in_commit_message(self, hitl_runner) -> None:
         issue = IssueFactory.create(number=99)

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -731,3 +731,151 @@ class TestGetMainCommitsSinceDiverge:
         # Second call is git log
         log_call = mock_exec.call_args_list[1]
         assert "-30" in log_call.args
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceManager.soft_reset_to_main
+# ---------------------------------------------------------------------------
+
+
+class TestSoftResetToMain:
+    """Tests for WorkspaceManager.soft_reset_to_main."""
+
+    @pytest.mark.asyncio
+    async def test_success_runs_three_git_commands(
+        self, config, tmp_path: Path
+    ) -> None:
+        """soft_reset_to_main should fetch, reset --soft, then reset HEAD."""
+        manager = WorkspaceManager(config)
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_run(*cmd, **kwargs):
+            calls.append(tuple(str(p) for p in cmd))
+            return ""
+
+        with patch("workspace.run_subprocess", side_effect=fake_run):
+            await manager.soft_reset_to_main(tmp_path)
+
+        assert len(calls) == 3
+        # 1. git fetch origin main
+        assert calls[0][:3] == ("git", "fetch", "origin")
+        # 2. git reset --soft origin/main
+        assert calls[1][:3] == ("git", "reset", "--soft")
+        assert f"origin/{config.main_branch}" in calls[1]
+        # 3. git reset HEAD (unstage)
+        assert calls[2] == ("git", "reset", "HEAD")
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_raises_and_skips_reset(
+        self, config, tmp_path: Path
+    ) -> None:
+        """If fetch fails, should raise RuntimeError without running reset."""
+        manager = WorkspaceManager(config)
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_run(*cmd, **kwargs):
+            calls.append(tuple(str(p) for p in cmd))
+            if cmd[:3] == ("git", "fetch", "origin"):
+                raise RuntimeError("network error")
+            return ""
+
+        with (
+            patch("workspace.run_subprocess", side_effect=fake_run),
+            pytest.raises(RuntimeError, match="network error"),
+        ):
+            await manager.soft_reset_to_main(tmp_path)
+
+        # Only fetch was attempted
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_soft_reset_failure_raises_and_skips_unstage(
+        self, config, tmp_path: Path
+    ) -> None:
+        """If git reset --soft fails, should raise without running unstage."""
+        manager = WorkspaceManager(config)
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_run(*cmd, **kwargs):
+            calls.append(tuple(str(p) for p in cmd))
+            if "--soft" in cmd:
+                raise RuntimeError("reset failed")
+            return ""
+
+        with (
+            patch("workspace.run_subprocess", side_effect=fake_run),
+            pytest.raises(RuntimeError, match="reset failed"),
+        ):
+            await manager.soft_reset_to_main(tmp_path)
+
+        # Fetch succeeded, reset --soft failed, unstage not attempted
+        assert len(calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_unstage_failure_raises(self, config, tmp_path: Path) -> None:
+        """If git reset HEAD (unstage) fails, should raise."""
+        manager = WorkspaceManager(config)
+        calls: list[tuple[str, ...]] = []
+
+        async def fake_run(*cmd, **kwargs):
+            calls.append(tuple(str(p) for p in cmd))
+            if cmd == ("git", "reset", "HEAD"):
+                raise RuntimeError("unstage failed")
+            return ""
+
+        with (
+            patch("workspace.run_subprocess", side_effect=fake_run),
+            pytest.raises(RuntimeError, match="unstage failed"),
+        ):
+            await manager.soft_reset_to_main(tmp_path)
+
+        assert len(calls) == 3
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceManager.get_branch_diff_stat
+# ---------------------------------------------------------------------------
+
+
+class TestGetBranchDiffStat:
+    """Tests for WorkspaceManager.get_branch_diff_stat."""
+
+    @pytest.mark.asyncio
+    async def test_returns_changed_files(self, config, tmp_path: Path) -> None:
+        manager = WorkspaceManager(config)
+        proc = make_proc(returncode=0, stdout=b"src/foo.py\nsrc/bar.py\n")
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await manager.get_branch_diff_stat(tmp_path)
+
+        assert result == ["src/foo.py", "src/bar.py"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_failure(self, config, tmp_path: Path) -> None:
+        manager = WorkspaceManager(config)
+        proc = make_proc(returncode=1, stderr=b"fatal: bad revision")
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await manager.get_branch_diff_stat(tmp_path)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_changes(self, config, tmp_path: Path) -> None:
+        manager = WorkspaceManager(config)
+        proc = make_proc(returncode=0, stdout=b"")
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await manager.get_branch_diff_stat(tmp_path)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_strips_whitespace(self, config, tmp_path: Path) -> None:
+        manager = WorkspaceManager(config)
+        proc = make_proc(returncode=0, stdout=b"  foo.py  \n  bar.py  \n\n")
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await manager.get_branch_diff_stat(tmp_path)
+
+        assert result == ["foo.py", "bar.py"]


### PR DESCRIPTION
## Summary

Closes #3246.

## Issue

[Memory] HITL scope-creep removal requires branch reset, not incremental revert

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow