### PR TITLE
fix: Reports back to modal, caretaker always shows workers

### DIFF
--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -7,17 +7,13 @@ import { SystemPanel } from './components/SystemPanel'
 import { OutcomesPanel } from './components/IssueHistoryPanel'
 import { StreamView } from './components/StreamView'
 import { SessionSidebar } from './components/SessionSidebar'
-import { BugReportPanel } from './components/BugReportPanel'
-import { CaretakerPanel } from './components/CaretakerPanel'
 import { theme } from './theme'
 
-const TABS = ['issues', 'hitl', 'outcomes', 'reports', 'caretaker', 'system']
+const TABS = ['issues', 'hitl', 'outcomes', 'system']
 
 const TAB_LABELS = {
   issues: 'Work Stream',
   outcomes: 'Outcomes',
-  reports: 'Reports',
-  caretaker: 'Caretaker',
   hitl: 'HITL',
   system: 'System',
 }
@@ -260,13 +256,6 @@ function AppContent() {
               ? <HITLTable items={hitlItems} onRefresh={refreshHitl} />
               : <div style={idleMessage}>Pipeline is not running — HITL actions are unavailable.</div>
           )}
-          {activeTab === 'reports' && (
-            <BugReportPanel
-              apiBaseUrl=""
-              reporterId={reporterId}
-            />
-          )}
-          {activeTab === 'caretaker' && <CaretakerPanel />}
           {activeTab === 'system' && (
             <SystemPanel
               backgroundWorkers={backgroundWorkers}

--- a/src/ui/src/components/CaretakerPanel.jsx
+++ b/src/ui/src/components/CaretakerPanel.jsx
@@ -42,16 +42,6 @@ export function CaretakerPanel() {
     worker: workerMap.get(def.key),
   }))
 
