### PR TITLE
fix: Wire reflections into implement phase + fix scaffold LoopDeps

### DIFF
--- a/scripts/scaffold_loop.py
+++ b/scripts/scaffold_loop.py
@@ -102,6 +102,7 @@ def _generate_test_file(worker_name: str, label: str, interval: int) -> str:
                 status_cb=MagicMock(),
                 enabled_cb=MagicMock(return_value=True),
                 sleep_fn=MagicMock(),
+                interval_cb=None,
             )
             return {cls}(config=config, deps=deps)
 

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -232,7 +232,33 @@ class ImplementPhase:
                 logger.debug("Run recording setup failed", exc_info=True)
                 ctx = None
 
+        # Inject prior reflections into the issue context so the agent
+        # benefits from learnings accumulated in previous cycles.
+        from reflections import append_reflection, read_reflections  # noqa: PLC0415
+
+        prior_reflections = read_reflections(self._config, issue.id)
+        if prior_reflections:
+            issue.body = (issue.body or "") + (
+                f"\n\n## Prior Reflections\n\n{prior_reflections}"
+            )
+
         result = await self._run_implementation(issue, branch, idx, review_feedback)
+
+        # Record a reflection for future cycles
+        if result.error:
+            append_reflection(
+                self._config,
+                issue.id,
+                "implement",
+                f"Attempt {idx} failed: {result.error[:200]}",
+            )
+        elif result.success:
+            append_reflection(
+                self._config,
+                issue.id,
+                "implement",
+                f"Attempt {idx} succeeded on branch {branch}.",
+            )
 
         # Finalize the recording
         if ctx is not None:


### PR DESCRIPTION
## Summary
1. **reflections.py was dead code** — now wired into `implement_phase.py`:
   - Reads prior reflections before each implementation attempt (injected into issue body)
   - Appends success/failure reflection after each attempt
   - Each retry cycle benefits from previous cycle's discoveries
2. **scaffold_loop.py** generated `LoopDeps` without `interval_cb` (required field) — fixed

## Test plan
- [x] 105 tests pass (8 reflections + 97 implement_phase)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)