### PR TITLE
refactor: Migrate phases and loops to port protocols (#5918)

### DIFF
--- a/src/bot_pr_loop.py
+++ b/src/bot_pr_loop.py
@@ -11,7 +11,7 @@ from models import ReviewVerdict
 
 if TYPE_CHECKING:
     from github_cache import GitHubDataCache
-    from pr_manager import PRManager
+    from ports import PRPort
     from state import StateTracker
 
 logger = logging.getLogger("hydraflow.bot_pr_loop")
@@ -24,7 +24,7 @@ class BotPRLoop(BaseBackgroundLoop):
         self,
         config: HydraFlowConfig,
         cache: GitHubDataCache,
-        prs: PRManager,
+        prs: PRPort,
         state: StateTracker,
         deps: LoopDeps,
     ) -> None:

--- a/src/ci_monitor_loop.py
+++ b/src/ci_monitor_loop.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
-from pr_manager import PRManager
+
+if TYPE_CHECKING:
+    from ports import PRPort
 
 logger = logging.getLogger("hydraflow.ci_monitor")
 
@@ -22,7 +24,7 @@ class CIMonitorLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        pr_manager: PRManager,
+        pr_manager: PRPort,
         deps: LoopDeps,
     ) -> None:
         super().__init__(

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -14,7 +14,7 @@ from dedup_store import DedupStore
 from runner_utils import stream_claude_process
 
 if TYPE_CHECKING:
-    from pr_manager import PRManager
+    from ports import PRPort
 
 logger = logging.getLogger("hydraflow.code_grooming_loop")
 
@@ -39,7 +39,7 @@ class CodeGroomingLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        pr_manager: PRManager,
+        pr_manager: PRPort,
         deps: LoopDeps,
     ) -> None:
         super().__init__(worker_name="code_grooming", config=config, deps=deps)

--- a/src/epic_sweeper_loop.py
+++ b/src/epic_sweeper_loop.py
@@ -15,8 +15,7 @@ from config import HydraFlowConfig
 from epic import check_all_checkboxes, parse_epic_sub_issues
 
 if TYPE_CHECKING:
-    from issue_fetcher import IssueFetcher
-    from pr_manager import PRManager
+    from ports import IssueFetcherPort, PRPort
     from state import StateTracker
 
 logger = logging.getLogger("hydraflow.epic_sweeper_loop")
@@ -28,8 +27,8 @@ class EpicSweeperLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        fetcher: IssueFetcher,
-        prs: PRManager,
+        fetcher: IssueFetcherPort,
+        prs: PRPort,
         state: StateTracker,
         deps: LoopDeps,
     ) -> None:

--- a/src/hitl_phase.py
+++ b/src/hitl_phase.py
@@ -5,22 +5,22 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from hitl_runner import HITLRunner
-from issue_fetcher import IssueFetcher
-from issue_store import IssueStore
 from models import GitHubIssue, HITLUpdatePayload
 from phase_utils import (
     MemorySuggester,
     _sentry_transaction,
     log_exception_with_bug_classification,
 )
-from pr_manager import PRManager
 from state import StateTracker
 from subprocess_util import AuthenticationError, CreditExhaustedError
-from workspace import WorkspaceManager
+
+if TYPE_CHECKING:
+    from ports import IssueFetcherPort, IssueStorePort, PRPort, WorkspacePort
 
 logger = logging.getLogger("hydraflow.hitl_phase")
 
@@ -39,11 +39,11 @@ class HITLPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        store: IssueStore,
-        fetcher: IssueFetcher,
-        worktrees: WorkspaceManager,
+        store: IssueStorePort,
+        fetcher: IssueFetcherPort,
+        worktrees: WorkspacePort,
         hitl_runner: HITLRunner,
-        prs: PRManager,
+        prs: PRPort,
         event_bus: EventBus,
         stop_event: asyncio.Event,
         active_issues_cb: Callable[[], None] | None = None,

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -7,13 +7,13 @@ import contextlib
 import logging
 import re
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from adr_utils import is_adr_issue_title, next_adr_number
 from agent import AgentRunner
 from beads_manager import BeadsManager
 from config import HydraFlowConfig
 from harness_insights import FailureCategory, HarnessInsightStore
-from issue_store import IssueStore
 from models import (
     GitHubIssue,
     PipelineStage,
@@ -32,11 +32,12 @@ from phase_utils import (
     run_with_fatal_guard,
     store_lifecycle,
 )
-from pr_manager import PRManager
 from run_recorder import RunRecorder
 from state import StateTracker
 from task_source import TaskTransitioner
-from workspace import WorkspaceManager
+
+if TYPE_CHECKING:
+    from ports import IssueStorePort, PRPort, WorkspacePort
 
 logger = logging.getLogger("hydraflow.implement_phase")
 
@@ -48,10 +49,10 @@ class ImplementPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        worktrees: WorkspaceManager,
+        worktrees: WorkspacePort,
         agents: AgentRunner,
-        prs: PRManager,
-        store: IssueStore,
+        prs: PRPort,
+        store: IssueStorePort,
         stop_event: asyncio.Event,
         run_recorder: RunRecorder | None = None,
         harness_insights: HarnessInsightStore | None = None,
@@ -545,7 +546,9 @@ class ImplementPhase:
                 result.branch, issue_number=issue.id
             )
             if pr is not None and pr.number > 0:
-                expected_title = PRManager.expected_pr_title(issue.id, issue.title)
+                from pr_manager import PRManager as _PRManager  # noqa: PLC0415
+
+                expected_title = _PRManager.expected_pr_title(issue.id, issue.title)
                 await self._prs.update_pr_title(pr.number, expected_title)
         result.pr_info = pr
         return pr

--- a/src/merge_conflict_resolver.py
+++ b/src/merge_conflict_resolver.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent import AgentRunner
 from config import HydraFlowConfig
@@ -18,11 +19,12 @@ from models import (
     WorkerStatus,
 )
 from phase_utils import MemorySuggester, is_likely_bug, publish_review_status
-from pr_manager import PRManager
 from prompt_stats import build_prompt_stats
 from state import StateTracker
 from transcript_summarizer import TranscriptSummarizer
-from workspace import WorkspaceManager
+
+if TYPE_CHECKING:
+    from ports import PRPort, WorkspacePort
 
 logger = logging.getLogger("hydraflow.merge_conflict_resolver")
 
