### PR TITLE
fix: Only pulse green dot for current live session

### DIFF
--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -232,7 +232,7 @@ export function SessionSidebar() {
                     onMouseLeave={() => setHoveredSession(null)}
                     style={rowStyle}
                   >
-                    <span style={isActive ? styles.dotActive : styles.dotCompleted} />
+                    <span style={isLiveSession ? styles.dotActive : styles.dotCompleted} />
                     <div style={styles.sessionInfo}>
                       <span style={styles.sessionRepo}>{shortRepo(session.repo)}</span>
                       <span style={styles.sessionTime}>


### PR DESCRIPTION
## Summary
- Changed `SessionSidebar.jsx` line 235 to use `isLiveSession` instead of `isActive` for the pulse animation dot
- `isLiveSession` is true only when `isActive && isCurrent`, so only the actual current session pulses green
- All other active sessions show a static green dot instead of blinking

## Test plan
- [ ] Start HydraFlow with an active session
- [ ] Verify only the current session's dot pulses green
- [ ] Verify other today's sessions show static (non-blinking) dots
- [ ] Verify completed sessions still show the completed dot style

Fixes #5814

🤖 Generated with [Claude Code](https://claude.com/claude-code)