### PR TITLE
RouteBackCoordinator: escalate via diagnose stage before HITL

### DIFF
--- a/src/route_back.py
+++ b/src/route_back.py
@@ -115,7 +115,25 @@ class RouteBackCounterPort(Protocol):
 
 
 class RouteBackCoordinator:
-    """Coordinates label swap + cache record + counter + escalation."""
+    """Coordinates label swap + cache record + counter + escalation.
+
+    Escalation chain when ``max_route_backs`` is exceeded:
+
+      1. Try to swap to ``diagnose_label`` first. The diagnostic stage
+         runs an automated diagnostic agent that triages the failure
+         (reads recent transcripts, classifies the root cause, and
+         either re-queues the issue with feedback or hands it to HITL).
+         This matches the existing :class:`PipelineEscalator` pattern
+         and gives the pipeline one more autonomous shot at recovering
+         before requiring a human.
+      2. If the diagnose label swap fails (or no ``diagnose_label`` was
+         configured), fall back to swapping the ``hitl_label`` directly.
+      3. If the HITL swap also fails, the result is ``FAILED`` and the
+         issue stays in its current stage for the next cycle to retry.
+
+    A direct-to-HITL coordinator (no diagnose stage) can be built by
+    passing ``diagnose_label=""``.
+    """
 
     def __init__(
         self,
@@ -124,19 +142,29 @@ class RouteBackCoordinator:
         prs: PRPort,
         counter: RouteBackCounterPort,
         hitl_label: str,
+        diagnose_label: str = "",
         max_route_backs: int = 2,
     ) -> None:
         """Build the coordinator.
 
-        ``hitl_label`` is the GitHub label applied when the counter
-        exceeds the cap (e.g. ``"hydraflow-hitl"``). ``max_route_backs``
-        is the soft cap — once an issue has been routed back this many
-        times, the next route-back attempt escalates instead.
+        ``hitl_label`` is the GitHub label applied as the final-fallback
+        escalation target (e.g. ``"hydraflow-hitl"``).
+
+        ``diagnose_label`` is the intermediate escalation target tried
+        BEFORE HITL when the counter exceeds the cap. Default empty
+        string disables the diagnose hop and goes straight to HITL.
+        Operators should pass ``config.diagnose_label[0]`` to match
+        the existing :class:`PipelineEscalator` behavior.
+
+        ``max_route_backs`` is the soft cap — once an issue has been
+        routed back this many times, the next route-back attempt
+        escalates instead.
         """
         self._cache = cache
         self._prs = prs
         self._counter = counter
         self._hitl_label = hitl_label
+        self._diagnose_label = diagnose_label
         self._max_route_backs = max_route_backs
 
     @property
@@ -267,7 +295,48 @@ class RouteBackCoordinator:
         reason: str,
         counter: int,
     ) -> RouteBackResult:
-        """Apply the HITL label and return an ESCALATED result."""
+        """Escalate via diagnose stage first, HITL as fallback.
+
+        Tries the ``diagnose_label`` swap first when one is configured.
+        The diagnostic stage runs an automated diagnostic agent that
+        triages the failure and either re-queues the issue with
+        feedback or hands it off to HITL — one more autonomous shot
+        at recovery before requiring a human.
+
+        Falls back to ``hitl_label`` directly if the diagnose swap
+        fails or no diagnose label was configured. If the HITL swap
+        also fails, returns ``FAILED`` so the next cycle can retry.
+        """
+        # Try diagnose stage first when configured.
+        if self._diagnose_label:
+            try:
+                await self._prs.swap_pipeline_labels(issue_id, self._diagnose_label)
+                escalation_reason = (
+                    f"route-back cap exceeded after {counter} attempts "
+                    f"(max={self._max_route_backs}); last reason from "
+                    f"{from_stage}: {reason} — escalated to diagnose for "
+                    f"automated triage before HITL"
+                )
+                logger.warning(
+                    "Issue #%d escalated to DIAGNOSE after %d route-backs: %s",
+                    issue_id,
+                    counter,
+                    reason,
+                )
+                return RouteBackResult(
+                    RouteBackOutcome.ESCALATED,
+                    counter=counter,
+                    reason=escalation_reason,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "route_back: diagnose escalation failed for issue #%d, "
+                    "falling back to HITL: %s",
+                    issue_id,
+                    exc,
+                )
+
+        # Fallback (or no diagnose configured): direct HITL swap.
         try:
             await self._prs.swap_pipeline_labels(issue_id, self._hitl_label)
         except Exception as exc:  # noqa: BLE001

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -394,14 +394,20 @@ def build_services(
     )
 
     # Route-back coordinator + precondition gate (#6423). The coordinator
-    # ties label swap + cache record + counter + HITL escalation. The gate
+    # ties label swap + cache record + counter + escalation. The gate
     # is the consumer-side filter implement_phase / review_phase use to
     # drop issues that fail their stage preconditions.
+    #
+    # Escalation chain when route-backs are exhausted: diagnose first
+    # (automated diagnostic agent gets one more autonomous shot at
+    # triaging the failure), HITL as fallback. Matches the existing
+    # PipelineEscalator pattern in src/phase_utils.py.
     route_back_coordinator = RouteBackCoordinator(
         cache=issue_cache,
         prs=prs,
         counter=state,  # StateTracker satisfies RouteBackCounterPort
         hitl_label=config.hitl_label[0],
+        diagnose_label=config.diagnose_label[0],
         max_route_backs=2,
     )
     # The gate enforces stage preconditions only when BOTH the cache is

--- a/tests/test_route_back.py
+++ b/tests/test_route_back.py
@@ -30,6 +30,7 @@ def _coordinator(
     *,
     max_route_backs: int = 2,
     counter: RouteBackCounterPort | None = None,
+    diagnose_label: str = "",
 ) -> tuple[RouteBackCoordinator, IssueCache, AsyncMock, InMemoryRouteBackCounter]:
     cache = IssueCache(tmp_path / "cache", enabled=True)
     prs = AsyncMock()
@@ -40,6 +41,7 @@ def _coordinator(
         prs=prs,
         counter=counter_impl,
         hitl_label="hydraflow-hitl",
+        diagnose_label=diagnose_label,
         max_route_backs=max_route_backs,
     )
     return coordinator, cache, prs, counter_impl  # type: ignore[return-value]
@@ -307,6 +309,110 @@ class TestEscalationLabelFailure:
         )
         assert result.outcome == RouteBackOutcome.FAILED
         assert "escalation label swap failed" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# Diagnose-first escalation chain
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnoseEscalationChain:
+    """When ``diagnose_label`` is configured, the coordinator should
+    try to swap to diagnose FIRST when route-backs are exhausted, and
+    only fall back to HITL if the diagnose swap fails. Matches the
+    existing ``PipelineEscalator`` pattern in src/phase_utils.py and
+    keeps autonomy by giving the diagnostic agent one more shot at
+    triaging the failure before requiring a human."""
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_diagnose_first(self, tmp_path: Path) -> None:
+        coordinator, _, prs, _ = _coordinator(
+            tmp_path,
+            max_route_backs=0,
+            diagnose_label="hydraflow-diagnose",
+        )
+
+        result = await coordinator.route_back(
+            42, from_stage="ready", to_stage="plan", reason="r"
+        )
+
+        assert result.outcome == RouteBackOutcome.ESCALATED
+        # Diagnose label was applied — NOT HITL.
+        prs.swap_pipeline_labels.assert_awaited_once_with(42, "hydraflow-diagnose")
+        assert "diagnose" in result.reason
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_hitl_when_diagnose_swap_fails(
+        self, tmp_path: Path
+    ) -> None:
+        coordinator, _, prs, _ = _coordinator(
+            tmp_path,
+            max_route_backs=0,
+            diagnose_label="hydraflow-diagnose",
+        )
+
+        # First call (diagnose) raises, second call (HITL) succeeds.
+        call_count = {"n": 0}
+
+        async def _swap(issue_id: int, label: str) -> None:
+            del issue_id, label
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("diagnose label swap failed")
+
+        prs.swap_pipeline_labels = AsyncMock(side_effect=_swap)
+
+        result = await coordinator.route_back(
+            42, from_stage="ready", to_stage="plan", reason="r"
+        )
+
+        assert result.outcome == RouteBackOutcome.ESCALATED
+        # Both diagnose AND hitl swaps were attempted, in that order.
+        calls = prs.swap_pipeline_labels.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args == (42, "hydraflow-diagnose")
+        assert calls[1].args == (42, "hydraflow-hitl")
+
+    @pytest.mark.asyncio
+    async def test_returns_failed_when_both_diagnose_and_hitl_fail(
+        self, tmp_path: Path
+    ) -> None:
+        coordinator, _, prs, _ = _coordinator(
+            tmp_path,
+            max_route_backs=0,
+            diagnose_label="hydraflow-diagnose",
+        )
+        prs.swap_pipeline_labels = AsyncMock(
+            side_effect=RuntimeError("everything is on fire")
+        )
+
+        result = await coordinator.route_back(
+            42, from_stage="ready", to_stage="plan", reason="r"
+        )
+
+        assert result.outcome == RouteBackOutcome.FAILED
+        # Both swaps were attempted before giving up.
+        assert prs.swap_pipeline_labels.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_no_diagnose_label_skips_directly_to_hitl(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty diagnose_label preserves the original direct-HITL
+        behavior — operators that don't want the diagnose hop can
+        opt out by passing diagnose_label=''."""
+        coordinator, _, prs, _ = _coordinator(
+            tmp_path,
+            max_route_backs=0,
+            diagnose_label="",  # disabled
+        )
+
+        result = await coordinator.route_back(
+            42, from_stage="ready", to_stage="plan", reason="r"
+        )
+
+        assert result.outcome == RouteBackOutcome.ESCALATED
+        prs.swap_pipeline_labels.assert_awaited_once_with(42, "hydraflow-hitl")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Swamp lifecycle's \`RouteBackCoordinator\` was going straight from \"route-back budget exhausted\" to HITL, skipping the existing **diagnose stage** that \`PipelineEscalator\` uses elsewhere in the pipeline. The diagnose stage runs an automated diagnostic agent that triages the failure (reads recent transcripts, classifies the root cause, re-queues with feedback or hands off to HITL) — one more autonomous shot at recovery before requiring a human.

## Escalation chain (new)

When \`max_route_backs\` is exceeded:

1. **Try \`diagnose_label\` swap first.** The diagnostic agent picks the issue up on its next cycle and attempts triage.
2. **Fall back to \`hitl_label\`** if the diagnose swap fails (or no \`diagnose_label\` was configured).
3. **Return FAILED** if the HITL swap also fails — issue stays in its current stage rather than getting stuck.

This matches the existing \`PipelineEscalator\` behavior in \`src/phase_utils.py\` where every callsite escalates via diagnose first with HITL as fallback.

## API change

\`RouteBackCoordinator.__init__\` gained a new keyword-only parameter:

\`\`\`python
diagnose_label: str = \"\"
\`\`\`

Default empty string preserves the original direct-to-HITL behavior. Existing tests pass unchanged because old behavior is the default.

## Service registry wiring

\`src/service_registry.py\`: passes \`config.diagnose_label[0]\` into the coordinator constructor. Activates the diagnose hop in production wiring while keeping the parameter optional for unit tests.

## Tests

\`tests/test_route_back.py\` — added \`TestDiagnoseEscalationChain\` with 4 cases:

| Test | Verifies |
|---|---|
| \`test_escalates_to_diagnose_first\` | With diagnose_label set, escalation swaps to diagnose label, NOT HITL |
| \`test_falls_back_to_hitl_when_diagnose_swap_fails\` | Counter-based mock raises on first (diagnose) swap, succeeds on second (HITL); verifies both swaps in correct order |
| \`test_returns_failed_when_both_diagnose_and_hitl_fail\` | Both label swaps raise → result is FAILED, both swaps attempted |
| \`test_no_diagnose_label_skips_directly_to_hitl\` | Empty diagnose_label preserves original direct-to-HITL behavior (opt-out) |

All 14 existing route-back tests still pass because the new parameter defaults to empty string.

## Quality gates

- \`make lint-check\` — all checks passed
- \`make typecheck\` — 0 errors, 0 warnings
- 62 tests pass across \`test_route_back.py\`, \`test_state_route_back.py\`, \`test_precondition_gate.py\`, \`test_service_registry.py\`

## Test plan

- [x] All 18 route-back tests pass (14 existing + 4 new)
- [x] Quality gates clean
- [ ] Manual: enable \`HYDRAFLOW_PRECONDITION_GATE_ENABLED\` on a dev run, force a route-back scenario, confirm exhausted issues go to diagnose first

Refs: #6423

🤖 Generated with [Claude Code](https://claude.com/claude-code)