### PR TITLE
refactor: Extract ADR utilities to break circular import (#5921)

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -11,9 +11,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from adr_pre_validator import ADRPreValidator, ADRValidationResult
+from adr_utils import ADR_FILE_RE
 from agent_cli import build_lightweight_command
 from models import ADRCouncilResult, CouncilVerdict, CouncilVote
-from phase_utils import ADR_FILE_RE
 from subprocess_util import make_clean_env, run_subprocess
 
 if TYPE_CHECKING:

--- a/src/adr_utils.py
+++ b/src/adr_utils.py
@@ -1,0 +1,117 @@
+"""ADR (Architecture Decision Record) utilities.
+
+Extracted from ``phase_utils`` to break the circular dependency:
+
+    phase_utils -> memory -> phase_utils (deferred import)
+
+After extraction, ``memory.py`` imports directly from this module at the
+top level instead of using a deferred import from ``phase_utils``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+__all__ = [
+    "ADR_FILE_RE",
+    "adr_validation_reasons",
+    "is_adr_issue_title",
+    "load_existing_adr_topics",
+    "next_adr_number",
+    "normalize_adr_topic",
+]
+
+logger = logging.getLogger("hydraflow.adr_utils")
+
+_ADR_TITLE_RE = re.compile(r"^\s*\[ADR\]\s+", re.IGNORECASE)
+_ADR_REQUIRED_HEADINGS = ("## Context", "## Decision", "## Consequences")
+
+# Module-level set tracking ADR numbers already handed out in this process,
+# so concurrent workers each get a unique number even before their files land.
+_assigned_adr_numbers: set[int] = set()
+
+ADR_FILE_RE = re.compile(r"^(\d{4})-.*\.md$")
+
+
+def is_adr_issue_title(title: str) -> bool:
+    """Return ``True`` when *title* starts with ``[ADR]`` (case-insensitive)."""
+    return bool(_ADR_TITLE_RE.match(title))
+
+
+def adr_validation_reasons(body: str) -> list[str]:
+    """Return shape-validation failures for ADR markdown content."""
+    reasons: list[str] = []
+    text = body.strip()
+    if len(text) < 120:
+        reasons.append("ADR body is too short (minimum 120 characters)")
+    lower = text.lower()
+    missing = [h for h in _ADR_REQUIRED_HEADINGS if h.lower() not in lower]
+    if missing:
+        reasons.append("Missing required ADR sections: " + ", ".join(missing))
+    return reasons
+
+
+def normalize_adr_topic(title: str) -> str:
+    """Extract a normalized topic key from a memory/ADR title for dedup.
+
+    Strips prefixes like ``[Memory]``, ``[ADR] Draft decision from memory #N:``,
+    lowercases, and removes non-alphanumeric characters.
+    """
+    cleaned = re.sub(
+        r"^\[(?:Memory|ADR)\]\s*(?:Draft decision from memory #\d+:\s*)?",
+        "",
+        title,
+        flags=re.IGNORECASE,
+    ).strip()
+    return re.sub(r"[^a-z0-9]+", " ", cleaned.lower()).strip()
+
+
+def load_existing_adr_topics(repo_root: Path) -> set[str]:
+    """Scan ``docs/adr/`` files and return normalized topic keys."""
+    adr_dir = repo_root / "docs" / "adr"
+    topics: set[str] = set()
+    if not adr_dir.is_dir():
+        return topics
+    for path in adr_dir.glob("*.md"):
+        if path.name.lower() == "readme.md":
+            continue
+        stem = path.stem
+        cleaned = re.sub(r"^\d+-", "", stem)
+        topic = re.sub(r"[^a-z0-9]+", " ", cleaned.lower()).strip()
+        if topic:
+            topics.add(topic)
+    return topics
+
+
+def next_adr_number(
+    adr_dir: Path,
+    *,
+    primary_adr_dir: Path | None = None,
+) -> int:
+    """Return the next available ADR number, unique across concurrent workers.
+
+    Scans both the local *adr_dir* **and** the *primary_adr_dir* (the
+    primary repo checkout, not a worktree copy) to find the highest
+    existing number.  Also considers numbers already handed out via
+    ``_assigned_adr_numbers`` so that concurrent workers in the same
+    process each receive a distinct number.
+
+    The returned number is recorded in ``_assigned_adr_numbers`` so
+    subsequent calls will never return the same value.
+    """
+    highest = 0
+    for d in (adr_dir, primary_adr_dir):
+        if d is not None and d.is_dir():
+            for f in d.iterdir():
+                m = ADR_FILE_RE.match(f.name)
+                if m:
+                    highest = max(highest, int(m.group(1)))
+
+    if _assigned_adr_numbers:
+        highest = max(highest, *_assigned_adr_numbers)
+
+    number = highest + 1
+    _assigned_adr_numbers.add(number)
+    return number

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -8,6 +8,7 @@ import logging
 import re
 from pathlib import Path
 
+from adr_utils import is_adr_issue_title, next_adr_number
 from agent import AgentRunner
 from beads_manager import BeadsManager
 from config import HydraFlowConfig
@@ -25,8 +26,6 @@ from phase_utils import (
     MemorySuggester,
     PipelineEscalator,
     _sentry_transaction,
-    is_adr_issue_title,
-    next_adr_number,
     record_harness_failure,
     release_batch_in_flight,
     run_refilling_pool,

--- a/src/memory.py
+++ b/src/memory.py
@@ -8,6 +8,7 @@ import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+from adr_utils import load_existing_adr_topics, normalize_adr_topic
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from execution import SubprocessRunner, get_default_runner
@@ -334,11 +335,6 @@ class MemorySyncWorker:
         """Write ADR draft decisions from architecture-shift memory issues to JSONL."""
         import json as _json  # noqa: PLC0415
         from datetime import UTC, datetime  # noqa: PLC0415
-
-        from phase_utils import (  # noqa: PLC0415
-            load_existing_adr_topics,
-            normalize_adr_topic,
-        )
 
         seen = self._load_adr_source_ids()
         existing_topics = load_existing_adr_topics(self._config.repo_root)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
+from adr_utils import is_adr_issue_title
 from bg_worker_manager import BGWorkerManager
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
@@ -33,7 +34,6 @@ from models import (
 )
 from phase_utils import (
     MemorySuggester,
-    is_adr_issue_title,
     is_likely_bug,
     log_exception_with_bug_classification,
     release_batch_in_flight,

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import re
 from collections.abc import Callable, Coroutine, Generator
 from contextlib import asynccontextmanager, contextmanager
-from pathlib import Path
 from typing import Any, TypeVar
 
+# ADR utilities — canonical home is ``adr_utils``; re-exported here for
+# backward compatibility so existing consumers don't break.
+from adr_utils import (  # noqa: F401
+    ADR_FILE_RE,
+    _assigned_adr_numbers,
+    adr_validation_reasons,
+    is_adr_issue_title,
+    load_existing_adr_topics,
+    next_adr_number,
+    normalize_adr_topic,
+)
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from harness_insights import FailureCategory, FailureRecord, HarnessInsightStore
@@ -23,13 +32,6 @@ logger = logging.getLogger("hydraflow.phase_utils")
 
 T = TypeVar("T")
 T_Result = TypeVar("T_Result")
-
-_ADR_TITLE_RE = re.compile(r"^\s*\[ADR\]\s+", re.IGNORECASE)
-_ADR_REQUIRED_HEADINGS = ("## Context", "## Decision", "## Consequences")
-
-# Module-level set tracking ADR numbers already handed out in this process,
-# so concurrent workers each get a unique number even before their files land.
-_assigned_adr_numbers: set[int] = set()
 
 
 @contextmanager
@@ -133,7 +135,7 @@ async def run_refilling_pool(
 
                     if isinstance(
                         exc,
-                        (AuthenticationError, CreditExhaustedError, MemoryError),
+                        AuthenticationError | CreditExhaustedError | MemoryError,
                     ):
                         for t in pending:
                             t.cancel()
@@ -286,59 +288,6 @@ async def publish_review_status(
     )
 
 
-def is_adr_issue_title(title: str) -> bool:
-    """Return ``True`` when *title* starts with ``[ADR]`` (case-insensitive)."""
-    return bool(_ADR_TITLE_RE.match(title))
-
-
-def adr_validation_reasons(body: str) -> list[str]:
-    """Return shape-validation failures for ADR markdown content."""
-    reasons: list[str] = []
-    text = body.strip()
-    if len(text) < 120:
-        reasons.append("ADR body is too short (minimum 120 characters)")
-    lower = text.lower()
-    missing = [h for h in _ADR_REQUIRED_HEADINGS if h.lower() not in lower]
-    if missing:
-        reasons.append("Missing required ADR sections: " + ", ".join(missing))
-    return reasons
-
-
-def normalize_adr_topic(title: str) -> str:
-    """Extract a normalized topic key from a memory/ADR title for dedup.
-
-    Strips prefixes like ``[Memory]``, ``[ADR] Draft decision from memory #N:``,
-    lowercases, and removes non-alphanumeric characters.
-    """
-    cleaned = re.sub(
-        r"^\[(?:Memory|ADR)\]\s*(?:Draft decision from memory #\d+:\s*)?",
-        "",
-        title,
-        flags=re.IGNORECASE,
-    ).strip()
-    return re.sub(r"[^a-z0-9]+", " ", cleaned.lower()).strip()
-
-
-def load_existing_adr_topics(repo_root: Path) -> set[str]:
-    """Scan ``docs/adr/`` files and return normalized topic keys."""
-    adr_dir = repo_root / "docs" / "adr"
-    topics: set[str] = set()
-    if not adr_dir.is_dir():
-        return topics
-    for path in adr_dir.glob("*.md"):
-        if path.name.lower() == "readme.md":
-            continue
-        stem = path.stem
-        cleaned = re.sub(r"^\d+-", "", stem)
-        topic = re.sub(r"[^a-z0-9]+", " ", cleaned.lower()).strip()
-        if topic:
-            topics.add(topic)
-    return topics
-
-
-ADR_FILE_RE = re.compile(r"^(\d{4})-.*\.md$")
-
-
 # ---------------------------------------------------------------------------
 # Exception classification
 # ---------------------------------------------------------------------------
@@ -399,7 +348,7 @@ def reraise_on_credit_or_bug(exc: BaseException) -> None:
     """
     from subprocess_util import AuthenticationError, CreditExhaustedError
 
-    if isinstance(exc, (AuthenticationError, CreditExhaustedError)):
+    if isinstance(exc, AuthenticationError | CreditExhaustedError):
         raise exc
     if is_likely_bug(exc):
         raise exc
@@ -574,35 +523,3 @@ class PipelineEscalator:
             details,
             stage=self._stage,
         )
