### PR TITLE
feat: planner LikeC4 diagrams + /tmp flow to worktree

### DIFF
--- a/src/planner.py
+++ b/src/planner.py
@@ -441,11 +441,11 @@ class PlannerRunner(BaseRunner):
 Do NOT run any commands that change state (no git commit, no installs).
 
 You MAY write architecture diagram files to `/tmp/hydraflow-diagrams/issue-{issue.id}/`
-using the Write tool. Use LikeC4 (.likec4) or Mermaid (.md) format to capture the code
-topology around the change area. These files will be copied into the implementation
+using the Write tool. Use LikeC4 (.likec4) format to capture the code topology around
+the change area — C4 structural diagrams (context, container, component) and dynamic
+views for request/data flows. These files will be copied into the implementation
 worktree and attached to the issue comment so the implementer has full architectural
-context. Also include the diagram inline in your plan as a ```mermaid code block so it
-renders on GitHub.
+context.
 
 Your job: explore code, map the relevant architecture, and produce a concrete implementation plan.
 
@@ -469,9 +469,8 @@ Use semantic tools first (before grep):
 1. Restate the issue in your own words.
 2. Explore relevant code with semantic tools.
 3. Map the code topology — trace call graphs, data flows, and component boundaries.
-   Write diagram files to `/tmp/hydraflow-diagrams/issue-{issue.id}/` (LikeC4 or Mermaid).
-   Also include a `## Code Topology` section in your plan with a ```mermaid code block
-   showing the relevant components and relationships (this renders on GitHub).
+   Write LikeC4 diagram files (.likec4) to `/tmp/hydraflow-diagrams/issue-{issue.id}/`
+   capturing the C4 model (specification, model, views) for the change area.
 4. Identify concrete file-level deltas.
 5. Build a Task Graph with dependency-ordered phases (full plans only).
 6. Write behavioral test specs for each phase — describe observable outcomes, not test code.

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -182,15 +182,14 @@ async def test_build_prompt_includes_read_only_instructions(config, event_bus, i
 
 @pytest.mark.asyncio
 async def test_build_prompt_includes_diagram_instructions(config, event_bus, issue):
-    """Planner should be told to write diagrams to /tmp and include inline Mermaid."""
+    """Planner should be told to write LikeC4 diagrams to /tmp."""
     runner = _make_runner(config, event_bus)
     task = issue.to_task()
     prompt, _ = await runner._build_prompt_with_stats(task)
 
     assert "/tmp/hydraflow-diagrams/" in prompt
-    assert "Code Topology" in prompt
-    assert "mermaid" in prompt
-    assert "Mermaid" in prompt
+    assert "LikeC4" in prompt
+    assert ".likec4" in prompt
 
 
 @pytest.mark.asyncio
@@ -2317,14 +2316,17 @@ class TestDiagramHelpers:
         assert "```likec4" in result
         assert "model { }" in result
 
-    def test_collect_diagram_attachments_markdown(self, tmp_path, monkeypatch) -> None:
+    def test_collect_diagram_attachments_markdown_passthrough(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Markdown files are included raw (no wrapping code fence)."""
         monkeypatch.setattr(PlannerRunner, "DIAGRAM_TMP_ROOT", tmp_path)
         d = tmp_path / "issue-2"
         d.mkdir()
-        (d / "flow.md").write_text("```mermaid\ngraph LR\n  A-->B\n```")
+        (d / "notes.md").write_text("# Architecture Notes\nSome context.")
 
         result = PlannerRunner.collect_diagram_attachments(2)
-        assert "```mermaid" in result
+        assert "# Architecture Notes" in result
 
     def test_copy_diagrams_to_workspace(self, tmp_path, monkeypatch) -> None:
         monkeypatch.setattr(PlannerRunner, "DIAGRAM_TMP_ROOT", tmp_path / "diag")


### PR DESCRIPTION
## Summary
- Planner writes LikeC4 C4 architecture diagrams to `/tmp/hydraflow-diagrams/issue-{N}/` during planning
- `plan_phase.py` reads those files and attaches them as code blocks in the plan comment on the GitHub issue
- `implement_phase.py` copies diagram files into `docs/architecture/` in the worktree before the agent runs, then cleans up `/tmp`
- Implementer gets diagrams both in the plan comment text AND as files on disk in the worktree
- Planner prompt updated: LikeC4 only (no Mermaid), Write allowed for `/tmp` only, Edit still blocked

## Test plan
- [x] 188 tests pass (planner + agent_cli)
- [x] `make quality-lite` passes
- [x] 8 new diagram helper tests (collect, copy, cleanup, edge cases)
- [ ] Integration: run planner on a real issue and verify diagrams appear in comment + worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)