### PR TITLE
Fixes #6214: Migrate _write_adr_decision to append_jsonl for crash-...

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from adr_pre_validator import ADRPreValidator, ADRValidationResult
 from adr_utils import ADR_FILE_RE
 from agent_cli import build_lightweight_command
+from file_util import append_jsonl
 from models import ADRCouncilResult, CouncilVerdict, CouncilVote
 from subprocess_util import make_clean_env, run_subprocess
 
@@ -31,18 +32,16 @@ def _write_adr_decision(
     """Write an ADR decision to adr_decisions.jsonl."""
     try:
         path = config.data_path("memory", "adr_decisions.jsonl")
-        path.parent.mkdir(parents=True, exist_ok=True)
         rec = {
             "title": title,
             "body": body,
             "type": decision_type,
             "timestamp": datetime.now(UTC).isoformat(),
         }
-        with path.open("a") as f:
-            f.write(_json.dumps(rec) + "\n")
+        append_jsonl(path, _json.dumps(rec))
         logger.info("ADR decision recorded: %s", title)
     except OSError:
-        logger.debug("Failed to write ADR decision", exc_info=True)
+        logger.warning("Failed to write ADR decision", exc_info=True)
 
 
 # Valid statuses are single words: Proposed, Accepted, Superseded, Deprecated, Rejected.

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -2469,3 +2469,52 @@ class TestADRCouncilReviewerCredentials:
         )
         assert reviewer._credentials is creds
         assert reviewer._credentials.gh_token == "test-token-xyz"
+
+
+class TestWriteAdrDecision:
+    """Tests for _write_adr_decision using append_jsonl."""
+
+    def test_calls_append_jsonl_with_correct_args(self, tmp_path: Path) -> None:
+        """_write_adr_decision delegates to append_jsonl with path and JSON."""
+        import json
+
+        from adr_reviewer import _write_adr_decision
+
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        expected_path = config.data_path("memory", "adr_decisions.jsonl")
+
+        with patch("adr_reviewer.append_jsonl") as mock_append:
+            _write_adr_decision(config, "My ADR", "body text", "accepted")
+
+        mock_append.assert_called_once()
+        call_path, call_data = mock_append.call_args[0]
+        assert call_path == expected_path
+        rec = json.loads(call_data)
+        assert rec["title"] == "My ADR"
+        assert rec["body"] == "body text"
+        assert rec["type"] == "accepted"
+        assert "timestamp" in rec
+
+    def test_logs_warning_on_oserror(self, tmp_path: Path) -> None:
+        """_write_adr_decision logs warning when append_jsonl raises OSError."""
+        from adr_reviewer import _write_adr_decision
+
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+
+        with (
+            patch("adr_reviewer.append_jsonl", side_effect=OSError("disk full")),
+            patch("adr_reviewer.logger") as mock_logger,
+        ):
+            _write_adr_decision(config, "Fail ADR", "body", "accepted")
+
+        mock_logger.warning.assert_called()
+
+    def test_does_not_propagate_oserror(self, tmp_path: Path) -> None:
+        """_write_adr_decision swallows OSError without propagating."""
+        from adr_reviewer import _write_adr_decision
+
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+
+        with patch("adr_reviewer.append_jsonl", side_effect=OSError("fail")):
+            # Should not raise
+            _write_adr_decision(config, "Fail ADR", "body", "accepted")


### PR DESCRIPTION
## Summary

Closes #6214.

## Issue

Migrate _write_adr_decision to append_jsonl for crash-safe writes

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow