### PR TITLE
Fixes #6211: "metrics_manager.py append_jsonl calls lack file locking"

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -14,7 +14,7 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, Field, ValidationError
 
-from file_util import append_jsonl, atomic_write
+from file_util import append_jsonl, atomic_write, file_lock
 
 
 class _Counter:
@@ -140,8 +140,10 @@ class EventLog:
 
     def _append_sync(self, line: str) -> None:
         """Synchronous append — called via ``asyncio.to_thread``."""
+        lock_path = self._path.with_suffix(".lock")
         try:
-            append_jsonl(self._path, line)
+            with file_lock(lock_path):
+                append_jsonl(self._path, line)
         except OSError:
             logger.warning(
                 "Could not append to event log %s",

--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -162,9 +162,11 @@ class HarnessInsightStore:
         """Append *record* as a JSON line to ``harness_failures.jsonl``."""
         if not self._hindsight:
             try:
-                from file_util import append_jsonl  # noqa: PLC0415
+                from file_util import append_jsonl, file_lock  # noqa: PLC0415
 
-                append_jsonl(self._failures_path, record.model_dump_json())
+                lock_path = self._failures_path.with_suffix(".lock")
+                with file_lock(lock_path):
+                    append_jsonl(self._failures_path, record.model_dump_json())
             except OSError:
                 logger.warning(
                     "Could not append failure to %s",
@@ -434,6 +436,8 @@ async def auto_file_suggestions(
 
         import json as _json  # noqa: PLC0415
 
+        from file_util import append_jsonl, file_lock  # noqa: PLC0415
+
         suggestions_path = config.data_path("memory", "harness_suggestions.jsonl")
         suggestions_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -453,8 +457,9 @@ async def auto_file_suggestions(
                     "suggestion": suggestion.suggestion,
                     "timestamp": datetime.now(UTC).isoformat(),
                 }
-                with suggestions_path.open("a") as f:
-                    f.write(_json.dumps(rec) + "\n")
+                lock_path = suggestions_path.with_suffix(".lock")
+                with file_lock(lock_path):
+                    append_jsonl(suggestions_path, _json.dumps(rec))
                 store.mark_pattern_proposed(key)
                 logger.warning(
                     "Harness insight: %s (%d occurrences)",

--- a/src/metrics_manager.py
+++ b/src/metrics_manager.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
+from file_util import append_jsonl, file_lock
 from models import MetricsSnapshot, MetricsSyncResult, QueueStats
 from pr_manager import PRManager
 from state import StateTracker
@@ -112,11 +113,11 @@ class MetricsManager:
         """Append a snapshot to the local JSONL cache file."""
         cache_dir = self._cache_dir
         snapshots_file = cache_dir / "snapshots.jsonl"
+        lock_file = cache_dir / ".snapshots.lock"
         try:
-            from file_util import append_jsonl  # noqa: PLC0415
-
             cache_dir.mkdir(parents=True, exist_ok=True)
-            append_jsonl(snapshots_file, snapshot.model_dump_json())
+            with file_lock(lock_file):
+                append_jsonl(snapshots_file, snapshot.model_dump_json())
             logger.debug("Metrics snapshot cached locally at %s", snapshots_file)
         except OSError:
             logger.warning(

--- a/src/retrospective.py
+++ b/src/retrospective.py
@@ -236,9 +236,11 @@ class RetrospectiveCollector:
         """Append a JSON line to the retrospective log."""
         if not self._hindsight:
             try:
-                from file_util import append_jsonl  # noqa: PLC0415
+                from file_util import append_jsonl, file_lock  # noqa: PLC0415
 
-                append_jsonl(self._retro_path, entry.model_dump_json())
+                lock_path = self._retro_path.with_suffix(".lock")
+                with file_lock(lock_path):
+                    append_jsonl(self._retro_path, entry.model_dump_json())
             except OSError:
                 logger.warning(
                     "Could not append to retrospective log %s",

--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -230,9 +230,11 @@ class ReviewInsightStore:
         """Append *record* as a JSON line to ``reviews.jsonl``."""
         if not self._hindsight:
             try:
-                from file_util import append_jsonl  # noqa: PLC0415
+                from file_util import append_jsonl, file_lock  # noqa: PLC0415
 
-                append_jsonl(self._reviews_path, record.model_dump_json())
+                lock_path = self._reviews_path.with_suffix(".lock")
+                with file_lock(lock_path):
+                    append_jsonl(self._reviews_path, record.model_dump_json())
             except OSError:
                 logger.warning(
                     "Could not append review to %s",

--- a/tests/test_event_persistence.py
+++ b/tests/test_event_persistence.py
@@ -270,8 +270,8 @@ class TestEventLogRotation:
 
         await log.rotate(max_size_bytes=1, max_age_days=7)
 
-        # Only the events.jsonl file should remain
-        files = list(tmp_path.iterdir())
+        # Only the events.jsonl file (and its lock file) should remain
+        files = [f for f in tmp_path.iterdir() if f.suffix != ".lock"]
         assert len(files) == 1
         assert files[0].name == "events.jsonl"
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1240,3 +1240,60 @@ class TestEventLogMaybeRotate:
         # Simulate by making the file disappear between checks
         log_path.unlink()
         assert await event_log.maybe_rotate() is False
+
+
+# ---------------------------------------------------------------------------
+# File locking tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppendSyncFileLocking:
+    """Verify _append_sync acquires file_lock before append_jsonl."""
+
+    def test_append_sync_acquires_file_lock(self, tmp_path: Path) -> None:
+        """_append_sync wraps append_jsonl inside file_lock."""
+        from events import EventLog
+
+        log_path = tmp_path / "events.jsonl"
+        event_log = EventLog(log_path)
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("events.file_lock", return_value=FakeLock()),
+            patch("events.append_jsonl", fake_append),
+        ):
+            event_log._append_sync('{"type":"test"}')
+
+        assert call_order == ["lock_enter", "append_jsonl", "lock_exit"]
+
+    def test_append_sync_lock_path_is_sibling(self, tmp_path: Path) -> None:
+        """Lock file is a sibling of the JSONL file with .lock suffix."""
+        from events import EventLog
+
+        log_path = tmp_path / "events.jsonl"
+        event_log = EventLog(log_path)
+
+        lock_path_used = None
+
+        with (
+            patch("events.file_lock") as mock_lock,
+            patch("events.append_jsonl"),
+        ):
+            mock_lock.return_value.__enter__ = lambda s: s
+            mock_lock.return_value.__exit__ = lambda s, *a: None
+            event_log._append_sync('{"type":"test"}')
+            lock_path_used = mock_lock.call_args[0][0]
+
+        assert lock_path_used == tmp_path / "events.lock"

--- a/tests/test_harness_insights.py
+++ b/tests/test_harness_insights.py
@@ -585,6 +585,96 @@ class TestAppendFailureOSError:
 
 
 # ---------------------------------------------------------------------------
+# File locking tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppendFailureFileLocking:
+    """Verify append_failure acquires file_lock before append_jsonl."""
+
+    def test_append_failure_acquires_file_lock(self, tmp_path) -> None:
+        """append_failure wraps append_jsonl inside file_lock."""
+        from unittest.mock import patch
+
+        store = HarnessInsightStore(tmp_path / "memory")
+        record = _make_record()
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("file_util.file_lock", return_value=FakeLock()),
+            patch("file_util.append_jsonl", fake_append),
+        ):
+            store.append_failure(record)
+
+        assert call_order == ["lock_enter", "append_jsonl", "lock_exit"]
+
+
+class TestAutoFileSuggestionsFileLocking:
+    """Verify auto_file_suggestions acquires file_lock before writing."""
+
+    @pytest.mark.asyncio
+    async def test_auto_file_suggestions_uses_file_lock(self, tmp_path) -> None:
+        """auto_file_suggestions wraps append_jsonl inside file_lock."""
+        from unittest.mock import patch
+
+        from harness_insights import auto_file_suggestions
+
+        store = HarnessInsightStore(tmp_path / "memory")
+        config = ConfigFactory.create(repo_root=tmp_path)
+
+        # Write enough records to trigger a suggestion
+        failures_path = tmp_path / "memory" / "harness_failures.jsonl"
+        failures_path.parent.mkdir(parents=True, exist_ok=True)
+
+        for i in range(5):
+            rec = FailureRecord(
+                issue_number=i,
+                category=FailureCategory.QUALITY_GATE,
+                details="ruff lint error",
+                timestamp=f"2026-01-0{i + 1}T00:00:00Z",
+            )
+            with failures_path.open("a") as f:
+                f.write(rec.model_dump_json() + "\n")
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("file_util.file_lock", return_value=FakeLock()),
+            patch("file_util.append_jsonl", fake_append),
+        ):
+            await auto_file_suggestions(store, config)
+
+        # Should have at least one lock cycle
+        if call_order:
+            assert call_order[0] == "lock_enter"
+            assert "append_jsonl" in call_order
+            assert call_order[-1] == "lock_exit"
+
+
+# ---------------------------------------------------------------------------
 # FailureRecord timestamp validation (issue #1048)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metrics_manager.py
+++ b/tests/test_metrics_manager.py
@@ -507,5 +507,68 @@ class TestLoadLocalHistoryOSError:
 
 
 # ---------------------------------------------------------------------------
+# TestFileLocking
+# ---------------------------------------------------------------------------
+
+
+class TestFileLocking:
+    """Verify _save_to_local_cache acquires file_lock before append_jsonl."""
+
+    def test_save_to_local_cache_acquires_file_lock(
+        self, state, event_bus, tmp_path
+    ) -> None:
+        """_save_to_local_cache wraps append_jsonl inside file_lock."""
+        mgr, _, _, _ = make_manager(
+            state, event_bus, state_file=tmp_path / "state.json"
+        )
+        snapshot = MetricsSnapshot(timestamp="2025-01-01T00:00:00")
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("metrics_manager.file_lock", return_value=FakeLock()),
+            patch("metrics_manager.append_jsonl", fake_append),
+        ):
+            mgr._save_to_local_cache(snapshot)
+
+        assert call_order == ["lock_enter", "append_jsonl", "lock_exit"]
+
+    def test_lock_file_path_is_sibling_of_snapshots(
+        self, state, event_bus, tmp_path
+    ) -> None:
+        """The lock file used is in the same directory as snapshots.jsonl."""
+        mgr, _, _, _ = make_manager(
+            state, event_bus, state_file=tmp_path / "state.json"
+        )
+        snapshot = MetricsSnapshot(timestamp="2025-01-01T00:00:00")
+
+        lock_path_used = None
+
+        with (
+            patch("metrics_manager.file_lock") as mock_lock,
+            patch("metrics_manager.append_jsonl"),
+        ):
+            mock_lock.return_value.__enter__ = lambda s: s
+            mock_lock.return_value.__exit__ = lambda s, *a: None
+            mgr._save_to_local_cache(snapshot)
+            lock_path_used = mock_lock.call_args[0][0]
+
+        expected_dir = tmp_path / "metrics" / "test-owner-test-repo"
+        assert lock_path_used.parent == expected_dir
+        assert lock_path_used.name == ".snapshots.lock"
+
+
+# ---------------------------------------------------------------------------
 # TestMetricsIssueOptIn
 # ---------------------------------------------------------------------------

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -846,6 +846,45 @@ class TestAppendEntryOSError:
 
 
 # ---------------------------------------------------------------------------
+# File locking tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppendEntryFileLocking:
+    """Verify _append_entry acquires file_lock before append_jsonl."""
+
+    def test_append_entry_acquires_file_lock(self, config: HydraFlowConfig) -> None:
+        """_append_entry wraps append_jsonl inside file_lock."""
+        collector, _, _ = _make_collector(config)
+        entry = RetrospectiveEntry(
+            issue_number=42,
+            pr_number=100,
+            timestamp="2026-02-20T10:30:00Z",
+        )
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("file_util.file_lock", return_value=FakeLock()),
+            patch("file_util.append_jsonl", fake_append),
+        ):
+            collector._append_entry(entry)
+
+        assert call_order == ["lock_enter", "append_jsonl", "lock_exit"]
+
+
+# ---------------------------------------------------------------------------
 # Hindsight dual-write tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_review_insights.py
+++ b/tests/test_review_insights.py
@@ -535,6 +535,43 @@ class TestAppendReviewOSError:
 
 
 # ---------------------------------------------------------------------------
+# File locking tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppendReviewFileLocking:
+    """Verify append_review acquires file_lock before append_jsonl."""
+
+    def test_append_review_acquires_file_lock(self, tmp_path) -> None:
+        """append_review wraps append_jsonl inside file_lock."""
+        from unittest.mock import patch
+
+        store = ReviewInsightStore(tmp_path / "memory")
+        record = _make_record(categories=["missing_tests"])
+
+        call_order: list[str] = []
+
+        class FakeLock:
+            def __enter__(self_lock):
+                call_order.append("lock_enter")
+                return self_lock
+
+            def __exit__(self_lock, *args):
+                call_order.append("lock_exit")
+
+        def fake_append(path, data):
+            call_order.append("append_jsonl")
+
+        with (
+            patch("file_util.file_lock", return_value=FakeLock()),
+            patch("file_util.append_jsonl", fake_append),
+        ):
+            store.append_review(record)
+
+        assert call_order == ["lock_enter", "append_jsonl", "lock_exit"]
+
+
+# ---------------------------------------------------------------------------
 # ReviewRecord timestamp validation (issue #1048)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #6211.

## Issue

"metrics_manager.py append_jsonl calls lack file locking"

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow