### PR TITLE
Bump default Docker memory limit from 4g to 8g

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1205,7 +1205,7 @@ class HydraFlowConfig(BaseModel):
         description="CPU cores per container",
     )
     docker_memory_limit: str = Field(
-        default="4g",
+        default="8g",
         description="Memory limit per container",
     )
     docker_network_mode: Literal["bridge", "none", "host"] = Field(
@@ -1947,7 +1947,7 @@ def _apply_env_overrides(config: HydraFlowConfig) -> None:
     # Docker resource limit overrides (validated fields handled manually
     # because str/int overrides need format/bounds validation that
     # the data-driven tables don't provide)
-    if config.docker_memory_limit == "4g":  # still at default
+    if config.docker_memory_limit == "8g":  # still at default
         env_mem = os.environ.get("HYDRAFLOW_DOCKER_MEMORY_LIMIT")
         if env_mem is not None:
             if not re.fullmatch(r"\d+[bkmg]", env_mem, re.IGNORECASE):

--- a/tests/test_config_docker.py
+++ b/tests/test_config_docker.py
@@ -65,7 +65,7 @@ class TestDockerConfigDefaults:
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.docker_memory_limit == "4g"
+        assert cfg.docker_memory_limit == "8g"
 
     def test_docker_pids_limit_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
@@ -564,7 +564,7 @@ class TestDockerSizeNotationValidator:
             worktree_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
-        assert cfg.docker_memory_limit == "4g"
+        assert cfg.docker_memory_limit == "8g"
 
     def test_invalid_size_with_suffix_gb(self, tmp_path: Path) -> None:
         """'4gb' should fail — only single-char unit suffix is valid."""


### PR DESCRIPTION
## Summary
- Default `docker_memory_limit` changed from `4g` to `8g`
- Claude CLI + Node.js runtime was hitting the 4g cap, causing exit code 137 (OOM kill) on every container

## Test plan
- [x] Docker config tests pass
- [x] Lint clean
- [ ] No more exit code 137 on JS projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)