### PR TITLE
fix: play button doesn't toggle to stop for selected repo

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1389,6 +1389,7 @@ export function HydraFlowProvider({ children }) {
   const startOrchestrator = useCallback(async () => {
     if (state.selectedRepoSlug) {
       const result = await startRuntime(state.selectedRepoSlug)
+      if (result.ok) await refreshControlStatus()
       return result.ok
     }
     try {
@@ -1404,6 +1405,7 @@ export function HydraFlowProvider({ children }) {
   const stopOrchestrator = useCallback(async () => {
     if (state.selectedRepoSlug) {
       const result = await stopRuntime(state.selectedRepoSlug)
+      if (result.ok) await refreshControlStatus()
       return result.ok
     }
     try {


### PR DESCRIPTION
## Summary
- When a repo is selected, `startOrchestrator`/`stopOrchestrator` delegate to `startRuntime`/`stopRuntime` but never called `refreshControlStatus()` afterward
- This left `orchestratorStatus` stuck on `idle`, so the Header button never switched from Start → Stop
- Added `refreshControlStatus()` call after successful runtime start/stop to sync the button state

## Test plan
- [x] All 92 HydraFlowContext tests pass
- [x] All 79 Header + SessionSidebar tests pass
- [x] quality-lite passes (lint, typecheck, security)
- [ ] Manual: select a repo, click Start → verify button shows Stop
- [ ] Manual: click Stop → verify button shows Start

🤖 Generated with [Claude Code](https://claude.com/claude-code)