### PR TITLE
refactor: Rename worktree -> workspace for naming consistency (#5925)

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -811,7 +811,7 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
         repo_root = Path(self._config.repo_root)
         branch = f"adr/accept-{result.adr_number:04d}"
         worktree_path = (
-            Path(self._config.worktree_base) / f"adr-accept-{result.adr_number:04d}"
+            Path(self._config.workspace_base) / f"adr-accept-{result.adr_number:04d}"
         )
 
         try:

--- a/src/agent.py
+++ b/src/agent.py
@@ -120,7 +120,7 @@ Run through this checklist before your final commit:
         result = WorkerResult(
             issue_number=task.id,
             branch=branch,
-            worktree_path=str(worktree_path),
+            workspace_path=str(worktree_path),
         )
 
         await self._emit_status(task.id, worker_id, WorkerStatus.RUNNING)

--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -133,6 +133,6 @@ class BGWorkerManager:
             "pr_unsticker": self._config.pr_unstick_interval,
             "report_issue": self._config.report_issue_interval,
             "epic_monitor": self._config.epic_monitor_interval,
-            "worktree_gc": self._config.worktree_gc_interval,
+            "workspace_gc": self._config.workspace_gc_interval,
         }
         return defaults.get(name, self._config.poll_interval)

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,13 @@ import shutil
 from pathlib import Path
 from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 import file_util
 
@@ -48,7 +54,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("stale_report_threshold_hours", "HYDRAFLOW_STALE_REPORT_THRESHOLD_HOURS", 6),
     ("epic_monitor_interval", "HYDRAFLOW_EPIC_MONITOR_INTERVAL", 1800),
     ("epic_sweep_interval", "HYDRAFLOW_EPIC_SWEEP_INTERVAL", 3600),
-    ("worktree_gc_interval", "HYDRAFLOW_WORKTREE_GC_INTERVAL", 1800),
+    ("workspace_gc_interval", "HYDRAFLOW_WORKTREE_GC_INTERVAL", 1800),
     ("stale_issue_gc_interval", "HYDRAFLOW_STALE_ISSUE_GC_INTERVAL", 3600),
     ("stale_issue_threshold_days", "HYDRAFLOW_STALE_ISSUE_THRESHOLD_DAYS", 14),
     ("ci_monitor_interval", "HYDRAFLOW_CI_MONITOR_INTERVAL", 300),
@@ -448,11 +454,12 @@ class HydraFlowConfig(BaseModel):
         le=86400,
         description="Epic sweeper loop interval in seconds (default 1 hour)",
     )
-    worktree_gc_interval: int = Field(
+    workspace_gc_interval: int = Field(
         default=1800,
         ge=300,
         le=86400,
-        description="Worktree GC loop interval in seconds (default 30 min)",
+        description="Workspace GC loop interval in seconds (default 30 min)",
+        validation_alias=AliasChoices("workspace_gc_interval", "worktree_gc_interval"),
     )
     stale_issue_gc_interval: int = Field(
         default=3600,
@@ -1035,8 +1042,10 @@ class HydraFlowConfig(BaseModel):
 
     # Paths (auto-detected)
     repo_root: Path = Field(default=Path("."), description="Repository root directory")
-    worktree_base: Path = Field(
-        default=Path("."), description="Base directory for worktrees"
+    workspace_base: Path = Field(
+        default=Path("."),
+        description="Base directory for workspaces",
+        validation_alias=AliasChoices("workspace_base", "worktree_base"),
     )
     data_root: Path = Field(
         default=Path("."),
@@ -1459,16 +1468,16 @@ class HydraFlowConfig(BaseModel):
         """Return the canonical branch name for a given issue number."""
         return f"agent/issue-{issue_number}"
 
-    def worktree_path_for_issue(self, issue_number: int) -> Path:
-        """Return the repo-scoped worktree directory path for a given issue number."""
-        return self.worktree_base / self.repo_slug / f"issue-{issue_number}"
+    def workspace_path_for_issue(self, issue_number: int) -> Path:
+        """Return the repo-scoped workspace directory path for a given issue number."""
+        return self.workspace_base / self.repo_slug / f"issue-{issue_number}"
 
     @model_validator(mode="after")
     def resolve_defaults(self) -> HydraFlowConfig:
         """Resolve paths, repo slug, and apply env var overrides.
 
         Resolution order (seven steps):
-          1. ``_resolve_base_paths`` — repo_root, worktree_base, data_root
+          1. ``_resolve_base_paths`` — repo_root, workspace_base, data_root
           2. ``_resolve_repo_and_identity`` — repo slug, gh_token, git identity
           3. ``_resolve_repo_scoped_paths`` — state_file, event_log_path, config_file
           4. ``_apply_env_overrides`` — env-var overrides for labels, tokens, etc.
@@ -1573,7 +1582,7 @@ def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
 
 
 def _resolve_base_paths(config: HydraFlowConfig) -> None:
-    """Resolve repo_root, worktree_base, and data_root.
+    """Resolve repo_root, workspace_base, and data_root.
 
     These base paths have no dependency on the repo slug and must be resolved
     first so that ``_resolve_repo_and_identity`` can use ``repo_root`` for
@@ -1583,12 +1592,12 @@ def _resolve_base_paths(config: HydraFlowConfig) -> None:
         object.__setattr__(config, "repo_root", _find_repo_root())
     else:
         object.__setattr__(config, "repo_root", config.repo_root.expanduser().resolve())
-    if config.worktree_base == Path("."):
+    if config.workspace_base == Path("."):
         default_worktrees = Path("~/.hydraflow/worktrees").expanduser().resolve()
-        object.__setattr__(config, "worktree_base", default_worktrees)
+        object.__setattr__(config, "workspace_base", default_worktrees)
     else:
         object.__setattr__(
-            config, "worktree_base", config.worktree_base.expanduser().resolve()
+            config, "workspace_base", config.workspace_base.expanduser().resolve()
         )
     env_home = os.environ.get("HYDRAFLOW_HOME", "").strip()
     if env_home:

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -135,7 +135,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         "unstick_auto_merge",
         "unstick_all_causes",
         "memory_auto_approve",
-        "worktree_base",
+        "workspace_base",
     }
 
     def _build_system_worker_inference_stats() -> dict[str, dict[str, int]]:
@@ -286,7 +286,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 batch_size=_cfg.batch_size,
                 model=_cfg.model,
                 pr_unstick_batch_size=_cfg.pr_unstick_batch_size,
-                worktree_base=str(_cfg.worktree_base),
+                workspace_base=str(_cfg.workspace_base),
             ),
         )
         data = response.model_dump()

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1259,7 +1259,7 @@ def create_router(
             "timestamp": datetime.now(UTC).isoformat(),
             "orchestrator_running": orchestrator_running,
             "active_issue_count": len(state.get_active_issue_numbers()),
-            "active_worktrees": len(state.get_active_worktrees()),
+            "active_workspaces": len(state.get_active_workspaces()),
             "worker_count": worker_count,
             "worker_errors": worker_errors,
             "dashboard": dashboard_binding,

--- a/src/hitl_phase.py
+++ b/src/hitl_phase.py
@@ -41,7 +41,7 @@ class HITLPhase:
         state: StateTracker,
         store: IssueStorePort,
         fetcher: IssueFetcherPort,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         hitl_runner: HITLRunner,
         prs: PRPort,
         event_bus: EventBus,
@@ -52,7 +52,7 @@ class HITLPhase:
         self._state = state
         self._store = store
         self._fetcher = fetcher
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._hitl_runner = hitl_runner
         self._prs = prs
         self._bus = event_bus
@@ -206,10 +206,10 @@ class HITLPhase:
 
                     # Get or create worktree
                     branch = self._config.branch_for_issue(issue_number)
-                    wt_path = self._config.worktree_path_for_issue(issue_number)
+                    wt_path = self._config.workspace_path_for_issue(issue_number)
                     if not wt_path.is_dir():
-                        wt_path = await self._worktrees.create(issue_number, branch)
-                    self._state.set_worktree(issue_number, str(wt_path))
+                        wt_path = await self._workspaces.create(issue_number, branch)
+                    self._state.set_workspace(issue_number, str(wt_path))
 
                     # Swap to active label
                     await self._prs.swap_pipeline_labels(
@@ -330,8 +330,8 @@ class HITLPhase:
                     # Clean up worktree on success; keep on failure for retry
                     if result.success:
                         try:
-                            await self._worktrees.destroy(issue_number)
-                            self._state.remove_worktree(issue_number)
+                            await self._workspaces.destroy(issue_number)
+                            self._state.remove_workspace(issue_number)
                         except RuntimeError as exc:
                             logger.warning(
                                 "Could not destroy worktree for issue #%d: %s",

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -49,7 +49,7 @@ class ImplementPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         agents: AgentRunner,
         prs: PRPort,
         store: IssueStorePort,
@@ -60,7 +60,7 @@ class ImplementPhase:
     ) -> None:
         self._config = config
         self._state = state
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._agents = agents
         self._prs = prs
         self._transitioner: TaskTransitioner = prs
@@ -354,7 +354,7 @@ class ImplementPhase:
         When *reset_for_retry* is True, resets an existing worktree to
         ``origin/main`` to discard stale state from a prior failed attempt.
         """
-        wt_path = self._config.worktree_path_for_issue(issue.id)
+        wt_path = self._config.workspace_path_for_issue(issue.id)
         if wt_path.is_dir():
             if reset_for_retry:
                 logger.info(
@@ -362,7 +362,7 @@ class ImplementPhase:
                     issue.id,
                 )
                 try:
-                    await self._worktrees.reset_to_main(wt_path)
+                    await self._workspaces.reset_to_main(wt_path)
                 except (RuntimeError, OSError):
                     logger.warning(
                         "Worktree reset failed for issue #%d — continuing with existing state",
@@ -372,8 +372,8 @@ class ImplementPhase:
             else:
                 logger.info("Resuming existing worktree for issue #%d", issue.id)
         else:
-            wt_path = await self._worktrees.create(issue.id, branch)
-        self._state.set_worktree(issue.id, str(wt_path))
+            wt_path = await self._workspaces.create(issue.id, branch)
+        self._state.set_workspace(issue.id, str(wt_path))
         await self._prs.push_branch(wt_path, branch, force=reset_for_retry)
         await self._transitioner.post_comment(
             issue.id,
@@ -484,9 +484,9 @@ class ImplementPhase:
         if self._is_zero_commit_failure(result):
             return await self._handle_zero_commits(issue, result)
 
-        if result.worktree_path:
+        if result.workspace_path:
             pushed = await self._prs.push_branch(
-                Path(result.worktree_path), result.branch
+                Path(result.workspace_path), result.branch
             )
             if pushed:
                 early_return = await self._handle_successful_push(

--- a/src/merge_conflict_resolver.py
+++ b/src/merge_conflict_resolver.py
@@ -41,7 +41,7 @@ class MergeConflictResolver:
     def __init__(
         self,
         config: HydraFlowConfig,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         agents: AgentPort | None,
         prs: PRPort,
         event_bus: EventBus,
@@ -50,7 +50,7 @@ class MergeConflictResolver:
         suggest_memory: MemorySuggesterFn | None = None,
     ) -> None:
         self._config = config
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._agents = agents
         self._prs = prs
         self._bus = event_bus
@@ -72,7 +72,7 @@ class MergeConflictResolver:
         Returns True on success, False on failure (escalates to HITL).
         """
         await publish_fn(pr, worker_id, "merge_main")
-        merged = await self._worktrees.merge_main(wt_path, pr.branch)
+        merged = await self._workspaces.merge_main(wt_path, pr.branch)
         used_rebuild = False
         if not merged:
             logger.info(
@@ -89,7 +89,7 @@ class MergeConflictResolver:
         if merged:
             if used_rebuild:
                 # Branch history was rewritten — need force-push
-                new_wt = self._config.worktree_path_for_issue(pr.issue_number)
+                new_wt = self._config.workspace_path_for_issue(pr.issue_number)
                 await self._prs.push_branch(new_wt, pr.branch, force=True)
             else:
                 await self._prs.push_branch(wt_path, pr.branch)
@@ -154,10 +154,10 @@ class MergeConflictResolver:
         for attempt in range(1, max_attempts + 1):
             # Abort any prior failed merge before retrying
             if attempt > 1:
-                await self._worktrees.abort_merge(wt_path)
+                await self._workspaces.abort_merge(wt_path)
 
             # Start merge leaving conflict markers in place
-            clean = await self._worktrees.start_merge_main(wt_path, pr.branch)
+            clean = await self._workspaces.start_merge_main(wt_path, pr.branch)
             if clean:
                 return ConflictResolutionResult(success=True, used_rebuild=False)
 
@@ -237,7 +237,7 @@ class MergeConflictResolver:
                 last_error = repr(exc)
 
         # All merge attempts exhausted — abort merge and try fresh rebuild
-        await self._worktrees.abort_merge(wt_path)
+        await self._workspaces.abort_merge(wt_path)
 
         logger.info(
             "All %d merge attempts exhausted for PR #%d — trying fresh branch rebuild",
@@ -290,8 +290,8 @@ class MergeConflictResolver:
         )
 
         # Destroy old worktree and create fresh one from main
-        await self._worktrees.destroy(pr.issue_number)
-        new_wt = await self._worktrees.create(pr.issue_number, pr.branch)
+        await self._workspaces.destroy(pr.issue_number)
+        new_wt = await self._workspaces.create(pr.issue_number, pr.branch)
 
         logger.info(
             "Fresh branch rebuild: created clean worktree at %s for PR #%d",

--- a/src/models.py
+++ b/src/models.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 
 from pydantic import (
     AfterValidator,
+    AliasChoices,  # noqa: F401 — used in Field(validation_alias=...)
     BaseModel,
     ConfigDict,
     Field,
@@ -575,8 +576,10 @@ class WorkerResult(BaseModel):
 
     issue_number: int = Field(description="GitHub issue number being implemented")
     branch: str = Field(description="Git branch name for the implementation")
-    worktree_path: str = Field(
-        default="", description="Path to the git worktree directory"
+    workspace_path: str = Field(
+        default="",
+        description="Path to the workspace directory",
+        validation_alias=AliasChoices("workspace_path", "worktree_path"),
     )
     success: bool = Field(
         default=False,
@@ -1244,7 +1247,10 @@ class StateData(BaseModel):
 
     schema_version: int = 1
     processed_issues: dict[str, str] = Field(default_factory=dict)
-    active_worktrees: dict[str, str] = Field(default_factory=dict)
+    active_workspaces: dict[str, str] = Field(
+        default_factory=dict,
+        validation_alias=AliasChoices("active_workspaces", "active_worktrees"),
+    )
     active_branches: dict[str, str] = Field(default_factory=dict)
     reviewed_prs: dict[str, str] = Field(default_factory=dict)
     hitl_origins: dict[str, str] = Field(default_factory=dict)
@@ -1631,7 +1637,7 @@ class ControlStatusConfig(BaseModel):
     batch_size: int = 0
     model: str = ""
     pr_unstick_batch_size: int = 10
-    worktree_base: str = ""
+    workspace_base: str = ""
 
 
 class ControlStatusResponse(BaseModel):

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -129,7 +129,7 @@ class HydraFlowOrchestrator:
             "report_issue": svc.report_issue_loop,
             "epic_monitor": svc.epic_monitor_loop,
             "epic_sweeper": svc.epic_sweeper_loop,
-            "worktree_gc": svc.worktree_gc_loop,
+            "workspace_gc": svc.workspace_gc_loop,
             "runs_gc": svc.runs_gc_loop,
             "adr_reviewer": svc.adr_reviewer_loop,
             "health_monitor": svc.health_monitor_loop,
@@ -200,9 +200,9 @@ class HydraFlowOrchestrator:
     async def _deferred_pipeline_start(self) -> None:
         """Run repo initialization that was skipped when pipeline was disabled."""
         try:
-            await self._svc.worktrees.sanitize_repo()
+            await self._svc.workspaces.sanitize_repo()
             await self._svc.prs.ensure_labels_exist()
-            await self._svc.worktrees.enable_rerere()
+            await self._svc.workspaces.enable_rerere()
             self._warn_if_agents_md_missing()
             if self._current_session is None:
                 await self._start_session()
@@ -688,9 +688,9 @@ class HydraFlowOrchestrator:
 
         session_started = False
         if self._pipeline_enabled:
-            await self._svc.worktrees.sanitize_repo()
+            await self._svc.workspaces.sanitize_repo()
             await self._svc.prs.ensure_labels_exist()
-            await self._svc.worktrees.enable_rerere()
+            await self._svc.workspaces.enable_rerere()
             self._warn_if_agents_md_missing()
             await self._start_session()
             session_started = True
@@ -705,7 +705,7 @@ class HydraFlowOrchestrator:
             self._svc.reviewers.terminate()
             self._svc.hitl_runner.terminate()
             with contextlib.suppress(Exception):
-                await self._svc.worktrees.sanitize_repo()
+                await self._svc.workspaces.sanitize_repo()
             await asyncio.sleep(0)
             self._running = False
             await self._publish_status()
@@ -823,7 +823,7 @@ class HydraFlowOrchestrator:
             ("report_issue", self._svc.report_issue_loop.run),
             ("epic_monitor", self._svc.epic_monitor_loop.run),
             ("epic_sweeper", self._svc.epic_sweeper_loop.run),
-            ("worktree_gc", self._svc.worktree_gc_loop.run),
+            ("workspace_gc", self._svc.workspace_gc_loop.run),
             ("runs_gc", self._svc.runs_gc_loop.run),
             ("adr_reviewer", self._svc.adr_reviewer_loop.run),
             ("health_monitor", self._svc.health_monitor_loop.run),

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -205,7 +205,7 @@ class PostMergeHandler:
             should_merge = await ci_gate_fn(
                 pr,
                 issue,
-                self._config.worktree_path_for_issue(pr.issue_number),
+                self._config.workspace_path_for_issue(pr.issue_number),
                 result,
                 worker_id,
                 code_scanning_alerts=code_scanning_alerts,

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -104,7 +104,7 @@ class PRUnsticker:
         event_bus: EventBus,
         pr_manager: PRPort,
         agents: AgentRunner,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         fetcher: IssueFetcherPort,
         hitl_runner: HITLRunner | None = None,
         stop_event: asyncio.Event | None = None,
@@ -117,7 +117,7 @@ class PRUnsticker:
         self._bus = event_bus
         self._prs = pr_manager
         self._agents = agents
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._fetcher = fetcher
         self._hitl_runner = hitl_runner
         self._stop_event = stop_event or asyncio.Event()
@@ -275,10 +275,10 @@ class PRUnsticker:
                 return False
 
             # Get or create worktree
-            wt_path = self._config.worktree_path_for_issue(issue_number)
+            wt_path = self._config.workspace_path_for_issue(issue_number)
             if not wt_path.is_dir():
-                wt_path = await self._worktrees.create(issue_number, branch)
-            self._state.set_worktree(issue_number, str(wt_path))
+                wt_path = await self._workspaces.create(issue_number, branch)
+            self._state.set_workspace(issue_number, str(wt_path))
 
             # Dispatch to cause-specific resolver
             resolution = await self._resolve_by_cause(
@@ -294,7 +294,7 @@ class PRUnsticker:
             if resolution.success:
                 # Push the fixed branch
                 if resolution.used_rebuild:
-                    new_wt = self._config.worktree_path_for_issue(issue_number)
+                    new_wt = self._config.workspace_path_for_issue(issue_number)
                     await self._prs.push_branch(new_wt, branch, force=True)
                 else:
                     await self._prs.push_branch(wt_path, branch)
@@ -411,10 +411,10 @@ class PRUnsticker:
     ) -> bool:
         """Rebase on main and run agent with a CI/quality fix prompt."""
         # First rebase on main
-        clean = await self._worktrees.start_merge_main(wt_path, branch)
+        clean = await self._workspaces.start_merge_main(wt_path, branch)
         if not clean:
             # If there are conflicts during rebase, try to resolve them first
-            await self._worktrees.abort_merge(wt_path)
+            await self._workspaces.abort_merge(wt_path)
 
         cause_str = self._state.get_hitl_cause(issue_number) or ""
         prompt, prompt_stats = self._build_ci_fix_prompt(issue, pr_url, cause_str)
@@ -574,9 +574,9 @@ diff — you may catch things `make quality` won't.
 
         for attempt in range(1, max_attempts + 1):
             # Rebase on main
-            clean = await self._worktrees.start_merge_main(wt_path, branch)
+            clean = await self._workspaces.start_merge_main(wt_path, branch)
             if not clean:
-                await self._worktrees.abort_merge(wt_path)
+                await self._workspaces.abort_merge(wt_path)
 
             # Isolate which test hangs
             isolation_output = await self._isolate_hanging_tests(wt_path)
@@ -1017,15 +1017,15 @@ TROUBLESHOOTING_PATTERN_END
         for item in remaining:
             issue_number = item.issue
             branch = self._config.branch_for_issue(issue_number)
-            wt_path = self._config.worktree_path_for_issue(issue_number)
+            wt_path = self._config.workspace_path_for_issue(issue_number)
 
             if not wt_path.is_dir():
                 continue
 
             try:
-                clean = await self._worktrees.start_merge_main(wt_path, branch)
+                clean = await self._workspaces.start_merge_main(wt_path, branch)
                 if not clean:
-                    await self._worktrees.abort_merge(wt_path)
+                    await self._workspaces.abort_merge(wt_path)
                     logger.warning(
                         "Re-rebase for issue #%d hit conflicts after sibling "
                         "merge — will resolve on next unstick cycle",

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -83,7 +83,7 @@ class ReviewGuardContext:
     """Successful result from _run_initial_guards."""
 
     task: Task
-    worktree_path: Path
+    workspace_path: Path
 
 
 @dataclass(slots=True)
@@ -102,7 +102,7 @@ class ReviewPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         reviewers: ReviewRunner,
         prs: PRPort,
         stop_event: asyncio.Event,
@@ -120,7 +120,7 @@ class ReviewPhase:
     ) -> None:
         self._config = config
         self._state = state
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._reviewers = reviewers
         self._prs = prs
         self._transitioner: TaskTransitioner = prs
@@ -308,9 +308,9 @@ class ReviewPhase:
         self, pr: PRInfo, task: Task, idx: int
     ) -> Path | None:
         """Ensure worktree exists and main is merged. Returns path or None on conflict."""
-        wt_path = self._config.worktree_path_for_issue(pr.issue_number)
+        wt_path = self._config.workspace_path_for_issue(pr.issue_number)
         if not wt_path.exists():
-            wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
+            wt_path = await self._workspaces.create(pr.issue_number, pr.branch)
         merged = await self._merge_with_main(pr, task, wt_path, idx)
         if not merged:
             return None
@@ -394,7 +394,7 @@ class ReviewPhase:
         result = await self._run_and_post_review(
             pr,
             guards.task,
-            guards.worktree_path,
+            guards.workspace_path,
             pre_review.diff,
             idx,
             code_scanning_alerts=pre_review.code_scanning_alerts,
@@ -403,7 +403,7 @@ class ReviewPhase:
         return await self._run_post_review_actions(
             pr,
             guards.task,
-            guards.worktree_path,
+            guards.workspace_path,
             result,
             pre_review,
             idx,
@@ -432,7 +432,7 @@ class ReviewPhase:
                 summary="Merge conflicts with main — escalated to HITL",
             )
 
-        return ReviewGuardContext(task=task, worktree_path=wt_path)
+        return ReviewGuardContext(task=task, workspace_path=wt_path)
 
     async def _run_pre_review_checks(
         self,
@@ -719,8 +719,8 @@ class ReviewPhase:
 
         if not skip:
             try:
-                await self._worktrees.post_work_cleanup(pr.issue_number)
-                self._state.remove_worktree(pr.issue_number)
+                await self._workspaces.post_work_cleanup(pr.issue_number)
+                self._state.remove_workspace(pr.issue_number)
             except RuntimeError as exc:
                 logger.warning(
                     "Could not clean up worktree for issue #%d: %s",
@@ -1083,9 +1083,9 @@ class ReviewPhase:
         This keeps the standard review path aligned with unsticker behavior:
         resolve merge conflicts on the branch, push updates, then retry merge.
         """
-        wt_path = self._config.worktree_path_for_issue(pr.issue_number)
+        wt_path = self._config.workspace_path_for_issue(pr.issue_number)
         if not wt_path.exists():
-            wt_path = await self._worktrees.create(pr.issue_number, pr.branch)
+            wt_path = await self._workspaces.create(pr.issue_number, pr.branch)
 
         resolution = await self._conflict_resolver.resolve_merge_conflicts(
             pr,
@@ -1099,7 +1099,7 @@ class ReviewPhase:
 
         if resolution.used_rebuild:
             await self._prs.push_branch(
-                self._config.worktree_path_for_issue(pr.issue_number),
+                self._config.workspace_path_for_issue(pr.issue_number),
                 pr.branch,
                 force=True,
             )

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -76,7 +76,7 @@ class ServiceRegistry:
     """Holds all service instances for the orchestrator."""
 
     # Core infrastructure
-    worktrees: WorkspaceManager
+    workspaces: WorkspaceManager
     subprocess_runner: SubprocessRunner
     agents: AgentRunner
     planners: PlannerRunner
@@ -119,7 +119,7 @@ class ServiceRegistry:
     report_issue_loop: ReportIssueLoop
     epic_monitor_loop: EpicMonitorLoop
     epic_sweeper_loop: EpicSweeperLoop
-    worktree_gc_loop: WorkspaceGCLoop
+    workspace_gc_loop: WorkspaceGCLoop
     runs_gc_loop: RunsGCLoop
     adr_reviewer_loop: ADRReviewerLoop
     health_monitor_loop: HealthMonitorLoop
@@ -195,7 +195,7 @@ def build_services(
         )
 
     # Core runners
-    worktrees = WorkspaceManager(config)
+    workspaces = WorkspaceManager(config)  # noqa: F841
     subprocess_runner = get_docker_runner(config)
     agents = AgentRunner(
         config,
@@ -284,7 +284,7 @@ def build_services(
         state,
         store,
         fetcher,
-        worktrees,
+        workspaces,
         hitl_runner,
         prs,
         event_bus,
@@ -295,7 +295,7 @@ def build_services(
     implementer = ImplementPhase(
         config,
         state,
-        worktrees,
+        workspaces,
         agents,
         prs,
         store,
@@ -312,7 +312,7 @@ def build_services(
 
     conflict_resolver = MergeConflictResolver(
         config=config,
-        worktrees=worktrees,
+        workspaces=workspaces,
         agents=agents,
         prs=prs,
         event_bus=event_bus,
@@ -326,7 +326,7 @@ def build_services(
         event_bus,
         prs,
         agents,
-        worktrees,
+        workspaces,
         fetcher,
         hitl_runner=hitl_runner,
         stop_event=stop_event,
@@ -387,7 +387,7 @@ def build_services(
     reviewer = ReviewPhase(
         config,
         state,
-        worktrees,
+        workspaces,
         reviewers,
         prs,
         stop_event,
@@ -432,9 +432,9 @@ def build_services(
         state=state,
         deps=loop_deps,
     )
-    worktree_gc_loop = WorkspaceGCLoop(
+    workspace_gc_loop = WorkspaceGCLoop(  # noqa: F841
         config=config,
-        worktrees=worktrees,
+        workspaces=workspaces,
         prs=prs,
         state=state,
         deps=loop_deps,
@@ -487,7 +487,7 @@ def build_services(
     )
 
     return ServiceRegistry(
-        worktrees=worktrees,
+        workspaces=workspaces,
         subprocess_runner=subprocess_runner,
         agents=agents,
         planners=planners,
@@ -518,7 +518,7 @@ def build_services(
         report_issue_loop=report_issue_loop,
         epic_monitor_loop=epic_monitor_loop,
         epic_sweeper_loop=epic_sweeper_loop,
-        worktree_gc_loop=worktree_gc_loop,
+        workspace_gc_loop=workspace_gc_loop,
         runs_gc_loop=runs_gc_loop,
         adr_reviewer_loop=adr_reviewer_loop,
         health_monitor_loop=health_monitor_loop,

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -34,7 +34,7 @@ from ._report import ReportStateMixin
 from ._review import ReviewStateMixin
 from ._session import SessionStateMixin
 from ._worker import WorkerStateMixin
-from ._worktree import WorktreeStateMixin
+from ._workspace import WorkspaceStateMixin
 
 logger = logging.getLogger("hydraflow.state")
 
@@ -45,7 +45,7 @@ __all__ = ["StateTracker", "build_state_tracker"]
 
 class StateTracker(
     IssueStateMixin,
-    WorktreeStateMixin,
+    WorkspaceStateMixin,
     HITLStateMixin,
     ReviewStateMixin,
     EpicStateMixin,

--- a/src/state/_issue.py
+++ b/src/state/_issue.py
@@ -40,14 +40,14 @@ class IssueStateMixin:
         """Record the processing status for *issue_number*.
 
         When *status* is terminal (merged, failed, completed, hitl_closed),
-        the corresponding ``active_branches`` and ``active_worktrees``
+        the corresponding ``active_branches`` and ``active_workspaces``
         entries are removed to prevent stale state accumulation.
         """
         self._data.processed_issues[self._key(issue_number)] = status
         if status in self._TERMINAL_STATUSES:
             key = self._key(issue_number)
             self._data.active_branches.pop(key, None)
-            self._data.active_worktrees.pop(key, None)
+            self._data.active_workspaces.pop(key, None)
         self.save()
 
     # --- PR tracking ---

--- a/src/state/_workspace.py
+++ b/src/state/_workspace.py
@@ -1,4 +1,4 @@
-"""Worktree and branch tracking state."""
+"""Workspace and branch tracking state."""
 
 from __future__ import annotations
 
@@ -10,8 +10,8 @@ if TYPE_CHECKING:
     from models import StateData
 
 
-class WorktreeStateMixin:
-    """Methods for worktree and branch tracking."""
+class WorkspaceStateMixin:
+    """Methods for workspace and branch tracking."""
 
     _data: StateData
 
@@ -23,20 +23,20 @@ class WorktreeStateMixin:
     @staticmethod
     def _int_keys(d: dict[str, _V]) -> dict[int, _V]: ...  # provided by StateTracker
 
-    # --- worktree tracking ---
+    # --- workspace tracking ---
 
-    def get_active_worktrees(self) -> dict[int, str]:
-        """Return ``{issue_number: worktree_path}`` mapping."""
-        return self._int_keys(self._data.active_worktrees)
+    def get_active_workspaces(self) -> dict[int, str]:
+        """Return ``{issue_number: workspace_path}`` mapping."""
+        return self._int_keys(self._data.active_workspaces)
 
-    def set_worktree(self, issue_number: int, path: str) -> None:
-        """Record the worktree filesystem *path* for *issue_number*."""
-        self._data.active_worktrees[self._key(issue_number)] = path
+    def set_workspace(self, issue_number: int, path: str) -> None:
+        """Record the workspace filesystem *path* for *issue_number*."""
+        self._data.active_workspaces[self._key(issue_number)] = path
         self.save()
 
-    def remove_worktree(self, issue_number: int) -> None:
-        """Remove the worktree mapping for *issue_number* (no-op if absent)."""
-        self._data.active_worktrees.pop(self._key(issue_number), None)
+    def remove_workspace(self, issue_number: int) -> None:
+        """Remove the workspace mapping for *issue_number* (no-op if absent)."""
+        self._data.active_workspaces.pop(self._key(issue_number), None)
         self.save()
 
     # --- branch tracking ---

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -223,7 +223,7 @@ export const BACKGROUND_WORKERS = [
   { key: 'memory_sync',     label: 'Memory Manager', description: 'Ingests memory and transcript issues into durable learnings.', color: theme.accent, system: true },
   { key: 'pr_unsticker',    label: 'PR Unsticker',   description: 'Requeues stalled HITL PRs once requirements are actionable.', color: theme.orange, system: true },
   { key: 'report_issue',   label: 'Report Issue',   description: 'Processes queued bug reports into GitHub issues.', color: theme.red },
-  { key: 'worktree_gc',    label: 'Worktree GC',    description: 'Garbage-collects stale worktrees and orphaned branches.', color: theme.textMuted, system: true },
+  { key: 'workspace_gc',   label: 'Workspace GC',   description: 'Garbage-collects stale workspaces and orphaned branches.', color: theme.textMuted, system: true },
   { key: 'adr_reviewer',   label: 'ADR Reviewer',   description: 'Reviews proposed ADRs via a 3-judge council and routes to accept, reject, or escalate.', color: theme.accent },
   { key: 'epic_sweeper',    label: 'Epic Sweeper',    description: 'Periodically sweeps open epics and auto-closes those with all sub-issues resolved.', color: theme.purple, system: true },
   { key: 'bot_pr', label: 'Bot PR Manager', description: 'Auto-merges dependency update PRs from configured bots after CI passes.', color: theme.green },

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -41,7 +41,7 @@ class WorkspaceManager:
     def __init__(self, config: HydraFlowConfig) -> None:
         self._config = config
         self._repo_root = config.repo_root
-        self._base = config.worktree_base
+        self._base = config.workspace_base
         self._ui_dirs = self._detect_ui_dirs()
 
     def _detect_ui_dirs(self) -> list[str]:
@@ -241,7 +241,7 @@ class WorkspaceManager:
         Prevents work loss when a worktree is cleaned up after a crash or
         timeout that left uncommitted changes behind.
         """
-        wt_path = self._config.worktree_path_for_issue(issue_number)
+        wt_path = self._config.workspace_path_for_issue(issue_number)
         if not wt_path.exists():
             return
 
@@ -347,7 +347,7 @@ class WorkspaceManager:
 
     async def _create_unlocked(self, issue_number: int, branch: str) -> Path:
         """Inner create logic — must be called under ``_repo_workspace_lock``."""
-        wt_path = self._config.worktree_path_for_issue(issue_number)
+        wt_path = self._config.workspace_path_for_issue(issue_number)
         logger.info(
             "Creating workspace %s on branch %s",
             wt_path,
@@ -464,7 +464,7 @@ class WorkspaceManager:
 
     async def _destroy_unlocked(self, issue_number: int) -> None:
         """Inner destroy logic — must be called under ``_repo_workspace_lock``."""
-        wt_path = self._config.worktree_path_for_issue(issue_number)
+        wt_path = self._config.workspace_path_for_issue(issue_number)
         if self._config.dry_run:
             logger.info("[dry-run] Would destroy workspace %s", wt_path)
             return

--- a/src/workspace_gc_loop.py
+++ b/src/workspace_gc_loop.py
@@ -31,20 +31,20 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
     def __init__(
         self,
         config: HydraFlowConfig,
-        worktrees: WorkspacePort,
+        workspaces: WorkspacePort,
         prs: PRPort,
         state: StateTracker,
         deps: LoopDeps,
         is_in_pipeline_cb: Callable[[int], bool] | None = None,
     ) -> None:
-        super().__init__(worker_name="worktree_gc", config=config, deps=deps)
-        self._worktrees = worktrees
+        super().__init__(worker_name="workspace_gc", config=config, deps=deps)
+        self._workspaces = workspaces
         self._prs = prs
         self._state = state
         self._is_in_pipeline = is_in_pipeline_cb
 
     def _get_default_interval(self) -> int:
-        return self._config.worktree_gc_interval
+        return self._config.workspace_gc_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Run one GC cycle: state workspaces, orphan dirs, orphan branches."""
@@ -53,17 +53,17 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
         errors = 0
 
         # Phase 1: GC workspaces tracked in state
-        active_worktrees = self._state.get_active_worktrees()
-        for issue_number in list(active_worktrees.keys()):
+        active_workspaces = self._state.get_active_workspaces()
+        for issue_number in list(active_workspaces.keys()):
             if self._stop_event.is_set() or collected >= _MAX_GC_PER_CYCLE:
                 break
             try:
                 if await self._is_safe_to_gc(issue_number):
                     # Remove from state first so a crash between steps
                     # leaves the entry gone (destroy is idempotent).
-                    self._state.remove_worktree(issue_number)
+                    self._state.remove_workspace(issue_number)
                     self._state.remove_branch(issue_number)
-                    await self._worktrees.destroy(issue_number)
+                    await self._workspaces.destroy(issue_number)
                     collected += 1
                     logger.info("GC: collected workspace for issue #%d", issue_number)
                 else:
@@ -79,7 +79,7 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
         # Phase 2: scan filesystem for orphaned issue-* dirs not in state
         if not self._stop_event.is_set():
             orphan_count = await self._collect_orphaned_dirs(
-                active_worktrees, _MAX_GC_PER_CYCLE - collected
+                active_workspaces, _MAX_GC_PER_CYCLE - collected
             )
             collected += orphan_count
 
@@ -227,7 +227,7 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
     async def _collect_orphaned_dirs(self, tracked: dict[int, str], budget: int) -> int:
         """Scan filesystem for orphaned issue-* dirs not tracked in state."""
         collected = 0
-        repo_wt_base = self._config.worktree_base / self._config.repo_slug
+        repo_wt_base = self._config.workspace_base / self._config.repo_slug
         if not repo_wt_base.exists():
             return 0
 
@@ -245,7 +245,7 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
                 continue
             try:
                 if await self._is_safe_to_gc(issue_number):
-                    await self._worktrees.destroy(issue_number)
+                    await self._workspaces.destroy(issue_number)
                     collected += 1
                     logger.info(
                         "GC: collected orphaned worktree dir for issue #%d",
@@ -277,7 +277,7 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
             logger.warning("GC: could not list local branches", exc_info=True)
             return 0
 
-        active_worktrees = self._state.get_active_worktrees()
+        active_workspaces = self._state.get_active_workspaces()
         active_issues = set(self._state.get_active_issue_numbers())
 
         for line in output.strip().splitlines():
@@ -290,7 +290,7 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
             issue_number = int(match.group(1))
             try:
                 # Skip if worktree exists, issue is active, or in pipeline
-                if issue_number in active_worktrees or issue_number in active_issues:
+                if issue_number in active_workspaces or issue_number in active_issues:
                     continue
                 if self._is_in_pipeline and self._is_in_pipeline(issue_number):
                     continue
@@ -317,13 +317,13 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
 
     async def _prune_stale_branch_entries(self, budget: int = _MAX_GC_PER_CYCLE) -> int:
         """Remove ``active_branches`` entries whose issue has no worktree and is safe to GC."""
-        active_worktrees = self._state.get_active_worktrees()
+        active_workspaces = self._state.get_active_workspaces()
         active_branches = self._state.get_active_branches()
         pruned = 0
         for issue_number in list(active_branches.keys()):
             if self._stop_event.is_set() or pruned >= budget:
                 break
-            if issue_number in active_worktrees:
+            if issue_number in active_workspaces:
                 continue  # worktree still exists — branch entry is valid
             try:
                 if await self._is_safe_to_gc(issue_number):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,7 +130,7 @@ def config(tmp_path: Path) -> HydraFlowConfig:
 
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
 
@@ -141,7 +141,7 @@ def dry_config(tmp_path: Path) -> HydraFlowConfig:
     return ConfigFactory.create(
         dry_run=True,
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
 
@@ -248,7 +248,7 @@ class WorkerResultFactory:
         success: bool | None = None,
         transcript: str | None = None,
         commits: int | None = None,
-        worktree_path: str | None = None,
+        workspace_path: str | None = None,
         error: str | None = None,
         duration_seconds: float | None = None,
         pre_quality_review_attempts: int | None = None,
@@ -275,8 +275,8 @@ class WorkerResultFactory:
                 "issue_number": issue_number,
                 "branch": branch,
             }
-            if worktree_path is not None:
-                kwargs["worktree_path"] = worktree_path
+            if workspace_path is not None:
+                kwargs["workspace_path"] = workspace_path
             if success is not None:
                 kwargs["success"] = success
             if error is not None:
@@ -298,9 +298,9 @@ class WorkerResultFactory:
         return WorkerResult(
             issue_number=issue_number,
             branch=branch,
-            worktree_path=(
-                worktree_path
-                if worktree_path is not None
+            workspace_path=(
+                workspace_path
+                if workspace_path is not None
                 else "/tmp/worktrees/issue-42"
             ),
             success=True if success is None else success,
@@ -356,8 +356,8 @@ class WorkerResultBuilder:
         self._kwargs["commits"] = value
         return self
 
-    def with_worktree_path(self, value: str) -> WorkerResultBuilder:
-        self._kwargs["worktree_path"] = value
+    def with_workspace_path(self, value: str) -> WorkerResultBuilder:
+        self._kwargs["workspace_path"] = value
         return self
 
     def with_error(self, value: str) -> WorkerResultBuilder:
@@ -1123,10 +1123,10 @@ class ReviewMockBuilder:
         # Worktree mock
         mock_wt = AsyncMock()
         mock_wt.destroy = AsyncMock()
-        self._orch._svc.worktrees = mock_wt
+        self._orch._svc.workspaces = mock_wt
 
         # Create worktree directory
-        wt = self._config.worktree_base / f"issue-{self._issue_number}"
+        wt = self._config.workspace_base / f"issue-{self._issue_number}"
         wt.mkdir(parents=True, exist_ok=True)
 
         return mock_reviewers, mock_prs, mock_wt

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -274,7 +274,7 @@ class ConfigFactory:
         max_issue_body_chars: int = 10_000,
         max_review_diff_chars: int = 15_000,
         repo_root: Path | None = None,
-        worktree_base: Path | None = None,
+        workspace_base: Path | None = None,
         state_file: Path | None = None,
         event_log_path: Path | None = None,
         config_file: Path | None = None,
@@ -332,7 +332,7 @@ class ConfigFactory:
         epic_decompose_complexity_threshold: int = 8,
         epic_monitor_interval: int = 1800,
         epic_sweep_interval: int = 3600,
-        worktree_gc_interval: int = 1800,
+        workspace_gc_interval: int = 1800,
         epic_stale_days: int = 7,
         epic_merge_strategy: Literal[
             "independent", "bundled", "bundled_hitl", "ordered"
@@ -481,7 +481,7 @@ class ConfigFactory:
                 max_issue_body_chars=max_issue_body_chars,
                 max_review_diff_chars=max_review_diff_chars,
                 repo_root=root,
-                worktree_base=worktree_base or root.parent / "test-worktrees",
+                workspace_base=workspace_base or root.parent / "test-worktrees",
                 state_file=state_file or root / ".hydraflow-state.json",
                 event_log_path=event_log_path or root / ".hydraflow-events.jsonl",
                 memory_compaction_model=memory_compaction_model,
@@ -537,7 +537,7 @@ class ConfigFactory:
                 epic_decompose_complexity_threshold=epic_decompose_complexity_threshold,
                 epic_monitor_interval=epic_monitor_interval,
                 epic_sweep_interval=epic_sweep_interval,
-                worktree_gc_interval=worktree_gc_interval,
+                workspace_gc_interval=workspace_gc_interval,
                 epic_stale_days=epic_stale_days,
                 epic_merge_strategy=epic_merge_strategy,
                 collaborator_check_enabled=collaborator_check_enabled,
@@ -625,7 +625,7 @@ class PipelineHarness:
 
         self.config = config or ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             max_workers=1,
             max_planners=1,
@@ -658,9 +658,9 @@ class PipelineHarness:
         self._hitl_fetcher = AsyncMock()
         self._hitl_fetcher.fetch_issue_by_number = AsyncMock()
 
-        self.worktrees = AsyncMock()
-        self.worktrees.create = AsyncMock(side_effect=self._default_worktree_create)
-        self.worktrees.destroy = AsyncMock()
+        self.workspaces = AsyncMock()
+        self.workspaces.create = AsyncMock(side_effect=self._default_workspace_create)
+        self.workspaces.destroy = AsyncMock()
 
         self._conflict_resolver = MagicMock()
         self._conflict_resolver.merge_with_main = AsyncMock(return_value=True)
@@ -696,7 +696,7 @@ class PipelineHarness:
         self.implement_phase = ImplementPhase(
             config=self.config,
             state=self.state,
-            worktrees=self.worktrees,
+            workspaces=self.workspaces,
             agents=self.agents,
             prs=self.prs,
             store=self.store,
@@ -705,7 +705,7 @@ class PipelineHarness:
         self.review_phase = ReviewPhase(
             config=self.config,
             state=self.state,
-            worktrees=self.worktrees,
+            workspaces=self.workspaces,
             reviewers=self.reviewers,
             prs=self.prs,
             stop_event=self.stop_event,
@@ -719,7 +719,7 @@ class PipelineHarness:
             state=self.state,
             store=self.store,
             fetcher=self._hitl_fetcher,
-            worktrees=self.worktrees,
+            workspaces=self.workspaces,
             hitl_runner=self.hitl_runner,
             prs=self.prs,
             event_bus=self.bus,
@@ -729,7 +729,7 @@ class PipelineHarness:
     def _ensure_test_dirs(self) -> None:
         paths = {
             self.config.repo_root,
-            self.config.worktree_base,
+            self.config.workspace_base,
             self.config.state_file.parent,
             self.config.data_root,
             self.config.plans_dir,
@@ -787,8 +787,8 @@ class PipelineHarness:
         self.prs.fetch_ci_failure_logs = AsyncMock(return_value="")
         self.prs.merge_pr = AsyncMock(return_value=True)
 
-    def _default_worktree_create(self, issue_number: int, branch: str):
-        path = self.config.worktree_path_for_issue(issue_number)
+    def _default_workspace_create(self, issue_number: int, branch: str):
+        path = self.config.workspace_path_for_issue(issue_number)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.mkdir(parents=True, exist_ok=True)
         return path
@@ -834,14 +834,14 @@ class PipelineHarness:
         )
 
         branch = self.config.branch_for_issue(task.id)
-        worktree_path = self.config.worktree_path_for_issue(task.id)
+        workspace_path = self.config.workspace_path_for_issue(task.id)
         worker_return = (
             worker_result
             if worker_result is not None
             else WorkerResultFactory.create(
                 issue_number=task.id,
                 branch=branch,
-                worktree_path=str(worktree_path),
+                workspace_path=str(workspace_path),
                 success=True,
                 commits=1,
             )
@@ -928,7 +928,7 @@ def make_docker_manager(tmp_path: Path) -> WorkspaceManager:
         cfg = ConfigFactory.create(
             execution_mode="docker",
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
     return WorkspaceManager(cfg)
@@ -1055,7 +1055,7 @@ def make_implement_phase(
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=success,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         agent_run = _default_agent_run
@@ -1073,7 +1073,7 @@ def make_implement_phase(
 
     mock_wt = AsyncMock()
     mock_wt.create = AsyncMock(
-        side_effect=lambda num, branch: config.worktree_base / f"issue-{num}"
+        side_effect=lambda num, branch: config.workspace_base / f"issue-{num}"
     )
 
     mock_prs = AsyncMock()
@@ -1096,7 +1096,7 @@ def make_implement_phase(
     phase = ImplementPhase(
         config=config,
         state=state,
-        worktrees=mock_wt,
+        workspaces=mock_wt,
         agents=mock_agents,
         prs=mock_prs,
         store=mock_store,
@@ -1210,7 +1210,7 @@ def make_hitl_phase(config):
 
     Promoted from test_hitl_phase._make_phase() for reuse across test files.
 
-    Returns (phase, state, fetcher_mock, prs_mock, worktrees_mock,
+    Returns (phase, state, fetcher_mock, prs_mock, workspaces_mock,
              hitl_runner_mock, bus).
     """
     from events import EventBus
@@ -1222,9 +1222,9 @@ def make_hitl_phase(config):
     bus = EventBus()
     fetcher_mock = AsyncMock()
     store = IssueStore(config, AsyncMock(), bus)
-    worktrees = AsyncMock()
-    worktrees.create = AsyncMock(return_value=config.worktree_base / "issue-42")
-    worktrees.destroy = AsyncMock()
+    workspaces = AsyncMock()
+    workspaces.create = AsyncMock(return_value=config.workspace_base / "issue-42")
+    workspaces.destroy = AsyncMock()
     hitl_runner = AsyncMock()
     prs = AsyncMock()
     prs.remove_label = AsyncMock()
@@ -1238,13 +1238,13 @@ def make_hitl_phase(config):
         state,
         store,
         fetcher_mock,
-        worktrees,
+        workspaces,
         hitl_runner,
         prs,
         bus,
         stop_event,
     )
-    return phase, state, fetcher_mock, prs, worktrees, hitl_runner, bus
+    return phase, state, fetcher_mock, prs, workspaces, hitl_runner, bus
 
 
 def make_triage_phase(config):
@@ -1287,7 +1287,7 @@ def make_conflict_resolver(config, *, agents=None, suggest_memory=None):
     state = StateTracker(config.state_file)
     return MergeConflictResolver(
         config=config,
-        worktrees=AsyncMock(),
+        workspaces=AsyncMock(),
         agents=agents,
         prs=AsyncMock(),
         event_bus=EventBus(),
@@ -1435,7 +1435,7 @@ def make_review_phase(
     * ``_prs.push_branch`` → ``True``
     * ``_prs.merge_pr`` → ``True``
     * ``_prs.remove_label`` / ``add_labels`` / ``post_pr_comment`` / ``submit_review``
-    * worktree directory ``issue-{issue_number}`` created under ``config.worktree_base``
+    * worktree directory ``issue-{issue_number}`` created under ``config.workspace_base``
     """
     from events import EventBus
     from issue_store import IssueStore
@@ -1462,7 +1462,7 @@ def make_review_phase(
 
     conflict_resolver = MergeConflictResolver(
         config=config,
-        worktrees=mock_wt,
+        workspaces=mock_wt,
         agents=agents,
         prs=mock_prs,
         event_bus=bus,
@@ -1485,7 +1485,7 @@ def make_review_phase(
     phase = ReviewPhase(
         config=config,
         state=state,
-        worktrees=mock_wt,
+        workspaces=mock_wt,
         reviewers=mock_reviewers,
         prs=mock_prs,
         stop_event=stop_event,
@@ -1517,7 +1517,7 @@ def make_review_phase(
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock(return_value=True)
 
-        wt = config.worktree_base / f"issue-{issue_number}"
+        wt = config.workspace_base / f"issue-{issue_number}"
         wt.mkdir(parents=True, exist_ok=True)
 
     return phase
@@ -1546,15 +1546,15 @@ def mock_fetcher_noop(orch: Any) -> None:
     orch._svc.store.get_active_issues = lambda: {}  # type: ignore[method-assign]
     orch._svc.fetcher.fetch_issue_by_number = AsyncMock(return_value=None)  # type: ignore[method-assign]
     orch._svc.fetcher.fetch_reviewable_prs = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
-    orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
-    orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
+    orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
+    orch._svc.workspaces.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
 
 def make_worker_result(
     issue_number: int = 42,
     branch: str = "agent/issue-42",
     success: bool = True,
-    worktree_path: str = "/tmp/worktrees/issue-42",
+    workspace_path: str = "/tmp/worktrees/issue-42",
     transcript: str = "Implemented the feature.",
 ) -> Any:
     """Thin wrapper around ``WorkerResultFactory.create`` with common defaults."""
@@ -1566,7 +1566,7 @@ def make_worker_result(
         success=success,
         transcript=transcript,
         commits=1,
-        worktree_path=worktree_path,
+        workspace_path=workspace_path,
         use_defaults=True,
     )
 

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -235,13 +235,13 @@ class ScriptedImplementPhase:
         config: HydraFlowConfig,
         store: IssueStore,
         script: PipelineScript,
-        worktrees: FakeWorkspaceManager,
+        workspaces: FakeWorkspaceManager,
         github: ScriptedGitHub,
     ) -> None:
         self._config = config
         self._store = store
         self._script = script
-        self._worktrees = worktrees
+        self._workspaces = workspaces
         self._github = github
 
     async def run_batch(
@@ -276,7 +276,7 @@ class ScriptedImplementPhase:
             if behavior == "fail":
                 # Intentional: consume issue from queue without re-enqueuing,
                 # simulating a terminal failure (worktree cleaned, issue dropped).
-                self._worktrees.cleanup(issue.id)
+                self._workspaces.cleanup(issue.id)
                 results.append(
                     WorkerResultFactory.create(
                         issue_number=issue.id,
@@ -408,13 +408,13 @@ def build_scripted_services(
     script: PipelineScript,
 ) -> SimpleNamespace:
     """Return a fake ServiceRegistry wired with scripted phases."""
-    worktrees = FakeWorkspaceManager()
+    workspaces = FakeWorkspaceManager()  # noqa: F841
     github = ScriptedGitHub()
 
     store = IssueStore(config, StaticTaskFetcher(), event_bus)
 
     services = SimpleNamespace()
-    services.worktrees = worktrees
+    services.workspaces = workspaces
     services.subprocess_runner = MagicMock()
     services.agents = FakeRunner()
     services.planners = FakeRunner()
@@ -433,7 +433,7 @@ def build_scripted_services(
         config,
         store,
         script,
-        worktrees,
+        workspaces,
         github,
     )
     services.metrics_manager = MagicMock()
@@ -450,7 +450,7 @@ def build_scripted_services(
     services.epic_manager = MagicMock()
     services.epic_monitor_loop = FakeBackgroundLoop()
     services.epic_sweeper_loop = FakeBackgroundLoop()
-    services.worktree_gc_loop = FakeBackgroundLoop()
+    services.workspace_gc_loop = FakeBackgroundLoop()
     services.runs_gc_loop = FakeBackgroundLoop()
     services.adr_reviewer_loop = FakeBackgroundLoop()
     services.health_monitor_loop = FakeBackgroundLoop()

--- a/tests/test_acceptance_criteria.py
+++ b/tests/test_acceptance_criteria.py
@@ -685,7 +685,7 @@ class TestRunPrecheckContext:
             subskill_confidence_threshold=0.7,
             debug_escalation_enabled=False,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         gen, _ = _make_generator(cfg, event_bus)
@@ -714,7 +714,7 @@ class TestRunPrecheckContext:
             max_subskill_attempts=1,
             debug_escalation_enabled=False,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         gen, _ = _make_generator(cfg, event_bus)
@@ -757,7 +757,7 @@ class TestRunPrecheckContext:
             max_subskill_attempts=1,
             debug_escalation_enabled=False,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         gen, _ = _make_generator(cfg, event_bus)

--- a/tests/test_agent_advanced.py
+++ b/tests/test_agent_advanced.py
@@ -387,7 +387,7 @@ class TestBuildPromptFallbackAndTruncation:
         cfg = ConfigFactory.create(
             test_command="npm test",
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         (tmp_path / "repo").mkdir(parents=True, exist_ok=True)

--- a/tests/test_agent_execution.py
+++ b/tests/test_agent_execution.py
@@ -115,7 +115,7 @@ class TestBuildCommand:
             implementation_tool="codex",
             model="gpt-5-codex",
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = AgentRunner(cfg, event_bus)

--- a/tests/test_agent_lifecycle.py
+++ b/tests/test_agent_lifecycle.py
@@ -407,7 +407,7 @@ class TestPreQualityReviewLoop:
         cfg = ConfigFactory.create(
             max_pre_quality_review_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = AgentRunner(cfg, event_bus)
@@ -512,7 +512,7 @@ class TestPreQualityReviewLoop:
         cfg = ConfigFactory.create(
             max_quality_fix_attempts=0,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = AgentRunner(cfg, event_bus)

--- a/tests/test_agent_output.py
+++ b/tests/test_agent_output.py
@@ -354,7 +354,7 @@ class TestQualityFixLoop:
         cfg = ConfigFactory.create(
             max_quality_fix_attempts=3,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = AgentRunner(cfg, event_bus)
@@ -417,7 +417,7 @@ class TestQualityFixLoop:
         cfg = ConfigFactory.create(
             max_quality_fix_attempts=0,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = AgentRunner(cfg, event_bus)

--- a/tests/test_base_runner.py
+++ b/tests/test_base_runner.py
@@ -636,15 +636,15 @@ class TestBuildCommand:
     def test_build_command_path_argument_is_unused(
         self, config, event_bus: EventBus, tmp_path: Path
     ) -> None:
-        """The worktree_path arg is accepted for API compatibility but not included in cmd."""
+        """The workspace_path arg is accepted for API compatibility but not included in cmd."""
         runner = _TestRunner(config, event_bus)
         cmd = runner._build_command(tmp_path)
         assert "--cwd" not in cmd
 
-    def test_build_command_accepts_none_worktree_path(
+    def test_build_command_accepts_none_workspace_path(
         self, config, event_bus: EventBus
     ) -> None:
-        """The worktree_path parameter is optional (None) for runners that don't need worktrees."""
+        """The workspace_path parameter is optional (None) for runners that don't need worktrees."""
         runner = _TestRunner(config, event_bus)
         cmd = runner._build_command(None)
         assert cmd[0] == "claude"
@@ -652,7 +652,7 @@ class TestBuildCommand:
     def test_build_command_works_without_arguments(
         self, config, event_bus: EventBus
     ) -> None:
-        """The worktree_path parameter defaults to None when omitted."""
+        """The workspace_path parameter defaults to None when omitted."""
         runner = _TestRunner(config, event_bus)
         cmd = runner._build_command()
         assert cmd[0] == "claude"

--- a/tests/test_beads_manager.py
+++ b/tests/test_beads_manager.py
@@ -646,7 +646,7 @@ class TestImplementPhaseBeadsIntegration:
 
             captured.append(kwargs)
             return WorkerResultFactory.create(
-                issue_number=issue.id, success=True, worktree_path=str(wt_path)
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
             )
 
         issue = TaskFactory.create(id=42)
@@ -674,7 +674,7 @@ class TestImplementPhaseBeadsIntegration:
 
             captured.append(kwargs)
             return WorkerResultFactory.create(
-                issue_number=issue.id, success=True, worktree_path=str(wt_path)
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
             )
 
         issue = TaskFactory.create(id=42)
@@ -694,7 +694,7 @@ class TestImplementPhaseBeadsIntegration:
 
             captured.append(kwargs)
             return WorkerResultFactory.create(
-                issue_number=issue.id, success=True, worktree_path=str(wt_path)
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
             )
 
         issue = TaskFactory.create(id=42)

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -57,9 +57,9 @@ class TestWorkerResultBuilder:
         same = builder.with_issue_number(1)
         assert same is builder
 
-    def test_with_worktree_path(self):
-        result = WorkerResultBuilder().with_worktree_path("/tmp/wt").build()
-        assert result.worktree_path == "/tmp/wt"
+    def test_with_workspace_path(self):
+        result = WorkerResultBuilder().with_workspace_path("/tmp/wt").build()
+        assert result.workspace_path == "/tmp/wt"
 
     def test_with_quality_attempts(self):
         result = (
@@ -85,7 +85,7 @@ class TestWorkerResultBuilder:
         assert result.success is False
         assert result.transcript == ""
         assert result.commits == 0
-        assert result.worktree_path == ""
+        assert result.workspace_path == ""
 
     def test_model_defaults_with_overrides(self):
         """with_model_defaults() still respects explicit .with_*() overrides."""

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -29,7 +29,7 @@ _INTERVAL_BOUNDS_SKIP: set[str] = {
     "report_issue_interval",
     "epic_monitor_interval",
     "epic_sweep_interval",
-    "worktree_gc_interval",
+    "workspace_gc_interval",
     "runs_gc_interval",
     "health_monitor_interval",
     "sentry_poll_interval",

--- a/tests/test_config_core.py
+++ b/tests/test_config_core.py
@@ -317,14 +317,14 @@ class TestHydraFlowConfigPathResolution:
         # Act
         cfg = HydraFlowConfig(
             repo_root=explicit_root,
-            worktree_base=explicit_root / "wt",
+            workspace_base=explicit_root / "wt",
             state_file=explicit_root / "state.json",
         )
 
         # Assert
         assert cfg.repo_root == explicit_root
 
-    def test_explicit_worktree_base_is_preserved(self, tmp_path: Path) -> None:
+    def test_explicit_workspace_base_is_preserved(self, tmp_path: Path) -> None:
         # Arrange
         explicit_root = tmp_path / "repo"
         explicit_wt = tmp_path / "worktrees"
@@ -332,12 +332,12 @@ class TestHydraFlowConfigPathResolution:
         # Act
         cfg = HydraFlowConfig(
             repo_root=explicit_root,
-            worktree_base=explicit_wt,
+            workspace_base=explicit_wt,
             state_file=explicit_root / "state.json",
         )
 
         # Assert
-        assert cfg.worktree_base == explicit_wt
+        assert cfg.workspace_base == explicit_wt
 
     def test_explicit_state_file_is_preserved(self, tmp_path: Path) -> None:
         # Arrange
@@ -347,26 +347,28 @@ class TestHydraFlowConfigPathResolution:
         # Act
         cfg = HydraFlowConfig(
             repo_root=explicit_root,
-            worktree_base=explicit_root / "wt",
+            workspace_base=explicit_root / "wt",
             state_file=explicit_state,
         )
 
         # Assert
         assert cfg.state_file == explicit_state
 
-    def test_default_worktree_base_derived_from_repo_root(self, tmp_path: Path) -> None:
-        """When worktree_base is left as Path('.'), it should default to ~/.hydraflow/worktrees."""
+    def test_default_workspace_base_derived_from_repo_root(
+        self, tmp_path: Path
+    ) -> None:
+        """When workspace_base is left as Path('.'), it should default to ~/.hydraflow/worktrees."""
         # Arrange
         git_root = tmp_path / "hydra"
         git_root.mkdir()
         (git_root / ".git").mkdir()
 
-        # Act – pass repo_root explicitly but leave worktree_base and state_file at their defaults (Path("."))
+        # Act – pass repo_root explicitly but leave workspace_base and state_file at their defaults (Path("."))
         cfg = HydraFlowConfig(repo_root=git_root)
 
         # Assert
         assert (
-            cfg.worktree_base == Path("~/.hydraflow/worktrees").expanduser().resolve()
+            cfg.workspace_base == Path("~/.hydraflow/worktrees").expanduser().resolve()
         )
 
     def test_default_state_file_derived_from_repo_root(self, tmp_path: Path) -> None:
@@ -398,10 +400,10 @@ class TestHydraFlowConfigPathResolution:
         # Assert
         assert cfg.repo_root.is_absolute()
 
-    def test_auto_detected_worktree_base_uses_hydraflow_worktrees_name(
+    def test_auto_detected_workspace_base_uses_hydraflow_worktrees_name(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Auto-derived worktree_base should be ~/.hydraflow/worktrees."""
+        """Auto-derived workspace_base should be ~/.hydraflow/worktrees."""
         # Arrange
         git_root = tmp_path / "repo"
         git_root.mkdir()
@@ -413,7 +415,7 @@ class TestHydraFlowConfigPathResolution:
 
         # Assert
         assert (
-            cfg.worktree_base == Path("~/.hydraflow/worktrees").expanduser().resolve()
+            cfg.workspace_base == Path("~/.hydraflow/worktrees").expanduser().resolve()
         )
 
     def test_auto_detected_state_file_named_hydraflow_state_json(
@@ -436,7 +438,7 @@ class TestHydraFlowConfigPathResolution:
 
 
 # ---------------------------------------------------------------------------
-# HydraFlowConfig – branch_for_issue / worktree_path_for_issue helpers
+# HydraFlowConfig – branch_for_issue / workspace_path_for_issue helpers
 # ---------------------------------------------------------------------------
 
 
@@ -446,7 +448,7 @@ class TestBranchForIssue:
     def test_returns_canonical_branch_name(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.branch_for_issue(42) == "agent/issue-42"
@@ -454,7 +456,7 @@ class TestBranchForIssue:
     def test_single_digit_issue(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.branch_for_issue(1) == "agent/issue-1"
@@ -462,24 +464,24 @@ class TestBranchForIssue:
     def test_large_issue_number(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.branch_for_issue(99999) == "agent/issue-99999"
 
 
 class TestWorktreePathForIssue:
-    """Tests for HydraFlowConfig.worktree_path_for_issue()."""
+    """Tests for HydraFlowConfig.workspace_path_for_issue()."""
 
-    def test_returns_path_under_worktree_base(self, tmp_path: Path) -> None:
+    def test_returns_path_under_workspace_base(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo="org/my-repo",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert (
-            cfg.worktree_path_for_issue(42)
+            cfg.workspace_path_for_issue(42)
             == tmp_path / "wt" / "org-my-repo" / "issue-42"
         )
 
@@ -487,29 +489,29 @@ class TestWorktreePathForIssue:
         cfg = HydraFlowConfig(
             repo="org/my-repo",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert (
-            cfg.worktree_path_for_issue(1)
+            cfg.workspace_path_for_issue(1)
             == tmp_path / "wt" / "org-my-repo" / "issue-1"
         )
 
-    def test_uses_configured_worktree_base(self, tmp_path: Path) -> None:
+    def test_uses_configured_workspace_base(self, tmp_path: Path) -> None:
         custom_base = tmp_path / "custom-worktrees"
         cfg = HydraFlowConfig(
             repo="org/proj",
             repo_root=tmp_path,
-            worktree_base=custom_base,
+            workspace_base=custom_base,
             state_file=tmp_path / "s.json",
         )
-        assert cfg.worktree_path_for_issue(7) == custom_base / "org-proj" / "issue-7"
+        assert cfg.workspace_path_for_issue(7) == custom_base / "org-proj" / "issue-7"
 
     def test_repo_slug_from_repo(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo="acme/widgets",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.repo_slug == "acme-widgets"
@@ -522,7 +524,7 @@ class TestWorktreePathForIssue:
         cfg = HydraFlowConfig(
             repo="",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.repo_slug == tmp_path.name
@@ -549,7 +551,7 @@ class TestResolveDefaults:
         monkeypatch.setenv("HYDRAFLOW_GITHUB_REPO", "env-org/env-repo")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.repo == "env-org/env-repo"
@@ -561,7 +563,7 @@ class TestResolveDefaults:
         cfg = HydraFlowConfig(
             repo="explicit-org/explicit-repo",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.repo == "explicit-org/explicit-repo"
@@ -572,7 +574,7 @@ class TestResolveDefaults:
         monkeypatch.setenv("HYDRAFLOW_DATA_POLL_INTERVAL", "120")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.data_poll_interval == 120
@@ -592,7 +594,7 @@ class TestDirectoryProperties:
         """log_dir should return repo_root / .hydraflow / logs."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.log_dir == tmp_path / ".hydraflow" / "logs"
@@ -603,7 +605,7 @@ class TestDirectoryProperties:
         """plans_dir should return repo_root / .hydraflow / plans."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.plans_dir == tmp_path / ".hydraflow" / "plans"
@@ -614,7 +616,7 @@ class TestDirectoryProperties:
         """memory_dir should return repo_root / .hydraflow / memory."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.memory_dir == tmp_path / ".hydraflow" / "memory"
@@ -625,7 +627,7 @@ class TestDirectoryProperties:
         custom_root.mkdir(parents=True)
         cfg = HydraFlowConfig(
             repo_root=custom_root,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.log_dir.parent.parent == custom_root
@@ -755,7 +757,7 @@ class TestNamespaceRepoPaths:
 class TestTwoPhasePathResolution:
     """Tests verifying that repo-scoped paths depend on repo being resolved first.
 
-    The resolve_defaults validator must resolve base paths (repo_root, worktree_base,
+    The resolve_defaults validator must resolve base paths (repo_root, workspace_base,
     data_root) before resolving the repo slug, and resolve the repo slug before
     computing repo-scoped paths (state_file, event_log_path).
     """

--- a/tests/test_config_docker.py
+++ b/tests/test_config_docker.py
@@ -38,7 +38,7 @@ class TestDockerConfigDefaults:
     def test_execution_mode_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "host"
@@ -46,7 +46,7 @@ class TestDockerConfigDefaults:
     def test_docker_image_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == "ghcr.io/t-rav/hydraflow-agent:latest"
@@ -54,7 +54,7 @@ class TestDockerConfigDefaults:
     def test_docker_cpu_limit_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(2.0)
@@ -62,7 +62,7 @@ class TestDockerConfigDefaults:
     def test_docker_memory_limit_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "4g"
@@ -70,7 +70,7 @@ class TestDockerConfigDefaults:
     def test_docker_pids_limit_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_pids_limit == 256
@@ -78,7 +78,7 @@ class TestDockerConfigDefaults:
     def test_docker_tmp_size_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_tmp_size == "1g"
@@ -86,7 +86,7 @@ class TestDockerConfigDefaults:
     def test_docker_network_mode_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_network_mode == "bridge"
@@ -94,7 +94,7 @@ class TestDockerConfigDefaults:
     def test_docker_spawn_delay_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(2.0)
@@ -102,7 +102,7 @@ class TestDockerConfigDefaults:
     def test_docker_read_only_root_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_read_only_root is True
@@ -110,7 +110,7 @@ class TestDockerConfigDefaults:
     def test_docker_no_new_privileges_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_no_new_privileges is True
@@ -133,7 +133,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             execution_mode="docker",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "docker"
@@ -142,7 +142,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_image="my-registry/my-image:v1",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == "my-registry/my-image:v1"
@@ -151,7 +151,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_cpu_limit=4.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(4.0)
@@ -160,7 +160,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_memory_limit="8g",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "8g"
@@ -169,7 +169,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_network_mode="none",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_network_mode == "none"
@@ -178,7 +178,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_spawn_delay=5.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(5.0)
@@ -187,7 +187,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_read_only_root=False,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_read_only_root is False
@@ -196,7 +196,7 @@ class TestDockerConfigCustomValues:
         cfg = HydraFlowConfig(
             docker_no_new_privileges=False,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_no_new_privileges is False
@@ -217,7 +217,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 execution_mode="kubernetes",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -228,7 +228,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_network_mode="overlay",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -239,7 +239,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_cpu_limit=0.1,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -250,7 +250,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_cpu_limit=32.0,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -258,7 +258,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_cpu_limit=0.5,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(0.5)
@@ -267,7 +267,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_cpu_limit=16.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(16.0)
@@ -279,7 +279,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_spawn_delay=-1.0,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -290,7 +290,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_spawn_delay=60.0,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -298,7 +298,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_spawn_delay=0.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(0.0)
@@ -307,7 +307,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_spawn_delay=30.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(30.0)
@@ -319,7 +319,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_pids_limit=15,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -330,7 +330,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_pids_limit=4097,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -338,7 +338,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_pids_limit=16,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_pids_limit == 16
@@ -347,7 +347,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             docker_pids_limit=4096,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_pids_limit == 4096
@@ -357,7 +357,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_memory_limit="4gb",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -366,7 +366,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_memory_limit="lots",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -375,7 +375,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 docker_tmp_size="big",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -389,7 +389,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 execution_mode="docker",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -402,7 +402,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             execution_mode="docker",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "docker"
@@ -411,7 +411,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             execution_mode="host",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "host"
@@ -434,7 +434,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
             HydraFlowConfig(
                 execution_mode="docker",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
         warnings = "\n".join(rec.getMessage() for rec in caplog.records)
@@ -459,7 +459,7 @@ class TestDockerConfigValidation(GitIdentityEnvMixin):
                 git_user_name="Bot Name",
                 git_user_email="",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
         warnings = "\n".join(rec.getMessage() for rec in caplog.records)
@@ -478,7 +478,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="512m",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "512m"
@@ -487,7 +487,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="1024k",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "1024k"
@@ -496,7 +496,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="100b",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "100b"
@@ -506,7 +506,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="4G",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "4G"
@@ -515,7 +515,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="512M",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "512M"
@@ -525,7 +525,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_tmp_size="512m",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_tmp_size == "512m"
@@ -535,7 +535,7 @@ class TestDockerSizeNotationValidator:
             HydraFlowConfig(
                 docker_memory_limit="",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -544,7 +544,7 @@ class TestDockerSizeNotationValidator:
             HydraFlowConfig(
                 docker_memory_limit="4",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -553,7 +553,7 @@ class TestDockerSizeNotationValidator:
             HydraFlowConfig(
                 docker_memory_limit="g",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -561,7 +561,7 @@ class TestDockerSizeNotationValidator:
         cfg = HydraFlowConfig(
             docker_memory_limit="4g",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "4g"
@@ -572,7 +572,7 @@ class TestDockerSizeNotationValidator:
             HydraFlowConfig(
                 docker_memory_limit="4gb",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -581,7 +581,7 @@ class TestDockerSizeNotationValidator:
             HydraFlowConfig(
                 docker_memory_limit="abc",
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -603,7 +603,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_EXECUTION_MODE", "docker")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "docker"
@@ -614,7 +614,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_IMAGE", "custom/image:v2")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == "custom/image:v2"
@@ -625,7 +625,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_MEMORY_LIMIT", "16g")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_memory_limit == "16g"
@@ -636,7 +636,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_NETWORK_MODE", "none")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_network_mode == "none"
@@ -647,7 +647,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_CPU_LIMIT", "8.0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(8.0)
@@ -658,7 +658,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_SPAWN_DELAY", "5.0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(5.0)
@@ -669,7 +669,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_READ_ONLY_ROOT", "false")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_read_only_root is False
@@ -680,7 +680,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_NO_NEW_PRIVILEGES", "0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_no_new_privileges is False
@@ -695,7 +695,7 @@ class TestDockerConfigEnvVarOverrides:
         with pytest.raises(ValueError, match="docker.*not found on PATH"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -705,7 +705,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_CPU_LIMIT", "50.0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_cpu_limit == pytest.approx(2.0)
@@ -716,7 +716,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_SPAWN_DELAY", "999.0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == pytest.approx(2.0)
@@ -727,7 +727,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_PIDS_LIMIT", "512")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_pids_limit == 512
@@ -739,7 +739,7 @@ class TestDockerConfigEnvVarOverrides:
         with pytest.raises(ValueError, match="HYDRAFLOW_DOCKER_PIDS_LIMIT"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -750,7 +750,7 @@ class TestDockerConfigEnvVarOverrides:
         with pytest.raises(ValueError, match="HYDRAFLOW_DOCKER_PIDS_LIMIT"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -764,7 +764,7 @@ class TestDockerConfigEnvVarOverrides:
         with caplog.at_level(logging.WARNING):
             cfg = HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
         assert cfg.docker_pids_limit == 256
@@ -776,7 +776,7 @@ class TestDockerConfigEnvVarOverrides:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_TMP_SIZE", "2g")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_tmp_size == "2g"
@@ -788,7 +788,7 @@ class TestDockerConfigEnvVarOverrides:
         with pytest.raises(ValueError, match="Invalid HYDRAFLOW_DOCKER_MEMORY_LIMIT"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -799,7 +799,7 @@ class TestDockerConfigEnvVarOverrides:
         with pytest.raises(ValueError, match="Invalid HYDRAFLOW_DOCKER_TMP_SIZE"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -814,7 +814,7 @@ class TestDockerConfigEnvVarOverrides:
         cfg = HydraFlowConfig(
             execution_mode="host",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.execution_mode == "docker"
@@ -831,7 +831,7 @@ class TestDockerConfig:
     def test_docker_image_has_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == "ghcr.io/t-rav/hydraflow-agent:latest"
@@ -839,7 +839,7 @@ class TestDockerConfig:
     def test_docker_spawn_delay_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == 2.0
@@ -847,7 +847,7 @@ class TestDockerConfig:
     def test_docker_network_empty_by_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_network == ""
@@ -855,7 +855,7 @@ class TestDockerConfig:
     def test_docker_extra_mounts_empty_by_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_extra_mounts == []
@@ -866,7 +866,7 @@ class TestDockerConfig:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_SPAWN_DELAY", "not-a-number")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_spawn_delay == 2.0
@@ -877,7 +877,7 @@ class TestDockerConfig:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_NETWORK", "hydra-net")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_network == "hydra-net"
@@ -888,7 +888,7 @@ class TestDockerConfig:
         monkeypatch.setenv("HYDRAFLOW_DOCKER_NETWORK", "from-env")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             docker_network="explicit-net",
         )
@@ -897,7 +897,7 @@ class TestDockerConfig:
     def test_docker_custom_values(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             docker_image="hydra-agent:latest",
             docker_spawn_delay=3.5,
@@ -915,7 +915,7 @@ class TestDockerConfig:
         with pytest.raises(pydantic.ValidationError):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 docker_spawn_delay=-1.0,
             )
@@ -926,7 +926,7 @@ class TestDockerConfig:
         with pytest.raises(pydantic.ValidationError):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 docker_spawn_delay=31.0,
             )

--- a/tests/test_config_docker_image.py
+++ b/tests/test_config_docker_image.py
@@ -32,7 +32,7 @@ class TestDockerImageConfig:
         cfg = HydraFlowConfig(
             docker_image="explicit/image:v1",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == "explicit/image:v1"
@@ -44,7 +44,7 @@ class TestDockerImageConfig:
         monkeypatch.delenv("HYDRAFLOW_DOCKER_IMAGE", raising=False)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.docker_image == DEFAULT_DOCKER_IMAGE

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -44,7 +44,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, str(override_value))
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == override_value
@@ -69,7 +69,7 @@ class TestEnvVarOverrideTable:
         cfg = HydraFlowConfig(
             **{field: explicit},  # type: ignore[arg-type]
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == explicit
@@ -91,7 +91,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, "not-a-number")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == default
@@ -113,7 +113,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, "custom-value")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         result = getattr(cfg, field)
@@ -144,7 +144,7 @@ class TestEnvVarOverrideTable:
         cfg = HydraFlowConfig(
             **{field: explicit},  # type: ignore[arg-type]
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert str(getattr(cfg, field)) == explicit
@@ -167,7 +167,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, str(override_value))
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == pytest.approx(override_value)
@@ -191,7 +191,7 @@ class TestEnvVarOverrideTable:
         cfg = HydraFlowConfig(
             **{field: explicit},  # type: ignore[arg-type]
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == pytest.approx(explicit)
@@ -213,7 +213,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, "not-a-number")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == pytest.approx(default)
@@ -235,7 +235,7 @@ class TestEnvVarOverrideTable:
         monkeypatch.setenv(env_key, "false")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) is False
@@ -258,7 +258,7 @@ class TestEnvVarOverrideTable:
             monkeypatch.setenv(env_key, truthy)
             cfg = HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
             assert getattr(cfg, field) is True, f"'{truthy}' should parse as True"
@@ -281,7 +281,7 @@ class TestEnvVarOverrideTable:
             monkeypatch.setenv(env_key, falsy)
             cfg = HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
             assert getattr(cfg, field) is False, f"'{falsy}' should parse as False"
@@ -307,7 +307,7 @@ class TestEnvVarOverrideTable:
         cfg = HydraFlowConfig(
             **{field: explicit},  # type: ignore[arg-type]
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) is explicit
@@ -337,7 +337,7 @@ class TestEnvVarOverrideTable:
             monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/docker")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == non_default
@@ -368,7 +368,7 @@ class TestEnvVarOverrideTable:
         cfg = HydraFlowConfig(
             **{field: non_default},  # type: ignore[arg-type]
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert getattr(cfg, field) == non_default
@@ -392,7 +392,7 @@ class TestEnvVarOverrideTable:
         with caplog.at_level(logging.WARNING, logger="hydraflow.config"):
             cfg = HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
         assert getattr(cfg, field) == default

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -162,7 +162,7 @@ class TestConfigFileMergePriority:
         cfg = HydraFlowConfig(
             **file_values,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
@@ -180,7 +180,7 @@ class TestConfigFileMergePriority:
         cfg = HydraFlowConfig(
             **file_values,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
@@ -196,7 +196,7 @@ class TestConfigFileMergePriority:
         cfg = HydraFlowConfig(
             **file_values,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
@@ -212,7 +212,7 @@ class TestConfigFileMergePriority:
         cfg = HydraFlowConfig(
             **file_values,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
@@ -261,7 +261,7 @@ class TestWorkerCountRoundTrip:
         cfg = HydraFlowConfig(
             **file_values,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 

--- a/tests/test_config_persist_endpoint.py
+++ b/tests/test_config_persist_endpoint.py
@@ -82,7 +82,7 @@ class TestPatchConfigEndpoint:
         config_path = tmp_path / ".hydraflow" / "config.json"
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         # Set config_file path on config
@@ -156,7 +156,7 @@ class TestPatchConfigEndpoint:
         config_path = tmp_path / ".hydraflow" / "config.json"
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         object.__setattr__(cfg, "config_file", config_path)
@@ -241,7 +241,7 @@ class TestPatchConfigEndpoint:
         config_path = tmp_path / ".hydraflow" / "config.json"
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         object.__setattr__(cfg, "config_file", config_path)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -40,7 +40,7 @@ _BOUNDED_INT_IDS = [f[0] for f in _BOUNDED_INT_FIELDS]
 def _make_cfg(tmp_path: Path, **overrides: object) -> HydraFlowConfig:
     return HydraFlowConfig(
         repo_root=tmp_path,
-        worktree_base=tmp_path / "wt",
+        workspace_base=tmp_path / "wt",
         state_file=tmp_path / "s.json",
         **overrides,  # type: ignore[arg-type]
     )
@@ -160,7 +160,7 @@ class TestHydraFlowConfigGhToken:
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == ""
@@ -169,7 +169,7 @@ class TestHydraFlowConfigGhToken:
         cfg = HydraFlowConfig(
             gh_token="ghp_explicit123",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == "ghp_explicit123"
@@ -180,7 +180,7 @@ class TestHydraFlowConfigGhToken:
         monkeypatch.setenv("HYDRAFLOW_GH_TOKEN", "ghp_from_env")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == "ghp_from_env"
@@ -192,7 +192,7 @@ class TestHydraFlowConfigGhToken:
         cfg = HydraFlowConfig(
             gh_token="ghp_explicit",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == "ghp_explicit"
@@ -206,7 +206,7 @@ class TestHydraFlowConfigGhToken:
         (tmp_path / ".env").write_text("HYDRAFLOW_GH_TOKEN=ghp_from_dotenv\n")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == "ghp_from_dotenv"
@@ -222,7 +222,7 @@ class TestHydraFlowConfigGhToken:
         )
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.gh_token == "ghp_from_dotenv"
@@ -258,7 +258,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         self._clear_git_identity_env(monkeypatch)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == ""
@@ -269,7 +269,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         self._clear_git_identity_env(monkeypatch)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_email == ""
@@ -278,7 +278,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             git_user_name="Bot",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == "Bot"
@@ -287,7 +287,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             git_user_email="bot@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_email == "bot@example.com"
@@ -299,7 +299,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         monkeypatch.setenv("HYDRAFLOW_GIT_USER_NAME", "EnvBot")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == "EnvBot"
@@ -311,7 +311,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         monkeypatch.setenv("HYDRAFLOW_GIT_USER_EMAIL", "env@example.com")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_email == "env@example.com"
@@ -324,7 +324,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             git_user_name="ExplicitBot",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == "ExplicitBot"
@@ -337,7 +337,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         cfg = HydraFlowConfig(
             git_user_email="explicit@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_email == "explicit@example.com"
@@ -352,7 +352,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         )
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == "Dotenv Bot"
@@ -368,7 +368,7 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
         )
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_user_name == "Dotenv Bot"
@@ -389,7 +389,7 @@ class TestHydraFlowConfigHitlActiveLabel:
         monkeypatch.setenv("HYDRAFLOW_LABEL_HITL_ACTIVE", "custom-active")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.hitl_active_label == ["custom-active"]
@@ -401,7 +401,7 @@ class TestHydraFlowConfigHitlActiveLabel:
         cfg = HydraFlowConfig(
             hitl_active_label=["explicit-active"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.hitl_active_label == ["explicit-active"]
@@ -418,7 +418,7 @@ class TestHydraFlowConfigDupLabel:
     def test_dup_label_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.dup_label == ["hydraflow-dup"]
@@ -427,7 +427,7 @@ class TestHydraFlowConfigDupLabel:
         cfg = HydraFlowConfig(
             dup_label=["my-dup"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.dup_label == ["my-dup"]
@@ -438,7 +438,7 @@ class TestHydraFlowConfigDupLabel:
         monkeypatch.setenv("HYDRAFLOW_LABEL_DUP", "custom-dup")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.dup_label == ["custom-dup"]
@@ -450,7 +450,7 @@ class TestHydraFlowConfigDupLabel:
         cfg = HydraFlowConfig(
             dup_label=["explicit-dup"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.dup_label == ["explicit-dup"]
@@ -462,7 +462,7 @@ class TestHydraFlowConfigEpicChildLabel:
     def test_epic_child_label_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.epic_child_label == ["hydraflow-epic-child"]
@@ -471,7 +471,7 @@ class TestHydraFlowConfigEpicChildLabel:
         cfg = HydraFlowConfig(
             epic_child_label=["my-epic-child"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.epic_child_label == ["my-epic-child"]
@@ -482,7 +482,7 @@ class TestHydraFlowConfigEpicChildLabel:
         monkeypatch.setenv("HYDRAFLOW_LABEL_EPIC_CHILD", "custom-epic-child")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.epic_child_label == ["custom-epic-child"]
@@ -494,7 +494,7 @@ class TestHydraFlowConfigEpicChildLabel:
         cfg = HydraFlowConfig(
             epic_child_label=["explicit-epic-child"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.epic_child_label == ["explicit-epic-child"]
@@ -511,7 +511,7 @@ class TestHydraFlowConfigMinPlanWords:
     def test_min_plan_words_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.min_plan_words == 200
@@ -522,7 +522,7 @@ class TestHydraFlowConfigMinPlanWords:
         monkeypatch.setenv("HYDRAFLOW_MIN_PLAN_WORDS", "300")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.min_plan_words == 300
@@ -534,7 +534,7 @@ class TestHydraFlowConfigMinPlanWords:
         cfg = HydraFlowConfig(
             min_plan_words=100,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.min_plan_words == 100
@@ -554,7 +554,7 @@ class TestHydraFlowConfigMaxReviewFixAttempts:
         monkeypatch.setenv("HYDRAFLOW_MAX_REVIEW_FIX_ATTEMPTS", "4")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_fix_attempts == 4
@@ -566,7 +566,7 @@ class TestHydraFlowConfigMaxReviewFixAttempts:
         cfg = HydraFlowConfig(
             max_review_fix_attempts=1,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_fix_attempts == 1
@@ -581,7 +581,7 @@ class TestHydraFlowConfigMaxPreQualityReviewAttempts:
         monkeypatch.setenv("HYDRAFLOW_MAX_PRE_QUALITY_REVIEW_ATTEMPTS", "4")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_pre_quality_review_attempts == 4
@@ -593,7 +593,7 @@ class TestHydraFlowConfigMaxPreQualityReviewAttempts:
         cfg = HydraFlowConfig(
             max_pre_quality_review_attempts=2,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_pre_quality_review_attempts == 2
@@ -613,7 +613,7 @@ class TestHydraFlowConfigMinReviewFindings:
         monkeypatch.setenv("HYDRAFLOW_MIN_REVIEW_FINDINGS", "5")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.min_review_findings == 5
@@ -625,7 +625,7 @@ class TestHydraFlowConfigMinReviewFindings:
         cfg = HydraFlowConfig(
             min_review_findings=1,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.min_review_findings == 1
@@ -645,7 +645,7 @@ class TestHydraFlowConfigMaxMergeConflictFixAttempts:
         monkeypatch.setenv("HYDRAFLOW_MAX_MERGE_CONFLICT_FIX_ATTEMPTS", "5")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_merge_conflict_fix_attempts == 5
@@ -657,7 +657,7 @@ class TestHydraFlowConfigMaxMergeConflictFixAttempts:
         cfg = HydraFlowConfig(
             max_merge_conflict_fix_attempts=1,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_merge_conflict_fix_attempts == 1
@@ -668,7 +668,7 @@ class TestHydraFlowConfigMaxMergeConflictFixAttempts:
         monkeypatch.setenv("HYDRAFLOW_MAX_MERGE_CONFLICT_FIX_ATTEMPTS", "not-a-number")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_merge_conflict_fix_attempts == 3
@@ -680,7 +680,7 @@ class TestHydraFlowConfigLitePlanLabels:
     def test_lite_plan_labels_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.lite_plan_labels == ["bug", "typo", "docs"]
@@ -691,7 +691,7 @@ class TestHydraFlowConfigLitePlanLabels:
         monkeypatch.setenv("HYDRAFLOW_LITE_PLAN_LABELS", "hotfix,patch")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.lite_plan_labels == ["hotfix", "patch"]
@@ -703,7 +703,7 @@ class TestHydraFlowConfigLitePlanLabels:
         cfg = HydraFlowConfig(
             lite_plan_labels=["custom"],
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.lite_plan_labels == ["custom"]
@@ -711,7 +711,7 @@ class TestHydraFlowConfigLitePlanLabels:
     def test_pr_unstick_interval_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.pr_unstick_interval == 3600
@@ -719,7 +719,7 @@ class TestHydraFlowConfigLitePlanLabels:
     def test_pr_unstick_batch_size_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.pr_unstick_batch_size == 10
@@ -730,7 +730,7 @@ class TestHydraFlowConfigLitePlanLabels:
         monkeypatch.setenv("HYDRAFLOW_PR_UNSTICK_INTERVAL", "1800")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.pr_unstick_interval == 1800
@@ -741,7 +741,7 @@ class TestHydraFlowConfigLitePlanLabels:
         monkeypatch.setenv("HYDRAFLOW_PR_UNSTICK_BATCH_SIZE", "5")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.pr_unstick_batch_size == 5
@@ -758,7 +758,7 @@ class TestHydraFlowConfigThresholds:
     def test_quality_fix_rate_threshold_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.quality_fix_rate_threshold == pytest.approx(0.5)
@@ -766,7 +766,7 @@ class TestHydraFlowConfigThresholds:
     def test_approval_rate_threshold_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.approval_rate_threshold == pytest.approx(0.5)
@@ -774,7 +774,7 @@ class TestHydraFlowConfigThresholds:
     def test_hitl_rate_threshold_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.hitl_rate_threshold == pytest.approx(0.2)
@@ -783,7 +783,7 @@ class TestHydraFlowConfigThresholds:
         cfg = HydraFlowConfig(
             quality_fix_rate_threshold=0.8,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.quality_fix_rate_threshold == pytest.approx(0.8)
@@ -792,7 +792,7 @@ class TestHydraFlowConfigThresholds:
         cfg = HydraFlowConfig(
             approval_rate_threshold=0.7,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.approval_rate_threshold == pytest.approx(0.7)
@@ -801,7 +801,7 @@ class TestHydraFlowConfigThresholds:
         cfg = HydraFlowConfig(
             hitl_rate_threshold=0.1,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.hitl_rate_threshold == pytest.approx(0.1)
@@ -811,7 +811,7 @@ class TestHydraFlowConfigThresholds:
             HydraFlowConfig(
                 quality_fix_rate_threshold=-0.1,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -820,7 +820,7 @@ class TestHydraFlowConfigThresholds:
             HydraFlowConfig(
                 quality_fix_rate_threshold=1.1,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -828,7 +828,7 @@ class TestHydraFlowConfigThresholds:
         cfg = HydraFlowConfig(
             quality_fix_rate_threshold=0.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.quality_fix_rate_threshold == pytest.approx(0.0)
@@ -837,7 +837,7 @@ class TestHydraFlowConfigThresholds:
         cfg = HydraFlowConfig(
             quality_fix_rate_threshold=1.0,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.quality_fix_rate_threshold == pytest.approx(1.0)
@@ -854,7 +854,7 @@ class TestHydraFlowConfigTestCommand:
     def test_test_command_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.test_command == "make test"
@@ -863,7 +863,7 @@ class TestHydraFlowConfigTestCommand:
         cfg = HydraFlowConfig(
             test_command="npm test",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.test_command == "npm test"
@@ -874,7 +874,7 @@ class TestHydraFlowConfigTestCommand:
         monkeypatch.setenv("HYDRAFLOW_TEST_COMMAND", "pytest -x")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.test_command == "pytest -x"
@@ -886,7 +886,7 @@ class TestHydraFlowConfigTestCommand:
         cfg = HydraFlowConfig(
             test_command="cargo test",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.test_command == "cargo test"
@@ -903,7 +903,7 @@ class TestHydraFlowConfigMaxIssueBodyChars:
     def test_max_issue_body_chars_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_body_chars == 10_000
@@ -912,7 +912,7 @@ class TestHydraFlowConfigMaxIssueBodyChars:
         cfg = HydraFlowConfig(
             max_issue_body_chars=5_000,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_body_chars == 5_000
@@ -924,7 +924,7 @@ class TestHydraFlowConfigMaxIssueBodyChars:
         monkeypatch.setenv("HYDRAFLOW_MAX_ISSUE_BODY_CHARS", "20000")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_body_chars == 20_000
@@ -937,7 +937,7 @@ class TestHydraFlowConfigMaxIssueBodyChars:
         cfg = HydraFlowConfig(
             max_issue_body_chars=5_000,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_body_chars == 5_000
@@ -954,7 +954,7 @@ class TestHydraFlowConfigMaxReviewDiffChars:
     def test_max_review_diff_chars_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_diff_chars == 15_000
@@ -963,7 +963,7 @@ class TestHydraFlowConfigMaxReviewDiffChars:
         cfg = HydraFlowConfig(
             max_review_diff_chars=30_000,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_diff_chars == 30_000
@@ -975,7 +975,7 @@ class TestHydraFlowConfigMaxReviewDiffChars:
         monkeypatch.setenv("HYDRAFLOW_MAX_REVIEW_DIFF_CHARS", "50000")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_diff_chars == 50_000
@@ -988,7 +988,7 @@ class TestHydraFlowConfigMaxReviewDiffChars:
         cfg = HydraFlowConfig(
             max_review_diff_chars=25_000,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_review_diff_chars == 25_000
@@ -1005,7 +1005,7 @@ class TestMaxIssueAttempts:
     def test_default_is_three(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_attempts == 3
@@ -1016,7 +1016,7 @@ class TestMaxIssueAttempts:
         monkeypatch.setenv("HYDRAFLOW_MAX_ISSUE_ATTEMPTS", "5")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_attempts == 5
@@ -1028,7 +1028,7 @@ class TestMaxIssueAttempts:
         cfg = HydraFlowConfig(
             max_issue_attempts=4,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_issue_attempts == 4
@@ -1040,7 +1040,7 @@ class TestUpdatedIntervalDefaults:
     def test_memory_sync_default_is_3600(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.memory_sync_interval == 3600
@@ -1048,7 +1048,7 @@ class TestUpdatedIntervalDefaults:
     def test_memory_sync_max_increased_to_14400(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             memory_sync_interval=14400,
         )
@@ -1060,7 +1060,7 @@ class TestUpdatedIntervalDefaults:
         monkeypatch.setenv("HYDRAFLOW_MEMORY_SYNC_INTERVAL", "900")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.memory_sync_interval == 900
@@ -1077,7 +1077,7 @@ class TestTranscriptSummarizationConfig:
     def test_default_enabled(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.transcript_summarization_enabled is True
@@ -1085,7 +1085,7 @@ class TestTranscriptSummarizationConfig:
     def test_default_model(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.transcript_summary_model == "haiku"
@@ -1093,7 +1093,7 @@ class TestTranscriptSummarizationConfig:
     def test_default_max_chars(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_transcript_summary_chars == 50_000
@@ -1104,7 +1104,7 @@ class TestTranscriptSummarizationConfig:
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED", "false")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.transcript_summarization_enabled is False
@@ -1115,7 +1115,7 @@ class TestTranscriptSummarizationConfig:
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED", "0")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.transcript_summarization_enabled is False
@@ -1126,7 +1126,7 @@ class TestTranscriptSummarizationConfig:
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL", "sonnet")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.transcript_summary_model == "sonnet"
@@ -1137,7 +1137,7 @@ class TestTranscriptSummarizationConfig:
         monkeypatch.setenv("HYDRAFLOW_MAX_TRANSCRIPT_SUMMARY_CHARS", "20000")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.max_transcript_summary_chars == 20_000
@@ -1150,7 +1150,7 @@ class TestTranscriptSummarizationConfig:
             HydraFlowConfig(
                 max_transcript_summary_chars=1000,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -1162,7 +1162,7 @@ class TestTranscriptSummarizationConfig:
             HydraFlowConfig(
                 max_transcript_summary_chars=1_000_000,
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -1173,7 +1173,7 @@ class TestTranscriptSummarizationConfig:
         cfg = HydraFlowConfig(
             transcript_summary_model="opus",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         # Explicit "opus" != default "haiku", so env var should NOT override
@@ -1213,7 +1213,7 @@ class TestLabelValidation:
             HydraFlowConfig(
                 **{field: []},  # type: ignore[arg-type]
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
             )
 
@@ -1224,7 +1224,7 @@ class TestLabelValidation:
         monkeypatch.setenv("HYDRAFLOW_LABEL_READY", "")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.ready_label == ["hydraflow-ready"]
@@ -1233,7 +1233,7 @@ class TestLabelValidation:
         """verify_label should default to ['hydraflow-verify']."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.verify_label == ["hydraflow-verify"]
@@ -1245,7 +1245,7 @@ class TestLabelValidation:
         monkeypatch.setenv("HYDRAFLOW_LABEL_VERIFY", "custom-verify")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.verify_label == ["custom-verify"]
@@ -1254,7 +1254,7 @@ class TestLabelValidation:
         """verify_label should appear in all_pipeline_labels."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert "hydraflow-verify" in cfg.all_pipeline_labels
@@ -1383,7 +1383,7 @@ class TestTimeoutAndLimitFields:
         """quality_timeout should default to 3600."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.quality_timeout == 3600
@@ -1392,7 +1392,7 @@ class TestTimeoutAndLimitFields:
         """git_command_timeout should default to 30."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.git_command_timeout == 30
@@ -1401,7 +1401,7 @@ class TestTimeoutAndLimitFields:
         """summarizer_timeout should default to 120."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.summarizer_timeout == 120
@@ -1410,7 +1410,7 @@ class TestTimeoutAndLimitFields:
         """error_output_max_chars should default to 3000."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.error_output_max_chars == 3000
@@ -1419,7 +1419,7 @@ class TestTimeoutAndLimitFields:
         """quality_timeout should accept a custom value within range."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             quality_timeout=1800,
         )
@@ -1429,7 +1429,7 @@ class TestTimeoutAndLimitFields:
         """git_command_timeout should accept a custom value within range."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             git_command_timeout=60,
         )
@@ -1439,7 +1439,7 @@ class TestTimeoutAndLimitFields:
         """summarizer_timeout should accept a custom value within range."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             summarizer_timeout=300,
         )
@@ -1449,7 +1449,7 @@ class TestTimeoutAndLimitFields:
         """error_output_max_chars should accept a custom value within range."""
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             error_output_max_chars=5000,
         )
@@ -1460,7 +1460,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="greater than or equal to 60"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 quality_timeout=10,
             )
@@ -1470,7 +1470,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="less than or equal to 7200"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 quality_timeout=10000,
             )
@@ -1480,7 +1480,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="greater than or equal to 5"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 git_command_timeout=1,
             )
@@ -1490,7 +1490,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="greater than or equal to 30"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 summarizer_timeout=5,
             )
@@ -1502,7 +1502,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="greater than or equal to 500"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 error_output_max_chars=100,
             )
@@ -1512,7 +1512,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="less than or equal to 120"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 git_command_timeout=300,
             )
@@ -1522,7 +1522,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="less than or equal to 600"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 summarizer_timeout=1200,
             )
@@ -1534,7 +1534,7 @@ class TestTimeoutAndLimitFields:
         with pytest.raises(ValueError, match="less than or equal to 20000"):
             HydraFlowConfig(
                 repo_root=tmp_path,
-                worktree_base=tmp_path / "wt",
+                workspace_base=tmp_path / "wt",
                 state_file=tmp_path / "s.json",
                 error_output_max_chars=50_000,
             )
@@ -1551,7 +1551,7 @@ class TestUnstickConfigFields:
     def test_unstick_auto_merge_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.unstick_auto_merge is True
@@ -1559,7 +1559,7 @@ class TestUnstickConfigFields:
     def test_unstick_all_causes_default(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.unstick_all_causes is True
@@ -1570,7 +1570,7 @@ class TestUnstickConfigFields:
         monkeypatch.setenv("HYDRAFLOW_UNSTICK_AUTO_MERGE", "false")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.unstick_auto_merge is False
@@ -1581,7 +1581,7 @@ class TestUnstickConfigFields:
         monkeypatch.setenv("HYDRAFLOW_UNSTICK_ALL_CAUSES", "false")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.unstick_all_causes is False
@@ -1667,7 +1667,7 @@ class TestAgentToolFields:
     def test_tool_defaults(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.implementation_tool == "claude"
@@ -1694,7 +1694,7 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE_TOOL", "codex")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.implementation_tool == "codex"
@@ -1724,7 +1724,7 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_BACKGROUND_TOOL", "pi")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.implementation_tool == "pi"
@@ -1743,7 +1743,7 @@ class TestAgentToolFields:
     def test_profile_tool_overrides_apply_to_defaults(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             system_tool="codex",
             background_tool="codex",
@@ -1763,7 +1763,7 @@ class TestAgentToolFields:
     def test_profile_model_overrides_apply_to_defaults(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             system_model="gpt-5-codex",
             background_model="gpt-5-codex",
@@ -1783,7 +1783,7 @@ class TestAgentToolFields:
     ) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             system_tool="codex",
             background_tool="codex",
@@ -1806,7 +1806,7 @@ class TestTieringFields:
     ) -> None:
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         assert cfg.subskill_tool == "claude"

--- a/tests/test_dashboard_routes_control.py
+++ b/tests/test_dashboard_routes_control.py
@@ -161,13 +161,13 @@ class TestPatchConfigWithRegistry:
 
         base_cfg = ConfigFactory.create(
             repo_root=tmp_path / "base-repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         repo_cfg = ConfigFactory.create(
             repo="acme/widgets",
             repo_root=tmp_path / "widgets",
-            worktree_base=tmp_path / "widgets-worktrees",
+            workspace_base=tmp_path / "widgets-worktrees",
             state_file=tmp_path / "widgets-state.json",
         )
         runtime_state = StateTracker(repo_cfg.state_file)

--- a/tests/test_dashboard_routes_repo.py
+++ b/tests/test_dashboard_routes_repo.py
@@ -895,7 +895,7 @@ class TestRepoStoreRuntimeIntegration:
         repo_store = RepoRegistryStore(tmp_path / "repos-data")
         base_config = ConfigFactory.create(
             repo_root=tmp_path / "base",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
 
@@ -948,7 +948,7 @@ class TestRepoStoreRuntimeIntegration:
         repo_store = RepoRegistryStore(tmp_path / "repos-data")
         base_config = ConfigFactory.create(
             repo_root=tmp_path / "base",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         repo_path = tmp_path / "widgets"
@@ -988,7 +988,7 @@ class TestRepoStoreRuntimeIntegration:
         repo_store = RepoRegistryStore(tmp_path / "repos-data")
         base_config = ConfigFactory.create(
             repo_root=tmp_path / "base",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         repo_path = tmp_path / "widgets"

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -1077,7 +1077,7 @@ class TestGetDockerRunner:
         monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/docker")
         cfg = HydraFlowConfig(
             repo_root=repo_root,
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             execution_mode="docker",
             docker_image="hydra:latest",

--- a/tests/test_epic_group_planning.py
+++ b/tests/test_epic_group_planning.py
@@ -291,7 +291,7 @@ class TestPlanEpicGroup:
 
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         # Override the iteration limit
@@ -521,7 +521,7 @@ class TestPlanIssuesMixedEpicAndStandalone:
 
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         # epic_group_planning defaults to False in ConfigFactory

--- a/tests/test_exception_chaining.py
+++ b/tests/test_exception_chaining.py
@@ -24,7 +24,7 @@ from tests.helpers import ConfigFactory
 def config(tmp_path: Path):
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "wt",
+        workspace_base=tmp_path / "wt",
         state_file=tmp_path / "s.json",
     )
 
@@ -346,7 +346,7 @@ class TestMergeConflictResolverExceptionChaining:
 
         return MergeConflictResolver(
             config=config,
-            worktrees=MagicMock(),
+            workspaces=MagicMock(),
             agents=MagicMock(),
             prs=MagicMock(),
             event_bus=event_bus,
@@ -361,7 +361,7 @@ class TestMergeConflictResolverExceptionChaining:
         task = TaskFactory.create(id=5)
 
         # Mock worktrees.start_merge_main to return False (has conflicts)
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
         resolver._publish_review_status = AsyncMock()
 
         # Mock agents._build_command to raise TypeError (a likely bug)
@@ -379,9 +379,9 @@ class TestMergeConflictResolverExceptionChaining:
         task = TaskFactory.create(id=5)
 
         # Mock worktrees.start_merge_main to return False (has conflicts)
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
         resolver._publish_review_status = AsyncMock()
-        resolver._worktrees.abort_merge = AsyncMock()
+        resolver._workspaces.abort_merge = AsyncMock()
 
         # Mock agents._build_command to raise RuntimeError (transient)
         resolver._agents._build_command = MagicMock(

--- a/tests/test_hitl_phase.py
+++ b/tests/test_hitl_phase.py
@@ -425,7 +425,7 @@ class TestHITLResetsAttempts:
         )
 
         # Create worktree directory
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
         wt.create = AsyncMock(return_value=wt_path)
 

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -48,11 +48,11 @@ class TestImplementBatch:
         expected = [
             WorkerResultFactory.create(
                 issue_number=1,
-                worktree_path=str(config.worktree_path_for_issue(1)),
+                workspace_path=str(config.workspace_path_for_issue(1)),
             ),
             WorkerResultFactory.create(
                 issue_number=2,
-                worktree_path=str(config.worktree_path_for_issue(2)),
+                workspace_path=str(config.workspace_path_for_issue(2)),
             ),
         ]
 
@@ -95,7 +95,7 @@ class TestImplementBatch:
             await asyncio.sleep(0)  # yield
             concurrency_counter["current"] -= 1
             return WorkerResultFactory.create(
-                issue_number=issue.id, worktree_path=str(wt_path)
+                issue_number=issue.id, workspace_path=str(wt_path)
             )
 
         issues = [TaskFactory.create(id=i) for i in range(1, 6)]
@@ -148,7 +148,7 @@ class TestImplementBatch:
         issue = TaskFactory.create(id=77)
 
         # Pre-create worktree directory to simulate resume
-        wt_path = config.worktree_path_for_issue(77)
+        wt_path = config.workspace_path_for_issue(77)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = make_implement_phase(
@@ -245,7 +245,7 @@ class TestImplementIncludesPush:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = (
@@ -388,7 +388,7 @@ class TestWorkerExceptionIsolation:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(
@@ -447,7 +447,7 @@ class TestWorktreeCreationFailure:
         async def create_side_effect(num: int, branch: str) -> Path:
             if num == 1:
                 raise RuntimeError("disk full")
-            return config.worktree_base / f"issue-{num}"
+            return config.workspace_base / f"issue-{num}"
 
         phase, mock_wt, _ = (
             ImplementPhaseMockBuilder(config)
@@ -491,7 +491,7 @@ class TestWorktreeCreationFailure:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, mock_wt, _ = make_implement_phase(
@@ -499,7 +499,7 @@ class TestWorktreeCreationFailure:
         )
 
         # Simulate existing worktree directory
-        wt_path = config.worktree_path_for_issue(99)
+        wt_path = config.workspace_path_for_issue(99)
         wt_path.mkdir(parents=True, exist_ok=True)
         phase._state = state
 
@@ -526,7 +526,7 @@ class TestWorktreeCreationFailure:
 
         phase, mock_wt, _ = make_implement_phase(config, [issue])
 
-        wt_path = config.worktree_path_for_issue(99)
+        wt_path = config.workspace_path_for_issue(99)
         wt_path.mkdir(parents=True, exist_ok=True)
         phase._state = state
 
@@ -569,13 +569,13 @@ class TestWorktreeCreationFailure:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, mock_wt, _ = make_implement_phase(
             config, [issue], agent_run=capturing_agent
         )
-        wt_path = config.worktree_path_for_issue(99)
+        wt_path = config.workspace_path_for_issue(99)
         wt_path.mkdir(parents=True, exist_ok=True)
         phase._state = state
 
@@ -608,7 +608,7 @@ class TestWorktreeCreationFailure:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(config, issues, agent_run=slow_agent_run)
@@ -651,7 +651,7 @@ class TestImplementLifecycleMetrics:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 duration_seconds=60.5,
             )
 
@@ -680,7 +680,7 @@ class TestImplementLifecycleMetrics:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 duration_seconds=0.0,
             )
 
@@ -709,7 +709,7 @@ class TestImplementLifecycleMetrics:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 quality_fix_attempts=2,
             )
 
@@ -751,7 +751,7 @@ class TestImplementLifecycleMetrics:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 duration_seconds=30.0,
                 quality_fix_attempts=1,
             )
@@ -792,7 +792,7 @@ class TestReviewFeedbackPassing:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(
@@ -827,7 +827,7 @@ class TestReviewFeedbackPassing:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(
@@ -863,7 +863,7 @@ class TestReviewFeedbackPassing:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(
@@ -895,7 +895,7 @@ class TestReviewFeedbackPassing:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = (
@@ -938,7 +938,7 @@ class TestReviewFeedbackPassing:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = make_implement_phase(
@@ -984,7 +984,7 @@ class TestWorkerResultMetaPersistence:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 quality_fix_attempts=2,
                 duration_seconds=150.5,
             )
@@ -1019,7 +1019,7 @@ class TestWorkerResultMetaPersistence:
                 issue_number=issue.id,
                 branch=branch,
                 success=False,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 quality_fix_attempts=0,
                 duration_seconds=30.0,
                 error="make quality failed",
@@ -1062,7 +1062,7 @@ class TestZeroCommitEscalation:
                 success=False,
                 error="No commits found on branch",
                 commits=0,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = make_implement_phase(
@@ -1099,7 +1099,7 @@ class TestZeroCommitEscalation:
                 success=False,
                 error="No commits found on branch",
                 commits=0,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = make_implement_phase(
@@ -1131,7 +1131,7 @@ class TestZeroCommitEscalation:
                 success=False,
                 error="make quality failed",
                 commits=2,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = (
@@ -1172,7 +1172,7 @@ class TestZeroCommitEscalation:
                 success=False,
                 error="No commits found on branch",
                 commits=0,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = make_implement_phase(
@@ -1216,7 +1216,7 @@ class TestPostMortemMemoryFiling:
                 success=False,
                 error="No commits found on branch",
                 commits=0,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 transcript="MEMORY_SUGGESTION_START\ntitle: test\nlearning: learned\nMEMORY_SUGGESTION_END",
             )
 
@@ -1258,7 +1258,7 @@ class TestPostMortemMemoryFiling:
                 success=False,
                 error="No commits found on branch",
                 commits=0,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 transcript="",
             )
 
@@ -1292,7 +1292,7 @@ class TestPostMortemMemoryFiling:
                 branch=branch,
                 success=True,
                 commits=1,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 transcript="MEMORY_SUGGESTION_START\ntitle: zero diff\nlearning: no changes\nMEMORY_SUGGESTION_END",
             )
 
@@ -1334,7 +1334,7 @@ class TestRetryCapEscalation:
         config = ConfigFactory.create(
             max_issue_attempts=3,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1357,7 +1357,7 @@ class TestRetryCapEscalation:
         config = ConfigFactory.create(
             max_issue_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1377,7 +1377,7 @@ class TestRetryCapEscalation:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, mock_prs = make_implement_phase(
@@ -1414,7 +1414,7 @@ class TestRetryCapEscalation:
         config = ConfigFactory.create(
             max_issue_attempts=3,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1456,7 +1456,7 @@ class TestCommitsPersistedInMeta:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 commits=3,
                 quality_fix_attempts=1,
                 duration_seconds=90.0,
@@ -1513,7 +1513,7 @@ class TestCheckAttemptCap:
         config = ConfigFactory.create(
             max_issue_attempts=3,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1531,7 +1531,7 @@ class TestCheckAttemptCap:
         config = ConfigFactory.create(
             max_issue_attempts=3,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1553,7 +1553,7 @@ class TestCheckAttemptCap:
         config = ConfigFactory.create(
             max_issue_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1577,7 +1577,7 @@ class TestCheckAttemptCap:
         config = ConfigFactory.create(
             max_issue_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1599,7 +1599,7 @@ class TestCheckAttemptCap:
         config = ConfigFactory.create(
             max_issue_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1631,7 +1631,7 @@ class TestRunImplementation:
         """When worktree dir exists, should reuse it."""
         issue = TaskFactory.create()
 
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = make_implement_phase(config, [issue])
@@ -1660,7 +1660,7 @@ class TestRunImplementation:
             return WorkerResultFactory.create(
                 issue_number=issue.id,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
             )
 
         phase, _, _ = make_implement_phase(config, [issue], agent_run=capturing_agent)
@@ -1702,7 +1702,7 @@ class TestRunImplementation:
                 issue_number=issue.id,
                 branch=branch,
                 success=True,
-                worktree_path=str(wt_path),
+                workspace_path=str(wt_path),
                 duration_seconds=60.0,
                 quality_fix_attempts=2,
             )
@@ -1731,7 +1731,7 @@ class TestHandleImplementationResult:
             success=False,
             error="No commits found on branch",
             commits=0,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(config, [issue])
@@ -1753,7 +1753,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(
@@ -1775,7 +1775,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -1804,7 +1804,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -1834,7 +1834,7 @@ class TestHandleImplementationResult:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -1866,14 +1866,14 @@ class TestHandleImplementationResult:
         assert phase._state.to_dict()["processed_issues"].get(str(42)) == "failed"
 
     @pytest.mark.asyncio
-    async def test_empty_worktree_path_skips_push_and_pr(
+    async def test_empty_workspace_path_skips_push_and_pr(
         self, config: HydraFlowConfig
     ) -> None:
-        """When result.worktree_path is empty, push and PR creation should be skipped."""
+        """When result.workspace_path is empty, push and PR creation should be skipped."""
         issue = TaskFactory.create()
         result = WorkerResultFactory.create(
             success=True,
-            worktree_path="",
+            workspace_path="",
         )
 
         phase, _, mock_prs = make_implement_phase(config, [issue])
@@ -1897,7 +1897,7 @@ class TestWorkerInner:
         config = ConfigFactory.create(
             max_issue_attempts=1,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         issue = TaskFactory.create()
@@ -1915,7 +1915,7 @@ class TestWorkerInner:
             nonlocal agent_called
             agent_called = True
             return WorkerResultFactory.create(
-                issue_number=issue.id, worktree_path=str(wt_path)
+                issue_number=issue.id, workspace_path=str(wt_path)
             )
 
         phase, _, _ = make_implement_phase(config, [issue], agent_run=tracking_agent)
@@ -1963,7 +1963,7 @@ class TestWorkerInner:
             nonlocal agent_called
             agent_called = True
             return WorkerResultFactory.create(
-                issue_number=issue.id, worktree_path=str(wt_path)
+                issue_number=issue.id, workspace_path=str(wt_path)
             )
 
         phase, _, mock_prs = (
@@ -2216,7 +2216,7 @@ class TestWorktreeResetOnRetry:
     ) -> None:
         """Existing worktree should be reset when there's a prior error."""
         issue = TaskFactory.create()
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = make_implement_phase(config, [issue])
@@ -2234,7 +2234,7 @@ class TestWorktreeResetOnRetry:
     async def test_no_reset_when_no_prior_error(self, config: HydraFlowConfig) -> None:
         """Should not reset worktree when there's no prior error."""
         issue = TaskFactory.create()
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = make_implement_phase(config, [issue])
@@ -2262,7 +2262,7 @@ class TestWorktreeResetOnRetry:
     async def test_reset_failure_does_not_crash(self, config: HydraFlowConfig) -> None:
         """If reset_to_main raises, should log warning and continue."""
         issue = TaskFactory.create()
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase, mock_wt, _ = (
@@ -2305,7 +2305,7 @@ class TestPriorFailureFeedback:
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(
-                issue_number=issue.id, success=True, worktree_path=str(wt_path)
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
             )
 
         phase, _, _ = make_implement_phase(config, [issue], agent_run=capturing_agent)
@@ -2335,7 +2335,7 @@ class TestPriorFailureFeedback:
         ) -> WorkerResult:
             captured.append(prior_failure)
             return WorkerResultFactory.create(
-                issue_number=issue.id, success=True, worktree_path=str(wt_path)
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
             )
 
         phase, _, _ = make_implement_phase(config, [issue], agent_run=capturing_agent)
@@ -2363,7 +2363,7 @@ class TestZeroCommitCorrectiveRetry:
             success=False,
             error="No commits found on branch",
             commits=0,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(config, [issue])
@@ -2451,7 +2451,7 @@ class TestHandleZeroCommits:
             success=False,
             error="No commits found on branch",
             commits=0,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(config, [issue])
@@ -2480,7 +2480,7 @@ class TestHandleSuccessfulPush:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(
@@ -2500,7 +2500,7 @@ class TestHandleSuccessfulPush:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -2526,7 +2526,7 @@ class TestHandleSuccessfulPush:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -2552,7 +2552,7 @@ class TestHandleSuccessfulPush:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=False,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = make_implement_phase(
@@ -2580,7 +2580,7 @@ class TestHandleNoPrFallback:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -2604,7 +2604,7 @@ class TestHandleNoPrFallback:
         result = WorkerResultFactory.create(
             issue_number=42,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(42)),
+            workspace_path=str(config.workspace_path_for_issue(42)),
         )
 
         phase, _, mock_prs = (
@@ -2638,7 +2638,7 @@ class TestRetryPrTitleConsistency:
         result = WorkerResultFactory.create(
             issue_number=99,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(99)),
+            workspace_path=str(config.workspace_path_for_issue(99)),
         )
         existing_pr = PRInfoFactory.create(number=200, issue_number=99)
 
@@ -2668,7 +2668,7 @@ class TestRetryPrTitleConsistency:
         result = WorkerResultFactory.create(
             issue_number=99,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(99)),
+            workspace_path=str(config.workspace_path_for_issue(99)),
         )
 
         phase, _, mock_prs = (
@@ -2692,7 +2692,7 @@ class TestRetryPrTitleConsistency:
         result = WorkerResultFactory.create(
             issue_number=99,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(99)),
+            workspace_path=str(config.workspace_path_for_issue(99)),
         )
 
         phase, _, mock_prs = make_implement_phase(
@@ -2715,7 +2715,7 @@ class TestRetryPrTitleConsistency:
         result = WorkerResultFactory.create(
             issue_number=99,
             success=True,
-            worktree_path=str(config.worktree_path_for_issue(99)),
+            workspace_path=str(config.workspace_path_for_issue(99)),
         )
         zero_pr = PRInfoFactory.create(number=0, issue_number=99)
 

--- a/tests/test_integration_file_io.py
+++ b/tests/test_integration_file_io.py
@@ -191,7 +191,7 @@ class TestStateTrackerPersistence:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
         tracker.mark_issue(42, "planned")
-        tracker.set_worktree(42, "/tmp/wt/issue-42")
+        tracker.set_workspace(42, "/tmp/wt/issue-42")
         tracker.set_branch(42, "agent/issue-42")
         tracker.mark_pr(101, "approved")
         tracker.set_hitl_origin(42, "hydraflow-review")
@@ -201,7 +201,7 @@ class TestStateTrackerPersistence:
         tracker2 = StateTracker(state_file)
         data = tracker2.to_dict()
         assert data["processed_issues"]["42"] == "planned"
-        assert tracker2.get_active_worktrees() == {42: "/tmp/wt/issue-42"}
+        assert tracker2.get_active_workspaces() == {42: "/tmp/wt/issue-42"}
         assert tracker2.get_branch(42) == "agent/issue-42"
         assert data["reviewed_prs"]["101"] == "approved"
         assert tracker2.get_hitl_origin(42) == "hydraflow-review"
@@ -215,7 +215,7 @@ class TestStateTrackerPersistence:
 
         tracker = StateTracker(state_file)
         # Should have reset to defaults
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
         assert tracker.get_branch(1) is None
 
     def test_empty_file_resets(self, tmp_path: Path) -> None:
@@ -225,7 +225,7 @@ class TestStateTrackerPersistence:
         state_file.write_text("")
 
         tracker = StateTracker(state_file)
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_non_object_json_resets(self, tmp_path: Path) -> None:
         from state import StateTracker
@@ -234,7 +234,7 @@ class TestStateTrackerPersistence:
         state_file.write_text("[1, 2, 3]")
 
         tracker = StateTracker(state_file)
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_last_updated_set_on_save(self, tmp_path: Path) -> None:
         from state import StateTracker
@@ -254,14 +254,14 @@ class TestStateTrackerPersistence:
         tracker = StateTracker(state_file)
 
         tracker.mark_issue(1, "planned")
-        tracker.set_worktree(2, "/wt/2")
+        tracker.set_workspace(2, "/wt/2")
         tracker.set_branch(3, "branch-3")
         tracker.mark_pr(4, "reviewed")
 
         tracker2 = StateTracker(state_file)
         data = tracker2.to_dict()
         assert data["processed_issues"]["1"] == "planned"
-        assert data["active_worktrees"]["2"] == "/wt/2"
+        assert data["active_workspaces"]["2"] == "/wt/2"
         assert data["active_branches"]["3"] == "branch-3"
         assert data["reviewed_prs"]["4"] == "reviewed"
 

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -99,9 +99,9 @@ async def test_post_merge_chain_updates_state_and_cleans_worktree(tmp_path):
     assert outcome is not None
     assert outcome.outcome == IssueOutcomeType.MERGED
 
-    cleanup_calls = harness.worktrees.post_work_cleanup.await_args_list
+    cleanup_calls = harness.workspaces.post_work_cleanup.await_args_list
     assert cleanup_calls and cleanup_calls[-1] == call(result.task.id)
-    assert harness.state.get_active_worktrees() == {}
+    assert harness.state.get_active_workspaces() == {}
 
     assert any(
         e.type == EventType.REVIEW_UPDATE and e.data.get("status") == "merging"

--- a/tests/test_integration_worktree.py
+++ b/tests/test_integration_worktree.py
@@ -61,7 +61,7 @@ class TestSetupDotenv:
         execution_mode = "docker" if docker else "host"
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             execution_mode=execution_mode,
         )
         from workspace import WorkspaceManager
@@ -113,7 +113,7 @@ class TestSetupClaudeSettings:
 
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 
@@ -161,14 +161,14 @@ class TestWorkspaceDestroy:
         repo = _make_repo(tmp_path, "repo")
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 
         mgr = WorkspaceManager(config)
 
         # Create the workspace directory manually
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
         (wt_path / "file.txt").write_text("test")
 
@@ -182,7 +182,7 @@ class TestWorkspaceDestroy:
         repo = _make_repo(tmp_path, "repo")
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 
@@ -190,7 +190,7 @@ class TestWorkspaceDestroy:
         # Should not raise
         await mgr.destroy(999)
         # Non-existent worktree means no path was created
-        wt_path = config.worktree_path_for_issue(999)
+        wt_path = config.workspace_path_for_issue(999)
         assert not wt_path.exists()
 
 
@@ -212,7 +212,7 @@ class TestDetectUiDirs:
 
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 
@@ -229,7 +229,7 @@ class TestDetectUiDirs:
 
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 
@@ -244,7 +244,7 @@ class TestDetectUiDirs:
 
         config = ConfigFactory.create(
             repo_root=repo,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
         )
         from workspace import WorkspaceManager
 

--- a/tests/test_issue_fetcher.py
+++ b/tests/test_issue_fetcher.py
@@ -1177,7 +1177,7 @@ def _collab_config(tmp_path: Path, *, enabled: bool = True) -> HydraFlowConfig:
 
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
         collaborator_check_enabled=enabled,
     )

--- a/tests/test_loop_wiring_completeness.py
+++ b/tests/test_loop_wiring_completeness.py
@@ -31,7 +31,7 @@ _INTERVAL_BOUNDS_SKIP: set[str] = {
     "report_issue",
     "epic_monitor",
     "epic_sweeper",
-    "worktree_gc",
+    "workspace_gc",
     "runs_gc",
     "health_monitor",
     "bot_pr",

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -30,7 +30,7 @@ class TestMergeConflictResolver:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.merge_main = AsyncMock(return_value=True)
+        resolver._workspaces.merge_main = AsyncMock(return_value=True)
         resolver._prs.push_branch = AsyncMock(return_value=True)
         publish_fn = AsyncMock()
         escalate_fn = AsyncMock()
@@ -38,7 +38,7 @@ class TestMergeConflictResolver:
         result = await resolver.merge_with_main(
             pr,
             issue,
-            config.worktree_path_for_issue(42),
+            config.workspace_path_for_issue(42),
             0,
             escalate_fn=escalate_fn,
             publish_fn=publish_fn,
@@ -56,14 +56,14 @@ class TestMergeConflictResolver:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.merge_main = AsyncMock(return_value=False)
         publish_fn = AsyncMock()
         escalate_fn = AsyncMock()
 
         result = await resolver.merge_with_main(
             pr,
             issue,
-            config.worktree_path_for_issue(42),
+            config.workspace_path_for_issue(42),
             0,
             escalate_fn=escalate_fn,
             publish_fn=publish_fn,
@@ -87,7 +87,7 @@ class TestMergeConflictResolver:
         issue = TaskFactory.create()
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -102,10 +102,10 @@ class TestMergeConflictResolver:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=True)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=True)
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -125,10 +125,10 @@ class TestMergeConflictResolver:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -149,10 +149,10 @@ class TestMergeConflictResolver:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
@@ -176,12 +176,12 @@ class TestSourceParameter:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         await resolver.resolve_merge_conflicts(
             pr,
             issue,
-            config.worktree_path_for_issue(42),
+            config.workspace_path_for_issue(42),
             worker_id=0,
             source="pr_unsticker",
         )
@@ -203,13 +203,13 @@ class TestSourceParameter:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
         resolver._suggest_memory = AsyncMock()
 
         await resolver.resolve_merge_conflicts(
             pr,
             issue,
-            config.worktree_path_for_issue(42),
+            config.workspace_path_for_issue(42),
             worker_id=0,
             source="test_source",
         )
@@ -235,7 +235,7 @@ class TestWorkerIdNone:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         # Spy on the event bus
         publish_calls = []
@@ -248,7 +248,7 @@ class TestWorkerIdNone:
         resolver._bus.publish = track_publish
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=None
+            pr, issue, config.workspace_path_for_issue(42), worker_id=None
         )
 
         # No REVIEW_UPDATE events should have been published
@@ -273,7 +273,7 @@ class TestWorkerIdNone:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         publish_calls = []
         original_publish = resolver._bus.publish
@@ -285,7 +285,7 @@ class TestWorkerIdNone:
         resolver._bus.publish = track_publish
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=1
+            pr, issue, config.workspace_path_for_issue(42), worker_id=1
         )
 
         # Should have published at least one REVIEW_UPDATE event
@@ -339,7 +339,7 @@ class TestFreshBranchRebuild:
             max_merge_conflict_fix_attempts=1,
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -355,10 +355,10 @@ class TestFreshBranchRebuild:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
-        resolver._worktrees.abort_merge = AsyncMock()
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.abort_merge = AsyncMock()
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(
             return_value=tmp_path / "worktrees" / "issue-42"
         )
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff --git a/foo.py\n+bar")
@@ -369,8 +369,8 @@ class TestFreshBranchRebuild:
 
         assert result.success is True
         assert result.used_rebuild is True
-        resolver._worktrees.destroy.assert_awaited_once()
-        resolver._worktrees.create.assert_awaited_once()
+        resolver._workspaces.destroy.assert_awaited_once()
+        resolver._workspaces.create.assert_awaited_once()
         resolver._prs.get_pr_diff.assert_awaited_once_with(pr.number)
 
     @pytest.mark.asyncio
@@ -379,7 +379,7 @@ class TestFreshBranchRebuild:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -391,16 +391,16 @@ class TestFreshBranchRebuild:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        new_wt = cfg.worktree_path_for_issue(pr.issue_number)
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        new_wt = cfg.workspace_path_for_issue(pr.issue_number)
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
 
         result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
 
         assert result is True
-        resolver._worktrees.destroy.assert_awaited_once_with(pr.issue_number)
-        resolver._worktrees.create.assert_awaited_once_with(pr.issue_number, pr.branch)
+        resolver._workspaces.destroy.assert_awaited_once_with(pr.issue_number)
+        resolver._workspaces.create.assert_awaited_once_with(pr.issue_number, pr.branch)
         mock_agents._build_command.assert_called_once_with(new_wt)
         mock_agents._execute.assert_awaited_once()
         mock_agents._verify_result.assert_awaited_once()
@@ -413,7 +413,7 @@ class TestFreshBranchRebuild:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=False,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -432,7 +432,7 @@ class TestFreshBranchRebuild:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         resolver = make_conflict_resolver(cfg, agents=None)
@@ -449,7 +449,7 @@ class TestFreshBranchRebuild:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -462,7 +462,7 @@ class TestFreshBranchRebuild:
         result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
 
         assert result is False
-        resolver._worktrees.destroy.assert_not_awaited()
+        resolver._workspaces.destroy.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fresh_rebuild_uses_force_flag(self, tmp_path: Path) -> None:
@@ -471,7 +471,7 @@ class TestFreshBranchRebuild:
             max_merge_conflict_fix_attempts=1,
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -487,12 +487,12 @@ class TestFreshBranchRebuild:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        new_wt = cfg.worktree_path_for_issue(pr.issue_number)
-        resolver._worktrees.merge_main = AsyncMock(return_value=False)
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
-        resolver._worktrees.abort_merge = AsyncMock()
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        new_wt = cfg.workspace_path_for_issue(pr.issue_number)
+        resolver._workspaces.merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.abort_merge = AsyncMock()
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
         resolver._prs.push_branch = AsyncMock(return_value=True)
 
@@ -510,7 +510,7 @@ class TestFreshBranchRebuild:
 
         assert result is True
         resolver._prs.push_branch.assert_awaited_once_with(
-            cfg.worktree_path_for_issue(pr.issue_number), pr.branch, force=True
+            cfg.workspace_path_for_issue(pr.issue_number), pr.branch, force=True
         )
 
 
@@ -530,7 +530,7 @@ class TestFreshRebuildTitleUpdate:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -542,9 +542,9 @@ class TestFreshRebuildTitleUpdate:
         pr = PRInfoFactory.create(number=200, issue_number=77)
         issue = TaskFactory.create(id=77, title="Fix the gizmo")
 
-        new_wt = cfg.worktree_path_for_issue(pr.issue_number)
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        new_wt = cfg.workspace_path_for_issue(pr.issue_number)
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
         resolver._prs.update_pr_title = AsyncMock(return_value=True)
         # Resolver now uses self._prs.expected_pr_title (PRPort protocol)
@@ -562,7 +562,7 @@ class TestFreshRebuildTitleUpdate:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -574,9 +574,9 @@ class TestFreshRebuildTitleUpdate:
         pr = PRInfoFactory.create(number=200, issue_number=77)
         issue = TaskFactory.create(id=77, title="Fix the gizmo")
 
-        new_wt = cfg.worktree_path_for_issue(pr.issue_number)
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        new_wt = cfg.workspace_path_for_issue(pr.issue_number)
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
         resolver._prs.update_pr_title = AsyncMock(return_value=True)
 
@@ -637,10 +637,10 @@ class TestArchitectureLayering:
         )
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         suggest_fn.assert_awaited_once()
@@ -661,10 +661,10 @@ class TestArchitectureLayering:
         )
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         result = await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -682,7 +682,7 @@ class TestArchitectureLayering:
         resolver = make_conflict_resolver(config, agents=mock_agents)
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
-        resolver._worktrees.start_merge_main = AsyncMock(return_value=False)
+        resolver._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         # Track events
         from events import EventType
@@ -697,7 +697,7 @@ class TestArchitectureLayering:
         resolver._bus.publish = track
 
         await resolver.resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=1
+            pr, issue, config.workspace_path_for_issue(42), worker_id=1
         )
 
         review_events = [e for e in published if e.type == EventType.REVIEW_UPDATE]
@@ -712,7 +712,7 @@ class TestArchitectureLayering:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=True,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
@@ -724,9 +724,9 @@ class TestArchitectureLayering:
         pr = PRInfoFactory.create(number=200, issue_number=77)
         issue = TaskFactory.create(id=77, title="Fix the gizmo")
 
-        new_wt = cfg.worktree_path_for_issue(pr.issue_number)
-        resolver._worktrees.destroy = AsyncMock()
-        resolver._worktrees.create = AsyncMock(return_value=new_wt)
+        new_wt = cfg.workspace_path_for_issue(pr.issue_number)
+        resolver._workspaces.destroy = AsyncMock()
+        resolver._workspaces.create = AsyncMock(return_value=new_wt)
         resolver._prs.get_pr_diff = AsyncMock(return_value="diff content")
         resolver._prs.update_pr_title = AsyncMock(return_value=True)
         resolver._prs.expected_pr_title = lambda n, t: f"Fixes #{n}: {t}"

--- a/tests/test_models_core.py
+++ b/tests/test_models_core.py
@@ -509,9 +509,9 @@ class TestWorkerResult:
         assert result.issue_number == 10
         assert result.branch == "agent/issue-10"
 
-    def test_worktree_path_defaults_to_empty_string(self) -> None:
+    def test_workspace_path_defaults_to_empty_string(self) -> None:
         result = WorkerResult(issue_number=1, branch="b")
-        assert result.worktree_path == ""
+        assert result.workspace_path == ""
 
     def test_success_defaults_to_false(self) -> None:
         result = WorkerResult(issue_number=1, branch="b")
@@ -554,7 +554,7 @@ class TestWorkerResult:
         result = WorkerResultFactory.create(
             issue_number=7,
             branch="agent/issue-7",
-            worktree_path="/tmp/wt/issue-7",
+            workspace_path="/tmp/wt/issue-7",
             success=True,
             error=None,
             transcript="Done in 3 steps.",
@@ -565,7 +565,7 @@ class TestWorkerResult:
         # Assert
         assert result.issue_number == 7
         assert result.branch == "agent/issue-7"
-        assert result.worktree_path == "/tmp/wt/issue-7"
+        assert result.workspace_path == "/tmp/wt/issue-7"
         assert result.success is True
         assert result.error is None
         assert result.transcript == "Done in 3 steps."

--- a/tests/test_multi_repo_integration.py
+++ b/tests/test_multi_repo_integration.py
@@ -28,7 +28,7 @@ def _make_config(tmp_path: Path, slug: str):
     return ConfigFactory.create(
         repo=f"owner/{slug}",
         repo_root=base / "repo",
-        worktree_base=base / "worktrees",
+        workspace_base=base / "worktrees",
         state_file=base / "state.json",
     )
 
@@ -195,13 +195,13 @@ class TestActiveIssuesIndependence:
 
 
 class TestWorktreePathIsolation:
-    def test_worktree_paths_isolated_per_repo(self, tmp_path: Path) -> None:
+    def test_workspace_paths_isolated_per_repo(self, tmp_path: Path) -> None:
         """Each repo config should produce different worktree paths."""
         alpha_cfg = _make_config(tmp_path, "repo-alpha")
         beta_cfg = _make_config(tmp_path, "repo-beta")
 
-        alpha_path = alpha_cfg.worktree_path_for_issue(42)
-        beta_path = beta_cfg.worktree_path_for_issue(42)
+        alpha_path = alpha_cfg.workspace_path_for_issue(42)
+        beta_path = beta_cfg.workspace_path_for_issue(42)
 
         assert alpha_path != beta_path
         assert "repo-alpha" in str(alpha_path) or "alpha" in str(alpha_path)

--- a/tests/test_orchestrator_core.py
+++ b/tests/test_orchestrator_core.py
@@ -34,7 +34,7 @@ class TestInit:
     # Service-registry wiring: each entry is (svc_attr, module, type_name)
     # ------------------------------------------------------------------
     _SVC_WIRING = [
-        ("worktrees", "workspace", "WorkspaceManager"),
+        ("workspaces", "workspace", "WorkspaceManager"),
         ("agents", "agent", "AgentRunner"),
         ("prs", "pr_manager", "PRManager"),
         ("planners", "planner", "PlannerRunner"),
@@ -318,7 +318,7 @@ class TestRunCallsSanitizeRepo:
         orch._svc.implementer.run_batch = AsyncMock(return_value=([], []))  # type: ignore[method-assign]
 
         with patch.object(
-            orch._svc.worktrees, "sanitize_repo", new_callable=AsyncMock
+            orch._svc.workspaces, "sanitize_repo", new_callable=AsyncMock
         ) as mock_sanitize:
             await orch.run()
 
@@ -1010,7 +1010,7 @@ class TestServiceRegistry:
         """Core services are accessible through _svc."""
         orch = HydraFlowOrchestrator(config)
         svc = orch._svc
-        assert svc.worktrees is not None
+        assert svc.workspaces is not None
         assert svc.agents is not None
         assert svc.prs is not None
         assert svc.store is not None

--- a/tests/test_orchestrator_integration.py
+++ b/tests/test_orchestrator_integration.py
@@ -82,7 +82,7 @@ def _queue_depth(orch: HydraFlowOrchestrator, stage: str) -> int:
 def _config(tmp_path):
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
         poll_interval=5,
         data_poll_interval=10,
@@ -239,7 +239,7 @@ async def test_failed_implementation_discards_worktree(tmp_path) -> None:
             lambda: _queue_depth(orch, "ready") == 0,
         )
 
-        worktrees = cast(FakeWorkspaceManager, orch._svc.worktrees)
+        worktrees = cast(FakeWorkspaceManager, orch._svc.workspaces)
         assert issue_number in worktrees.cleaned
 
 

--- a/tests/test_orchestrator_loops.py
+++ b/tests/test_orchestrator_loops.py
@@ -406,8 +406,8 @@ class TestSupervisorLoops:
         """If one loop crashes despite try/except, others should keep running."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         implement_calls = 0
 
@@ -690,8 +690,8 @@ class TestAuthFailure:
         """An AuthenticationError in any loop should stop the orchestrator."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_triage() -> None:
             raise AuthenticationError("401 Unauthorized")
@@ -718,8 +718,8 @@ class TestAuthFailure:
         """Auth failure should publish a SYSTEM_ALERT event."""
         orch = HydraFlowOrchestrator(config, event_bus=event_bus)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_plan() -> list[PlanResult]:
             raise AuthenticationError("401 Unauthorized")
@@ -750,8 +750,8 @@ class TestAuthFailure:
         """Auth failure should set the _auth_failed flag."""
         orch = HydraFlowOrchestrator(config)
         orch._svc.prs.ensure_labels_exist = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.enable_rerere = AsyncMock()  # type: ignore[method-assign]
-        orch._svc.worktrees.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.enable_rerere = AsyncMock()  # type: ignore[method-assign]
+        orch._svc.workspaces.sanitize_repo = AsyncMock()  # type: ignore[method-assign]
 
         async def auth_failing_implement() -> tuple[list[WorkerResult], list[Task]]:
             raise AuthenticationError("401 Unauthorized")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -135,7 +135,7 @@ def test_build_command_supports_codex_backend(tmp_path):
         planner_tool="codex",
         planner_model="gpt-5-codex",
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "wt",
+        workspace_base=tmp_path / "wt",
         state_file=tmp_path / "s.json",
     )
     runner = _make_runner(cfg, None)

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -87,7 +87,7 @@ class TestWorkspacePortConformance:
         from workspace import WorkspaceManager
 
         config = MagicMock()
-        config.worktree_base = Path("/tmp/wt")
+        config.workspace_base = Path("/tmp/wt")
         config.repo_root = Path("/tmp/repo")
         config.main_branch = "main"
         config.git_command_timeout = 30

--- a/tests/test_post_merge_handler.py
+++ b/tests/test_post_merge_handler.py
@@ -870,7 +870,7 @@ class TestVisualGateInHandleApproved:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         handler = _make_handler(cfg)
@@ -902,7 +902,7 @@ class TestVisualGateInHandleApproved:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         handler = _make_handler(cfg)
@@ -935,7 +935,7 @@ class TestVisualGateInHandleApproved:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         handler = _make_handler(cfg)
@@ -966,7 +966,7 @@ class TestVisualGateInHandleApproved:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         handler = _make_handler(cfg)

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -393,7 +393,7 @@ async def test_create_issue_passes_correct_gh_args(config, event_bus, tmp_path):
         ready_label=config.ready_label,
         repo=config.repo,
         repo_root=tmp_path,
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
     mgr = make_pr_manager(cfg, event_bus)
@@ -548,7 +548,7 @@ class TestUploadScreenshotGist:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             screenshot_gist_public=False,
         )
@@ -570,7 +570,7 @@ class TestUploadScreenshotGist:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             screenshot_gist_public=True,
         )
@@ -1542,7 +1542,7 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         epic_child_label=["custom-epic-child"],
         verify_label=["custom-verify"],
         repo_root=tmp_path,
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
     mgr = make_pr_manager(cfg, event_bus)

--- a/tests/test_pr_manager_labels.py
+++ b/tests/test_pr_manager_labels.py
@@ -206,7 +206,7 @@ class TestCommentHelper:
     async def test_comment_issue_target(self, event_bus, tmp_path):
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)
@@ -224,7 +224,7 @@ class TestCommentHelper:
     async def test_comment_pr_target(self, event_bus, tmp_path):
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)
@@ -254,7 +254,7 @@ class TestCommentHelper:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)

--- a/tests/test_pr_manager_queries.py
+++ b/tests/test_pr_manager_queries.py
@@ -448,7 +448,7 @@ class TestRetryWrapperUsage:
         cfg = ConfigFactory.create(
             gh_max_retries=5,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)
@@ -671,7 +671,7 @@ class TestListHitlItemsExceptionHandling:
             ready_label=config.ready_label,
             repo=config.repo,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)
@@ -701,7 +701,7 @@ class TestListHitlItemsExceptionHandling:
             ready_label=config.ready_label,
             repo=config.repo,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)
@@ -756,7 +756,7 @@ class TestListHitlItemsExceptionHandling:
             ready_label=config.ready_label,
             repo=config.repo,
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         mgr = make_pr_manager(cfg, event_bus)

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -36,7 +36,7 @@ class UnstickerHarness:
 def _make_config(tmp_path: Path, **overrides) -> MagicMock:
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
         **overrides,
     )
@@ -49,7 +49,7 @@ def _make_unsticker(
     state=None,
     pr_manager=None,
     agents=None,
-    worktrees=None,
+    workspaces=None,
     fetcher=None,
     hitl_runner=None,
     stop_event=None,
@@ -64,7 +64,7 @@ def _make_unsticker(
     bus.publish = AsyncMock()
     prs = pr_manager or AsyncMock()
     ag = agents or AsyncMock()
-    wt = worktrees or AsyncMock()
+    wt = workspaces or AsyncMock()
     ft = fetcher or AsyncMock()
     hr = hitl_runner or AsyncMock()
     se = stop_event or asyncio.Event()
@@ -292,7 +292,7 @@ class TestCleanMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42)])
@@ -325,7 +325,7 @@ class TestSuccessfulResolution:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42)])
@@ -360,7 +360,7 @@ class TestFailedResolution:
             return_value=ConflictResolutionResult(success=False, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42)])
@@ -430,7 +430,7 @@ class TestCIFailureResolution:
 
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -469,7 +469,7 @@ class TestGenericResolution:
         h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42)])
@@ -497,7 +497,7 @@ class TestGenericResolution:
         h.fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
         h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42)])
@@ -530,7 +530,7 @@ class TestAutoMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -566,7 +566,7 @@ class TestAutoMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         await h.unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -597,7 +597,7 @@ class TestAutoMerge:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         await h.unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -627,7 +627,7 @@ class TestAutoMergeDisabled:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         stats = await h.unsticker.unstick([_make_hitl_item(42, pr=100)])
@@ -652,7 +652,7 @@ class TestCascadingRebase:
 
         # Create worktree dirs (repo-scoped path)
         for i in [1, 2]:
-            h.unsticker._config.worktree_path_for_issue(i).mkdir(
+            h.unsticker._config.workspace_path_for_issue(i).mkdir(
                 parents=True, exist_ok=True
             )
 
@@ -806,7 +806,7 @@ class TestGoalDrivenLoop:
         )
 
         for i in [1, 2]:
-            h.unsticker._config.worktree_path_for_issue(i).mkdir(
+            h.unsticker._config.workspace_path_for_issue(i).mkdir(
                 parents=True, exist_ok=True
             )
 
@@ -849,7 +849,7 @@ class TestMergeConflictDelegation:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         pr_url = "https://github.com/test-org/test-repo/pull/100"
@@ -884,7 +884,7 @@ class TestMergeConflictDelegation:
             return_value=ConflictResolutionResult(success=True, used_rebuild=False)
         )
 
-        h.unsticker._config.worktree_path_for_issue(42).mkdir(
+        h.unsticker._config.workspace_path_for_issue(42).mkdir(
             parents=True, exist_ok=True
         )
 
@@ -920,7 +920,7 @@ class TestFreshBranchRebuild:
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         pr_url = "https://github.com/test-org/test-repo/pull/100"
@@ -949,7 +949,7 @@ class TestFreshBranchRebuild:
             return_value=ConflictResolutionResult(success=False, used_rebuild=False)
         )
 
-        h.unsticker._config.worktree_path_for_issue(42).mkdir(
+        h.unsticker._config.workspace_path_for_issue(42).mkdir(
             parents=True, exist_ok=True
         )
 
@@ -981,7 +981,7 @@ class TestResolverNoneEdgeCases:
         h.fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
         h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
-        h.unsticker._config.worktree_path_for_issue(42).mkdir(
+        h.unsticker._config.workspace_path_for_issue(42).mkdir(
             parents=True, exist_ok=True
         )
 
@@ -1017,7 +1017,7 @@ def _setup_ci_fix_memory_test(
 
     h.prs.push_branch = AsyncMock(return_value=True)
 
-    h.unsticker._config.worktree_path_for_issue(42).mkdir(parents=True, exist_ok=True)
+    h.unsticker._config.workspace_path_for_issue(42).mkdir(parents=True, exist_ok=True)
     (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
     return h
@@ -1081,7 +1081,7 @@ class TestCITimeoutResolution:
 
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1163,7 +1163,7 @@ class TestCITimeoutResolution:
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1210,7 +1210,7 @@ class TestCITimeoutResolution:
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1291,7 +1291,7 @@ class TestCITimeoutResolution:
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1355,7 +1355,7 @@ Done."""
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1406,7 +1406,7 @@ Done."""
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1475,7 +1475,7 @@ Done."""
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1549,7 +1549,7 @@ TROUBLESHOOTING_PATTERN_END
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1611,7 +1611,7 @@ TROUBLESHOOTING_PATTERN_END
         )
         h.prs.push_branch = AsyncMock(return_value=True)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
         (tmp_path / "repo" / ".hydraflow" / "logs").mkdir(parents=True)
 
@@ -1735,7 +1735,7 @@ class TestNarrowedExceptionHandling:
         """RuntimeError during re-rebase should be caught gracefully."""
         h = _make_unsticker(tmp_path)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         h.wt.start_merge_main = AsyncMock(side_effect=RuntimeError("git failed"))
@@ -1755,7 +1755,7 @@ class TestNarrowedExceptionHandling:
         """TypeError during re-rebase must propagate."""
         h = _make_unsticker(tmp_path)
 
-        wt_dir = h.unsticker._config.worktree_path_for_issue(42)
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
         wt_dir.mkdir(parents=True)
 
         h.wt.start_merge_main = AsyncMock(side_effect=TypeError("bad type"))

--- a/tests/test_prompt_budget_config.py
+++ b/tests/test_prompt_budget_config.py
@@ -30,7 +30,7 @@ class TestPromptBudgetDefaults:
     def cfg(self, tmp_path: Path) -> HydraFlowConfig:
         return ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
 
@@ -83,7 +83,7 @@ class TestPromptBudgetOverrides:
         """All 12 fields accept non-default values via constructor."""
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_discussion_comment_chars=1_000,
             max_common_feedback_chars=4_000,
@@ -127,7 +127,7 @@ class TestAgentRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_discussion_comment_chars=100,
         )
@@ -146,7 +146,7 @@ class TestAgentRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_discussion_comment_chars=500,
         )
@@ -165,7 +165,7 @@ class TestAgentRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_impl_plan_chars=1_000,
         )
@@ -187,7 +187,7 @@ class TestAgentRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_review_feedback_chars=100,
         )
@@ -219,7 +219,7 @@ class TestPlannerRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_planner_line_chars=100,
             max_planner_comment_chars=1_000,
@@ -244,7 +244,7 @@ class TestPlannerRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_planner_failed_plan_chars=500,
             max_planner_line_chars=500,
@@ -277,7 +277,7 @@ class TestHITLRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_hitl_cause_chars=100,
         )
@@ -299,7 +299,7 @@ class TestHITLRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_hitl_correction_chars=500,
         )
@@ -329,7 +329,7 @@ class TestReviewRunnerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_ci_log_prompt_chars=1_000,
         )
@@ -435,7 +435,7 @@ class TestPRUnstickerUsesConfig:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             max_unsticker_cause_chars=100,
         )

--- a/tests/test_prompt_evals.py
+++ b/tests/test_prompt_evals.py
@@ -24,7 +24,7 @@ from triage import TriageRunner
 def _cfg(tmp_path: Path, **overrides: object):
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "wt",
+        workspace_base=tmp_path / "wt",
         state_file=tmp_path / "state.json",
         **overrides,
     )

--- a/tests/test_race_condition_guards.py
+++ b/tests/test_race_condition_guards.py
@@ -27,7 +27,7 @@ class TestImplementPhaseActiveIssuesLock:
 
     def test_has_active_issues_lock(self, tmp_path) -> None:
         config = ConfigFactory.create(
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "repo",
         )
         phase, _, _ = make_implement_phase(config, [])
@@ -43,7 +43,7 @@ class TestImplementPhaseActiveIssuesLock:
         from state import StateTracker
 
         config = ConfigFactory.create(
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "repo",
             max_workers=3,
         )
@@ -70,7 +70,7 @@ class TestImplementPhaseActiveIssuesLock:
                 branch=br,
                 success=True,
                 commits=1,
-                worktree_path=str(wt),
+                workspace_path=str(wt),
                 use_defaults=True,
             )
         )
@@ -92,7 +92,7 @@ class TestImplementPhaseActiveIssuesLock:
         phase = ImplementPhase(
             config=config,
             state=state,
-            worktrees=mock_worktrees,
+            workspaces=mock_worktrees,
             agents=mock_agents,
             prs=mock_prs,
             store=mock_store,
@@ -127,7 +127,7 @@ class TestReviewPhaseActiveIssuesLock:
 
     def test_has_active_issues_lock(self, tmp_path) -> None:
         config = ConfigFactory.create(
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "repo",
         )
         phase = make_review_phase(config)
@@ -352,7 +352,7 @@ def _make_orchestrator(tmp_path):
 
     config = ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
     (tmp_path / "repo").mkdir(parents=True, exist_ok=True)

--- a/tests/test_repo_guard.py
+++ b/tests/test_repo_guard.py
@@ -222,7 +222,7 @@ class TestWorktreeOriginValidation:
         config.repo = repo
         config.repo_root = Path("/tmp/repo")  # noqa: S108
         config.repo_slug = repo.replace("/", "-") if repo else ""
-        config.worktree_base = Path("/tmp/worktrees")  # noqa: S108
+        config.workspace_base = Path("/tmp/worktrees")  # noqa: S108
         config.main_branch = "main"
         config.gh_token = ""
         config.dry_run = False

--- a/tests/test_review_phase_ci.py
+++ b/tests/test_review_phase_ci.py
@@ -42,7 +42,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -65,7 +65,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -94,7 +94,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=0,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -117,7 +117,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -145,7 +145,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -188,7 +188,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=3,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -219,7 +219,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -251,7 +251,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -280,7 +280,7 @@ class TestWaitAndFixCI:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -316,7 +316,7 @@ class TestWaitAndFixCIEdgeCases:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -351,7 +351,7 @@ class TestWaitAndFixCIEdgeCases:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -389,7 +389,7 @@ class TestWaitAndFixCIWithLogs:
         config = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "state.json",
         )
         phase = make_review_phase(config, default_mocks=True)
@@ -434,7 +434,7 @@ class TestCodeScanningAlertsFetch:
         """When code_scanning_enabled is True and alerts exist, returns them."""
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -451,7 +451,7 @@ class TestCodeScanningAlertsFetch:
         """When API returns empty list, returns None."""
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -467,7 +467,7 @@ class TestCodeScanningAlertsFetch:
         """When API raises, returns None gracefully."""
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -489,7 +489,7 @@ class TestCodeScanningAlertThreading:
         """Alerts are passed through to the reviewer.review call."""
         cfg = ConfigFactory.create(
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -511,7 +511,7 @@ class TestCodeScanningAlertThreading:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -549,7 +549,7 @@ class TestVisualGate:
         cfg = ConfigFactory.create(
             visual_gate_enabled=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -570,7 +570,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -597,7 +597,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -620,7 +620,7 @@ class TestVisualGate:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -647,7 +647,7 @@ class TestVisualGate:
         cfg = ConfigFactory.create(
             visual_gate_enabled=True,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -673,7 +673,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -702,7 +702,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -727,7 +727,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -758,7 +758,7 @@ class TestVisualGate:
             visual_gate_enabled=True,
             visual_gate_bypass=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -57,7 +57,7 @@ def _setup_escalate_to_hitl_mocks(phase: ReviewPhase) -> None:
 def _setup_conflict_scenario(phase: ReviewPhase) -> None:
     """Set up mocks for a merge-conflict escalation scenario (merge_main returns False)."""
     _setup_escalate_to_hitl_mocks(phase)
-    phase._worktrees.merge_main = AsyncMock(return_value=False)
+    phase._workspaces.merge_main = AsyncMock(return_value=False)
 
 
 def _setup_rejected_review_mocks(phase: ReviewPhase) -> None:
@@ -140,7 +140,7 @@ class TestReviewPRs:
         ]
 
         for i in range(1, 7):
-            wt = config.worktree_base / f"issue-{i}"
+            wt = config.workspace_base / f"issue-{i}"
             wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs(prs, issues)
@@ -158,7 +158,7 @@ class TestPostMergeConflictFix:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(number=101, issue_number=42, branch="agent/issue-42")
         issue = TaskFactory.create(id=42)
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         phase._conflict_resolver.resolve_merge_conflicts = AsyncMock(
@@ -177,7 +177,7 @@ class TestPostMergeConflictFix:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(number=101, issue_number=42, branch="agent/issue-42")
         issue = TaskFactory.create(id=42)
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         phase._conflict_resolver.resolve_merge_conflicts = AsyncMock(
@@ -200,7 +200,7 @@ class TestPostMergeConflictFix:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
 
         # Worktree for issue-999 exists
-        wt = config.worktree_path_for_issue(999)
+        wt = config.workspace_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -250,12 +250,12 @@ class TestPostMergeConflictFix:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         results = await phase.review_prs([pr], [issue])
 
         assert results[0].merged is True
-        phase._worktrees.merge_main.assert_awaited_once()
+        phase._workspaces.merge_main.assert_awaited_once()
         phase._prs.push_branch.assert_awaited()
         phase._reviewers.review.assert_awaited_once()
 
@@ -275,10 +275,10 @@ class TestPostMergeConflictFix:
 
         _setup_conflict_scenario(phase)
         # Agent resolution also fails
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -305,10 +305,10 @@ class TestPostMergeConflictFix:
         pr = PRInfoFactory.create()
 
         _setup_conflict_scenario(phase)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -330,10 +330,10 @@ class TestPostMergeConflictFix:
         pr = PRInfoFactory.create()
 
         _setup_conflict_scenario(phase)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -354,9 +354,9 @@ class TestPostMergeConflictFix:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=False)  # Conflicts
+        phase._workspaces.merge_main = AsyncMock(return_value=False)  # Conflicts
         # But agent resolves them
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         results = await phase.review_prs([pr], [issue])
 
@@ -375,7 +375,7 @@ class TestPostMergeConflictFix:
 
         _setup_conflict_scenario(phase)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -396,7 +396,7 @@ class TestPostMergeConflictFix:
         phase._prs.merge_pr = AsyncMock(return_value=False)  # Override for this test
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         results = await phase.review_prs([pr], [issue])
 
@@ -421,7 +421,7 @@ class TestPostMergeConflictFix:
         phase._prs.merge_pr = AsyncMock(return_value=False)  # Override for this test
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         await phase.review_prs([pr], [issue])
 
@@ -439,7 +439,7 @@ class TestPostMergeConflictFix:
         phase._prs.merge_pr = AsyncMock(return_value=False)  # Override for this test
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         await phase.review_prs([pr], [issue])
 
@@ -677,7 +677,7 @@ class TestPostMergeConflictFix:
         phase._prs.submit_review = fake_submit_review  # type: ignore[method-assign]
 
         for i in (1, 2):
-            wt = config.worktree_base / f"issue-{i}"
+            wt = config.workspace_base / f"issue-{i}"
             wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs(prs, issues)
@@ -744,7 +744,7 @@ class TestPostMergeConflictFix:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -795,7 +795,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [issue])
@@ -819,7 +819,7 @@ class TestReviewExceptionIsolation:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -864,7 +864,7 @@ class TestReviewExceptionIsolation:
         phase._prs.add_labels = AsyncMock()
 
         for i in (1, 2):
-            wt = config.worktree_base / f"issue-{i}"
+            wt = config.workspace_base / f"issue-{i}"
             wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs(prs, issues)
@@ -894,7 +894,7 @@ class TestActiveIssuesCleanup:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_path_for_issue(999)
+        wt = config.workspace_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr], [])  # no matching issues
@@ -912,11 +912,11 @@ class TestActiveIssuesCleanup:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(
+        phase._workspaces.merge_main = AsyncMock(
             side_effect=RuntimeError("merge exploded")
         )
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -939,7 +939,7 @@ class TestActiveIssuesCleanup:
         phase._prs.get_pr_diff = AsyncMock(return_value="diff")
         phase._prs.push_branch = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Exception isolation catches the error and returns a failed result
@@ -958,7 +958,7 @@ class TestActiveIssuesCleanup:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.create = AsyncMock(
+        phase._workspaces.create = AsyncMock(
             side_effect=RuntimeError("worktree create failed")
         )
 
@@ -1023,7 +1023,7 @@ class TestReviewUpdateStartEvent:
         phase = make_review_phase(config, event_bus=event_bus)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_path_for_issue(999)
+        wt = config.workspace_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [])
@@ -1079,7 +1079,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_path_for_issue(42), "diff", 0
+            pr, issue, config.workspace_path_for_issue(42), "diff", 0
         )
 
         assert result.fixes_made is True
@@ -1098,7 +1098,7 @@ class TestRunAndPostReview:
         phase._prs.post_pr_comment = AsyncMock()
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_path_for_issue(42), "diff", 0
+            pr, issue, config.workspace_path_for_issue(42), "diff", 0
         )
 
         assert (
@@ -1122,7 +1122,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         await phase._run_and_post_review(
-            pr, issue, config.worktree_path_for_issue(42), "diff", 0
+            pr, issue, config.workspace_path_for_issue(42), "diff", 0
         )
 
         phase._prs.submit_review.assert_not_awaited()
@@ -1143,7 +1143,7 @@ class TestRunAndPostReview:
         phase._prs.submit_review = AsyncMock()
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_path_for_issue(42), "diff", 0
+            pr, issue, config.workspace_path_for_issue(42), "diff", 0
         )
 
         assert (
@@ -1169,7 +1169,7 @@ class TestRunAndPostReview:
         )
 
         result = await phase._run_and_post_review(
-            pr, issue, config.worktree_path_for_issue(42), "diff", 0
+            pr, issue, config.workspace_path_for_issue(42), "diff", 0
         )
 
         assert result.verdict == ReviewVerdict.REQUEST_CHANGES
@@ -1190,7 +1190,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1211,7 +1211,7 @@ class TestHandleApprovedMerge:
         phase._prs.merge_pr = AsyncMock(return_value=False)
         _setup_escalate_to_hitl_mocks(phase)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1231,7 +1231,7 @@ class TestHandleApprovedMerge:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase._handle_approved_merge(pr, issue, result, "diff", 0)
@@ -1414,7 +1414,7 @@ class TestReviewOneInner:
         phase = make_review_phase(config)
         pr = PRInfoFactory.create(issue_number=999)
 
-        wt = config.worktree_path_for_issue(999)
+        wt = config.workspace_path_for_issue(999)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {})
@@ -1447,7 +1447,7 @@ class TestReviewOneInner:
         _setup_conflict_scenario(phase)
         phase._prs.push_branch = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -1554,7 +1554,7 @@ class TestHandleRejectedReview:
         config = ConfigFactory.create(
             max_review_fix_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         phase = make_review_phase(config)
@@ -1583,7 +1583,7 @@ class TestHandleRejectedReview:
         config = ConfigFactory.create(
             max_review_fix_attempts=2,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         phase = make_review_phase(config, event_bus=event_bus)
@@ -1610,7 +1610,7 @@ class TestHandleRejectedReview:
         config = ConfigFactory.create(
             max_review_fix_attempts=1,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         phase = make_review_phase(config)
@@ -1663,7 +1663,7 @@ class TestAttemptReviewFix:
         pr = PRInfoFactory.create()
         phase._prs.get_pr_diff = AsyncMock(return_value="updated diff")
         phase._prs.push_branch = AsyncMock(return_value=True)
-        wt = config.worktree_base / f"issue-{pr.issue_number}"
+        wt = config.workspace_base / f"issue-{pr.issue_number}"
         wt.mkdir(parents=True, exist_ok=True)
         return phase, pr, issue, wt
 
@@ -1772,7 +1772,7 @@ class TestHandleSelfFixReReview:
         pr = PRInfoFactory.create()
         phase._prs.get_pr_diff = AsyncMock(return_value="updated diff")
         phase._prs.push_branch = AsyncMock(return_value=True)
-        wt = config.worktree_base / f"issue-{pr.issue_number}"
+        wt = config.workspace_base / f"issue-{pr.issue_number}"
         wt.mkdir(parents=True, exist_ok=True)
         return phase, pr, issue, wt
 
@@ -1900,7 +1900,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(AuthenticationError, match="401"):
@@ -1922,7 +1922,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(CreditExhaustedError, match="limit reached"):
@@ -1940,7 +1940,7 @@ class TestCriticalExceptionPropagation:
         phase._reviewers.review = AsyncMock(side_effect=MemoryError("OOM"))
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(MemoryError, match="OOM"):
@@ -1970,7 +1970,7 @@ class TestCriticalExceptionPropagation:
             await phase._handle_self_fix_re_review(
                 pr,
                 issue,
-                config.worktree_path_for_issue(42),
+                config.workspace_path_for_issue(42),
                 original_result,
                 "diff",
                 worker_id=0,
@@ -1996,7 +1996,7 @@ class TestCriticalExceptionPropagation:
             await phase._handle_self_fix_re_review(
                 pr,
                 issue,
-                config.worktree_path_for_issue(42),
+                config.workspace_path_for_issue(42),
                 original_result,
                 "diff",
                 worker_id=0,
@@ -2018,7 +2018,7 @@ class TestCriticalExceptionPropagation:
         )
         phase._prs.get_pr_diff = AsyncMock(return_value="diff text")
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with pytest.raises(AuthenticationError):
@@ -2223,7 +2223,7 @@ class TestCleanupWorktree:
 
         await phase._cleanup_worktree(pr, result, skip=False)
 
-        phase._worktrees.post_work_cleanup.assert_awaited_once_with(pr.issue_number)
+        phase._workspaces.post_work_cleanup.assert_awaited_once_with(pr.issue_number)
 
     @pytest.mark.asyncio
     async def test_preserves_when_skipped(self, config: HydraFlowConfig) -> None:
@@ -2234,7 +2234,7 @@ class TestCleanupWorktree:
 
         await phase._cleanup_worktree(pr, result, skip=True)
 
-        phase._worktrees.post_work_cleanup.assert_not_awaited()
+        phase._workspaces.post_work_cleanup.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_preserves_when_stop_event_set_and_not_merged(
@@ -2249,7 +2249,7 @@ class TestCleanupWorktree:
 
         await phase._cleanup_worktree(pr, result, skip=False)
 
-        phase._worktrees.post_work_cleanup.assert_not_awaited()
+        phase._workspaces.post_work_cleanup.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_destroys_when_stop_event_set_but_merged(
@@ -2264,7 +2264,7 @@ class TestCleanupWorktree:
 
         await phase._cleanup_worktree(pr, result, skip=False)
 
-        phase._worktrees.post_work_cleanup.assert_awaited_once_with(pr.issue_number)
+        phase._workspaces.post_work_cleanup.assert_awaited_once_with(pr.issue_number)
 
 
 class TestRequiredDIParameters:
@@ -2388,7 +2388,7 @@ class TestRunInitialGuards:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create(issue_number=issue.id)
 
-        wt_path = config.worktree_path_for_issue(issue.id)
+        wt_path = config.workspace_path_for_issue(issue.id)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         phase._prepare_review_worktree = AsyncMock(return_value=wt_path)
@@ -2397,7 +2397,7 @@ class TestRunInitialGuards:
 
         assert isinstance(guards, ReviewGuardContext)
         assert guards.task == issue
-        assert guards.worktree_path == wt_path
+        assert guards.workspace_path == wt_path
         phase._prepare_review_worktree.assert_awaited_once_with(pr, issue, 0)
 
 
@@ -2479,7 +2479,7 @@ class TestRunPostReviewActions:
         phase = make_review_phase(config)
         issue = TaskFactory.create()
         pr = PRInfoFactory.create(issue_number=issue.id)
-        wt_path = config.worktree_path_for_issue(issue.id)
+        wt_path = config.workspace_path_for_issue(issue.id)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         initial = ReviewResultFactory.create(
@@ -2524,7 +2524,7 @@ class TestRunPostReviewActions:
         phase = make_review_phase(config)
         issue = TaskFactory.create()
         pr = PRInfoFactory.create(issue_number=issue.id)
-        wt_path = config.worktree_path_for_issue(issue.id)
+        wt_path = config.workspace_path_for_issue(issue.id)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         result = ReviewResultFactory.create(
@@ -2580,7 +2580,7 @@ class TestBaselinePolicyIntegration:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -2612,7 +2612,7 @@ class TestBaselinePolicyIntegration:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -2647,7 +2647,7 @@ class TestBaselinePolicyIntegration:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})
@@ -2671,7 +2671,7 @@ class TestBaselinePolicyIntegration:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         result = await phase._review_one_inner(0, pr, {42: issue})

--- a/tests/test_review_phase_hitl.py
+++ b/tests/test_review_phase_hitl.py
@@ -52,7 +52,7 @@ def _setup_escalate_to_hitl_mocks(phase: ReviewPhase) -> None:
 def _setup_conflict_scenario(phase: ReviewPhase) -> None:
     """Set up mocks for a merge-conflict escalation scenario (merge_main returns False)."""
     _setup_escalate_to_hitl_mocks(phase)
-    phase._worktrees.merge_main = AsyncMock(return_value=False)
+    phase._workspaces.merge_main = AsyncMock(return_value=False)
 
 
 # ---------------------------------------------------------------------------
@@ -76,10 +76,10 @@ class TestHITLEscalationEvents:
         pr = PRInfoFactory.create()
 
         _setup_conflict_scenario(phase)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -109,9 +109,9 @@ class TestHITLEscalationEvents:
         phase._prs.push_branch = AsyncMock(return_value=True)
         phase._prs.merge_pr = AsyncMock(return_value=False)
         _setup_escalate_to_hitl_mocks(phase)
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -135,7 +135,7 @@ class TestHITLEscalationEvents:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, event_bus=event_bus)
@@ -154,9 +154,9 @@ class TestHITLEscalationEvents:
         phase._prs.merge_pr = AsyncMock(return_value=True)
         phase._prs.wait_for_ci = AsyncMock(return_value=(False, "Failed checks: ci"))
         _setup_escalate_to_hitl_mocks(phase)
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -188,9 +188,9 @@ class TestHITLEscalationEvents:
         phase._prs.merge_pr = AsyncMock(return_value=True)
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -223,9 +223,9 @@ class TestHITLEscalationEvents:
         _setup_escalate_to_hitl_mocks(phase)
         phase._prs.post_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -274,7 +274,7 @@ class TestRequestChangesRetry:
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         return phase, pr, issue
@@ -299,7 +299,7 @@ class TestRequestChangesRetry:
 
         await phase.review_prs([pr], [issue])
 
-        phase._worktrees.destroy.assert_not_awaited()
+        phase._workspaces.destroy.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_request_changes_under_cap_stores_feedback(
@@ -372,7 +372,7 @@ class TestRequestChangesRetry:
         phase._prs.post_comment = AsyncMock()
         phase._prs.submit_review = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -380,7 +380,7 @@ class TestRequestChangesRetry:
         # Should swap to ready label (same as REQUEST_CHANGES)
         phase._prs.transition.assert_any_await(42, "ready", pr_number=101)
         # Worktree should be preserved
-        phase._worktrees.destroy.assert_not_awaited()
+        phase._workspaces.destroy.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_approve_resets_review_attempts(
@@ -401,7 +401,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -427,7 +427,7 @@ class TestRequestChangesRetry:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -464,7 +464,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -493,7 +493,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -529,7 +529,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -545,7 +545,7 @@ class TestAdversarialReview:
         cfg = ConfigFactory.create(
             min_review_findings=0,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg)
@@ -565,7 +565,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -600,7 +600,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -637,7 +637,7 @@ class TestAdversarialReview:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1077,14 +1077,14 @@ class TestRunVisualValidation:
         cfg = ConfigFactory.create(
             visual_validation_enabled=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg)
         pr = PRInfoFactory.create()
 
         # Act
-        result = await phase._run_visual_validation(pr, config.worktree_base, 0)
+        result = await phase._run_visual_validation(pr, config.workspace_base, 0)
 
         # Assert
         assert result is None
@@ -1097,7 +1097,7 @@ class TestRunVisualValidation:
         pr = PRInfoFactory.create()
 
         # Act
-        result = await phase._run_visual_validation(pr, config.worktree_base, 0)
+        result = await phase._run_visual_validation(pr, config.workspace_base, 0)
 
         # Assert
         assert result is not None
@@ -1116,7 +1116,7 @@ class TestRunVisualValidation:
         )
 
         # Act
-        result = await phase._run_visual_validation(pr, config.worktree_base, 0)
+        result = await phase._run_visual_validation(pr, config.workspace_base, 0)
 
         # Assert
         assert result is None

--- a/tests/test_review_phase_merge.py
+++ b/tests/test_review_phase_merge.py
@@ -38,7 +38,7 @@ class TestResolveMergeConflicts:
         issue = TaskFactory.create()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -54,10 +54,10 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=True)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=True)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -79,10 +79,10 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -102,16 +102,16 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result.success is False
         # abort_merge called between retries + final abort
-        assert phase._worktrees.abort_merge.await_count >= 1
+        assert phase._workspaces.abort_merge.await_count >= 1
 
     @pytest.mark.asyncio
     async def test_retries_on_verify_failure(self, config: HydraFlowConfig) -> None:
@@ -129,11 +129,11 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -150,7 +150,7 @@ class TestResolveMergeConflicts:
         cfg = ConfigFactory.create(
             enable_fresh_branch_rebuild=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         mock_agents = AsyncMock()
@@ -163,11 +163,11 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, cfg.worktree_base / "issue-42", worker_id=0
+            pr, issue, cfg.workspace_base / "issue-42", worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -191,11 +191,11 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         # Second call to _execute should have received a prompt with the error
@@ -220,15 +220,15 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         # abort_merge called once before attempt 2
-        phase._worktrees.abort_merge.assert_awaited_once()
+        phase._workspaces.abort_merge.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_saves_transcript_per_attempt(self, config: HydraFlowConfig) -> None:
@@ -246,11 +246,11 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         log_dir = config.repo_root / ".hydraflow" / "logs"
@@ -266,7 +266,7 @@ class TestResolveMergeConflicts:
             max_merge_conflict_fix_attempts=1,
             enable_fresh_branch_rebuild=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         mock_agents = AsyncMock()
@@ -279,11 +279,11 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, cfg.worktree_base / "issue-42", worker_id=0
+            pr, issue, cfg.workspace_base / "issue-42", worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
@@ -298,7 +298,7 @@ class TestResolveMergeConflicts:
             max_merge_conflict_fix_attempts=0,
             enable_fresh_branch_rebuild=False,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         mock_agents = AsyncMock()
@@ -307,17 +307,17 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         result = await phase._resolve_merge_conflicts(
-            pr, issue, cfg.worktree_base / "issue-42", worker_id=0
+            pr, issue, cfg.workspace_base / "issue-42", worker_id=0
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
         mock_agents._execute.assert_not_awaited()
         # Final abort_merge should still be called
-        phase._worktrees.abort_merge.assert_awaited_once()
+        phase._workspaces.abort_merge.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_conflict_resolution_calls_file_memory_suggestion(
@@ -334,13 +334,13 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         mock_fms = AsyncMock()
         phase._conflict_resolver._suggest_memory = mock_fms
 
         await phase._resolve_merge_conflicts(
-            pr, issue, config.worktree_path_for_issue(42), worker_id=0
+            pr, issue, config.workspace_path_for_issue(42), worker_id=0
         )
 
         mock_fms.assert_awaited_once_with(
@@ -364,7 +364,7 @@ class TestResolveMergeConflicts:
         pr = PRInfoFactory.create()
         issue = TaskFactory.create()
 
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         with patch(
             "phase_utils.file_memory_suggestion",
@@ -372,7 +372,7 @@ class TestResolveMergeConflicts:
             side_effect=RuntimeError("network error"),
         ):
             result = await phase._resolve_merge_conflicts(
-                pr, issue, config.worktree_path_for_issue(42), worker_id=0
+                pr, issue, config.workspace_path_for_issue(42), worker_id=0
             )
 
             assert result == ConflictResolutionResult(success=True, used_rebuild=False)
@@ -388,11 +388,11 @@ class TestMergeWithMain:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_path_for_issue(42), 0
+            pr, issue, config.workspace_path_for_issue(42), 0
         )
 
         assert result is True
@@ -412,12 +412,12 @@ class TestMergeWithMain:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=False)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
         phase._prs.push_branch = AsyncMock(return_value=True)
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_path_for_issue(42), 0
+            pr, issue, config.workspace_path_for_issue(42), 0
         )
 
         assert result is True
@@ -431,7 +431,7 @@ class TestMergeWithMain:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=False)
+        phase._workspaces.merge_main = AsyncMock(return_value=False)
         phase._prs.push_branch = AsyncMock()
         phase._prs.post_pr_comment = AsyncMock()
         phase._prs.remove_label = AsyncMock()
@@ -440,7 +440,7 @@ class TestMergeWithMain:
         phase._prs.add_pr_labels = AsyncMock()
 
         result = await phase._merge_with_main(
-            pr, issue, config.worktree_path_for_issue(42), 0
+            pr, issue, config.workspace_path_for_issue(42), 0
         )
 
         assert result is False

--- a/tests/test_review_phase_metrics.py
+++ b/tests/test_review_phase_metrics.py
@@ -143,9 +143,9 @@ class TestLifecycleMetricRecording:
 
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=False)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         await phase.review_prs([pr], [issue])
 
@@ -164,7 +164,7 @@ class TestLifecycleMetricRecording:
         phase._prs.merge_pr = AsyncMock(return_value=False)
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         await phase.review_prs([pr], [issue])
 
@@ -181,7 +181,7 @@ class TestLifecycleMetricRecording:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -212,7 +212,7 @@ class TestLifecycleMetricRecording:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True)
@@ -291,7 +291,7 @@ class TestRetrospectiveIntegration:
         phase._prs.merge_pr = AsyncMock(return_value=False)
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=True)
+        phase._workspaces.merge_main = AsyncMock(return_value=True)
 
         await phase.review_prs([pr], [issue])
 
@@ -507,8 +507,8 @@ class TestGranularReviewStatusEvents:
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
 
-        phase._worktrees.merge_main = AsyncMock(return_value=False)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
 
         await phase.review_prs([pr], [issue])
 
@@ -540,9 +540,9 @@ class TestGranularReviewStatusEvents:
 
         phase._prs.remove_pr_label = AsyncMock()
         phase._prs.add_pr_labels = AsyncMock()
-        phase._worktrees.merge_main = AsyncMock(return_value=False)
-        phase._worktrees.start_merge_main = AsyncMock(return_value=False)
-        phase._worktrees.abort_merge = AsyncMock()
+        phase._workspaces.merge_main = AsyncMock(return_value=False)
+        phase._workspaces.start_merge_main = AsyncMock(return_value=False)
+        phase._workspaces.abort_merge = AsyncMock()
 
         await phase.review_prs([pr], [issue])
 
@@ -611,7 +611,7 @@ class TestGranularReviewStatusEvents:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True, event_bus=event_bus)
@@ -641,7 +641,7 @@ class TestGranularReviewStatusEvents:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=2,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True, event_bus=event_bus)
@@ -689,7 +689,7 @@ class TestGranularReviewStatusEvents:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg, default_mocks=True, event_bus=event_bus)
@@ -1464,7 +1464,7 @@ class TestReviewPostMortemMemoryFiling:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg)
@@ -1489,7 +1489,7 @@ class TestReviewPostMortemMemoryFiling:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         with patch(
@@ -1510,7 +1510,7 @@ class TestReviewPostMortemMemoryFiling:
         cfg = ConfigFactory.create(
             max_ci_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg)
@@ -1533,7 +1533,7 @@ class TestReviewPostMortemMemoryFiling:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
@@ -1551,7 +1551,7 @@ class TestReviewPostMortemMemoryFiling:
         cfg = ConfigFactory.create(
             max_review_fix_attempts=1,
             repo_root=config.repo_root,
-            worktree_base=config.worktree_base,
+            workspace_base=config.workspace_base,
             state_file=config.state_file,
         )
         phase = make_review_phase(cfg)
@@ -1570,7 +1570,7 @@ class TestReviewPostMortemMemoryFiling:
         phase._prs.remove_label = AsyncMock()
         phase._prs.add_labels = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Set review attempts to cap so next review triggers escalation

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -49,7 +49,7 @@ def test_build_command_does_not_include_cwd(config, tmp_path):
     assert "--cwd" not in cmd
 
 
-def test_build_command_accepts_none_worktree_path(config):
+def test_build_command_accepts_none_workspace_path(config):
     """ReviewRunner._build_command accepts None since it doesn't use the path."""
     runner = _make_runner(config, None)
     cmd = runner._build_command(None)
@@ -70,7 +70,7 @@ def test_build_command_supports_codex_backend(tmp_path):
         review_tool="codex",
         review_model="gpt-5-codex",
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "wt",
+        workspace_base=tmp_path / "wt",
         state_file=tmp_path / "s.json",
     )
     runner = _make_runner(cfg, None)
@@ -1955,7 +1955,7 @@ class TestRunPrecheckContext:
         cfg = ConfigFactory.create(
             max_subskill_attempts=1,
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         runner = _make_runner(cfg, event_bus)

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -47,7 +47,7 @@ class TestBuildServices:
         registry = build_services(config, bus, state, stop_event, callbacks)
 
         assert isinstance(registry, ServiceRegistry)
-        assert isinstance(registry.worktrees, WorkspaceManager)
+        assert isinstance(registry.workspaces, WorkspaceManager)
 
     def test_all_fields_are_set(self, config: HydraFlowConfig) -> None:
         """All ServiceRegistry fields should be non-None."""

--- a/tests/test_state_counters.py
+++ b/tests/test_state_counters.py
@@ -455,7 +455,7 @@ class TestIssueAttemptTracking:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,
@@ -517,7 +517,7 @@ class TestActiveIssueNumbersTracking:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,

--- a/tests/test_state_int_key_helpers.py
+++ b/tests/test_state_int_key_helpers.py
@@ -98,15 +98,15 @@ class TestAccessorMethodsUseHelpers:
 
     def test_set_and_get_worktree(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(10, "/tmp/wt-10")
-        worktrees = tracker.get_active_worktrees()
+        tracker.set_workspace(10, "/tmp/wt-10")
+        worktrees = tracker.get_active_workspaces()
         assert worktrees == {10: "/tmp/wt-10"}
 
-    def test_remove_worktree(self, tmp_path: Path) -> None:
+    def test_remove_workspace(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(10, "/tmp/wt-10")
-        tracker.remove_worktree(10)
-        assert tracker.get_active_worktrees() == {}
+        tracker.set_workspace(10, "/tmp/wt-10")
+        tracker.remove_workspace(10)
+        assert tracker.get_active_workspaces() == {}
 
     def test_set_and_get_branch(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
@@ -239,7 +239,7 @@ class TestStateRoundtrip:
 
         # Populate various int-keyed fields
         tracker.mark_issue(1, "triaged")
-        tracker.set_worktree(2, "/tmp/wt-2")
+        tracker.set_workspace(2, "/tmp/wt-2")
         tracker.set_branch(3, "issue-3")
         tracker.mark_pr(4, "approved")
         tracker.set_hitl_origin(5, "hydraflow-implement")
@@ -259,7 +259,7 @@ class TestStateRoundtrip:
 
         # Verify all fields roundtrip correctly
         assert tracker2.to_dict()["processed_issues"]["1"] == "triaged"
-        assert tracker2.get_active_worktrees() == {2: "/tmp/wt-2"}
+        assert tracker2.get_active_workspaces() == {2: "/tmp/wt-2"}
         assert tracker2.get_branch(3) == "issue-3"
         assert tracker2.to_dict()["reviewed_prs"]["4"] == "approved"
         assert tracker2.get_hitl_origin(5) == "hydraflow-implement"
@@ -278,24 +278,24 @@ class TestStateRoundtrip:
     def test_json_uses_string_keys(self, tmp_path: Path) -> None:
         """Verify the persisted JSON file uses string keys (backwards compat)."""
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(42, "/tmp/wt-42")
+        tracker.set_workspace(42, "/tmp/wt-42")
         tracker.increment_review_attempts(99)
 
         raw = json.loads((tmp_path / "state.json").read_text())
         # JSON keys must be strings
-        assert "42" in raw["active_worktrees"]
+        assert "42" in raw["active_workspaces"]
         assert "99" in raw["review_attempts"]
         # int keys should NOT appear
-        assert 42 not in raw["active_worktrees"]
+        assert 42 not in raw["active_workspaces"]
         assert 99 not in raw["review_attempts"]
 
     def test_multiple_entries_roundtrip(self, tmp_path: Path) -> None:
         """Multiple entries in the same dict field survive roundtrip."""
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(1, "/a")
-        tracker.set_worktree(2, "/b")
-        tracker.set_worktree(3, "/c")
+        tracker.set_workspace(1, "/a")
+        tracker.set_workspace(2, "/b")
+        tracker.set_workspace(3, "/c")
 
         tracker2 = StateTracker(tmp_path / "state.json")
-        wts = tracker2.get_active_worktrees()
+        wts = tracker2.get_active_workspaces()
         assert wts == {1: "/a", 2: "/b", 3: "/c"}

--- a/tests/test_state_mixin_decomposition.py
+++ b/tests/test_state_mixin_decomposition.py
@@ -20,7 +20,7 @@ from state._report import ReportStateMixin
 from state._review import ReviewStateMixin
 from state._session import SessionStateMixin
 from state._worker import WorkerStateMixin
-from state._worktree import WorktreeStateMixin
+from state._workspace import WorkspaceStateMixin
 from tests.helpers import make_tracker
 
 # ---------------------------------------------------------------------------
@@ -35,7 +35,7 @@ class TestFacadeComposition:
         "mixin",
         [
             IssueStateMixin,
-            WorktreeStateMixin,
+            WorkspaceStateMixin,
             HITLStateMixin,
             ReviewStateMixin,
             EpicStateMixin,
@@ -51,7 +51,7 @@ class TestFacadeComposition:
     def test_mro_contains_all_mixins(self) -> None:
         mixin_names = {
             "IssueStateMixin",
-            "WorktreeStateMixin",
+            "WorkspaceStateMixin",
             "HITLStateMixin",
             "ReviewStateMixin",
             "EpicStateMixin",
@@ -84,7 +84,7 @@ class TestCrossMixinPersistence:
         tracker.increment_issue_attempts(1)
 
         # Worktree domain
-        tracker.set_worktree(1, "/wt/1")
+        tracker.set_workspace(1, "/wt/1")
         tracker.set_branch(1, "agent/issue-1")
 
         # HITL domain
@@ -117,7 +117,7 @@ class TestCrossMixinPersistence:
 
         assert tracker2.to_dict()["processed_issues"]["1"] == "planned"
         assert tracker2.get_issue_attempts(1) == 1
-        assert tracker2.get_active_worktrees() == {1: "/wt/1"}
+        assert tracker2.get_active_workspaces() == {1: "/wt/1"}
         assert tracker2.get_branch(1) == "agent/issue-1"
         assert tracker2.get_hitl_origin(1) == "review"
         assert tracker2.get_hitl_cause(1) == "ci_failure"
@@ -245,18 +245,18 @@ class TestIssueStateMixin:
         assert len(t.get_hook_failures(1)) == 500
 
 
-class TestWorktreeStateMixin:
+class TestWorkspaceStateMixin:
     def test_worktree_lifecycle(self, tmp_path: Path) -> None:
         t = make_tracker(tmp_path)
-        t.set_worktree(1, "/wt/1")
-        assert t.get_active_worktrees() == {1: "/wt/1"}
-        t.remove_worktree(1)
-        assert t.get_active_worktrees() == {}
+        t.set_workspace(1, "/wt/1")
+        assert t.get_active_workspaces() == {1: "/wt/1"}
+        t.remove_workspace(1)
+        assert t.get_active_workspaces() == {}
 
     def test_remove_absent_worktree_is_noop(self, tmp_path: Path) -> None:
         t = make_tracker(tmp_path)
-        t.remove_worktree(999)  # should not raise
-        assert t.get_active_worktrees() == {}  # state remains empty
+        t.remove_workspace(999)  # should not raise
+        assert t.get_active_workspaces() == {}  # state remains empty
 
     def test_branch_tracking(self, tmp_path: Path) -> None:
         t = make_tracker(tmp_path)

--- a/tests/test_state_outcomes.py
+++ b/tests/test_state_outcomes.py
@@ -605,7 +605,7 @@ class TestDisabledWorkersPersistence:
         state_file = tmp_path / "state.json"
         data = {
             "processed_issues": {},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "bg_worker_states": {
@@ -629,7 +629,7 @@ class TestDisabledWorkersPersistence:
         state_file = tmp_path / "state.json"
         data = {
             "processed_issues": {"42": "merged"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "bg_worker_states": "not_a_dict",
@@ -651,7 +651,7 @@ class TestDisabledWorkersPersistence:
         state_file = tmp_path / "state.json"
         data = {
             "processed_issues": {},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "disabled_workers": ["memory_sync"],
@@ -700,12 +700,12 @@ class TestActiveCrate:
 
 
 # ---------------------------------------------------------------------------
-# get_active_worktrees ValueError handling (issue #2576)
+# get_active_workspaces ValueError handling (issue #2576)
 # ---------------------------------------------------------------------------
 
 
 class TestGetActiveWorktreesValueError:
-    """Verify get_active_worktrees handles non-integer keys gracefully."""
+    """Verify get_active_workspaces handles non-integer keys gracefully."""
 
     def test_skips_non_integer_keys(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -716,11 +716,11 @@ class TestGetActiveWorktreesValueError:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
         # Inject corrupt data directly
-        tracker._data.active_worktrees["abc"] = "/wt/abc"
-        tracker._data.active_worktrees["42"] = "/wt/42"
+        tracker._data.active_workspaces["abc"] = "/wt/abc"
+        tracker._data.active_workspaces["42"] = "/wt/42"
 
         with caplog.at_level(logging.WARNING, logger="hydraflow.state"):
-            result = tracker.get_active_worktrees()
+            result = tracker.get_active_workspaces()
 
         assert result == {42: "/wt/42"}
         assert "Skipping non-integer state key" in caplog.text
@@ -729,20 +729,20 @@ class TestGetActiveWorktreesValueError:
         """All non-integer keys should result in an empty dict."""
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        tracker._data.active_worktrees["foo"] = "/wt/foo"
-        tracker._data.active_worktrees["bar"] = "/wt/bar"
+        tracker._data.active_workspaces["foo"] = "/wt/foo"
+        tracker._data.active_workspaces["bar"] = "/wt/bar"
 
-        result = tracker.get_active_worktrees()
+        result = tracker.get_active_workspaces()
         assert result == {}
 
     def test_valid_keys_unaffected(self, tmp_path: Path) -> None:
         """Valid integer-string keys should still convert correctly."""
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        tracker.set_worktree(10, "/wt/10")
-        tracker.set_worktree(20, "/wt/20")
+        tracker.set_workspace(10, "/wt/10")
+        tracker.set_workspace(20, "/wt/20")
 
-        result = tracker.get_active_worktrees()
+        result = tracker.get_active_workspaces()
         assert result == {10: "/wt/10", 20: "/wt/20"}
 
 
@@ -777,7 +777,7 @@ class TestStateKeyHelpers:
         tracker = StateTracker(state_file)
 
         tracker.mark_issue(100, "reviewed")
-        tracker.set_worktree(100, "/wt/100")
+        tracker.set_workspace(100, "/wt/100")
         tracker.set_branch(100, "agent/issue-100")
         tracker.increment_issue_attempts(100)
         tracker.set_hitl_origin(100, "hydraflow-review")
@@ -786,7 +786,7 @@ class TestStateKeyHelpers:
 
         tracker2 = StateTracker(state_file)
         assert tracker2._data.processed_issues["100"] == "reviewed"
-        assert tracker2.get_active_worktrees() == {100: "/wt/100"}
+        assert tracker2.get_active_workspaces() == {100: "/wt/100"}
         assert tracker2.get_branch(100) == "agent/issue-100"
         assert tracker2.get_issue_attempts(100) == 1
         assert tracker2.get_hitl_origin(100) == "hydraflow-review"

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -211,7 +211,7 @@ class TestStateDataModel:
         """StateData() should have correct zero/empty defaults."""
         data = StateData()
         assert data.processed_issues == {}
-        assert data.active_worktrees == {}
+        assert data.active_workspaces == {}
         assert data.active_branches == {}
         assert data.reviewed_prs == {}
         assert data.hitl_origins == {}
@@ -228,7 +228,7 @@ class TestStateDataModel:
         """model_validate should accept a well-formed dict."""
         raw = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {"2": "/wt/2"},
+            "active_workspaces": {"2": "/wt/2"},
             "active_branches": {"2": "agent/issue-2"},
             "reviewed_prs": {"10": "merged"},
             "hitl_origins": {"42": "hydraflow-review"},
@@ -249,7 +249,7 @@ class TestStateDataModel:
         """Missing keys should get defaults -- enables migration from old files."""
         data = StateData.model_validate({"processed_issues": {"1": "success"}})
         assert data.processed_issues == {"1": "success"}
-        assert data.active_worktrees == {}
+        assert data.active_workspaces == {}
         assert data.lifetime_stats.issues_completed == 0
 
     def test_rejects_wrong_types(self) -> None:
@@ -327,7 +327,7 @@ class TestWorkerResultMeta:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,

--- a/tests/test_state_sessions.py
+++ b/tests/test_state_sessions.py
@@ -174,7 +174,7 @@ class TestLoadUnicodeDecodeError:
 
         assert "Corrupt state file, resetting" in caplog.text
         # Should have default state
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
         assert tracker.to_dict()["processed_issues"] == {}
 
 

--- a/tests/test_state_terminal_cleanup.py
+++ b/tests/test_state_terminal_cleanup.py
@@ -1,4 +1,4 @@
-"""Tests that terminal state transitions clean up active_branches and active_worktrees."""
+"""Tests that terminal state transitions clean up active_branches and active_workspaces."""
 
 from __future__ import annotations
 
@@ -24,9 +24,9 @@ class TestTerminalStateCleanup:
         self, tmp_path: Path, status: str
     ) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(42, "/tmp/wt-42")
+        tracker.set_workspace(42, "/tmp/wt-42")
         tracker.mark_issue(42, status)
-        assert tracker.get_active_worktrees().get(42) is None
+        assert tracker.get_active_workspaces().get(42) is None
 
     def test_non_terminal_status_preserves_branch(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
@@ -36,9 +36,9 @@ class TestTerminalStateCleanup:
 
     def test_non_terminal_status_preserves_worktree(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(42, "/tmp/wt-42")
+        tracker.set_workspace(42, "/tmp/wt-42")
         tracker.mark_issue(42, "in_progress")
-        assert tracker.get_active_worktrees()[42] == "/tmp/wt-42"
+        assert tracker.get_active_workspaces()[42] == "/tmp/wt-42"
 
     def test_terminal_cleanup_does_not_affect_other_issues(
         self, tmp_path: Path
@@ -46,22 +46,22 @@ class TestTerminalStateCleanup:
         tracker = make_tracker(tmp_path)
         tracker.set_branch(1, "agent/issue-1")
         tracker.set_branch(2, "agent/issue-2")
-        tracker.set_worktree(1, "/tmp/wt-1")
-        tracker.set_worktree(2, "/tmp/wt-2")
+        tracker.set_workspace(1, "/tmp/wt-1")
+        tracker.set_workspace(2, "/tmp/wt-2")
         tracker.mark_issue(1, "merged")
         assert tracker.get_branch(1) is None
         assert tracker.get_branch(2) == "agent/issue-2"
-        assert 1 not in tracker.get_active_worktrees()
-        assert tracker.get_active_worktrees()[2] == "/tmp/wt-2"
+        assert 1 not in tracker.get_active_workspaces()
+        assert tracker.get_active_workspaces()[2] == "/tmp/wt-2"
 
     def test_terminal_cleanup_persists(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
         tracker.set_branch(10, "agent/issue-10")
-        tracker.set_worktree(10, "/tmp/wt-10")
+        tracker.set_workspace(10, "/tmp/wt-10")
         tracker.mark_issue(10, "failed")
         reloaded = make_tracker(tmp_path)
         assert reloaded.get_branch(10) is None
-        assert 10 not in reloaded.get_active_worktrees()
+        assert 10 not in reloaded.get_active_workspaces()
 
     def test_terminal_cleanup_noop_when_no_entries(self, tmp_path: Path) -> None:
         """Cleaning up non-existent entries should not raise."""

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -15,10 +15,10 @@ from tests.helpers import make_tracker
 
 
 class TestInitialization:
-    def test_fresh_tracker_has_no_active_worktrees(self, tmp_path: Path) -> None:
+    def test_fresh_tracker_has_no_active_workspaces(self, tmp_path: Path) -> None:
         """A fresh tracker with no backing file should have no active worktrees."""
         tracker = make_tracker(tmp_path)
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_fresh_tracker_has_no_processed_issues(self, tmp_path: Path) -> None:
         """A fresh tracker with no backing file should have no processed issues."""
@@ -44,7 +44,7 @@ class TestInitialization:
             "active_crate_number",
             "bead_mappings",
             "active_issue_numbers",
-            "active_worktrees",
+            "active_workspaces",
             "baseline_audit",
             "bg_worker_states",
             "bot_pr_processed",
@@ -94,7 +94,7 @@ class TestInitialization:
         legacy_data = {
             "current_batch": 7,
             "processed_issues": {"3": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {"42": "approve"},
             "last_updated": None,
@@ -112,7 +112,7 @@ class TestInitialization:
         state_file = tmp_path / "state.json"
         initial_data = {
             "processed_issues": {"7": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,
@@ -163,9 +163,9 @@ class TestLoadSave:
     def test_round_trip_preserves_worktree(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        tracker.set_worktree(10, "/tmp/wt-10")
+        tracker.set_workspace(10, "/tmp/wt-10")
         tracker2 = StateTracker(state_file)
-        assert tracker2.get_active_worktrees() == {10: "/tmp/wt-10"}
+        assert tracker2.get_active_workspaces() == {10: "/tmp/wt-10"}
 
     def test_round_trip_preserves_branch(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
@@ -328,48 +328,48 @@ class TestIssueTracking:
 
 
 class TestWorktreeTracking:
-    def test_set_worktree_stores_path(self, tmp_path: Path) -> None:
+    def test_set_workspace_stores_path(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(7, "/tmp/wt-7")
-        assert tracker.get_active_worktrees() == {7: "/tmp/wt-7"}
+        tracker.set_workspace(7, "/tmp/wt-7")
+        assert tracker.get_active_workspaces() == {7: "/tmp/wt-7"}
 
-    def test_set_worktree_triggers_save(self, tmp_path: Path) -> None:
+    def test_set_workspace_triggers_save(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
         tracker = StateTracker(state_file)
-        tracker.set_worktree(7, "/tmp/wt-7")
+        tracker.set_workspace(7, "/tmp/wt-7")
         assert state_file.exists()
 
-    def test_remove_worktree_deletes_entry(self, tmp_path: Path) -> None:
+    def test_remove_workspace_deletes_entry(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(7, "/tmp/wt-7")
-        tracker.remove_worktree(7)
-        assert 7 not in tracker.get_active_worktrees()
+        tracker.set_workspace(7, "/tmp/wt-7")
+        tracker.remove_workspace(7)
+        assert 7 not in tracker.get_active_workspaces()
 
-    def test_remove_worktree_nonexistent_is_noop(self, tmp_path: Path) -> None:
+    def test_remove_workspace_nonexistent_is_noop(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
         # Should not raise
-        tracker.remove_worktree(999)
-        assert tracker.get_active_worktrees() == {}
+        tracker.remove_workspace(999)
+        assert tracker.get_active_workspaces() == {}
 
-    def test_get_active_worktrees_returns_int_keys(self, tmp_path: Path) -> None:
+    def test_get_active_workspaces_returns_int_keys(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(10, "/wt/10")
-        tracker.set_worktree(20, "/wt/20")
-        wt = tracker.get_active_worktrees()
+        tracker.set_workspace(10, "/wt/10")
+        tracker.set_workspace(20, "/wt/20")
+        wt = tracker.get_active_workspaces()
         assert all(isinstance(k, int) for k in wt)
 
     def test_multiple_worktrees(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(1, "/wt/1")
-        tracker.set_worktree(2, "/wt/2")
-        assert tracker.get_active_worktrees() == {1: "/wt/1", 2: "/wt/2"}
+        tracker.set_workspace(1, "/wt/1")
+        tracker.set_workspace(2, "/wt/2")
+        assert tracker.get_active_workspaces() == {1: "/wt/1", 2: "/wt/2"}
 
     def test_remove_one_worktree_leaves_others(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(1, "/wt/1")
-        tracker.set_worktree(2, "/wt/2")
-        tracker.remove_worktree(1)
-        assert tracker.get_active_worktrees() == {2: "/wt/2"}
+        tracker.set_workspace(1, "/wt/1")
+        tracker.set_workspace(2, "/wt/2")
+        tracker.remove_workspace(1)
+        assert tracker.get_active_workspaces() == {2: "/wt/2"}
 
 
 # ---------------------------------------------------------------------------
@@ -507,7 +507,7 @@ class TestHITLOriginTracking:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,
@@ -585,7 +585,7 @@ class TestHITLCauseTracking:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "hitl_origins": {"42": "hydraflow-review"},
@@ -762,11 +762,11 @@ class TestReset:
         tracker.reset()
         assert tracker.to_dict()["processed_issues"].get(str(1)) is None
 
-    def test_reset_clears_active_worktrees(self, tmp_path: Path) -> None:
+    def test_reset_clears_active_workspaces(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
-        tracker.set_worktree(1, "/wt/1")
+        tracker.set_workspace(1, "/wt/1")
         tracker.reset()
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_reset_clears_active_branches(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
@@ -792,7 +792,7 @@ class TestReset:
     def test_reset_clears_all_state_at_once(self, tmp_path: Path) -> None:
         tracker = make_tracker(tmp_path)
         tracker.mark_issue(1, "success")
-        tracker.set_worktree(1, "/wt/1")
+        tracker.set_workspace(1, "/wt/1")
         tracker.set_branch(1, "agent/issue-1")
         tracker.mark_pr(10, "open")
         tracker.set_hitl_origin(1, "hydraflow-review")
@@ -802,7 +802,7 @@ class TestReset:
 
         tracker.reset()
 
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
         assert tracker.to_dict()["processed_issues"].get(str(1)) is None
         assert tracker.get_branch(1) is None
         assert tracker.to_dict()["reviewed_prs"].get(str(10)) is None
@@ -824,14 +824,14 @@ class TestCorruptFileHandling:
 
         # Should not raise; should silently reset to defaults
         tracker = StateTracker(state_file)
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_empty_file_falls_back_to_defaults(self, tmp_path: Path) -> None:
         state_file = tmp_path / "state.json"
         state_file.write_text("")
 
         tracker = StateTracker(state_file)
-        assert tracker.get_active_worktrees() == {}
+        assert tracker.get_active_workspaces() == {}
 
     def test_load_with_corrupt_file_falls_back_to_defaults(
         self, tmp_path: Path
@@ -853,7 +853,7 @@ class TestCorruptFileHandling:
         # A state file containing 'null' (valid JSON but unexpected) should
         # not raise and should behave as if the state is empty.
         tracker = StateTracker(state_file)
-        worktrees = tracker.get_active_worktrees()
+        worktrees = tracker.get_active_workspaces()
         assert worktrees == {}
         assert tracker.to_dict().get("processed_issues") == {}
 
@@ -873,7 +873,7 @@ class TestToDict:
         d = tracker.to_dict()
         expected_keys = {
             "processed_issues",
-            "active_worktrees",
+            "active_workspaces",
             "active_branches",
             "reviewed_prs",
             "hitl_origins",
@@ -1000,7 +1000,7 @@ class TestLifetimeStats:
         state_file = tmp_path / "state.json"
         old_data = {
             "processed_issues": {"1": "success"},
-            "active_worktrees": {},
+            "active_workspaces": {},
             "active_branches": {},
             "reviewed_prs": {},
             "last_updated": None,

--- a/tests/test_stop_resume.py
+++ b/tests/test_stop_resume.py
@@ -88,7 +88,7 @@ def _make_orchestrator(tmp_path: Path) -> HydraFlowOrchestrator:
 
     config = ConfigFactory.create(
         repo_root=tmp_path / "repo",
-        worktree_base=tmp_path / "worktrees",
+        workspace_base=tmp_path / "worktrees",
         state_file=tmp_path / "state.json",
     )
     (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
@@ -110,7 +110,7 @@ def _make_orchestrator(tmp_path: Path) -> HydraFlowOrchestrator:
         svc.store.clear_active = MagicMock()
 
         # Other services we need
-        svc.worktrees = AsyncMock()
+        svc.workspaces = AsyncMock()
         svc.subprocess_runner = MagicMock()
         svc.prs = AsyncMock()
         svc.prs.ensure_labels_exist = AsyncMock()
@@ -486,13 +486,13 @@ class TestWorktreePreservation:
         phase._prs.pull_main = AsyncMock()
 
         # Create worktree path
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
 
         # Worktree cleanup should NOT be called — review was interrupted (not merged)
-        phase._worktrees.post_work_cleanup.assert_not_awaited()
+        phase._workspaces.post_work_cleanup.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_review_phase_cleans_worktree_for_merged_pr_with_stop(
@@ -529,13 +529,13 @@ class TestWorktreePreservation:
         phase._prs.swap_pipeline_labels = AsyncMock()
         phase._prs.pull_main = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         await phase.review_prs([pr], [issue])
 
         # Worktree SHOULD be cleaned up — merge completed, nothing to resume
-        phase._worktrees.post_work_cleanup.assert_awaited_once_with(42)
+        phase._workspaces.post_work_cleanup.assert_awaited_once_with(42)
 
     @pytest.mark.asyncio
     async def test_review_phase_cleans_worktree_when_not_stopped(self, config) -> None:
@@ -559,14 +559,14 @@ class TestWorktreePreservation:
         phase._prs.swap_pipeline_labels = AsyncMock()
         phase._prs.pull_main = AsyncMock()
 
-        wt = config.worktree_path_for_issue(42)
+        wt = config.workspace_path_for_issue(42)
         wt.mkdir(parents=True, exist_ok=True)
 
         # Stop event is NOT set
         await phase.review_prs([pr], [issue])
 
         # Worktree cleanup should be called normally
-        phase._worktrees.post_work_cleanup.assert_awaited_once_with(42)
+        phase._workspaces.post_work_cleanup.assert_awaited_once_with(42)
 
 
 # ---------------------------------------------------------------------------
@@ -616,7 +616,7 @@ class TestReviewPhaseStop:
 
         # Create worktree paths
         for num in (10, 20):
-            (config.worktree_base / f"issue-{num}").mkdir(parents=True, exist_ok=True)
+            (config.workspace_base / f"issue-{num}").mkdir(parents=True, exist_ok=True)
 
         results = await phase.review_prs([pr1, pr2], [issue1, issue2])
 

--- a/tests/test_type_replacements.py
+++ b/tests/test_type_replacements.py
@@ -156,7 +156,7 @@ class TestHitlPhaseCallableType:
             state=MagicMock(),
             store=MagicMock(),
             fetcher=MagicMock(),
-            worktrees=MagicMock(),
+            workspaces=MagicMock(),
             hitl_runner=MagicMock(),
             prs=MagicMock(),
             event_bus=MagicMock(),
@@ -202,7 +202,7 @@ class TestPrUnstickerReturnType:
             event_bus=MagicMock(),
             pr_manager=MagicMock(),
             agents=MagicMock(),
-            worktrees=MagicMock(),
+            workspaces=MagicMock(),
             fetcher=MagicMock(),
         )
         result = await unsticker.unstick([])

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -156,7 +156,7 @@ class TestBuildCommand:
             verification_judge_tool="codex",
             review_model="gpt-5-codex",
             repo_root=tmp_path / "repo",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
         )
         judge = _make_judge(cfg)
@@ -1152,7 +1152,7 @@ class TestReviewPhaseWiring:
         mock_judge.judge = AsyncMock(return_value=JudgeVerdict(issue_number=42))
 
         # Create worktree dir
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         from merge_conflict_resolver import MergeConflictResolver
@@ -1160,7 +1160,7 @@ class TestReviewPhaseWiring:
 
         conflict_resolver = MergeConflictResolver(
             config=config,
-            worktrees=mock_wt,
+            workspaces=mock_wt,
             agents=None,
             prs=mock_prs,
             event_bus=event_bus,
@@ -1181,7 +1181,7 @@ class TestReviewPhaseWiring:
         phase = ReviewPhase(
             config=config,
             state=state,
-            worktrees=mock_wt,
+            workspaces=mock_wt,
             reviewers=mock_reviewers,
             prs=mock_prs,
             stop_event=stop_event,
@@ -1236,7 +1236,7 @@ class TestReviewPhaseWiring:
         mock_prs.post_pr_comment = AsyncMock()
         mock_prs.submit_review = AsyncMock()
 
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         from merge_conflict_resolver import MergeConflictResolver
@@ -1244,7 +1244,7 @@ class TestReviewPhaseWiring:
 
         conflict_resolver = MergeConflictResolver(
             config=config,
-            worktrees=mock_wt,
+            workspaces=mock_wt,
             agents=None,
             prs=mock_prs,
             event_bus=event_bus,
@@ -1265,7 +1265,7 @@ class TestReviewPhaseWiring:
         phase = ReviewPhase(
             config=config,
             state=state,
-            worktrees=mock_wt,
+            workspaces=mock_wt,
             reviewers=mock_reviewers,
             prs=mock_prs,
             stop_event=stop_event,

--- a/tests/test_visual_validation.py
+++ b/tests/test_visual_validation.py
@@ -497,7 +497,7 @@ class TestReviewPhaseVisualValidation:
         bus = EventBus()
         conflict_resolver = MergeConflictResolver(
             config=config,
-            worktrees=AsyncMock(spec=WorkspaceManager),
+            workspaces=AsyncMock(spec=WorkspaceManager),
             agents=None,
             prs=mock_prs,
             event_bus=bus,
@@ -517,7 +517,7 @@ class TestReviewPhaseVisualValidation:
         phase = ReviewPhase(
             config=config,
             state=state,
-            worktrees=AsyncMock(spec=WorkspaceManager),
+            workspaces=AsyncMock(spec=WorkspaceManager),
             reviewers=AsyncMock(spec=ReviewRunner),
             prs=mock_prs,
             stop_event=asyncio.Event(),
@@ -552,7 +552,7 @@ class TestReviewPhaseVisualValidation:
         bus = EventBus()
         conflict_resolver = MergeConflictResolver(
             config=config,
-            worktrees=AsyncMock(spec=WorkspaceManager),
+            workspaces=AsyncMock(spec=WorkspaceManager),
             agents=None,
             prs=mock_prs,
             event_bus=bus,
@@ -572,7 +572,7 @@ class TestReviewPhaseVisualValidation:
         phase = ReviewPhase(
             config=config,
             state=state,
-            worktrees=AsyncMock(spec=WorkspaceManager),
+            workspaces=AsyncMock(spec=WorkspaceManager),
             reviewers=AsyncMock(spec=ReviewRunner),
             prs=mock_prs,
             stop_event=asyncio.Event(),

--- a/tests/test_workspace_create.py
+++ b/tests/test_workspace_create.py
@@ -27,7 +27,7 @@ class TestCreate:
         manager = WorkspaceManager(config)
 
         # Pre-create the base directory so mkdir doesn't cause issues
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
 
@@ -70,7 +70,7 @@ class TestCreate:
     ) -> None:
         """create should fetch the remote branch and checkout instead of creating new."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
 
@@ -122,7 +122,7 @@ class TestCreate:
     ) -> None:
         """create should checkout -b from origin/main when no remote branch exists."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
 
@@ -159,7 +159,7 @@ class TestCreate:
     ) -> None:
         """create should invoke _setup_env, _create_venv, and _install_hooks."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc()
 
@@ -179,13 +179,13 @@ class TestCreate:
         setup_env.assert_called_once()
         create_venv.assert_awaited_once()
         install_hooks.assert_awaited_once()
-        assert result == config.worktree_path_for_issue(7)
+        assert result == config.workspace_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_returns_correct_path(self, config, tmp_path: Path) -> None:
-        """create should return <worktree_base>/issue-<number>."""
+        """create should return <workspace_base>/issue-<number>."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc()
 
@@ -198,7 +198,7 @@ class TestCreate:
         ):
             result = await manager.create(issue_number=99, branch="agent/issue-99")
 
-        assert result == config.worktree_path_for_issue(99)
+        assert result == config.workspace_path_for_issue(99)
 
     @pytest.mark.asyncio
     async def test_create_dry_run_skips_git_commands(
@@ -211,7 +211,7 @@ class TestCreate:
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
         mock_exec.assert_not_called()
-        assert result == dry_config.worktree_path_for_issue(7)
+        assert result == dry_config.workspace_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_raises_when_fetch_origin_main_fails(
@@ -219,7 +219,7 @@ class TestCreate:
     ) -> None:
         """create should propagate RuntimeError when 'git fetch origin main' fails."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         fail_proc = make_proc(returncode=1, stderr=b"fatal: network error")
 
@@ -235,7 +235,7 @@ class TestCreate:
     ) -> None:
         """create should retry when git fetch hits origin/main ref-lock races."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         race_proc = make_proc(
             returncode=1,
@@ -280,7 +280,7 @@ class TestCreate:
         ):
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
-        assert result == config.worktree_path_for_issue(7)
+        assert result == config.workspace_path_for_issue(7)
         # clone, set-url, fetch (fail), fetch (retry), ls-remote, checkout -b
         assert call_count >= 4
         sleep_mock.assert_awaited_once()
@@ -291,7 +291,7 @@ class TestCreate:
     ) -> None:
         """Concurrent create() calls should never overlap git fetch origin/main."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         fetch_in_flight = 0
         max_fetch_in_flight = 0
@@ -325,7 +325,7 @@ class TestCreate:
     ) -> None:
         """create should propagate RuntimeError when 'git checkout -b' fails after clone."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
         fail_proc = make_proc(returncode=1, stderr=b"fatal: checkout failed")
@@ -359,7 +359,7 @@ class TestCreate:
     ) -> None:
         """create should propagate OSError from _setup_env (not wrapped in try/except)."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
 
@@ -379,7 +379,7 @@ class TestCreate:
     ) -> None:
         """create should return a valid path even when uv sync fails inside _create_venv."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
         fail_proc = make_proc(returncode=1, stderr=b"uv sync failed")
@@ -397,7 +397,7 @@ class TestCreate:
             result = await manager.create(issue_number=7, branch="agent/issue-7")
 
         # _create_venv catches RuntimeError internally, so create completes
-        assert result == config.worktree_path_for_issue(7)
+        assert result == config.workspace_path_for_issue(7)
 
     @pytest.mark.asyncio
     async def test_create_cleans_up_on_checkout_failure(
@@ -405,7 +405,7 @@ class TestCreate:
     ) -> None:
         """Cleanup should remove cloned directory when checkout fails."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
         fail_proc = make_proc(returncode=1, stderr=b"fatal: checkout failed")
@@ -416,7 +416,7 @@ class TestCreate:
                 return fail_proc
             return success_proc
 
-        wt_path = config.worktree_path_for_issue(7)
+        wt_path = config.workspace_path_for_issue(7)
         # Create the directory so cleanup finds it
         wt_path.mkdir(parents=True, exist_ok=True)
 
@@ -447,9 +447,9 @@ class TestCreate:
     ) -> None:
         """Cleanup should remove cloned directory when post-creation setup fails."""
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
-        wt_path = config.worktree_path_for_issue(7)
+        wt_path = config.workspace_path_for_issue(7)
         # Pre-create the directory so cleanup finds it
         wt_path.mkdir(parents=True, exist_ok=True)
 
@@ -483,7 +483,7 @@ class TestDestroy:
         manager = WorkspaceManager(config)
 
         # Simulate existing worktree path
-        wt_path = config.worktree_path_for_issue(7)
+        wt_path = config.workspace_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         await manager.destroy(issue_number=7)
@@ -498,7 +498,7 @@ class TestDestroy:
         manager = WorkspaceManager(config)
 
         # wt_path does NOT exist — destroy should not raise
-        wt_path = config.worktree_path_for_issue(999)
+        wt_path = config.workspace_path_for_issue(999)
         await manager.destroy(issue_number=999)
         assert not wt_path.exists()
 
@@ -509,7 +509,7 @@ class TestDestroy:
         """destroy should remove the workspace directory via shutil.rmtree."""
         manager = WorkspaceManager(config)
 
-        wt_path = config.worktree_path_for_issue(7)
+        wt_path = config.workspace_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
         (wt_path / "somefile.txt").write_text("content")
 
@@ -524,7 +524,7 @@ class TestDestroy:
         """In dry-run mode, destroy should not remove the directory."""
         manager = WorkspaceManager(dry_config)
 
-        wt_path = dry_config.worktree_path_for_issue(7)
+        wt_path = dry_config.workspace_path_for_issue(7)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         await manager.destroy(issue_number=7)
@@ -549,7 +549,7 @@ class TestDestroyAll:
         manager = WorkspaceManager(config)
 
         # Create two issue directories in the repo-scoped subdirectory
-        repo_base = config.worktree_base / config.repo_slug
+        repo_base = config.workspace_base / config.repo_slug
         (repo_base / "issue-1").mkdir(parents=True, exist_ok=True)
         (repo_base / "issue-2").mkdir(parents=True, exist_ok=True)
 
@@ -565,9 +565,9 @@ class TestDestroyAll:
 
     @pytest.mark.asyncio
     async def test_destroy_all_noop_when_base_missing(self, config) -> None:
-        """destroy_all should return immediately if worktree_base does not exist."""
+        """destroy_all should return immediately if workspace_base does not exist."""
         manager = WorkspaceManager(config)
-        # config.worktree_base was NOT created
+        # config.workspace_base was NOT created
 
         with patch.object(manager, "destroy", new_callable=AsyncMock) as mock_destroy:
             await manager.destroy_all()
@@ -581,7 +581,7 @@ class TestDestroyAll:
         """destroy_all should skip directories not named issue-N."""
         manager = WorkspaceManager(config)
 
-        repo_base = config.worktree_base / config.repo_slug
+        repo_base = config.workspace_base / config.repo_slug
         (repo_base / "random-dir").mkdir(parents=True, exist_ok=True)
         (repo_base / "issue-5").mkdir(parents=True, exist_ok=True)
 
@@ -604,9 +604,9 @@ class TestDestroyAll:
 class TestRepoScopedPaths:
     """Verify worktree paths are namespaced by repo slug."""
 
-    def test_worktree_path_includes_repo_slug(self, config) -> None:
-        """worktree_path_for_issue should include repo_slug in the path."""
-        path = config.worktree_path_for_issue(42)
+    def test_workspace_path_includes_repo_slug(self, config) -> None:
+        """workspace_path_for_issue should include repo_slug in the path."""
+        path = config.workspace_path_for_issue(42)
         assert config.repo_slug in str(path)
         assert path.name == "issue-42"
         assert path.parent.name == config.repo_slug
@@ -615,16 +615,16 @@ class TestRepoScopedPaths:
         """Two different repos should have non-overlapping worktree paths."""
         cfg_a = ConfigFactory.create(
             repo="org/repo-a",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "a",
         )
         cfg_b = ConfigFactory.create(
             repo="org/repo-b",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "b",
         )
-        path_a = cfg_a.worktree_path_for_issue(10)
-        path_b = cfg_b.worktree_path_for_issue(10)
+        path_a = cfg_a.workspace_path_for_issue(10)
+        path_b = cfg_b.workspace_path_for_issue(10)
         assert path_a != path_b
         assert "org-repo-a" in str(path_a)
         assert "org-repo-b" in str(path_b)
@@ -638,12 +638,12 @@ class TestPerRepoWorktreeLock:
         """create should delegate to _create_unlocked under the lock."""
         manager = WorkspaceManager(config)
 
-        mock_create = AsyncMock(return_value=config.worktree_path_for_issue(7))
+        mock_create = AsyncMock(return_value=config.workspace_path_for_issue(7))
         with patch.object(manager, "_create_unlocked", mock_create):
             result = await manager.create(7, "agent/issue-7")
 
         mock_create.assert_awaited_once_with(7, "agent/issue-7")
-        assert result == config.worktree_path_for_issue(7)
+        assert result == config.workspace_path_for_issue(7)
 
     def test_same_repo_gets_same_lock(self, config) -> None:
         """Two managers for the same repo should share the same lock."""
@@ -655,12 +655,12 @@ class TestPerRepoWorktreeLock:
         """Two managers for different repos should have independent locks."""
         cfg_a = ConfigFactory.create(
             repo="org/alpha",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             repo_root=tmp_path / "a",
         )
         cfg_b = ConfigFactory.create(
             repo="org/beta",
-            worktree_base=tmp_path / "wt",
+            workspace_base=tmp_path / "wt",
             repo_root=tmp_path / "b",
         )
         lock_a = WorkspaceManager(cfg_a)._repo_workspace_lock()
@@ -678,7 +678,7 @@ class TestDestroyAllRepoScoped:
         """destroy_all should remove worktrees under the repo-scoped directory."""
         cfg = ConfigFactory.create(
             repo="org/alpha",
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             repo_root=tmp_path / "repo",
         )
         manager = WorkspaceManager(cfg)

--- a/tests/test_workspace_docker.py
+++ b/tests/test_workspace_docker.py
@@ -455,7 +455,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -476,7 +476,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -492,7 +492,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -508,7 +508,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -523,7 +523,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             ui_dirs=["custom/ui", "other/frontend"],
         )
@@ -540,7 +540,7 @@ class TestDetectUiDirs:
 
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             ui_dirs=["old/ui"],
         )
@@ -642,7 +642,7 @@ class TestResetToMain:
         """reset_to_main should fetch, hard-reset, and clean."""
         config = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(config)
@@ -669,7 +669,7 @@ class TestResetToMain:
         """reset_to_main should use the configured main branch name."""
         config = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         # Override main_branch for this test
@@ -732,7 +732,7 @@ class TestPostWorkCleanup:
     async def test_post_work_salvages_uncommitted_changes(self, config) -> None:
         manager = WorkspaceManager(config)
 
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         calls: list[tuple[str, ...]] = []
@@ -758,7 +758,7 @@ class TestPostWorkCleanup:
     async def test_post_work_skips_salvage_when_clean(self, config) -> None:
         manager = WorkspaceManager(config)
 
-        wt_path = config.worktree_path_for_issue(42)
+        wt_path = config.workspace_path_for_issue(42)
         wt_path.mkdir(parents=True, exist_ok=True)
 
         calls: list[tuple[str, ...]] = []
@@ -803,7 +803,7 @@ class TestCreateCallsPreWorkCheck:
     @pytest.mark.asyncio
     async def test_create_calls_pre_work_check(self, config) -> None:
         manager = WorkspaceManager(config)
-        config.worktree_base.mkdir(parents=True, exist_ok=True)
+        config.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc(returncode=0)
 

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -349,7 +349,7 @@ class TestSetupNodeModules:
         repo_root = tmp_path / "repo"
         cfg = ConfigFactory.create(
             repo_root=repo_root,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
             ui_dirs=["frontend", "admin"],
         )
@@ -394,7 +394,7 @@ class TestConfigureGitIdentity:
             git_user_name="Bot",
             git_user_email="bot@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -419,7 +419,7 @@ class TestConfigureGitIdentity:
 
         cfg = ConfigFactory.create(
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -440,7 +440,7 @@ class TestConfigureGitIdentity:
             git_user_name="Bot",
             git_user_email="",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -466,7 +466,7 @@ class TestConfigureGitIdentity:
             git_user_name="",
             git_user_email="bot@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -488,7 +488,7 @@ class TestConfigureGitIdentity:
             git_user_name="Bot",
             git_user_email="bot@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
@@ -509,11 +509,11 @@ class TestConfigureGitIdentity:
             git_user_name="Bot",
             git_user_email="bot@example.com",
             repo_root=tmp_path,
-            worktree_base=tmp_path / "worktrees",
+            workspace_base=tmp_path / "worktrees",
             state_file=tmp_path / "state.json",
         )
         manager = WorkspaceManager(cfg)
-        cfg.worktree_base.mkdir(parents=True, exist_ok=True)
+        cfg.workspace_base.mkdir(parents=True, exist_ok=True)
 
         success_proc = make_proc()
         configure_identity = AsyncMock()

--- a/tests/test_workspace_gc_loop.py
+++ b/tests/test_workspace_gc_loop.py
@@ -25,17 +25,17 @@ def _make_loop(
     *,
     enabled: bool = True,
     interval: int = 600,
-    active_worktrees: dict[int, str] | None = None,
+    active_workspaces: dict[int, str] | None = None,
     active_issue_numbers: list[int] | None = None,
     hitl_causes: dict[int, str] | None = None,
     pipeline_issues: set[int] | None = None,
 ) -> tuple[WorkspaceGCLoop, StateTracker, asyncio.Event]:
     """Build a WorkspaceGCLoop with test-friendly defaults."""
-    deps = make_bg_loop_deps(tmp_path, enabled=enabled, worktree_gc_interval=interval)
+    deps = make_bg_loop_deps(tmp_path, enabled=enabled, workspace_gc_interval=interval)
 
     state = StateTracker(deps.config.state_file)
-    for num, path in (active_worktrees or {}).items():
-        state.set_worktree(num, path)
+    for num, path in (active_workspaces or {}).items():
+        state.set_workspace(num, path)
     if active_issue_numbers:
         state.set_active_issue_numbers(active_issue_numbers)
     for num, cause in (hitl_causes or {}).items():
@@ -43,13 +43,13 @@ def _make_loop(
 
     in_pipeline = pipeline_issues or set()
 
-    worktrees = MagicMock()
-    worktrees.destroy = AsyncMock()
+    workspaces = MagicMock()
+    workspaces.destroy = AsyncMock()
     prs = MagicMock()
 
     loop = WorkspaceGCLoop(
         config=deps.config,
-        worktrees=worktrees,
+        workspaces=workspaces,
         prs=prs,
         state=state,
         deps=deps.loop_deps,
@@ -63,7 +63,7 @@ def _make_loop(
 class TestWorkspaceGCLoopBasics:
     def test_worker_name(self, tmp_path: Path) -> None:
         loop, _state, _stop = _make_loop(tmp_path)
-        assert loop._worker_name == "worktree_gc"
+        assert loop._worker_name == "workspace_gc"
 
     def test_default_interval(self, tmp_path: Path) -> None:
         loop, _state, _stop = _make_loop(tmp_path, interval=900)
@@ -91,43 +91,43 @@ class TestWorkspaceGCLoopBasics:
             if e.type == EventType.BACKGROUND_WORKER_STATUS
         ]
         assert len(events) >= 1
-        assert events[0].data["worker"] == "worktree_gc"
+        assert events[0].data["worker"] == "workspace_gc"
         assert events[0].data["status"] == "ok"
 
 
 class TestWorktreeGCCollectsClosedIssues:
     @pytest.mark.asyncio
     async def test_gc_closed_issue_worktree(self, tmp_path: Path) -> None:
-        loop, state, _stop = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _stop = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="closed")
         await loop._do_work()
-        loop._worktrees.destroy.assert_awaited_once_with(42)
-        assert 42 not in state.get_active_worktrees()
+        loop._workspaces.destroy.assert_awaited_once_with(42)
+        assert 42 not in state.get_active_workspaces()
 
     @pytest.mark.asyncio
     async def test_gc_returns_collected_count(self, tmp_path: Path) -> None:
-        loop, _state, _stop = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _state, _stop = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="closed")
         result = await loop._do_work()
         assert result["collected"] >= 1
 
     @pytest.mark.asyncio
     async def test_state_removed_before_destroy(self, tmp_path: Path) -> None:
-        loop, state, _stop = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _stop = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="closed")
         call_order: list[str] = []
-        original_remove = state.remove_worktree
+        original_remove = state.remove_workspace
 
         def tracked_remove(num: int) -> None:
             call_order.append("remove_state")
             original_remove(num)
 
-        state.remove_worktree = tracked_remove  # type: ignore[method-assign]
+        state.remove_workspace = tracked_remove  # type: ignore[method-assign]
 
         async def tracked_destroy(num: int) -> None:
             call_order.append("destroy")
 
-        loop._worktrees.destroy = tracked_destroy  # type: ignore[method-assign]
+        loop._workspaces.destroy = tracked_destroy  # type: ignore[method-assign]
         await loop._do_work()
         assert call_order == ["remove_state", "destroy"]
 
@@ -136,45 +136,45 @@ class TestWorktreeGCSkipsActive:
     @pytest.mark.asyncio
     async def test_skips_active_issue(self, tmp_path: Path) -> None:
         loop, _s, _e = _make_loop(
-            tmp_path, active_worktrees={42: "/p/42"}, active_issue_numbers=[42]
+            tmp_path, active_workspaces={42: "/p/42"}, active_issue_numbers=[42]
         )
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
 
     @pytest.mark.asyncio
     async def test_skips_hitl_in_progress(self, tmp_path: Path) -> None:
         loop, _s, _e = _make_loop(
-            tmp_path, active_worktrees={42: "/p/42"}, hitl_causes={42: "ci_failure"}
+            tmp_path, active_workspaces={42: "/p/42"}, hitl_causes={42: "ci_failure"}
         )
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
 
     @pytest.mark.asyncio
     async def test_skips_open_issue_with_pr(self, tmp_path: Path) -> None:
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="open")
         loop._has_open_pr = AsyncMock(return_value=True)
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
 
     @pytest.mark.asyncio
     async def test_gc_open_issue_without_pr(self, tmp_path: Path) -> None:
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="open")
         loop._has_open_pr = AsyncMock(return_value=False)
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_awaited_once_with(42)
+        loop._workspaces.destroy.assert_awaited_once_with(42)
         assert result["collected"] >= 1
 
     @pytest.mark.asyncio
     async def test_skips_unknown_issue_state(self, tmp_path: Path) -> None:
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="unknown")
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
 
 
@@ -182,16 +182,16 @@ class TestWorktreeGCBudgetCap:
     @pytest.mark.asyncio
     async def test_budget_caps_phase1_at_max(self, tmp_path: Path) -> None:
         wts = {i: f"/p/issue-{i}" for i in range(1, _MAX_GC_PER_CYCLE + 5)}
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees=wts)
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces=wts)
         loop._get_issue_state = AsyncMock(return_value="closed")
         result = await loop._do_work()
         assert result["collected"] == _MAX_GC_PER_CYCLE
-        assert loop._worktrees.destroy.await_count == _MAX_GC_PER_CYCLE
+        assert loop._workspaces.destroy.await_count == _MAX_GC_PER_CYCLE
 
     @pytest.mark.asyncio
     async def test_budget_shared_across_phases(self, tmp_path: Path) -> None:
         wts = {i: f"/p/issue-{i}" for i in range(1, 6)}
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees=wts)
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces=wts)
         loop._get_issue_state = AsyncMock(return_value="closed")
         calls: list[int] = []
 
@@ -208,29 +208,29 @@ class TestWorktreeGCOrphanedDirs:
     @pytest.mark.asyncio
     async def test_collects_orphaned_filesystem_dirs(self, tmp_path: Path) -> None:
         loop, _s, _e = _make_loop(tmp_path)
-        orphan = loop._config.worktree_base / loop._config.repo_slug / "issue-99"
+        orphan = loop._config.workspace_base / loop._config.repo_slug / "issue-99"
         orphan.mkdir(parents=True)
         loop._get_issue_state = AsyncMock(return_value="closed")
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_awaited_once_with(99)
+        loop._workspaces.destroy.assert_awaited_once_with(99)
         assert result["collected"] >= 1
 
     @pytest.mark.asyncio
     async def test_skips_non_issue_dirs(self, tmp_path: Path) -> None:
         loop, _s, _e = _make_loop(tmp_path)
-        base = loop._config.worktree_base / loop._config.repo_slug
+        base = loop._config.workspace_base / loop._config.repo_slug
         (base / "random-dir").mkdir(parents=True)
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["collected"] == 0
 
     @pytest.mark.asyncio
     async def test_skips_non_numeric_issue_dirs(self, tmp_path: Path) -> None:
         loop, _s, _e = _make_loop(tmp_path)
-        base = loop._config.worktree_base / loop._config.repo_slug
+        base = loop._config.workspace_base / loop._config.repo_slug
         (base / "issue-abc").mkdir(parents=True)
         await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_zero_when_base_missing(self, tmp_path: Path) -> None:
@@ -254,7 +254,7 @@ class TestWorktreeGCOrphanedBranches:
 
     @pytest.mark.asyncio
     async def test_skips_branches_with_active_worktree(self, tmp_path: Path) -> None:
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees={99: "/p/99"})
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces={99: "/p/99"})
         loop._collect_orphaned_branches = (
             WorkspaceGCLoop._collect_orphaned_branches.__get__(loop)
         )  # type: ignore[attr-defined]
@@ -386,28 +386,28 @@ class TestWorktreeGCSubprocessArgs:
 class TestWorktreeGCErrorHandling:
     @pytest.mark.asyncio
     async def test_api_error_skips_worktree(self, tmp_path: Path) -> None:
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(side_effect=RuntimeError("API failure"))
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
-        assert 42 in state.get_active_worktrees()
+        loop._workspaces.destroy.assert_not_awaited()
+        assert 42 in state.get_active_workspaces()
         assert result["skipped"] == 1
 
     @pytest.mark.asyncio
     async def test_destroy_error_increments_error_count(self, tmp_path: Path) -> None:
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="closed")
-        loop._worktrees.destroy = AsyncMock(side_effect=RuntimeError("destroy failed"))
+        loop._workspaces.destroy = AsyncMock(side_effect=RuntimeError("destroy failed"))
         result = await loop._do_work()
         assert result["errors"] == 1
 
     @pytest.mark.asyncio
     async def test_has_open_pr_error_skips_worktree(self, tmp_path: Path) -> None:
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="open")
         loop._has_open_pr = AsyncMock(side_effect=RuntimeError("PR check failed"))
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
 
 
@@ -415,16 +415,16 @@ class TestWorktreeGCStopEvent:
     @pytest.mark.asyncio
     async def test_stop_event_halts_gc(self, tmp_path: Path) -> None:
         loop, _s, stop = _make_loop(
-            tmp_path, active_worktrees={1: "/p/1", 2: "/p/2", 3: "/p/3"}
+            tmp_path, active_workspaces={1: "/p/1", 2: "/p/2", 3: "/p/3"}
         )
         stop.set()
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["collected"] == 0
 
     @pytest.mark.asyncio
     async def test_stop_event_skips_later_phases(self, tmp_path: Path) -> None:
-        loop, _s, stop = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, _s, stop = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
 
         async def gc_and_stop(issue_number: int) -> str:
             stop.set()
@@ -444,13 +444,13 @@ class TestWorktreeGCOrphanedDirsBudget:
         """Phase 2 stops collecting when budget is exhausted."""
         # Phase 1 collects 18, leaving budget of 2 for Phase 2
         wts = {i: f"/p/issue-{i}" for i in range(1, 19)}
-        loop, _s, _e = _make_loop(tmp_path, active_worktrees=wts)
+        loop, _s, _e = _make_loop(tmp_path, active_workspaces=wts)
         loop._get_issue_state = AsyncMock(return_value="closed")
 
         # Create 5 orphaned dirs — only 2 should be collected (budget = 20 - 18)
         slug = loop._config.repo_slug
         for i in range(100, 105):
-            (loop._config.worktree_base / slug / f"issue-{i}").mkdir(parents=True)
+            (loop._config.workspace_base / slug / f"issue-{i}").mkdir(parents=True)
 
         result = await loop._do_work()
         assert result["collected"] == _MAX_GC_PER_CYCLE  # 18 + 2 = 20
@@ -464,8 +464,8 @@ class TestWorktreeGCOrphanedDirsErrors:
         """A destroy failure for one orphaned dir does not stop processing others."""
         loop, _s, _e = _make_loop(tmp_path)
         slug = loop._config.repo_slug
-        (loop._config.worktree_base / slug / "issue-50").mkdir(parents=True)
-        (loop._config.worktree_base / slug / "issue-51").mkdir(parents=True)
+        (loop._config.workspace_base / slug / "issue-50").mkdir(parents=True)
+        (loop._config.workspace_base / slug / "issue-51").mkdir(parents=True)
 
         loop._get_issue_state = AsyncMock(return_value="closed")
 
@@ -477,7 +477,7 @@ class TestWorktreeGCOrphanedDirsErrors:
             if issue_number == 50:
                 raise RuntimeError("destroy failed")
 
-        loop._worktrees.destroy = fail_then_succeed  # type: ignore[method-assign]
+        loop._workspaces.destroy = fail_then_succeed  # type: ignore[method-assign]
 
         result = await loop._do_work()
         # issue-50 fails, issue-51 succeeds
@@ -496,7 +496,7 @@ class TestWorktreeGCStopEventPhase2:
         loop, _s, stop = _make_loop(tmp_path)
         slug = loop._config.repo_slug
         for i in range(100, 105):
-            (loop._config.worktree_base / slug / f"issue-{i}").mkdir(parents=True)
+            (loop._config.workspace_base / slug / f"issue-{i}").mkdir(parents=True)
 
         call_count = 0
 
@@ -617,22 +617,22 @@ class TestWorktreeGCPipelineProtection:
     async def test_skips_worktree_for_queued_issue(self, tmp_path: Path) -> None:
         """Worktrees for issues still in the pipeline queue are not collected."""
         loop, state, _e = _make_loop(
-            tmp_path, active_worktrees={42: "/p/42"}, pipeline_issues={42}
+            tmp_path, active_workspaces={42: "/p/42"}, pipeline_issues={42}
         )
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
-        assert 42 in state.get_active_worktrees()
+        assert 42 in state.get_active_workspaces()
 
     @pytest.mark.asyncio
     async def test_collects_worktree_not_in_pipeline(self, tmp_path: Path) -> None:
         """Worktrees for issues no longer in the pipeline are collected normally."""
         loop, _s, _e = _make_loop(
-            tmp_path, active_worktrees={42: "/p/42"}, pipeline_issues=set()
+            tmp_path, active_workspaces={42: "/p/42"}, pipeline_issues=set()
         )
         loop._get_issue_state = AsyncMock(return_value="closed")
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_awaited_once_with(42)
+        loop._workspaces.destroy.assert_awaited_once_with(42)
         assert result["collected"] >= 1
 
     @pytest.mark.asyncio
@@ -642,7 +642,7 @@ class TestWorktreeGCPipelineProtection:
         """GitHub labels protect queued issues even if IssueStore callback misses them."""
         loop, state, _e = _make_loop(
             tmp_path,
-            active_worktrees={42: "/p/42"},
+            active_workspaces={42: "/p/42"},
             pipeline_issues=set(),
         )
         loop._get_issue_state = AsyncMock(return_value="open")
@@ -650,18 +650,18 @@ class TestWorktreeGCPipelineProtection:
         loop._has_open_pr = AsyncMock(return_value=False)
 
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["skipped"] == 1
-        assert 42 in state.get_active_worktrees()
+        assert 42 in state.get_active_workspaces()
 
     @pytest.mark.asyncio
     async def test_skips_orphaned_dir_for_pipeline_issue(self, tmp_path: Path) -> None:
         """Orphaned filesystem dirs for pipeline issues are not collected."""
         loop, _s, _e = _make_loop(tmp_path, pipeline_issues={99})
-        orphan = loop._config.worktree_base / loop._config.repo_slug / "issue-99"
+        orphan = loop._config.workspace_base / loop._config.repo_slug / "issue-99"
         orphan.mkdir(parents=True)
         result = await loop._do_work()
-        loop._worktrees.destroy.assert_not_awaited()
+        loop._workspaces.destroy.assert_not_awaited()
         assert result["collected"] == 0
 
     @pytest.mark.asyncio
@@ -683,7 +683,7 @@ class TestGCRemovesBranchStateOnWorktreeCollection:
 
     @pytest.mark.asyncio
     async def test_phase1_removes_branch_entry(self, tmp_path: Path) -> None:
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         state.set_branch(42, "agent/issue-42")
         loop._get_issue_state = AsyncMock(return_value="closed")
         await loop._do_work()
@@ -692,7 +692,7 @@ class TestGCRemovesBranchStateOnWorktreeCollection:
     @pytest.mark.asyncio
     async def test_phase1_noop_when_no_branch_entry(self, tmp_path: Path) -> None:
         """No error when GC'ing a worktree that has no branch entry."""
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         loop._get_issue_state = AsyncMock(return_value="closed")
         await loop._do_work()
         assert state.get_branch(42) is None
@@ -700,7 +700,7 @@ class TestGCRemovesBranchStateOnWorktreeCollection:
     @pytest.mark.asyncio
     async def test_phase1_removes_branch_before_destroy(self, tmp_path: Path) -> None:
         """remove_branch must be called before destroy (crash-safe ordering)."""
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         state.set_branch(42, "agent/issue-42")
         loop._get_issue_state = AsyncMock(return_value="closed")
 
@@ -715,7 +715,7 @@ class TestGCRemovesBranchStateOnWorktreeCollection:
             call_order.append("destroy")
 
         state.remove_branch = tracked_remove_branch  # type: ignore[method-assign]
-        loop._worktrees.destroy = tracked_destroy  # type: ignore[method-assign]
+        loop._workspaces.destroy = tracked_destroy  # type: ignore[method-assign]
         await loop._do_work()
         assert "remove_branch" in call_order
         assert call_order.index("remove_branch") < call_order.index("destroy")
@@ -752,7 +752,7 @@ class TestGCPrunesStaleActiveBranches:
 
     @pytest.mark.asyncio
     async def test_skips_branch_with_active_worktree(self, tmp_path: Path) -> None:
-        loop, state, _e = _make_loop(tmp_path, active_worktrees={42: "/p/42"})
+        loop, state, _e = _make_loop(tmp_path, active_workspaces={42: "/p/42"})
         state.set_branch(42, "agent/issue-42")
         loop._is_safe_to_gc = AsyncMock(return_value=True)
         pruned = await loop._prune_stale_branch_entries()
@@ -846,11 +846,11 @@ class TestCollectOrphanedBranchesPerItemIsolation:
                 raise RuntimeError("callback boom")
             return False
 
-        deps = make_bg_loop_deps(tmp_path, enabled=True, worktree_gc_interval=600)
+        deps = make_bg_loop_deps(tmp_path, enabled=True, workspace_gc_interval=600)
         state = StateTracker(deps.config.state_file)
         loop = WorkspaceGCLoop(
             config=deps.config,
-            worktrees=MagicMock(),
+            workspaces=MagicMock(),
             prs=MagicMock(),
             state=state,
             deps=deps.loop_deps,


### PR DESCRIPTION
## Summary
- Renames config fields (`worktree_base` -> `workspace_base`, `worktree_gc_interval` -> `workspace_gc_interval`), state fields (`active_worktrees` -> `active_workspaces`), model fields (`worktree_path` -> `workspace_path`), and the state mixin (`WorktreeStateMixin` -> `WorkspaceStateMixin`) to match the canonical `WorkspaceManager` class name
- Renames `worktrees` parameter/field to `workspaces` across all phase files, service registry, orchestrator, and background loops
- Renames state mixin file `_worktree.py` -> `_workspace.py` and methods (`set_worktree` -> `set_workspace`, etc.)
- Adds backward-compatible `AliasChoices` for config env vars (`HYDRAFLOW_WORKTREE_GC_INTERVAL`) and state.json fields (`active_worktrees`) so existing deployments continue to work
- Keeps git CLI worktree references (`git worktree add/remove`) and internal `worktree_path` parameters in runners/ports unchanged

Closes #5925

## Test plan
- [x] `make lint` passes (0 errors)
- [x] `make typecheck` passes (0 errors)
- [x] `make security` passes
- [x] 8867 tests pass (5 pre-existing failures unrelated to this change)
- [ ] Existing state.json files load correctly (backward compat via AliasChoices)
- [ ] Config env vars still work with old names (backward compat via AliasChoices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)