### PR TITLE
feat(ui): move Diagnostics from main tab to System sub-tab

### DIFF
--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useRef, useEffect, lazy, Suspense } from 'react'
+import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react'
 import { HydraFlowProvider, useHydraFlow } from './context/HydraFlowContext'
 import { Header } from './components/Header'
 import { HumanInputBanner } from './components/HumanInputBanner'
@@ -9,15 +9,12 @@ import { StreamView } from './components/StreamView'
 import { SessionSidebar } from './components/SessionSidebar'
 import { theme } from './theme'
 
-const DiagnosticsTab = lazy(() => import('./components/diagnostics/DiagnosticsTab').then(m => ({ default: m.DiagnosticsTab })))
-
-const TABS = ['issues', 'hitl', 'outcomes', 'diagnostics', 'system']
+const TABS = ['issues', 'hitl', 'outcomes', 'system']
 
 const TAB_LABELS = {
   issues: 'Work Stream',
   outcomes: 'Outcomes',
   hitl: 'HITL',
-  diagnostics: 'Diagnostics',
   system: 'System',
 }
 
@@ -258,11 +255,6 @@ function AppContent() {
             orchestratorStatus === 'running'
               ? <HITLTable items={hitlItems} onRefresh={refreshHitl} />
               : <div style={idleMessage}>Pipeline is not running — HITL actions are unavailable.</div>
-          )}
-          {activeTab === 'diagnostics' && (
-            <Suspense fallback={<div style={idleMessage}>Loading diagnostics…</div>}>
-              <DiagnosticsTab />
-            </Suspense>
           )}
           {activeTab === 'system' && (
             <SystemPanel

--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react'
+import React, { useState, useCallback, useMemo, lazy, Suspense } from 'react'
 import { theme } from '../theme'
 import { BACKGROUND_WORKERS, WORKER_GROUPS, INTERVAL_PRESETS, WORKER_PRESETS, EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS, UNSTICK_BATCH_OPTIONS } from '../constants'
 import { useHydraFlow } from '../context/HydraFlowContext'
@@ -8,11 +8,16 @@ import { WorkerLogStream } from './WorkerLogStream'
 import { MetricsPanel } from './MetricsPanel'
 import { InsightsPanel } from './InsightsPanel'
 
+const DiagnosticsTab = lazy(() =>
+  import('./diagnostics/DiagnosticsTab').then(m => ({ default: m.DiagnosticsTab }))
+)
+
 const SUB_TABS = [
   { key: 'workers', label: 'Workers' },
   { key: 'pipeline', label: 'Pipeline' },
   { key: 'metrics', label: 'Metrics' },
   { key: 'insights', label: 'Insights' },
+  { key: 'diagnostics', label: 'Diagnostics' },
   { key: 'livestream', label: 'Livestream' },
 ]
 
@@ -549,6 +554,11 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
           <MetricsPanel />
         )}
         {activeSubTab === 'insights' && <InsightsPanel />}
+        {activeSubTab === 'diagnostics' && (
+          <Suspense fallback={<div style={styles.diagnosticsLoading}>Loading diagnostics…</div>}>
+            <DiagnosticsTab />
+          </Suspense>
+        )}
         {activeSubTab === 'livestream' && <Livestream events={events} />}
       </div>
     </div>
