### PR TITLE
Start default repo with pipeline paused until play button is pressed

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1987,6 +1987,11 @@ def create_router(
             event_bus=event_bus,
             state=state,
         )
+        # Start the orchestrator with pipeline workers disabled so the
+        # default repo behaves like added repos — pipeline only runs
+        # when the user clicks the play button in the sidebar.
+        for w in _DEFAULT_PIPELINE_WORKERS:
+            new_orch.set_bg_worker_enabled(w, False)
         set_orchestrator(new_orch)
         set_run_task(asyncio.create_task(new_orch.run()))
         await event_bus.publish(


### PR DESCRIPTION
## Summary
- Default repo pipeline workers (triage, plan, implement, review, hitl) now start **disabled** when the orchestrator launches
- User must click the play button in the sidebar to start processing — same UX as added repos
- Background workers and dashboard remain active immediately
- Headless mode (no dashboard) is unaffected — pipeline starts automatically as before

## Test plan
- [x] 354 dashboard route tests pass
- [x] Lint clean
- [ ] Start orchestrator → verify default repo shows as stopped in sidebar
- [ ] Click play on default repo → verify pipeline starts processing
- [ ] Verify added repos still behave the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)