### PR TITLE
Fix rolling transcript logs missing after repo selection

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -174,15 +174,27 @@ export function reducer(state, action) {
     case 'transcript_line': {
       if (isDuplicate(state, action)) return state
       let key = action.data.issue || action.data.pr
+      let role = 'implementer'
       if (action.data.source === 'triage') {
         key = `triage-${action.data.issue}`
+        role = 'triage'
       } else if (action.data.source === 'planner') {
         key = `plan-${action.data.issue}`
+        role = 'planner'
       } else if (action.data.source === 'reviewer') {
         key = `review-${action.data.pr}`
+        role = 'reviewer'
       }
-      if (!key || !state.workers[key]) return addEvent(state, action)
-      const w = state.workers[key]
+      if (!key) return addEvent(state, action)
+      const w = state.workers[key] || {
+        status: 'active',
+        worker: 0,
+        role,
+        title: `Issue #${action.data.issue || action.data.pr || ''}`,
+        branch: '',
+        transcript: [],
+        pr: action.data.pr || null,
+      }
       return {
         ...addEvent(state, action),
         workers: {


### PR DESCRIPTION
## Summary
- `transcript_line` events were silently dropped when the worker slot didn't exist
- This happened after `SELECT_REPO` clears `workers:{}` and the WS replays history — transcript lines arriving before their `worker_update` got discarded
- Now the reducer auto-creates the worker slot from the transcript_line data
- Rolling logs show immediately after switching repos

## Test plan
- [x] Lint clean
- [ ] Click on a running repo → rolling transcript lines appear in cards
- [ ] Switch between repos → transcripts update correctly
- [ ] All repos view still shows transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)