### PR TITLE
feat: Makefile contract validation — language-agnostic quality port

### DIFF
--- a/src/makefile_contract.py
+++ b/src/makefile_contract.py
@@ -1,0 +1,168 @@
+"""Makefile contract validation and repair.
+
+The Makefile is HydraFlow's language-agnostic quality port.  Every target
+repo — regardless of language (Python, Node, C#, Java, Go, Rust, …) — must
+expose the same canonical ``make`` targets so the pipeline can call them
+without knowing the underlying toolchain.
+
+This module provides:
+
+* **REQUIRED_TARGETS** — the canonical contract.
+* **validate()** — check whether a Makefile satisfies the contract.
+* **validate_and_repair()** — validate, and scaffold missing targets when
+  possible (delegates to ``makefile_scaffold.merge_makefile``).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger("hydraflow.makefile_contract")
+
+# ── Contract definition ──────────────────────────────────────────────
+#
+# Every target repo must expose these ``make`` targets.  The pipeline
+# calls them by name — the Makefile recipes are language-specific
+# adapters behind a universal interface.
+#
+# Blocking targets fail the pipeline if they return non-zero.
+# Advisory targets log warnings but do not block.
+
+REQUIRED_TARGETS: tuple[str, ...] = (
+    "lint",
+    "lint-check",
+    "test",
+    "typecheck",
+    "security",
+    "quality-lite",
+    "quality",
+)
+
+OPTIONAL_TARGETS: tuple[str, ...] = (
+    "lint-fix",
+    "help",
+    "smoke",
+    "coverage-check",
+)
+
+
+@dataclass
+class ContractResult:
+    """Outcome of a Makefile contract validation."""
+
+    valid: bool
+    """True when all required targets are present."""
+
+    missing: list[str] = field(default_factory=list)
+    """Required targets that are absent."""
+
+    present: list[str] = field(default_factory=list)
+    """Required targets that are present."""
+
+    optional_missing: list[str] = field(default_factory=list)
+    """Optional targets that are absent (informational)."""
+
+    warnings: list[str] = field(default_factory=list)
+    """Recipe-mismatch warnings from scaffold merge."""
+
+    repaired: bool = False
+    """True when missing targets were scaffolded in-place."""
+
+
+def _parse_target_names(content: str) -> set[str]:
+    """Extract target names from Makefile content (lightweight)."""
+    import re  # noqa: PLC0415
+
+    targets: set[str] = set()
+    for match in re.finditer(
+        r"^([a-zA-Z_][a-zA-Z0-9_-]*)\s*:(?![=:])", content, re.MULTILINE
+    ):
+        targets.add(match.group(1))
+    return targets
+
+
+def validate(worktree_path: Path) -> ContractResult:
+    """Check whether the Makefile in *worktree_path* satisfies the contract.
+
+    Does **not** modify any files — read-only validation.
+    """
+    makefile = worktree_path / "Makefile"
+    if not makefile.is_file():
+        return ContractResult(
+            valid=False,
+            missing=list(REQUIRED_TARGETS),
+            optional_missing=list(OPTIONAL_TARGETS),
+        )
+
+    content = makefile.read_text(encoding="utf-8")
+    targets = _parse_target_names(content)
+
+    missing = [t for t in REQUIRED_TARGETS if t not in targets]
+    present = [t for t in REQUIRED_TARGETS if t in targets]
+    optional_missing = [t for t in OPTIONAL_TARGETS if t not in targets]
+
+    return ContractResult(
+        valid=len(missing) == 0,
+        missing=missing,
+        present=present,
+        optional_missing=optional_missing,
+    )
+
+
+def validate_and_repair(
+    worktree_path: Path,
+    language: str | None = None,
+) -> ContractResult:
+    """Validate the contract and scaffold missing targets if possible.
+
+    When *language* is ``None`` the stack is auto-detected via
+    ``polyglot_prep.detect_prep_stack``.
+
+    Returns a :class:`ContractResult` with ``repaired=True`` when
+    targets were added.
+    """
+    result = validate(worktree_path)
+    if result.valid:
+        return result
+
+    # Resolve language for scaffolding
+    if language is None:
+        from polyglot_prep import detect_prep_stack  # noqa: PLC0415
+
+        language = detect_prep_stack(worktree_path)
+
+    makefile = worktree_path / "Makefile"
+
+    if makefile.is_file():
+        from makefile_scaffold import merge_makefile  # noqa: PLC0415
+
+        content = makefile.read_text(encoding="utf-8")
+        new_content, warnings = merge_makefile(content, language)
+        if new_content != content:
+            makefile.write_text(new_content, encoding="utf-8")
+            logger.info(
+                "Repaired Makefile: added %d missing targets (%s)",
+                len(result.missing),
+                ", ".join(result.missing),
+            )
+        result.warnings = warnings
+    else:
+        from makefile_scaffold import generate_makefile  # noqa: PLC0415
+
+        content = generate_makefile(language)
+        if content:
+            makefile.write_text(content, encoding="utf-8")
+            logger.info("Generated Makefile for %s stack", language)
+        else:
+            logger.warning(
+                "Cannot scaffold Makefile — unsupported language: %s", language
+            )
+            return result
+
+    # Re-validate after repair
+    post = validate(worktree_path)
+    post.repaired = True
+    post.warnings = result.warnings
+    return post

--- a/tests/test_makefile_contract.py
+++ b/tests/test_makefile_contract.py
@@ -1,0 +1,199 @@
+"""Tests for makefile_contract module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from makefile_contract import (
+    OPTIONAL_TARGETS,
+    REQUIRED_TARGETS,
+    ContractResult,
+    validate,
+    validate_and_repair,
+)
+
+
+@pytest.fixture()
+def tmp_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo directory."""
+    return tmp_path
+
+
+class TestContractConstants:
+    """Verify the contract definition is coherent."""
+
+    def test_required_targets_are_nonempty(self) -> None:
+        assert len(REQUIRED_TARGETS) > 0
+
+    def test_quality_in_required(self) -> None:
+        assert "quality" in REQUIRED_TARGETS
+
+    def test_quality_lite_in_required(self) -> None:
+        assert "quality-lite" in REQUIRED_TARGETS
+
+    def test_no_overlap_between_required_and_optional(self) -> None:
+        overlap = set(REQUIRED_TARGETS) & set(OPTIONAL_TARGETS)
+        assert overlap == set()
+
+
+class TestValidate:
+    """Test read-only validation."""
+
+    def test_missing_makefile_fails(self, tmp_repo: Path) -> None:
+        result = validate(tmp_repo)
+
+        assert result.valid is False
+        assert set(result.missing) == set(REQUIRED_TARGETS)
+
+    def test_empty_makefile_fails(self, tmp_repo: Path) -> None:
+        (tmp_repo / "Makefile").write_text("", encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is False
+        assert set(result.missing) == set(REQUIRED_TARGETS)
+
+    def test_complete_makefile_passes(self, tmp_repo: Path) -> None:
+        lines = [f"{t}:\n\techo {t}\n" for t in REQUIRED_TARGETS]
+        (tmp_repo / "Makefile").write_text("\n".join(lines), encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is True
+        assert result.missing == []
+        assert set(result.present) == set(REQUIRED_TARGETS)
+
+    def test_partial_makefile_reports_missing(self, tmp_repo: Path) -> None:
+        content = "lint:\n\techo lint\n\ntest:\n\techo test\n"
+        (tmp_repo / "Makefile").write_text(content, encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is False
+        assert "lint" not in result.missing
+        assert "test" not in result.missing
+        assert "quality" in result.missing
+
+    def test_optional_targets_tracked(self, tmp_repo: Path) -> None:
+        lines = [f"{t}:\n\techo {t}\n" for t in REQUIRED_TARGETS]
+        (tmp_repo / "Makefile").write_text("\n".join(lines), encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is True
+        for opt in OPTIONAL_TARGETS:
+            assert opt in result.optional_missing
+
+    def test_prerequisite_only_targets_detected(self, tmp_repo: Path) -> None:
+        content = (
+            "lint:\n\techo lint\n\n"
+            "lint-check:\n\techo lint-check\n\n"
+            "test:\n\techo test\n\n"
+            "typecheck:\n\techo typecheck\n\n"
+            "security:\n\techo security\n\n"
+            "quality-lite: lint-check typecheck security\n\n"
+            "quality: quality-lite test\n"
+        )
+        (tmp_repo / "Makefile").write_text(content, encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is True
+
+    def test_variable_assignments_not_confused_with_targets(
+        self, tmp_repo: Path
+    ) -> None:
+        content = (
+            "CC := gcc\n"
+            "CFLAGS ::= -Wall\n"
+            "lint:\n\techo lint\n\n"
+            "lint-check:\n\techo lint-check\n\n"
+            "test:\n\techo test\n\n"
+            "typecheck:\n\techo typecheck\n\n"
+            "security:\n\techo security\n\n"
+            "quality-lite: lint-check typecheck security\n\n"
+            "quality: quality-lite test\n"
+        )
+        (tmp_repo / "Makefile").write_text(content, encoding="utf-8")
+
+        result = validate(tmp_repo)
+
+        assert result.valid is True
+        assert "CC" not in result.present
+
+
+class TestValidateAndRepair:
+    """Test validation with auto-repair."""
+
+    def test_repair_generates_makefile_for_python(self, tmp_repo: Path) -> None:
+        (tmp_repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        result = validate_and_repair(tmp_repo)
+
+        assert result.repaired is True
+        assert (tmp_repo / "Makefile").is_file()
+
+        post = validate(tmp_repo)
+        assert post.valid is True
+
+    def test_repair_merges_missing_targets(self, tmp_repo: Path) -> None:
+        (tmp_repo / "Makefile").write_text(
+            "lint:\n\truff check . --fix\n", encoding="utf-8"
+        )
+        (tmp_repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        result = validate_and_repair(tmp_repo, language="python")
+
+        assert result.repaired is True
+        content = (tmp_repo / "Makefile").read_text()
+        assert "quality:" in content
+        assert "typecheck:" in content
+
+    def test_repair_preserves_existing_targets(self, tmp_repo: Path) -> None:
+        original = "lint:\n\tmy-custom-linter .\n"
+        (tmp_repo / "Makefile").write_text(original, encoding="utf-8")
+        (tmp_repo / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        validate_and_repair(tmp_repo, language="python")
+
+        content = (tmp_repo / "Makefile").read_text()
+        assert "my-custom-linter" in content
+
+    def test_already_valid_returns_not_repaired(self, tmp_repo: Path) -> None:
+        lines = [f"{t}:\n\techo {t}\n" for t in REQUIRED_TARGETS]
+        (tmp_repo / "Makefile").write_text("\n".join(lines), encoding="utf-8")
+
+        result = validate_and_repair(tmp_repo, language="python")
+
+        assert result.valid is True
+        assert result.repaired is False
+
+    def test_unsupported_language_no_makefile(self, tmp_repo: Path) -> None:
+        result = validate_and_repair(tmp_repo, language="brainfuck")
+
+        assert result.valid is False
+        assert result.repaired is False
+
+    def test_explicit_language_skips_detection(self, tmp_repo: Path) -> None:
+        (tmp_repo / "package.json").write_text('{"name":"x"}')
+
+        result = validate_and_repair(tmp_repo, language="node")
+
+        assert result.repaired is True
+        content = (tmp_repo / "Makefile").read_text()
+        assert "eslint" in content
+
+
+class TestContractResult:
+    """Test ContractResult dataclass."""
+
+    def test_default_values(self) -> None:
+        result = ContractResult(valid=True)
+
+        assert result.missing == []
+        assert result.present == []
+        assert result.optional_missing == []
+        assert result.warnings == []
+        assert result.repaired is False


### PR DESCRIPTION
## Summary

- Adds `makefile_contract.py` — formalizes the Makefile as HydraFlow's language-agnostic quality port
- Defines `REQUIRED_TARGETS` (lint, lint-check, test, typecheck, security, quality-lite, quality) as the universal contract every target repo must satisfy
- `validate()` — read-only contract check, returns missing/present targets
- `validate_and_repair()` — validates then auto-scaffolds missing targets via existing `makefile_scaffold.merge_makefile()` for any supported language (Python, Node, C#, Java, Go, Rust, Ruby, Rails, C++)
- 18 unit tests covering: missing Makefile, empty Makefile, partial targets, complete contract, prerequisite-only targets, variable assignments, repair for Python/Node, preservation of custom recipes

## Architecture

The Makefile is the hexagonal port between HydraFlow's pipeline and language-specific toolchains:

```
Pipeline (make quality)  ←→  Makefile (port)  ←→  ruff/pyright/bandit (Python adapter)
                                               ←→  eslint/tsc/npm-audit (Node adapter)  
                                               ←→  dotnet format/build/test (C# adapter)
                                               ←→  ... any language
```

This module makes the contract explicit and enforceable at runtime — not just during prep scaffolding.

## Related Issues

- #6045 — Promote audit skills to built-in post-implementation checks
- #6046 — Static import-direction checker
- #6052 — Promote prompt instructions to code-level enforcement

## Test plan

- [ ] 18/18 unit tests pass
- [ ] Lint, typecheck, security all clean
- [ ] Contract validation can be wired into implement phase pre-flight (follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)