### PR TITLE
fix: update bd init flag from --mode server to --server

### DIFF
--- a/src/beads_manager.py
+++ b/src/beads_manager.py
@@ -98,14 +98,12 @@ class BeadsManager:
     async def init(self, cwd: Path) -> None:
         """Initialize a beads project in *cwd* (idempotent).
 
-        Uses ``--mode server`` to avoid the embedded Dolt CGO requirement.
+        Uses ``--server`` to avoid the embedded Dolt CGO requirement.
         Server mode uses a Dolt SQL server backend which works in all
         environments including Docker containers built without CGO.
         """
         try:
-            await run_subprocess(
-                "bd", "init", "--mode", "server", cwd=cwd, timeout=30.0
-            )
+            await run_subprocess("bd", "init", "--server", cwd=cwd, timeout=30.0)
         except FileNotFoundError as exc:
             raise BeadsNotInstalledError() from exc
 

--- a/tests/test_beads_manager.py
+++ b/tests/test_beads_manager.py
@@ -99,7 +99,7 @@ async def test_init_success(manager):
         mock_run.return_value = "Initialized"
         await manager.init(Path("/repo"))
         mock_run.assert_called_once_with(
-            "bd", "init", "--mode", "server", cwd=Path("/repo"), timeout=30.0
+            "bd", "init", "--server", cwd=Path("/repo"), timeout=30.0
         )
 
 


### PR DESCRIPTION
## Summary
- The `bd` CLI replaced `--mode server` with `--server` as a standalone flag
- Updated `beads_manager.py` and its test to use the new flag
- Fixes plan phase failures: `Error: unknown flag: --mode`

## Test plan
- [x] Unit test updated to match new flag
- [ ] Verify plan phase no longer errors on `bd init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)