-
-
-def next_adr_number(
-    adr_dir: Path,
-    *,
-    primary_adr_dir: Path | None = None,
-) -> int:
-    """Return the next available ADR number, unique across concurrent workers.
-
-    Scans both the local *adr_dir* **and** the *primary_adr_dir* (the
-    primary repo checkout, not a worktree copy) to find the highest
-    existing number.  Also considers numbers already handed out via
-    ``_assigned_adr_numbers`` so that concurrent workers in the same
-    process each receive a distinct number.
-
-    The returned number is recorded in ``_assigned_adr_numbers`` so
-    subsequent calls will never return the same value.
-    """
-    highest = 0
-    for d in (adr_dir, primary_adr_dir):
-        if d is not None and d.is_dir():
-            for f in d.iterdir():
-                m = ADR_FILE_RE.match(f.name)
-                if m:
-                    highest = max(highest, int(m.group(1)))
-
-    if _assigned_adr_numbers:
-        highest = max(highest, *_assigned_adr_numbers)
-
-    number = highest + 1
-    _assigned_adr_numbers.add(number)
-    return number

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
     from hindsight_wal import HindsightWAL
     from visual_validator import VisualValidator
 
+from adr_utils import (
+    adr_validation_reasons,
+    is_adr_issue_title,
+    load_existing_adr_topics,
+    normalize_adr_topic,
+)
 from baseline_policy import BaselinePolicy
 from comment_formatter import SelfReviewError
 from config import HydraFlowConfig
