### PR TITLE
refactor: Replace AgentRunner with AgentPort protocol (#5919)

### DIFF
--- a/src/merge_conflict_resolver.py
+++ b/src/merge_conflict_resolver.py
@@ -27,8 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
     from typing import Any
 
-    from agent import AgentRunner  # noqa: F401
-    from ports import PRPort, WorkspacePort
+    from ports import AgentPort, PRPort, WorkspacePort
 
     #: Async callable that suggests memory entries from transcripts.
     MemorySuggesterFn = Callable[[str, str, str], Coroutine[Any, Any, None]]
@@ -43,7 +42,7 @@ class MergeConflictResolver:
         self,
         config: HydraFlowConfig,
         worktrees: WorkspacePort,
-        agents: AgentRunner | None,
+        agents: AgentPort | None,
         prs: PRPort,
         event_bus: EventBus,
         state: StateTracker,

--- a/src/ports.py
+++ b/src/ports.py
@@ -40,6 +40,7 @@ it via ``inspect.signature`` comparison.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, runtime_checkable
 
@@ -49,12 +50,20 @@ from models import (
     CodeScanningAlert,
     GitHubIssue,
     HITLItem,
+    LoopResult,
     PRInfo,
     ReviewVerdict,
     Task,
+    TranscriptEventData,
 )
 
-__all__ = ["IssueFetcherPort", "IssueStorePort", "PRPort", "WorkspacePort"]
+__all__ = [
+    "AgentPort",
+    "IssueFetcherPort",
+    "IssueStorePort",
+    "PRPort",
+    "WorkspacePort",
+]
 
 
 @runtime_checkable
@@ -422,4 +431,40 @@ class IssueFetcherPort(Protocol):
         require_complete: bool = False,
     ) -> list[GitHubIssue]:
         """Fetch open issues matching *any* of *labels*, deduplicated."""
+        ...
+
+
+@runtime_checkable
+class AgentPort(Protocol):
+    """Port for agent runner operations used by infrastructure modules.
+
+    Implemented by: ``agent.AgentRunner`` (via ``base_runner.BaseRunner``)
+
+    Defines only the methods needed by infrastructure modules like
+    ``merge_conflict_resolver`` so they can accept the agent runner via
+    dependency injection without importing from the Runner layer.
+
+    Parameter names and types are kept identical to the concrete
+    implementations to satisfy structural subtype checks.
+    """
+
+    def _build_command(self, _worktree_path: Path | None = None) -> list[str]:
+        """Construct the CLI command for the agent."""
+        ...
+
+    async def _execute(
+        self,
+        cmd: list[str],
+        prompt: str,
+        cwd: Path,
+        event_data: TranscriptEventData,
+        *,
+        on_output: Callable[[str], bool] | None = None,
+        telemetry_stats: Mapping[str, object] | None = None,
+    ) -> str:
+        """Run the agent subprocess and return the transcript."""
+        ...
+
+    async def _verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
+        """Verify the agent produced valid commits and quality passes."""
         ...

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -524,7 +524,7 @@ class TestFreshRebuildTitleUpdate:
 
     @pytest.mark.asyncio
     async def test_updates_title_on_success(self, tmp_path: Path) -> None:
-        """After successful fresh rebuild, PR title should be updated."""
+        """After successful fresh rebuild, PR title should be updated via PRPort."""
         from pr_manager import PRManager
 
         cfg = ConfigFactory.create(
@@ -547,11 +547,13 @@ class TestFreshRebuildTitleUpdate:
         resolver._worktrees.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
         resolver._prs.update_pr_title = AsyncMock(return_value=True)
+        # Resolver now uses self._prs.expected_pr_title (PRPort protocol)
+        expected_title = PRManager.expected_pr_title(77, "Fix the gizmo")
+        resolver._prs.expected_pr_title = PRManager.expected_pr_title
 
         result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
 
         assert result is True
-        expected_title = PRManager.expected_pr_title(77, "Fix the gizmo")
         resolver._prs.update_pr_title.assert_awaited_once_with(200, expected_title)
 
     @pytest.mark.asyncio
@@ -607,8 +609,8 @@ class TestArchitectureLayering:
         source = Path(mod.__file__).read_text()
         assert "from phase_utils import" not in source
 
-    def test_constructor_accepts_base_runner(self) -> None:
-        """Constructor should accept BaseRunner (not AgentRunner) for agents param."""
+    def test_constructor_accepts_agent_port(self) -> None:
+        """Constructor should accept AgentPort (not AgentRunner) for agents param."""
         import inspect
 
         from merge_conflict_resolver import MergeConflictResolver
@@ -616,7 +618,7 @@ class TestArchitectureLayering:
         sig = inspect.signature(MergeConflictResolver.__init__)
         agents_param = sig.parameters["agents"]
         annotation_str = str(agents_param.annotation)
-        assert "BaseRunner" in annotation_str
+        assert "AgentPort" in annotation_str
         assert "AgentRunner" not in annotation_str
 
     @pytest.mark.asyncio
@@ -700,7 +702,7 @@ class TestArchitectureLayering:
 
         review_events = [e for e in published if e.type == EventType.REVIEW_UPDATE]
         assert len(review_events) >= 1
-        assert review_events[0].data.role == "reviewer"
+        assert review_events[0].data["role"] == "reviewer"
 
     @pytest.mark.asyncio
     async def test_fresh_rebuild_uses_prs_expected_pr_title(

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -436,3 +436,57 @@ class TestIssueFetcherPortSignatures:
 
         result = _assert_param_names_match(IssueFetcherPort, IssueFetcher, method)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# AgentPort
+# ---------------------------------------------------------------------------
+
+
+class TestAgentPortConformance:
+    """AgentRunner must satisfy the AgentPort protocol."""
+
+    def test_agent_runner_satisfies_agent_port(self) -> None:
+        """AgentRunner is a structural subtype of AgentPort."""
+        from agent import AgentRunner
+        from ports import AgentPort
+
+        assert isinstance(AgentRunner.__new__(AgentRunner), AgentPort), (
+            "AgentRunner no longer satisfies the AgentPort protocol. "
+            "Check that all methods declared in AgentPort exist on AgentRunner."
+        )
+
+
+class TestAgentPortMethods:
+    """All methods declared in AgentPort exist on AgentRunner."""
+
+    _REQUIRED_METHODS = [
+        "_build_command",
+        "_execute",
+        "_verify_result",
+    ]
+
+    @pytest.mark.parametrize("method", _REQUIRED_METHODS)
+    def test_method_exists_on_agent_runner(self, method: str) -> None:
+        from agent import AgentRunner
+
+        assert hasattr(AgentRunner, method), (
+            f"AgentRunner is missing '{method}' which is declared in AgentPort"
+        )
+
+
+class TestAgentPortSignatures:
+    """AgentPort method signatures must match AgentRunner's implementations."""
+
+    _SIGNED_METHODS = [
+        "_build_command",
+        "_execute",
+    ]
+
+    @pytest.mark.parametrize("method", _SIGNED_METHODS)
+    def test_signature_matches_agent_runner(self, method: str) -> None:
+        from agent import AgentRunner
+        from ports import AgentPort
+
+        result = _assert_param_names_match(AgentPort, AgentRunner, method)
+        assert result is None


### PR DESCRIPTION
## Summary
- Adds `AgentPort` protocol to `ports.py` defining the three methods `merge_conflict_resolver` needs from the agent runner (`_build_command`, `_execute`, `_verify_result`)
- Changes `merge_conflict_resolver.py` constructor from `agents: AgentRunner | None` to `agents: AgentPort | None`, removing the last upward import into the Runner layer
- Updates existing test for `fresh_branch_rebuild` title update to work with protocol-based `expected_pr_title`
- Adds `AgentPort` conformance, method existence, and signature tests to `test_ports.py`

The prior fix (77e7655f) moved `AgentRunner` to `TYPE_CHECKING` but kept the type annotation, leaving a residual dependency on the Runner layer. This commit completes the fix by introducing a proper protocol.

Closes #5919

## Test plan
- [x] `make lint` passes
- [x] `make typecheck` passes (0 errors)
- [x] `make security` passes
- [x] 223 focused tests pass (test_merge_conflict_resolver, test_exception_classify, test_post_merge_handler, test_ports)
- [x] No upward imports remain in merge_conflict_resolver.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)