### PR TITLE
refactor: Replace brittle interfaces with typed context objects (#5924)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2501,6 +2501,28 @@ class MergeConflictFixFn(Protocol):
     ) -> bool: ...
 
 
+@dataclass(slots=True)
+class MergeApprovalContext:
+    """Groups the 12 parameters of ``PostMergeHandler.handle_approved``.
+
+    Replacing a flat parameter list with a typed context object makes call
+    sites self-documenting and eliminates positional-argument ordering bugs.
+    """
+
+    pr: PRInfo
+    issue: Task
+    result: ReviewResult
+    diff: str
+    worker_id: int
+    ci_gate_fn: CiGateFn
+    escalate_fn: EscalateFn
+    publish_fn: PublishFn
+    code_scanning_alerts: list[CodeScanningAlert] | None = None
+    visual_gate_fn: VisualGateFn | None = None
+    visual_decision: VisualValidationDecision | None = None
+    merge_conflict_fix_fn: MergeConflictFixFn | None = None
+
+
 class StatusCallback(Protocol):
     """Sync callback for background worker status updates.
 

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -18,23 +18,18 @@ if TYPE_CHECKING:
     from ports import IssueStorePort, PRPort
 
 from models import (
-    CiGateFn,
-    CodeScanningAlert,
     CriterionVerdict,
-    EscalateFn,
     GitHubIssue,
     HitlEscalation,
     JudgeResult,
     JudgeVerdict,
-    MergeConflictFixFn,
+    MergeApprovalContext,
     PRInfo,
-    PublishFn,
     ReviewResult,
     StatusCallback,
     SystemAlertPayload,
     Task,
     VerificationCriterion,
-    VisualGateFn,
     VisualGatePayload,
     VisualValidationDecision,
     VisualValidationPolicy,
@@ -171,24 +166,26 @@ class PostMergeHandler:
 
     async def handle_approved(
         self,
-        pr: PRInfo,
-        issue: Task,
-        result: ReviewResult,
-        diff: str,
-        worker_id: int,
-        ci_gate_fn: CiGateFn,
-        escalate_fn: EscalateFn,
-        publish_fn: PublishFn,
-        code_scanning_alerts: list[CodeScanningAlert] | None = None,
-        visual_gate_fn: VisualGateFn | None = None,
-        visual_decision: VisualValidationDecision | None = None,
-        merge_conflict_fix_fn: MergeConflictFixFn | None = None,
+        ctx: MergeApprovalContext,
     ) -> None:
         """Attempt merge for an approved PR (with optional CI gate).
 
         For epic children with bundled merge strategies, the PR is approved
         but merge is deferred until all siblings are ready.
         """
+        pr = ctx.pr
+        issue = ctx.issue
+        result = ctx.result
+        diff = ctx.diff
+        worker_id = ctx.worker_id
+        ci_gate_fn = ctx.ci_gate_fn
+        escalate_fn = ctx.escalate_fn
+        publish_fn = ctx.publish_fn
+        code_scanning_alerts = ctx.code_scanning_alerts
+        visual_gate_fn = ctx.visual_gate_fn
+        visual_decision = ctx.visual_decision
+        merge_conflict_fix_fn = ctx.merge_conflict_fix_fn
+
         # Notify EpicManager of approval (for bundled merge coordination)
         if self._epic_manager is not None:
             await self._notify_epic_approval(pr.issue_number)

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -37,6 +37,7 @@ from models import (
     ConflictResolutionResult,
     HitlEscalation,
     JudgeResult,
+    MergeApprovalContext,
     PipelineStage,
     PRInfo,
     ReviewResult,
@@ -106,10 +107,11 @@ class ReviewPhase:
         prs: PRPort,
         stop_event: asyncio.Event,
         store: IssueStorePort,
+        conflict_resolver: MergeConflictResolver,
+        post_merge: PostMergeHandler,
         event_bus: EventBus | None = None,
         harness_insights: HarnessInsightStore | None = None,
-        conflict_resolver: MergeConflictResolver | None = None,
-        post_merge: PostMergeHandler | None = None,
+        review_insights: ReviewInsightStore | None = None,
         update_bg_worker_status: StatusCallback | None = None,
         baseline_policy: BaselinePolicy | None = None,
         hindsight: HindsightClient | None = None,
@@ -128,30 +130,14 @@ class ReviewPhase:
         self._suggest_memory = MemorySuggester(config, prs, state)
         self._update_bg_worker_status = update_bg_worker_status
         self._harness_insights = harness_insights
-        self._insights = ReviewInsightStore(config.memory_dir, dolt=dolt, wal=wal)
+        self._insights = review_insights or ReviewInsightStore(
+            config.memory_dir, dolt=dolt, wal=wal
+        )
         self._wal = wal
         self._active_issues: set[int] = set()
         self._active_issues_lock = asyncio.Lock()
-        self._conflict_resolver = conflict_resolver or MergeConflictResolver(
-            config=config,
-            worktrees=worktrees,
-            agents=None,
-            prs=prs,
-            event_bus=self._bus,
-            state=state,
-            summarizer=None,
-        )
-        self._post_merge = post_merge or PostMergeHandler(
-            config=config,
-            state=state,
-            prs=prs,
-            event_bus=self._bus,
-            ac_generator=None,
-            retrospective=None,
-            verification_judge=None,
-            epic_checker=None,
-            store=store,
-        )
+        self._conflict_resolver = conflict_resolver
+        self._post_merge = post_merge
         self._baseline_policy = baseline_policy
         self._hindsight = hindsight
         self._visual_validator: VisualValidator | None = None
@@ -1070,12 +1056,12 @@ class ReviewPhase:
         visual_decision: VisualValidationDecision | None = None,
     ) -> None:
         """Attempt merge for an approved PR (with optional CI gate)."""
-        await self._post_merge.handle_approved(
-            pr,
-            issue,
-            result,
-            diff,
-            worker_id,
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff=diff,
+            worker_id=worker_id,
             ci_gate_fn=self.wait_and_fix_ci,
             escalate_fn=self._escalate_to_hitl,
             publish_fn=self._publish_review_status,
@@ -1084,6 +1070,7 @@ class ReviewPhase:
             visual_decision=visual_decision,
             merge_conflict_fix_fn=self._attempt_post_merge_conflict_fix,
         )
+        await self._post_merge.handle_approved(ctx)
 
     async def _attempt_post_merge_conflict_fix(
         self,

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -48,6 +48,7 @@ from pr_unsticker_loop import PRUnstickerLoop
 from report_issue_loop import ReportIssueLoop
 from research_runner import ResearchRunner
 from retrospective import RetrospectiveCollector
+from review_insights import ReviewInsightStore
 from review_phase import ReviewPhase
 from reviewer import ReviewRunner
 from run_recorder import RunRecorder
@@ -373,6 +374,16 @@ def build_services(
         epic_manager=epic_manager,
         store=store,
     )
+    # ReviewInsightStore shared between AgentRunner and ReviewPhase
+    review_insights = ReviewInsightStore(
+        config.memory_dir,
+        hindsight=hindsight_client,
+        dolt=dolt_backend,
+        wal=hindsight_wal,
+    )
+    # Inject shared store into AgentRunner (replacing its self-constructed copy)
+    agents._insights = review_insights
+
     reviewer = ReviewPhase(
         config,
         state,
@@ -381,10 +392,11 @@ def build_services(
         prs,
         stop_event,
         store,
+        conflict_resolver,
+        post_merge_handler,
         event_bus=event_bus,
         harness_insights=harness_insights,
-        conflict_resolver=conflict_resolver,
-        post_merge=post_merge_handler,
+        review_insights=review_insights,
         update_bg_worker_status=callbacks.update_bg_worker_status,
         baseline_policy=baseline_policy,
         hindsight=hindsight_client,

--- a/src/state/_worker.py
+++ b/src/state/_worker.py
@@ -143,12 +143,12 @@ class WorkerStateMixin:
         stored.pop("enabled", None)  # enabled is runtime-only
         raw_details = stored.get("details")
         details = self._normalise_details(
-            raw_details if isinstance(raw_details, (dict, str)) else None
+            raw_details if isinstance(raw_details, dict | str) else None
         )
         status = str(stored.get("status", "disabled"))
         raw_last_run = stored.get("last_run")
         last_run = self._coerce_last_run(
-            raw_last_run if isinstance(raw_last_run, (str, int, float)) else None
+            raw_last_run if isinstance(raw_last_run, str | int | float) else None
         )
         self._persist_worker_state(name, status, last_run, details)
         self.save()

--- a/src/stream_parser.py
+++ b/src/stream_parser.py
@@ -478,7 +478,7 @@ def _map_top_level_usage_scalars(event: dict[str, Any]) -> dict[str, int]:
     """Map only top-level scalar usage keys (avoid nested tool payload false positives)."""
     totals: dict[str, int] = {}
     for key, value in event.items():
-        if not isinstance(value, (int, float)):
+        if not isinstance(value, int | float):
             continue
         canonical = _canonical_usage_key(str(key))
         if not canonical:
@@ -492,7 +492,7 @@ def _iter_numeric_fields(obj: Any) -> list[tuple[str, int]]:
     out: list[tuple[str, int]] = []
     if isinstance(obj, dict):
         for k, v in obj.items():
-            if isinstance(v, (int, float)):
+            if isinstance(v, int | float):
                 out.append((str(k), int(v)))
             else:
                 out.extend(_iter_numeric_fields(v))

--- a/src/visual_validator.py
+++ b/src/visual_validator.py
@@ -42,7 +42,7 @@ def classify_failure(error: Exception) -> VisualFailureClass:
     """Classify an exception into a visual failure class."""
     if isinstance(error, TimeoutError):
         return VisualFailureClass.TIMEOUT
-    if isinstance(error, (ConnectionError, OSError)):
+    if isinstance(error, ConnectionError | OSError):
         return VisualFailureClass.INFRA_FAILURE
     return VisualFailureClass.CAPTURE_ERROR
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -710,9 +710,9 @@ class PipelineHarness:
             prs=self.prs,
             stop_event=self.stop_event,
             store=self.store,
-            event_bus=self.bus,
             conflict_resolver=self._conflict_resolver,
             post_merge=self.post_merge,
+            event_bus=self.bus,
         )
         self.hitl_phase = HITLPhase(
             config=self.config,
@@ -1460,30 +1460,27 @@ def make_review_phase(
 
     bus = event_bus or EventBus()
 
-    conflict_resolver = None
-    if agents is not None:
-        conflict_resolver = MergeConflictResolver(
-            config=config,
-            worktrees=mock_wt,
-            agents=agents,
-            prs=mock_prs,
-            event_bus=bus,
-            state=state,
-            summarizer=None,
-        )
+    conflict_resolver = MergeConflictResolver(
+        config=config,
+        worktrees=mock_wt,
+        agents=agents,
+        prs=mock_prs,
+        event_bus=bus,
+        state=state,
+        summarizer=None,
+    )
 
-    post_merge = None
-    if ac_generator is not None:
-        post_merge = PostMergeHandler(
-            config=config,
-            state=state,
-            prs=mock_prs,
-            event_bus=bus,
-            ac_generator=ac_generator,
-            retrospective=None,
-            verification_judge=None,
-            epic_checker=None,
-        )
+    post_merge = PostMergeHandler(
+        config=config,
+        state=state,
+        prs=mock_prs,
+        event_bus=bus,
+        ac_generator=ac_generator,
+        retrospective=None,
+        verification_judge=None,
+        epic_checker=None,
+        store=mock_store,
+    )
 
     phase = ReviewPhase(
         config=config,
@@ -1493,9 +1490,9 @@ def make_review_phase(
         prs=mock_prs,
         stop_event=stop_event,
         store=mock_store,
-        event_bus=bus,
         conflict_resolver=conflict_resolver,
         post_merge=post_merge,
+        event_bus=bus,
         baseline_policy=baseline_policy,
     )
 

--- a/tests/test_no_shadow_imports.py
+++ b/tests/test_no_shadow_imports.py
@@ -41,7 +41,7 @@ def _module_level_names(tree: ast.Module) -> set[str]:
     """
     names: set[str] = set()
     for node in ast.iter_child_nodes(tree):
