### PR TITLE
Fixes #6076: "ConversationTurn.source field never populated"

### DIFF
--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -470,7 +470,7 @@ class ShapePhase:
         # Source 2: GitHub comments (authoritative, works for all channels)
         enriched = await self._store.enrich_with_comments(issue)
         reply = self._find_human_reply(enriched.comments or [])
-        if reply:
+        if reply is not None:
             return (reply, "github")
         return None
 

--- a/tests/test_shape_conversation.py
+++ b/tests/test_shape_conversation.py
@@ -78,11 +78,13 @@ class TestConversationStateModel:
                     content="Go deeper on B",
                     timestamp="t2",
                     signal="positive",
+                    source="github",
                 ),
             ],
         )
         assert len(conv.turns) == 2
         assert conv.turns[1].signal == "positive"
+        assert conv.turns[1].source == "github"
 
 
 class TestFinalizeDetection:


### PR DESCRIPTION
## Summary

Closes #6076.

## Issue

"ConversationTurn.source field never populated"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow