### PR TITLE
fix: Final review corrections — env var, fixable check, loading, caretaker panel

### DIFF
--- a/src/ci_monitor_loop.py
+++ b/src/ci_monitor_loop.py
@@ -47,6 +47,7 @@ class CIMonitorLoop(BaseBackgroundLoop):
             logger.warning("CI monitor: could not fetch CI status", exc_info=True)
             return {"error": True}
 
+        # Empty conclusion = no runs or in-progress; treat same as green (no action)
         is_green = conclusion in ("success", "")
 
         if is_green:

--- a/src/config.py
+++ b/src/config.py
@@ -114,6 +114,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
 ]
 
 _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
+    (
+        "security_patch_severity_threshold",
+        "HYDRAFLOW_SECURITY_PATCH_SEVERITY_THRESHOLD",
+        "high",
+    ),
     ("dashboard_host", "HYDRAFLOW_DASHBOARD_HOST", "127.0.0.1"),
     ("test_command", "HYDRAFLOW_TEST_COMMAND", "make test"),
     ("docker_image", "HYDRAFLOW_DOCKER_IMAGE", "ghcr.io/t-rav/hydraflow-agent:latest"),

--- a/src/security_patch_loop.py
+++ b/src/security_patch_loop.py
@@ -56,10 +56,14 @@ class SecurityPatchLoop(BaseBackgroundLoop):
 
     @staticmethod
     def _is_fixable(alert: dict) -> bool:
-        """Return True if the alert has a patched version available."""
+        """Return True if the alert has a patched version with a known identifier."""
         vuln = alert.get("security_vulnerability") or {}
         patched = vuln.get("first_patched_version")
-        return patched is not None
+        if patched is None:
+            return False
+        if isinstance(patched, dict):
+            return bool(patched.get("identifier"))
+        return bool(patched)
 
     @staticmethod
     def _extract_info(alert: dict) -> tuple[str, str, str]:

--- a/src/ui/src/components/CaretakerPanel.jsx
+++ b/src/ui/src/components/CaretakerPanel.jsx
@@ -13,6 +13,8 @@ const CARETAKER_WORKERS = [
   { key: 'worktree_gc', label: 'Worktree GC', description: 'Garbage-collects stale worktrees and orphaned branches.' },
   { key: 'health_monitor', label: 'Health Monitor', description: 'Analyzes pipeline trends, auto-tunes parameters, detects knowledge gaps.' },
   { key: 'epic_sweeper', label: 'Epic Sweeper', description: 'Auto-closes epics with all sub-issues resolved.' },
+  { key: 'security_patch', label: 'Security Patch', description: 'Polls Dependabot alerts and files issues for fixable vulnerabilities.' },
+  { key: 'code_grooming', label: 'Code Grooming', description: 'Runs periodic audit scans and files issues for critical findings.' },
 ]
 
 function relativeTime(isoString) {

--- a/src/ui/src/hooks/useReportPoller.js
+++ b/src/ui/src/hooks/useReportPoller.js
@@ -20,7 +20,10 @@ export function useReportPoller(apiBaseUrl, reporterId, { interval = 10_000 } = 
   const intervalRef = useRef(null)
 
   const fetchReports = useCallback(async () => {
-    if (!reporterId) return
+    if (!reporterId) {
+      setLoading(false)
+      return
+    }
     try {
       const res = await fetch(
         `${apiBaseUrl}/api/reports?reporter_id=${encodeURIComponent(reporterId)}`


### PR DESCRIPTION
## Summary
Fixes from comprehensive session review:
1. `security_patch_severity_threshold` now overridable via `HYDRAFLOW_SECURITY_PATCH_SEVERITY_THRESHOLD` env var
2. `_is_fixable` checks `identifier` field inside `first_patched_version` dict (not just `is not None`)
3. `useReportPoller` sets `loading=false` when `reporterId` is empty (prevents infinite spinner)
4. Added `security_patch` and `code_grooming` to `CaretakerPanel` worker list

## Test plan
- [x] 38 caretaker loop tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)