### PR TITLE
fix: Harden flaky session_start_event test

### DIFF
--- a/tests/test_orchestrator_hooks.py
+++ b/tests/test_orchestrator_hooks.py
@@ -980,9 +980,14 @@ class TestStartSession:
         orch = HydraFlowOrchestrator(config, event_bus=bus)
 
         await orch._start_session()
+        await asyncio.sleep(0)  # Flush pending event-loop callbacks
 
-        events = [e for e in bus.get_history() if e.type == EventType.SESSION_START]
-        assert len(events) == 1
+        history = bus.get_history()
+        events = [e for e in history if e.type == EventType.SESSION_START]
+        assert len(events) == 1, (
+            f"Expected 1 SESSION_START event, got {len(events)}. "
+            f"Total history: {len(history)} events, types: {[e.type for e in history]}"
+        )
         assert events[0].data["repo"] == config.repo
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `test_publishes_session_start_event` failed once in a 5000+ test run (flaky under load)
- Added `await asyncio.sleep(0)` after `_start_session()` to flush pending event-loop callbacks before checking history
- Added diagnostic assertion message to capture all event types if it fails again

## Test plan
- [x] Test passes in isolation
- [x] Test passes with full test_orchestrator_hooks.py suite
- [ ] Passes in full `make test-fast` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)