### PR TITLE
fix: always write JSONL for insights (dual-write)

### DIFF
--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -160,18 +160,18 @@ class HarnessInsightStore:
 
     def append_failure(self, record: FailureRecord) -> None:
         """Append *record* as a JSON line to ``harness_failures.jsonl``."""
-        if self._hindsight is None:
-            try:
-                from file_util import append_jsonl  # noqa: PLC0415
+        try:
+            from file_util import append_jsonl  # noqa: PLC0415
 
-                append_jsonl(self._failures_path, record.model_dump_json())
-            except OSError:
-                logger.warning(
-                    "Could not append failure to %s",
-                    self._failures_path,
-                    exc_info=True,
-                )
-        else:
+            append_jsonl(self._failures_path, record.model_dump_json())
+        except OSError:
+            logger.warning(
+                "Could not append failure to %s",
+                self._failures_path,
+                exc_info=True,
+            )
+
+        if self._hindsight is not None:
             from hindsight import Bank, schedule_retain  # noqa: PLC0415
 
             schedule_retain(

--- a/src/retrospective.py
+++ b/src/retrospective.py
@@ -248,18 +248,18 @@ class RetrospectiveCollector:
 
     def _append_entry(self, entry: RetrospectiveEntry) -> None:
         """Append a JSON line to the retrospective log."""
-        if self._hindsight is None:
-            try:
-                from file_util import append_jsonl  # noqa: PLC0415
+        try:
+            from file_util import append_jsonl  # noqa: PLC0415
 
-                append_jsonl(self._retro_path, entry.model_dump_json())
-            except OSError:
-                logger.warning(
-                    "Could not append to retrospective log %s",
-                    self._retro_path,
-                    exc_info=True,
-                )
-        else:
+            append_jsonl(self._retro_path, entry.model_dump_json())
+        except OSError:
+            logger.warning(
+                "Could not append to retrospective log %s",
+                self._retro_path,
+                exc_info=True,
+            )
+
+        if self._hindsight is not None:
             from hindsight import Bank, schedule_retain  # noqa: PLC0415
 
             content = (

--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -228,18 +228,18 @@ class ReviewInsightStore:
 
     def append_review(self, record: ReviewRecord) -> None:
         """Append *record* as a JSON line to ``reviews.jsonl``."""
-        if self._hindsight is None:
-            try:
-                from file_util import append_jsonl  # noqa: PLC0415
+        try:
+            from file_util import append_jsonl  # noqa: PLC0415
 
-                append_jsonl(self._reviews_path, record.model_dump_json())
-            except OSError:
-                logger.warning(
-                    "Could not append review to %s",
-                    self._reviews_path,
-                    exc_info=True,
-                )
-        else:
+            append_jsonl(self._reviews_path, record.model_dump_json())
+        except OSError:
+            logger.warning(
+                "Could not append review to %s",
+                self._reviews_path,
+                exc_info=True,
+            )
+
+        if self._hindsight is not None:
             from hindsight import Bank, schedule_retain  # noqa: PLC0415
 
             schedule_retain(

--- a/tests/test_harness_insights.py
+++ b/tests/test_harness_insights.py
@@ -736,8 +736,10 @@ class TestHarnessInsightHindsightDualWrite:
         assert failures_path.exists()
         assert "42" in failures_path.read_text()
 
-    def test_no_event_loop_skips_dual_write(self, tmp_path: Path) -> None:
-        """When no event loop is running, dual-write is silently skipped."""
+    def test_no_event_loop_skips_hindsight_but_writes_file(
+        self, tmp_path: Path
+    ) -> None:
+        """When no event loop is running, hindsight write is skipped but file write still happens."""
         from unittest.mock import MagicMock, patch
 
         mock_hindsight = MagicMock()
@@ -750,12 +752,12 @@ class TestHarnessInsightHindsightDualWrite:
         ):
             store.append_failure(record)  # should not raise
 
-        # File write skipped because hindsight is set
+        # File write always happens
         failures_path = tmp_path / "harness_failures.jsonl"
-        assert not failures_path.exists()
+        assert failures_path.exists()
 
-    def test_file_write_skipped_when_hindsight_configured(self, tmp_path: Path) -> None:
-        """When hindsight client is set, JSONL file write is skipped."""
+    def test_dual_write_file_and_hindsight(self, tmp_path: Path) -> None:
+        """When hindsight client is set, both JSONL file and hindsight are written."""
         from unittest.mock import MagicMock, patch
 
         mock_hindsight = MagicMock()
@@ -773,9 +775,9 @@ class TestHarnessInsightHindsightDualWrite:
             mock_loop.create_task.assert_called_once()
             mock_retain.assert_called_once()
 
-        # File write does NOT happen
+        # File write also happens
         failures_path = tmp_path / "harness_failures.jsonl"
-        assert not failures_path.exists()
+        assert failures_path.exists()
 
     def test_falsy_mock_hindsight_still_retains(self, tmp_path: Path) -> None:
         """A falsy-but-non-None hindsight mock must still trigger schedule_retain."""
@@ -791,9 +793,9 @@ class TestHarnessInsightHindsightDualWrite:
             # schedule_retain must be called even though mock is falsy
             mock_retain.assert_called_once()
 
-        # File write must NOT happen when hindsight is set (even if falsy)
+        # File write always happens (dual-write)
         failures_path = tmp_path / "harness_failures.jsonl"
-        assert not failures_path.exists()
+        assert failures_path.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -908,8 +908,10 @@ class TestRetrospectiveHindsightDualWrite:
         assert retro_path.exists()
         assert "42" in retro_path.read_text()
 
-    def test_no_event_loop_skips_dual_write(self, config: HydraFlowConfig) -> None:
-        """When no event loop is running, dual-write is silently skipped."""
+    def test_no_event_loop_skips_hindsight_but_writes_file(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """When no event loop is running, hindsight write is skipped but file write still happens."""
         from unittest.mock import MagicMock
 
         mock_hindsight = MagicMock()
@@ -931,14 +933,12 @@ class TestRetrospectiveHindsightDualWrite:
         ):
             collector._append_entry(entry)  # should not raise
 
-        # File write skipped because hindsight is set
+        # File write always happens
         retro_path = config.data_path("memory", "retrospectives.jsonl")
-        assert not retro_path.exists()
+        assert retro_path.exists()
 
-    def test_file_write_skipped_when_hindsight_configured(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """When hindsight client is set, JSONL file write is skipped."""
+    def test_dual_write_file_and_hindsight(self, config: HydraFlowConfig) -> None:
+        """When hindsight client is set, both JSONL file and hindsight are written."""
         from unittest.mock import MagicMock
 
         mock_hindsight = MagicMock()
@@ -966,9 +966,9 @@ class TestRetrospectiveHindsightDualWrite:
             mock_loop.create_task.assert_called_once()
             mock_retain.assert_called_once()
 
-        # File write does NOT happen
+        # File write also happens
         retro_path = config.data_path("memory", "retrospectives.jsonl")
-        assert not retro_path.exists()
+        assert retro_path.exists()
 
     def test_falsy_mock_hindsight_still_retains(self, config: HydraFlowConfig) -> None:
         """A falsy-but-non-None hindsight mock must still trigger schedule_retain."""
@@ -993,9 +993,9 @@ class TestRetrospectiveHindsightDualWrite:
             # schedule_retain must be called even though mock is falsy
             mock_retain.assert_called_once()
 
-        # File write must NOT happen when hindsight is set (even if falsy)
+        # File write always happens (dual-write)
         retro_path = config.data_path("memory", "retrospectives.jsonl")
-        assert not retro_path.exists()
+        assert retro_path.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_insights.py
+++ b/tests/test_review_insights.py
@@ -753,8 +753,10 @@ class TestReviewInsightHindsightDualWrite:
         assert reviews_path.exists()
         assert "42" in reviews_path.read_text()
 
-    def test_no_event_loop_skips_dual_write(self, tmp_path: Path) -> None:
-        """When no event loop is running, dual-write is silently skipped."""
+    def test_no_event_loop_skips_hindsight_but_writes_file(
+        self, tmp_path: Path
+    ) -> None:
+        """When no event loop is running, hindsight write is skipped but file write still happens."""
         from unittest.mock import MagicMock, patch
 
         mock_hindsight = MagicMock()
@@ -767,12 +769,12 @@ class TestReviewInsightHindsightDualWrite:
         ):
             store.append_review(record)  # should not raise
 
-        # File write skipped because hindsight is set
+        # File write always happens
         reviews_path = tmp_path / "reviews.jsonl"
-        assert not reviews_path.exists()
+        assert reviews_path.exists()
 
-    def test_file_write_skipped_when_hindsight_configured(self, tmp_path: Path) -> None:
-        """When hindsight client is set, JSONL file write is skipped."""
+    def test_dual_write_file_and_hindsight(self, tmp_path: Path) -> None:
+        """When hindsight client is set, both JSONL file and hindsight are written."""
         from unittest.mock import MagicMock, patch
 
         mock_hindsight = MagicMock()
@@ -790,9 +792,9 @@ class TestReviewInsightHindsightDualWrite:
             mock_loop.create_task.assert_called_once()
             mock_retain.assert_called_once()
 
-        # File write does NOT happen
+        # File write also happens
         reviews_path = tmp_path / "reviews.jsonl"
-        assert not reviews_path.exists()
+        assert reviews_path.exists()
 
     def test_falsy_mock_hindsight_still_retains(self, tmp_path: Path) -> None:
         """A falsy-but-non-None hindsight mock must still trigger schedule_retain."""
@@ -808,9 +810,9 @@ class TestReviewInsightHindsightDualWrite:
             # schedule_retain must be called even though mock is falsy
             mock_retain.assert_called_once()
 
-        # File write must NOT happen when hindsight is set (even if falsy)
+        # File write always happens (dual-write)
         reviews_path = tmp_path / "reviews.jsonl"
-        assert not reviews_path.exists()
+        assert reviews_path.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When Hindsight was enabled, harness failures, review insights, and retrospective entries were **only** written to Hindsight banks — the JSONL files the dashboard reads from were skipped entirely, leaving failure patterns and retrospectives permanently empty in the UI
- Changed all three stores (`HarnessInsightStore`, `ReviewInsightStore`, `RetrospectiveCollector`) from if/else (file OR Hindsight) to always-file + optional Hindsight
- Updated 9 tests across 3 test files to match the new dual-write behavior

## Test plan
- [x] `pytest tests/test_harness_insights.py tests/test_review_insights.py tests/test_retrospective.py` — all pass
- [ ] Deploy and verify failure patterns / retrospective panels populate after pipeline activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)