### PR TITLE
fix: Remove dead curated knowledge code from InsightsPanel

### DIFF
--- a/src/ui/src/components/InsightsPanel.jsx
+++ b/src/ui/src/components/InsightsPanel.jsx
@@ -341,13 +341,6 @@ function LearningsSection() {
   if (!data) return <div style={styles.empty}>Loading learnings...</div>
   if (data.total_items === 0) return <div style={styles.empty}>No learnings recorded yet.</div>
 
-  const curated = data.curated || {}
-  const hasCurated =
-    curated.overview ||
-    (curated.architecture && curated.architecture.length > 0) ||
-    (curated.key_services && curated.key_services.length > 0) ||
-    (curated.standards && curated.standards.length > 0)
-
   const filterLower = memoryFilter.toLowerCase()
   const filteredItems = (data.items || []).filter((item) => {
     if (!filterLower) return true
@@ -362,52 +355,9 @@ function LearningsSection() {
       <div style={styles.header}>
         <span style={styles.totalBadge}>{data.total_items}</span>
         <span style={styles.headerText}>memory items</span>
-        {data.digest_chars > 0 && (
-          <span style={styles.digestPill}>{Math.round(data.digest_chars / 1000)}k chars in digest</span>
-        )}
       </div>
 
-      {hasCurated && (
-        <LearningsSubSection title="Curated Knowledge" defaultExpanded>
-          {curated.overview && (
-            <div style={styles.section}>
-              <div style={styles.sectionTitle}>Project Overview</div>
-              <div style={styles.overviewText}>{curated.overview}</div>
-            </div>
-          )}
-
-          {curated.architecture && curated.architecture.length > 0 && (
-            <div style={styles.section}>
-              <div style={styles.sectionTitle}>Architecture Notes</div>
-              {curated.architecture.map((note, i) => (
-                <div key={i} style={styles.learningItem}>{note}</div>
-              ))}
-            </div>
-          )}
-
-          {curated.key_services && curated.key_services.length > 0 && (
-            <div style={styles.section}>
-              <div style={styles.sectionTitle}>Key Services</div>
-              <div style={styles.tagCloud}>
-                {curated.key_services.map((svc, i) => (
-                  <span key={i} style={styles.serviceTag}>{svc}</span>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {curated.standards && curated.standards.length > 0 && (
-            <div style={styles.section}>
-              <div style={styles.sectionTitle}>Standards</div>
-              {curated.standards.map((std, i) => (
-                <div key={i} style={styles.learningItem}>{std}</div>
-              ))}
-            </div>
-          )}
-        </LearningsSubSection>
-      )}
-
-      <LearningsSubSection title="Memory Items" defaultExpanded={false}>
+      <LearningsSubSection title="Memory Items" defaultExpanded>
         <div style={styles.section}>
           <input
             type="text"
@@ -710,32 +660,12 @@ const styles = {
     borderBottom: `1px solid ${theme.border}`,
     color: theme.text,
   },
-  digestPill: {
-    fontSize: 11,
-    color: theme.accent,
-    border: `1px solid ${theme.accent}`,
-    borderRadius: 6,
-    padding: '1px 6px',
-  },
-  overviewText: {
-    fontSize: 12,
-    color: theme.text,
-    lineHeight: 1.5,
-  },
   learningItem: {
     fontSize: 12,
     color: theme.text,
     paddingLeft: 12,
     borderLeft: `2px solid ${theme.border}`,
     lineHeight: 1.5,
-  },
-  serviceTag: {
-    fontSize: 11,
-    color: theme.text,
-    background: theme.surfaceInset,
-    border: `1px solid ${theme.border}`,
-    borderRadius: 12,
-    padding: '2px 10px',
   },
   memoryCard: {
     display: 'flex',

--- a/src/ui/src/components/__tests__/InsightsPanel.test.jsx
+++ b/src/ui/src/components/__tests__/InsightsPanel.test.jsx
@@ -18,13 +18,6 @@ const { InsightsPanel } = await import('../InsightsPanel')
 function memoriesPayload(overrides = {}) {
   return {
     total_items: 2,
-    digest_chars: 5000,
-    curated: {
-      overview: 'A multi-agent orchestration system',
-      architecture: ['Async loops', 'Event-driven'],
-      key_services: ['Triage', 'Planner', 'Reviewer'],
-      standards: ['Always write tests'],
-    },
     items: [
       { issue_number: 42, learning: 'Always validate inputs' },
       { issue_number: 55, learning: 'Use async for I/O' },
@@ -83,27 +76,10 @@ describe('InsightsPanel — LearningsSection sub-sections', () => {
     expect(screen.getByText('Learnings')).toBeInTheDocument()
   })
 
-  it('shows Curated Knowledge sub-section with overview and architecture', async () => {
+  it('shows Memory Items sub-section expanded by default with search filtering', async () => {
     render(<InsightsPanel />)
     // Expand Learnings section
     fireEvent.click(screen.getByText('Learnings'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Curated Knowledge')).toBeInTheDocument()
-      expect(screen.getByText('A multi-agent orchestration system')).toBeInTheDocument()
-    })
-  })
-
-  it('shows Memory Items sub-section with search filtering', async () => {
-    render(<InsightsPanel />)
-    fireEvent.click(screen.getByText('Learnings'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Memory Items')).toBeInTheDocument()
-    })
-
-    // Expand Memory Items sub-section
-    fireEvent.click(screen.getByText('Memory Items'))
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText('Filter by issue # or text...')).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- Removed references to `data.curated` and `data.digest_chars` which were dropped from `/api/memories` during the manifest_curator removal (PR #5759/#5804)
- Memory Items section is now default-expanded instead of collapsed behind the (now removed) Curated Knowledge section
- Cleaned up dead styles: `digestPill`, `overviewText`, `serviceTag`

## Test plan
- [x] All 5 InsightsPanel tests pass
- [ ] Verify Learnings section shows memory items when items.jsonl has data
- [ ] Verify Troubleshooting Patterns sub-section still works

Fixes #5826

🤖 Generated with [Claude Code](https://claude.com/claude-code)