@@ -33,9 +35,9 @@ class MergeConflictResolver:
     def __init__(
         self,
         config: HydraFlowConfig,
-        worktrees: WorkspaceManager,
+        worktrees: WorkspacePort,
         agents: AgentRunner | None,
-        prs: PRManager,
+        prs: PRPort,
         event_bus: EventBus,
         state: StateTracker,
         summarizer: TranscriptSummarizer | None,
@@ -325,7 +327,9 @@ class MergeConflictResolver:
             verify = await self._agents._verify_result(new_wt, pr.branch)
             if verify.passed:
                 await self._maybe_summarize_conflict(transcript, issue.id, pr.number)
-                expected_title = PRManager.expected_pr_title(issue.id, issue.title)
+                from pr_manager import PRManager as _PRManager  # noqa: PLC0415
+
+                expected_title = _PRManager.expected_pr_title(issue.id, issue.title)
                 await self._prs.update_pr_title(pr.number, expected_title)
                 logger.info("Fresh branch rebuild succeeded for PR #%d", pr.number)
                 return True

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -22,10 +22,9 @@ from adr_utils import (  # noqa: F401
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from harness_insights import FailureCategory, FailureRecord, HarnessInsightStore
-from issue_store import IssueStore
 from memory import file_memory_suggestion
 from models import PipelineStage, PRInfo, ReviewUpdatePayload, Task
-from ports import PRPort
+from ports import IssueStorePort, PRPort
 from state import StateTracker
 
 logger = logging.getLogger("hydraflow.phase_utils")
@@ -154,7 +153,7 @@ async def run_refilling_pool(
     return results
 
 
-def release_batch_in_flight(store: IssueStore, issue_numbers: set[int]) -> None:
+def release_batch_in_flight(store: IssueStorePort, issue_numbers: set[int]) -> None:
     """Release in-flight protection for a batch of issues.
 
     Should be called in a ``finally`` block after ``run_concurrent_batch``
@@ -247,7 +246,7 @@ def record_harness_failure(
 
 @asynccontextmanager
 async def store_lifecycle(
-    store: IssueStore,
+    store: IssueStorePort,
     issue_number: int,
     stage: str,
 ):
@@ -465,7 +464,7 @@ class PipelineEscalator:
         self,
         state: StateTracker,
         prs: PRPort,
-        store: IssueStore,
+        store: IssueStorePort,
         harness_insights: HarnessInsightStore | None,
         *,
         origin_label: str,

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -11,7 +11,6 @@ from analysis import PlanAnalyzer
 from config import HydraFlowConfig
 from events import EventBus
 from harness_insights import FailureCategory, HarnessInsightStore
-from issue_store import IssueStore
 from models import EpicGapReview, IssueOutcomeType, PipelineStage, PlanResult, Task
 from phase_utils import (
     MemorySuggester,
@@ -23,7 +22,6 @@ from phase_utils import (
     store_lifecycle,
 )
 from planner import PlannerRunner
-from pr_manager import PRManager
 from research_runner import ResearchRunner
 from state import StateTracker
 from task_source import TaskTransitioner
@@ -32,6 +30,7 @@ from transcript_summarizer import TranscriptSummarizer
 if TYPE_CHECKING:
     from beads_manager import BeadsManager
     from epic import EpicManager
+    from ports import IssueStorePort, PRPort
 
 logger = logging.getLogger("hydraflow.plan_phase")
 
@@ -46,9 +45,9 @@ class PlanPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        store: IssueStore,
+        store: IssueStorePort,
         planners: PlannerRunner,
-        prs: PRManager,
+        prs: PRPort,
         event_bus: EventBus,
         stop_event: asyncio.Event,
         transcript_summarizer: TranscriptSummarizer | None = None,

--- a/src/ports.py
+++ b/src/ports.py
@@ -11,11 +11,15 @@ infrastructure (GitHub API, git CLI, agent subprocesses).
         │
         ├─► TaskFetcher / TaskTransitioner (task_source.py — already formal)
         ├─► PRPort                          (GitHub PR / label / CI operations)
-        └─► WorkspacePort                   (git workspace lifecycle)
+        ├─► WorkspacePort                   (git workspace lifecycle)
+        ├─► IssueStorePort                  (in-memory work queue operations)
+        └─► IssueFetcherPort                (GitHub issue fetching)
 
 Concrete adapters:
-  - PRPort      → pr_manager.PRManager
-  - WorkspacePort → workspace.WorkspaceManager
+  - PRPort          → pr_manager.PRManager
+  - WorkspacePort   → workspace.WorkspaceManager
+  - IssueStorePort  → issue_store.IssueStore
+  - IssueFetcherPort → issue_fetcher.IssueFetcher
 
 Both concrete classes satisfy their respective protocols via structural
 subtyping (typing.runtime_checkable).  No changes to the concrete classes
@@ -37,13 +41,20 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import runtime_checkable
+from typing import Any, runtime_checkable
 
 from typing_extensions import Protocol
 
-from models import CodeScanningAlert, GitHubIssue, HITLItem, PRInfo, ReviewVerdict
+from models import (
+    CodeScanningAlert,
+    GitHubIssue,
+    HITLItem,
+    PRInfo,
+    ReviewVerdict,
+    Task,
+)
 
-__all__ = ["PRPort", "WorkspacePort"]
+__all__ = ["IssueFetcherPort", "IssueStorePort", "PRPort", "WorkspacePort"]
 
 
 @runtime_checkable
@@ -173,12 +184,108 @@ class PRPort(Protocol):
         """Return open issues carrying any of *hitl_labels*."""
         ...
 
+    # --- Branch inspection ---
+
+    async def find_open_pr_for_branch(
+        self, branch: str, *, issue_number: int = 0
+    ) -> PRInfo | None:
+        """Return the open PR for *branch*, or ``None`` when absent/unreadable."""
+        ...
+
+    async def branch_has_diff_from_main(self, branch: str) -> bool:
+        """Return whether *branch* has commits ahead of configured main branch."""
+        ...
+
+    @staticmethod
+    def expected_pr_title(issue_number: int, issue_title: str) -> str:
+        """Return the canonical PR title for an issue: ``Fixes #N: <title>``."""
+        ...
+
+    async def update_pr_title(self, pr_number: int, title: str) -> bool:
+        """Update the title of an existing PR. Returns True on success."""
+        ...
+
+    # --- PR detail accessors ---
+
+    async def get_pr_diff_names(self, pr_number: int) -> list[str]:
+        """Fetch the list of files changed in *pr_number*."""
+        ...
+
+    async def get_pr_approvers(self, pr_number: int) -> list[str]:
+        """Fetch the list of GitHub usernames that approved *pr_number*."""
+        ...
+
+    async def get_pr_head_sha(self, pr_number: int) -> str:
+        """Fetch the HEAD commit SHA for *pr_number*. Returns empty string on failure."""
+        ...
+
+    async def get_pr_mergeable(self, pr_number: int) -> bool | None:
+        """Return whether *pr_number* is mergeable. ``None`` if unknown."""
+        ...
+
+    async def post_pr_comment(self, pr_number: int, body: str) -> None:
+        """Post a comment on a GitHub pull request."""
+        ...
+
+    # --- Issue detail accessors ---
+
+    async def list_issues_by_label(self, label: str) -> list[dict[str, Any]]:
+        """Return open issues with the given label as a list of dicts."""
+        ...
+
+    async def get_issue_state(self, issue_number: int) -> str:
+        """Return the resolved state of a GitHub issue (``'COMPLETED'``, ``'OPEN'``, etc.)."""
+        ...
+
+    async def get_issue_updated_at(self, issue_number: int) -> str:
+        """Return the updated_at timestamp for an issue as ISO string."""
+        ...
+
+    async def update_issue_body(self, issue_number: int, body: str) -> None:
+        """Update the body of a GitHub issue."""
+        ...
+
+    # --- CI / repo operations ---
+
+    async def get_latest_ci_status(self) -> tuple[str, str]:
+        """Return (conclusion, url) for the latest CI run on the main branch."""
+        ...
+
+    async def get_dependabot_alerts(self, state: str = "open") -> list[dict]:
+        """Fetch Dependabot alerts for the repository."""
+        ...
+
+    async def pull_main(self) -> bool:
+        """Pull latest main into the local repo."""
+        ...
+
+    # --- Asset upload ---
+
+    async def upload_screenshot(self, png_path: Path) -> str:
+        """Upload a local PNG to GitHub and return the URL. Empty string on failure."""
+        ...
+
     # --- TaskTransitioner compatibility ---
-    # PRManager satisfies TaskTransitioner (post_comment, close_task,
-    # transition, create_task) — those methods are defined on PRPort via the
-    # shared post_comment above.  The remaining transition methods are
-    # intentionally omitted here to keep PRPort focused on infrastructure
-    # concerns; use TaskTransitioner from task_source for domain transitions.
+    # PRManager satisfies both PRPort and TaskTransitioner.  Phases assign
+    # ``self._transitioner: TaskTransitioner = prs`` from a PRPort-typed
+    # parameter, so PRPort must include these methods for structural
+    # compatibility.
+
+    async def transition(
+        self, issue_number: int, new_stage: str, *, pr_number: int | None = None
+    ) -> None:
+        """Move *issue_number* to *new_stage* in the pipeline."""
+        ...
+
+    async def close_task(self, issue_number: int) -> None:
+        """Close a task (GitHub issue)."""
+        ...
+
+    async def create_task(
+        self, title: str, body: str, labels: list[str] | None = None
+    ) -> int:
+        """Create a new task (GitHub issue). Returns the new issue number."""
+        ...
 
 
 @runtime_checkable
@@ -209,4 +316,110 @@ class WorkspacePort(Protocol):
 
     async def get_conflicting_files(self, worktree_path: Path) -> list[str]:
         """Return a list of files with merge conflicts in *worktree_path*."""
+        ...
+
+    async def reset_to_main(self, worktree_path: Path) -> None:
+        """Hard-reset worktree to ``origin/main`` and clean untracked files."""
+        ...
+
+    async def post_work_cleanup(self, issue_number: int) -> None:
+        """Clean up after an issue is done (salvage uncommitted changes, destroy workspace)."""
+        ...
+
+    async def abort_merge(self, worktree_path: Path) -> None:
+        """Abort an in-progress merge in *worktree_path*."""
+        ...
+
+    async def start_merge_main(self, worktree_path: Path, branch: str) -> bool:
+        """Begin merging main into *branch*, leaving conflicts for manual resolution.
+
+        Returns *True* if the merge completed cleanly, *False* if conflicts remain.
+        """
+        ...
+
+
+@runtime_checkable
+class IssueStorePort(Protocol):
+    """Port for in-memory issue work-queue operations.
+
+    Implemented by: ``issue_store.IssueStore``
+
+    Only the methods consumed by domain code (phases, background loops,
+    phase utilities) are declared here.  Orchestrator-only and dashboard-only
+    methods stay on the concrete class.
+    """
+
+    # --- Queue accessors ---
+
+    def get_triageable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the find queue."""
+        ...
+
+    def get_plannable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the plan queue."""
+        ...
+
+    def get_implementable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the ready queue."""
+        ...
+
+    def get_reviewable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the review queue."""
+        ...
+
+    # --- Transition / lifecycle ---
+
+    def enqueue_transition(self, task: Task, next_stage: str) -> None:
+        """Immediately route *task* into *next_stage* in-memory."""
+        ...
+
+    def mark_active(self, issue_number: int, stage: str) -> None:
+        """Mark a task as actively being processed in *stage*."""
+        ...
+
+    def mark_complete(self, issue_number: int) -> None:
+        """Mark a task as done processing; increment throughput counter."""
+        ...
+
+    def mark_merged(self, issue_number: int) -> None:
+        """Record an issue as merged so it appears in the pipeline snapshot."""
+        ...
+
+    def release_in_flight(self, issue_numbers: set[int]) -> None:
+        """Remove *issue_numbers* from the in-flight protection set."""
+        ...
+
+    def is_active(self, issue_number: int) -> bool:
+        """Return True if the task is currently being processed."""
+        ...
+
+    # --- Enrichment ---
+
+    async def enrich_with_comments(self, task: Task) -> Task:
+        """Fetch issue comments and return an enriched copy of *task*."""
+        ...
+
+
+@runtime_checkable
+class IssueFetcherPort(Protocol):
+    """Port for GitHub issue fetching operations.
+
+    Implemented by: ``issue_fetcher.IssueFetcher``
+
+    Only the methods consumed by domain code (phases, background loops)
+    are declared here.
+    """
+
+    async def fetch_issue_by_number(self, issue_number: int) -> GitHubIssue | None:
+        """Fetch a single issue by number. Returns ``None`` on failure."""
+        ...
+
+    async def fetch_issues_by_labels(
+        self,
+        labels: list[str],
+        limit: int,
+        exclude_labels: list[str] | None = None,
+        require_complete: bool = False,
+    ) -> list[GitHubIssue]:
+        """Fetch open issues matching *any* of *labels*, deduplicated."""
         ...

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -15,7 +15,8 @@ from events import EventBus, EventType, HydraFlowEvent
 
 if TYPE_CHECKING:
     from epic import EpicManager
-    from issue_store import IssueStore
+    from ports import IssueStorePort, PRPort
+
 from models import (
     CiGateFn,
     CodeScanningAlert,
@@ -38,7 +39,6 @@ from models import (
     VisualValidationDecision,
     VisualValidationPolicy,
 )
-from pr_manager import PRManager
 from prompt_telemetry import PromptTelemetry
 from retrospective import RetrospectiveCollector
 from state import StateTracker
@@ -88,7 +88,7 @@ class PostMergeHandler:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        prs: PRManager,
+        prs: PRPort,
         event_bus: EventBus,
         ac_generator: AcceptanceCriteriaGenerator | None,
         retrospective: RetrospectiveCollector | None,
@@ -96,7 +96,7 @@ class PostMergeHandler:
         epic_checker: EpicCompletionChecker | None,
         update_bg_worker_status: StatusCallback | None = None,
         epic_manager: EpicManager | None = None,
-        store: IssueStore | None = None,
+        store: IssueStorePort | None = None,
     ) -> None:
         self._config = config
         self._state = state

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -18,17 +18,15 @@ if TYPE_CHECKING:
     from config import HydraFlowConfig
     from events import EventBus
     from hitl_runner import HITLRunner
-    from issue_fetcher import IssueFetcher
     from issue_store import IssueStore
     from merge_conflict_resolver import MergeConflictResolver
     from models import GitHubIssue, HITLItem, UnstickResult
-    from pr_manager import PRManager
+    from ports import IssueFetcherPort, PRPort, WorkspacePort
     from state import StateTracker
     from troubleshooting_store import (
         TroubleshootingPattern,
         TroubleshootingPatternStore,
     )
-    from workspace import WorkspaceManager
 
 logger = logging.getLogger("hydraflow.pr_unsticker")
 
@@ -104,10 +102,10 @@ class PRUnsticker:
         config: HydraFlowConfig,
         state: StateTracker,
         event_bus: EventBus,
-        pr_manager: PRManager,
+        pr_manager: PRPort,
         agents: AgentRunner,
-        worktrees: WorkspaceManager,
-        fetcher: IssueFetcher,
+        worktrees: WorkspacePort,
+        fetcher: IssueFetcherPort,
         hitl_runner: HITLRunner | None = None,
         stop_event: asyncio.Event | None = None,
         resolver: MergeConflictResolver | None = None,

--- a/src/pr_unsticker_loop.py
+++ b/src/pr_unsticker_loop.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
-from pr_manager import PRManager
 from pr_unsticker import PRUnsticker
+
+if TYPE_CHECKING:
+    from ports import PRPort
 
 logger = logging.getLogger("hydraflow.pr_unsticker_loop")
 
@@ -20,7 +22,7 @@ class PRUnstickerLoop(BaseBackgroundLoop):
         self,
         config: HydraFlowConfig,
         pr_unsticker: PRUnsticker,
-        prs: PRManager,
+        prs: PRPort,
         deps: LoopDeps,
     ) -> None:
         super().__init__(worker_name="pr_unsticker", config=config, deps=deps)

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -18,17 +18,19 @@ import re
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from agent_cli import build_agent_command
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from execution import SubprocessRunner
 from models import PendingReport, TranscriptEventData
-from pr_manager import PRManager
 from runner_utils import AuthenticationRetryError, stream_claude_process
 from screenshot_scanner import scan_base64_for_secrets
 from state import StateTracker
+
+if TYPE_CHECKING:
+    from pr_manager import PRManager
 
 logger = logging.getLogger("hydraflow.report_issue_loop")
 

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from dolt_backend import DoltBackend
     from hindsight import HindsightClient
     from hindsight_wal import HindsightWAL
+    from ports import IssueStorePort, PRPort, WorkspacePort
     from visual_validator import VisualValidator
 
 from adr_utils import (
@@ -29,7 +30,6 @@ from comment_formatter import SelfReviewError
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from harness_insights import FailureCategory, HarnessInsightStore
-from issue_store import IssueStore
 from merge_conflict_resolver import MergeConflictResolver
 from models import (
     BaselineApprovalResult,
@@ -60,7 +60,6 @@ from phase_utils import (
     store_lifecycle,
 )
 from post_merge_handler import PostMergeHandler
-from pr_manager import PRManager
 from review_insights import (
     _PROPOSAL_STALE_DAYS,
     CATEGORY_DESCRIPTIONS,
@@ -74,7 +73,6 @@ from review_insights import (
 from reviewer import ReviewRunner
 from state import StateTracker
 from task_source import TaskTransitioner
-from workspace import WorkspaceManager
 
 logger = logging.getLogger("hydraflow.review_phase")
 
@@ -103,11 +101,11 @@ class ReviewPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        worktrees: WorkspaceManager,
+        worktrees: WorkspacePort,
         reviewers: ReviewRunner,
-        prs: PRManager,
+        prs: PRPort,
         stop_event: asyncio.Event,
-        store: IssueStore,
+        store: IssueStorePort,
         event_bus: EventBus | None = None,
         harness_insights: HarnessInsightStore | None = None,
         conflict_resolver: MergeConflictResolver | None = None,

--- a/src/security_patch_loop.py
+++ b/src/security_patch_loop.py
@@ -10,7 +10,7 @@ from config import HydraFlowConfig
 from dedup_store import DedupStore
 
 if TYPE_CHECKING:
-    from pr_manager import PRManager
+    from ports import PRPort
 
 logger = logging.getLogger("hydraflow.security_patch_loop")
 
@@ -34,7 +34,7 @@ class SecurityPatchLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        pr_manager: PRManager,
+        pr_manager: PRPort,
         deps: LoopDeps,
     ) -> None:
         super().__init__(worker_name="security_patch", config=config, deps=deps)

--- a/src/stale_issue_gc_loop.py
+++ b/src/stale_issue_gc_loop.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
-from pr_manager import PRManager
+
+if TYPE_CHECKING:
+    from ports import PRPort
 
 logger = logging.getLogger("hydraflow.stale_issue_gc")
 
@@ -27,7 +29,7 @@ class StaleIssueGCLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        pr_manager: PRManager,
+        pr_manager: PRPort,
         deps: LoopDeps,
     ) -> None:
         super().__init__(

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -14,7 +14,6 @@ from adr_utils import (
 )
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
-from issue_store import IssueStore
 from models import HITLUpdatePayload, Task, TriageResult
 from phase_utils import (
     _sentry_transaction,
@@ -23,13 +22,13 @@ from phase_utils import (
     run_refilling_pool,
     store_lifecycle,
 )
-from pr_manager import PRManager
 from state import StateTracker
 from task_source import TaskTransitioner
 from triage import TriageRunner
 
 if TYPE_CHECKING:
     from epic import EpicManager
+    from ports import IssueStorePort, PRPort
 
 logger = logging.getLogger("hydraflow.triage_phase")
 
@@ -48,9 +47,9 @@ class TriagePhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        store: IssueStore,
+        store: IssueStorePort,
         triage: TriageRunner,
-        prs: PRManager,
+        prs: PRPort,
         event_bus: EventBus,
         stop_event: asyncio.Event,
         epic_manager: EpicManager | None = None,

--- a/src/workspace_gc_loop.py
+++ b/src/workspace_gc_loop.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
-from pr_manager import PRManager
 from state import StateTracker
 from subprocess_util import run_subprocess
-from workspace import WorkspaceManager
+
+if TYPE_CHECKING:
+    from ports import PRPort, WorkspacePort
 
 logger = logging.getLogger("hydraflow.workspace_gc_loop")
 
@@ -30,8 +31,8 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        worktrees: WorkspaceManager,
-        prs: PRManager,
+        worktrees: WorkspacePort,
+        prs: PRPort,
         state: StateTracker,
         deps: LoopDeps,
         is_in_pipeline_cb: Callable[[int], bool] | None = None,

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -21,7 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from ports import PRPort, WorkspacePort
+from ports import IssueFetcherPort, IssueStorePort, PRPort, WorkspacePort
 
 # ---------------------------------------------------------------------------
 # PRPort
@@ -128,6 +128,23 @@ class TestPRPortMethods:
         "close_issue",
         "create_issue",
         "list_hitl_items",
+        "find_open_pr_for_branch",
+        "branch_has_diff_from_main",
+        "expected_pr_title",
+        "update_pr_title",
+        "get_pr_diff_names",
+        "get_pr_approvers",
+        "get_pr_head_sha",
+        "get_pr_mergeable",
+        "post_pr_comment",
+        "list_issues_by_label",
+        "get_issue_state",
+        "get_issue_updated_at",
+        "update_issue_body",
+        "get_latest_ci_status",
+        "get_dependabot_alerts",
+        "pull_main",
+        "upload_screenshot",
     ]
 
     @pytest.mark.parametrize("method", _REQUIRED_METHODS)
@@ -148,6 +165,10 @@ class TestWorkspacePortMethods:
         "destroy_all",
         "merge_main",
         "get_conflicting_files",
+        "reset_to_main",
+        "post_work_cleanup",
+        "abort_merge",
+        "start_merge_main",
     ]
 
     @pytest.mark.parametrize("method", _REQUIRED_METHODS)
@@ -212,6 +233,23 @@ class TestPRPortSignatures:
         "close_issue",
         "create_issue",
         "list_hitl_items",
+        "find_open_pr_for_branch",
+        "branch_has_diff_from_main",
+        "expected_pr_title",
+        "update_pr_title",
+        "get_pr_diff_names",
+        "get_pr_approvers",
+        "get_pr_head_sha",
+        "get_pr_mergeable",
+        "post_pr_comment",
+        "list_issues_by_label",
+        "get_issue_state",
+        "get_issue_updated_at",
+        "update_issue_body",
+        "get_latest_ci_status",
+        "get_dependabot_alerts",
+        "pull_main",
+        "upload_screenshot",
     ]
 
     @pytest.mark.parametrize("method", _SIGNED_METHODS)
@@ -231,6 +269,10 @@ class TestWorkspacePortSignatures:
         "destroy_all",
         "merge_main",
         "get_conflicting_files",
+        "reset_to_main",
+        "post_work_cleanup",
+        "abort_merge",
+        "start_merge_main",
     ]
 
     @pytest.mark.parametrize("method", _SIGNED_METHODS)
@@ -239,3 +281,158 @@ class TestWorkspacePortSignatures:
 
         result = _assert_param_names_match(WorkspacePort, WorkspaceManager, method)
         assert result is None  # raises AssertionError on mismatch
+
+
+# ---------------------------------------------------------------------------
+# IssueStorePort
+# ---------------------------------------------------------------------------
+
+
+class TestIssueStorePortConformance:
+    """IssueStore must satisfy the IssueStorePort protocol."""
+
+    def test_issue_store_satisfies_port(self) -> None:
+        """IssueStore is a structural subtype of IssueStorePort."""
+        from events import EventBus
+        from issue_store import IssueStore
+        from task_source import TaskFetcher
+
+        config = MagicMock()
+        config.data_poll_interval = 30
+        config.find_label = ["hydraflow-find"]
+        config.planner_label = ["hydraflow-plan"]
+        config.ready_label = ["hydraflow-ready"]
+        config.review_label = ["hydraflow-review"]
+        config.hitl_label = ["hydraflow-hitl"]
+        config.hitl_active_label = ["hydraflow-hitl-active"]
+        config.epic_child_label = []
+
+        fetcher = AsyncMock(spec=TaskFetcher)
+        bus = EventBus()
+
+        store = IssueStore(config, fetcher, bus)
+        assert isinstance(store, IssueStorePort), (
+            "IssueStore no longer satisfies the IssueStorePort protocol. "
+            "Check that all methods declared in IssueStorePort exist on IssueStore."
+        )
+
+    def test_async_mock_satisfies_issue_store_port(self) -> None:
+        """An AsyncMock spec'd to IssueStorePort is accepted."""
+        mock: IssueStorePort = AsyncMock(spec=IssueStorePort)  # type: ignore[assignment]
+        assert isinstance(mock, IssueStorePort)
+
+
+class TestIssueStorePortMethods:
+    """All methods declared in IssueStorePort exist on IssueStore."""
+
+    _REQUIRED_METHODS = [
+        "get_triageable",
+        "get_plannable",
+        "get_implementable",
+        "get_reviewable",
+        "enqueue_transition",
+        "mark_active",
+        "mark_complete",
+        "mark_merged",
+        "release_in_flight",
+        "is_active",
+        "enrich_with_comments",
+    ]
+
+    @pytest.mark.parametrize("method", _REQUIRED_METHODS)
+    def test_method_exists_on_issue_store(self, method: str) -> None:
+        from issue_store import IssueStore
+
+        assert hasattr(IssueStore, method), (
+            f"IssueStore is missing '{method}' which is declared in IssueStorePort"
+        )
+
+
+class TestIssueStorePortSignatures:
+    """IssueStorePort method signatures must match IssueStore's implementations."""
+
+    _SIGNED_METHODS = [
+        "get_triageable",
+        "get_plannable",
+        "get_implementable",
+        "get_reviewable",
+        "enqueue_transition",
+        "mark_active",
+        "mark_complete",
+        "mark_merged",
+        "release_in_flight",
+        "is_active",
+        "enrich_with_comments",
+    ]
+
+    @pytest.mark.parametrize("method", _SIGNED_METHODS)
+    def test_signature_matches_issue_store(self, method: str) -> None:
+        from issue_store import IssueStore
+
+        result = _assert_param_names_match(IssueStorePort, IssueStore, method)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# IssueFetcherPort
+# ---------------------------------------------------------------------------
+
+
+class TestIssueFetcherPortConformance:
+    """IssueFetcher must satisfy the IssueFetcherPort protocol."""
+
+    def test_issue_fetcher_satisfies_port(self) -> None:
+        """IssueFetcher is a structural subtype of IssueFetcherPort."""
+        from issue_fetcher import IssueFetcher
+
+        config = MagicMock()
+        config.repo = "org/repo"
+        config.gh_token = None
+        config.dry_run = False
+        config.data_poll_interval = 30
+        config.collaborator_cache_ttl = 600
+        config.collaborator_check_enabled = False
+
+        fetcher = IssueFetcher(config)
+        assert isinstance(fetcher, IssueFetcherPort), (
+            "IssueFetcher no longer satisfies the IssueFetcherPort protocol. "
+            "Check that all methods declared in IssueFetcherPort exist on IssueFetcher."
+        )
+
+    def test_async_mock_satisfies_issue_fetcher_port(self) -> None:
+        """An AsyncMock spec'd to IssueFetcherPort is accepted."""
+        mock: IssueFetcherPort = AsyncMock(spec=IssueFetcherPort)  # type: ignore[assignment]
+        assert isinstance(mock, IssueFetcherPort)
+
+
+class TestIssueFetcherPortMethods:
+    """All methods declared in IssueFetcherPort exist on IssueFetcher."""
+
+    _REQUIRED_METHODS = [
+        "fetch_issue_by_number",
+        "fetch_issues_by_labels",
+    ]
+
+    @pytest.mark.parametrize("method", _REQUIRED_METHODS)
+    def test_method_exists_on_issue_fetcher(self, method: str) -> None:
+        from issue_fetcher import IssueFetcher
+
+        assert hasattr(IssueFetcher, method), (
+            f"IssueFetcher is missing '{method}' which is declared in IssueFetcherPort"
+        )
+
+
+class TestIssueFetcherPortSignatures:
+    """IssueFetcherPort method signatures must match IssueFetcher's implementations."""
+
+    _SIGNED_METHODS = [
+        "fetch_issue_by_number",
+        "fetch_issues_by_labels",
+    ]
+
+    @pytest.mark.parametrize("method", _SIGNED_METHODS)
+    def test_signature_matches_issue_fetcher(self, method: str) -> None:
+        from issue_fetcher import IssueFetcher
+
+        result = _assert_param_names_match(IssueFetcherPort, IssueFetcher, method)
+        assert result is None


### PR DESCRIPTION
## Summary
- Adds `IssueStorePort` and `IssueFetcherPort` protocols to ports.py
- Expands `PRPort` and `WorkspacePort` with all methods phases/loops actually use
- Migrates all 5 phase files from concrete infrastructure imports to protocol types
- Migrates ~10 background loops to use protocol types
- Migrates support files (phase_utils, merge_conflict_resolver, post_merge_handler, pr_unsticker)
- Keeps concrete imports only in composition root (service_registry, orchestrator, dashboard) and report_issue_loop (uses private PRManager members)

Closes #5918

## Test plan
- [x] `make quality` passes (lint, typecheck, security, tests)
- [x] Conformance tests verify IssueStore and IssueFetcher implement their ports
- [x] Zero type errors across all 20 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)