-        if isinstance(node, (ast.Import, ast.ImportFrom)):
+        if isinstance(node, ast.Import | ast.ImportFrom):
             for alias in node.names:
                 names.add(alias.asname or alias.name)
     return names
@@ -56,10 +56,10 @@ def _inline_shadow_imports(tree: ast.Module) -> list[tuple[int, str]]:
     violations: list[tuple[int, str]] = []
 
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if not isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
             continue
         for child in ast.walk(node):
-            if isinstance(child, (ast.Import, ast.ImportFrom)):
+            if isinstance(child, ast.Import | ast.ImportFrom):
                 for alias in child.names:
                     name = alias.asname or alias.name
                     if name in top_names:

--- a/tests/test_post_merge_handler.py
+++ b/tests/test_post_merge_handler.py
@@ -21,6 +21,7 @@ from models import (
     CriterionResult,
     CriterionVerdict,
     JudgeVerdict,
+    MergeApprovalContext,
     ReviewResult,
 )
 from post_merge_handler import PostMergeHandler
@@ -43,17 +44,18 @@ class _ApprovedSetup:
 
     async def call(self, diff: str = "diff", attempt: int = 0, **kwargs) -> None:
         """Invoke handle_approved with the baseline args, allowing overrides."""
-        await self.handler.handle_approved(
-            self.pr,
-            self.issue,
-            self.result,
-            diff,
-            attempt,
+        ctx = MergeApprovalContext(
+            pr=self.pr,
+            issue=self.issue,
+            result=self.result,
+            diff=diff,
+            worker_id=attempt,
             ci_gate_fn=kwargs.pop("ci_gate_fn", self.ci_gate_fn),
             escalate_fn=kwargs.pop("escalate_fn", self.escalate_fn),
             publish_fn=kwargs.pop("publish_fn", self.publish_fn),
             **kwargs,
         )
+        await self.handler.handle_approved(ctx)
 
 
 def _make_handler(
@@ -727,16 +729,17 @@ class TestMergeOutcomeRecording:
         escalate_fn = AsyncMock()
         ci_gate_fn = AsyncMock(return_value=True)
 
-        await handler.handle_approved(
-            pr,
-            issue,
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=ci_gate_fn,
             escalate_fn=escalate_fn,
             publish_fn=publish_fn,
         )
+        await handler.handle_approved(ctx)
 
         outcome = state.get_outcome(42)
         assert outcome is not None
@@ -843,17 +846,18 @@ class TestVisualGateInHandleApproved:
         ci_gate_fn = AsyncMock(return_value=True)
         visual_gate_fn = AsyncMock(return_value=True)
 
-        await handler.handle_approved(
-            PRInfoFactory.create(),
-            TaskFactory.create(),
-            ReviewResultFactory.create(),
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=PRInfoFactory.create(),
+            issue=TaskFactory.create(),
+            result=ReviewResultFactory.create(),
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=ci_gate_fn,
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
             visual_gate_fn=visual_gate_fn,
         )
+        await handler.handle_approved(ctx)
 
         # Gate disabled by default — visual_gate_fn should not be called
         visual_gate_fn.assert_not_awaited()
@@ -874,17 +878,18 @@ class TestVisualGateInHandleApproved:
         result = ReviewResultFactory.create()
         visual_gate_fn = AsyncMock(return_value=True)
 
-        await handler.handle_approved(
-            PRInfoFactory.create(),
-            TaskFactory.create(),
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=PRInfoFactory.create(),
+            issue=TaskFactory.create(),
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=AsyncMock(return_value=True),
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
             visual_gate_fn=visual_gate_fn,
         )
+        await handler.handle_approved(ctx)
 
         visual_gate_fn.assert_awaited_once()
         assert result.merged is True
@@ -905,17 +910,18 @@ class TestVisualGateInHandleApproved:
         result = ReviewResultFactory.create()
         visual_gate_fn = AsyncMock(return_value=False)
 
-        await handler.handle_approved(
-            PRInfoFactory.create(),
-            TaskFactory.create(),
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=PRInfoFactory.create(),
+            issue=TaskFactory.create(),
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=AsyncMock(return_value=True),
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
             visual_gate_fn=visual_gate_fn,
         )
+        await handler.handle_approved(ctx)
 
         visual_gate_fn.assert_awaited_once()
         assert result.merged is False
@@ -936,17 +942,18 @@ class TestVisualGateInHandleApproved:
         handler._prs.merge_pr = AsyncMock(return_value=True)
         result = ReviewResultFactory.create()
 
-        await handler.handle_approved(
-            PRInfoFactory.create(),
-            TaskFactory.create(),
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=PRInfoFactory.create(),
+            issue=TaskFactory.create(),
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=AsyncMock(return_value=True),
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
             # No visual_gate_fn provided
         )
+        await handler.handle_approved(ctx)
 
         assert result.merged is False
         handler._prs.merge_pr.assert_not_awaited()
@@ -969,17 +976,18 @@ class TestVisualGateInHandleApproved:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        await handler.handle_approved(
-            pr,
-            issue,
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=AsyncMock(return_value=True),
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
             # No visual_gate_fn provided
         )
+        await handler.handle_approved(ctx)
 
         # Merge is blocked when no visual_gate_fn is provided
         assert result.merged is False
@@ -1217,17 +1225,18 @@ class TestNarrowedExceptionHandling:
 
         handler._prs.merge_pr = AsyncMock(return_value=True)
 
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff="diff",
+            worker_id=0,
+            ci_gate_fn=AsyncMock(return_value=True),
+            escalate_fn=AsyncMock(),
+            publish_fn=AsyncMock(),
+        )
         with pytest.raises(TypeError, match="missing required arg"):
-            await handler.handle_approved(
-                pr,
-                issue,
-                result,
-                "diff",
-                0,
-                ci_gate_fn=AsyncMock(return_value=True),
-                escalate_fn=AsyncMock(),
-                publish_fn=AsyncMock(),
-            )
+            await handler.handle_approved(ctx)
 
     @pytest.mark.asyncio
     async def test_status_callback_propagates_attribute_error(
@@ -1247,17 +1256,18 @@ class TestNarrowedExceptionHandling:
 
         handler._prs.merge_pr = AsyncMock(return_value=True)
 
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff="diff",
+            worker_id=0,
+            ci_gate_fn=AsyncMock(return_value=True),
+            escalate_fn=AsyncMock(),
+            publish_fn=AsyncMock(),
+        )
         with pytest.raises(AttributeError, match="no attr"):
-            await handler.handle_approved(
-                pr,
-                issue,
-                result,
-                "diff",
-                0,
-                ci_gate_fn=AsyncMock(return_value=True),
-                escalate_fn=AsyncMock(),
-                publish_fn=AsyncMock(),
-            )
+            await handler.handle_approved(ctx)
 
     @pytest.mark.asyncio
     async def test_safe_hook_inner_post_comment_catches_os_error(
@@ -1364,16 +1374,17 @@ class TestNarrowedExceptionHandling:
         handler._prs.merge_pr = AsyncMock(return_value=True)
 
         # Should not raise — RuntimeError from retrospective is caught
-        await handler.handle_approved(
-            pr,
-            issue,
-            result,
-            "diff",
-            0,
+        ctx = MergeApprovalContext(
+            pr=pr,
+            issue=issue,
+            result=result,
+            diff="diff",
+            worker_id=0,
             ci_gate_fn=AsyncMock(return_value=True),
             escalate_fn=AsyncMock(),
             publish_fn=AsyncMock(),
         )
+        await handler.handle_approved(ctx)
         mock_retro.record.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -2267,30 +2267,24 @@ class TestCleanupWorktree:
         phase._worktrees.post_work_cleanup.assert_awaited_once_with(pr.issue_number)
 
 
-class TestConstructorDefaultHelpers:
-    """Tests that ReviewPhase builds default helpers when not provided."""
+class TestRequiredDIParameters:
+    """Tests that ReviewPhase requires DI parameters (no fallback constructors)."""
 
-    def test_builds_default_conflict_resolver(self, config: HydraFlowConfig) -> None:
-        """ReviewPhase should build a MergeConflictResolver when not provided."""
+    def test_conflict_resolver_injected(self, config: HydraFlowConfig) -> None:
+        """ReviewPhase should receive a MergeConflictResolver via DI."""
         from merge_conflict_resolver import MergeConflictResolver
 
         phase = make_review_phase(config)
 
         assert isinstance(phase._conflict_resolver, MergeConflictResolver)
 
-    def test_builds_default_post_merge_handler(self, config: HydraFlowConfig) -> None:
-        """ReviewPhase should build a PostMergeHandler with all optional deps None."""
+    def test_post_merge_handler_injected(self, config: HydraFlowConfig) -> None:
+        """ReviewPhase should receive a PostMergeHandler via DI."""
         from post_merge_handler import PostMergeHandler
 
         phase = make_review_phase(config)
 
         assert isinstance(phase._post_merge, PostMergeHandler)
-        # Verify all optional post-merge dependencies default to None, not to
-        # values carried over from removed ReviewPhase constructor parameters.
-        assert phase._post_merge._ac_generator is None
-        assert phase._post_merge._retrospective is None
-        assert phase._post_merge._verification_judge is None
-        assert phase._post_merge._epic_checker is None
 
 
 class TestADRReviewPath:

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -1155,6 +1155,29 @@ class TestReviewPhaseWiring:
         wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
+        from merge_conflict_resolver import MergeConflictResolver
+        from post_merge_handler import PostMergeHandler
+
+        conflict_resolver = MergeConflictResolver(
+            config=config,
+            worktrees=mock_wt,
+            agents=None,
+            prs=mock_prs,
+            event_bus=event_bus,
+            state=state,
+            summarizer=None,
+        )
+        post_merge = PostMergeHandler(
+            config=config,
+            state=state,
+            prs=mock_prs,
+            event_bus=event_bus,
+            ac_generator=None,
+            retrospective=None,
+            verification_judge=mock_judge,
+            epic_checker=None,
+        )
+
         phase = ReviewPhase(
             config=config,
             state=state,
@@ -1163,9 +1186,10 @@ class TestReviewPhaseWiring:
             prs=mock_prs,
             stop_event=stop_event,
             store=MagicMock(),
+            conflict_resolver=conflict_resolver,
+            post_merge=post_merge,
             event_bus=event_bus,
         )
-        phase._post_merge._verification_judge = mock_judge
 
         pr = PRInfoFactory.create()
         issue = TaskFactory.create(
@@ -1215,6 +1239,29 @@ class TestReviewPhaseWiring:
         wt_path = config.worktree_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
+        from merge_conflict_resolver import MergeConflictResolver
+        from post_merge_handler import PostMergeHandler
+
+        conflict_resolver = MergeConflictResolver(
+            config=config,
+            worktrees=mock_wt,
+            agents=None,
+            prs=mock_prs,
+            event_bus=event_bus,
+            state=state,
+            summarizer=None,
+        )
+        post_merge = PostMergeHandler(
+            config=config,
+            state=state,
+            prs=mock_prs,
+            event_bus=event_bus,
+            ac_generator=None,
+            retrospective=None,
+            verification_judge=None,  # No verification_judge
+            epic_checker=None,
+        )
+
         phase = ReviewPhase(
             config=config,
             state=state,
@@ -1223,8 +1270,9 @@ class TestReviewPhaseWiring:
             prs=mock_prs,
             stop_event=stop_event,
             store=MagicMock(),
+            conflict_resolver=conflict_resolver,
+            post_merge=post_merge,
             event_bus=event_bus,
-            # No verification_judge
         )
 
         pr = PRInfoFactory.create()

--- a/tests/test_visual_validation.py
+++ b/tests/test_visual_validation.py
@@ -484,6 +484,8 @@ class TestReviewPhaseVisualValidation:
 
         from events import EventBus
         from issue_store import IssueStore
+        from merge_conflict_resolver import MergeConflictResolver
+        from post_merge_handler import PostMergeHandler
         from review_phase import ReviewPhase
         from reviewer import ReviewRunner
         from state import StateTracker
@@ -491,15 +493,38 @@ class TestReviewPhaseVisualValidation:
 
         config = ConfigFactory.create()
         state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        bus = EventBus()
+        conflict_resolver = MergeConflictResolver(
+            config=config,
+            worktrees=AsyncMock(spec=WorkspaceManager),
+            agents=None,
+            prs=mock_prs,
+            event_bus=bus,
+            state=state,
+            summarizer=None,
+        )
+        post_merge = PostMergeHandler(
+            config=config,
+            state=state,
+            prs=mock_prs,
+            event_bus=bus,
+            ac_generator=None,
+            retrospective=None,
+            verification_judge=None,
+            epic_checker=None,
+        )
         phase = ReviewPhase(
             config=config,
             state=state,
             worktrees=AsyncMock(spec=WorkspaceManager),
             reviewers=AsyncMock(spec=ReviewRunner),
-            prs=AsyncMock(),
+            prs=mock_prs,
             stop_event=asyncio.Event(),
             store=AsyncMock(spec=IssueStore),
-            event_bus=EventBus(),
+            conflict_resolver=conflict_resolver,
+            post_merge=post_merge,
+            event_bus=bus,
         )
 
         task = TaskFactory.create(tags=[], comments=[])
@@ -514,6 +539,8 @@ class TestReviewPhaseVisualValidation:
 
         from events import EventBus
         from issue_store import IssueStore
+        from merge_conflict_resolver import MergeConflictResolver
+        from post_merge_handler import PostMergeHandler
         from review_phase import ReviewPhase
         from reviewer import ReviewRunner
         from state import StateTracker
@@ -521,15 +548,38 @@ class TestReviewPhaseVisualValidation:
 
         config = ConfigFactory.create(visual_validation_enabled=False)
         state = StateTracker(config.state_file)
+        mock_prs = AsyncMock()
+        bus = EventBus()
+        conflict_resolver = MergeConflictResolver(
+            config=config,
+            worktrees=AsyncMock(spec=WorkspaceManager),
+            agents=None,
+            prs=mock_prs,
+            event_bus=bus,
+            state=state,
+            summarizer=None,
+        )
+        post_merge = PostMergeHandler(
+            config=config,
+            state=state,
+            prs=mock_prs,
+            event_bus=bus,
+            ac_generator=None,
+            retrospective=None,
+            verification_judge=None,
+            epic_checker=None,
+        )
         phase = ReviewPhase(
             config=config,
             state=state,
             worktrees=AsyncMock(spec=WorkspaceManager),
             reviewers=AsyncMock(spec=ReviewRunner),
-            prs=AsyncMock(),
+            prs=mock_prs,
             stop_event=asyncio.Event(),
             store=AsyncMock(spec=IssueStore),
-            event_bus=EventBus(),
+            conflict_resolver=conflict_resolver,
+            post_merge=post_merge,
+            event_bus=bus,
         )
 
         task = TaskFactory.create()


### PR DESCRIPTION
## Summary
- Adds `MergeApprovalContext` dataclass replacing 12-param `handle_approved` signature
- Removes ReviewPhase fallback dependency constructors (all deps now required via DI)
- Centralizes `ReviewInsightStore` construction in service_registry
- Fixes pre-existing UP038 isinstance lint warnings

Closes #5924

## Test plan
- [x] `make quality-lite` passes (pre-push verified)
- [x] Zero type errors
- [x] Test updates for context object pattern and required DI

🤖 Generated with [Claude Code](https://claude.com/claude-code)