### PR TITLE
docs: Enforce worktree-only workflow in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,19 @@ HydraFlow runs five concurrent async loops from `orchestrator.py`:
 
 HydraFlow creates isolated git worktrees for each issue. **Always clean up worktrees when their PRs are merged or issues are closed. Always implement issue work on a dedicated git worktree branch; do not implement directly in the primary repo checkout.**
 
-**CRITICAL: Always use a worktree for code changes.** Before writing any code, create a worktree with `git worktree add` (manual git commands, NOT the `EnterWorktree` tool which auto-cleans up). Never commit directly to `main` or the current working branch. This prevents conflicts with other sessions and keeps the primary checkout clean.
+**CRITICAL: The `main` branch is protected. Direct commits and pushes to `main` will be rejected.** All code changes — including one-line fixes — MUST go through a worktree branch and a pull request. Never stage, commit, or modify files in the primary repo checkout.
+
+**Workflow for every code change:**
+1. Create a worktree: `git worktree add ../hydraflow-worktrees/<name> origin/main`
+2. Create a branch in the worktree: `git checkout -b <branch-name> origin/main`
+3. Make changes, commit, and push the branch
+4. Create a PR via `gh pr create`
+5. Clean up: `git worktree remove ../hydraflow-worktrees/<name>`
+
+**Do NOT use `EnterWorktree` tool** — it auto-cleans up and loses work. Use manual `git worktree add` commands.
 
 - **Default location:** `../hydraflow-worktrees/` (sibling to repo root)
-- **Naming:** `issue-{issue_number}/`
+- **Naming:** `issue-{issue_number}/` for issue work, descriptive names for other changes
 - **Config:** `worktree_base` field in `HydraFlowConfig`
 - **Cleanup:** `make clean` removes all worktrees and state
 - Worktrees get independent venvs (`uv sync`), symlinked `.env`, and pre-commit hooks
@@ -100,6 +109,10 @@ The `/hf.quality-gate` command runs a structured quality check sequence. Use it 
 ## Never Skip Commit Hooks
 
 **NEVER** use `git commit --no-verify` or `--no-hooks` flags. Always fix code issues first.
+
+## Never Commit to Main
+
+**NEVER** commit directly to `main`. The branch is protected and pushes will be rejected. All changes go through worktree branches and PRs — no exceptions, not even for one-line fixes.
 
 ## Development Commands
 


### PR DESCRIPTION
## Summary
- Clarifies that `main` is protected and all pushes will be rejected
- Adds explicit step-by-step workflow for every code change (worktree → branch → PR)
- Adds "Never Commit to Main" section as a standalone rule
- Agents were modifying files in the primary checkout — this makes the rules unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)