### PR TITLE
fix: Normalize string 'null' in Outcomes tab badges and crate pills

### DIFF
--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -401,7 +401,8 @@ export function OutcomesPanel() {
   const summaryCounts = useMemo(() => {
     const counts = {}
     for (const item of filtered) {
-      const t = item.outcome?.outcome || 'unknown'
+      const rawOutcome = item.outcome?.outcome
+      const t = (!rawOutcome || rawOutcome === 'null') ? 'unknown' : rawOutcome
       counts[t] = (counts[t] || 0) + 1
     }
     return counts
@@ -431,7 +432,7 @@ export function OutcomesPanel() {
     title: (item) => {
       const title = item.title || ''
       const outcomeReason = item.outcome?.reason || ''
-      const hasCrate = item.crate_title != null || item.crate_number != null
+      const hasCrate = (item.crate_title != null && item.crate_title !== 'null') || (item.crate_number != null && String(item.crate_number) !== 'null')
       return (
         <div style={styles.titleCell} title={title || `Issue #${item.issue_number}`}>
           <div style={styles.titleMain}>
@@ -467,7 +468,8 @@ export function OutcomesPanel() {
       <span style={statusStyle(item.status || 'unknown')}>{item.status || 'unknown'}</span>
     ),
     outcome: (item) => {
-      const outcomeType = item.outcome?.outcome || 'pending'
+      const rawOc = item.outcome?.outcome
+      const outcomeType = (!rawOc || rawOc === 'null') ? 'pending' : rawOc
       return (
         <span style={styles.outcomeCell}>
           <span style={outcomeBadgeStyles[outcomeType] || outcomeBadgeStyles.pending}>{(outcomeType || 'pending').replace(/_/g, ' ')}</span>


### PR DESCRIPTION
## Summary
- Normalizes the string `"null"` to proper fallback values in `IssueHistoryPanel.jsx`
- Outcome badges: `"null"` → `"pending"` (line ~470) and `"unknown"` (summary counts, line ~404)
- Crate pills: filters out `"null"` crate_title and crate_number so `#null` pills don't render

## Test plan
- [ ] Verify no "null" badges appear on the Outcomes tab
- [ ] Verify no "#null" crate pills appear in title column
- [ ] Verify items with valid outcomes (merged, failed, etc.) still render correctly
- [ ] Summary pills should not include a "null" entry

Fixes #5833

🤖 Generated with [Claude Code](https://claude.com/claude-code)