-  const hasAny = caretakerWorkers.some(c => c.worker)
-
-  if (!hasAny) {
-    return (
-      <div style={styles.container} data-testid="caretaker-empty">
-        <div style={styles.empty}>No caretaker workers are running.</div>
-      </div>
-    )
-  }
-
   return (
     <div style={styles.container}>
       <div style={styles.header}>

--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react'
 import { theme } from '../theme'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { PIPELINE_STAGES, SENSITIVE_SELECTORS } from '../constants'
+import { BugReportPanel } from './BugReportPanel'
 import { ReportIssueModal } from './ReportIssueModal'
 import html2canvasLib from 'html2canvas'
 
@@ -187,6 +188,7 @@ export function Header({ connected, orchestratorStatus }) {
     stageStatus,
     config,
     submitReport,
+    reporterId,
     startOrchestrator,
     stopOrchestrator,
   } = useHydraFlow()
@@ -196,6 +198,7 @@ export function Header({ connected, orchestratorStatus }) {
 
   const [reportModalOpen, setReportModalOpen] = useState(false)
   const [screenshotDataUrl, setScreenshotDataUrl] = useState(null)
+  const [trackerOpen, setTrackerOpen] = useState(false)
 
   const handleReportClick = useCallback(async () => {
     // Capture screenshot BEFORE opening the modal so the overlay isn't in the shot.
@@ -292,6 +295,17 @@ export function Header({ connected, orchestratorStatus }) {
             <path d="M4.72.22a.75.75 0 0 1 1.06 0l1 .999a3.488 3.488 0 0 1 2.441 0l.999-1a.748.748 0 0 1 1.265.332.75.75 0 0 1-.205.729l-.775.776c.616.63.995 1.493.995 2.444v.327c0 .1-.009.197-.025.292.408.14.764.392 1.029.722l1.968-.787a.75.75 0 0 1 .556 1.392L13 7.258V9h2.25a.75.75 0 0 1 0 1.5H13v.5c0 .409-.049.806-.141 1.186l2.17.868a.75.75 0 0 1-.557 1.392l-2.184-.873A4.997 4.997 0 0 1 8 16a4.997 4.997 0 0 1-4.288-2.427l-2.183.873a.75.75 0 0 1-.558-1.392l2.17-.868A5.036 5.036 0 0 1 3 11v-.5H.75a.75.75 0 0 1 0-1.5H3V7.258L.971 6.446a.75.75 0 0 1 .558-1.392l1.967.787c.265-.33.62-.583 1.03-.722a1.677 1.677 0 0 1-.026-.292V4.5c0-.951.38-1.814.995-2.444L4.72 1.28a.75.75 0 0 1 0-1.06Zm.53 6.28a.75.75 0 0 0-.75.75V11a3.5 3.5 0 1 0 7 0V7.25a.75.75 0 0 0-.75-.75ZM6.173 5h3.654A.172.172 0 0 0 10 4.827V4.5a2 2 0 1 0-4 0v.327c0 .096.077.173.173.173Z" fill="currentColor" />
           </svg>
         </button>
+        <button
+          style={styles.trackerBtn}
+          onClick={() => setTrackerOpen(true)}
+          data-testid="tracker-button"
+          aria-label="Bug report tracker"
+          title="Bug report tracker"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M1.75 0h12.5C15.216 0 16 .784 16 1.75v12.5A1.75 1.75 0 0 1 14.25 16H1.75A1.75 1.75 0 0 1 0 14.25V1.75C0 .784.784 0 1.75 0ZM1.5 1.75v12.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V1.75a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25ZM11 11a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm-4 0a1 1 0 1 1-2 0 1 1 0 0 1 2 0Zm1-5.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Zm-4 0A.75.75 0 0 1 4.75 5h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" fill="currentColor" />
+          </svg>
+        </button>
       </div>
       <ReportIssueModal
         isOpen={reportModalOpen}
@@ -299,6 +313,21 @@ export function Header({ connected, orchestratorStatus }) {
         onSubmit={handleReportSubmit}
         onClose={() => setReportModalOpen(false)}
       />
+      {trackerOpen && (
+        <div style={trackerOverlay} onClick={() => setTrackerOpen(false)} data-testid="tracker-overlay">
+          <div style={trackerModal} onClick={e => e.stopPropagation()}>
+            <div style={trackerHeader}>
+              <span style={trackerTitle}>Bug Report Tracker</span>
+              <button style={trackerClose} onClick={() => setTrackerOpen(false)} data-testid="tracker-close">×</button>
+            </div>
+            <BugReportPanel
+              apiBaseUrl=""
+              reporterId={reporterId}
+              onOpenReportModal={() => { setTrackerOpen(false); handleReportClick() }}
+            />
+          </div>
+        </div>
+      )}
     </header>
   )
 }
@@ -421,6 +450,30 @@ export const pipelineLabelStylesMap = Object.fromEntries(PIPELINE_STAGES.map(s =
 // Pre-computed connection dot variants
 export const dotConnected = { ...styles.dot, background: theme.green }
 export const dotDisconnected = { ...styles.dot, background: theme.red }
+
+// Tracker button + modal styles
+styles.trackerBtn = {
+  position: 'relative', display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
+  padding: 6, borderRadius: 6, border: `1px solid ${theme.border}`,
+  background: theme.surface, color: theme.textMuted, cursor: 'pointer', transition: 'opacity 0.15s',
+}
+
+const trackerOverlay = {
+  position: 'fixed', inset: 0, background: theme.overlay,
+  display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1000,
+}
+const trackerModal = {
+  background: theme.surface, border: `1px solid ${theme.border}`, borderRadius: 12,
+  width: 700, maxWidth: '95vw', maxHeight: '85vh', display: 'flex', flexDirection: 'column', overflow: 'hidden',
+}
+const trackerHeader = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  padding: '16px 20px', borderBottom: `1px solid ${theme.border}`,
+}
+const trackerTitle = { fontSize: 14, fontWeight: 700, color: theme.textBright }
+const trackerClose = {
+  background: 'none', border: 'none', color: theme.textMuted, fontSize: 18, cursor: 'pointer', padding: 4,
+}
 
 // Pre-computed report button variant
 const reportBtnDisabled = { ...styles.reportBtn, opacity: 0.4, cursor: 'not-allowed' }

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -231,10 +231,10 @@ describe('Config warning banner', () => {
 })
 
 describe('Main tab bar', () => {
-  it('has exactly 6 main tabs', async () => {
+  it('has exactly 4 main tabs', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Reports', 'Caretaker', 'System']
+    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'System']
     const tabContainer = screen.getByTestId('main-tabs')
     expect(tabContainer.childElementCount).toBe(tabLabels.length)
     for (const label of tabLabels) {

--- a/src/ui/src/components/__tests__/CaretakerPanel.test.jsx
+++ b/src/ui/src/components/__tests__/CaretakerPanel.test.jsx
@@ -75,9 +75,10 @@ describe('CaretakerPanel', () => {
     expect(ctx.triggerBgWorker).toHaveBeenCalledWith('stale_issue_gc')
   })
 
-  it('shows empty state when no caretaker workers exist', () => {
+  it('shows all workers even when backend has not reported', () => {
     mockUseHydraFlow.mockReturnValue(defaultContext({ backgroundWorkers: [] }))
     render(<CaretakerPanel />)
-    expect(screen.getByTestId('caretaker-empty')).toBeTruthy()
+    // Workers should still render with 'disabled' status
+    expect(screen.getByText('Stale Issue GC')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
Per user feedback:
- **Reports** moved back to a Header modal (tracker button opens BugReportPanel with table/filters inside overlay)
- **Caretaker** always shows all workers (no empty state) — disabled workers show OFF with gray dot
- **Tabs** back to 4: Work Stream, HITL, Outcomes, System
- Removed Reports and Caretaker standalone tabs

## Test plan
- [x] 962 UI tests pass
- [x] 33 App tests pass (4 tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)