### PR TITLE
Fix pipeline workers re-enabled by restore_state after orchestrator start

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -2048,13 +2048,26 @@ def create_router(
             event_bus=event_bus,
             state=state,
         )
-        # Start the orchestrator with pipeline workers disabled so the
-        # default repo behaves like added repos — pipeline only runs
-        # when the user clicks the play button in the sidebar.
-        for w in _DEFAULT_PIPELINE_WORKERS:
-            new_orch.set_bg_worker_enabled(w, False)
         set_orchestrator(new_orch)
-        set_run_task(asyncio.create_task(new_orch.run()))
+
+        async def _run_with_pipeline_paused() -> None:
+            """Start the orchestrator then immediately disable pipeline workers.
+
+            _restore_state() runs inside run() and may re-enable workers from
+            persisted state, so we disable AFTER run() has started and the
+            orchestrator is running.
+            """
+            # Start run() in background, wait for it to be running
+            run_task = asyncio.create_task(new_orch.run())
+            # Wait until the orchestrator marks itself running
+            while not new_orch.running:
+                await asyncio.sleep(0.05)
+            # Now disable pipeline workers — after _restore_state() has completed
+            for w in _DEFAULT_PIPELINE_WORKERS:
+                new_orch.set_bg_worker_enabled(w, False)
+            await run_task
+
+        set_run_task(asyncio.create_task(_run_with_pipeline_paused()))
         await event_bus.publish(
             HydraFlowEvent(
                 type=EventType.ORCHESTRATOR_STATUS,


### PR DESCRIPTION
## Summary
- Pipeline workers were being disabled BEFORE `run()`, but `run()` calls `_restore_state()` which re-enabled them from persisted state
- Now waits for the orchestrator to be running (after `_restore_state` completes), then disables pipeline workers
- This is why the default repo showed as running with a blinking dot even though you never pressed play

## Test plan
- [x] 354 dashboard route tests pass
- [x] Lint clean
- [ ] Press Start → default repo should NOT show as running (no blinking dot)
- [ ] Press play on default repo → starts processing
- [ ] All repos view shows no hydraflow data until play is pressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)