### PR TITLE
fix: Deserialize cached open PRs as PRListItem on disk load

### DIFF
--- a/src/github_cache.py
+++ b/src/github_cache.py
@@ -217,11 +217,15 @@ class GitHubDataCache:
             fetched_str = raw.get("fetched_at")
             fetched_at = datetime.fromisoformat(fetched_str) if fetched_str else None
 
-            # Load as raw dicts — they'll be replaced by proper models on
-            # the first poll().  Good enough for dashboard display.
             if "open_prs" in raw:
+                from models import PRListItem  # noqa: PLC0415
+
                 self._open_prs = CacheSnapshot(
-                    data=raw["open_prs"], fetched_at=fetched_at
+                    data=[
+                        PRListItem.model_validate(p) if isinstance(p, dict) else p
+                        for p in raw["open_prs"]
+                    ],
+                    fetched_at=fetched_at,
                 )
             if "hitl_items" in raw:
                 self._hitl_items = CacheSnapshot(


### PR DESCRIPTION
## Summary
- GitHub cache loads `open_prs` from disk as raw dicts, but `BotPRLoop` accesses `.author`/`.pr`/`.title` attributes
- Now deserializes them as `PRListItem` models via `model_validate()` on cache load
- Fixes `AttributeError: 'dict' object has no attribute 'author'` on bot_pr_loop startup

## Test plan
- [x] 15 bot_pr_loop tests pass
- [ ] Verify bot PR loop runs clean after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)