### PR TITLE
refactor: Reduce orchestrator overreach — expose active_count, move I/O (#5920)

### DIFF
--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -53,6 +53,11 @@ class BaseRunner:
         self._last_context_stats: dict[str, int] = {"cache_hits": 0, "cache_misses": 0}
         self._hindsight = hindsight
 
+    @property
+    def active_count(self) -> int:
+        """Number of currently running subprocesses."""
+        return len(self._active_procs)
+
     def terminate(self) -> None:
         """Kill all active subprocesses."""
         terminate_processes(self._active_procs)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -44,8 +44,6 @@ from state_restorer import StateRestorer
 from subprocess_util import (
     AuthenticationError,
     CreditExhaustedError,
-    configure_gh_concurrency,
-    run_subprocess,
 )
 
 if TYPE_CHECKING:
@@ -104,9 +102,6 @@ class HydraFlowOrchestrator:
         self._session_issue_results: dict[int, bool] = {}
         # Loop tasks (set by _supervise_loops for stop() to cancel)
         self._loop_tasks: dict[str, asyncio.Task[None]] = {}
-
-        # Configure global GitHub API concurrency limiter
-        configure_gh_concurrency(config.gh_api_concurrency)
 
         # Build all services via the factory
         svc = build_services(
@@ -207,7 +202,7 @@ class HydraFlowOrchestrator:
         try:
             await self._svc.worktrees.sanitize_repo()
             await self._svc.prs.ensure_labels_exist()
-            await self._enable_rerere()
+            await self._svc.worktrees.enable_rerere()
             self._warn_if_agents_md_missing()
             if self._current_session is None:
                 await self._start_session()
@@ -223,10 +218,10 @@ class HydraFlowOrchestrator:
     def _has_active_processes(self) -> bool:
         """Return True if any runner pool still has live subprocesses."""
         return bool(
-            self._svc.planners._active_procs
-            or self._svc.agents._active_procs
-            or self._svc.reviewers._active_procs
-            or self._svc.hitl_runner._active_procs
+            self._svc.planners.active_count
+            or self._svc.agents.active_count
+            or self._svc.reviewers.active_count
+            or self._svc.hitl_runner.active_count
         )
 
     @property
@@ -485,11 +480,11 @@ class HydraFlowOrchestrator:
 
         # Map stage keys to runner pools for active worker counts
         stage_runners: dict[str, int] = {
-            "triage": len(self._svc.triage._active_procs),
-            "plan": len(self._svc.planners._active_procs),
-            "implement": len(self._svc.agents._active_procs),
-            "review": len(self._svc.reviewers._active_procs),
-            "hitl": len(self._svc.hitl_runner._active_procs),
+            "triage": self._svc.triage.active_count,
+            "plan": self._svc.planners.active_count,
+            "implement": self._svc.agents.active_count,
+            "review": self._svc.reviewers.active_count,
+            "hitl": self._svc.hitl_runner.active_count,
         }
 
         # Map IssueStore stage names to our stage keys
@@ -695,7 +690,7 @@ class HydraFlowOrchestrator:
         if self._pipeline_enabled:
             await self._svc.worktrees.sanitize_repo()
             await self._svc.prs.ensure_labels_exist()
-            await self._enable_rerere()
+            await self._svc.worktrees.enable_rerere()
             self._warn_if_agents_md_missing()
             await self._start_session()
             session_started = True
@@ -715,21 +710,6 @@ class HydraFlowOrchestrator:
             self._running = False
             await self._publish_status()
             logger.info("HydraFlow stopped")
-
-    async def _enable_rerere(self) -> None:
-        """Enable git rerere so resolved conflicts are remembered for next time."""
-        try:
-            await run_subprocess(
-                "git",
-                "config",
-                "rerere.enabled",
-                "true",
-                cwd=self._config.repo_root,
-                gh_token=self._config.gh_token,
-            )
-            logger.info("git rerere enabled")
-        except (RuntimeError, FileNotFoundError):
-            logger.debug("Could not enable git rerere", exc_info=True)
 
     def _warn_if_agents_md_missing(self) -> None:
         """Log a warning if AGENTS.md is absent from the repo root.

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -156,6 +156,12 @@ def build_services(
 
     This replaces the 170-line orchestrator constructor body.
     """
+    # Configure global GitHub API concurrency limiter (startup config
+    # belongs in the composition root, not the orchestrator).
+    from subprocess_util import configure_gh_concurrency
+
+    configure_gh_concurrency(config.gh_api_concurrency)
+
     # Hindsight semantic memory (optional)
     hindsight_client = None
     hindsight_wal: HindsightWAL | None = None

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -689,6 +689,23 @@ class WorkspaceManager:
             )
             return ""
 
+    # --- git config utilities ---
+
+    async def enable_rerere(self) -> None:
+        """Enable git rerere so resolved conflicts are remembered for next time."""
+        try:
+            await run_subprocess(
+                "git",
+                "config",
+                "rerere.enabled",
+                "true",
+                cwd=self._repo_root,
+                gh_token=self._config.gh_token,
+            )
+            logger.info("git rerere enabled")
+        except (RuntimeError, FileNotFoundError):
+            logger.debug("Could not enable git rerere", exc_info=True)
+
     # --- environment setup ---
 
     def _setup_env(self, wt_path: Path) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1548,7 +1548,7 @@ def mock_fetcher_noop(orch: Any) -> None:
     orch._svc.store.get_active_issues = lambda: {}  # type: ignore[method-assign]
     orch._svc.fetcher.fetch_issue_by_number = AsyncMock(return_value=None)  # type: ignore[method-assign]
     orch._svc.fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
-    orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
+    orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
     orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
 

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -32,10 +32,15 @@ from tests.conftest import (
 
 
 class FakeRunner:
-    """Minimal runner stub with terminate() and _active_procs."""
+    """Minimal runner stub with terminate(), _active_procs, and active_count."""
 
     def __init__(self) -> None:
         self._active_procs: set[int] = set()
+
+    @property
+    def active_count(self) -> int:
+        """Number of currently running subprocesses."""
+        return len(self._active_procs)
 
     def terminate(self) -> None:
         self._active_procs.clear()

--- a/tests/test_base_runner.py
+++ b/tests/test_base_runner.py
@@ -46,6 +46,25 @@ class TestBaseRunnerInit:
         runner = _TestRunner(config, event_bus)
         assert runner._active_procs == set()
 
+    def test_active_count_starts_at_zero(self, config, event_bus: EventBus) -> None:
+        runner = _TestRunner(config, event_bus)
+        assert runner.active_count == 0
+
+    def test_active_count_reflects_active_procs_size(
+        self, config, event_bus: EventBus
+    ) -> None:
+        runner = _TestRunner(config, event_bus)
+        mock_proc1 = MagicMock()
+        mock_proc1.pid = 1
+        mock_proc2 = MagicMock()
+        mock_proc2.pid = 2
+        runner._active_procs.add(mock_proc1)
+        assert runner.active_count == 1
+        runner._active_procs.add(mock_proc2)
+        assert runner.active_count == 2
+        runner._active_procs.discard(mock_proc1)
+        assert runner.active_count == 1
+
     def test_uses_provided_runner(self, config, event_bus: EventBus) -> None:
         mock_runner = MagicMock()
         runner = _TestRunner(config, event_bus, runner=mock_runner)

--- a/tests/test_orchestrator_core.py
+++ b/tests/test_orchestrator_core.py
@@ -846,7 +846,7 @@ class TestOrchestratorShutdownLifecycle:
     async def test_no_orphaned_processes_after_stop(
         self, config: HydraFlowConfig
     ) -> None:
-        """All runner _active_procs sets are empty after run() returns."""
+        """All runner active_count values are zero after run() returns."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
         mock_fetcher_noop(orch)
@@ -860,10 +860,10 @@ class TestOrchestratorShutdownLifecycle:
 
         await orch.run()
 
-        assert len(orch._svc.planners._active_procs) == 0
-        assert len(orch._svc.agents._active_procs) == 0
-        assert len(orch._svc.reviewers._active_procs) == 0
-        assert len(orch._svc.hitl_runner._active_procs) == 0
+        assert orch._svc.planners.active_count == 0
+        assert orch._svc.agents.active_count == 0
+        assert orch._svc.reviewers.active_count == 0
+        assert orch._svc.hitl_runner.active_count == 0
 
     @pytest.mark.asyncio
     async def test_stop_calls_terminate_eagerly_and_in_finally(

--- a/tests/test_orchestrator_loops.py
+++ b/tests/test_orchestrator_loops.py
@@ -406,7 +406,7 @@ class TestSupervisorLoops:
         """If one loop crashes despite try/except, others should keep running."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
         orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         implement_calls = 0
@@ -690,7 +690,7 @@ class TestAuthFailure:
         """An AuthenticationError in any loop should stop the orchestrator."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
         orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_triage() -> None:
@@ -718,7 +718,7 @@ class TestAuthFailure:
         """Auth failure should publish a SYSTEM_ALERT event."""
         orch = HydraFlowOrchestrator(config, event_bus=event_bus)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
         orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_plan() -> list[PlanResult]:
@@ -750,7 +750,7 @@ class TestAuthFailure:
         """Auth failure should set the _auth_failed flag."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
         orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_implement() -> tuple[list[WorkerResult], list[Task]]:

--- a/tests/test_stop_resume.py
+++ b/tests/test_stop_resume.py
@@ -96,10 +96,11 @@ def _make_orchestrator(tmp_path: Path) -> HydraFlowOrchestrator:
 
     with patch("orchestrator.build_services") as mock_build:
         svc = MagicMock()
-        # Runners with _active_procs
+        # Runners with active_count property
         for runner_attr in ("planners", "agents", "reviewers", "hitl_runner"):
             runner = MagicMock()
             runner._active_procs = set()
+            runner.active_count = 0
             runner.terminate = MagicMock()
             setattr(svc, runner_attr, runner)
 

--- a/tests/test_workspace_git.py
+++ b/tests/test_workspace_git.py
@@ -683,3 +683,46 @@ class TestGetMainCommitsSinceDiverge:
         # Second call is git log
         log_call = mock_exec.call_args_list[1]
         assert "-30" in log_call.args
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceManager.enable_rerere
+# ---------------------------------------------------------------------------
+
+
+class TestEnableRerere:
+    """Tests for WorkspaceManager.enable_rerere."""
+
+    @pytest.mark.asyncio
+    async def test_enable_rerere_runs_git_config(self, config) -> None:
+        """enable_rerere should run ``git config rerere.enabled true`` in repo root."""
+        manager = WorkspaceManager(config)
+        success_proc = make_proc(returncode=0)
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=success_proc
+        ) as mock_exec:
+            await manager.enable_rerere()
+
+        args = mock_exec.call_args.args
+        assert "git" in args
+        assert "config" in args
+        assert "rerere.enabled" in args
+        assert "true" in args
+
+    @pytest.mark.asyncio
+    async def test_enable_rerere_swallows_runtime_error(self, config) -> None:
+        """enable_rerere should not raise when git config fails."""
+        manager = WorkspaceManager(config)
+        fail_proc = make_proc(returncode=1, stderr=b"fatal: not in a git repo")
+
+        with patch("asyncio.create_subprocess_exec", return_value=fail_proc):
+            await manager.enable_rerere()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_enable_rerere_swallows_file_not_found(self, config) -> None:
+        """enable_rerere should not raise when git binary is missing."""
+        manager = WorkspaceManager(config)
+
+        with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError):
+            await manager.enable_rerere()  # Should not raise


### PR DESCRIPTION
## Summary
- Adds public `active_count` property to BaseRunner (replaces 9 accesses to private `_active_procs`)
- Moves `_enable_rerere()` from orchestrator to WorkspaceManager (git config is infrastructure)
- Moves `configure_gh_concurrency()` from orchestrator init to `build_services()` (startup config belongs in composition root)

Closes #5920

## Test plan
- [x] `make quality` passes (8717 passed, lint OK, typecheck OK, security OK)
- [x] `active_count` property tested (2 new tests in test_base_runner.py)
- [x] `enable_rerere` works in workspace manager (3 new tests in test_workspace_git.py)
- [x] All orchestrator tests updated to use public API
- [x] FakeRunner in integration utils updated with active_count property

🤖 Generated with [Claude Code](https://claude.com/claude-code)