### PR TITLE
chore: Remove monocle stop hook from settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -180,10 +180,6 @@
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/hf.cleanup-code-change-marker.sh",
             "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash -c 'set -a && source \"$CLAUDE_PROJECT_DIR\"/.env && set +a && python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/monocle_hook.py'"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Removes the `monocle_hook.py` Stop handler from `.claude/settings.json`
- No longer needed since monocle-apptrace is installed directly in agent Docker images (#6188)

## Test plan
- [x] Quality-lite checks pass (lint, typecheck, security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)