### PR TITLE
Fixes #6229: "labels_must_not_be_empty validator missing parked_lab...

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1528,6 +1528,8 @@ class HydraFlowConfig(BaseModel):
         "shape_label",
         "planner_label",
         "verify_label",
+        "parked_label",
+        "diagnose_label",
     )
     @classmethod
     def labels_must_not_be_empty(cls, v: list[str]) -> list[str]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -241,6 +241,8 @@ class ConfigFactory:
         verify_label: list[str] | None = None,
         find_label: list[str] | None = None,
         planner_label: list[str] | None = None,
+        parked_label: list[str] | None = None,
+        diagnose_label: list[str] | None = None,
         planner_tool: Literal["claude", "codex", "pi"] = "claude",
         planner_model: str = "opus",
         triage_tool: Literal["claude", "codex", "pi"] = "claude",
@@ -444,6 +446,12 @@ class ConfigFactory:
                 planner_label=planner_label
                 if planner_label is not None
                 else ["hydraflow-plan"],
+                parked_label=parked_label
+                if parked_label is not None
+                else ["hydraflow-parked"],
+                diagnose_label=diagnose_label
+                if diagnose_label is not None
+                else ["hydraflow-diagnose"],
                 planner_tool=planner_tool,
                 planner_model=planner_model,
                 triage_tool=triage_tool,

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1180,6 +1180,8 @@ class TestLabelValidation:
             "epic_child_label",
             "find_label",
             "planner_label",
+            "parked_label",
+            "diagnose_label",
         ],
     )
     def test_empty_label_list_raises_validation_error(
@@ -1630,6 +1632,22 @@ class TestLabelsMustNotBeEmpty:
         with pytest.raises(ValidationError):
             ConfigFactory.create(repo_root=tmp_path / "repo", review_label=[])
 
+    def test_rejects_empty_parked_label(self, tmp_path: Path) -> None:
+        from pydantic import ValidationError
+
+        from tests.helpers import ConfigFactory
+
+        with pytest.raises(ValidationError):
+            ConfigFactory.create(repo_root=tmp_path / "repo", parked_label=[])
+
+    def test_rejects_empty_diagnose_label(self, tmp_path: Path) -> None:
+        from pydantic import ValidationError
+
+        from tests.helpers import ConfigFactory
+
+        with pytest.raises(ValidationError):
+            ConfigFactory.create(repo_root=tmp_path / "repo", diagnose_label=[])
+
     def test_accepts_non_empty_labels(self, tmp_path: Path) -> None:
         from tests.helpers import ConfigFactory
 
@@ -1640,6 +1658,22 @@ class TestLabelsMustNotBeEmpty:
         )
         assert cfg.ready_label == ["valid"]
         assert cfg.review_label == ["valid"]
+
+    def test_accepts_custom_parked_label(self, tmp_path: Path) -> None:
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path / "repo", parked_label=["custom-parked"]
+        )
+        assert cfg.parked_label == ["custom-parked"]
+
+    def test_accepts_custom_diagnose_label(self, tmp_path: Path) -> None:
+        from tests.helpers import ConfigFactory
+
+        cfg = ConfigFactory.create(
+            repo_root=tmp_path / "repo", diagnose_label=["custom-diagnose"]
+        )
+        assert cfg.diagnose_label == ["custom-diagnose"]
 
 
 class TestAgentToolFields:


### PR DESCRIPTION
## Summary

Closes #6229.

## Issue

"labels_must_not_be_empty validator missing parked_label and diagnose_label"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow