### PR TITLE
feat: CodeGroomingLoop — periodic audit scans filing prioritized issues

### DIFF
--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -1,0 +1,148 @@
+"""Background worker loop — run code audits and file issues for critical findings."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from agent_cli import build_agent_command
+from base_background_loop import BaseBackgroundLoop, LoopDeps
+from config import HydraFlowConfig
+from dedup_store import DedupStore
+from runner_utils import stream_claude_process
+
+if TYPE_CHECKING:
+    from pr_manager import PRManager
+
+logger = logging.getLogger("hydraflow.code_grooming_loop")
+
+# Severities that warrant filing an issue.
+_ACTIONABLE_SEVERITIES = frozenset({"critical", "high"})
+
+
+class CodeGroomingLoop(BaseBackgroundLoop):
+    """Periodically runs code quality audits and files issues for critical findings.
+
+    Invokes the Claude CLI with the ``/hf.audit-code`` skill, parses the
+    output for structured findings, and files GitHub issues for any
+    critical or high severity items.  Uses :class:`DedupStore` to avoid
+    filing duplicate issues for the same finding.
+    """
+
+    _FINDING_RE = re.compile(
+        r"\{[^{}]*\"id\"\s*:\s*\"[^\"]+\"[^{}]*\}",
+        re.DOTALL,
+    )
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        pr_manager: PRManager,
+        deps: LoopDeps,
+    ) -> None:
+        super().__init__(worker_name="code_grooming", config=config, deps=deps)
+        self._pr_manager = pr_manager
+        self._dedup = DedupStore(
+            "code_grooming_findings",
+            config.data_root / "memory" / "code_grooming_dedup.json",
+        )
+
+    def _get_default_interval(self) -> int:
+        return self._config.code_grooming_interval
+
+    async def _run_audit(self) -> list[dict]:
+        """Run the code audit skill and return parsed findings.
+
+        Each finding is expected to be a JSON object with at least
+        ``id``, ``severity``, ``title``, and ``description`` keys.
+        """
+        cmd = build_agent_command(
+            tool=self._config.background_tool
+            if self._config.background_tool != "inherit"
+            else "claude",
+            model=self._config.background_model or "sonnet",
+            max_turns=10,
+        )
+
+        transcript = await stream_claude_process(
+            cmd=cmd,
+            prompt="/hf.audit-code",
+            cwd=self._config.repo_root,
+            active_procs=set(),
+            event_bus=self._bus,
+            event_data={"source": "code_grooming"},
+            logger=logger,
+            gh_token=self._config.gh_token,
+        )
+
+        return self._parse_findings(transcript)
+
+    @classmethod
+    def _parse_findings(cls, transcript: str) -> list[dict]:
+        """Extract structured finding dicts from audit transcript."""
+        findings: list[dict] = []
+        for match in cls._FINDING_RE.finditer(transcript):
+            try:
+                obj = json.loads(match.group(0))
+                if isinstance(obj, dict) and "id" in obj and "severity" in obj:
+                    findings.append(obj)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        return findings
+
+    async def _do_work(self) -> dict[str, Any] | None:
+        if self._config.dry_run:
+            return None
+
+        try:
+            findings = await self._run_audit()
+        except Exception:
+            logger.exception("Code grooming audit failed")
+            return {"filed": 0, "error": True}
+
+        seen = self._dedup.get()
+        filed = 0
+        skipped_dedup = 0
+        skipped_severity = 0
+
+        for finding in findings:
+            finding_id = finding.get("id", "")
+            if not finding_id:
+                continue
+
+            if finding_id in seen:
+                skipped_dedup += 1
+                continue
+
+            severity = finding.get("severity", "").lower()
+            if severity not in _ACTIONABLE_SEVERITIES:
+                skipped_severity += 1
+                continue
+
+            title = f"[Code Grooming] {finding.get('title', 'Code quality finding')}"
+            body = (
+                f"## Code Quality Finding\n\n"
+                f"**ID:** {finding_id}\n"
+                f"**Severity:** {severity}\n\n"
+                f"### Description\n\n"
+                f"{finding.get('description', 'No description available.')}\n"
+            )
+
+            await self._pr_manager.create_issue(title, body, labels=["code-quality"])
+            self._dedup.add(finding_id)
+            filed += 1
+
+            logger.info(
+                "Filed code grooming issue: %s (%s)",
+                finding_id,
+                severity,
+            )
+
+        return {
+            "total_findings": len(findings),
+            "filed": filed,
+            "skipped_dedup": skipped_dedup,
+            "skipped_severity": skipped_severity,
+        }

--- a/src/config.py
+++ b/src/config.py
@@ -110,6 +110,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("sentry_poll_interval", "SENTRY_POLL_INTERVAL", 600),
     ("sentry_min_events", "SENTRY_MIN_EVENTS", 2),
     ("security_patch_interval", "HYDRAFLOW_SECURITY_PATCH_INTERVAL", 3600),
+    ("code_grooming_interval", "HYDRAFLOW_CODE_GROOMING_INTERVAL", 86400),
 ]
 
 _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
@@ -752,6 +753,13 @@ class HydraFlowConfig(BaseModel):
     security_patch_severity_threshold: str = Field(
         default="high",
         description="Minimum severity to file issues for (critical, high, medium, low)",
+    )
+    # Code grooming
+    code_grooming_interval: int = Field(
+        default=86400,
+        ge=3600,
+        le=604800,
+        description="Seconds between code grooming audit cycles",
     )
 
     # Hindsight semantic memory

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -384,6 +384,7 @@ class ConfigFactory:
         hindsight_timeout: int = 30,
         security_patch_interval: int = 3600,
         security_patch_severity_threshold: str = "high",
+        code_grooming_interval: int = 86400,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -604,6 +605,7 @@ class ConfigFactory:
                 hindsight_timeout=hindsight_timeout,
                 security_patch_interval=security_patch_interval,
                 security_patch_severity_threshold=security_patch_severity_threshold,
+                code_grooming_interval=code_grooming_interval,
             )
 
 

--- a/tests/test_code_grooming_loop.py
+++ b/tests/test_code_grooming_loop.py
@@ -1,0 +1,159 @@
+"""Tests for the CodeGroomingLoop background worker."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from code_grooming_loop import CodeGroomingLoop
+from tests.helpers import ConfigFactory, make_bg_loop_deps
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_loop(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+    dry_run: bool = False,
+    code_grooming_interval: int = 86400,
+    existing_dedup: list[str] | None = None,
+) -> tuple[CodeGroomingLoop, AsyncMock, asyncio.Event]:
+    """Build a CodeGroomingLoop with test-friendly defaults."""
+    deps = make_bg_loop_deps(
+        tmp_path,
+        enabled=enabled,
+        dry_run=dry_run,
+        code_grooming_interval=code_grooming_interval,
+    )
+    pr_manager = AsyncMock()
+    pr_manager.create_issue = AsyncMock(return_value=42)
+
+    # Seed dedup store file if needed
+    dedup_path = deps.config.data_root / "memory" / "code_grooming_dedup.json"
+    if existing_dedup:
+        dedup_path.parent.mkdir(parents=True, exist_ok=True)
+        dedup_path.write_text(json.dumps(existing_dedup))
+
+    loop = CodeGroomingLoop(
+        config=deps.config,
+        pr_manager=pr_manager,
+        deps=deps.loop_deps,
+    )
+    return loop, pr_manager, deps.stop_event
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestCodeGroomingLoopBasics:
+    def test_worker_name(self, tmp_path: Path) -> None:
+        loop, _pm, _stop = _make_loop(tmp_path)
+        assert loop._worker_name == "code_grooming"
+
+    def test_default_interval_from_config(self, tmp_path: Path) -> None:
+        loop, _pm, _stop = _make_loop(tmp_path, code_grooming_interval=43200)
+        assert loop._get_default_interval() == 43200
+
+    def test_default_interval_config_field(self) -> None:
+        config = ConfigFactory.create(code_grooming_interval=86400)
+        assert config.code_grooming_interval == 86400
+
+
+class TestCodeGroomingLoopWork:
+    @pytest.mark.asyncio
+    async def test_no_findings_returns_zero(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(tmp_path)
+        # Mock the agent to return no findings
+        with patch.object(loop, "_run_audit", new_callable=AsyncMock, return_value=[]):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 0
+        pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_critical_finding_files_issue(self, tmp_path: Path) -> None:
+        finding = {
+            "id": "dead-code-auth-module",
+            "severity": "critical",
+            "title": "Dead code in auth module",
+            "description": "Unused function handle_legacy_auth in src/auth.py",
+        }
+        loop, pm, _stop = _make_loop(tmp_path)
+        with patch.object(
+            loop, "_run_audit", new_callable=AsyncMock, return_value=[finding]
+        ):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 1
+        pm.create_issue.assert_called_once()
+        call_args = pm.create_issue.call_args
+        assert "[Code Grooming]" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_duplicate_finding_skipped(self, tmp_path: Path) -> None:
+        finding = {
+            "id": "dead-code-auth-module",
+            "severity": "high",
+            "title": "Dead code in auth module",
+            "description": "Unused function",
+        }
+        loop, pm, _stop = _make_loop(tmp_path, existing_dedup=["dead-code-auth-module"])
+        with patch.object(
+            loop, "_run_audit", new_callable=AsyncMock, return_value=[finding]
+        ):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 0
+        assert result["skipped_dedup"] == 1
+        pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_returns_none(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(tmp_path, dry_run=True)
+        result = await loop._do_work()
+        assert result is None
+        pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_agent_failure_caught_gracefully(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(tmp_path)
+        with patch.object(
+            loop,
+            "_run_audit",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("agent crashed"),
+        ):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 0
+        assert result["error"] is True
+        pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_low_severity_finding_skipped(self, tmp_path: Path) -> None:
+        finding = {
+            "id": "minor-style-issue",
+            "severity": "low",
+            "title": "Minor style issue",
+            "description": "Inconsistent naming",
+        }
+        loop, pm, _stop = _make_loop(tmp_path)
+        with patch.object(
+            loop, "_run_audit", new_callable=AsyncMock, return_value=[finding]
+        ):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 0
+        assert result["skipped_severity"] == 1


### PR DESCRIPTION
## Summary
- New `CodeGroomingLoop` background worker extending `BaseBackgroundLoop`
- Runs `/hf.audit-code` skill via Claude CLI, parses structured findings
- Files issues for critical/high severity findings with dedup via DedupStore
- Config: `code_grooming_interval` (24h default)

## Test plan
- [x] 9 TDD tests pass
- [ ] Wire into orchestrator service registry
- [ ] Manual: verify audit runs and findings filed

Fixes #5749

🤖 Generated with [Claude Code](https://claude.com/claude-code)