### PR TITLE
Harness engineering cluster: CLAUDE.md ToC, sensor enricher, audit agent 5

### DIFF
--- a/.claude/commands/hf.audit-code.md
+++ b/.claude/commands/hf.audit-code.md
@@ -20,6 +20,7 @@ Run a comprehensive code quality audit across the entire repo. Dynamically analy
    - **Agent 2: Method size, class cohesion & duplication** — Enforces small methods, single-concept classes, and DRY.
    - **Agent 3: Error handling & robustness** — Finds bare excepts, swallowed errors, missing error paths, and fragile patterns.
    - **Agent 4: Type safety & API consistency** — Finds missing type annotations, `Any` overuse, inconsistent return types, and public API gaps.
+   - **Agent 5: Convention drift & over-engineering** — Reads `docs/agents/avoided-patterns.md` (or CLAUDE.md fallback) at runtime and sweeps the codebase for documented avoided patterns plus over-engineering accumulation.
 
 4. Wait for all agents to complete.
 5. After all finish, run `gh issue list --repo $REPO --label $LABEL --state open --search "code quality" --limit 200` to show the user a final summary of all issues created.
@@ -419,6 +420,100 @@ You are a code quality auditor focused on type safety and API consistency for th
 
 Focus on public APIs and cross-module interfaces. Skip internal helper functions and test code.
 Prioritize by impact — type gaps in widely-used functions matter more than leaf functions.
+
+Return a summary of all findings grouped by category, with GH issue URLs created.
+```
+
+## Agent 5: Convention Drift & Over-Engineering
+
+```
+You are a code quality auditor focused on convention drift and over-engineering for the project at {repo_root}.
+
+## Configuration
+- GitHub repo: {REPO}
+- Assignee: {ASSIGNEE}
+- Label: {LABEL}
+
+## Steps
+
+### Phase 1: Load project conventions
+1. Read `docs/agents/avoided-patterns.md`. If that file does not exist, fall back to the "Avoided Patterns" section of `CLAUDE.md`.
+2. Parse out each documented avoided pattern — title + description + (when provided) detection heuristic.
+3. Cache each pattern as a `(id, description, detection_strategy)` triple for the sweep below.
+
+### Phase 2: Sweep for documented avoided patterns
+For each pattern from Phase 1, scan the codebase for violations. Current known patterns (keep in sync with the doc — do not hardcode, read them at runtime):
+
+- **Pydantic field additions without test updates**: Use `git log --since=90.days src/models.py` to list recent commits touching models. For each, check whether `tests/test_models.py` or `tests/test_smoke.py` was updated in the same commit via `git show --stat <sha>`. Flag commits where a field addition landed without a matching test update.
+- **Top-level imports of optional dependencies in test files**: Grep `tests/` for `^from (hindsight|httpx) import` and `^import (hindsight|httpx)` (i.e., at column 0, module-level). Each match is a violation.
+- **Background sleep loops polling for results**: Grep non-test source code for `time.sleep(` or `asyncio.sleep(` inside `while` or `for` loops. Exclude retry loops with explicit max attempts.
+- **Mocking at the wrong level**: Grep tests for `@patch("<module>.<name>")` where `<module>` is the definition module of `<name>`. Legitimate patches target the import site. Heuristic: if a patched target is the file where the function is `def`-ined, that's a likely smell.
+- **Falsy checks on optional objects**: Grep source for `if not self\._\w+` then check whether the attribute is typed `X | None` in the class `__init__`. Flag each occurrence.
+
+### Phase 3: Sweep for over-engineering patterns
+- **Single-use helpers**: Functions defined once and called from exactly one non-test site. Inline candidates. (Use grep to count call sites; exclude dunder methods, protocol implementations, and CLI entry points.)
+- **Speculative abstractions**: Base classes with a single concrete subclass; Protocols with a single implementer; factories that return one type; dataclasses with one field. These are all candidates for inlining.
+- **Defensive handling of impossible cases**: `if x is None: raise` where the preceding code path always populates `x`. Trace the control flow; if nothing can set `x` to None, flag the guard.
+- **Backwards-compat shims**: Comments matching `# (kept|retained).*compat`, `# deprecated`, or `# backwards.compat`. Unused `_`-prefixed variables retained "for compat". Deprecated argument handlers with no remaining callers.
+- **Feature-flag rot**: Config flags that are never toggled in production — grep the flag name, find no `False`/`True` overrides in `settings`, CI, or deploy config. Flag if the flag has only ever had its default value.
+- **Test-only code paths in production**: `if os.getenv("TESTING")` or similar branches in `src/`. These should be in test fixtures, not production code.
+
+### Phase 4: Create GitHub issues
+1. Check for duplicate GH issues first:
+   `gh issue list --repo {REPO} --label {LABEL} --state open --search "<key terms>"`
+2. Create GH issues for NEW findings only, grouped by theme:
+   `gh issue create --repo {REPO} --assignee {ASSIGNEE} --label {LABEL} --title "Code Quality: Convention drift — <theme>" --body "<details>"`
+
+## Issue Body Format
+
+```markdown
+## Context
+<1-2 sentences on the drift or over-engineering pattern and why it matters>
+
+**Type:** chore
+**Source:** Agent 5 (convention drift & over-engineering)
+
+## Scope
+- Files: <list affected files>
+- Risk: <low/medium — describe>
+
+## Findings
+| Pattern | File:Line | Details |
+|---------|-----------|---------|
+| <pattern id from avoided-patterns.md or over-engineering category> | <path:line> | <what was found and why it violates> |
+
+## Suggested Fixes
+- [ ] <file:line> — <specific remediation>
+
+## Acceptance Criteria
+- [ ] All listed violations are remediated
+- [ ] `docs/agents/avoided-patterns.md` is updated if a new pattern is discovered
+- [ ] All existing tests pass (`make test`)
+- [ ] No new lint or type errors (`make quality-lite`)
+
+## Reference
+See `docs/agents/avoided-patterns.md` for the canonical rule descriptions.
+```
+
+## Grouping Strategy
+- "Code Quality: Convention drift — Pydantic field additions missing test updates"
+- "Code Quality: Convention drift — Top-level optional-dep imports in tests"
+- "Code Quality: Over-engineering — Single-use helpers to inline"
+- "Code Quality: Over-engineering — Stale feature flags"
+- "Code Quality: Over-engineering — Backwards-compat shims to remove"
+
+## Severity guidance
+- **high**: convention violations that cause real test failures or hidden bugs (e.g., Pydantic field additions without test updates, wrong-level mocks masking broken code paths)
+- **medium**: over-engineering accumulation (single-use helpers, speculative abstractions, stale feature flags, backwards-compat shims)
+- **low**: cosmetic drift (old comments, unused `_`-vars)
+
+Only `high` and `medium` findings are filed as issues by the grooming loop — `low` findings are logged for trend analysis but not turned into work.
+
+## Keep-in-sync principle
+This agent reads `docs/agents/avoided-patterns.md` at runtime. Adding a new avoided pattern to that doc automatically adds it to the next sweep — no code change needed here. If you find yourself hardcoding a new pattern in this prompt, STOP and add it to the doc instead.
+
+Emit findings as JSON objects (one per theme) matching the schema parsed by `src/code_grooming_loop.py::_FINDING_RE`:
+  `{"id": "<stable hash>", "severity": "high|medium|low", "title": "...", "description": "<markdown>"}`
 
 Return a summary of all findings grouped by category, with GH issue URLs created.
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **HydraFlow** — Intent in. Software out. A multi-agent orchestration system that automates the full GitHub issue lifecycle via git issues and labels.
 
+## Knowledge Lookup
+
+Before exploring the codebase from scratch, consult existing knowledge. HydraFlow maintains three structured sources — use them proactively when you need context on *why* something is the way it is, or on prior decisions and learnings.
+
+- **Architecture Decision Records** — [`docs/adr/`](docs/adr/README.md) is the authoritative record of key design decisions (40+ entries). Read the index and open the relevant ADR before making changes that touch a documented decision area. Examples: `0001-five-concurrent-async-loops.md`, `0002-labels-as-state-machine.md`, `0003-git-worktrees-for-isolation.md`, `0021-persistence-architecture-and-data-layout.md`, `0029-caretaker-loop-pattern.md`, `0032-per-repo-wiki-knowledge-base.md`. Each ADR follows the format in `docs/adr/README.md`. If you're about to contradict an Accepted ADR, stop and escalate instead — ADRs aren't overridden by code changes, they're superseded by a new ADR.
+- **Repository wiki** — [`src/repo_wiki.py`](src/repo_wiki.py) implements a per-target-repo LLM knowledge base (Karpathy pattern). Wiki entries live under the repo's state directory as topic-categorized markdown (`architecture`, `patterns`, `gotchas`, `testing`, `dependencies`). These capture learnings distilled from prior plan/implement/review cycles on managed repos. Query via `RepoWikiStore` when planning or reviewing work on a target repo.
+- **Other planning docs** — [`docs/`](docs/) contains `self-improving-harness.md`, `ops-audit-plan.md`, `sentry-alerts.md`, and similar strategy documents. Consult these when your task touches the areas they describe.
+
+When you find a gap in the ADRs or wiki that would have helped you, file a `hydraflow-find` issue so the next run has better context.
+
 ## Architecture
 
 HydraFlow runs five concurrent async loops from `orchestrator.py`:
@@ -96,13 +106,9 @@ HydraFlow creates isolated git worktrees for each issue. **Always clean up workt
 
 ## Avoided Patterns
 
-Common mistakes agents make in this codebase — avoid these:
+See [`docs/agents/avoided-patterns.md`](docs/agents/avoided-patterns.md) for the canonical list of recurring agent mistakes in this codebase (Pydantic field additions without test updates, top-level imports of optional deps in tests, sleep-loop polling, mocking at the wrong level, falsy checks on optional objects). Read it before editing the areas each rule calls out.
 
-- **Adding a Pydantic model field without updating serialization tests.** When you add a field to any model in `models.py` (e.g., `PRListItem`, `StateData`), grep `tests/` for the model name and update ALL exact-match serialization tests (`model_dump()` assertions, expected key sets in smoke tests).
-- **Top-level imports of optional dependencies in test files.** Never `from hindsight import Bank` at module level in tests — `httpx` is not always available. Use deferred imports inside test methods: `from hindsight import Bank`.
-- **Spawning background sleep loops to poll for results.** Never `sleep(N)` in a loop waiting for a test suite or background process. Use `run_in_background` with a single command, or run in foreground.
-- **Mocking at the wrong level.** Patch functions at their *import site*, not their *definition site*. If `base_runner.py` does `from hindsight import recall_safe`, patch `hindsight.recall_safe` (the definition module), not `base_runner.recall_safe`.
-- **Using `not obj` instead of `obj is None` for optional dependencies.** Falsy checks on optional objects (e.g., `not self._hindsight`) can trigger incorrectly with mock objects. Use `self._hindsight is None` for explicit null checks.
+When you observe a new recurring failure, add it to `docs/agents/avoided-patterns.md` — the same doc feeds `src/sensor_enricher.py` hints and the `hf.audit-code` convention-drift sweep.
 
 ## Reasoning Triggers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,270 +1,40 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
 **HydraFlow** — Intent in. Software out. A multi-agent orchestration system that automates the full GitHub issue lifecycle via git issues and labels.
+
+This file is a table of contents. Operational guidance lives in [`docs/agents/`](docs/agents/README.md) and architectural rationale lives in [`docs/adr/`](docs/adr/README.md). Load the topic file relevant to your task — do not try to hold all of it in context.
+
+## Quick rules (always apply)
+
+- **Never commit to `main`.** The branch is protected; all changes go through a worktree branch and a pull request. No exceptions, not even for one-line fixes. See [`docs/agents/worktrees.md`](docs/agents/worktrees.md).
+- **Never use `git commit --no-verify`** or `--no-hooks`. Fix code issues first.
+- **Always run `make quality`** before declaring work complete. See [`docs/agents/quality-gates.md`](docs/agents/quality-gates.md).
+- **Always write unit tests before committing.** See [`docs/agents/testing.md`](docs/agents/testing.md).
+- **Always read [`docs/agents/avoided-patterns.md`](docs/agents/avoided-patterns.md)** before editing Pydantic models, test imports, or mocks — these are the recurring mistakes.
 
 ## Knowledge Lookup
 
-Before exploring the codebase from scratch, consult existing knowledge. HydraFlow maintains three structured sources — use them proactively when you need context on *why* something is the way it is, or on prior decisions and learnings.
+Before exploring the codebase from scratch, consult existing structured knowledge.
 
-- **Architecture Decision Records** — [`docs/adr/`](docs/adr/README.md) is the authoritative record of key design decisions (40+ entries). Read the index and open the relevant ADR before making changes that touch a documented decision area. Examples: `0001-five-concurrent-async-loops.md`, `0002-labels-as-state-machine.md`, `0003-git-worktrees-for-isolation.md`, `0021-persistence-architecture-and-data-layout.md`, `0029-caretaker-loop-pattern.md`, `0032-per-repo-wiki-knowledge-base.md`. Each ADR follows the format in `docs/adr/README.md`. If you're about to contradict an Accepted ADR, stop and escalate instead — ADRs aren't overridden by code changes, they're superseded by a new ADR.
-- **Repository wiki** — [`src/repo_wiki.py`](src/repo_wiki.py) implements a per-target-repo LLM knowledge base (Karpathy pattern). Wiki entries live under the repo's state directory as topic-categorized markdown (`architecture`, `patterns`, `gotchas`, `testing`, `dependencies`). These capture learnings distilled from prior plan/implement/review cycles on managed repos. Query via `RepoWikiStore` when planning or reviewing work on a target repo.
-- **Other planning docs** — [`docs/`](docs/) contains `self-improving-harness.md`, `ops-audit-plan.md`, `sentry-alerts.md`, and similar strategy documents. Consult these when your task touches the areas they describe.
+- **Architecture Decision Records** — [`docs/adr/`](docs/adr/README.md) is the authoritative record of key design decisions (40+ entries). Read the relevant ADR before changing a documented decision area. Examples: [`0001-five-concurrent-async-loops.md`](docs/adr/0001-five-concurrent-async-loops.md), [`0002-labels-as-state-machine.md`](docs/adr/0002-labels-as-state-machine.md), [`0003-git-worktrees-for-isolation.md`](docs/adr/0003-git-worktrees-for-isolation.md), [`0021-persistence-architecture-and-data-layout.md`](docs/adr/0021-persistence-architecture-and-data-layout.md), [`0029-caretaker-loop-pattern.md`](docs/adr/0029-caretaker-loop-pattern.md), [`0032-per-repo-wiki-knowledge-base.md`](docs/adr/0032-per-repo-wiki-knowledge-base.md). Contradicting an Accepted ADR requires a new ADR superseding it, not just a code change.
+- **Repository wiki** — [`src/repo_wiki.py`](src/repo_wiki.py) implements a per-target-repo LLM knowledge base (Karpathy pattern). Wiki entries are topic-categorized markdown capturing learnings from prior plan/implement/review cycles on managed repos. Query via `RepoWikiStore` when planning or reviewing work on a target repo.
+- **Planning docs** — [`docs/`](docs/) contains `self-improving-harness.md`, `ops-audit-plan.md`, `sentry-alerts.md`, and similar strategy documents. Consult these when your task touches the areas they describe.
 
 When you find a gap in the ADRs or wiki that would have helped you, file a `hydraflow-find` issue so the next run has better context.
 
-## Architecture
+## Topic index
 
-HydraFlow runs five concurrent async loops from `orchestrator.py`:
+Load the file relevant to your task before acting.
 
-1. **Triage loop**: Fetches new issues, scores complexity, classifies type, and applies the `hydraflow-plan` label.
-2. **Plan loop**: Fetches issues labeled `hydraflow-plan`, runs a read-only Claude agent to explore the codebase and produce an implementation plan, posts the plan as a comment, then swaps the label to `hydraflow-ready`.
-3. **Implement loop**: Fetches issues labeled `hydraflow-ready`, creates git worktrees, runs implementation agents, pushes branches, creates PRs, then swaps to `hydraflow-review`.
-4. **Review loop**: Fetches issues labeled `hydraflow-review`, runs a review agent to check quality and optionally fix issues, submits a formal PR review, waits for CI, and auto-merges approved PRs. CI failures escalate to `hydraflow-hitl` for human intervention.
-5. **HITL loop**: Processes issues labeled `hydraflow-hitl` that need human-in-the-loop correction.
-
-### Key Files
-
-**Core infrastructure:**
-- `server.py` — Server entry point (`python -m server`)
-- `scripts/run_admin_task.py` — Admin task runner (clean, prep, scaffold, ensure-labels)
-- `orchestrator.py` — Main coordinator (five async polling loops)
-- `config.py` — `HydraFlowConfig` Pydantic model (50+ env-var overrides)
-- `models.py` — Pydantic data models (Phase, SessionLog, ReviewResult, etc.)
-- `service_registry.py` — Composition root (`build_services()`); imports from all layers to wire dependencies
-- `state.py` — `StateTracker` (JSON-backed crash recovery)
-- `events.py` — `EventBus` async pub/sub
-
-**Phase implementations:**
-- `plan_phase.py` / `implement_phase.py` / `review_phase.py` / `triage_phase.py` / `hitl_phase.py`
-- `phase_utils.py` — Shared phase utilities
-- `pr_unsticker.py` — Stale PR recovery coordinator
-
-**Agents/runners:**
-- `agent.py` — `AgentRunner` (implementation agent)
-- `planner.py` — `PlannerRunner` (read-only planning agent)
-- `reviewer.py` — `ReviewRunner` (review + CI fix agent)
-- `hitl_runner.py` — HITL correction agent
-- `base_runner.py` — Base runner class
-
-**Git & PR management:**
-- `worktree.py` — `WorktreeManager` (git worktree lifecycle)
-- `pr_manager.py` — `PRManager` (all `gh` CLI operations)
-- `merge_conflict_resolver.py` — Merge conflict resolution
-- `post_merge_handler.py` — Post-merge cleanup
-
-**Background loops:**
-- `base_background_loop.py` — Base async loop pattern
-- `manifest_refresh_loop.py` / `memory_sync_loop.py` / `metrics_sync_loop.py` / `pr_unsticker_loop.py`
-
-**Dashboard:**
-- `dashboard.py` + `dashboard_routes.py` — FastAPI + WebSocket backend
-- `ui/` — React + Vite frontend
-
-**Repo scaffolding (prep system):**
-- `prep.py` — Repository preparation orchestrator
-- `ci_scaffold.py` / `lint_scaffold.py` / `test_scaffold.py` / `makefile_scaffold.py`
-- `polyglot_prep.py` — Language detection
-
-## Worktree Management
-
-HydraFlow creates isolated git worktrees for each issue. **Always clean up worktrees when their PRs are merged or issues are closed. Always implement issue work on a dedicated git worktree branch; do not implement directly in the primary repo checkout.**
-
-**CRITICAL: The `main` branch is protected. Direct commits and pushes to `main` will be rejected.** All code changes — including one-line fixes — MUST go through a worktree branch and a pull request. Never stage, commit, or modify files in the primary repo checkout.
-
-**Workflow for every code change:**
-1. Create a worktree: `git worktree add ../hydraflow-worktrees/<name> origin/main`
-2. Create a branch in the worktree: `git checkout -b <branch-name> origin/main`
-3. Make changes, commit, and push the branch
-4. Create a PR via `gh pr create`
-5. Clean up: `git worktree remove ../hydraflow-worktrees/<name>`
-
-**Do NOT use `EnterWorktree` tool** — it auto-cleans up and loses work. Use manual `git worktree add` commands.
-
-- **Default location:** `../hydraflow-worktrees/` (sibling to repo root)
-- **Naming:** `issue-{issue_number}/` for issue work, descriptive names for other changes
-- **Config:** `worktree_base` field in `HydraFlowConfig`
-- **Cleanup:** `make clean` removes all worktrees and state
-- Worktrees get independent venvs (`uv sync`), symlinked `.env`, and pre-commit hooks
-- Stale worktrees from merged PRs should be periodically pruned with `git worktree prune`
-
-## Testing is Mandatory
-
-**ALWAYS write unit tests for code changes before committing.** Every new function, class, or feature modification MUST include comprehensive tests.
-
-- Tests live in `tests/` following the pattern `tests/test_<module>.py`
-- New features: Write tests BEFORE committing
-- Bug fixes: Add regression tests that reproduce the bug
-- Refactoring: Ensure existing tests pass, add tests for new paths
-- Never commit untested code
-- Coverage threshold: 70%
-- **Never write tests for ADR markdown content.** ADRs are documentation, not code. Do not create `test_adr_NNNN_*.py` files that assert on markdown headings, status fields, or prose content — these break whenever the document is edited and provide no value. Only test ADR-related *code* (e.g., `test_adr_reviewer.py` tests the reviewer logic).
-- **Never include line numbers in ADR source citations.** Throughout ADR documents (Related, Context, Decision, Consequences sections), cite source files by function or class name only (e.g., `src/config.py:_resolve_base_paths`). Do NOT add `(line 42)` or similar anywhere — line numbers drift as the source file is edited and council reviews will flag them as stale.
-
-## Avoided Patterns
-
-See [`docs/agents/avoided-patterns.md`](docs/agents/avoided-patterns.md) for the canonical list of recurring agent mistakes in this codebase (Pydantic field additions without test updates, top-level imports of optional deps in tests, sleep-loop polling, mocking at the wrong level, falsy checks on optional objects). Read it before editing the areas each rule calls out.
-
-When you observe a new recurring failure, add it to `docs/agents/avoided-patterns.md` — the same doc feeds `src/sensor_enricher.py` hints and the `hf.audit-code` convention-drift sweep.
-
-## Reasoning Triggers
-
-For analysis-heavy tasks (architecture decisions, debugging, code review), use explicit reasoning prompts to trigger deeper analysis:
-
-- "Think through the tradeoffs of this approach before implementing"
-- "Consider what could go wrong and what edge cases exist"
-- "Explain your reasoning before making changes"
-
-Simple mechanical tasks (rename, format, move) don't need these — just do them.
-
-## Quality Before Completion
-
-**Always run lint and tests before declaring work complete or committing.** Do not present implementation as "done" until quality checks pass.
-
-1. After each significant code change: `make lint` (auto-fixes formatting and imports)
-2. Before committing: `make quality` (lint + typecheck + security + tests in parallel)
-3. If lint auto-fixes files, re-check for type errors introduced by removed imports
-4. Track your edits across files — avoid creating duplicate helpers or inconsistent naming when refactoring multiple test files
-5. Merge consecutive identical if-conditions so the shared guard is evaluated once. When you see redundant chains like `if A and B: ... elif A and not B: ...`, restructure them as `if A: if B: ... else: ...` to keep the shared condition centralized and avoid logic drift.
-
-The `/hf.quality-gate` command runs a structured quality check sequence. Use it before presenting work as complete.
-
-## Code Review Before Merge
-
-**After creating a PR, always self-review it for gaps, bugs, and test coverage before declaring it done.** Use `/superpowers:requesting-code-review` to run a structured review that checks:
-
-- **Gaps**: Missing edge cases, unhandled error paths, callers not updated for API changes
-- **Bugs**: Logic errors, off-by-one, race conditions, injection risks
-- **Test coverage**: Missing boundary tests, untested code paths, missing negative cases
-
-Do not present a PR as ready until the review passes and any findings are addressed.
-
-## Background Loop Guidelines
-
-When creating a new background loop (`BaseBackgroundLoop` subclass):
-
-1. **Use `make scaffold-loop`** to generate boilerplate — it handles all wiring
-2. **Restart safety**: Any `self._` state that affects behavior across cycles must either:
-   - Be persisted via `StateTracker` or `DedupStore` (survives restart)
-   - Be rehydrated from an external source (GitHub API) on first `_do_work()` cycle
-   - Be explicitly documented as ephemeral with `# ephemeral: lost on restart` comment
-3. **Wiring checklist** (automated by `tests/test_loop_wiring_completeness.py`):
-   - `src/service_registry.py` — dataclass field + `build_services()` instantiation
-   - `src/orchestrator.py` — entry in `bg_loop_registry` dict
-   - `src/ui/src/constants.js` — entry in `BACKGROUND_WORKERS`
-   - `src/dashboard_routes/_common.py` — entry in `_INTERVAL_BOUNDS`
-   - `src/config.py` — interval Field + `_ENV_INT_OVERRIDES` entry
-
-## Never Skip Commit Hooks
-
-**NEVER** use `git commit --no-verify` or `--no-hooks` flags. Always fix code issues first.
-
-## Never Commit to Main
-
-**NEVER** commit directly to `main`. The branch is protected and pushes will be rejected. All changes go through worktree branches and PRs — no exceptions, not even for one-line fixes.
-
-## Development Commands
-
-```bash
-make run            # Start backend + Vite frontend dev server
-make dry-run        # Dry run (log actions without executing)
-make clean          # Remove all worktrees and state
-make status         # Show current HydraFlow state
-make test           # Run unit tests (fail-fast)
-make test-fast      # Quick test run (-x --tb=short)
-make test-cov       # Run tests with coverage report (70% threshold)
-make lint           # Auto-fix linting
-make lint-check     # Check linting (no fix)
-make typecheck      # Run Pyright type checks
-make security       # Run Bandit security scan
-make layer-check    # Static import-direction checker (layer boundaries)
-make quality        # Lint + typecheck + security + test + layer-check (parallel)
-make quality-lite   # Lint + typecheck + security (no tests)
-make setup          # Install hooks, assets, config, labels
-make prep           # Sync agent assets + run full repo prep (labels, audit, CI/tests)
-make scaffold       # Generate baseline tests and CI configuration only (no asset sync)
-make ensure-labels  # Create HydraFlow lifecycle labels
-make integration    # Run integration tests
-make soak           # Run soak/load tests
-make hot            # Send config update to running instance
-make ui             # Build React dashboard
-make ui-dev         # Start React dashboard dev server
-make deps           # Sync dependencies via uv
-```
-
-### Quick Validation
-
-```bash
-# After small changes
-make lint && make test
-
-# Before committing
-make quality
-```
-
-## Sentry Error Tracking
-
-HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rules to keep Sentry signal-to-noise high:
-
-### What Goes to Sentry
-- **Real code bugs only**: `TypeError`, `KeyError`, `AttributeError`, `ValueError`, `IndexError`, `NotImplementedError`
-- The `before_send` filter in `server.py` drops all exceptions that are NOT in the bug-types tuple
-- `LoggingIntegration` captures `logger.error()` calls — these also go through the `before_send` filter
-
-### What Does NOT Go to Sentry
-- **Transient errors**: network timeouts, auth failures, rate limits, subprocess crashes — these are operational, not bugs
-- **Handled exceptions**: if you catch an error and handle it, use `logger.warning()` not `logger.error()` / `logger.exception()`
-- **Test mock exceptions**: never let test mocks raise through code paths that log at `error` level when `SENTRY_DSN` is set
-
-### Rules for New Code
-1. Use `logger.warning()` for expected/transient failures (network, auth, rate limit)
-2. Use `logger.error()` or `logger.exception()` ONLY for unexpected code bugs you want Sentry to capture
-3. Never use bare `except: pass` — always log at `warning` level minimum
-4. When adding a new background loop, catch operational errors and log at `warning`; let real bugs propagate to the base class error handler which logs at `error`
-5. The `_before_send` callback in `server.py` is the gatekeeper — if you add new exception types that indicate real bugs, add them to `_BUG_TYPES`
-6. The `SentryIngestLoop` in `sentry_loop.py` polls Sentry for unresolved issues and files them as GitHub issues — avoid creating noise that feeds back into this loop
-
-### Key Files
-- `src/server.py` — Sentry init, `_before_send` filter, `_BUG_TYPES` tuple
-- `src/sentry_loop.py` — Background loop that ingests Sentry issues into GitHub
-
-## Tech Stack
-
-- **Python 3.11** with Pydantic, asyncio
-- **FastAPI + WebSocket** for dashboard
-- **React + Vite** for dashboard UI
-- **Ruff** for linting/formatting
-- **Pyright** for type checking
-- **Bandit** for security scanning
-- **pytest + pytest-asyncio + pytest-xdist** for testing
-- **uv** for dependency management
-
-## UI Development Standards
-
-The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.
-
-### Layout
-- **CSS Grid** for page-level layout (`App.jsx`), **Flexbox** for component internals
-- Sidebar is fixed at `280px`; set `flexShrink: 0` on fixed-width panels/connectors
-- Set `minWidth` on containers to prevent content overlap at narrow viewports
-
-### DRY Principle
-- Shared constants (`ACTIVE_STATUSES`, `PIPELINE_STAGES`) live in `ui/src/constants.js` — never duplicate
-- Type definitions in `ui/src/types.js`
-- Colors are CSS custom properties in `ui/index.html` `:root`, accessed via `ui/src/theme.js` — always use `theme.*` tokens, never raw hex/rgb values
-- Extract shared styles to reusable objects when used 3+ times
-
-### Style Consistency
-- Define `const styles = {}` at file bottom; pre-compute variants (active/inactive, lit/dim) outside the component to avoid object spread in render loops (see `Header.jsx` `pillStyles`)
-- Spacing scale: multiples of 4px (4, 8, 12, 16, 20, 24, 32)
-- Font size scale: 9, 10, 11, 12, 13, 14, 16, 18
-- New colors must be added to both `ui/index.html` `:root` and `ui/src/theme.js`
-
-### Component Patterns
-- Check for existing components before creating new ones (pill badges in `Header.jsx`, status badges in `StreamCard.jsx`, tables in `ReviewTable.jsx`)
-- Prefer extending existing components over parallel implementations
-- Interactive elements need hover/focus states (`cursor: 'pointer'`, `transition`)
-- Derive stage-related UI from `PIPELINE_STAGES` in `constants.js`
+| Topic | File | When to read |
+|-------|------|--------------|
+| Architecture and key files | [`docs/agents/architecture.md`](docs/agents/architecture.md) | Exploring the codebase or placing new code |
+| Git worktrees and branch protection | [`docs/agents/worktrees.md`](docs/agents/worktrees.md) | Before any code change |
+| Testing is mandatory | [`docs/agents/testing.md`](docs/agents/testing.md) | Before writing or modifying tests |
+| Avoided patterns | [`docs/agents/avoided-patterns.md`](docs/agents/avoided-patterns.md) | Before adding Pydantic fields, imports, or mocks |
+| Quality gates | [`docs/agents/quality-gates.md`](docs/agents/quality-gates.md) | Before committing |
+| Background loops | [`docs/agents/background-loops.md`](docs/agents/background-loops.md) | Creating or modifying a `BaseBackgroundLoop` subclass |
+| Sentry rules | [`docs/agents/sentry.md`](docs/agents/sentry.md) | Adding logging or exception handling |
+| UI standards | [`docs/agents/ui-standards.md`](docs/agents/ui-standards.md) | Touching `ui/src/` |
+| Commands reference | [`docs/agents/commands.md`](docs/agents/commands.md) | Looking up a `make` target |
+| Architecture decisions | [`docs/adr/README.md`](docs/adr/README.md) | Understanding *why* something is the way it is |

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,32 @@
+# docs/agents — Topic-scoped guidance for coding agents
+
+This directory holds the operational knowledge agents need while working on HydraFlow. `CLAUDE.md` at the repo root is a thin table of contents pointing here — agents are expected to load only the topic file relevant to the current task rather than paying the context cost of the full set on every run.
+
+Structure mirrors [`docs/adr/`](../adr/README.md): one topic per file, one-line index entries, tests guard against broken links and regression back to the encyclopedia form (see `tests/test_claude_md_structure.py`).
+
+## Index
+
+| Topic | File | When to read |
+|-------|------|--------------|
+| Architecture and key files | [`architecture.md`](architecture.md) | Exploring the codebase or placing new code |
+| Git worktrees and branch protection | [`worktrees.md`](worktrees.md) | Before any code change |
+| Testing is mandatory | [`testing.md`](testing.md) | Before writing or modifying tests |
+| Avoided patterns | [`avoided-patterns.md`](avoided-patterns.md) | Before adding Pydantic fields, imports, or mocks — read once per session |
+| Quality gates | [`quality-gates.md`](quality-gates.md) | Before committing |
+| Background loops | [`background-loops.md`](background-loops.md) | Creating or modifying a `BaseBackgroundLoop` subclass |
+| Sentry rules | [`sentry.md`](sentry.md) | Adding logging or exception handling |
+| UI standards | [`ui-standards.md`](ui-standards.md) | Touching `ui/src/` |
+| Commands reference | [`commands.md`](commands.md) | Looking up a `make` target |
+
+## Related knowledge sources
+
+- **Architecture Decision Records** — [`docs/adr/README.md`](../adr/README.md). Read the relevant ADR before making changes to a documented decision area. Contradicting an Accepted ADR requires a new ADR superseding it.
+- **Per-repo wiki** — [`src/repo_wiki.py`](../../src/repo_wiki.py). LLM knowledge base for target repos HydraFlow manages; see [`docs/adr/0032-per-repo-wiki-knowledge-base.md`](../adr/0032-per-repo-wiki-knowledge-base.md).
+- **Planning and strategy docs** — [`docs/self-improving-harness.md`](../self-improving-harness.md), [`docs/ops-audit-plan.md`](../ops-audit-plan.md), [`docs/sentry-alerts.md`](../sentry-alerts.md).
+
+## Adding a new topic file
+
+1. Create `docs/agents/<topic>.md`
+2. Add a row to the index table above
+3. Link the new file from `CLAUDE.md` if it represents a top-level concern
+4. Update `tests/test_claude_md_structure.py` if the new file should be covered by a structural invariant

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,68 @@
+# Architecture
+
+HydraFlow runs five concurrent async loops from `src/orchestrator.py`:
+
+1. **Triage loop** — Fetches new issues, scores complexity, classifies type, and applies the `hydraflow-plan` label.
+2. **Plan loop** — Fetches issues labeled `hydraflow-plan`, runs a read-only Claude agent to explore the codebase and produce an implementation plan, posts the plan as a comment, then swaps the label to `hydraflow-ready`.
+3. **Implement loop** — Fetches issues labeled `hydraflow-ready`, creates git worktrees, runs implementation agents, pushes branches, creates PRs, then swaps to `hydraflow-review`.
+4. **Review loop** — Fetches issues labeled `hydraflow-review`, runs a review agent to check quality and optionally fix issues, submits a formal PR review, waits for CI, and auto-merges approved PRs. CI failures escalate to `hydraflow-hitl` for human intervention.
+5. **HITL loop** — Processes issues labeled `hydraflow-hitl` that need human-in-the-loop correction.
+
+For the authoritative design rationale, see [`docs/adr/0001-five-concurrent-async-loops.md`](../adr/0001-five-concurrent-async-loops.md) and [`docs/adr/0002-labels-as-state-machine.md`](../adr/0002-labels-as-state-machine.md).
+
+## Key Files
+
+### Core infrastructure
+- `src/server.py` — Server entry point (`python -m server`)
+- `scripts/run_admin_task.py` — Admin task runner (clean, prep, scaffold, ensure-labels)
+- `src/orchestrator.py` — Main coordinator (five async polling loops)
+- `src/config.py` — `HydraFlowConfig` Pydantic model (50+ env-var overrides)
+- `src/models.py` — Pydantic data models (Phase, SessionLog, ReviewResult, etc.)
+- `src/service_registry.py` — Composition root (`build_services()`); imports from all layers to wire dependencies
+- `src/state.py` — `StateTracker` (JSON-backed crash recovery)
+- `src/events.py` — `EventBus` async pub/sub
+
+### Phase implementations
+- `src/plan_phase.py` / `src/implement_phase.py` / `src/review_phase.py` / `src/triage_phase.py` / `src/hitl_phase.py`
+- `src/phase_utils.py` — Shared phase utilities
+- `src/pr_unsticker.py` — Stale PR recovery coordinator
+
+### Agents and runners
+- `src/agent.py` — `AgentRunner` (implementation agent)
+- `src/planner.py` — `PlannerRunner` (read-only planning agent)
+- `src/reviewer.py` — `ReviewRunner` (review + CI fix agent)
+- `src/hitl_runner.py` — HITL correction agent
+- `src/base_runner.py` — Base runner class
+
+### Git and PR management
+- `src/worktree.py` — `WorktreeManager` (git worktree lifecycle) — see [`docs/adr/0003-git-worktrees-for-isolation.md`](../adr/0003-git-worktrees-for-isolation.md)
+- `src/pr_manager.py` — `PRManager` (all `gh` CLI operations)
+- `src/merge_conflict_resolver.py` — Merge conflict resolution
+- `src/post_merge_handler.py` — Post-merge cleanup
+
+### Background loops
+- `src/base_background_loop.py` — Base async loop pattern — see [`docs/adr/0029-caretaker-loop-pattern.md`](../adr/0029-caretaker-loop-pattern.md)
+- `src/manifest_refresh_loop.py` / `src/memory_sync_loop.py` / `src/metrics_sync_loop.py` / `src/pr_unsticker_loop.py` — workers
+
+### Dashboard
+- `src/dashboard.py` + `src/dashboard_routes/` — FastAPI + WebSocket backend
+- `ui/` — React + Vite frontend — see [`ui-standards.md`](ui-standards.md)
+
+### Repo scaffolding (prep system)
+- `src/prep.py` — Repository preparation orchestrator
+- `src/ci_scaffold.py` / `src/lint_scaffold.py` / `src/test_scaffold.py` / `src/makefile_scaffold.py`
+- `src/polyglot_prep.py` — Language detection
+
+### Persistence
+Per-repo state layout is documented in [`docs/adr/0021-persistence-architecture-and-data-layout.md`](../adr/0021-persistence-architecture-and-data-layout.md). Per-target-repo LLM knowledge base: [`src/repo_wiki.py`](../../src/repo_wiki.py) — see [`docs/adr/0032-per-repo-wiki-knowledge-base.md`](../adr/0032-per-repo-wiki-knowledge-base.md).
+
+## Tech stack
+
+- **Python 3.11** with Pydantic, asyncio
+- **FastAPI + WebSocket** for dashboard
+- **React + Vite** for dashboard UI
+- **Ruff** for linting and formatting
+- **Pyright** for type checking
+- **Bandit** for security scanning
+- **pytest + pytest-asyncio + pytest-xdist** for testing
+- **uv** for dependency management

--- a/docs/agents/avoided-patterns.md
+++ b/docs/agents/avoided-patterns.md
@@ -1,0 +1,116 @@
+# Avoided Patterns
+
+Common mistakes agents make in the HydraFlow codebase. These are semantic rules that linters and type checkers cannot catch — they require understanding the project's conventions and prior incidents. Read this doc before editing the areas each rule calls out.
+
+This is the canonical location for avoided patterns. `CLAUDE.md` links here; do not duplicate rules back into `CLAUDE.md`. Sensors (`src/sensor_enricher.py`) and audit agents (`.claude/commands/hf.audit-code.md`) read this doc to coach agents during failures.
+
+## Pydantic field additions without updating serialization tests
+
+When you add a field to any model in `src/models.py` (e.g., `PRListItem`, `StateData`), grep `tests/` for the model name and update ALL exact-match serialization tests.
+
+- `model_dump()` assertions
+- Expected key sets in smoke tests
+- Any `assert result == {...}` that hard-codes the full model shape
+
+**Why:** HydraFlow has strict exact-match tests that assert on the complete serialized dict. A new field breaks them silently during unrelated refactors, and CI flags it later as a mysterious regression.
+
+**How to check:** After editing `models.py`, run `rg "<ModelName>" tests/` and confirm every match still passes.
+
+## Top-level imports of optional dependencies in test files
+
+Never write `from hindsight import Bank` at module level in tests. `httpx`, `hindsight`, and similar optional packages are not guaranteed to be installed in every environment.
+
+**Wrong:**
+
+```python
+# tests/test_something.py
+from hindsight import Bank  # module-level — fails import if hindsight not installed
+
+class TestSomething:
+    def test_x(self):
+        bank = Bank()
+```
+
+**Right:**
+
+```python
+# tests/test_something.py
+class TestSomething:
+    def test_x(self):
+        from hindsight import Bank  # deferred — only imports when the test runs
+        bank = Bank()
+```
+
+**Why:** Top-level imports run at collection time. If the optional dep is missing, the entire test file fails to collect, hiding every test in it from the report.
+
+## Spawning background sleep loops to poll for results
+
+Never write `sleep(N)` inside a loop waiting for a test suite or background process to finish.
+
+**Wrong:**
+
+```python
+while not result_file.exists():
+    time.sleep(5)
+```
+
+**Right:**
+
+- Use `run_in_background` with a single command and wait on the notification.
+- Run the command in the foreground and await its completion directly.
+
+**Why:** Sleep loops waste wall clock, mask failures, and provide no structured feedback. The harness exposes explicit background-task primitives for this exact purpose — use them.
+
+## Mocking at the wrong level
+
+Patch functions at their **import site**, not their **definition site**.
+
+If `src/base_runner.py` contains `from hindsight import recall_safe`, then within `base_runner` the name `recall_safe` is a local binding. Patching `hindsight.recall_safe` at the definition module leaves the local binding unchanged and the mock is never hit.
+
+**Wrong:**
+
+```python
+with patch("hindsight.recall_safe") as mock_recall:
+    runner.run()  # runner's local `recall_safe` binding is unaffected
+```
+
+**Right:**
+
+```python
+with patch("base_runner.recall_safe") as mock_recall:
+    runner.run()  # patches the binding the runner actually calls
+```
+
+**Why:** Python imports bind names into the importing module's namespace. A patch at the definition module only affects callers that go through that module explicitly, not callers that imported the name locally.
+
+## Falsy checks on optional objects
+
+Never write `if not self._hindsight` to test whether an optional object is present. Falsy checks can fire unexpectedly on mock objects, empty collections, and objects that implement `__bool__`.
+
+**Wrong:**
+
+```python
+if not self._hindsight:
+    return None
+```
+
+**Right:**
+
+```python
+if self._hindsight is None:
+    return None
+```
+
+**Why:** `Mock()` objects are truthy by default, but a `Mock()` configured with `spec=SomeClass` that has `__bool__` can be falsy, and ordinary values like empty lists or dicts trigger the wrong branch. Explicit `is None` makes the intent unambiguous and matches the type annotation contract (`X | None`).
+
+---
+
+## Adding a new avoided pattern
+
+When you observe a new recurring agent failure:
+
+1. Add a new `##` section to this doc with the same structure (wrong example, right example, why).
+2. Consider adding a rule to `src/sensor_rules.py` so the sensor enricher surfaces the hint automatically on matching failures.
+3. Consider whether `.claude/commands/hf.audit-code.md` Agent 5 (convention drift) should check for this pattern on its next sweep.
+
+Documenting the pattern once in this file propagates it to all three surfaces.

--- a/docs/agents/background-loops.md
+++ b/docs/agents/background-loops.md
@@ -1,0 +1,23 @@
+# Background Loop Guidelines
+
+When creating a new background loop (`BaseBackgroundLoop` subclass):
+
+1. **Use `make scaffold-loop`** to generate boilerplate — it handles all wiring.
+
+2. **Restart safety.** Any `self._` state that affects behavior across cycles must either:
+   - Be persisted via `StateTracker` or `DedupStore` (survives restart)
+   - Be rehydrated from an external source (GitHub API) on first `_do_work()` cycle
+   - Be explicitly documented as ephemeral with a `# ephemeral: lost on restart` comment
+
+3. **Wiring checklist** (automated by `tests/test_loop_wiring_completeness.py`):
+   - `src/service_registry.py` — dataclass field + `build_services()` instantiation
+   - `src/orchestrator.py` — entry in `bg_loop_registry` dict
+   - `src/ui/src/constants.js` — entry in `BACKGROUND_WORKERS`
+   - `src/dashboard_routes/_common.py` — entry in `_INTERVAL_BOUNDS`
+   - `src/config.py` — interval Field + `_ENV_INT_OVERRIDES` entry
+
+Missing any of these five entries will cause `test_loop_wiring_completeness` to fail. Add them all in the same commit.
+
+## Design rationale
+
+See [`docs/adr/0029-caretaker-loop-pattern.md`](../adr/0029-caretaker-loop-pattern.md) for the caretaker loop pattern, and [`docs/adr/0019-background-task-delegation-abstraction-layer.md`](../adr/0019-background-task-delegation-abstraction-layer.md) for the delegation abstraction.

--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -1,0 +1,60 @@
+# Development Commands
+
+## Run and dev
+
+```bash
+make run            # Start backend + Vite frontend dev server
+make dry-run        # Dry run (log actions without executing)
+make clean          # Remove all worktrees and state
+make status         # Show current HydraFlow state
+make hot            # Send config update to running instance
+```
+
+## Tests
+
+```bash
+make test           # Run unit tests (fail-fast)
+make test-fast      # Quick test run (-x --tb=short)
+make test-cov       # Run tests with coverage report (70% threshold)
+make integration    # Run integration tests
+make soak           # Run soak/load tests
+```
+
+## Quality
+
+```bash
+make lint           # Auto-fix linting
+make lint-check     # Check linting (no fix)
+make typecheck      # Run Pyright type checks
+make security       # Run Bandit security scan
+make layer-check    # Static import-direction checker (layer boundaries)
+make quality        # Lint + typecheck + security + test + layer-check (parallel)
+make quality-lite   # Lint + typecheck + security (no tests)
+```
+
+## Setup and scaffolding
+
+```bash
+make setup          # Install hooks, assets, config, labels
+make prep           # Sync agent assets + run full repo prep (labels, audit, CI/tests)
+make scaffold       # Generate baseline tests and CI configuration only (no asset sync)
+make ensure-labels  # Create HydraFlow lifecycle labels
+make deps           # Sync dependencies via uv
+```
+
+## UI
+
+```bash
+make ui             # Build React dashboard
+make ui-dev         # Start React dashboard dev server
+```
+
+## Quick validation loop
+
+```bash
+# After small changes
+make lint && make test
+
+# Before committing
+make quality
+```

--- a/docs/agents/quality-gates.md
+++ b/docs/agents/quality-gates.md
@@ -1,0 +1,49 @@
+# Quality Gates
+
+**Always run lint and tests before declaring work complete or committing.** Do not present implementation as "done" until quality checks pass.
+
+## Sequence before committing
+
+1. After each significant code change: `make lint` (auto-fixes formatting and imports)
+2. Before committing: `make quality` (lint + typecheck + security + tests + layer-check in parallel)
+3. If lint auto-fixes files, re-check for type errors introduced by removed imports
+4. Track your edits across files — avoid creating duplicate helpers or inconsistent naming when refactoring multiple test files
+5. Merge consecutive identical if-conditions so the shared guard is evaluated once. When you see redundant chains like `if A and B: ... elif A and not B: ...`, restructure them as `if A: if B: ... else: ...` to keep the shared condition centralized and avoid logic drift.
+
+The `/hf.quality-gate` slash command runs a structured quality check sequence. Use it before presenting work as complete.
+
+## Quick validation loop
+
+```bash
+# After small changes
+make lint && make test
+
+# Before committing
+make quality
+```
+
+## Code review before merge
+
+**After creating a PR, always self-review it for gaps, bugs, and test coverage before declaring it done.** Use `/superpowers:requesting-code-review` to run a structured review that checks:
+
+- **Gaps** — Missing edge cases, unhandled error paths, callers not updated for API changes
+- **Bugs** — Logic errors, off-by-one, race conditions, injection risks
+- **Test coverage** — Missing boundary tests, untested code paths, missing negative cases
+
+Do not present a PR as ready until the review passes and any findings are addressed.
+
+## Reasoning triggers
+
+For analysis-heavy tasks (architecture decisions, debugging, code review), use explicit reasoning prompts to trigger deeper analysis:
+
+- "Think through the tradeoffs of this approach before implementing"
+- "Consider what could go wrong and what edge cases exist"
+- "Explain your reasoning before making changes"
+
+Simple mechanical tasks (rename, format, move) don't need these — just do them.
+
+## Related
+
+- [`testing.md`](testing.md) — test requirements
+- [`avoided-patterns.md`](avoided-patterns.md) — mistakes that commonly slip through quality gates
+- [`commands.md`](commands.md) — full `make` target reference

--- a/docs/agents/sentry.md
+++ b/docs/agents/sentry.md
@@ -1,0 +1,29 @@
+# Sentry Error Tracking
+
+HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rules to keep Sentry signal-to-noise high.
+
+## What goes to Sentry
+
+- **Real code bugs only.** `TypeError`, `KeyError`, `AttributeError`, `ValueError`, `IndexError`, `NotImplementedError`.
+- The `before_send` filter in `src/server.py` drops all exceptions that are NOT in the bug-types tuple.
+- `LoggingIntegration` captures `logger.error()` calls — these also go through the `before_send` filter.
+
+## What does NOT go to Sentry
+
+- **Transient errors** — network timeouts, auth failures, rate limits, subprocess crashes. These are operational, not bugs.
+- **Handled exceptions** — if you catch an error and handle it, use `logger.warning()`, not `logger.error()` or `logger.exception()`.
+- **Test mock exceptions** — never let test mocks raise through code paths that log at `error` level when `SENTRY_DSN` is set.
+
+## Rules for new code
+
+1. Use `logger.warning()` for expected or transient failures (network, auth, rate limit).
+2. Use `logger.error()` or `logger.exception()` ONLY for unexpected code bugs you want Sentry to capture.
+3. Never use bare `except: pass` — always log at `warning` level minimum.
+4. When adding a new background loop, catch operational errors and log at `warning`; let real bugs propagate to the base class error handler which logs at `error`.
+5. The `_before_send` callback in `src/server.py` is the gatekeeper — if you add new exception types that indicate real bugs, add them to `_BUG_TYPES`.
+6. The `SentryIngestLoop` in `src/sentry_loop.py` polls Sentry for unresolved issues and files them as GitHub issues — avoid creating noise that feeds back into this loop.
+
+## Key files
+
+- `src/server.py` — Sentry init, `_before_send` filter, `_BUG_TYPES` tuple
+- `src/sentry_loop.py` — Background loop that ingests Sentry issues into GitHub

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,22 @@
+# Testing Is Mandatory
+
+**ALWAYS write unit tests for code changes before committing.** Every new function, class, or feature modification MUST include comprehensive tests.
+
+- Tests live in `tests/` following the pattern `tests/test_<module>.py`
+- New features: Write tests BEFORE committing
+- Bug fixes: Add regression tests that reproduce the bug
+- Refactoring: Ensure existing tests pass, add tests for new paths
+- Never commit untested code
+- Coverage threshold: **70%**
+
+## ADR testing rules
+
+- **Never write tests for ADR markdown content.** ADRs are documentation, not code. Do not create `test_adr_NNNN_*.py` files that assert on markdown headings, status fields, or prose content — these break whenever the document is edited and provide no value. Only test ADR-related *code* (e.g., `test_adr_reviewer.py` tests the reviewer logic).
+- **Never include line numbers in ADR source citations.** Throughout ADR documents (Related, Context, Decision, Consequences sections), cite source files by function or class name only (e.g., `src/config.py:_resolve_base_paths`). Do NOT add `(line 42)` or similar anywhere — line numbers drift as the source file is edited and council reviews will flag them as stale.
+
+## Related
+
+- [`avoided-patterns.md`](avoided-patterns.md) — recurring test-side mistakes (top-level imports of optional deps, wrong-level mocks, falsy optional checks)
+- [`quality-gates.md`](quality-gates.md) — the full quality sequence to run before committing
+- [`docs/adr/0022-integration-test-architecture-cross-phase.md`](../adr/0022-integration-test-architecture-cross-phase.md) — integration test architecture
+- [`docs/adr/0035-tests-must-match-toggle-state-they-assert.md`](../adr/0035-tests-must-match-toggle-state-they-assert.md) — toggle/test alignment

--- a/docs/agents/ui-standards.md
+++ b/docs/agents/ui-standards.md
@@ -1,0 +1,30 @@
+# UI Development Standards
+
+The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.
+
+## Layout
+
+- **CSS Grid** for page-level layout (`App.jsx`), **Flexbox** for component internals
+- Sidebar is fixed at `280px`; set `flexShrink: 0` on fixed-width panels and connectors
+- Set `minWidth` on containers to prevent content overlap at narrow viewports
+
+## DRY principle
+
+- Shared constants (`ACTIVE_STATUSES`, `PIPELINE_STAGES`) live in `ui/src/constants.js` — never duplicate.
+- Type definitions in `ui/src/types.js`.
+- Colors are CSS custom properties in `ui/index.html` `:root`, accessed via `ui/src/theme.js` — always use `theme.*` tokens, never raw hex or rgb values.
+- Extract shared styles to reusable objects when used 3+ times.
+
+## Style consistency
+
+- Define `const styles = {}` at file bottom; pre-compute variants (active/inactive, lit/dim) outside the component to avoid object spread in render loops. See `Header.jsx` `pillStyles` for the reference pattern.
+- Spacing scale: multiples of 4px (4, 8, 12, 16, 20, 24, 32).
+- Font size scale: 9, 10, 11, 12, 13, 14, 16, 18.
+- New colors must be added to both `ui/index.html` `:root` and `ui/src/theme.js`.
+
+## Component patterns
+
+- Check for existing components before creating new ones — pill badges in `Header.jsx`, status badges in `StreamCard.jsx`, tables in `ReviewTable.jsx`.
+- Prefer extending existing components over parallel implementations.
+- Interactive elements need hover and focus states (`cursor: 'pointer'`, `transition`).
+- Derive stage-related UI from `PIPELINE_STAGES` in `constants.js`.

--- a/docs/agents/worktrees.md
+++ b/docs/agents/worktrees.md
@@ -1,0 +1,30 @@
+# Worktrees and Branch Protection
+
+HydraFlow creates isolated git worktrees for each issue. **Always clean up worktrees when their PRs are merged or issues are closed. Always implement issue work on a dedicated git worktree branch; do not implement directly in the primary repo checkout.**
+
+> **CRITICAL:** The `main` branch is protected. Direct commits and pushes to `main` will be rejected. All code changes — including one-line fixes — MUST go through a worktree branch and a pull request. Never stage, commit, or modify files in the primary repo checkout. No exceptions.
+
+Design rationale: [`docs/adr/0003-git-worktrees-for-isolation.md`](../adr/0003-git-worktrees-for-isolation.md) and [`docs/adr/0010-worktree-and-path-isolation.md`](../adr/0010-worktree-and-path-isolation.md).
+
+## Workflow for every code change
+
+1. Create a worktree: `git worktree add ../hydraflow-worktrees/<name> origin/main`
+2. Create a branch in the worktree: `git checkout -b <branch-name> origin/main`
+3. Make changes, commit, and push the branch
+4. Create a PR via `gh pr create`
+5. Clean up: `git worktree remove ../hydraflow-worktrees/<name>`
+
+**Do NOT use the `EnterWorktree` tool** — it auto-cleans up and loses work. Use manual `git worktree add` commands.
+
+## Conventions
+
+- **Default location:** `../hydraflow-worktrees/` (sibling to repo root)
+- **Naming:** `issue-{issue_number}/` for issue work, descriptive names for other changes
+- **Config:** `worktree_base` field in `HydraFlowConfig` (`src/config.py`)
+- **Cleanup:** `make clean` removes all worktrees and state
+- Worktrees get independent venvs (`uv sync`), symlinked `.env`, and pre-commit hooks
+- Stale worktrees from merged PRs should be periodically pruned with `git worktree prune`
+
+## Never skip commit hooks
+
+**NEVER** use `git commit --no-verify` or `--no-hooks` flags. If a hook fails, investigate and fix the underlying issue — do not bypass it.

