### PR TITLE
fix: Wire 4 caretaker loops into orchestrator and service registry

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -140,6 +140,10 @@ class HydraFlowOrchestrator:
             "health_monitor": svc.health_monitor_loop,
             "bot_pr": svc.bot_pr_loop,
             "sentry_ingest": svc.sentry_loop,
+            "stale_issue_gc": svc.stale_issue_gc_loop,
+            "ci_monitor": svc.ci_monitor_loop,
+            "security_patch": svc.security_patch_loop,
+            "code_grooming": svc.code_grooming_loop,
         }
         self._bg_workers = BGWorkerManager(config, self._state, bg_loop_registry)
         self._hitl_ctrl = HITLController(svc.hitl_phase, svc.fetcher, config.hitl_label)

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -17,6 +17,8 @@ from base_background_loop import LoopDeps
 from baseline_policy import BaselinePolicy
 from beads_manager import BeadsManager
 from bot_pr_loop import BotPRLoop
+from ci_monitor_loop import CIMonitorLoop  # noqa: TCH001
+from code_grooming_loop import CodeGroomingLoop  # noqa: TCH001
 from config import HydraFlowConfig
 from crate_manager import CrateManager
 from docker_runner import get_docker_runner
@@ -50,7 +52,9 @@ from review_phase import ReviewPhase
 from reviewer import ReviewRunner
 from run_recorder import RunRecorder
 from runs_gc_loop import RunsGCLoop
+from security_patch_loop import SecurityPatchLoop  # noqa: TCH001
 from sentry_loop import SentryLoop  # noqa: TCH001 — used in dataclass field
+from stale_issue_gc_loop import StaleIssueGCLoop  # noqa: TCH001
 from state import StateTracker
 from transcript_summarizer import TranscriptSummarizer
 from triage import TriageRunner
@@ -120,6 +124,10 @@ class ServiceRegistry:
     health_monitor_loop: HealthMonitorLoop
     bot_pr_loop: BotPRLoop
     sentry_loop: SentryLoop
+    stale_issue_gc_loop: StaleIssueGCLoop
+    ci_monitor_loop: CIMonitorLoop
+    security_patch_loop: SecurityPatchLoop
+    code_grooming_loop: CodeGroomingLoop
 
     # Optional integrations
     hindsight: HindsightClient | None = None
@@ -436,6 +444,26 @@ def build_services(
         store=store,
         runner=subprocess_runner,
     )
+    stale_issue_gc_loop = StaleIssueGCLoop(  # noqa: F841
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
+    ci_monitor_loop = CIMonitorLoop(  # noqa: F841
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
+    security_patch_loop = SecurityPatchLoop(  # noqa: F841
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
+    code_grooming_loop = CodeGroomingLoop(  # noqa: F841
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
 
     return ServiceRegistry(
         worktrees=worktrees,
@@ -479,4 +507,8 @@ def build_services(
         github_cache=gh_cache,
         github_cache_loop=gh_cache_loop,
         sentry_loop=sentry_loop,
+        stale_issue_gc_loop=stale_issue_gc_loop,
+        ci_monitor_loop=ci_monitor_loop,
+        security_patch_loop=security_patch_loop,
+        code_grooming_loop=code_grooming_loop,
     )

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -229,4 +229,8 @@ export const BACKGROUND_WORKERS = [
   { key: 'bot_pr', label: 'Bot PR Manager', description: 'Auto-merges dependency update PRs from configured bots after CI passes.', color: theme.green },
   { key: 'health_monitor', label: 'Health Monitor', description: 'Analyzes pipeline trends, auto-tunes parameters, detects knowledge gaps, and ingests log patterns.', color: theme.green, system: true },
   { key: 'sentry_ingest', label: 'Sentry Ingest', description: 'Polls Sentry for unresolved errors and files them as GitHub issues for the pipeline.', color: theme.red },
+  { key: 'stale_issue_gc', label: 'Stale Issue GC', description: 'Auto-closes HITL issues with no activity beyond the configured threshold.', color: theme.textMuted },
+  { key: 'ci_monitor', label: 'CI Monitor', description: 'Detects failing CI on main and files/auto-closes issues.', color: theme.yellow },
+  { key: 'security_patch', label: 'Security Patch', description: 'Polls Dependabot alerts and files issues for fixable vulnerabilities.', color: theme.red },
+  { key: 'code_grooming', label: 'Code Grooming', description: 'Runs periodic audit scans and files issues for critical findings.', color: theme.accent },
 ]


### PR DESCRIPTION
## Summary
- Wired `StaleIssueGCLoop`, `CIMonitorLoop`, `SecurityPatchLoop`, `CodeGroomingLoop` into `ServiceRegistry` and orchestrator `bg_loop_registry`
- All 4 loops were dead code — existed as files but never instantiated or started
- Added 4 new workers to `BACKGROUND_WORKERS` in UI constants for SystemPanel/CaretakerPanel

## Test plan
- [x] All 38 caretaker loop tests pass
- [x] Lint passes
- [ ] Manual: verify workers appear in Caretaker tab and run on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)