### PR TITLE
chore: post-merge cleanup for in-process tracing + diagnostics

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -1185,7 +1185,7 @@ SUMMARY: <one-line summary>
             existing: list[dict] = []
             if results_path.exists():
                 try:
-                    existing = _json.loads(results_path.read_text())
+                    existing = _json.loads(results_path.read_text(encoding="utf-8"))
                 except (ValueError, OSError):
                     existing = []
             existing.append(
@@ -1197,7 +1197,7 @@ SUMMARY: <one-line summary>
                     "blocking": blocking,
                 }
             )
-            results_path.write_text(_json.dumps(existing, indent=2))
+            results_path.write_text(_json.dumps(existing, indent=2), encoding="utf-8")
         except Exception:
             logger.warning(
                 "Failed to append skill result for %s", skill_name, exc_info=True

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -260,7 +260,7 @@ class BaseRunner:
         dedup_items_removed = 0
         dedup_chars_saved = 0
 
-        if self._hindsight and query_context:
+        if self._hindsight is not None and query_context:
             from hindsight import Bank, format_memories_as_markdown, recall_safe
 
             max_chars = self._config.max_memory_prompt_chars

--- a/src/dashboard_routes/_diagnostics_routes.py
+++ b/src/dashboard_routes/_diagnostics_routes.py
@@ -194,10 +194,10 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
     @router.get("/issue/{issue}/{phase}")
     def issue_phase(issue: int, phase: str) -> list[dict[str, Any]]:
         if not _PHASE_PATTERN.fullmatch(phase):
-            return []
+            raise HTTPException(status_code=404, detail="not found")
         phase_dir = _safe_traces_subdir(config.data_root, issue, phase)
         if phase_dir is None or not phase_dir.is_dir():
-            return []
+            raise HTTPException(status_code=404, detail="not found")
         summaries: list[dict[str, Any]] = []
         for run_dir in sorted(phase_dir.iterdir()):
             if not run_dir.is_dir() or not run_dir.name.startswith("run-"):

--- a/src/trace_collector.py
+++ b/src/trace_collector.py
@@ -354,6 +354,6 @@ class TraceCollector:
         )
         out_dir.mkdir(parents=True, exist_ok=True)
         out_path = out_dir / f"subprocess-{self._subprocess_idx}.json"
-        out_path.write_text(trace.model_dump_json(indent=2))
+        out_path.write_text(trace.model_dump_json(indent=2), encoding="utf-8")
 
         return trace

--- a/src/trace_mining_loop.py
+++ b/src/trace_mining_loop.py
@@ -118,7 +118,9 @@ class TraceMiningLoop(BaseBackgroundLoop):
                     # Mark as crashed since the run never called end_trace_run
                     crashed_summary = summary.model_copy(update={"crashed": True})
                     summary_path = run_dir / "summary.json"
-                    summary_path.write_text(crashed_summary.model_dump_json(indent=2))
+                    summary_path.write_text(
+                        crashed_summary.model_dump_json(indent=2), encoding="utf-8"
+                    )
             except Exception:
                 logger.warning(
                     "Failed to finalize orphan run %s", run_dir, exc_info=True
@@ -150,7 +152,9 @@ class TraceMiningLoop(BaseBackgroundLoop):
                 continue
 
             try:
-                summary = TraceSummary.model_validate_json(summary_path.read_text())
+                summary = TraceSummary.model_validate_json(
+                    summary_path.read_text(encoding="utf-8")
+                )
             except Exception:
                 logger.warning(
                     "Skipping malformed summary at %s", summary_path, exc_info=True
@@ -220,7 +224,9 @@ class TraceMiningLoop(BaseBackgroundLoop):
                 continue
 
             try:
-                summary = TraceSummary.model_validate_json(summary_path.read_text())
+                summary = TraceSummary.model_validate_json(
+                    summary_path.read_text(encoding="utf-8")
+                )
             except Exception:
                 logger.warning(
                     "Skipping malformed summary at %s", summary_path, exc_info=True

--- a/src/trace_rollup.py
+++ b/src/trace_rollup.py
@@ -45,7 +45,9 @@ def write_phase_rollup(
     traces: list[SubprocessTrace] = []
     for path in subprocess_files:
         try:
-            traces.append(SubprocessTrace.model_validate_json(path.read_text()))
+            traces.append(
+                SubprocessTrace.model_validate_json(path.read_text(encoding="utf-8"))
+            )
         except Exception:
             logger.warning("Skipping malformed subprocess trace: %s", path)
 
@@ -59,7 +61,7 @@ def write_phase_rollup(
         try:
             import json  # noqa: PLC0415
 
-            loaded = json.loads(skill_results_path.read_text())
+            loaded = json.loads(skill_results_path.read_text(encoding="utf-8"))
             if isinstance(loaded, list):
                 skill_results = loaded
         except Exception:
@@ -74,12 +76,12 @@ def write_phase_rollup(
     )
 
     summary_path = run_dir / "summary.json"
-    summary_path.write_text(summary.model_dump_json(indent=2))
+    summary_path.write_text(summary.model_dump_json(indent=2), encoding="utf-8")
 
     # Update the latest pointer atomically (temp write + replace)
     latest_path = run_dir.parent / "latest"
     latest_tmp = run_dir.parent / "latest.tmp"
-    latest_tmp.write_text(f"run-{run_id}\n")
+    latest_tmp.write_text(f"run-{run_id}\n", encoding="utf-8")
     latest_tmp.replace(latest_path)
 
     # Append to factory_metrics.jsonl for the diagnostics dashboard

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -306,7 +306,7 @@ export const BACKGROUND_WORKERS = [
   { key: 'ci_monitor', label: 'CI Monitor', description: 'Detects failing CI on main and files/auto-closes issues.', color: theme.yellow, group: 'repo_health', tags: ['quality'] },
   { key: 'security_patch', label: 'Security Patch', description: 'Polls Dependabot alerts and files issues for fixable vulnerabilities.', color: theme.red, group: 'repo_health', tags: ['security'] },
   { key: 'code_grooming', label: 'Code Grooming', description: 'Runs periodic audit scans and files issues for critical findings.', color: theme.accent, group: 'repo_health', tags: ['quality'] },
-  { key: 'trace_mining', label: 'Trace Mining', description: 'Parses Monocle traces, aggregates tool/token stats, and syncs insights to Hindsight.', color: theme.accent, group: 'learning', tags: ['observability'] },
+  { key: 'trace_mining', label: 'Trace Mining', description: 'Aggregates in-process subprocess traces, rolls up tool/token/skill stats per phase run, and syncs insights to Hindsight.', color: theme.accent, group: 'learning', tags: ['observability'] },
   { key: 'repo_wiki', label: 'Repo Wiki', description: 'Lints and maintains per-repo knowledge wikis compiled from plan/implement/review cycles.', color: theme.purple, group: 'learning', tags: ['knowledge'] },
   { key: 'diagnostic', label: 'Diagnostic Agent', description: 'Analyzes escalated issues, classifies severity, and attempts targeted fixes before HITL.', color: theme.blue, system: true, group: 'operations', tags: ['recovery'] },
 ]

--- a/tests/test_dashboard_routes_diagnostics.py
+++ b/tests/test_dashboard_routes_diagnostics.py
@@ -160,10 +160,17 @@ class TestDiagnosticsIssueDrillEndpoints:
 
     def test_issue_phase_rejects_non_canonical_phase(self, app: FastAPI) -> None:
         client = TestClient(app)
-        # Uppercase / space is not in the [a-z_-]+ pattern
+        # Uppercase / space is not in the [a-z_-]+ pattern. Matches the
+        # drill-down sibling's 404 behavior so consumers get a consistent
+        # error signal for bad phase names.
         response = client.get("/api/diagnostics/issue/42/Plan%20A")
-        assert response.status_code == 200
-        assert response.json() == []
+        assert response.status_code == 404
+
+    def test_issue_phase_missing_dir_returns_404(self, app: FastAPI) -> None:
+        """A valid phase name with no on-disk directory returns 404."""
+        client = TestClient(app)
+        response = client.get("/api/diagnostics/issue/999/implement")
+        assert response.status_code == 404
 
     def test_issue_phase_run_rejects_non_canonical_phase(self, app: FastAPI) -> None:
         client = TestClient(app)
@@ -187,16 +194,12 @@ class TestPathTraversalProtection:
 
     def test_phase_traversal_blocked_at_router_level(self, app: FastAPI) -> None:
         """FastAPI/starlette normalizes ``..`` before routing, so a traversal
-        attempt never reaches the handler — any non-2xx or empty response is
-        acceptable; what matters is that no file outside the traces root is
-        read.
+        attempt never reaches the handler. The phase-list endpoint now
+        raises 404 on bad phases to match the drill-down sibling.
         """
         client = TestClient(app)
         response = client.get("/api/diagnostics/issue/42/..%2F..%2Fetc")
-        # Router rejects it (404) OR handler rejects it (200 + empty list)
-        assert response.status_code in (200, 404)
-        if response.status_code == 200:
-            assert response.json() == []
+        assert response.status_code == 404
 
     def test_phase_run_traversal_blocked_at_router_level(self, app: FastAPI) -> None:
         client = TestClient(app)


### PR DESCRIPTION
## Summary

Post-merge review of #6190 (in-process tracing) and #6193 (Factory Diagnostics) caught four real issues that slipped through development review. All small, all mechanical.

1. **`base_runner._inject_memory` violated the Avoided Pattern from CLAUDE.md.** Uses `if self._hindsight and …` — the exact falsy check #6254 fixed everywhere else. Now `self._hindsight is not None and …`.

2. **`trace_mining` worker description in the dashboard sidebar still referenced Monocle.** The Monocle collector was removed; the operator-visible description now reads: *"Aggregates in-process subprocess traces, rolls up tool/token/skill stats per phase run, and syncs insights to Hindsight."*

3. **Missing `encoding="utf-8"` on 8 `Path.write_text()`/`read_text()` calls in the tracing/rollup path.** The `_diagnostics_routes.py` side already used `encoding="utf-8"` but the tracing backend files didn't — inconsistent locale behavior on non-UTF-8 hosts. Fixed across `trace_collector.py`, `trace_rollup.py`, `trace_mining_loop.py`, and `agent.py::_append_skill_result`.

4. **`/api/diagnostics/issue/{issue}/{phase}` returned `200 + []` on bad phase patterns** while the drill-down sibling `/{run_id}` raised 404 on the same input. Consumers couldn't distinguish "no runs yet" from "you asked with a nonsense phase name." Both endpoints now raise `HTTPException(404)` for consistency. Updated the affected test and added a new test covering the missing-directory path.

## Test plan

- [x] `python -m ruff check src/ tests/` — clean
- [x] `python -m pyright` on touched files — 0 errors
- [x] `python -m pytest tests/` — **9511 passed, 4 skipped, 0 failures**
- [x] Diagnostics/tracing suites specifically — 60 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)