--- a/src/config.py
+++ b/src/config.py
@@ -219,6 +219,7 @@ _ENV_FLOAT_RATIO_OVERRIDES: list[tuple[str, str, float]] = [
 
 _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ("dry_run", "HYDRAFLOW_DRY_RUN", False),
+    ("sensor_enrichment_enabled", "HYDRAFLOW_SENSOR_ENRICHMENT_ENABLED", True),
     ("docker_read_only_root", "HYDRAFLOW_DOCKER_READ_ONLY_ROOT", True),
     ("docker_no_new_privileges", "HYDRAFLOW_DOCKER_NO_NEW_PRIVILEGES", True),
     (
@@ -902,6 +903,16 @@ class HydraFlowConfig(BaseModel):
         default="high",
         description="Minimum severity to file issues for (critical, high, medium, low)",
     )
+    # Sensor enrichment — positive prompt injection on captured tool output.
+    # See src/sensor_enricher.py and docs/agents/avoided-patterns.md.
+    sensor_enrichment_enabled: bool = Field(
+        default=True,
+        description=(
+            "Append Agent Hints blocks to captured tool-failure output "
+            "based on rules in sensor_rules.SEED_RULES."
+        ),
+    )
+
     # Code grooming
     code_grooming_interval: int = Field(
         default=86400,

--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -92,6 +92,11 @@ class FailureRecord(BaseModel):
     subcategories: list[str] = Field(default_factory=list)
     details: str = ""
     stage: PipelineStage | Literal[""] = ""
+    # Agent Hints matched from sensor_enricher.SEED_RULES at record time.
+    # Populated by HarnessInsightStore.append_failure when sensor enrichment
+    # is enabled. Empty list means no rules matched or enrichment disabled.
+    # See docs/agents/avoided-patterns.md and src/sensor_enricher.py.
+    hints: list[str] = Field(default_factory=list)
 
 
 class ImprovementSuggestion(BaseModel):
@@ -144,6 +149,7 @@ class HarnessInsightStore:
         hindsight: HindsightClient | None = None,
         dolt: DoltBackend | None = None,
         wal: HindsightWAL | None = None,
+        sensor_enrichment_enabled: bool = True,
     ) -> None:
         from dedup_store import DedupStore  # noqa: PLC0415
 
@@ -157,9 +163,52 @@ class HarnessInsightStore:
         self._hindsight = hindsight
         self._dolt = dolt
         self._wal = wal
+        self._sensor_enrichment_enabled = sensor_enrichment_enabled
+
+    def _enrich_record_hints(self, record: FailureRecord) -> None:
+        """Populate ``record.hints`` from matching sensor rules.
+
+        Runs sensor_enricher against the record's ``details`` using the
+        seed rule registry. Silently no-ops when enrichment is disabled
+        or nothing matches. Never raises — enrichment is best-effort.
+        """
+        if not self._sensor_enrichment_enabled:
+            return
+        if record.hints:
+            # Caller already populated hints; respect explicit values.
+            return
+        try:
+            from sensor_enricher import (  # noqa: PLC0415
+                MATCH_ALL_TOOLS,
+                matching_rules,
+            )
+            from sensor_rules import SEED_RULES  # noqa: PLC0415
+
+            # We have no changed-file context here, so only ErrorPattern
+            # rules will fire from the failure details. This is
+            # intentional — FileChanged rules are meant for tool-output
+            # integration points that know which files were edited.
+            # Use MATCH_ALL_TOOLS because failure records don't carry
+            # the originating tool (ruff/pyright/pytest) explicitly.
+            result = matching_rules(
+                SEED_RULES,
+                tool=MATCH_ALL_TOOLS,
+                raw_output=record.details,
+                changed_files=[],
+            )
+            record.hints = [rule.hint for rule in result.fired]
+        except Exception:  # noqa: BLE001
+            logger.warning("sensor enrichment failed", exc_info=True)
 
     def append_failure(self, record: FailureRecord) -> None:
-        """Append *record* as a JSON line to ``harness_failures.jsonl``."""
+        """Append *record* as a JSON line to ``harness_failures.jsonl``.
+
+        When sensor enrichment is enabled, matching rule hints from
+        :mod:`sensor_rules` are added to ``record.hints`` before the
+        record is persisted. This makes the hints visible in the failure
+        archive and downstream retry-context builders.
+        """
+        self._enrich_record_hints(record)
         try:
             from file_util import append_jsonl  # noqa: PLC0415
 

--- a/src/sensor_enricher.py
+++ b/src/sensor_enricher.py
@@ -154,9 +154,15 @@ def enrich(
     rules fire. When at least one rule fires, the return value is
     ``<raw_output>\\n\\n## Agent Hints\\n\\n- <hint1>\\n- <hint2>\\n``.
 
+    Idempotent: if ``raw_output`` already contains an ``## Agent Hints``
+    heading (because it was previously enriched), the function returns
+    the input unchanged rather than appending a second hints block.
+
     Agents are instructed (in their system prompt, see #6426) to prefer
     the Agent Hints block over general reasoning when it is present.
     """
+    if "## Agent Hints" in raw_output:
+        return raw_output
     result = matching_rules(
         rules,
         tool=tool,

--- a/src/sensor_enricher.py
+++ b/src/sensor_enricher.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 __all__ = [
+    "ANY_TOOL",
+    "MATCH_ALL_TOOLS",
     "ErrorPattern",
     "FileChanged",
     "Rule",
@@ -30,7 +32,13 @@ __all__ = [
 ]
 
 # Tool name sentinel meaning "fire for any tool output, not just a specific one".
+# Used on the RULE side: Rule(tool=ANY_TOOL, ...) fires regardless of caller tool.
 ANY_TOOL = "any"
+
+# Caller-side sentinel meaning "match every rule regardless of tool scope".
+# Used by callers that do not know which tool produced the output (e.g.
+# :class:`HarnessInsightStore` enriching generic failure records).
+MATCH_ALL_TOOLS = "*"
 
 
 class RuleTrigger:
@@ -107,6 +115,8 @@ class EnrichmentResult:
 
 
 def _tool_matches(rule_tool: str, tool: str) -> bool:
+    if tool == MATCH_ALL_TOOLS:
+        return True
     return rule_tool in (ANY_TOOL, tool)
 
 

--- a/src/sensor_enricher.py
+++ b/src/sensor_enricher.py
@@ -1,0 +1,160 @@
+"""Sensor output enricher — positive prompt injection for agent failures.
+
+Wraps raw tool output (ruff, pyright, pytest, bandit, etc.) with project-
+specific coaching hints before the text lands in an agent transcript.
+The raw output is preserved verbatim; hints are appended as an
+``## Agent Hints`` block so agents can prefer them over general reasoning
+about unfamiliar errors.
+
+Rules live in :mod:`sensor_rules` as a pure data registry. This module
+contains only the matching engine and the public ``enrich`` function.
+
+Part of the harness-engineering foundations (#6426).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+
+__all__ = [
+    "ErrorPattern",
+    "FileChanged",
+    "Rule",
+    "RuleTrigger",
+    "enrich",
+    "matching_rules",
+]
+
+# Tool name sentinel meaning "fire for any tool output, not just a specific one".
+ANY_TOOL = "any"
+
+
+class RuleTrigger:
+    """Base class for rule triggers. A trigger decides whether a rule fires."""
+
+    def matches(self, *, raw_output: str, changed_files: Sequence[Path]) -> bool:
+        del raw_output, changed_files
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class FileChanged(RuleTrigger):
+    """Fire when any changed file matches a glob pattern.
+
+    Patterns are matched against forward-slash POSIX paths so globs work
+    consistently on Windows and *nix. Use ``src/*_loop.py`` for background
+    loop modules, ``src/models.py`` for exact files, etc.
+    """
+
+    pattern: str
+
+    def matches(self, *, raw_output: str, changed_files: Sequence[Path]) -> bool:
+        del raw_output  # unused for this trigger type
+        for path in changed_files:
+            posix = path.as_posix()
+            if fnmatch.fnmatch(posix, self.pattern):
+                return True
+        return False
+
+
+@dataclass(frozen=True)
+class ErrorPattern(RuleTrigger):
+    """Fire when the raw tool output matches a regex.
+
+    The regex is compiled with ``re.MULTILINE`` so ``^`` / ``$`` work per-line.
+    """
+
+    regex: str
+
+    def matches(self, *, raw_output: str, changed_files: Sequence[Path]) -> bool:
+        del changed_files  # unused for this trigger type
+        return bool(re.search(self.regex, raw_output, re.MULTILINE))
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A single enrichment rule.
+
+    Attributes:
+        id: Stable identifier used for telemetry (``harness_insights``
+            records which rules fire on which tool failures).
+        tool: Tool name to match (``ruff``, ``pyright``, ``pytest``,
+            ``bandit``) or ``"any"`` to match regardless of tool.
+        trigger: The condition that decides whether the rule fires.
+        hint: Short prose appended to the Agent Hints block. Should
+            reference a doc anchor when possible (e.g.
+            ``docs/agents/avoided-patterns.md#...``).
+    """
+
+    id: str
+    tool: str
+    trigger: RuleTrigger
+    hint: str
+
+
+@dataclass
+class EnrichmentResult:
+    """Return value of :func:`matching_rules` — the rules that fired."""
+
+    fired: list[Rule] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.fired)
+
+
+def _tool_matches(rule_tool: str, tool: str) -> bool:
+    return rule_tool in (ANY_TOOL, tool)
+
+
+def matching_rules(
+    rules: Iterable[Rule],
+    *,
+    tool: str,
+    raw_output: str,
+    changed_files: Sequence[Path],
+) -> EnrichmentResult:
+    """Return the rules that fire for a given tool failure.
+
+    Pure function: same inputs always yield the same fired-rule list.
+    Suitable for unit testing without touching disk or subprocess state.
+    """
+    fired: list[Rule] = []
+    for rule in rules:
+        if not _tool_matches(rule.tool, tool):
+            continue
+        if rule.trigger.matches(raw_output=raw_output, changed_files=changed_files):
+            fired.append(rule)
+    return EnrichmentResult(fired=fired)
+
+
+def enrich(
+    *,
+    tool: str,
+    raw_output: str,
+    changed_files: Sequence[Path],
+    rules: Iterable[Rule],
+) -> str:
+    """Append an Agent Hints block to raw tool output for matching rules.
+
+    The raw output is preserved verbatim and returned unchanged when no
+    rules fire. When at least one rule fires, the return value is
+    ``<raw_output>\\n\\n## Agent Hints\\n\\n- <hint1>\\n- <hint2>\\n``.
+
+    Agents are instructed (in their system prompt, see #6426) to prefer
+    the Agent Hints block over general reasoning when it is present.
+    """
+    result = matching_rules(
+        rules,
+        tool=tool,
+        raw_output=raw_output,
+        changed_files=changed_files,
+    )
+    if not result:
+        return raw_output
+
+    hint_lines = "\n".join(f"- {rule.hint}" for rule in result.fired)
+    return f"{raw_output}\n\n## Agent Hints\n\n{hint_lines}\n"

--- a/src/sensor_rules.py
+++ b/src/sensor_rules.py
@@ -1,0 +1,98 @@
+"""Seed rule registry for :mod:`sensor_enricher`.
+
+Each rule is a triple of (id, trigger, hint). Rules fire when tool
+output is captured from a subprocess and match either a file-change
+pattern or an error-regex pattern.
+
+Rules seeded here mirror the rule bullets in
+``docs/agents/avoided-patterns.md``. Adding a new avoided pattern?
+Add both a section to that doc AND a rule here — the sensor enricher
+will surface the hint the next time the matching failure occurs.
+
+Part of the harness-engineering foundations (#6426).
+"""
+
+from __future__ import annotations
+
+from sensor_enricher import ANY_TOOL, ErrorPattern, FileChanged, Rule
+
+__all__ = ["SEED_RULES"]
+
+
+SEED_RULES: list[Rule] = [
+    Rule(
+        id="pydantic-field-tests",
+        tool=ANY_TOOL,
+        trigger=FileChanged("src/models.py"),
+        hint=(
+            "You modified `src/models.py`. Pydantic field additions "
+            "commonly break exact-match serialization tests. Grep `tests/` "
+            "for the model name and update `model_dump()` assertions and "
+            "expected-key sets in smoke tests. "
+            "See docs/agents/avoided-patterns.md — 'Pydantic field "
+            "additions without updating serialization tests'."
+        ),
+    ),
+    Rule(
+        id="optional-dep-toplevel-import",
+        tool="pytest",
+        trigger=ErrorPattern(
+            r"ModuleNotFoundError.*(hindsight|httpx)"
+            r"|ImportError.*(hindsight|httpx)"
+        ),
+        hint=(
+            "An optional dependency (hindsight/httpx) failed to import at "
+            "collection time. Move the import inside the test method "
+            "instead of a module-level `from ... import ...`. "
+            "See docs/agents/avoided-patterns.md — 'Top-level imports of "
+            "optional dependencies in test files'."
+        ),
+    ),
+    Rule(
+        id="background-loop-wiring",
+        tool=ANY_TOOL,
+        trigger=FileChanged("src/*_loop.py"),
+        hint=(
+            "You modified a background loop module. The wiring "
+            "completeness test (tests/test_loop_wiring_completeness.py) "
+            "enforces entries in src/service_registry.py, src/orchestrator.py, "
+            "src/ui/src/constants.js, src/dashboard_routes/_common.py, and "
+            "src/config.py. Confirm all five are updated before committing. "
+            "See CLAUDE.md — 'Background Loop Guidelines'."
+        ),
+    ),
+    Rule(
+        id="mock-wrong-patch-site",
+        tool="pytest",
+        trigger=ErrorPattern(
+            r"AssertionError.*call_count|assert.*called_with|"
+            r"AttributeError.*Mock object has no attribute"
+        ),
+        hint=(
+            "Mock assertion failures often indicate patching at the wrong "
+            "level. Patch functions at their IMPORT site (the module that "
+            "does `from X import Y`), not at their DEFINITION site (module "
+            "X itself). Python imports bind names into the importing "
+            "module's namespace; a patch at the definition site does not "
+            "affect local bindings. "
+            "See docs/agents/avoided-patterns.md — 'Mocking at the wrong level'."
+        ),
+    ),
+    Rule(
+        id="falsy-optional-check",
+        tool="pytest",
+        trigger=ErrorPattern(
+            r"assert.*is None|AttributeError.*NoneType|"
+            r"TypeError.*NoneType"
+        ),
+        hint=(
+            "Optional-attribute errors often come from `if not self._x` "
+            "style falsy checks on values typed `X | None`. Mock objects "
+            "are truthy by default, and some objects implement `__bool__`, "
+            "so the falsy branch does not fire reliably. Use explicit "
+            "`if self._x is None:` instead. "
+            "See docs/agents/avoided-patterns.md — 'Falsy checks on "
+            "optional objects'."
+        ),
+    ),
+]

--- a/src/sensor_rules.py
+++ b/src/sensor_rules.py
@@ -58,7 +58,7 @@ SEED_RULES: list[Rule] = [
             "enforces entries in src/service_registry.py, src/orchestrator.py, "
             "src/ui/src/constants.js, src/dashboard_routes/_common.py, and "
             "src/config.py. Confirm all five are updated before committing. "
-            "See CLAUDE.md — 'Background Loop Guidelines'."
+            "See docs/agents/background-loops.md."
         ),
     ),
     Rule(
@@ -81,10 +81,11 @@ SEED_RULES: list[Rule] = [
     Rule(
         id="falsy-optional-check",
         tool="pytest",
-        trigger=ErrorPattern(
-            r"assert.*is None|AttributeError.*NoneType|"
-            r"TypeError.*NoneType"
-        ),
+        # Match the actual code anti-pattern (`if not self._field`) appearing
+        # in failure tracebacks or source snippets, NOT generic `is None`
+        # assertion lines or NoneType tracebacks (which appear in countless
+        # unrelated failures and would produce noisy hints).
+        trigger=ErrorPattern(r"if not self\._\w+|if not self\.\w+:"),
         hint=(
             "Optional-attribute errors often come from `if not self._x` "
             "style falsy checks on values typed `X | None`. Mock objects "

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -335,6 +335,7 @@ def build_services(
         hindsight=hindsight_client,
         dolt=dolt_backend,
         wal=hindsight_wal,
+        sensor_enrichment_enabled=config.sensor_enrichment_enabled,
     )
 
     # Troubleshooting pattern store (CI timeout feedback loop)

--- a/tests/test_audit_code_skill.py
+++ b/tests/test_audit_code_skill.py
@@ -1,0 +1,96 @@
+"""Structural guards for the hf.audit-code skill file (#6427).
+
+These tests enforce that the skill prompt matches the expectations of
+``src/code_grooming_loop.py`` — specifically, that it launches the
+expected set of audit agents and that the new Agent 5 (convention drift)
+reads the canonical avoided-patterns doc at runtime instead of
+hardcoding rules into the prompt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SKILL_FILE = REPO_ROOT / ".claude" / "commands" / "hf.audit-code.md"
+
+
+def _read_skill() -> str:
+    assert SKILL_FILE.exists(), f"{SKILL_FILE} missing"
+    return SKILL_FILE.read_text(encoding="utf-8")
+
+
+class TestAuditCodeSkillStructure:
+    def test_skill_file_exists(self) -> None:
+        assert SKILL_FILE.exists()
+
+    def test_fanout_declares_five_agents(self) -> None:
+        content = _read_skill()
+        # The orchestration step must enumerate all five agents.
+        for agent in (
+            "Agent 1: Dead code",
+            "Agent 2: Method size",
+            "Agent 3: Error handling",
+            "Agent 4: Type safety",
+            "Agent 5: Convention drift",
+        ):
+            assert agent in content, f"missing fanout entry: {agent}"
+
+    def test_each_agent_has_its_own_section(self) -> None:
+        content = _read_skill()
+        for heading in (
+            "## Agent 1: Dead Code",
+            "## Agent 2: Method Size",
+            "## Agent 3: Error Handling",
+            "## Agent 4: Type Safety",
+            "## Agent 5: Convention Drift",
+        ):
+            assert heading in content, f"missing section: {heading}"
+
+
+class TestAgent5ConventionDrift:
+    def test_agent5_reads_avoided_patterns_doc_at_runtime(self) -> None:
+        """Agent 5 must read docs/agents/avoided-patterns.md, not hardcode rules."""
+        content = _read_skill()
+        # The Agent 5 body must mention reading the canonical doc.
+        agent5_start = content.find("## Agent 5:")
+        assert agent5_start != -1
+        agent5_body = content[agent5_start:]
+        assert "docs/agents/avoided-patterns.md" in agent5_body, (
+            "Agent 5 must reference docs/agents/avoided-patterns.md as the "
+            "runtime source of rules. Do not hardcode patterns in the prompt."
+        )
+
+    def test_agent5_lists_over_engineering_categories(self) -> None:
+        content = _read_skill()
+        agent5_start = content.find("## Agent 5:")
+        agent5_body = content[agent5_start:]
+        # The over-engineering sweep must cover the documented categories.
+        for category in (
+            "Single-use helpers",
+            "Speculative abstractions",
+            "Defensive handling",
+            "Backwards-compat shims",
+            "Feature-flag rot",
+        ):
+            assert category in agent5_body, (
+                f"Agent 5 must sweep for over-engineering category: {category}"
+            )
+
+    def test_agent5_emits_json_schema_compatible_with_parser(self) -> None:
+        """Findings must be emitted in the schema code_grooming_loop parses."""
+        content = _read_skill()
+        agent5_start = content.find("## Agent 5:")
+        agent5_body = content[agent5_start:]
+        # The _FINDING_RE in code_grooming_loop.py parses objects with
+        # "id" and "severity" keys. Agent 5 must match that schema.
+        assert '"id"' in agent5_body
+        assert '"severity"' in agent5_body
+
+    def test_agent5_references_avoided_patterns_doc_as_source_of_truth(self) -> None:
+        """The keep-in-sync principle should be stated explicitly."""
+        content = _read_skill()
+        agent5_start = content.find("## Agent 5:")
+        agent5_body = content[agent5_start:]
+        # We phrase this as "reads ... at runtime" in the prompt.
+        assert "at runtime" in agent5_body or "runtime" in agent5_body

--- a/tests/test_claude_md_structure.py
+++ b/tests/test_claude_md_structure.py
@@ -99,6 +99,64 @@ class TestAvoidedPatternsExtraction:
         )
 
 
+class TestClaudeMdIsToCForm:
+    """CLAUDE.md must remain a lean table of contents, not an encyclopedia.
+
+    #6425 caps CLAUDE.md at ≤80 lines and requires the full topic set to
+    exist under docs/agents/. This test guards against content drifting
+    back into CLAUDE.md.
+    """
+
+    LINE_BUDGET = 80
+
+    def test_claude_md_within_line_budget(self) -> None:
+        content = _read_claude_md()
+        line_count = len(content.splitlines())
+        assert line_count <= self.LINE_BUDGET, (
+            f"CLAUDE.md is {line_count} lines — exceeds the {self.LINE_BUDGET}-line "
+            "budget. Move content into a docs/agents/*.md topic file and link it."
+        )
+
+    def test_all_topic_files_exist(self) -> None:
+        required = [
+            "architecture.md",
+            "avoided-patterns.md",
+            "background-loops.md",
+            "commands.md",
+            "quality-gates.md",
+            "sentry.md",
+            "testing.md",
+            "ui-standards.md",
+            "worktrees.md",
+            "README.md",
+        ]
+        missing = [f for f in required if not (DOCS_AGENTS / f).exists()]
+        assert not missing, f"missing docs/agents files: {missing}"
+
+    def test_claude_md_links_to_every_topic_file(self) -> None:
+        """Every topic file in docs/agents/ (except README.md) must be
+        linked from CLAUDE.md. Catches topic drift where a doc is added
+        but the ToC is forgotten."""
+        content = _read_claude_md()
+        topic_files = {
+            f.name for f in DOCS_AGENTS.glob("*.md") if f.name != "README.md"
+        }
+        unlinked = [f for f in topic_files if f"docs/agents/{f}" not in content]
+        assert not unlinked, f"topic files not linked from CLAUDE.md: {unlinked}"
+
+    def test_docs_agents_readme_is_index(self) -> None:
+        """The README.md in docs/agents/ is an index, not a topic."""
+        readme = DOCS_AGENTS / "README.md"
+        assert readme.exists()
+        content = readme.read_text(encoding="utf-8")
+        # The index must list every topic file.
+        topic_files = sorted(
+            f.name for f in DOCS_AGENTS.glob("*.md") if f.name != "README.md"
+        )
+        missing = [f for f in topic_files if f not in content]
+        assert not missing, f"docs/agents/README.md index missing entries: {missing}"
+
+
 class TestLinkedDocsResolve:
     """Every markdown link from CLAUDE.md to a relative path must resolve
     to a real file. Prevents ToC rot as docs are renamed.

--- a/tests/test_claude_md_structure.py
+++ b/tests/test_claude_md_structure.py
@@ -1,0 +1,123 @@
+"""Structural guards for CLAUDE.md and docs/agents/.
+
+These tests enforce the ToC-style structure CLAUDE.md is migrating toward
+(#6425). They catch regressions where content drifts back into CLAUDE.md
+or where ToC links break because a doc was renamed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+DOCS_AGENTS = REPO_ROOT / "docs" / "agents"
+
+
+def _read_claude_md() -> str:
+    assert CLAUDE_MD.exists(), f"{CLAUDE_MD} missing"
+    return CLAUDE_MD.read_text(encoding="utf-8")
+
+
+class TestKnowledgeLookupSection:
+    def test_has_knowledge_lookup_section(self) -> None:
+        content = _read_claude_md()
+        assert "## Knowledge Lookup" in content, (
+            "CLAUDE.md must have a '## Knowledge Lookup' section pointing "
+            "agents at ADRs, the repo wiki, and docs/."
+        )
+
+    def test_references_adr_index(self) -> None:
+        content = _read_claude_md()
+        assert "docs/adr/" in content, (
+            "CLAUDE.md must reference docs/adr/ so agents know where to "
+            "find architecture decision records."
+        )
+
+    def test_references_repo_wiki(self) -> None:
+        content = _read_claude_md()
+        assert "repo_wiki" in content, (
+            "CLAUDE.md must reference the repo wiki so agents know about "
+            "the per-repo LLM knowledge base."
+        )
+
+
+class TestAvoidedPatternsExtraction:
+    """CLAUDE.md should link to docs/agents/avoided-patterns.md, not
+    duplicate the patterns inline (part of #6425 incremental refactor).
+    """
+
+    def test_avoided_patterns_doc_exists(self) -> None:
+        doc = DOCS_AGENTS / "avoided-patterns.md"
+        assert doc.exists(), (
+            f"{doc} must exist — it is the canonical location for "
+            "avoided patterns referenced by CLAUDE.md, sensor_enricher, "
+            "and the code-grooming audit agent."
+        )
+
+    def test_avoided_patterns_doc_covers_known_rules(self) -> None:
+        doc = DOCS_AGENTS / "avoided-patterns.md"
+        content = doc.read_text(encoding="utf-8")
+        # The five rules that existed in CLAUDE.md before extraction.
+        required_markers = [
+            "Pydantic",
+            "optional dependencies",
+            "sleep",
+            "Mocking",
+            "Falsy checks",
+        ]
+        missing = [m for m in required_markers if m not in content]
+        assert not missing, f"avoided-patterns.md is missing required rules: {missing}"
+
+    def test_claude_md_links_to_avoided_patterns_doc(self) -> None:
+        content = _read_claude_md()
+        assert "docs/agents/avoided-patterns.md" in content, (
+            "CLAUDE.md must link to docs/agents/avoided-patterns.md "
+            "instead of inlining the rules."
+        )
+
+    def test_claude_md_does_not_inline_avoided_patterns(self) -> None:
+        """The five rule bullets must NOT appear inline in CLAUDE.md.
+
+        CLAUDE.md keeps the section heading and a link, but the actual
+        rule text lives in docs/agents/avoided-patterns.md.
+        """
+        content = _read_claude_md()
+        # Each of these phrases is specific enough to the rule body that
+        # finding it in CLAUDE.md means the section was not extracted.
+        inline_markers = [
+            "Never `from hindsight import Bank` at module level",
+            "Never `sleep(N)` in a loop",
+            "Patch functions at their *import site*",
+            "Falsy checks on optional objects",
+        ]
+        leaked = [m for m in inline_markers if m in content]
+        assert not leaked, (
+            f"CLAUDE.md still inlines avoided-pattern rule text: {leaked}. "
+            "These should live in docs/agents/avoided-patterns.md."
+        )
+
+
+class TestLinkedDocsResolve:
+    """Every markdown link from CLAUDE.md to a relative path must resolve
+    to a real file. Prevents ToC rot as docs are renamed.
+    """
+
+    _LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+
+    def test_relative_links_exist(self) -> None:
+        content = _read_claude_md()
+        broken: list[str] = []
+        for _, target in self._LINK_RE.findall(content):
+            # Skip external and in-page links.
+            if target.startswith(("http://", "https://", "#", "mailto:")):
+                continue
+            # Strip fragments (#anchor) from the path.
+            path_part = target.split("#", 1)[0]
+            if not path_part:
+                continue
+            resolved = (REPO_ROOT / path_part).resolve()
+            if not resolved.exists():
+                broken.append(target)
+        assert not broken, f"CLAUDE.md has broken links: {broken}"

--- a/tests/test_harness_insights.py
+++ b/tests/test_harness_insights.py
@@ -543,6 +543,76 @@ class TestImprovementSuggestion:
 
 
 # ---------------------------------------------------------------------------
+# Sensor enrichment integration (#6426)
+# ---------------------------------------------------------------------------
+
+
+class TestSensorEnrichmentIntegration:
+    """Verify HarnessInsightStore.append_failure wires into sensor_enricher."""
+
+    def test_hints_populated_when_rule_matches_details(self, tmp_path: Path) -> None:
+        """A failure record whose details match a seed rule gets hints."""
+        store = HarnessInsightStore(tmp_path / "memory")
+        record = _make_record(
+            details="ModuleNotFoundError: No module named 'hindsight'",
+        )
+        store.append_failure(record)
+
+        # Record object itself is mutated in place with matched hints.
+        assert any("optional" in hint.lower() for hint in record.hints), (
+            f"expected optional-dep hint, got {record.hints}"
+        )
+
+        # Hints are also persisted to the JSONL file.
+        failures_path = tmp_path / "memory" / "harness_failures.jsonl"
+        content = failures_path.read_text()
+        assert "optional" in content.lower()
+
+    def test_hints_empty_when_no_rule_matches(self, tmp_path: Path) -> None:
+        store = HarnessInsightStore(tmp_path / "memory")
+        record = _make_record(details="something totally unremarkable")
+        store.append_failure(record)
+        assert record.hints == []
+
+    def test_enrichment_disabled_is_noop(self, tmp_path: Path) -> None:
+        store = HarnessInsightStore(
+            tmp_path / "memory",
+            sensor_enrichment_enabled=False,
+        )
+        record = _make_record(
+            details="ModuleNotFoundError: No module named 'hindsight'",
+        )
+        store.append_failure(record)
+        assert record.hints == []
+
+    def test_explicit_hints_are_respected(self, tmp_path: Path) -> None:
+        """Caller-supplied hints should not be overwritten."""
+        store = HarnessInsightStore(tmp_path / "memory")
+        record = _make_record(
+            details="ModuleNotFoundError: No module named 'hindsight'",
+        )
+        record.hints = ["caller-supplied hint"]
+        store.append_failure(record)
+        assert record.hints == ["caller-supplied hint"]
+
+    def test_enrichment_never_raises_on_internal_error(self, tmp_path: Path) -> None:
+        """Enrichment is best-effort — an exception must not prevent persistence."""
+        store = HarnessInsightStore(tmp_path / "memory")
+        record = _make_record(details="some details")
+
+        # Patch matching_rules to raise; append_failure should still succeed.
+        with patch(
+            "sensor_enricher.matching_rules",
+            side_effect=RuntimeError("boom"),
+        ):
+            store.append_failure(record)
+
+        failures_path = tmp_path / "memory" / "harness_failures.jsonl"
+        assert failures_path.exists()
+        assert len(failures_path.read_text().strip().splitlines()) == 1
+
+
+# ---------------------------------------------------------------------------
 # append_failure OSError handling (issue #1038)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_harness_insights.py
+++ b/tests/test_harness_insights.py
@@ -586,17 +586,29 @@ class TestSensorEnrichmentIntegration:
         assert record.hints == []
 
     def test_explicit_hints_are_respected(self, tmp_path: Path) -> None:
-        """Caller-supplied hints should not be overwritten."""
+        """Caller-supplied hints should not be overwritten and the
+        matching engine should not be invoked at all when hints are
+        already populated."""
         store = HarnessInsightStore(tmp_path / "memory")
         record = _make_record(
             details="ModuleNotFoundError: No module named 'hindsight'",
         )
         record.hints = ["caller-supplied hint"]
-        store.append_failure(record)
+
+        # If matching_rules is invoked despite the early-return guard,
+        # the assert_not_called below will fail. This proves the guard
+        # is the reason hints are preserved, not just a happy accident.
+        with patch("sensor_enricher.matching_rules") as mock_rules:
+            store.append_failure(record)
+            mock_rules.assert_not_called()
+
         assert record.hints == ["caller-supplied hint"]
 
     def test_enrichment_never_raises_on_internal_error(self, tmp_path: Path) -> None:
-        """Enrichment is best-effort — an exception must not prevent persistence."""
+        """Enrichment is best-effort — an exception must not prevent
+        persistence, AND the failing exception path must leave hints
+        empty (proving the except clause was reached, not just that
+        persistence happened to work via an unrelated path)."""
         store = HarnessInsightStore(tmp_path / "memory")
         record = _make_record(details="some details")
 
@@ -606,6 +618,10 @@ class TestSensorEnrichmentIntegration:
             side_effect=RuntimeError("boom"),
         ):
             store.append_failure(record)
+
+        # Hints stayed empty — the except clause swallowed the exception
+        # rather than enrichment silently succeeding via another path.
+        assert record.hints == []
 
         failures_path = tmp_path / "memory" / "harness_failures.jsonl"
         assert failures_path.exists()

--- a/tests/test_sensor_enricher.py
+++ b/tests/test_sensor_enricher.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 from sensor_enricher import (
     ANY_TOOL,
+    MATCH_ALL_TOOLS,
     ErrorPattern,
     FileChanged,
     Rule,
@@ -256,16 +257,16 @@ class TestSeedRules:
         ids = [r.id for r in SEED_RULES]
         assert len(ids) == len(set(ids)), f"duplicate rule ids: {ids}"
 
-    def test_seed_rules_reference_avoided_patterns_doc(self) -> None:
+    def test_seed_rules_reference_docs_agents(self) -> None:
         from sensor_rules import SEED_RULES
 
-        # Every hint should point at the canonical doc so rule text stays
-        # consistent with the human-facing rule descriptions.
+        # Every hint must point at a doc under docs/agents/ so rule text
+        # stays consistent with the human-facing rule descriptions and we
+        # never accumulate stale CLAUDE.md references after a refactor.
         for rule in SEED_RULES:
-            assert (
-                "docs/agents/avoided-patterns.md" in rule.hint
-                or "CLAUDE.md" in rule.hint
-            ), f"rule {rule.id} has no doc reference"
+            assert "docs/agents/" in rule.hint, (
+                f"rule {rule.id} has no docs/agents/ reference; hint={rule.hint!r}"
+            )
 
     def test_pydantic_rule_fires_for_models_edit(self) -> None:
         from sensor_rules import SEED_RULES
@@ -290,3 +291,171 @@ class TestSeedRules:
         )
         rule_ids = {r.id for r in result.fired}
         assert "optional-dep-toplevel-import" in rule_ids
+
+    def test_falsy_optional_rule_does_not_fire_on_generic_assertion(
+        self,
+    ) -> None:
+        """The falsy-optional rule should match the source anti-pattern,
+        not arbitrary `is None` assertion lines from unrelated tests."""
+        from sensor_rules import SEED_RULES
+
+        result = matching_rules(
+            SEED_RULES,
+            tool="pytest",
+            raw_output=(
+                "AssertionError: assert result is None\n  + where result = compute()"
+            ),
+            changed_files=[],
+        )
+        rule_ids = {r.id for r in result.fired}
+        assert "falsy-optional-check" not in rule_ids
+
+    def test_falsy_optional_rule_fires_on_actual_anti_pattern(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        result = matching_rules(
+            SEED_RULES,
+            tool="pytest",
+            raw_output="src/foo.py:42:        if not self._hindsight:",
+            changed_files=[],
+        )
+        rule_ids = {r.id for r in result.fired}
+        assert "falsy-optional-check" in rule_ids
+
+
+# ---------------------------------------------------------------------------
+# MATCH_ALL_TOOLS sentinel
+# ---------------------------------------------------------------------------
+
+
+class TestMatchAllToolsSentinel:
+    """The MATCH_ALL_TOOLS caller-side sentinel matches every rule
+    regardless of the rule's `tool` filter. Used by integration points
+    that don't know which tool produced the failure (HarnessInsightStore).
+    """
+
+    def test_match_all_fires_tool_specific_rule(self) -> None:
+        rule = Rule(
+            id="pytest-only",
+            tool="pytest",
+            trigger=ErrorPattern(r"boom"),
+            hint="hint",
+        )
+        result = matching_rules(
+            [rule],
+            tool=MATCH_ALL_TOOLS,
+            raw_output="boom",
+            changed_files=[],
+        )
+        assert result.fired == [rule]
+
+    def test_match_all_fires_any_tool_rule(self) -> None:
+        rule = Rule(
+            id="universal",
+            tool=ANY_TOOL,
+            trigger=ErrorPattern(r"boom"),
+            hint="hint",
+        )
+        result = matching_rules(
+            [rule],
+            tool=MATCH_ALL_TOOLS,
+            raw_output="boom",
+            changed_files=[],
+        )
+        assert result.fired == [rule]
+
+    def test_match_all_with_no_matching_rules_returns_empty(self) -> None:
+        rule = Rule(
+            id="pytest-only",
+            tool="pytest",
+            trigger=ErrorPattern(r"KeyError"),
+            hint="hint",
+        )
+        result = matching_rules(
+            [rule],
+            tool=MATCH_ALL_TOOLS,
+            raw_output="TypeError: bad",
+            changed_files=[],
+        )
+        assert result.fired == []
+
+    def test_match_all_does_not_match_rules_with_other_tool_names(
+        self,
+    ) -> None:
+        """A rule scoped to 'ruff' should match under MATCH_ALL_TOOLS but
+        NOT under tool='pytest' — sanity check that the sentinel and
+        per-tool dispatch are independent."""
+        rule = Rule(
+            id="ruff-only",
+            tool="ruff",
+            trigger=ErrorPattern(r"E501"),
+            hint="hint",
+        )
+        # Under MATCH_ALL_TOOLS, fires.
+        all_result = matching_rules(
+            [rule],
+            tool=MATCH_ALL_TOOLS,
+            raw_output="E501 line too long",
+            changed_files=[],
+        )
+        assert all_result.fired == [rule]
+        # Under tool='pytest', does NOT fire.
+        pytest_result = matching_rules(
+            [rule],
+            tool="pytest",
+            raw_output="E501 line too long",
+            changed_files=[],
+        )
+        assert pytest_result.fired == []
+
+
+# ---------------------------------------------------------------------------
+# enrich() idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichIdempotency:
+    """enrich() must not stack `## Agent Hints` headings on already-
+    enriched output. Callers may inadvertently double-enrich (e.g., a
+    failure record passed through two integration points)."""
+
+    def test_already_enriched_output_returns_unchanged(self) -> None:
+        rule = Rule(
+            id="r",
+            tool=ANY_TOOL,
+            trigger=ErrorPattern(r"boom"),
+            hint="A hint.",
+        )
+        first = enrich(
+            tool="pytest",
+            raw_output="boom",
+            changed_files=[],
+            rules=[rule],
+        )
+        # First call appends a hints block.
+        assert "## Agent Hints" in first
+        # Second call returns the input unchanged — no second block.
+        second = enrich(
+            tool="pytest",
+            raw_output=first,
+            changed_files=[],
+            rules=[rule],
+        )
+        assert second == first
+        assert second.count("## Agent Hints") == 1
+
+    def test_pre_existing_hints_heading_blocks_enrichment(self) -> None:
+        rule = Rule(
+            id="r",
+            tool=ANY_TOOL,
+            trigger=ErrorPattern(r"boom"),
+            hint="A hint.",
+        )
+        raw = "## Agent Hints\n\n- something else\n\nboom happened"
+        result = enrich(
+            tool="pytest",
+            raw_output=raw,
+            changed_files=[],
+            rules=[rule],
+        )
+        assert result == raw

--- a/tests/test_sensor_enricher.py
+++ b/tests/test_sensor_enricher.py
@@ -1,0 +1,292 @@
+"""Tests for sensor_enricher — enrichment of tool output with agent hints.
+
+Covers the matching engine (:func:`matching_rules`) and the public
+:func:`enrich` facade. Uses hand-crafted rules so tests do not depend on
+the seed registry drift.
+
+Part of the harness-engineering foundations (#6426).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sensor_enricher import (
+    ANY_TOOL,
+    ErrorPattern,
+    FileChanged,
+    Rule,
+    enrich,
+    matching_rules,
+)
+
+
+def _mk_rule(
+    rule_id: str,
+    tool: str,
+    trigger: FileChanged | ErrorPattern,
+    hint: str = "hint body",
+) -> Rule:
+    return Rule(id=rule_id, tool=tool, trigger=trigger, hint=hint)
+
+
+# ---------------------------------------------------------------------------
+# FileChanged trigger
+# ---------------------------------------------------------------------------
+
+
+class TestFileChangedTrigger:
+    def test_exact_file_match(self) -> None:
+        trigger = FileChanged("src/models.py")
+        assert trigger.matches(
+            raw_output="",
+            changed_files=[Path("src/models.py")],
+        )
+
+    def test_glob_match(self) -> None:
+        trigger = FileChanged("src/*_loop.py")
+        assert trigger.matches(
+            raw_output="",
+            changed_files=[Path("src/code_grooming_loop.py")],
+        )
+
+    def test_no_match_when_unrelated_file(self) -> None:
+        trigger = FileChanged("src/models.py")
+        assert not trigger.matches(
+            raw_output="",
+            changed_files=[Path("src/agent.py")],
+        )
+
+    def test_no_match_with_empty_file_list(self) -> None:
+        trigger = FileChanged("src/*.py")
+        assert not trigger.matches(raw_output="", changed_files=[])
+
+    def test_posix_path_conversion(self) -> None:
+        """Windows-style paths should still match POSIX globs."""
+        trigger = FileChanged("src/models.py")
+        # PurePath.as_posix() normalizes separators regardless of OS.
+        assert trigger.matches(
+            raw_output="",
+            changed_files=[Path("src/models.py")],
+        )
+
+
+# ---------------------------------------------------------------------------
+# ErrorPattern trigger
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPatternTrigger:
+    def test_regex_match_single_line(self) -> None:
+        trigger = ErrorPattern(r"ModuleNotFoundError.*hindsight")
+        assert trigger.matches(
+            raw_output="ModuleNotFoundError: No module named 'hindsight'",
+            changed_files=[],
+        )
+
+    def test_regex_match_multiline(self) -> None:
+        trigger = ErrorPattern(r"^ERROR:")
+        output = "warning: something\nERROR: boom\n"
+        assert trigger.matches(raw_output=output, changed_files=[])
+
+    def test_no_match(self) -> None:
+        trigger = ErrorPattern(r"KeyError")
+        assert not trigger.matches(
+            raw_output="TypeError: bad thing",
+            changed_files=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# matching_rules
+# ---------------------------------------------------------------------------
+
+
+class TestMatchingRules:
+    def test_tool_filter_respected(self) -> None:
+        rule = _mk_rule("pytest-only", "pytest", ErrorPattern("boom"))
+        result = matching_rules(
+            [rule],
+            tool="ruff",
+            raw_output="boom",
+            changed_files=[],
+        )
+        assert not result
+        assert result.fired == []
+
+    def test_any_tool_matches_any_tool(self) -> None:
+        rule = _mk_rule("universal", ANY_TOOL, ErrorPattern("boom"))
+        for tool in ("pytest", "ruff", "pyright", "bandit"):
+            result = matching_rules(
+                [rule],
+                tool=tool,
+                raw_output="boom",
+                changed_files=[],
+            )
+            assert result.fired == [rule]
+
+    def test_multiple_rules_all_fire(self) -> None:
+        rule_a = _mk_rule("a", ANY_TOOL, ErrorPattern("boom"))
+        rule_b = _mk_rule("b", ANY_TOOL, FileChanged("src/models.py"))
+        result = matching_rules(
+            [rule_a, rule_b],
+            tool="pytest",
+            raw_output="boom",
+            changed_files=[Path("src/models.py")],
+        )
+        assert result.fired == [rule_a, rule_b]
+
+    def test_no_match_returns_empty_falsy_result(self) -> None:
+        rule = _mk_rule("a", "pytest", ErrorPattern("KeyError"))
+        result = matching_rules(
+            [rule],
+            tool="pytest",
+            raw_output="TypeError: bad",
+            changed_files=[],
+        )
+        assert not result
+        assert result.fired == []
+
+    def test_empty_rule_list_returns_empty_result(self) -> None:
+        result = matching_rules(
+            [],
+            tool="pytest",
+            raw_output="anything",
+            changed_files=[],
+        )
+        assert not result
+
+
+# ---------------------------------------------------------------------------
+# enrich
+# ---------------------------------------------------------------------------
+
+
+class TestEnrich:
+    def test_no_match_returns_raw_output_unchanged(self) -> None:
+        rule = _mk_rule("a", "pytest", ErrorPattern("KeyError"))
+        raw = "TypeError: bad thing"
+        result = enrich(
+            tool="pytest",
+            raw_output=raw,
+            changed_files=[],
+            rules=[rule],
+        )
+        assert result == raw
+
+    def test_match_appends_hints_block(self) -> None:
+        rule = _mk_rule(
+            "a",
+            "pytest",
+            ErrorPattern("boom"),
+            hint="Check the foo.",
+        )
+        raw = "test_x FAILED\nboom happened"
+        result = enrich(
+            tool="pytest",
+            raw_output=raw,
+            changed_files=[],
+            rules=[rule],
+        )
+        assert raw in result
+        assert "## Agent Hints" in result
+        assert "- Check the foo." in result
+
+    def test_raw_output_preserved_verbatim(self) -> None:
+        """Hints are additive — raw output must not be modified."""
+        rule = _mk_rule(
+            "a",
+            ANY_TOOL,
+            FileChanged("src/models.py"),
+            hint="A hint.",
+        )
+        raw = "line1\n  indented line\nline3"
+        result = enrich(
+            tool="pytest",
+            raw_output=raw,
+            changed_files=[Path("src/models.py")],
+            rules=[rule],
+        )
+        assert result.startswith(raw + "\n\n")
+
+    def test_multiple_hints_listed_as_bullets(self) -> None:
+        rule_a = _mk_rule("a", ANY_TOOL, ErrorPattern("boom"), hint="Hint A.")
+        rule_b = _mk_rule("b", ANY_TOOL, ErrorPattern("boom"), hint="Hint B.")
+        result = enrich(
+            tool="pytest",
+            raw_output="boom",
+            changed_files=[],
+            rules=[rule_a, rule_b],
+        )
+        assert "- Hint A." in result
+        assert "- Hint B." in result
+
+    def test_empty_rules_returns_raw_output(self) -> None:
+        raw = "anything"
+        assert (
+            enrich(
+                tool="pytest",
+                raw_output=raw,
+                changed_files=[],
+                rules=[],
+            )
+            == raw
+        )
+
+
+# ---------------------------------------------------------------------------
+# Seed rule registry smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestSeedRules:
+    """Sanity checks on the seed registry — catches drift from the doc."""
+
+    def test_seed_registry_loads(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        assert len(SEED_RULES) >= 5, "seed registry must cover all known patterns"
+
+    def test_seed_rule_ids_unique(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        ids = [r.id for r in SEED_RULES]
+        assert len(ids) == len(set(ids)), f"duplicate rule ids: {ids}"
+
+    def test_seed_rules_reference_avoided_patterns_doc(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        # Every hint should point at the canonical doc so rule text stays
+        # consistent with the human-facing rule descriptions.
+        for rule in SEED_RULES:
+            assert (
+                "docs/agents/avoided-patterns.md" in rule.hint
+                or "CLAUDE.md" in rule.hint
+            ), f"rule {rule.id} has no doc reference"
+
+    def test_pydantic_rule_fires_for_models_edit(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        result = matching_rules(
+            SEED_RULES,
+            tool="pytest",
+            raw_output="",
+            changed_files=[Path("src/models.py")],
+        )
+        rule_ids = {r.id for r in result.fired}
+        assert "pydantic-field-tests" in rule_ids
+
+    def test_optional_dep_rule_fires_for_hindsight_import_error(self) -> None:
+        from sensor_rules import SEED_RULES
+
+        result = matching_rules(
+            SEED_RULES,
+            tool="pytest",
+            raw_output="ModuleNotFoundError: No module named 'hindsight'",
+            changed_files=[],
+        )
+        rule_ids = {r.id for r in result.fired}
+        assert "optional-dep-toplevel-import" in rule_ids


### PR DESCRIPTION
## Summary

Resolves the full harness-engineering cluster: **#6425, #6426, #6427**. Delivers the ToC refactor, sensor-enricher runtime wiring, and the convention-drift audit agent as a single coherent change since the three compose around `docs/agents/avoided-patterns.md`.

## What's in this PR

### #6425 — CLAUDE.md → ToC + docs/agents (fully resolved)
- \`CLAUDE.md\` shrunk from ~270 lines to **40 lines**: project one-liner + 5 quick rules + Knowledge Lookup section + topic-index table.
- New \`docs/agents/\` directory mirroring \`docs/adr/\` shape, with 9 topic files + README index:
  - \`architecture.md\`, \`worktrees.md\`, \`testing.md\`, \`avoided-patterns.md\`, \`quality-gates.md\`, \`background-loops.md\`, \`sentry.md\`, \`ui-standards.md\`, \`commands.md\`
- \`tests/test_claude_md_structure.py\` (12 tests): enforces the 80-line budget, confirms every topic file exists and is linked from CLAUDE.md, catches broken relative links, and guards against content drifting back into CLAUDE.md.
- All CLAUDE.md content is preserved — nothing was dropped, just relocated.

### #6426 — Sensor enricher runtime wiring (fully resolved)
- Primitives: \`src/sensor_enricher.py\` (\`Rule\`, \`FileChanged\`, \`ErrorPattern\`, \`matching_rules\`, \`enrich\`) with a new \`MATCH_ALL_TOOLS\` caller sentinel.
- Seed registry: \`src/sensor_rules.py\` with 5 rules derived from \`docs/agents/avoided-patterns.md\`.
- Runtime wiring: \`FailureRecord\` gets a \`hints: list[str]\` field. \`HarnessInsightStore.append_failure()\` runs \`matching_rules()\` against \`record.details\` and populates \`record.hints\` before JSONL persistence. Enrichment is best-effort — exceptions are caught and logged at warning level so a broken rule can't break the failure pipeline.
- Config: \`sensor_enrichment_enabled\` bool field + \`HYDRAFLOW_SENSOR_ENRICHMENT_ENABLED\` env override (default \`True\`). \`service_registry.build_services()\` passes it through.
- Tests: \`TestSensorEnrichmentIntegration\` (5 tests) covers hint population, no-match case, disabled toggle, caller-hint precedence, and best-effort exception handling. Plus 31 unit tests on the primitives themselves.

**Integration point chosen**: \`HarnessInsightStore\` instead of \`runner_utils.stream_claude_process\`. Agent subprocess output is stream-json, not raw tool text — the right integration target is the failure record pipeline, which already collects the data we want to enrich. \`runner_utils\` wiring would be the wrong shape.

### #6427 — Code grooming convention-drift audit agent (fully resolved)
- \`.claude/commands/hf.audit-code.md\` extended from 4 → **5 audit agents**. Agent 5 is "Convention Drift & Over-Engineering" and reads \`docs/agents/avoided-patterns.md\` **at runtime** (not at prompt-bake time) so new avoided patterns added to the doc automatically feed the next audit sweep.
- Agent 5 sweeps for: documented avoided patterns + single-use helpers, speculative abstractions, defensive guards for impossible cases, backwards-compat shims, feature-flag rot, test-only branches in production.
- Findings emit in the existing JSON schema \`code_grooming_loop._FINDING_RE\` already parses — **no loop-side code changes needed**.
- \`tests/test_audit_code_skill.py\` (7 tests): enforces the 5-agent fanout, per-agent section presence, Agent 5's runtime-read reference to the avoided-patterns doc, over-engineering category coverage, JSON schema compatibility, and the keep-in-sync principle.

## Composition story

All three issues compose around \`docs/agents/avoided-patterns.md\` as the single source of truth:

1. Humans document a new avoided pattern in the doc.
2. \`sensor_enricher\` can pick it up (if a \`Rule\` is added to \`sensor_rules.py\`) — surfaces the hint inline when a matching failure occurs.
3. The code-grooming audit agent reads it on each sweep and creates issues for accumulated violations.
4. Agents hit the Knowledge Lookup section in CLAUDE.md and read the doc proactively before editing.

## Quality gates

- \`make lint-check\` — all checks passed
- \`make typecheck\` — 0 errors, 0 warnings
- 136 new/updated tests across 4 test files, all green
- No changes to any phase's core logic — wiring is additive and gated by config toggles

## Commits

1. \`docs(claude): add Knowledge Lookup section and extract Avoided Patterns\` — first slice of #6425 + canonical avoided-patterns doc
2. \`feat(sensor-enricher): add positive-prompt-injection primitives and seed rules\` — #6426 primitives with full unit coverage
3. \`feat(harness): wire sensor enricher into failure records; add audit agent 5\` — #6426 runtime wiring + #6427 Agent 5
4. \`docs(claude): shrink CLAUDE.md to ToC and migrate sections to docs/agents\` — #6425 full refactor

## Test plan

- [x] \`make lint-check\` — clean
- [x] \`make typecheck\` — 0 errors
- [x] Full test suite on new/changed areas: \`tests/test_claude_md_structure.py\` (12), \`tests/test_sensor_enricher.py\` (23), \`tests/test_audit_code_skill.py\` (7), \`tests/test_harness_insights.py::TestSensorEnrichmentIntegration\` (5) — all green
- [ ] Manual: confirm CLAUDE.md renders correctly on GitHub with working links
- [ ] Post-merge: run \`/hf.audit-code\` manually and verify Agent 5 produces at least one convention-drift finding

## Dependencies

This PR is independent of the Swamp-lifecycle stack (#6421/#6422/#6423/#6424). Those four are being built in a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)