### PR TITLE
fix: Launch sentry_ingest loop in orchestrator

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -844,6 +844,7 @@ class HydraFlowOrchestrator:
             ("adr_reviewer", self._svc.adr_reviewer_loop.run),
             ("health_monitor", self._svc.health_monitor_loop.run),
             ("bot_pr", self._svc.bot_pr_loop.run),
+            ("sentry_ingest", self._svc.sentry_loop.run),
             ("github_cache", self._svc.github_cache_loop.run),
             ("pipeline_stats", self._pipeline_stats_loop),
         ]


### PR DESCRIPTION
## Summary
The SentryLoop was registered in BGWorkerManager but never added to `loop_factories` in the orchestrator's `run()`, so it was never actually started.

One-line fix: adds `("sentry_ingest", self._svc.sentry_loop.run)` to the loop list.

## Test plan
- [x] 8 orchestrator integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)