### PR TITLE
fix: Normalize PR title to canonical format before merge

### DIFF
--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -242,6 +242,18 @@ class PostMergeHandler:
                 if not visual_ok:
                     return
 
+        # Normalize PR title to canonical "Fixes #N: title" before merge
+        # so the merge commit and event history show a consistent format.
+        try:
+            expected_title = self._prs.expected_pr_title(issue.id, issue.title)
+            await self._prs.update_pr_title(pr.number, expected_title)
+        except Exception:
+            logger.debug(
+                "Could not normalize PR #%d title before merge",
+                pr.number,
+                exc_info=True,
+            )
+
         await publish_fn(pr, worker_id, "merging")
         success = await self._prs.merge_pr(pr.number)
         mergeable: bool | None = None


### PR DESCRIPTION
## Summary
- Added `update_pr_title(expected_pr_title())` call in `post_merge_handler.handle_approved()` immediately before `merge_pr()`
- Ensures all merged PRs have consistent "Fixes #N: title" format regardless of manual edits or creation path
- Wrapped in try/except so title normalization failure doesn't block merge

Fixes #5757

🤖 Generated with [Claude Code](https://claude.com/claude-code)