### PR TITLE
Fix screenshot capture on some machines

### DIFF
--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -4,6 +4,7 @@ import { useHydraFlow } from '../context/HydraFlowContext'
 import { PIPELINE_STAGES, SENSITIVE_SELECTORS } from '../constants'
 import { ReportIssueModal } from './ReportIssueModal'
 import { BugReportTracker } from './BugReportTracker'
+import html2canvasLib from 'html2canvas'
 
 function isCrossOriginImage(el) {
   if (!el || el.tagName !== 'IMG') return false
@@ -209,10 +210,8 @@ export function Header({ connected, orchestratorStatus }) {
     // Capture screenshot BEFORE opening the modal so the overlay isn't in the shot.
     let dataUrl = null
     try {
-      const mod = await import('html2canvas')
-      const html2canvas = mod.default || mod
       const root = document.getElementById('root')
-      dataUrl = await captureDashboardScreenshot(root, html2canvas)
+      dataUrl = await captureDashboardScreenshot(root, html2canvasLib)
     } catch (err) {
       console.error('Screenshot capture failed:', err)
     }

--- a/src/ui/vite.config.mjs
+++ b/src/ui/vite.config.mjs
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: '/',
+  optimizeDeps: {
+    include: ['html2canvas']
+  },
   build: {
     outDir: 'dist',
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- Replace dynamic `import('html2canvas')` with a static import to avoid machine-specific Vite pre-bundling/cache failures
- Add `html2canvas` to `optimizeDeps.include` in Vite config as an additional safeguard

## Test plan
- [ ] Verify screenshot capture works on report issue modal
- [ ] Verify no regressions in dashboard loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)