### PR TITLE
docs: ADRs for report pipeline, caretaker loops, and routes decomposition

### DIFF
--- a/docs/adr/0028-event-driven-report-pipeline.md
+++ b/docs/adr/0028-event-driven-report-pipeline.md
@@ -1,0 +1,42 @@
+# ADR-0028: Event-Driven Report Pipeline with Extractable Widget
+
+## Status
+
+Accepted
+
+## Context
+
+The bug report pipeline (`ReportIssueLoop`) silently updated `TrackedReport` status on disk but never notified the frontend. Users submitted bugs and saw "queued" indefinitely until the next 30-second HTTP poll. The `BugReportTracker` was a modal with no filtering, sorting, or inline submission — unusable for power users.
+
+Additionally, the report UI needed to be extractable as a standalone widget for embedding in external systems (other dashboards, Slack bots, monitoring tools) without depending on the HydraFlow React context.
+
+## Decision
+
+### Backend: Publish `REPORT_UPDATE` events at every status transition
+
+Added `EventType.REPORT_UPDATE` to the `EventBus`. `ReportIssueLoop._do_work()` now publishes events at 6 transition points: queued→in-progress, filed, retry, escalation, stale close, and fixed. The frontend reducer handles `report_update` WebSocket events to update `trackedReports` inline.
+
+**Why events over direct state mutation:** The `EventBus` is the established notification mechanism. WebSocket subscribers receive events automatically. Metrics and logging can also react. This is consistent with how `WORKER_UPDATE`, `MERGE_UPDATE`, etc. already work.
+
+### Frontend: Self-contained `useReportPoller` hook + `BugReportPanel` component
+
+Replaced the `BugReportTracker` modal with a full-width `BugReportPanel` dashboard tab. The panel uses `useReportPoller(apiBaseUrl, reporterId, { interval })` — a hook that manages its own polling, submission, and action dispatch.
+
+**Why HTTP polling over WebSocket-only:** The widget must work outside the HydraFlow dashboard where no WebSocket connection exists. HTTP polling at 10s intervals is portable — any system with HTTP access can embed it. The WebSocket `report_update` handler provides instant updates when available, and the poll catches up when it's not.
+
+**Why a hook, not context:** `useReportPoller` takes `apiBaseUrl` and `reporterId` as explicit props. No `HydraFlowProvider` needed. This makes the component truly extractable:
+
+```jsx
+<BugReportPanel apiBaseUrl="https://hydra.example.com" reporterId={userId} />
+```
+
+### Server: Status filter on `GET /api/reports`
+
+Added `?status=` query parameter to `GET /api/reports` for server-side filtering. The `useReportPoller` can request only active reports, reducing payload size for embedded widgets.
+
+## Consequences
+
+- Report status updates are live via WebSocket when available, polled via HTTP otherwise
+- The `BugReportPanel` can be extracted to a standalone npm package with zero HydraFlow dependencies
+- The old `BugReportTracker` modal and its tests were deleted
+- `REPORT_UPDATE` events appear in the WebSocket stream alongside all other events — external monitoring tools can subscribe

--- a/docs/adr/0029-caretaker-loop-pattern.md
+++ b/docs/adr/0029-caretaker-loop-pattern.md
@@ -1,0 +1,51 @@
+# ADR-0029: Caretaker Background Loop Pattern
+
+## Status
+
+Accepted
+
+## Context
+
+HydraFlow needed proactive maintenance workers — auto-closing stale issues, monitoring CI health, patching security vulnerabilities, and running code audits. These are "caretaker" concerns: low-priority, periodic, zero-token (except code grooming), and independent of the main pipeline.
+
+Four new loops were needed: `StaleIssueGCLoop`, `CIMonitorLoop`, `SecurityPatchLoop`, `CodeGroomingLoop`.
+
+## Decision
+
+### Pattern: Extend `BaseBackgroundLoop` with `DedupStore`
+
+All 4 loops follow the same pattern:
+
+1. **Extend `BaseBackgroundLoop`** — provides the polling loop, enabled/disabled check, error handling, status publishing, and interval management
+2. **Constructor takes `(config, pr_manager, deps: LoopDeps)`** — minimal dependencies, no direct state coupling
+3. **`_do_work()` returns a stats dict** — consumed by the `BACKGROUND_WORKER_STATUS` event for dashboard display
+4. **`DedupStore` for idempotency** — `SecurityPatchLoop` and `CodeGroomingLoop` track processed items to avoid filing duplicate issues across restarts
+
+### Wiring: ServiceRegistry + BGWorkerManager
+
+Each loop is:
+1. Instantiated in `build_services()` with `# noqa: F841` to suppress unused-variable lint
+2. Added as a field to the `ServiceRegistry` dataclass
+3. Registered in the orchestrator's `bg_loop_registry` dict by worker name
+4. Listed in `BACKGROUND_WORKERS` in `ui/src/constants.js` for dashboard display
+
+### Config: Interval + threshold fields with env var overrides
+
+Each loop gets a config field with `ge`/`le` validation and an `_ENV_INT_OVERRIDES` entry:
+- `stale_issue_gc_interval` (300-86400, default 3600)
+- `ci_monitor_interval` (60-86400, default 300)
+- `security_patch_interval` (300-86400, default 3600)
+- `code_grooming_interval` (3600-604800, default 86400)
+
+Intervals are also in `_INTERVAL_BOUNDS` in `_common.py` for dashboard API editing.
+
+### CaretakerPanel: Dedicated dashboard tab
+
+A dedicated "Caretaker" tab shows all maintenance workers with status dots, last-run times, enable/disable toggles, and manual trigger buttons. Worker definitions are derived from `BACKGROUND_WORKERS` constant (DRY).
+
+## Consequences
+
+- Adding a new caretaker loop requires: 1 file, 1 test file, 3 wiring points (service_registry, orchestrator, constants.js), 1 config field
+- All caretaker loops are enabled by default — operators can disable via dashboard or env vars
+- `CIMonitorLoop` persists its open-issue tracker via a GitHub label (`hydraflow-ci-failure`) to survive restarts
+- `DedupStore` files persist across restarts, preventing duplicate issue creation

--- a/docs/adr/0030-routes-domain-decomposition.md
+++ b/docs/adr/0030-routes-domain-decomposition.md
@@ -1,0 +1,51 @@
+# ADR-0030: Dashboard Routes Domain Decomposition
+
+## Status
+
+Accepted
+
+## Context
+
+`src/dashboard_routes/_routes.py` was 4,178 lines with 95 route handlers in a single `create_router()` function. Route handlers captured 17+ closure variables (config, event_bus, state, pr_manager, etc.). Navigation, testing, and modification were difficult.
+
+A `RouteContext` dataclass already existed (ADR-0007) bundling all dependencies, but all routes remained in one file.
+
+## Decision
+
+### Pattern: `register(router, ctx)` functions in domain files
+
+Extracted 70 route handlers into 7 domain-specific files, each exporting a `register(router: APIRouter, ctx: RouteContext) -> None` function:
+
+| Module | Routes | Scope |
+|--------|--------|-------|
+| `_epic_routes.py` | 3 | Epic tracking and release |
+| `_crates_routes.py` | 9 | Crate CRUD, items, active, advance |
+| `_hitl_routes.py` | 9 | HITL management, human-input |
+| `_control_routes.py` | 13 | Pipeline control, admin tasks, bot-pr settings |
+| `_metrics_routes.py` | 12 | Metrics, insights, runs, artifacts |
+| `_reports_routes.py` | 5 | Bug report submission and tracking |
+| `_state_routes.py` | 19 | Runtimes, repos, filesystem, GitHub |
+
+### Why `register()` over `include_router()`
+
+FastAPI's `include_router` with prefix mounting would change URL paths (e.g., `/api/control/start` becomes a sub-router concern). Since existing tests use `find_endpoint(router, "/api/control/start")` to locate handlers, changing the routing structure would break all 381 dashboard tests.
+
+The `register(router, ctx)` pattern is simpler: each domain function decorates the shared router directly. No URL changes, no test changes, no prefix management. The domain files are just organizational — the runtime behavior is identical.
+
+### What stays in `_routes.py`
+
+`RouteContext` dataclass, `create_router()` coordinator, issue history routes (complex cache infrastructure), core routes (healthz, pipeline, sessions, websocket, SPA catchall), and all shared helper functions. This reduced `_routes.py` from 4,178 to 2,019 lines (52% reduction).
+
+### Import structure
+
+- Domain files import `RouteContext` from `dashboard_routes._routes` (direct, not via package)
+- `_routes.py` imports domain files only inside `create_router()` (local imports, deferred)
+- `__init__.py` re-exports public symbols from `_routes.py` and `_common.py`
+- No circular import risk
+
+## Consequences
+
+- `_routes.py` is now navigable — 2,019 lines with a clear table of contents via the `_register_*` calls in `create_router()`
+- Adding a new route domain: create `_<domain>_routes.py`, add a `register()` call in `create_router()`
+- All 381 existing tests pass without modification (except 2 monkeypatch target updates)
+- Further decomposition of the remaining 25 core routes is possible using the same pattern


### PR DESCRIPTION
## Summary
Three ADRs documenting the architectural decisions from today's session:

- **ADR-0028:** Event-driven report pipeline with extractable widget — why REPORT_UPDATE events + HTTP polling + self-contained useReportPoller hook
- **ADR-0029:** Caretaker background loop pattern — BaseBackgroundLoop + DedupStore for StaleIssueGC, CIMonitor, SecurityPatch, CodeGrooming
- **ADR-0030:** Dashboard routes domain decomposition — register(router, ctx) pattern, 4,178→2,019 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)