### PR TITLE
fix: Use record.repo instead of record.slug when restoring repos

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -158,7 +158,7 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
             repo_cfg = load_runtime_config(
                 overrides={
                     "repo_root": str(repo_path),
-                    **({"repo": record.slug} if record.slug else {}),
+                    **({"repo": record.repo} if record.repo else {}),
                 }
             )
             await registry.register(repo_cfg)


### PR DESCRIPTION
## Summary

- Server restore loop passed `record.slug` (dash-separated, e.g. `T-rav-hydraflow`) as the `repo` config override
- `HydraFlowConfig` validates repo must be `owner/repo` format — caused `ValidationError` on startup
- Fix: use `record.repo` which has the correct format (`T-rav/hydraflow`)

## Test plan

- [x] Start server with stored repos in `.hydraflow/repos.json`
- [x] Verify no `ValidationError` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)