### PR TITLE
test: Integration tests for caretaker loop wiring, report events, and multi-repo

### DIFF
--- a/tests/test_caretaker_loop_wiring.py
+++ b/tests/test_caretaker_loop_wiring.py
@@ -1,0 +1,168 @@
+"""Integration tests: caretaker loop wiring into ServiceRegistry and orchestrator."""
+
+from __future__ import annotations
+
+import dataclasses
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ci_monitor_loop import CIMonitorLoop
+from code_grooming_loop import CodeGroomingLoop
+from security_patch_loop import SecurityPatchLoop
+from service_registry import ServiceRegistry
+from stale_issue_gc_loop import StaleIssueGCLoop
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+
+
+# ---------------------------------------------------------------------------
+# Task 1a: ServiceRegistry has the four caretaker loop fields with correct types
+# ---------------------------------------------------------------------------
+
+
+class TestServiceRegistryFields:
+    """ServiceRegistry dataclass declares a field for each caretaker loop."""
+
+    _CARETAKER_FIELDS = [
+        ("stale_issue_gc_loop", StaleIssueGCLoop),
+        ("ci_monitor_loop", CIMonitorLoop),
+        ("security_patch_loop", SecurityPatchLoop),
+        ("code_grooming_loop", CodeGroomingLoop),
+    ]
+
+    @pytest.mark.parametrize(
+        "field_name,expected_type",
+        _CARETAKER_FIELDS,
+        ids=[name for name, _ in _CARETAKER_FIELDS],
+    )
+    def test_field_exists_with_correct_type_annotation(
+        self, field_name: str, expected_type: type
+    ) -> None:
+        """ServiceRegistry has a dataclass field whose annotation matches the loop class."""
+        fields_by_name = {f.name: f for f in dataclasses.fields(ServiceRegistry)}
+        assert field_name in fields_by_name, (
+            f"ServiceRegistry is missing field {field_name!r}"
+        )
+        # The annotation is stored as a string (from __future__ annotations) or type.
+        annotation = fields_by_name[field_name].type
+        # Resolve string annotations against the module globals.
+        if isinstance(annotation, str):
+            import service_registry as sr_mod
+
+            resolved = eval(annotation, vars(sr_mod))  # noqa: S307
+        else:
+            resolved = annotation
+        assert resolved is expected_type
+
+
+# ---------------------------------------------------------------------------
+# Task 1b: Each loop is instantiated with the correct class by build_services
+# ---------------------------------------------------------------------------
+
+
+class TestServiceRegistryInstantiation:
+    """build_services creates loop instances of the correct type."""
+
+    _CARETAKER_FIELDS = [
+        ("stale_issue_gc_loop", StaleIssueGCLoop),
+        ("ci_monitor_loop", CIMonitorLoop),
+        ("security_patch_loop", SecurityPatchLoop),
+        ("code_grooming_loop", CodeGroomingLoop),
+    ]
+
+    @pytest.mark.parametrize(
+        "field_name,expected_type",
+        _CARETAKER_FIELDS,
+        ids=[name for name, _ in _CARETAKER_FIELDS],
+    )
+    def test_svc_field_is_correct_type(
+        self,
+        config: HydraFlowConfig,
+        field_name: str,
+        expected_type: type,
+    ) -> None:
+        """HydraFlowOrchestrator._svc.<field> is an instance of the correct class."""
+        from orchestrator import HydraFlowOrchestrator
+
+        orch = HydraFlowOrchestrator(config)
+        svc_obj = getattr(orch._svc, field_name)
+        assert isinstance(svc_obj, expected_type)
+
+
+# ---------------------------------------------------------------------------
+# Task 1c: bg_loop_registry in the orchestrator contains the correct keys
+# ---------------------------------------------------------------------------
+
+
+class TestBGLoopRegistryKeys:
+    """The orchestrator's bg_loop_registry dict has entries for all four caretaker loops."""
+
+    _EXPECTED_KEYS = [
+        ("stale_issue_gc", "stale_issue_gc_loop"),
+        ("ci_monitor", "ci_monitor_loop"),
+        ("security_patch", "security_patch_loop"),
+        ("code_grooming", "code_grooming_loop"),
+    ]
+
+    @pytest.mark.parametrize(
+        "registry_key,svc_field",
+        _EXPECTED_KEYS,
+        ids=[k for k, _ in _EXPECTED_KEYS],
+    )
+    def test_registry_contains_key_mapped_to_svc_field(
+        self,
+        config: HydraFlowConfig,
+        registry_key: str,
+        svc_field: str,
+    ) -> None:
+        """bg_loop_registry[key] is the same object as svc.<field>."""
+        from orchestrator import HydraFlowOrchestrator
+
+        orch = HydraFlowOrchestrator(config)
+        registry = orch._bg_workers._bg_loop_registry
+        assert registry_key in registry, (
+            f"bg_loop_registry missing key {registry_key!r}"
+        )
+        expected_obj = getattr(orch._svc, svc_field)
+        assert registry[registry_key] is expected_obj
+
+
+# ---------------------------------------------------------------------------
+# Task 1d: _get_default_interval returns the config value
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultIntervals:
+    """Each caretaker loop's _get_default_interval returns its config value."""
+
+    _INTERVAL_MAP = [
+        ("stale_issue_gc_loop", "stale_issue_gc_interval"),
+        ("ci_monitor_loop", "ci_monitor_interval"),
+        ("security_patch_loop", "security_patch_interval"),
+        ("code_grooming_loop", "code_grooming_interval"),
+    ]
+
+    @pytest.mark.parametrize(
+        "svc_field,config_attr",
+        _INTERVAL_MAP,
+        ids=[f for f, _ in _INTERVAL_MAP],
+    )
+    def test_default_interval_matches_config(
+        self,
+        config: HydraFlowConfig,
+        svc_field: str,
+        config_attr: str,
+    ) -> None:
+        """loop._get_default_interval() == config.<interval_attr>."""
+        from orchestrator import HydraFlowOrchestrator
+
+        orch = HydraFlowOrchestrator(config)
+        loop_obj = getattr(orch._svc, svc_field)
+        expected = getattr(config, config_attr)
+        assert loop_obj._get_default_interval() == expected

--- a/tests/test_report_event_flow.py
+++ b/tests/test_report_event_flow.py
@@ -1,0 +1,162 @@
+"""Integration test: report pipeline event flow through a real EventBus."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from events import EventType
+from models import PendingReport, TrackedReport
+from report_issue_loop import ReportIssueLoop
+from state import StateTracker
+from tests.helpers import make_bg_loop_deps
+
+
+def _make_loop(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+) -> tuple[ReportIssueLoop, StateTracker, MagicMock]:
+    """Build a ReportIssueLoop wired to a real EventBus (from make_bg_loop_deps).
+
+    Returns (loop, state, pr_manager).
+    """
+    deps = make_bg_loop_deps(tmp_path, enabled=enabled)
+
+    state = StateTracker(tmp_path / "state.json")
+    pr_manager = MagicMock()
+    pr_manager.upload_screenshot = AsyncMock(return_value="")
+    pr_manager.upload_screenshot_gist = AsyncMock(return_value="")
+    pr_manager.create_issue = AsyncMock(return_value=123)
+    pr_manager.add_labels = AsyncMock()
+    pr_manager._run_gh = AsyncMock(return_value='{"labels":[],"body":""}')
+    pr_manager._repo = "owner/repo"
+    runner = MagicMock()
+
+    loop = ReportIssueLoop(
+        config=deps.config,
+        state=state,
+        pr_manager=pr_manager,
+        deps=deps.loop_deps,
+        runner=runner,
+    )
+    return loop, state, pr_manager
+
+
+class TestReportEventFlow:
+    """End-to-end event flow: enqueue report -> _do_work -> verify bus history."""
+
+    @pytest.mark.asyncio
+    async def test_successful_report_emits_in_progress_then_filed(
+        self, tmp_path: Path
+    ) -> None:
+        """A successfully processed report emits REPORT_UPDATE events:
+        first with status=in-progress, then status=filed with issue_number.
+        """
+        loop, state, _pr = _make_loop(tmp_path)
+
+        # Enqueue a pending report *and* a tracked report so state updates work.
+        report = PendingReport(description="Login button does not respond")
+        state.enqueue_report(report)
+        tracked = TrackedReport(
+            id=report.id,
+            reporter_id="user-1",
+            description=report.description,
+        )
+        state.add_tracked_report(tracked)
+
+        fake_issue_url = "https://github.com/owner/repo/issues/42"
+
+        with patch(
+            "report_issue_loop.stream_claude_process",
+            new_callable=AsyncMock,
+        ) as mock_stream:
+            mock_stream.return_value = (
+                f"I created the issue here: {fake_issue_url}\nDone."
+            )
+            result = await loop._do_work()
+
+        # Basic result checks
+        assert result is not None
+        assert result["processed"] == 1
+        assert result["issue_number"] == 42
+
+        # Inspect the real EventBus history
+        history = loop._bus.get_history()
+        report_events = [e for e in history if e.type == EventType.REPORT_UPDATE]
+
+        # We expect at least 2 REPORT_UPDATE events: in-progress and filed
+        assert len(report_events) >= 2, (
+            f"Expected at least 2 REPORT_UPDATE events, got {len(report_events)}: "
+            f"{[e.data for e in report_events]}"
+        )
+
+        # First event: in-progress
+        first = report_events[0]
+        assert first.data["report_id"] == report.id
+        assert first.data["status"] == "in-progress"
+
+        # Second event: filed with issue_number
+        second = report_events[1]
+        assert second.data["report_id"] == report.id
+        assert second.data["status"] == "filed"
+        assert second.data["issue_number"] == 42
+
+    @pytest.mark.asyncio
+    async def test_no_reports_emits_no_events(self, tmp_path: Path) -> None:
+        """When the queue is empty, _do_work returns None and no events are emitted."""
+        loop, _state, _pr = _make_loop(tmp_path)
+
+        result = await loop._do_work()
+        assert result is None
+
+        history = loop._bus.get_history()
+        report_events = [e for e in history if e.type == EventType.REPORT_UPDATE]
+        assert len(report_events) == 0
+
+    @pytest.mark.asyncio
+    async def test_failed_report_emits_in_progress_only(self, tmp_path: Path) -> None:
+        """When the agent fails to extract an issue number, we still get the
+        in-progress event but no filed event.
+        """
+        loop, state, _pr = _make_loop(tmp_path)
+
+        report = PendingReport(description="Crash on page load")
+        state.enqueue_report(report)
+        tracked = TrackedReport(
+            id=report.id,
+            reporter_id="user-2",
+            description=report.description,
+        )
+        state.add_tracked_report(tracked)
+
+        with patch(
+            "report_issue_loop.stream_claude_process",
+            new_callable=AsyncMock,
+        ) as mock_stream:
+            # Return transcript with no issue URL
+            mock_stream.return_value = "I was unable to create the issue."
+            result = await loop._do_work()
+
+        # Result indicates failure (processed=0)
+        assert result is not None
+        assert result["processed"] == 0
+
+        history = loop._bus.get_history()
+        report_events = [e for e in history if e.type == EventType.REPORT_UPDATE]
+
+        # Should have the in-progress event
+        in_progress_events = [
+            e for e in report_events if e.data.get("status") == "in-progress"
+        ]
+        assert len(in_progress_events) == 1
+        assert in_progress_events[0].data["report_id"] == report.id
+
+        # Should NOT have a filed event
+        filed_events = [e for e in report_events if e.data.get("status") == "filed"]
+        assert len(filed_events) == 0


### PR DESCRIPTION
## Summary
- `test_caretaker_loop_wiring.py` — Verifies all 4 caretaker loops are registered in ServiceRegistry and orchestrator bg_loop_registry
- `test_report_event_flow.py` — End-to-end test: submit report → verify REPORT_UPDATE events fire with correct data
- `test_multi_repo_integration.py` — Multi-repo lifecycle: RepoRegistryStore CRUD, RepoRuntimeRegistry isolation, RepoRuntime state independence

## Test plan
- [x] 26 integration tests pass

Fixes #3250 (partially — adds integration coverage)
Closes #5747 (multi-repo infrastructure verified as complete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)