### PR TITLE
fix: Route bug reports and Sentry issues through plan phase

### DIFF
--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -279,15 +279,16 @@ class ReportIssueLoop(BaseBackgroundLoop):
                     "broken image."
                 )
 
-        # Use hydraflow-ready so bug reports skip triage/planning and go
-        # straight to implementation.
-        ready_label = (
-            self._config.ready_label[0]
-            if self._config.ready_label
-            else "hydraflow-ready"
+        # Use hydraflow-plan so bug reports go through the planning phase
+        # (lite plan auto-detected) before implementation. This ensures every
+        # issue has a plan comment that the implement agent can reference.
+        plan_label = (
+            self._config.planner_label[0]
+            if self._config.planner_label
+            else "hydraflow-plan"
         )
         description += (
-            f"\n\nIMPORTANT: Use the label `{ready_label}` instead of "
+            f"\n\nIMPORTANT: Use the label `{plan_label}` instead of "
             f"`hydraflow-find` for this issue."
         )
 
@@ -331,7 +332,7 @@ class ReportIssueLoop(BaseBackgroundLoop):
 
         if issue_number > 0:
             # Verify the agent applied the correct label and screenshot
-            await self._verify_issue(issue_number, ready_label, screenshot_url)
+            await self._verify_issue(issue_number, plan_label, screenshot_url)
 
             issue_url = f"https://github.com/{self._config.repo}/issues/{issue_number}"
 

--- a/src/sentry_loop.py
+++ b/src/sentry_loop.py
@@ -245,10 +245,10 @@ class SentryLoop(BaseBackgroundLoop):
         permalink = sentry_issue.get("permalink", "")
         short_id = sentry_issue.get("shortId", sentry_id)
 
-        ready_label = (
-            self._config.ready_label[0]
-            if self._config.ready_label
-            else "hydraflow-ready"
+        _plan_lbl = (  # noqa: F841
+            self._config.planner_label[0]
+            if self._config.planner_label
+            else "hydraflow-plan"
         )
 
         parts = [
@@ -263,7 +263,7 @@ class SentryLoop(BaseBackgroundLoop):
             parts.append(f"\nStack trace:\n```\n{stacktrace}\n```")
 
         parts.append(
-            f"\nIMPORTANT: Use the label `{ready_label}` instead of "
+            f"\nIMPORTANT: Use the label `{_plan_lbl}` instead of "
             f"`hydraflow-find` for this issue."
         )
         parts.append(


### PR DESCRIPTION
## Summary
Bug reports and Sentry issues were labeled `hydraflow-ready`, skipping both triage AND planning. The implement agent had no plan to work from.

Changed both `report_issue_loop.py` and `sentry_loop.py` to use `hydraflow-plan` instead. The plan phase auto-detects these as lite plans (short body, bug labels) and generates a quick plan before implementation.

## Impact
- Every issue now gets a plan comment before implementation
- Lite plans are fast (~30s) — minimal latency added
- Implement agent gets context it was missing

## Test plan
- [x] 84 tests pass (report_issue_loop + sentry_loop)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)