### PR TITLE
fix: add missing dashboard interval bounds for 7 background workers

### DIFF
--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -45,6 +45,13 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "repo_wiki": (300, 604800),
     "diagnostic": (10, 3600),
     "sentry_ingest": (60, 86400),
+    "report_issue": (10, 3600),
+    "epic_monitor": (60, 86400),
+    "epic_sweeper": (600, 86400),
+    "workspace_gc": (300, 86400),
+    "runs_gc": (300, 86400),
+    "health_monitor": (60, 86400),
+    "bot_pr": (60, 86400),
 }
 
 # Internal pipeline labels that must not be treated as epic names in the history panel.

--- a/tests/test_loop_wiring_completeness.py
+++ b/tests/test_loop_wiring_completeness.py
@@ -28,14 +28,6 @@ SRC = Path(__file__).resolve().parent.parent / "src"
 # are managed through a different mechanism (e.g. not dashboard-editable).
 # ---------------------------------------------------------------------------
 _INTERVAL_BOUNDS_SKIP: set[str] = {
-    "report_issue",
-    "epic_monitor",
-    "epic_sweeper",
-    "workspace_gc",
-    "runs_gc",
-    "health_monitor",
-    "bot_pr",
-    "sentry_ingest",
     "github_cache",
 }
 


### PR DESCRIPTION
## Summary
- Added `_INTERVAL_BOUNDS` entries for `report_issue`, `epic_monitor`, `epic_sweeper`, `workspace_gc`, `runs_gc`, `health_monitor`, and `bot_pr`
- These 7 workers had configurable intervals via env vars but couldn't be adjusted at runtime through the dashboard
- Removed the now-unnecessary `_INTERVAL_BOUNDS_SKIP` entries in the wiring completeness test

## Test plan
- [x] `test_loop_wiring_completeness.py` — all 5 tests pass
- [x] `test_dashboard_routes_common.py` — all 42 tests pass
- [ ] Verify dashboard interval adjustment works for newly added workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)