### PR TITLE
fix: Hide HITL and Outcomes when pipeline not running

### DIFF
--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -245,8 +245,16 @@ function AppContent() {
               onRequestChanges={handleRequestChanges}
             />
           )}
-          {activeTab === 'outcomes' && <OutcomesPanel />}
-          {activeTab === 'hitl' && <HITLTable items={hitlItems} onRefresh={refreshHitl} />}
+          {activeTab === 'outcomes' && (
+            orchestratorStatus === 'running'
+              ? <OutcomesPanel />
+              : <div style={idleMessage}>Pipeline is not running — outcomes data may be stale.</div>
+          )}
+          {activeTab === 'hitl' && (
+            orchestratorStatus === 'running'
+              ? <HITLTable items={hitlItems} onRefresh={refreshHitl} />
+              : <div style={idleMessage}>Pipeline is not running — HITL actions are unavailable.</div>
+          )}
           {activeTab === 'system' && (
             <SystemPanel
               backgroundWorkers={backgroundWorkers}
@@ -281,6 +289,13 @@ const _alertRefreshBase = {
   color: theme.red,
   marginLeft: 'auto',
   flexShrink: 0,
+}
+
+const idleMessage = {
+  padding: 32,
+  textAlign: 'center',
+  color: theme.dimText,
+  fontSize: 13,
 }
 
 const styles = {


### PR DESCRIPTION
## Summary
- When `orchestratorStatus !== 'running'`, HITL and Outcomes tabs show an idle message instead of stale data
- Prevents users from taking HITL actions (retry/skip/approve) that can't be processed
- Prevents confusion from stale outcomes data when pipeline is idle

## Test plan
- [ ] When pipeline is running: HITL and Outcomes tabs show normal content
- [ ] When pipeline is idle: both tabs show "Pipeline is not running" message
- [ ] Tab switching still works correctly in both states

Fixes #3300

🤖 Generated with [Claude Code](https://claude.com/claude-code)