### PR TITLE
Fixes #6057: Add arch-compliance as blocking BUILTIN_SKILL for per-...

### DIFF
--- a/.claude/commands/hf.arch-compliance.md
+++ b/.claude/commands/hf.arch-compliance.md
@@ -1,0 +1,79 @@
+# Architecture Compliance Check
+
+Review the current branch diff for architectural boundary violations. This is a lightweight, per-PR complement to the full `/hf.audit-architecture` sweep. It does not modify files.
+
+## When to Use
+
+- After implementing changes, before committing
+- When adding new imports or dependencies between modules
+- When you want to verify architectural boundaries are respected
+
+## Instructions
+
+1. Get the diff of changes on the current branch:
+   ```bash
+   git diff origin/main...HEAD
+   ```
+   If that's empty, fall back to `git diff` (unstaged) or `git diff --cached` (staged).
+
+2. Review the diff against the HydraFlow layer model:
+
+   ```
+   Layer 4 — Infrastructure/Adapters (I/O, external systems)
+     pr_manager.py, worktree.py, merge_conflict_resolver.py,
+     post_merge_handler.py, dashboard.py, dashboard_routes/
+
+   Layer 3 — Runners (subprocess orchestration, agent invocation)
+     base_runner.py, agent.py, planner.py, reviewer.py,
+     hitl_runner.py, triage_runner.py, runner_utils.py,
+     skill_registry.py, diff_sanity.py, scope_check.py,
+     test_adequacy.py, plan_compliance.py, arch_compliance.py
+
+   Layer 2 — Application (phase coordination, workflow orchestration)
+     orchestrator.py, plan_phase.py, implement_phase.py, review_phase.py,
+     triage_phase.py, hitl_phase.py, phase_utils.py, pr_unsticker.py,
+     base_background_loop.py, *_loop.py (background loops)
+
+   Layer 1 — Domain (pure data, business rules, no I/O)
+     models.py, config.py
+
+   Cross-cutting (available to all, imports only from Domain):
+     events.py, state/
+
+   Composition root (imports from ALL layers — exempt from direction checks):
+     service_registry.py
+   ```
+
+3. Check for these five violation categories:
+
+   - **Layer boundary violations** — New imports that go upward (Layer N importing Layer N+1)
+   - **New coupling** — Phase importing another phase, runner importing another runner
+   - **Domain pollution** — Infrastructure types leaking into `models.py` or `config.py`
+   - **Missing abstraction** — New concrete dependency that should go through a protocol/port
+   - **Bypass detection** — Direct `subprocess.run`, `httpx.get`, `open()` in application/runner layers
+
+4. For each violation found, note the file path, line, severity, and suggested fix.
+
+5. Produce structured output:
+
+If all checks pass:
+```
+ARCH_COMPLIANCE_RESULT: OK
+SUMMARY: No violations found
+```
+
+If violations are found:
+```
+ARCH_COMPLIANCE_RESULT: RETRY
+SUMMARY: <comma-separated list of violation categories found>
+VIOLATIONS:
+- [SEVERITY] file:line - violation description - suggested fix
+```
+
+## Important
+
+- Do NOT modify any files. This is a read-only review.
+- Only flag clear violations — be conservative to avoid false positives.
+- Do NOT flag `service_registry.py` for cross-layer imports (it is the composition root).
+- Do NOT flag existing code that was not changed in the diff.
+- This complements the static `make layer-check` — focus on judgment-based issues.

