### PR TITLE
fix: Final audit — WebSocket events, CI dedup, interval bounds, DRY panel

### DIFF
--- a/src/ci_monitor_loop.py
+++ b/src/ci_monitor_loop.py
@@ -31,15 +31,34 @@ class CIMonitorLoop(BaseBackgroundLoop):
             deps=deps,
         )
         self._prs = pr_manager
-        self._open_issue: int | None = None  # Track open CI-failure issue
+        self._open_issue: int | None = None
+        self._startup_check_done = False
 
     def _get_default_interval(self) -> int:
         return self._config.ci_monitor_interval
+
+    async def _rehydrate_open_issue(self) -> None:
+        """On first cycle, check if an open CI failure issue already exists."""
+        if self._startup_check_done:
+            return
+        self._startup_check_done = True
+        try:
+            issues = await self._prs.list_issues_by_label("hydraflow-ci-failure")
+            if issues:
+                self._open_issue = issues[0].get("number")
+                logger.info(
+                    "CI monitor: rehydrated open issue #%s from previous run",
+                    self._open_issue,
+                )
+        except Exception:
+            logger.debug("CI monitor: could not rehydrate open issue", exc_info=True)
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Check CI status and create/close issues as needed."""
         if self._config.dry_run:
             return None
+
+        await self._rehydrate_open_issue()
 
         try:
             conclusion, run_url = await self._prs.get_latest_ci_status()
@@ -91,7 +110,9 @@ class CIMonitorLoop(BaseBackgroundLoop):
                 "This issue was auto-created by the CI health monitor. "
                 "It will be auto-closed when CI recovers."
             )
-            issue_number = await self._prs.create_issue(title, body)
+            issue_number = await self._prs.create_issue(
+                title, body, labels=["hydraflow-ci-failure"]
+            )
             self._open_issue = issue_number
             logger.info(
                 "CI monitor: filed issue #%d for CI failure (%s)",

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -36,6 +36,10 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "pipeline_poller": (5, 14400),
     "adr_reviewer": (28800, 432000),
     "verify_monitor": (60, 86400),
+    "stale_issue_gc": (300, 86400),
+    "ci_monitor": (60, 86400),
+    "security_patch": (300, 86400),
+    "code_grooming": (3600, 604800),
 }
 
 # Internal pipeline labels that must not be treated as epic names in the history panel.

--- a/src/ui/src/components/CaretakerPanel.jsx
+++ b/src/ui/src/components/CaretakerPanel.jsx
@@ -1,21 +1,18 @@
 import React from 'react'
 import { theme } from '../theme'
+import { BACKGROUND_WORKERS } from '../constants'
 import { useHydraFlow } from '../context/HydraFlowContext'
 
 /**
- * Caretaker workers — maintenance and operational background loops.
- * These are the workers shown in the dedicated Caretaker tab.
+ * Keys of caretaker workers — maintenance and operational background loops.
+ * Descriptions and labels come from BACKGROUND_WORKERS in constants.js (DRY).
  */
-const CARETAKER_WORKERS = [
-  { key: 'stale_issue_gc', label: 'Stale Issue GC', description: 'Auto-closes HITL issues with no activity beyond threshold.' },
-  { key: 'ci_monitor', label: 'CI Monitor', description: 'Detects failing CI on main and files/closes issues.' },
-  { key: 'bot_pr', label: 'Bot PR Manager', description: 'Auto-merges dependency update PRs from configured bots after CI passes.' },
-  { key: 'worktree_gc', label: 'Worktree GC', description: 'Garbage-collects stale worktrees and orphaned branches.' },
-  { key: 'health_monitor', label: 'Health Monitor', description: 'Analyzes pipeline trends, auto-tunes parameters, detects knowledge gaps.' },
-  { key: 'epic_sweeper', label: 'Epic Sweeper', description: 'Auto-closes epics with all sub-issues resolved.' },
-  { key: 'security_patch', label: 'Security Patch', description: 'Polls Dependabot alerts and files issues for fixable vulnerabilities.' },
-  { key: 'code_grooming', label: 'Code Grooming', description: 'Runs periodic audit scans and files issues for critical findings.' },
-]
+const CARETAKER_KEYS = new Set([
+  'stale_issue_gc', 'ci_monitor', 'bot_pr', 'worktree_gc',
+  'health_monitor', 'epic_sweeper', 'security_patch', 'code_grooming',
+])
+
+const CARETAKER_WORKERS = BACKGROUND_WORKERS.filter(w => CARETAKER_KEYS.has(w.key))
 
 function relativeTime(isoString) {
   if (!isoString) return 'never'

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -553,6 +553,19 @@ export function reducer(state, action) {
       return { ...state, pipelineStats: action.data }
     }
 
+    case 'report_update':
+    case 'REPORT_UPDATE': {
+      // A tracked report changed status — update inline if we have a matching report,
+      // otherwise the next poll cycle will pick it up.
+      const reportId = action.data?.report_id
+      const newStatus = action.data?.status
+      if (!reportId || !newStatus) return state
+      const updated = state.trackedReports.map(r =>
+        r.id === reportId ? { ...r, status: newStatus } : r
+      )
+      return { ...state, trackedReports: updated }
+    }
+
     case 'WS_PIPELINE_UPDATE': {
       const { issueNumber, fromStage, toStage, status: pipeStatus } = action.data
       const next = { ...state.pipelineIssues }


### PR DESCRIPTION
## Summary
Fixes from comprehensive final audit:

1. **Critical:** `report_update` WebSocket events now handled in reducer — updates trackedReports inline for live status feedback
2. **High:** CIMonitorLoop rehydrates `_open_issue` from GitHub on startup via `hydraflow-ci-failure` label — prevents duplicate issues on restart
3. **Medium:** Added 4 new loops to `_INTERVAL_BOUNDS` — enables interval editing via dashboard API
4. **Low:** CaretakerPanel derives worker list from `BACKGROUND_WORKERS` constant (DRY)

## Remaining known items (accepted/deferred):
- CodeGroomingLoop `_FINDING_RE` regex may miss nested JSON — documented, will fix when audit skill output format is stabilized
- `onOpenReportModal` not wired in Reports tab — users use the header Report button
- Code grooming enabled by default — intentional, documented

## Test plan
- [x] 8 CI monitor tests pass
- [x] 7 CaretakerPanel tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)