### PR TITLE
feat: Per-issue reflections.txt for cross-cycle learning

### DIFF
--- a/src/reflections.py
+++ b/src/reflections.py
@@ -1,0 +1,70 @@
+"""Per-issue reflections — append-only learning file for cross-cycle context.
+
+Each issue gets a `reflections.txt` that accumulates learnings across
+implementation, review, and retry cycles. The planner and implement
+phases read it before starting work so each cycle benefits from
+previous discoveries.
+
+Inspired by the Ralph pattern (snarktank/ralph).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from config import HydraFlowConfig
+
+logger = logging.getLogger("hydraflow.reflections")
+
+
+def _reflections_path(config: HydraFlowConfig, issue_number: int) -> Path:
+    """Return the reflections file path for an issue."""
+    return config.data_root / "reflections" / f"issue-{issue_number}.txt"
+
+
+def read_reflections(config: HydraFlowConfig, issue_number: int) -> str:
+    """Read the reflections file for an issue. Returns empty string if none."""
+    path = _reflections_path(config, issue_number)
+    if not path.exists():
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        logger.debug("Could not read reflections for issue #%d", issue_number)
+        return ""
+
+
+def append_reflection(
+    config: HydraFlowConfig,
+    issue_number: int,
+    phase: str,
+    content: str,
+) -> None:
+    """Append a learning entry to the issue's reflections file."""
+    path = _reflections_path(config, issue_number)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    entry = f"\n--- {phase} | {timestamp} ---\n{content.strip()}\n"
+
+    try:
+        with path.open("a", encoding="utf-8") as f:
+            f.write(entry)
+        logger.debug(
+            "Appended %s reflection for issue #%d (%d chars)",
+            phase,
+            issue_number,
+            len(content),
+        )
+    except OSError:
+        logger.warning(
+            "Could not write reflection for issue #%d", issue_number, exc_info=True
+        )
+
+
+def clear_reflections(config: HydraFlowConfig, issue_number: int) -> None:
+    """Remove the reflections file for an issue (e.g., after merge)."""
+    path = _reflections_path(config, issue_number)
+    path.unlink(missing_ok=True)

--- a/tests/test_reflections.py
+++ b/tests/test_reflections.py
@@ -1,0 +1,69 @@
+"""Tests for per-issue reflections file."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from reflections import append_reflection, clear_reflections, read_reflections
+from tests.helpers import ConfigFactory
+
+
+class TestReflections:
+    def test_read_empty(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        assert read_reflections(config, 42) == ""
+
+    def test_append_and_read(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "implement", "Found that auth module uses JWT")
+        content = read_reflections(config, 42)
+        assert "implement" in content
+        assert "Found that auth module uses JWT" in content
+
+    def test_multiple_appends_accumulate(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "implement", "First attempt failed — wrong API")
+        append_reflection(config, 42, "review", "Reviewer noted missing error handling")
+        append_reflection(
+            config, 42, "implement", "Fixed error handling, retry succeeded"
+        )
+        content = read_reflections(config, 42)
+        # Each entry has "--- phase | timestamp ---" = 2 occurrences of "---" per entry
+        assert content.count("--- implement") + content.count("--- review") == 3
+        assert "First attempt" in content
+        assert "Reviewer noted" in content
+        assert "Fixed error" in content
+
+    def test_entries_have_timestamps(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "plan", "Codebase uses factory pattern")
+        content = read_reflections(config, 42)
+        assert "UTC" in content
+
+    def test_entries_have_phase(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "triage", "Low complexity, skip planning")
+        content = read_reflections(config, 42)
+        assert "triage" in content
+
+    def test_separate_issues_separate_files(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "implement", "Issue 42 learning")
+        append_reflection(config, 99, "implement", "Issue 99 learning")
+        assert "Issue 42" in read_reflections(config, 42)
+        assert "Issue 99" in read_reflections(config, 99)
+        assert "Issue 99" not in read_reflections(config, 42)
+
+    def test_clear_removes_file(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        append_reflection(config, 42, "implement", "Some learning")
+        assert read_reflections(config, 42) != ""
+        clear_reflections(config, 42)
+        assert read_reflections(config, 42) == ""
+
+    def test_clear_nonexistent_is_safe(self, tmp_path: Path) -> None:
+        config = ConfigFactory.create(repo_root=tmp_path)
+        clear_reflections(config, 999)  # Should not raise


### PR DESCRIPTION
## Summary
Append-only `reflections.txt` per issue that accumulates learnings across implementation, review, and retry cycles.

- `read_reflections(config, issue_number)` — read all previous learnings
- `append_reflection(config, issue_number, phase, content)` — add a timestamped entry
- `clear_reflections(config, issue_number)` — cleanup after merge

Files stored at `{data_root}/reflections/issue-{N}.txt`. Each entry tagged with phase (triage/plan/implement/review) and UTC timestamp.

Inspired by the Ralph pattern (snarktank/ralph) — lightweight alternative to Hindsight for fast intra-issue context.

## Test plan
- [x] 8 tests pass (empty read, append, accumulate, timestamps, phases, isolation, clear, clear-safe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)