@@ -593,6 +603,12 @@ const styles = {
     flex: 1,
     overflowY: 'auto',
     padding: 20,
+  },
+  diagnosticsLoading: {
+    padding: 32,
+    textAlign: 'center',
+    color: theme.dimText,
+    fontSize: 13,
   },
   heading: {
     fontSize: 16,

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -234,7 +234,7 @@ describe('Main tab bar', () => {
   it('has exactly 4 main tabs', async () => {
     const { default: App } = await import('../../App')
     render(<App />)
-    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'Diagnostics', 'System']
+    const tabLabels = ['Work Stream', 'HITL', 'Outcomes', 'System']
     const tabContainer = screen.getByTestId('main-tabs')
     expect(tabContainer.childElementCount).toBe(tabLabels.length)
     for (const label of tabLabels) {
@@ -253,6 +253,13 @@ describe('Main tab bar', () => {
     render(<App />)
     // Livestream is now a sub-tab inside System, not a top-level tab
     expect(screen.queryByText('Livestream')).not.toBeInTheDocument()
+  })
+
+  it('does not render Diagnostics in the main tab bar (moved to System sub-tab)', async () => {
+    const { default: App } = await import('../../App')
+    render(<App />)
+    const tabContainer = screen.getByTestId('main-tabs')
+    expect(within(tabContainer).queryByText('Diagnostics')).toBeNull()
   })
 
   it('Work Stream tab is rendered first (tab order)', async () => {

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -366,13 +366,14 @@ describe('SystemPanel', () => {
   })
 
   describe('Sub-tab Navigation', () => {
-    it('shows Workers, Pipeline, Metrics, Insights, and Livestream sub-tab labels', () => {
+    it('shows Workers, Pipeline, Metrics, Insights, Diagnostics, and Livestream sub-tab labels', () => {
       render(<SystemPanel backgroundWorkers={[]} />)
       expect(screen.getByText('Workers')).toBeInTheDocument()
       expect(screen.getByText('Pipeline')).toBeInTheDocument()
       expect(screen.getByText('Metrics')).toBeInTheDocument()
       expect(screen.queryByText('Processes')).not.toBeInTheDocument()
       expect(screen.getByText('Insights')).toBeInTheDocument()
+      expect(screen.getByText('Diagnostics')).toBeInTheDocument()
       expect(screen.getByText('Livestream')).toBeInTheDocument()
       expect(screen.queryByText('Event Log')).not.toBeInTheDocument()
     })
@@ -436,6 +437,24 @@ describe('SystemPanel', () => {
       fireEvent.click(screen.getByText('Insights'))
       expect(screen.getByText('Failure Patterns')).toBeInTheDocument()
       expect(screen.queryByText('Repo Health')).not.toBeInTheDocument()
+    })
+
+    it('clicking Diagnostics sub-tab mounts the DiagnosticsTab via Suspense', async () => {
+      // DiagnosticsTab fetches /api/diagnostics/* on mount; stub them so the
+      // dynamic-imported component can render in jsdom.
+      const originalFetch = global.fetch
+      global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => [] }))
+      try {
+        render(<SystemPanel backgroundWorkers={[]} />)
+        fireEvent.click(screen.getByText('Diagnostics'))
+        // Lazy-loaded; wait for the dynamic import to resolve and tab to mount.
+        await waitFor(() => {
+          expect(screen.getByText('Factory Diagnostics')).toBeInTheDocument()
+        })
+        expect(screen.queryByText('Repo Health')).not.toBeInTheDocument()
+      } finally {
+        global.fetch = originalFetch
+      }
     })
 
     it('renders event data in Livestream sub-tab', () => {


### PR DESCRIPTION
## Summary
- Diagnostics now lives as a sub-tab inside **System** (between Insights and Livestream), grouping observability with the rest of the system surface.
- Main tab bar drops to four tabs: Work Stream / HITL / Outcomes / System.
- `DiagnosticsTab` is lazy-loaded inside `SystemPanel` with a `Suspense` fallback (same pattern as the previous top-level mount).

## Changes
- `src/ui/src/App.jsx` — remove `'diagnostics'` from `TABS`/`TAB_LABELS`, drop the lazy import + Suspense block.
- `src/ui/src/components/SystemPanel.jsx` — add `'diagnostics'` to `SUB_TABS`, lazy-load `DiagnosticsTab`, render under Suspense.
- `src/ui/src/components/__tests__/App.test.jsx` — update the "exactly 4 main tabs" assertion (the prior list had 5 labels despite the 4-tab description) and add a guard that Diagnostics is no longer in the main tab bar.
- `src/ui/src/components/__tests__/SystemPanel.test.jsx` — extend the sub-tab labels test to include Diagnostics; add a test that clicking it mounts the lazy `DiagnosticsTab` (stubs `global.fetch` so the in-mount API calls succeed in jsdom).

## Test plan
- [ ] CI: vitest UI suite passes (`App.test.jsx`, `SystemPanel.test.jsx`).
- [ ] Manual: open dashboard → main tab bar shows only Work Stream / HITL / Outcomes / System.
- [ ] Manual: click System → Diagnostics sub-tab → "Factory Diagnostics" header renders, all charts mount, IssueTable populates if trace data exists.
- [ ] Manual: switching between Diagnostics and other System sub-tabs (Workers, Pipeline, Metrics, Insights, Livestream) works without losing state.

Note: vitest could not be run locally due to a pre-existing Node version mismatch on this workstation (Node 20.10 vs vitest 4 / vite 7 requiring 20.19+); JSX was syntax-checked via esbuild, and CI will run the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)