### PR TITLE
Clean up pipeline gating — remove conflicting disabled workers hack

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -2046,12 +2046,13 @@ def create_router(
 
         from orchestrator import HydraFlowOrchestrator
 
-        # Persist pipeline workers as disabled BEFORE creating the
-        # orchestrator.  _restore_state() reads this on startup so the
-        # workers are disabled from the very first loop iteration —
-        # no race window where they can pick up work.
+        # Remove pipeline workers from the disabled set — pipeline gating
+        # is handled solely by pipeline_enabled flag, not bg_worker_enabled.
         existing_disabled = state.get_disabled_workers()
-        state.set_disabled_workers(existing_disabled | set(_DEFAULT_PIPELINE_WORKERS))
+        pipeline_names = set(_DEFAULT_PIPELINE_WORKERS)
+        cleaned = existing_disabled - pipeline_names
+        if cleaned != existing_disabled:
+            state.set_disabled_workers(cleaned)
 
         new_orch = HydraFlowOrchestrator(
             config,


### PR DESCRIPTION
## Summary
- Removed `set_disabled_workers` call that persisted pipeline worker names to state.json
- Pipeline gating is now solely via `pipeline_enabled` boolean — one mechanism, no conflicts
- Cleans stale pipeline worker names from disabled set on orchestrator start
- Fixes: pipeline data showing in All Repos with no repos running, and bg_worker toggles not working because pipeline workers were stuck in disabled set

## Test plan
- [x] 390 tests pass
- [x] Lint clean
- [ ] Start orchestrator → no pipeline data, no containers spawned
- [ ] Press play on repo → pipeline starts
- [ ] All repos view shows no data until a repo is started
- [ ] Individual worker toggles in System panel work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)