@@ -46,10 +52,6 @@ from models import (
 from phase_utils import (
     MemorySuggester,
     _sentry_transaction,
-    adr_validation_reasons,
-    is_adr_issue_title,
-    load_existing_adr_topics,
-    normalize_adr_topic,
     publish_review_status,
     record_harness_failure,
     release_batch_in_flight,

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -6,17 +6,19 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING
 
+from adr_utils import (
+    adr_validation_reasons,
+    is_adr_issue_title,
+    load_existing_adr_topics,
+    normalize_adr_topic,
+)
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from issue_store import IssueStore
 from models import HITLUpdatePayload, Task, TriageResult
 from phase_utils import (
     _sentry_transaction,
-    adr_validation_reasons,
     escalate_to_hitl,
-    is_adr_issue_title,
-    load_existing_adr_topics,
-    normalize_adr_topic,
     release_batch_in_flight,
     run_refilling_pool,
     store_lifecycle,

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -80,14 +80,14 @@ Some consequences.
 
 
 class TestADRFileREShared:
-    """Verify ADR_FILE_RE is shared between adr_reviewer and phase_utils."""
+    """Verify ADR_FILE_RE is shared between adr_reviewer and adr_utils."""
 
-    def test_adr_reviewer_uses_phase_utils_regex(self) -> None:
-        """adr_reviewer.ADR_FILE_RE must be the exact same object as phase_utils.ADR_FILE_RE."""
+    def test_adr_reviewer_uses_adr_utils_regex(self) -> None:
+        """adr_reviewer.ADR_FILE_RE must be the exact same object as adr_utils.ADR_FILE_RE."""
         import adr_reviewer
-        import phase_utils
+        import adr_utils
 
-        assert adr_reviewer.ADR_FILE_RE is phase_utils.ADR_FILE_RE
+        assert adr_reviewer.ADR_FILE_RE is adr_utils.ADR_FILE_RE
 
     def test_shared_regex_matches_adr_filenames(self) -> None:
         """The shared regex correctly matches NNNN-*.md and captures the number."""

--- a/tests/test_adr_utils.py
+++ b/tests/test_adr_utils.py
@@ -1,0 +1,265 @@
+"""Tests for adr_utils.py — ADR utility functions extracted from phase_utils."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from adr_utils import (
+    ADR_FILE_RE,
+    adr_validation_reasons,
+    is_adr_issue_title,
+    load_existing_adr_topics,
+    next_adr_number,
+    normalize_adr_topic,
+)
+
+# ---------------------------------------------------------------------------
+# is_adr_issue_title
+# ---------------------------------------------------------------------------
+
+
+class TestIsAdrIssueTitle:
+    def test_matches_standard_adr_prefix(self) -> None:
+        assert is_adr_issue_title("[ADR] Use event sourcing for state") is True
+
+    def test_matches_case_insensitive(self) -> None:
+        assert is_adr_issue_title("[adr] lowercase prefix") is True
+        assert is_adr_issue_title("[Adr] mixed case") is True
+
+    def test_matches_with_leading_whitespace(self) -> None:
+        assert is_adr_issue_title("  [ADR] leading spaces") is True
+
+    def test_rejects_non_adr_title(self) -> None:
+        assert is_adr_issue_title("Fix broken tests") is False
+
+    def test_rejects_adr_not_at_start(self) -> None:
+        assert is_adr_issue_title("Issue about [ADR] formatting") is False
+
+    def test_rejects_empty_string(self) -> None:
+        assert is_adr_issue_title("") is False
+
+    def test_rejects_partial_prefix(self) -> None:
+        assert is_adr_issue_title("[AD] not quite") is False
+
+
+# ---------------------------------------------------------------------------
+# normalize_adr_topic
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeAdrTopic:
+    def test_strips_memory_prefix(self) -> None:
+        assert (
+            normalize_adr_topic("[Memory] ADR test policy — only structural tests")
+            == "adr test policy only structural tests"
+        )
+
+    def test_strips_adr_draft_prefix(self) -> None:
+        assert (
+            normalize_adr_topic(
+                "[ADR] Draft decision from memory #123: Worker topology shift"
+            )
+            == "worker topology shift"
+        )
+
+    def test_lowercases_and_normalizes(self) -> None:
+        assert normalize_adr_topic("Use Event Sourcing") == "use event sourcing"
+
+    def test_strips_non_alphanumeric(self) -> None:
+        assert normalize_adr_topic("foo--bar__baz") == "foo bar baz"
+
+    def test_empty_string(self) -> None:
+        assert normalize_adr_topic("") == ""
+
+    def test_only_prefix(self) -> None:
+        result = normalize_adr_topic("[Memory]")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# adr_validation_reasons
+# ---------------------------------------------------------------------------
+
+
+class TestAdrValidationReasons:
+    def test_valid_adr_body_returns_empty(self) -> None:
+        body = (
+            "## Context\n\nWe need to decide on X.\n\n"
+            "## Decision\n\nWe will do Y because of reasons.\n\n"
+            "## Consequences\n\nThis means Z will change and we need to update docs. "
+            "Additional detail here to meet length."
+        )
+        assert adr_validation_reasons(body) == []
+
+    def test_too_short_body(self) -> None:
+        body = "## Context\n## Decision\n## Consequences\nShort."
+        reasons = adr_validation_reasons(body)
+        assert any("too short" in r for r in reasons)
+
+    def test_missing_context_heading(self) -> None:
+        body = (
+            "## Decision\n\nWe will do Y.\n\n"
+            "## Consequences\n\nThis changes Z.\n" + "x" * 120
+        )
+        reasons = adr_validation_reasons(body)
+        assert any("## Context" in r for r in reasons)
+
+    def test_missing_decision_heading(self) -> None:
+        body = (
+            "## Context\n\nWe need to decide.\n\n"
+            "## Consequences\n\nThis changes Z.\n" + "x" * 120
+        )
+        reasons = adr_validation_reasons(body)
+        assert any("## Decision" in r for r in reasons)
+
+    def test_missing_consequences_heading(self) -> None:
+        body = (
+            "## Context\n\nWe need to decide.\n\n"
+            "## Decision\n\nWe will do Y.\n" + "x" * 120
+        )
+        reasons = adr_validation_reasons(body)
+        assert any("## Consequences" in r for r in reasons)
+
+    def test_multiple_failures(self) -> None:
+        body = "Short"
+        reasons = adr_validation_reasons(body)
+        assert len(reasons) == 2  # too short + missing all headings
+
+
+# ---------------------------------------------------------------------------
+# load_existing_adr_topics
+# ---------------------------------------------------------------------------
+
+
+class TestLoadExistingAdrTopics:
+    def test_loads_topics_from_adr_dir(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0001-five-concurrent-loops.md").write_text("# ADR\n")
+        (adr_dir / "0002-labels-state-machine.md").write_text("# ADR\n")
+        (adr_dir / "README.md").write_text("# Index\n")
+
+        topics = load_existing_adr_topics(tmp_path)
+        assert "five concurrent loops" in topics
+        assert "labels state machine" in topics
+
+    def test_skips_readme(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "README.md").write_text("# Index\n")
+
+        topics = load_existing_adr_topics(tmp_path)
+        assert len(topics) == 0
+
+    def test_returns_empty_for_missing_dir(self, tmp_path: Path) -> None:
+        topics = load_existing_adr_topics(tmp_path)
+        assert topics == set()
+
+    def test_strips_numeric_prefix(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0042-adopt-pydantic.md").write_text("# ADR\n")
+
+        topics = load_existing_adr_topics(tmp_path)
+        assert "adopt pydantic" in topics
+
+
+# ---------------------------------------------------------------------------
+# next_adr_number
+# ---------------------------------------------------------------------------
+
+
+class TestNextAdrNumber:
+    @pytest.fixture(autouse=True)
+    def _clear_assigned(self) -> Generator[None, None, None]:
+        """Reset the module-level assigned set before and after each test."""
+        import adr_utils
+
+        adr_utils._assigned_adr_numbers.clear()
+        yield
+        adr_utils._assigned_adr_numbers.clear()
+
+    def test_returns_one_for_empty_dir(self, tmp_path: Path) -> None:
+        assert next_adr_number(tmp_path) == 1
+
+    def test_returns_one_for_missing_dir(self, tmp_path: Path) -> None:
+        assert next_adr_number(tmp_path / "nonexistent") == 1
+
+    def test_increments_past_highest(self, tmp_path: Path) -> None:
+        (tmp_path / "0001-first.md").touch()
+        (tmp_path / "0003-third.md").touch()
+        assert next_adr_number(tmp_path) == 4
+
+    def test_ignores_non_adr_files(self, tmp_path: Path) -> None:
+        (tmp_path / "0005-fifth.md").touch()
+        (tmp_path / "README.md").touch()
+        (tmp_path / "template.md").touch()
+        assert next_adr_number(tmp_path) == 6
+
+    def test_concurrent_calls_return_unique_numbers(self, tmp_path: Path) -> None:
+        (tmp_path / "0002-existing.md").touch()
+        results = [next_adr_number(tmp_path) for _ in range(5)]
+        assert results == [3, 4, 5, 6, 7]
+
+    def test_scans_primary_adr_dir(self, tmp_path: Path) -> None:
+        local = tmp_path / "worktree" / "docs" / "adr"
+        local.mkdir(parents=True)
+        (local / "0001-local.md").touch()
+
+        primary = tmp_path / "primary" / "docs" / "adr"
+        primary.mkdir(parents=True)
+        (primary / "0010-primary.md").touch()
+
+        result = next_adr_number(local, primary_adr_dir=primary)
+        assert result == 11
+
+
+# ---------------------------------------------------------------------------
+# ADR_FILE_RE
+# ---------------------------------------------------------------------------
+
+
+class TestAdrFileRe:
+    def test_matches_four_digit_prefix(self) -> None:
+        m = ADR_FILE_RE.match("0023-some-title.md")
+        assert m is not None
+        assert m.group(1) == "0023"
+
+    def test_rejects_non_adr_filenames(self) -> None:
+        assert ADR_FILE_RE.match("README.md") is None
+        assert ADR_FILE_RE.match("abc-title.md") is None
+        assert ADR_FILE_RE.match("00-short.md") is None
+        assert ADR_FILE_RE.match("023-title.md") is None
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility — phase_utils re-exports
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatReexports:
+    """Ensure phase_utils still exposes ADR utilities for existing consumers."""
+
+    def test_phase_utils_reexports_is_adr_issue_title(self) -> None:
+        from adr_utils import is_adr_issue_title as au_fn
+        from phase_utils import is_adr_issue_title as pu_fn
+
+        assert pu_fn is au_fn
+
+    def test_phase_utils_reexports_adr_file_re(self) -> None:
+        from adr_utils import ADR_FILE_RE as au_re
+        from phase_utils import ADR_FILE_RE as pu_re
+
+        assert pu_re is au_re
+
+    def test_phase_utils_reexports_next_adr_number(self) -> None:
+        from adr_utils import next_adr_number as au_fn
+        from phase_utils import next_adr_number as pu_fn
+
+        assert pu_fn is au_fn

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -678,7 +678,7 @@ class TestMemorySyncWorkerSync:
         )
 
     def test_normalize_adr_topic_strips_prefixes(self) -> None:
-        from phase_utils import normalize_adr_topic
+        from adr_utils import normalize_adr_topic
 
         assert (
             normalize_adr_topic("[Memory] ADR test policy — only structural tests")
@@ -692,7 +692,7 @@ class TestMemorySyncWorkerSync:
         )
 
     def test_load_existing_adr_topics_reads_docs_adr(self, tmp_path: Path) -> None:
-        from phase_utils import load_existing_adr_topics
+        from adr_utils import load_existing_adr_topics
 
         adr_dir = tmp_path / "docs" / "adr"
         adr_dir.mkdir(parents=True)
@@ -1226,8 +1226,8 @@ class TestRouteAdrCandidatesPerItemIsolation:
         adr_sources_path.parent.mkdir(parents=True, exist_ok=True)
 
         with (
-            patch("phase_utils.load_existing_adr_topics", return_value=set()),
-            patch("phase_utils.normalize_adr_topic", side_effect=lambda t: t.lower()),
+            patch("memory.load_existing_adr_topics", return_value=set()),
+            patch("memory.normalize_adr_topic", side_effect=lambda t: t.lower()),
         ):
             await worker._route_adr_candidates(issues)
 

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -12,6 +12,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from adr_utils import next_adr_number
 from events import EventType
 from harness_insights import FailureCategory, HarnessInsightStore
 from models import PipelineStage
@@ -21,7 +22,6 @@ from phase_utils import (
     PipelineEscalator,
     escalate_to_hitl,
     is_likely_bug,
-    next_adr_number,
     publish_review_status,
     record_harness_failure,
     reraise_on_credit_or_bug,
@@ -604,11 +604,11 @@ class TestNextAdrNumber:
     @pytest.fixture(autouse=True)
     def _clear_assigned(self) -> Generator[None, None, None]:
         """Reset the module-level assigned set before and after each test."""
-        import phase_utils
+        import adr_utils
 
-        phase_utils._assigned_adr_numbers.clear()
+        adr_utils._assigned_adr_numbers.clear()
         yield
-        phase_utils._assigned_adr_numbers.clear()
+        adr_utils._assigned_adr_numbers.clear()
 
     def test_returns_one_for_empty_dir(self, tmp_path: Path) -> None:
         assert next_adr_number(tmp_path) == 1
@@ -648,17 +648,17 @@ class TestNextAdrNumber:
 
     def test_assigned_set_tracks_numbers(self, tmp_path: Path) -> None:
         """Returned numbers must be recorded in the module-level set."""
-        import phase_utils
+        import adr_utils
 
         next_adr_number(tmp_path)
         next_adr_number(tmp_path)
-        assert phase_utils._assigned_adr_numbers == {1, 2}
+        assert adr_utils._assigned_adr_numbers == {1, 2}
 
     def test_assigned_numbers_override_disk(self, tmp_path: Path) -> None:
         """Previously assigned numbers beat what's on disk."""
-        import phase_utils
+        import adr_utils
 
-        phase_utils._assigned_adr_numbers.add(20)
+        adr_utils._assigned_adr_numbers.add(20)
         result = next_adr_number(tmp_path)
         assert result == 21
 


### PR DESCRIPTION
## Summary
- Extracts ADR-related functions and constants from `phase_utils.py` into new `adr_utils.py` module
- Breaks the circular dependency chain: `phase_utils` -> `memory` -> `phase_utils` (deferred import)
- `memory.py` now imports `load_existing_adr_topics` and `normalize_adr_topic` from `adr_utils` at the top level (no more deferred import)
- All direct consumers (`adr_reviewer`, `implement_phase`, `review_phase`, `triage_phase`, `orchestrator`) updated to import from `adr_utils`
- Backward-compat re-exports remain in `phase_utils` so no external consumers break

Closes #5921

## Test plan
- [x] New `tests/test_adr_utils.py` covers all extracted functions (34 tests)
- [x] Existing tests updated to reference `adr_utils` module
- [x] `make lint` passes
- [x] `make typecheck` passes (0 errors)
- [x] `make security` passes
- [x] All affected test files pass (290 tests across 4 files)
- [x] No circular import — `memory.py` has zero references to `phase_utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)