### PR TITLE
Restore registered repos on server startup — fixes 404 and missing transcripts

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -12,6 +12,8 @@ from config import HydraFlowConfig
 from log import setup_logging
 from runtime_config import DEFAULT_LOG_FILE, load_runtime_config
 
+logger = logging.getLogger("hydraflow.server")
+
 
 async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     from dashboard import HydraFlowDashboard  # noqa: PLC0415
@@ -32,6 +34,31 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
 
     repo_store = RepoRegistryStore(config.data_root)
     registry = RepoRuntimeRegistry()
+
+    # Restore previously registered repos into the runtime registry.
+    # The repo store persists to disk, but the registry is in-memory —
+    # without this, added repos are lost on restart and their play
+    # buttons return 404.
+    for record in repo_store.list():
+        if not record.path:
+            continue
+        repo_path = Path(record.path)
+        if not repo_path.is_dir():
+            logger.warning(
+                "Skipping stored repo %s — path %s not found", record.slug, record.path
+            )
+            continue
+        try:
+            repo_cfg = load_runtime_config(
+                overrides={
+                    "repo_root": str(repo_path),
+                    **({"repo": record.slug} if record.slug else {}),
+                }
+            )
+            await registry.register(repo_cfg)
+            logger.info("Restored registered repo %r from store", record.slug)
+        except Exception:
+            logger.warning("Failed to restore repo %s", record.slug, exc_info=True)
 
     async def _register_repo(
         repo_path: Path, slug: str | None


### PR DESCRIPTION
## Summary
The runtime registry is in-memory — on restart, all added repos were lost. This caused:
- Play button returning 404 (runtime not in registry)
- No rolling transcript logs (WS couldn't find the repo's event bus)
- No sessions showing for added repos

Now restores all repos from the persistent store into the registry on server startup.

## Root Cause
`server.py` created an empty `RepoRuntimeRegistry()` but never loaded persisted repos from `RepoRegistryStore`. The store survived restarts but the registry didn't.

## Test plan
- [x] Server tests pass
- [x] Lint clean
- [ ] Restart server → added repo appears with working play button
- [ ] Press play → runtime starts, transcript events flow
- [ ] Rolling logs visible in stream cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)