--- a/src/arch_compliance.py
+++ b/src/arch_compliance.py
@@ -1,0 +1,119 @@
+"""Architecture Compliance skill — diff-focused architectural boundary check.
+
+Lightweight, per-PR complement to the full ``/hf.audit-architecture`` sweep.
+Checks the branch diff for layer violations, coupling, domain pollution,
+missing abstractions, and infrastructure bypass using LLM judgment.
+
+Complements (does not duplicate) the static ``make layer-check`` (#6048).
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def build_arch_compliance_prompt(
+    *, issue_number: int, issue_title: str, diff: str, **_kwargs: object
+) -> str:
+    """Build a prompt that asks an agent to review a diff for architecture violations."""
+    return f"""You are running the Architecture Compliance Check skill for issue #{issue_number}: {issue_title}.
+
+Review the git diff below and check for architectural violations against the HydraFlow layer model.
+
+## HydraFlow Layer Model
+
+The codebase has four layers. Dependencies MUST flow inward only (higher layers depend on lower layers, never the reverse):
+
+```
+Layer 4 — Infrastructure/Adapters (I/O, external systems)
+  pr_manager.py, worktree.py, merge_conflict_resolver.py,
+  post_merge_handler.py, dashboard.py, dashboard_routes/
+
+Layer 3 — Runners (subprocess orchestration, agent invocation)
+  base_runner.py, agent.py, planner.py, reviewer.py,
+  hitl_runner.py, triage_runner.py, runner_utils.py,
+  skill_registry.py, diff_sanity.py, scope_check.py,
+  test_adequacy.py, plan_compliance.py, arch_compliance.py
+
+Layer 2 — Application (phase coordination, workflow orchestration)
+  orchestrator.py, plan_phase.py, implement_phase.py, review_phase.py,
+  triage_phase.py, hitl_phase.py, phase_utils.py, pr_unsticker.py,
+  base_background_loop.py, *_loop.py (background loops)
+
+Layer 1 — Domain (pure data, business rules, no I/O)
+  models.py, config.py
+
+Cross-cutting (available to all, imports only from Domain):
+  events.py, state/
+
+Composition root (imports from ALL layers — exempt from direction checks):
+  service_registry.py
+```
+
+**Dependency direction rule:** A module at Layer N may import from layers 1..N but NEVER from layer N+1 or above. Cross-cutting modules may import from Layer 1 only. ``service_registry.py`` is the composition root and is exempt from direction checks.
+
+## Violation Categories
+
+Check for these five categories:
+
+1. **Layer boundary violations** — New imports that go upward (Layer N importing Layer N+1). Example: a runner importing from ``pr_manager`` (Layer 3→4).
+2. **New coupling** — Phase importing another phase, runner importing another runner, infrastructure module used directly in application layer.
+3. **Domain pollution** — Infrastructure types (HTTP responses, subprocess results, file handles) leaking into ``models.py`` or ``config.py``.
+4. **Missing abstraction** — New concrete dependency that should go through a protocol/port.
+5. **Bypass detection** — Direct ``subprocess.run``, ``httpx.get``, ``open()`` in application/runner layers instead of through infrastructure adapters.
+
+## Diff
+
+```diff
+{diff}
+```
+
+## Instructions
+
+- Only flag clear violations that are unambiguously architectural problems.
+- Do NOT flag ``service_registry.py`` for cross-layer imports — it is the composition root.
+- Do NOT flag existing code that was not changed in this diff.
+- Do NOT modify any files. This is a read-only review.
+- Be conservative: when in doubt, pass. False positives block the pipeline.
+- This skill complements the static ``make layer-check`` — focus on judgment-based issues that static tools cannot detect (coupling patterns, adapter thickness, interface design).
+
+## Required Output
+
+If all checks pass:
+ARCH_COMPLIANCE_RESULT: OK
+SUMMARY: No violations found
+
+If violations are found:
+ARCH_COMPLIANCE_RESULT: RETRY
+SUMMARY: <comma-separated list of violation categories found>
+VIOLATIONS:
+- [SEVERITY] file:line - violation description - suggested fix
+"""
+
+
+def parse_arch_compliance_result(transcript: str) -> tuple[bool, str, list[str]]:
+    """Parse the structured output from an architecture compliance check transcript.
+
+    Returns ``(passed, summary, findings)``.
+    """
+    status_match = re.search(
+        r"ARCH_COMPLIANCE_RESULT:\s*(OK|RETRY)", transcript, re.IGNORECASE
+    )
+    if not status_match:
+        return True, "No explicit result marker", []
+
+    passed = status_match.group(1).upper() == "OK"
+    summary_match = re.search(r"SUMMARY:\s*(.+)", transcript, re.IGNORECASE)
+    summary = summary_match.group(1).strip() if summary_match else ""
+
+    findings: list[str] = []
+    findings_match = re.search(
+        r"VIOLATIONS:\s*\n((?:\s*-\s*.+\n?)+)", transcript, re.IGNORECASE
+    )
+    if findings_match:
+        for line in findings_match.group(1).splitlines():
+            stripped = line.strip().lstrip("- ").strip()
+            if stripped:
+                findings.append(stripped)
+
+    return passed, summary, findings

--- a/src/config.py
+++ b/src/config.py
@@ -79,6 +79,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         3,
     ),
     ("max_diff_sanity_attempts", "HYDRAFLOW_MAX_DIFF_SANITY_ATTEMPTS", 1),
+    ("max_arch_compliance_attempts", "HYDRAFLOW_MAX_ARCH_COMPLIANCE_ATTEMPTS", 1),
     ("max_scope_check_attempts", "HYDRAFLOW_MAX_SCOPE_CHECK_ATTEMPTS", 1),
     ("max_test_adequacy_attempts", "HYDRAFLOW_MAX_TEST_ADEQUACY_ATTEMPTS", 1),
     ("max_plan_compliance_attempts", "HYDRAFLOW_MAX_PLAN_COMPLIANCE_ATTEMPTS", 1),
@@ -394,6 +395,12 @@ class HydraFlowConfig(BaseModel):
         ge=0,
         le=3,
         description="Max diff sanity check passes (0 = disabled)",
+    )
+    max_arch_compliance_attempts: int = Field(
+        default=1,
+        ge=0,
+        le=3,
+        description="Max architecture compliance check passes (0 = disabled)",
     )
     max_scope_check_attempts: int = Field(
         default=1,

--- a/src/skill_registry.py
+++ b/src/skill_registry.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
+from arch_compliance import build_arch_compliance_prompt, parse_arch_compliance_result
 from diff_sanity import build_diff_sanity_prompt, parse_diff_sanity_result
 from plan_compliance import build_plan_compliance_prompt, parse_plan_compliance_result
 from scope_check import build_scope_check_prompt, parse_scope_check_result
@@ -66,6 +67,14 @@ BUILTIN_SKILLS: list[AgentSkill] = [
         blocking=True,
         prompt_builder=build_diff_sanity_prompt,
         result_parser=parse_diff_sanity_result,
+    ),
+    AgentSkill(
+        name="arch-compliance",
+        purpose="Check diff for architectural layer violations, coupling, domain pollution, missing abstractions, and infrastructure bypass",
+        config_key="max_arch_compliance_attempts",
+        blocking=True,
+        prompt_builder=build_arch_compliance_prompt,
+        result_parser=parse_arch_compliance_result,
     ),
     AgentSkill(
         name="scope-check",

--- a/tests/test_arch_compliance.py
+++ b/tests/test_arch_compliance.py
@@ -1,0 +1,113 @@
+"""Tests for arch_compliance module — prompt builder and result parser."""
+
+from __future__ import annotations
+
+from arch_compliance import build_arch_compliance_prompt, parse_arch_compliance_result
+
+
+class TestBuildArchCompliancePrompt:
+    def test_includes_issue_context(self) -> None:
+        prompt = build_arch_compliance_prompt(
+            issue_number=42, issue_title="Fix the widget", diff="--- a/f\n+++ b/f"
+        )
+        assert "#42" in prompt
+        assert "Fix the widget" in prompt
+
+    def test_includes_diff(self) -> None:
+        diff = "+import os\n-import sys"
+        prompt = build_arch_compliance_prompt(
+            issue_number=1, issue_title="T", diff=diff
+        )
+        assert diff in prompt
+
+    def test_includes_structured_output_markers(self) -> None:
+        prompt = build_arch_compliance_prompt(issue_number=1, issue_title="T", diff="")
+        assert "ARCH_COMPLIANCE_RESULT: OK" in prompt
+        assert "ARCH_COMPLIANCE_RESULT: RETRY" in prompt
+
+    def test_includes_layer_model(self) -> None:
+        prompt = build_arch_compliance_prompt(issue_number=1, issue_title="T", diff="")
+        assert "Layer 1" in prompt
+        assert "Layer 2" in prompt
+        assert "Layer 3" in prompt
+        assert "Layer 4" in prompt
+        # Key modules must be assigned to layers
+        assert "models.py" in prompt
+        assert "config.py" in prompt
+        assert "orchestrator.py" in prompt
+        assert "base_runner.py" in prompt
+        assert "pr_manager.py" in prompt
+        assert "service_registry.py" in prompt
+
+    def test_checks_five_violation_categories(self) -> None:
+        prompt = build_arch_compliance_prompt(issue_number=1, issue_title="T", diff="")
+        # All five categories from the issue spec
+        assert "layer boundary" in prompt.lower() or "Layer boundary" in prompt
+        assert "coupling" in prompt.lower()
+        assert "pollution" in prompt.lower()
+        assert "abstraction" in prompt.lower()
+        assert "bypass" in prompt.lower() or "Bypass" in prompt
+
+    def test_accepts_extra_kwargs(self) -> None:
+        """Prompt builder should accept **_kwargs for forward compatibility."""
+        prompt = build_arch_compliance_prompt(
+            issue_number=1, issue_title="T", diff="", plan_text="some plan"
+        )
+        assert isinstance(prompt, str)
+
+    def test_mentions_service_registry_exemption(self) -> None:
+        """service_registry.py is the composition root and exempt from layer checks."""
+        prompt = build_arch_compliance_prompt(issue_number=1, issue_title="T", diff="")
+        assert "service_registry" in prompt
+        assert "composition root" in prompt.lower() or "exempt" in prompt.lower()
+
+    def test_conservative_language(self) -> None:
+        """Prompt should include conservative guidance to avoid false positives."""
+        prompt = build_arch_compliance_prompt(issue_number=1, issue_title="T", diff="")
+        assert "clear violation" in prompt.lower() or "only flag" in prompt.lower()
+
+
+class TestParseArchComplianceResult:
+    def test_ok_result(self) -> None:
+        transcript = "ARCH_COMPLIANCE_RESULT: OK\nSUMMARY: No violations found"
+        passed, summary, findings = parse_arch_compliance_result(transcript)
+        assert passed is True
+        assert summary == "No violations found"
+        assert findings == []
+
+    def test_retry_result_with_violations(self) -> None:
+        transcript = (
+            "ARCH_COMPLIANCE_RESULT: RETRY\n"
+            "SUMMARY: layer boundary violation, bypass detection\n"
+            "VIOLATIONS:\n"
+            "- [HIGH] src/planner.py:15 - imports pr_manager (Layer 3→4) - use port instead\n"
+            "- [MEDIUM] src/review_phase.py:42 - direct subprocess.run - use runner adapter\n"
+        )
+        passed, summary, findings = parse_arch_compliance_result(transcript)
+        assert passed is False
+        assert "layer boundary" in summary
+        assert len(findings) == 2
+        assert "planner.py" in findings[0]
+
+    def test_missing_marker_defaults_to_pass(self) -> None:
+        passed, summary, findings = parse_arch_compliance_result("no markers here")
+        assert passed is True
+        assert findings == []
+
+    def test_retry_without_violations_section(self) -> None:
+        transcript = "ARCH_COMPLIANCE_RESULT: RETRY\nSUMMARY: coupling detected"
+        passed, summary, findings = parse_arch_compliance_result(transcript)
+        assert passed is False
+        assert summary == "coupling detected"
+        assert findings == []
+
+    def test_case_insensitive_marker(self) -> None:
+        transcript = "arch_compliance_result: ok\nsummary: all clean"
+        passed, summary, _ = parse_arch_compliance_result(transcript)
+        assert passed is True
+        assert summary == "all clean"
+
+    def test_empty_transcript(self) -> None:
+        passed, summary, findings = parse_arch_compliance_result("")
+        assert passed is True
+        assert findings == []

--- a/tests/test_skill_registry.py
+++ b/tests/test_skill_registry.py
@@ -12,7 +12,7 @@ from skill_registry import (
 
 class TestAgentSkill:
     def test_builtin_skills_count(self):
-        assert len(BUILTIN_SKILLS) == 4
+        assert len(BUILTIN_SKILLS) == 5
 
     def test_diff_sanity_skill(self):
         skill = BUILTIN_SKILLS[0]
@@ -22,8 +22,16 @@ class TestAgentSkill:
         assert callable(skill.prompt_builder)
         assert callable(skill.result_parser)
 
-    def test_scope_check_skill(self):
+    def test_arch_compliance_skill(self):
         skill = BUILTIN_SKILLS[1]
+        assert skill.name == "arch-compliance"
+        assert skill.blocking is True
+        assert skill.config_key == "max_arch_compliance_attempts"
+        assert callable(skill.prompt_builder)
+        assert callable(skill.result_parser)
+
+    def test_scope_check_skill(self):
+        skill = BUILTIN_SKILLS[2]
         assert skill.name == "scope-check"
         assert skill.blocking is True
         assert skill.config_key == "max_scope_check_attempts"
@@ -31,7 +39,7 @@ class TestAgentSkill:
         assert callable(skill.result_parser)
 
     def test_plan_compliance_skill(self):
-        skill = BUILTIN_SKILLS[2]
+        skill = BUILTIN_SKILLS[3]
         assert skill.name == "plan-compliance"
         assert skill.blocking is False
         assert skill.config_key == "max_plan_compliance_attempts"
@@ -39,7 +47,7 @@ class TestAgentSkill:
         assert callable(skill.result_parser)
 
     def test_test_adequacy_skill(self):
-        skill = BUILTIN_SKILLS[3]
+        skill = BUILTIN_SKILLS[4]
         assert skill.name == "test-adequacy"
         assert skill.blocking is False
         assert skill.config_key == "max_test_adequacy_attempts"
@@ -61,13 +69,14 @@ class TestGetSkills:
     def test_modifying_copy_doesnt_affect_builtin(self):
         skills = get_skills()
         skills.clear()
-        assert len(BUILTIN_SKILLS) == 4
+        assert len(BUILTIN_SKILLS) == 5
 
 
 class TestFormatSkillsForPrompt:
     def test_includes_all_skills(self):
         result = format_skills_for_prompt(get_skills())
         assert "diff-sanity" in result
+        assert "arch-compliance" in result
         assert "scope-check" in result
         assert "plan-compliance" in result
         assert "test-adequacy" in result
@@ -111,8 +120,16 @@ class TestSkillPromptBuilders:
         assert "issue #42" in prompt.lower() or "#42" in prompt
         assert "diff" in prompt.lower()
 
-    def test_scope_check_builder(self):
+    def test_arch_compliance_builder(self):
         skill = BUILTIN_SKILLS[1]
+        prompt = skill.prompt_builder(
+            issue_number=57, issue_title="Arch check", diff="+ import pr_manager"
+        )
+        assert "#57" in prompt
+        assert "Layer" in prompt
+
+    def test_scope_check_builder(self):
+        skill = BUILTIN_SKILLS[2]
         prompt = skill.prompt_builder(
             issue_number=55,
             issue_title="Add scope",
@@ -123,7 +140,7 @@ class TestSkillPromptBuilders:
         assert "src/foo.py" in prompt
 
     def test_scope_check_builder_no_plan(self):
-        skill = BUILTIN_SKILLS[1]
+        skill = BUILTIN_SKILLS[2]
         prompt = skill.prompt_builder(
             issue_number=55,
             issue_title="Add scope",
@@ -133,7 +150,7 @@ class TestSkillPromptBuilders:
         assert "SCOPE_CHECK_RESULT: OK" in prompt
 
     def test_plan_compliance_builder_with_plan(self):
-        skill = BUILTIN_SKILLS[2]
+        skill = BUILTIN_SKILLS[3]
         prompt = skill.prompt_builder(
             issue_number=50,
             issue_title="Add feature",
@@ -144,7 +161,7 @@ class TestSkillPromptBuilders:
         assert "File Delta" in prompt
 
     def test_plan_compliance_builder_without_plan(self):
-        skill = BUILTIN_SKILLS[2]
+        skill = BUILTIN_SKILLS[3]
         prompt = skill.prompt_builder(
             issue_number=50,
             issue_title="Add feature",
@@ -154,7 +171,7 @@ class TestSkillPromptBuilders:
         assert prompt == ""
 
     def test_test_adequacy_builder(self):
-        skill = BUILTIN_SKILLS[3]
+        skill = BUILTIN_SKILLS[4]
         prompt = skill.prompt_builder(
             issue_number=99, issue_title="Add tests", diff="+ test code"
         )
@@ -181,8 +198,25 @@ class TestSkillResultParsers:
         assert passed is False
         assert len(findings) == 1
 
-    def test_scope_check_parser_ok(self):
+    def test_arch_compliance_parser_ok(self):
         skill = BUILTIN_SKILLS[1]
+        passed, summary, findings = skill.result_parser(
+            "ARCH_COMPLIANCE_RESULT: OK\nSUMMARY: No violations found"
+        )
+        assert passed is True
+        assert findings == []
+
+    def test_arch_compliance_parser_retry(self):
+        skill = BUILTIN_SKILLS[1]
+        passed, summary, findings = skill.result_parser(
+            "ARCH_COMPLIANCE_RESULT: RETRY\nSUMMARY: layer violation\n"
+            "VIOLATIONS:\n- [HIGH] src/planner.py:15 - imports pr_manager"
+        )
+        assert passed is False
+        assert len(findings) == 1
+
+    def test_scope_check_parser_ok(self):
+        skill = BUILTIN_SKILLS[2]
         passed, summary, unplanned = skill.result_parser(
             "SCOPE_CHECK_RESULT: OK\nSUMMARY: All planned"
         )
@@ -190,7 +224,7 @@ class TestSkillResultParsers:
         assert unplanned == []
 
     def test_scope_check_parser_retry(self):
-        skill = BUILTIN_SKILLS[1]
+        skill = BUILTIN_SKILLS[2]
         passed, summary, unplanned = skill.result_parser(
             "SCOPE_CHECK_RESULT: RETRY\nSUMMARY: scope creep\n"
             "UNPLANNED_FILES:\n- [FAIL] src/x.py — unrelated"
@@ -199,7 +233,7 @@ class TestSkillResultParsers:
         assert len(unplanned) == 1
 
     def test_plan_compliance_parser_ok(self):
-        skill = BUILTIN_SKILLS[2]
+        skill = BUILTIN_SKILLS[3]
         passed, summary, findings = skill.result_parser(
             "PLAN_COMPLIANCE_RESULT: OK\nSUMMARY: Matches plan"
         )
@@ -207,7 +241,7 @@ class TestSkillResultParsers:
         assert findings == []
 
     def test_plan_compliance_parser_retry(self):
-        skill = BUILTIN_SKILLS[2]
+        skill = BUILTIN_SKILLS[3]
         passed, summary, findings = skill.result_parser(
             "PLAN_COMPLIANCE_RESULT: RETRY\nSUMMARY: scope creep\n"
             "FINDINGS:\n- src/extra.py — unplanned"
@@ -216,14 +250,14 @@ class TestSkillResultParsers:
         assert len(findings) == 1
 
     def test_test_adequacy_parser_ok(self):
-        skill = BUILTIN_SKILLS[3]
+        skill = BUILTIN_SKILLS[4]
         passed, summary, gaps = skill.result_parser(
             "TEST_ADEQUACY_RESULT: OK\nSUMMARY: All covered"
         )
         assert passed is True
 
     def test_test_adequacy_parser_retry(self):
-        skill = BUILTIN_SKILLS[3]
+        skill = BUILTIN_SKILLS[4]
         passed, summary, gaps = skill.result_parser(
             "TEST_ADEQUACY_RESULT: RETRY\nSUMMARY: missing tests\nGAPS:\n- src/bar.py:func — needs test"
         )


### PR DESCRIPTION
## Summary

Closes #6057.

## Issue

Add arch-compliance as blocking BUILTIN_SKILL for per-PR checks

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow