### PR TITLE
fix: prevent agent image build race with base image

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "Dockerfile.agent"
-      - "Dockerfile.agent-base"
       - "scripts/docker-smoke-test.sh"
   pull_request:
     branches: [main]


### PR DESCRIPTION
## Summary
- Remove `Dockerfile.agent-base` from the push trigger paths in `build-agent-image.yml`
- When the base Dockerfile changes on main, both workflows fired simultaneously — the agent image build pulled the stale base image (pre-rebuild) and failed the `bd --version` smoke test
- The `workflow_run` trigger already correctly rebuilds the agent image after the base image completes
- PR paths still include `Dockerfile.agent-base` since the `base-changed` detection forces a full from-scratch build

## Test plan
- [ ] Verify CI passes on this PR (the workflow change itself doesn't affect PR builds)
- [ ] After merge, push a change to `Dockerfile.agent-base` and confirm only the base image workflow triggers on push (agent image triggers via workflow_run after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)