### PR TITLE
feat: scenario testing framework with MockWorld

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,73 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Pre-commit hook: centralized lint gate via Makefile.
+
+set -euo pipefail
+
+# Only check if Python files are staged
+STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM -- '*.py' || true)
+if [ -z "$STAGED_PY" ]; then
+    exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "pre-commit: running make lint-check..."
+if ! make lint-check; then
+    echo ""
+    echo "pre-commit: lint-check failed; attempting self-repair with 'make lint-fix'..."
+    if make lint-fix && make lint-check; then
+        printf '%s\n' "$STAGED_PY" | xargs -I {} git add "{}"
+        echo "pre-commit: self-repair succeeded and staged files were refreshed."
+    else
+        echo "Auto-repair failed. Run 'make lint-fix' and re-stage files."
+        exit 1
+    fi
+fi
+
+echo "pre-commit: lint OK"
+
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Pre-push hook: centralized lightweight quality gate via Makefile.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "pre-push: running make quality-lite..."
+make quality-lite
+
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "hydraflow",
+  "project_id": "8acad540-9756-4bc6-afef-4518c85453e4"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,27 @@ jobs:
       - name: Run smoke tests
         run: make smoke
 
+  scenario:
+    name: Scenario Tests
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Run scenario tests
+        run: make scenario
+      - name: Run scenario loop tests
+        run: make scenario-loops
+
   ui-build:
     name: Dashboard Build
     needs: changes

--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,6 @@ src/ui/src/test/shims/generated/
 
 # Local superpowers drafts (plans, specs)
 docs/superpowers/
+
+# Beads / Dolt files (added by bd init)
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -404,7 +404,7 @@ When modifying a prompt:
    the parser in the corresponding runner handles both Claude and Codex
    transcript formats (whitespace differences, trailing newlines, etc.).
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:d4f96305 -->
+<!-- BEGIN BEADS INTEGRATION v:1 profile:full hash:f65d5d33 -->
 ## Issue Tracking with bd (beads)
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.
@@ -469,6 +469,16 @@ bd close bd-42 --reason "Completed" --json
    - `bd create "Found bug" --description="Details about what was found" -p 1 --deps discovered-from:<parent-id>`
 5. **Complete**: `bd close <id> --reason "Done"`
 
+### Quality
+- Use `--acceptance` and `--design` fields when creating issues
+- Use `--validate` to check description completeness
+
+### Lifecycle
+- `bd defer <id>` / `bd supersede <id>` for issue management
+- `bd stale` / `bd orphans` / `bd lint` for hygiene
+- `bd human <id>` to flag for human decisions
+- `bd formula list` / `bd mol pour <name>` for structured workflows
+
 ### Auto-Sync
 
 bd automatically syncs via Dolt:
@@ -489,7 +499,7 @@ bd automatically syncs via Dolt:
 
 For more details, see README.md and docs/QUICKSTART.md.
 
-## Landing the Plane (Session Completion)
+## Session Completion
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
 

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,16 @@ soak: deps
 	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/ -m soak -v --timeout=7200
 	@echo "$(GREEN)Soak tests passed$(RESET)"
 
+scenario: deps
+	@echo "$(BLUE)Running scenario tests...$(RESET)"
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/scenarios/ -m scenario -v
+	@echo "$(GREEN)Scenario tests passed$(RESET)"
+
+scenario-loops: deps
+	@echo "$(BLUE)Running scenario loop tests...$(RESET)"
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/scenarios/ -m scenario_loops -v
+	@echo "$(GREEN)Scenario loop tests passed$(RESET)"
+
 test-fast: deps
 	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/ -x --tb=short
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,13 +125,15 @@ asyncio_mode = "auto"
 addopts = [
     "-q",
     "--tb=short",
-    "-m", "not soak and not docker",
+    "-m", "not soak and not docker and not scenario_loops",
 ]
 markers = [
     "integration: marks tests as integration tests",
     "unit: marks tests as unit tests",
     "soak: marks tests as soak/long-running tests (excluded from default runs)",
     "docker: marks tests requiring a running Docker daemon",
+    "scenario: scenario tests with MockWorld (full pipeline, deterministic)",
+    "scenario_loops: scenario tests exercising background loops (Tier B)",
 ]
 
 [tool.coverage.run]

--- a/tests/scenarios/conftest.py
+++ b/tests/scenarios/conftest.py
@@ -1,0 +1,14 @@
+"""Scenario test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+async def mock_world(tmp_path):
+    """Provide a fresh MockWorld for scenario tests."""
+    from tests.scenarios.fakes import MockWorld
+
+    world = MockWorld(tmp_path)
+    yield world

--- a/tests/scenarios/fakes/__init__.py
+++ b/tests/scenarios/fakes/__init__.py
@@ -1,0 +1,39 @@
+"""Stateful fakes for scenario testing.
+
+Fakes are imported lazily so Task 1 can scaffold the directory without
+requiring all fake modules to exist yet (they land in Tasks 2-5).
+"""
+
+from __future__ import annotations
+
+
+def __getattr__(name: str):  # noqa: PLR0911
+    if name == "MockWorld":
+        from tests.scenarios.fakes.mock_world import MockWorld
+
+        return MockWorld
+    if name == "FakeGitHub":
+        from tests.scenarios.fakes.fake_github import FakeGitHub
+
+        return FakeGitHub
+    if name == "FakeLLM":
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        return FakeLLM
+    if name == "FakeHindsight":
+        from tests.scenarios.fakes.fake_hindsight import FakeHindsight
+
+        return FakeHindsight
+    if name == "FakeWorkspace":
+        from tests.scenarios.fakes.fake_workspace import FakeWorkspace
+
+        return FakeWorkspace
+    if name == "FakeSentry":
+        from tests.scenarios.fakes.fake_sentry import FakeSentry
+
+        return FakeSentry
+    if name == "FakeClock":
+        from tests.scenarios.fakes.fake_clock import FakeClock
+
+        return FakeClock
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/scenarios/fakes/fake_clock.py
+++ b/tests/scenarios/fakes/fake_clock.py
@@ -1,0 +1,22 @@
+"""Controllable clock for scenario testing."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class FakeClock:
+    """Deterministic clock that advances only when told to."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._time = start
+
+    def now(self) -> float:
+        return self._time
+
+    def advance(self, seconds: float) -> None:
+        self._time += seconds
+
+    async def sleep(self, seconds: float) -> None:
+        self._time += seconds
+        await asyncio.sleep(0)  # yield to event loop

--- a/tests/scenarios/fakes/fake_github.py
+++ b/tests/scenarios/fakes/fake_github.py
@@ -87,14 +87,29 @@ class FakeGitHub:
     # --- PRManager interface (async methods called by phases) ---
 
     async def transition(
-        self, issue_number: int, from_label: str, to_label: str
+        self,
+        issue_number: int,
+        new_stage: str,
+        *,
+        pr_number: int | None = None,
     ) -> None:
+        _ = pr_number
+        stage_label_map = {
+            "find": "hydraflow-find",
+            "triage": "hydraflow-triage",
+            "plan": "hydraflow-plan",
+            "ready": "hydraflow-ready",
+            "review": "hydraflow-review",
+            "done": "hydraflow-done",
+            "hitl": "hydraflow-hitl",
+        }
+        new_label = stage_label_map.get(new_stage, new_stage)
         if issue_number in self._issues:
             issue = self._issues[issue_number]
-            if from_label in issue.labels:
-                issue.labels.remove(from_label)
-            if to_label not in issue.labels:
-                issue.labels.append(to_label)
+            issue.labels = [
+                lbl for lbl in issue.labels if not lbl.startswith("hydraflow-")
+            ]
+            issue.labels.append(new_label)
 
     async def swap_pipeline_labels(self, issue_number: int, new_label: str) -> None:
         if issue_number in self._issues:
@@ -148,7 +163,12 @@ class FakeGitHub:
                 return issue.number
         return 0
 
-    async def push_branch(self, branch: str, worktree_path: Any = None) -> bool:
+    async def push_branch(
+        self,
+        *args: Any,
+        **_kwargs: Any,
+    ) -> bool:
+        _ = args
         return True
 
     async def create_pr(
@@ -190,10 +210,9 @@ class FakeGitHub:
                     issue_number=p.issue_number,
                     branch=p.branch,
                 )
-        number = self._pr_counter
-        self._pr_counter += 1
+        # No open PR for this branch — signal absence with number=0
         return PRInfoFactory.create(
-            number=number,
+            number=0,
             issue_number=issue_number or 0,
             branch=branch,
         )

--- a/tests/scenarios/fakes/fake_github.py
+++ b/tests/scenarios/fakes/fake_github.py
@@ -1,0 +1,234 @@
+"""Stateful GitHub fake for scenario testing.
+
+Tracks issues (labels, state, comments) and PRs (merged, CI status)
+as in-memory state. Implements the async PRManager interface methods
+that phases call via PipelineHarness.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any
+
+from tests.conftest import PRInfoFactory
+
+
+@dataclass
+class FakeIssue:
+    number: int
+    title: str
+    body: str
+    labels: list[str] = field(default_factory=list)
+    state: str = "open"
+    comments: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FakePR:
+    number: int
+    issue_number: int
+    branch: str
+    merged: bool = False
+    ci_status: str = "pass"
+    draft: bool = False
+    url: str = ""
+
+
+class FakeGitHub:
+    """Stateful fake for GitHub API (PRManager + IssueFetcher)."""
+
+    def __init__(self) -> None:
+        self._issues: dict[int, FakeIssue] = {}
+        self._prs: dict[int, FakePR] = {}
+        self._pr_counter = 10_000
+        self._ci_scripts: dict[int, deque[tuple[bool, str]]] = {}
+        self._comments: list[tuple[int, str]] = []
+
+    # --- Seed API ---
+
+    def add_issue(
+        self,
+        number: int,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> None:
+        self._issues[number] = FakeIssue(
+            number=number,
+            title=title,
+            body=body,
+            labels=labels or [],
+        )
+
+    def script_ci(self, pr_number: int, results: list[tuple[bool, str]]) -> None:
+        self._ci_scripts[pr_number] = deque(results)
+
+    # --- Query API ---
+
+    def issue(self, number: int) -> FakeIssue:
+        if number not in self._issues:
+            msg = f"FakeGitHub: no issue {number}"
+            raise KeyError(msg)
+        return self._issues[number]
+
+    def pr(self, number: int) -> FakePR:
+        if number not in self._prs:
+            msg = f"FakeGitHub: no PR {number}"
+            raise KeyError(msg)
+        return self._prs[number]
+
+    def pr_for_issue(self, issue_number: int) -> FakePR | None:
+        for p in self._prs.values():
+            if p.issue_number == issue_number:
+                return p
+        return None
+
+    # --- PRManager interface (async methods called by phases) ---
+
+    async def transition(
+        self, issue_number: int, from_label: str, to_label: str
+    ) -> None:
+        if issue_number in self._issues:
+            issue = self._issues[issue_number]
+            if from_label in issue.labels:
+                issue.labels.remove(from_label)
+            if to_label not in issue.labels:
+                issue.labels.append(to_label)
+
+    async def swap_pipeline_labels(self, issue_number: int, new_label: str) -> None:
+        if issue_number in self._issues:
+            issue = self._issues[issue_number]
+            issue.labels = [
+                lbl for lbl in issue.labels if not lbl.startswith("hydraflow-")
+            ]
+            issue.labels.append(new_label)
+
+    async def add_labels(self, issue_number: int, labels: list[str]) -> None:
+        if issue_number in self._issues:
+            for label in labels:
+                if label not in self._issues[issue_number].labels:
+                    self._issues[issue_number].labels.append(label)
+
+    async def remove_label(self, issue_number: int, label: str) -> None:
+        if issue_number in self._issues:
+            issue = self._issues[issue_number]
+            issue.labels = [lbl for lbl in issue.labels if lbl != label]
+
+    async def post_comment(self, issue_number: int, body: str) -> None:
+        self._comments.append((issue_number, body))
+        if issue_number in self._issues:
+            self._issues[issue_number].comments.append(body)
+
+    async def post_pr_comment(self, pr_number: int, body: str) -> None:
+        self._comments.append((pr_number, body))
+
+    async def submit_review(
+        self, pr_number: int, body: str, event: str = "COMMENT"
+    ) -> None:
+        pass
+
+    async def create_task(
+        self, title: str, body: str, labels: list[str] | None = None
+    ) -> int:
+        num = max(self._issues.keys(), default=9000) + 1
+        self.add_issue(num, title, body, labels=labels)
+        return num
+
+    async def close_task(self, issue_number: int) -> None:
+        await self.close_issue(issue_number)
+
+    async def close_issue(self, issue_number: int) -> None:
+        if issue_number in self._issues:
+            self._issues[issue_number].state = "closed"
+
+    async def find_existing_issue(self, title: str) -> int:
+        for issue in self._issues.values():
+            if issue.title == title and issue.state == "open":
+                return issue.number
+        return 0
+
+    async def push_branch(self, branch: str, worktree_path: Any = None) -> bool:
+        return True
+
+    async def create_pr(
+        self,
+        issue: Any,
+        branch: str,
+        *,
+        draft: bool = False,
+        **_unused: Any,
+    ) -> Any:
+        number = self._pr_counter
+        self._pr_counter += 1
+        issue_number = getattr(issue, "id", getattr(issue, "number", 0))
+        self._prs[number] = FakePR(
+            number=number,
+            issue_number=issue_number,
+            branch=branch,
+            draft=draft,
+            url=f"https://github.com/test/repo/pull/{number}",
+        )
+        return PRInfoFactory.create(
+            number=number,
+            issue_number=issue_number,
+            branch=branch,
+            draft=draft,
+        )
+
+    async def find_open_pr_for_branch(
+        self,
+        branch: str,
+        *,
+        issue_number: int | None = None,
+        **_unused: Any,
+    ) -> Any:
+        for p in self._prs.values():
+            if p.branch == branch and not p.merged:
+                return PRInfoFactory.create(
+                    number=p.number,
+                    issue_number=p.issue_number,
+                    branch=p.branch,
+                )
+        number = self._pr_counter
+        self._pr_counter += 1
+        return PRInfoFactory.create(
+            number=number,
+            issue_number=issue_number or 0,
+            branch=branch,
+        )
+
+    async def branch_has_diff_from_main(self, branch: str) -> bool:
+        return True
+
+    async def add_pr_labels(self, pr_number: int, labels: list[str]) -> None:
+        pass
+
+    async def get_pr_diff(self, pr_number: int) -> str:
+        return "diff --git a/x b/x"
+
+    async def get_pr_head_sha(self, pr_number: int) -> str:
+        return "abc123"
+
+    async def get_pr_diff_names(self, pr_number: int) -> list[str]:
+        return ["src/app.py"]
+
+    async def get_pr_approvers(self, pr_number: int) -> list[str]:
+        return ["octocat"]
+
+    async def fetch_code_scanning_alerts(self, pr_number: int = 0, **_kw: Any) -> list:
+        return []
+
+    async def wait_for_ci(self, pr_number: int, **_kw: Any) -> tuple[bool, str]:
+        q = self._ci_scripts.get(pr_number)
+        if q:
+            return q.popleft()
+        return (True, "CI passed")
+
+    async def fetch_ci_failure_logs(self, pr_number: int, **_kw: Any) -> str:
+        return ""
+
+    async def merge_pr(self, pr_number: int, **_kw: Any) -> bool:
+        if pr_number in self._prs:
+            self._prs[pr_number].merged = True
+        return True

--- a/tests/scenarios/fakes/fake_hindsight.py
+++ b/tests/scenarios/fakes/fake_hindsight.py
@@ -1,0 +1,45 @@
+"""Stateful Hindsight fake for scenario testing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _MemoryEntry:
+    key: str
+    content: str
+
+
+class FakeHindsight:
+    """In-memory Hindsight fake with per-bank storage and fail mode."""
+
+    def __init__(self) -> None:
+        self._banks: dict[str, list[_MemoryEntry]] = {}
+        self._failing = False
+
+    def set_failing(self, failing: bool) -> None:
+        self._failing = failing
+
+    def _check_health(self) -> None:
+        if self._failing:
+            msg = "FakeHindsight is in fail mode"
+            raise ConnectionError(msg)
+
+    async def retain(self, bank: str, key: str, content: str) -> dict:
+        self._check_health()
+        self._banks.setdefault(bank, []).append(_MemoryEntry(key=key, content=content))
+        return {}
+
+    async def recall(self, bank: str, _query: str) -> list[dict]:
+        self._check_health()
+        entries = self._banks.get(bank, [])
+        return [{"key": e.key, "content": e.content} for e in entries]
+
+    async def reflect(self, bank: str, _query: str) -> str:
+        self._check_health()
+        _ = bank
+        return ""
+
+    def bank_entries(self, bank: str) -> list[dict]:
+        return [{"key": e.key, "content": e.content} for e in self._banks.get(bank, [])]

--- a/tests/scenarios/fakes/fake_llm.py
+++ b/tests/scenarios/fakes/fake_llm.py
@@ -62,8 +62,14 @@ class _FakeTriageRunner(_ScriptedRunner):
 
 class _FakePlannerRunner(_ScriptedRunner):
     async def plan(
-        self, task: Any, _worker_id: int = 0, _research_context: str = ""
+        self,
+        task: Any,
+        *,
+        worker_id: int = 0,
+        research_context: str = "",
+        **_unused: Any,
     ) -> Any:
+        _ = (worker_id, research_context)
         issue_number = getattr(task, "id", getattr(task, "number", 0))
         return self._pop(
             issue_number,
@@ -85,11 +91,14 @@ class _FakeAgentRunner(_ScriptedRunner):
         task: Any,
         worktree_path: Path,
         branch: str,
-        _worker_id: int = 0,
-        _review_feedback: str = "",
-        _prior_failure: str = "",
-        _bead_mapping: dict[str, str] | None = None,
+        *,
+        worker_id: int = 0,
+        review_feedback: str = "",
+        prior_failure: str = "",
+        bead_mapping: dict[str, str] | None = None,
+        **_unused: Any,
     ) -> Any:
+        _ = (worker_id, review_feedback, prior_failure, bead_mapping)
         issue_number = getattr(task, "id", getattr(task, "number", 0))
         return self._pop(
             issue_number,
@@ -110,10 +119,13 @@ class _FakeReviewRunner(_ScriptedRunner):
         issue: Any,
         _worktree_path: Path,
         _diff: str,
-        _worker_id: int = 0,
-        _code_scanning_alerts: list[Any] | None = None,
-        _bead_tasks: list[Any] | None = None,
+        *,
+        worker_id: int = 0,
+        code_scanning_alerts: list[Any] | None = None,
+        bead_tasks: list[Any] | None = None,
+        **_unused: Any,
     ) -> Any:
+        _ = (worker_id, code_scanning_alerts, bead_tasks)
         issue_number = getattr(issue, "id", getattr(issue, "number", 0))
         pr_number = getattr(pr, "number", 0)
         return self._pop(

--- a/tests/scenarios/fakes/fake_llm.py
+++ b/tests/scenarios/fakes/fake_llm.py
@@ -1,0 +1,167 @@
+"""Scripted LLM runner fakes for scenario testing.
+
+FakeLLM provides per-phase, per-issue result sequences. Each runner method
+pops the next result from a deque. When the deque is empty, a default
+success result is returned.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from models import EpicDecompResult, ReviewVerdict
+from tests.conftest import (
+    PlanResultFactory,
+    ReviewResultFactory,
+    TriageResultFactory,
+    WorkerResultFactory,
+)
+
+
+class _ScriptedRunner:
+    """Base for a runner that returns scripted results by issue number."""
+
+    def __init__(self) -> None:
+        self._scripts: dict[int, deque[Any]] = {}
+
+    def _add_script(self, issue_number: int, results: list[Any]) -> None:
+        self._scripts[issue_number] = deque(results)
+
+    def add_script(self, issue_number: int, results: list[Any]) -> None:
+        self._add_script(issue_number, results)
+
+    def _pop(self, issue_number: int, default_factory: Callable[[], Any]) -> Any:
+        q = self._scripts.get(issue_number)
+        if q:
+            return q.popleft()
+        return default_factory()
+
+    def set_tracing_context(self, _context: Any) -> None:
+        pass
+
+    def clear_tracing_context(self) -> None:
+        pass
+
+
+class _FakeTriageRunner(_ScriptedRunner):
+    async def evaluate(self, issue: Any, _worker_id: int = 0) -> Any:
+        issue_number = getattr(issue, "id", getattr(issue, "number", 0))
+        return self._pop(
+            issue_number,
+            lambda: TriageResultFactory.create(issue_number=issue_number, ready=True),
+        )
+
+    async def run_decomposition(self, _task: Any) -> EpicDecompResult:
+        # Real decomposition is not exercised in scenario tests; return a
+        # no-op result so triage_phase.py can safely read should_decompose.
+        return EpicDecompResult(should_decompose=False)
+
+
+class _FakePlannerRunner(_ScriptedRunner):
+    async def plan(
+        self, task: Any, _worker_id: int = 0, _research_context: str = ""
+    ) -> Any:
+        issue_number = getattr(task, "id", getattr(task, "number", 0))
+        return self._pop(
+            issue_number,
+            lambda: PlanResultFactory.create(issue_number=issue_number, success=True),
+        )
+
+    async def run_gap_review(
+        self,
+        _epic_number: int,
+        _child_plans: dict[Any, Any],
+        _child_titles: dict[Any, Any],
+    ) -> str:
+        return ""
+
+
+class _FakeAgentRunner(_ScriptedRunner):
+    async def run(
+        self,
+        task: Any,
+        worktree_path: Path,
+        branch: str,
+        _worker_id: int = 0,
+        _review_feedback: str = "",
+        _prior_failure: str = "",
+        _bead_mapping: dict[str, str] | None = None,
+    ) -> Any:
+        issue_number = getattr(task, "id", getattr(task, "number", 0))
+        return self._pop(
+            issue_number,
+            lambda: WorkerResultFactory.create(
+                issue_number=issue_number,
+                branch=branch,
+                workspace_path=str(worktree_path),
+                success=True,
+                commits=1,
+            ),
+        )
+
+
+class _FakeReviewRunner(_ScriptedRunner):
+    async def review(
+        self,
+        pr: Any,
+        issue: Any,
+        _worktree_path: Path,
+        _diff: str,
+        _worker_id: int = 0,
+        _code_scanning_alerts: list[Any] | None = None,
+        _bead_tasks: list[Any] | None = None,
+    ) -> Any:
+        issue_number = getattr(issue, "id", getattr(issue, "number", 0))
+        pr_number = getattr(pr, "number", 0)
+        return self._pop(
+            issue_number,
+            lambda: ReviewResultFactory.create(
+                pr_number=pr_number,
+                issue_number=issue_number,
+                verdict=ReviewVerdict.APPROVE,
+                merged=True,
+                ci_passed=True,
+            ),
+        )
+
+    async def fix_ci(
+        self,
+        pr: Any,
+        issue: Any,
+        _worktree_path: Path,
+        _failure_summary: str,
+        **_kwargs: Any,
+    ) -> Any:
+        issue_number = getattr(issue, "id", getattr(issue, "number", 0))
+        pr_number = getattr(pr, "number", 0)
+        return ReviewResultFactory.create(
+            pr_number=pr_number,
+            issue_number=issue_number,
+            verdict=ReviewVerdict.APPROVE,
+            ci_passed=True,
+        )
+
+
+class FakeLLM:
+    """Composable scripted LLM runners for all pipeline phases."""
+
+    def __init__(self) -> None:
+        self.triage_runner = _FakeTriageRunner()
+        self.planners = _FakePlannerRunner()
+        self.agents = _FakeAgentRunner()
+        self.reviewers = _FakeReviewRunner()
+
+    def script_triage(self, issue_number: int, results: list[Any]) -> None:
+        self.triage_runner.add_script(issue_number, results)
+
+    def script_plan(self, issue_number: int, results: list[Any]) -> None:
+        self.planners.add_script(issue_number, results)
+
+    def script_implement(self, issue_number: int, results: list[Any]) -> None:
+        self.agents.add_script(issue_number, results)
+
+    def script_review(self, issue_number: int, results: list[Any]) -> None:
+        self.reviewers.add_script(issue_number, results)

--- a/tests/scenarios/fakes/fake_llm.py
+++ b/tests/scenarios/fakes/fake_llm.py
@@ -26,9 +26,12 @@ class _ScriptedRunner:
 
     def __init__(self) -> None:
         self._scripts: dict[int, deque[Any]] = {}
+        self._last_scripted: dict[int, Any] = {}
 
     def _add_script(self, issue_number: int, results: list[Any]) -> None:
         self._scripts[issue_number] = deque(results)
+        # Clear any stale last-scripted so the new script takes precedence
+        self._last_scripted.pop(issue_number, None)
 
     def add_script(self, issue_number: int, results: list[Any]) -> None:
         self._add_script(issue_number, results)
@@ -36,7 +39,12 @@ class _ScriptedRunner:
     def _pop(self, issue_number: int, default_factory: Callable[[], Any]) -> Any:
         q = self._scripts.get(issue_number)
         if q:
-            return q.popleft()
+            result = q.popleft()
+            self._last_scripted[issue_number] = result
+            return result
+        # Deque empty — repeat last scripted result if we had one
+        if issue_number in self._last_scripted:
+            return self._last_scripted[issue_number]
         return default_factory()
 
     def set_tracing_context(self, _context: Any) -> None:

--- a/tests/scenarios/fakes/fake_sentry.py
+++ b/tests/scenarios/fakes/fake_sentry.py
@@ -1,0 +1,22 @@
+"""Stateful Sentry fake for scenario testing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class FakeSentry:
+    """Captures breadcrumbs and events for assertion."""
+
+    def __init__(self) -> None:
+        self.breadcrumbs: list[dict[str, Any]] = []
+        self.events: list[dict[str, Any]] = []
+
+    def add_breadcrumb(self, **kwargs: Any) -> None:
+        self.breadcrumbs.append(kwargs)
+
+    def capture_event(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+    def capture_exception(self, error: Exception | None = None) -> None:
+        self.events.append({"type": "exception", "error": str(error)})

--- a/tests/scenarios/fakes/fake_workspace.py
+++ b/tests/scenarios/fakes/fake_workspace.py
@@ -1,0 +1,26 @@
+"""Stateful workspace fake for scenario testing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+class FakeWorkspace:
+    """Tracks worktree create/destroy calls with filesystem paths."""
+
+    def __init__(self, base_path: Path) -> None:
+        self._base = base_path
+        self.created: list[int] = []
+        self.destroyed: list[int] = []
+
+    async def create(self, issue_number: int, _branch: str) -> Path:
+        self.created.append(issue_number)
+        path = self._base / f"issue-{issue_number}"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    async def destroy(self, issue_number: int) -> None:
+        self.destroyed.append(issue_number)
+
+    async def sanitize_repo(self) -> None:
+        pass

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -1,0 +1,274 @@
+"""MockWorld — composable test world for scenario testing.
+
+Wraps PipelineHarness with stateful fakes so scenarios can seed a world,
+run the pipeline, and assert on the world's final state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from tests.conftest import TaskFactory
+from tests.helpers import PipelineHarness, PipelineRunResult
+from tests.scenarios.fakes.fake_clock import FakeClock
+from tests.scenarios.fakes.fake_github import FakeGitHub
+from tests.scenarios.fakes.fake_hindsight import FakeHindsight
+from tests.scenarios.fakes.fake_llm import FakeLLM
+from tests.scenarios.fakes.fake_sentry import FakeSentry
+from tests.scenarios.fakes.fake_workspace import FakeWorkspace
+from tests.scenarios.fakes.scenario_result import IssueOutcome, ScenarioResult
+
+
+class MockWorld:
+    """Composable test world for scenario testing."""
+
+    def __init__(self, tmp_path: Path, *, config: Any = None) -> None:
+        self._tmp_path = tmp_path
+        self._harness = PipelineHarness(tmp_path, config=config)
+        self._llm = FakeLLM()
+        self._github = FakeGitHub()
+        self._hindsight = FakeHindsight()
+        self._sentry = FakeSentry()
+        self._workspace = FakeWorkspace(tmp_path / "worktrees")
+        self._clock = FakeClock(start=time.time())
+        self._issues: dict[int, dict[str, Any]] = {}
+        self._phase_hooks: list[tuple[str, Callable[[], None]]] = []
+
+        self._wire_runners()
+        self._wire_prs()
+        self._wire_workspaces()
+
+    def _wire_runners(self) -> None:
+        """Replace harness AsyncMock runners with FakeLLM runners."""
+        h = self._harness
+        h.triage_runner.evaluate = self._llm.triage_runner.evaluate
+        h.triage_runner.run_decomposition = self._llm.triage_runner.run_decomposition
+        h.planners.plan = self._llm.planners.plan
+        h.planners.run_gap_review = self._llm.planners.run_gap_review
+        h.agents.run = self._llm.agents.run
+        h.reviewers.review = self._llm.reviewers.review
+        h.reviewers.fix_ci = self._llm.reviewers.fix_ci
+
+    def _wire_prs(self) -> None:
+        """Replace harness PR manager mocks with FakeGitHub methods."""
+        h = self._harness
+        gh = self._github
+        h.prs.transition = gh.transition
+        h.prs.swap_pipeline_labels = gh.swap_pipeline_labels
+        h.prs.add_labels = gh.add_labels
+        h.prs.remove_label = gh.remove_label
+        h.prs.post_comment = gh.post_comment
+        h.prs.post_pr_comment = gh.post_pr_comment
+        h.prs.submit_review = gh.submit_review
+        h.prs.create_task = gh.create_task
+        h.prs.close_task = gh.close_task
+        h.prs.close_issue = gh.close_issue
+        h.prs.find_existing_issue = gh.find_existing_issue
+        h.prs.push_branch = gh.push_branch
+        h.prs.create_pr = gh.create_pr
+        h.prs.find_open_pr_for_branch = gh.find_open_pr_for_branch
+        h.prs.branch_has_diff_from_main = gh.branch_has_diff_from_main
+        h.prs.add_pr_labels = gh.add_pr_labels
+        h.prs.get_pr_diff = gh.get_pr_diff
+        h.prs.get_pr_head_sha = gh.get_pr_head_sha
+        h.prs.get_pr_diff_names = gh.get_pr_diff_names
+        h.prs.get_pr_approvers = gh.get_pr_approvers
+        h.prs.fetch_code_scanning_alerts = gh.fetch_code_scanning_alerts
+        h.prs.wait_for_ci = gh.wait_for_ci
+        h.prs.fetch_ci_failure_logs = gh.fetch_ci_failure_logs
+        h.prs.merge_pr = gh.merge_pr
+
+    def _wire_workspaces(self) -> None:
+        """Replace harness workspace mocks with FakeWorkspace."""
+        h = self._harness
+        h.workspaces.create = self._workspace.create
+        h.workspaces.destroy = self._workspace.destroy
+
+    # --- Seed API (fluent, returns self) ---
+
+    def add_issue(
+        self,
+        number: int,
+        title: str,
+        body: str,
+        labels: list[str] | None = None,
+    ) -> MockWorld:
+        self._issues[number] = {
+            "number": number,
+            "title": title,
+            "body": body,
+            "labels": labels or ["hydraflow-find"],
+        }
+        self._github.add_issue(number, title, body, labels=labels)
+        return self
+
+    def set_phase_result(self, phase: str, issue: int, result: Any) -> MockWorld:
+        return self.set_phase_results(phase, issue, [result])
+
+    def set_phase_results(
+        self, phase: str, issue: int, results: list[Any]
+    ) -> MockWorld:
+        phase_map = {
+            "triage": self._llm.script_triage,
+            "plan": self._llm.script_plan,
+            "implement": self._llm.script_implement,
+            "review": self._llm.script_review,
+        }
+        script_fn = phase_map.get(phase)
+        if script_fn is None:
+            msg = f"Unknown phase: {phase}; valid: {list(phase_map)}"
+            raise ValueError(msg)
+        script_fn(issue, results)
+        return self
+
+    def on_phase(self, phase: str, callback: Callable[[], None]) -> MockWorld:
+        self._phase_hooks.append((phase, callback))
+        return self
+
+    def fail_service(
+        self, name: str, _error: type[Exception] = ConnectionError
+    ) -> MockWorld:
+        if name == "hindsight":
+            self._hindsight.set_failing(True)
+        return self
+
+    def heal_service(self, name: str) -> MockWorld:
+        if name == "hindsight":
+            self._hindsight.set_failing(False)
+        return self
+
+    # --- Inspect world state ---
+
+    @property
+    def github(self) -> FakeGitHub:
+        return self._github
+
+    @property
+    def hindsight(self) -> FakeHindsight:
+        return self._hindsight
+
+    @property
+    def sentry(self) -> FakeSentry:
+        return self._sentry
+
+    @property
+    def clock(self) -> FakeClock:
+        return self._clock
+
+    @property
+    def harness(self) -> PipelineHarness:
+        return self._harness
+
+    # --- Run ---
+
+    def _fire_hooks(self, phase: str) -> None:
+        for hook_phase, callback in self._phase_hooks:
+            if hook_phase == phase:
+                callback()
+
+    async def run_pipeline(self) -> ScenarioResult:
+        """Run all seeded issues through the full pipeline."""
+        h = self._harness
+        start = time.monotonic()
+
+        for info in self._issues.values():
+            tags = info.get("labels", ["hydraflow-find"])
+            task = TaskFactory.create(
+                id=info["number"],
+                title=info["title"],
+                body=info["body"],
+                tags=tags,
+            )
+            h.seed_issue(task, stage="find")
+
+        snapshots: dict[str, Any] = {}
+
+        def _capture(label: str) -> None:
+            snapshots[label] = h.store.get_queue_stats().model_copy(deep=True)
+
+        # Triage
+        self._fire_hooks("triage")
+        triaged = await h.triage_phase.triage_issues()
+        _capture("after_triage")
+
+        # Plan
+        self._fire_hooks("plan")
+        plan_results = await h.plan_phase.plan_issues()
+        _capture("after_plan")
+
+        # Implement
+        self._fire_hooks("implement")
+        worker_results, _ = await h.implement_phase.run_batch()
+        _capture("after_implement")
+
+        # Review
+        self._fire_hooks("review")
+        review_results: list[Any] = []
+        if worker_results:
+            prs_to_review = [wr.pr_info for wr in worker_results if wr.pr_info]
+            if prs_to_review:
+                candidates = h.store.get_reviewable(h.config.batch_size)
+                review_results = await h.review_phase.review_prs(
+                    prs_to_review, candidates
+                )
+        _capture("after_review")
+
+        await asyncio.sleep(0)
+        events = h.bus.get_history()
+
+        # Build per-issue outcomes
+        outcomes: dict[int, IssueOutcome] = {}
+        for info in self._issues.values():
+            num = info["number"]
+            pr_record = self._github.pr_for_issue(num)
+            merged = pr_record.merged if pr_record else False
+
+            wr = next((w for w in worker_results if w.issue_number == num), None)
+            rr = next((r for r in review_results if r.issue_number == num), None)
+            pr_result = next((p for p in plan_results if p.issue_number == num), None)
+
+            if rr and getattr(rr, "merged", False):
+                final_stage = "done"
+            elif rr:
+                final_stage = "review"
+            elif wr:
+                final_stage = "implement"
+            elif pr_result:
+                final_stage = "plan"
+            else:
+                final_stage = "triage"
+
+            labels = (
+                self._github.issue(num).labels if num in self._github._issues else []
+            )
+            outcomes[num] = IssueOutcome(
+                number=num,
+                final_stage=final_stage,
+                plan_result=pr_result,
+                worker_result=wr,
+                review_result=rr,
+                labels=labels,
+                merged=merged,
+            )
+
+        pipeline_result = PipelineRunResult(
+            task=TaskFactory.create(id=0),
+            triaged_count=triaged,
+            plan_results=plan_results,
+            worker_results=worker_results,
+            review_results=review_results,
+            snapshots=snapshots,
+            events=events,
+        )
+
+        duration = time.monotonic() - start
+        result = ScenarioResult(
+            pipeline_results=[pipeline_result],
+            duration_seconds=duration,
+        )
+        result._outcomes = outcomes
+        return result

--- a/tests/scenarios/fakes/scenario_result.py
+++ b/tests/scenarios/fakes/scenario_result.py
@@ -1,0 +1,44 @@
+"""Result types for scenario tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from tests.helpers import PipelineRunResult
+
+
+@dataclass
+class IssueOutcome:
+    """Per-issue outcome view after a scenario run."""
+
+    number: int
+    final_stage: str
+    attempt_count: int = 0
+    triage_count: int = 0
+    plan_result: Any = None
+    worker_result: Any = None
+    review_result: Any = None
+    hitl_result: Any = None
+    labels: list[str] = field(default_factory=list)
+    merged: bool = False
+
+
+@dataclass
+class ScenarioResult:
+    """Outcome of a scenario run — wraps PipelineRunResult(s)."""
+
+    pipeline_results: list[PipelineRunResult]
+    loop_stats: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    duration_seconds: float = 0.0
+    _outcomes: dict[int, IssueOutcome] = field(default_factory=dict)
+    _config_snapshots: dict[str, Any] = field(default_factory=dict)
+
+    def issue(self, number: int) -> IssueOutcome:
+        if number not in self._outcomes:
+            msg = f"No outcome for issue {number}; available: {list(self._outcomes)}"
+            raise KeyError(msg)
+        return self._outcomes[number]
+
+    def config_snapshot(self, key: str) -> Any:
+        return self._config_snapshots.get(key)

--- a/tests/scenarios/fakes/test_fake_github.py
+++ b/tests/scenarios/fakes/test_fake_github.py
@@ -66,7 +66,7 @@ class TestFakeGitHubMutations:
     async def test_transition_updates_labels(self):
         gh = FakeGitHub()
         gh.add_issue(1, "t", "b", labels=["hydraflow-find"])
-        await gh.transition(1, "hydraflow-find", "hydraflow-plan")
+        await gh.transition(1, "plan")
         assert gh.issue(1).labels == ["hydraflow-plan"]
 
     async def test_swap_pipeline_labels_removes_existing(self):

--- a/tests/scenarios/fakes/test_fake_github.py
+++ b/tests/scenarios/fakes/test_fake_github.py
@@ -1,0 +1,90 @@
+"""Tests for FakeGitHub stateful fake."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import TaskFactory
+from tests.scenarios.fakes.fake_github import FakeGitHub
+
+pytestmark = pytest.mark.scenario
+
+
+class TestFakeGitHubIssues:
+    def test_add_and_query_issue(self):
+        gh = FakeGitHub()
+        gh.add_issue(1, "Fix bug", "body", labels=["hydraflow-ready"])
+        issue = gh.issue(1)
+        assert issue.labels == ["hydraflow-ready"]
+        assert issue.title == "Fix bug"
+
+    def test_issue_not_found_raises(self):
+        gh = FakeGitHub()
+        with pytest.raises(KeyError, match="999"):
+            gh.issue(999)
+
+
+class TestFakeGitHubPRs:
+    async def test_create_pr_tracks_state(self):
+        gh = FakeGitHub()
+        issue = TaskFactory.create(id=1)
+        pr = await gh.create_pr(issue, "agent/issue-1")
+        assert pr.number >= 1
+        assert gh.pr(pr.number).merged is False
+
+    async def test_merge_pr_sets_merged(self):
+        gh = FakeGitHub()
+        issue = TaskFactory.create(id=1)
+        pr = await gh.create_pr(issue, "agent/issue-1")
+        result = await gh.merge_pr(pr.number)
+        assert result is True
+        assert gh.pr(pr.number).merged is True
+
+    async def test_pr_for_issue(self):
+        gh = FakeGitHub()
+        issue = TaskFactory.create(id=1)
+        pr = await gh.create_pr(issue, "agent/issue-1")
+        found = gh.pr_for_issue(1)
+        assert found is not None
+        assert found.number == pr.number
+
+    async def test_wait_for_ci_default_pass(self):
+        gh = FakeGitHub()
+        passed, _ = await gh.wait_for_ci(100)
+        assert passed is True
+
+    async def test_wait_for_ci_scripted_failure(self):
+        gh = FakeGitHub()
+        gh.script_ci(100, [(False, "CI failed"), (True, "CI passed")])
+        r1 = await gh.wait_for_ci(100)
+        r2 = await gh.wait_for_ci(100)
+        assert r1[0] is False
+        assert r2[0] is True
+
+
+class TestFakeGitHubMutations:
+    async def test_transition_updates_labels(self):
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-find"])
+        await gh.transition(1, "hydraflow-find", "hydraflow-plan")
+        assert gh.issue(1).labels == ["hydraflow-plan"]
+
+    async def test_swap_pipeline_labels_removes_existing(self):
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-find", "bug"])
+        await gh.swap_pipeline_labels(1, "hydraflow-plan")
+        assert "hydraflow-plan" in gh.issue(1).labels
+        assert "hydraflow-find" not in gh.issue(1).labels
+        assert "bug" in gh.issue(1).labels  # non-pipeline labels preserved
+
+    async def test_close_issue_sets_state(self):
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b")
+        await gh.close_issue(1)
+        assert gh.issue(1).state == "closed"
+
+    async def test_post_comment_appends_to_issue(self):
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b")
+        await gh.post_comment(1, "a comment")
+        assert "a comment" in gh.issue(1).comments

--- a/tests/scenarios/fakes/test_fake_llm.py
+++ b/tests/scenarios/fakes/test_fake_llm.py
@@ -81,6 +81,22 @@ class TestFakeLLMScriptedResults:
         result = await llm.reviewers.review(pr, task, Path("/tmp"), "diff")
         assert result.verdict == ReviewVerdict.REQUEST_CHANGES
 
+    async def test_last_scripted_result_is_sticky(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        reject = PlanResultFactory.create(issue_number=1, success=False)
+        llm.script_plan(1, [reject])
+
+        task = TaskFactory.create(id=1)
+        r1 = await llm.planners.plan(task)
+        r2 = await llm.planners.plan(task)
+        r3 = await llm.planners.plan(task)
+        # All three calls return the scripted rejection, not the default success
+        assert r1.success is False
+        assert r2.success is False
+        assert r3.success is False
+
     async def test_tracing_context_methods_are_noops(self):
         from tests.scenarios.fakes.fake_llm import FakeLLM
 

--- a/tests/scenarios/fakes/test_fake_llm.py
+++ b/tests/scenarios/fakes/test_fake_llm.py
@@ -1,0 +1,96 @@
+"""Tests for FakeLLM scripted runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import (
+    PlanResultFactory,
+    ReviewResultFactory,
+    TaskFactory,
+    TriageResultFactory,
+    WorkerResultFactory,
+)
+
+pytestmark = pytest.mark.scenario
+
+
+class TestFakeLLMScriptedResults:
+    async def test_returns_scripted_triage_result(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        scripted = TriageResultFactory.create(issue_number=1, ready=False)
+        llm.script_triage(1, [scripted])
+
+        task = TaskFactory.create(id=1)
+        result = await llm.triage_runner.evaluate(task)
+        assert result.ready is False
+
+    async def test_triage_default_when_no_script(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        task = TaskFactory.create(id=1)
+        result = await llm.triage_runner.evaluate(task)
+        assert result.ready is True
+
+    async def test_plan_pops_sequence(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        fail = PlanResultFactory.create(issue_number=1, success=False)
+        succeed = PlanResultFactory.create(issue_number=1, success=True)
+        llm.script_plan(1, [fail, succeed])
+
+        task = TaskFactory.create(id=1)
+        r1 = await llm.planners.plan(task)
+        r2 = await llm.planners.plan(task)
+        assert r1.success is False
+        assert r2.success is True
+
+    async def test_implement_returns_scripted_worker_result(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        fail_result = WorkerResultFactory.create(
+            issue_number=1, success=False, error="compilation error"
+        )
+        llm.script_implement(1, [fail_result])
+
+        task = TaskFactory.create(id=1)
+        result = await llm.agents.run(task, Path("/tmp"), "branch")
+        assert result.success is False
+        assert result.error == "compilation error"
+
+    async def test_review_returns_scripted_result(self):
+        from models import ReviewVerdict
+        from tests.conftest import PRInfoFactory
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        reject = ReviewResultFactory.create(
+            issue_number=1, verdict=ReviewVerdict.REQUEST_CHANGES
+        )
+        llm.script_review(1, [reject])
+
+        pr = PRInfoFactory.create(issue_number=1)
+        task = TaskFactory.create(id=1)
+        result = await llm.reviewers.review(pr, task, Path("/tmp"), "diff")
+        assert result.verdict == ReviewVerdict.REQUEST_CHANGES
+
+    async def test_tracing_context_methods_are_noops(self):
+        from tests.scenarios.fakes.fake_llm import FakeLLM
+
+        llm = FakeLLM()
+        # These must not raise
+        llm.triage_runner.set_tracing_context(None)
+        llm.triage_runner.clear_tracing_context()
+        llm.planners.set_tracing_context(None)
+        llm.planners.clear_tracing_context()
+        llm.agents.set_tracing_context(None)
+        llm.agents.clear_tracing_context()
+        llm.reviewers.set_tracing_context(None)
+        llm.reviewers.clear_tracing_context()

--- a/tests/scenarios/fakes/test_mock_world.py
+++ b/tests/scenarios/fakes/test_mock_world.py
@@ -1,0 +1,52 @@
+"""Tests for MockWorld orchestrating fixture."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import WorkerResultFactory
+from tests.scenarios.fakes.mock_world import MockWorld
+
+pytestmark = pytest.mark.scenario
+
+
+class TestMockWorldSingleIssue:
+    async def test_single_issue_happy_path(self, tmp_path):
+        world = MockWorld(tmp_path)
+        world.add_issue(1, "Fix login bug", "The login is broken", ["hydraflow-find"])
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.final_stage == "done"
+
+    async def test_fluent_chaining(self, tmp_path):
+        world = (
+            MockWorld(tmp_path)
+            .add_issue(1, "Bug A", "body", ["hydraflow-find"])
+            .add_issue(2, "Bug B", "body", ["hydraflow-find"])
+        )
+        assert len(world._issues) == 2
+
+
+class TestMockWorldScriptedFailure:
+    async def test_implement_failure_with_scripted_result(self, tmp_path):
+        world = MockWorld(tmp_path)
+        world.add_issue(1, "Fix bug", "body", ["hydraflow-find"])
+        fail_result = WorkerResultFactory.create(
+            issue_number=1, success=False, error="compile error"
+        )
+        world.set_phase_result("implement", 1, fail_result)
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.worker_result is not None
+        assert outcome.worker_result.success is False
+
+
+class TestMockWorldServiceFailure:
+    async def test_fail_and_heal_service(self, tmp_path):
+        world = MockWorld(tmp_path)
+        world.fail_service("hindsight")
+        assert world.hindsight._failing is True
+        world.heal_service("hindsight")
+        assert world.hindsight._failing is False

--- a/tests/scenarios/fakes/test_supporting_fakes.py
+++ b/tests/scenarios/fakes/test_supporting_fakes.py
@@ -1,0 +1,80 @@
+"""Tests for FakeHindsight, FakeWorkspace, FakeSentry, FakeClock."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.fakes.fake_clock import FakeClock
+from tests.scenarios.fakes.fake_hindsight import FakeHindsight
+from tests.scenarios.fakes.fake_sentry import FakeSentry
+from tests.scenarios.fakes.fake_workspace import FakeWorkspace
+
+pytestmark = pytest.mark.scenario
+
+
+class TestFakeHindsight:
+    async def test_retain_and_recall(self):
+        hs = FakeHindsight()
+        await hs.retain("learnings", "key1", "test memory")
+        results = await hs.recall("learnings", "test")
+        assert len(results) == 1
+        assert results[0]["content"] == "test memory"
+
+    async def test_recall_empty_bank(self):
+        hs = FakeHindsight()
+        results = await hs.recall("learnings", "nothing")
+        assert results == []
+
+    async def test_fail_mode(self):
+        hs = FakeHindsight()
+        hs.set_failing(True)
+        with pytest.raises(ConnectionError):
+            await hs.retain("learnings", "k", "v")
+
+    async def test_heal_after_fail(self):
+        hs = FakeHindsight()
+        hs.set_failing(True)
+        hs.set_failing(False)
+        await hs.retain("learnings", "k", "v")
+        results = await hs.recall("learnings", "")
+        assert len(results) == 1
+
+
+class TestFakeWorkspace:
+    async def test_create_tracks_issue(self, tmp_path):
+        ws = FakeWorkspace(tmp_path)
+        path = await ws.create(42, "agent/issue-42")
+        assert 42 in ws.created
+        assert path.exists()
+
+    async def test_destroy_tracks_cleanup(self, tmp_path):
+        ws = FakeWorkspace(tmp_path)
+        await ws.create(42, "agent/issue-42")
+        await ws.destroy(42)
+        assert 42 in ws.destroyed
+
+
+class TestFakeSentry:
+    def test_capture_breadcrumb(self):
+        sentry = FakeSentry()
+        sentry.add_breadcrumb(category="test", message="hello")
+        assert len(sentry.breadcrumbs) == 1
+        assert sentry.breadcrumbs[0]["message"] == "hello"
+
+    def test_capture_exception(self):
+        sentry = FakeSentry()
+        sentry.capture_exception(ValueError("boom"))
+        assert len(sentry.events) == 1
+
+
+class TestFakeClock:
+    def test_advance_time(self):
+        clock = FakeClock(start=1000.0)
+        assert clock.now() == 1000.0
+        clock.advance(60.0)
+        assert clock.now() == 1060.0
+
+    async def test_sleep_advances_clock(self):
+        clock = FakeClock(start=1000.0)
+        await clock.sleep(30.0)
+        assert clock.now() == 1030.0

--- a/tests/scenarios/test_edge.py
+++ b/tests/scenarios/test_edge.py
@@ -1,0 +1,80 @@
+"""Edge case scenario tests — race conditions, mid-flight mutations."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import WorkerResultFactory
+
+pytestmark = pytest.mark.scenario
+
+
+class TestE1DuplicateIssues:
+    """E1: Duplicate issues — pipeline must not crash and must track each by number."""
+
+    async def test_same_title_body_both_tracked_by_number(self, mock_world):
+        """Two issues with identical title+body are seeded independently.
+
+        Discovered behavior: ``FakeGitHub.find_existing_issue`` resolves by
+        title, so when two open issues share a title only the first one
+        observed wins the dedup lookup. The pipeline still produces an
+        ``IssueOutcome`` for each issue number — duplicates do not crash the
+        pipeline and each is independently inspectable. Production-style
+        dedup is the responsibility of the upstream issue-creation path,
+        not the in-pipeline phases. If a future change makes the pipeline
+        actively dedup duplicates this test should be updated to assert the
+        new contract.
+        """
+        world = mock_world.add_issue(
+            1, "Fix auth bug", "The auth module is broken"
+        ).add_issue(2, "Fix auth bug", "The auth module is broken")
+        result = await world.run_pipeline()
+
+        # Both issues are tracked independently by number
+        assert result.issue(1).number == 1
+        assert result.issue(2).number == 2
+        # At least one of them must reach a real terminal stage; the other
+        # is allowed to lag because of upstream title-based dedup.
+        stages = {result.issue(1).final_stage, result.issue(2).final_stage}
+        assert "done" in stages or "review" in stages, (
+            f"Expected at least one duplicate to progress past triage; got {stages}"
+        )
+
+
+class TestE2IssueRelabeledMidFlight:
+    """E2: on_phase hook fires before a phase runs."""
+
+    async def test_on_phase_hook_fires(self, mock_world):
+        fired = {"count": 0}
+
+        def hook():
+            fired["count"] += 1
+
+        world = mock_world.add_issue(1, "Refactor DB", "Needs DB refactor").on_phase(
+            "plan", hook
+        )
+        result = await world.run_pipeline()
+
+        assert fired["count"] == 1, "on_phase hook should fire exactly once"
+        # Pipeline still processes the issue normally
+        assert result.issue(1) is not None
+
+
+class TestE5ZeroDiffImplement:
+    """E5: Agent produces zero commits — already-satisfied case."""
+
+    async def test_zero_commits_worker_result(self, mock_world):
+        zero_diff = WorkerResultFactory.create(
+            issue_number=1,
+            success=True,
+            commits=0,
+        )
+        world = mock_world.add_issue(
+            1, "Add type hints", "Already typed module"
+        ).set_phase_result("implement", 1, zero_diff)
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.worker_result is not None
+        assert outcome.worker_result.commits == 0
+        assert outcome.worker_result.success is True

--- a/tests/scenarios/test_happy.py
+++ b/tests/scenarios/test_happy.py
@@ -1,0 +1,95 @@
+"""Happy path scenario tests — prove the golden path works."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import PlanResultFactory
+
+pytestmark = pytest.mark.scenario
+
+
+class TestH1SingleIssueEndToEnd:
+    """H1: Single issue flows find → triage → plan → implement → review → done."""
+
+    async def test_single_issue_lifecycle(self, mock_world):
+        world = mock_world.add_issue(
+            1, "Add login button", "Add a login button to the homepage"
+        )
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.final_stage == "done"
+        assert outcome.merged is True
+        assert outcome.plan_result is not None
+        assert outcome.plan_result.success is True
+        assert outcome.worker_result is not None
+        assert outcome.worker_result.success is True
+
+
+class TestH2MultiIssueConcurrentBatch:
+    """H2: Multiple issues processed without cross-contamination."""
+
+    async def test_three_issues_all_complete(self, mock_world):
+        world = (
+            mock_world.add_issue(1, "Bug fix A", "Fix the A module")
+            .add_issue(2, "Bug fix B", "Fix the B module")
+            .add_issue(3, "Bug fix C", "Fix the C module")
+        )
+        result = await world.run_pipeline()
+
+        for num in (1, 2, 3):
+            outcome = result.issue(num)
+            assert outcome.final_stage == "done", f"Issue {num} did not complete"
+            assert outcome.merged is True, f"Issue {num} PR not merged"
+
+    async def test_no_cross_contamination(self, mock_world):
+        world = mock_world.add_issue(10, "Feature X", "Build X").add_issue(
+            20, "Feature Y", "Build Y"
+        )
+        result = await world.run_pipeline()
+
+        assert result.issue(10).worker_result is not None
+        assert result.issue(10).worker_result.issue_number == 10
+        assert result.issue(20).worker_result is not None
+        assert result.issue(20).worker_result.issue_number == 20
+
+
+class TestH4ReviewApproveAndMerge:
+    """H4: Review returns APPROVE, CI passes, PR merged."""
+
+    async def test_approve_merge_flow(self, mock_world):
+        world = mock_world.add_issue(1, "Small refactor", "Clean up utils module")
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.review_result is not None
+        assert outcome.merged is True
+        pr = world.github.pr_for_issue(1)
+        assert pr is not None
+        assert pr.merged is True
+
+
+class TestH5PlanProducesSubIssues:
+    """H5: Planner returns new_issues, sub-issues tracked in plan result."""
+
+    async def test_sub_issues_in_plan_result(self, mock_world):
+        from models import NewIssueSpec
+
+        plan_with_subs = PlanResultFactory.create(
+            issue_number=1,
+            success=True,
+            new_issues=[
+                NewIssueSpec(title="Sub-task 1", body="Do sub-task 1"),
+                NewIssueSpec(title="Sub-task 2", body="Do sub-task 2"),
+            ],
+        )
+        world = mock_world.add_issue(1, "Epic task", "Big feature").set_phase_result(
+            "plan", 1, plan_with_subs
+        )
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.plan_result is not None
+        assert outcome.plan_result.new_issues is not None
+        assert len(outcome.plan_result.new_issues) == 2

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -1,0 +1,56 @@
+"""Background loop scenario tests — Tier B sanity checks.
+
+These tests verify that MockWorld can interact with loop-adjacent state
+(workspace tracking, config snapshots). Full loop orchestration with
+real BaseBackgroundLoop subclasses is planned for v2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestL1HealthMonitorConfigAccess:
+    """L1: Verify the harness config is accessible for health-monitor-style reads."""
+
+    async def test_config_max_quality_fix_attempts_readable(self, tmp_path):
+        """The health monitor loop reads `config.max_quality_fix_attempts`.
+
+        This sanity-check ensures MockWorld exposes the config correctly
+        so loop-style tests can read and assert on tunable values.
+        """
+        world = MockWorld(tmp_path)
+        config = world.harness.config
+        # The config must expose the tunable health monitor adjusts
+        assert hasattr(config, "max_quality_fix_attempts")
+        # Default from ConfigFactory — reading it must not crash
+        value = config.max_quality_fix_attempts
+        assert isinstance(value, int)
+        assert value >= 0
+
+
+class TestL2WorkspaceGCTracking:
+    """L2: FakeWorkspace tracks create/destroy — the invariant gc-style loops rely on."""
+
+    async def test_workspace_lifecycle_is_observable(self, tmp_path):
+        """GC-style loops iterate over workspace state to decide what to prune.
+
+        This sanity-check verifies FakeWorkspace records both creates and
+        destroys distinctly so scenario tests (and any future loop tests)
+        can assert on GC behavior.
+        """
+        world = MockWorld(tmp_path)
+        ws = world._workspace
+
+        await ws.create(1, "agent/issue-1")
+        await ws.create(2, "agent/issue-2")
+        await ws.destroy(1)
+
+        assert ws.created == [1, 2]
+        assert ws.destroyed == [1]
+        # Issue 2 is still "active" — a GC loop would leave it alone
+        assert 2 not in ws.destroyed

--- a/tests/scenarios/test_sad.py
+++ b/tests/scenarios/test_sad.py
@@ -57,20 +57,14 @@ class TestS3ReviewRejects:
     """S3: Review rejects with REQUEST_CHANGES."""
 
     async def test_review_rejection_tracked(self, mock_world):
-        # review_phase may invoke reviewers.review multiple times (re-review
-        # path); script several REQUEST_CHANGES results so the rejection
-        # sticks across all internal re-review attempts.
-        rejects = [
-            ReviewResultFactory.create(
-                issue_number=1,
-                verdict=ReviewVerdict.REQUEST_CHANGES,
-                merged=False,
-            )
-            for _ in range(5)
-        ]
+        reject = ReviewResultFactory.create(
+            issue_number=1,
+            verdict=ReviewVerdict.REQUEST_CHANGES,
+            merged=False,
+        )
         world = mock_world.add_issue(
             1, "Fix UI glitch", "Button misaligned"
-        ).set_phase_results("review", 1, rejects)
+        ).set_phase_result("review", 1, reject)
         result = await world.run_pipeline()
 
         outcome = result.issue(1)

--- a/tests/scenarios/test_sad.py
+++ b/tests/scenarios/test_sad.py
@@ -1,0 +1,107 @@
+"""Sad path scenario tests — prove failure recovery works."""
+
+from __future__ import annotations
+
+import pytest
+
+from models import ReviewVerdict
+from tests.conftest import (
+    PlanResultFactory,
+    ReviewResultFactory,
+    WorkerResultFactory,
+)
+
+pytestmark = pytest.mark.scenario
+
+
+class TestS1PlanFailsThenSucceeds:
+    """S1: First plan fails, retry succeeds."""
+
+    async def test_plan_retry_sequence(self, mock_world):
+        fail = PlanResultFactory.create(
+            issue_number=1, success=False, error="LLM timeout"
+        )
+        succeed = PlanResultFactory.create(issue_number=1, success=True)
+
+        world = mock_world.add_issue(1, "Fix auth", "Auth is broken").set_phase_results(
+            "plan", 1, [fail, succeed]
+        )
+        result = await world.run_pipeline()
+
+        # The pipeline should have produced a plan result even if the first attempt failed
+        outcome = result.issue(1)
+        assert outcome.plan_result is not None
+
+
+class TestS2ImplementExhaustsAttempts:
+    """S2: Docker fails, issue does not complete."""
+
+    async def test_implement_failure_blocks_completion(self, mock_world):
+        fail = WorkerResultFactory.create(
+            issue_number=1, success=False, error="compilation error"
+        )
+        world = mock_world.add_issue(
+            1, "Fix DB migration", "Migration is broken"
+        ).set_phase_result("implement", 1, fail)
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.worker_result is not None
+        assert outcome.worker_result.success is False
+        # Failed implement means the issue should NOT be marked as done
+        assert outcome.final_stage != "done"
+        assert outcome.merged is False
+
+
+class TestS3ReviewRejects:
+    """S3: Review rejects with REQUEST_CHANGES."""
+
+    async def test_review_rejection_tracked(self, mock_world):
+        # review_phase may invoke reviewers.review multiple times (re-review
+        # path); script several REQUEST_CHANGES results so the rejection
+        # sticks across all internal re-review attempts.
+        rejects = [
+            ReviewResultFactory.create(
+                issue_number=1,
+                verdict=ReviewVerdict.REQUEST_CHANGES,
+                merged=False,
+            )
+            for _ in range(5)
+        ]
+        world = mock_world.add_issue(
+            1, "Fix UI glitch", "Button misaligned"
+        ).set_phase_results("review", 1, rejects)
+        result = await world.run_pipeline()
+
+        outcome = result.issue(1)
+        assert outcome.review_result is not None
+        assert outcome.review_result.verdict == ReviewVerdict.REQUEST_CHANGES
+        assert outcome.merged is False
+
+
+class TestS5HindsightDown:
+    """S5: Pipeline continues with Hindsight in fail mode."""
+
+    async def test_pipeline_completes_without_hindsight(self, mock_world):
+        world = mock_world.add_issue(1, "Add feature", "New feature request")
+        world.fail_service("hindsight")
+        result = await world.run_pipeline()
+
+        # Pipeline should still complete the happy path even without memory
+        outcome = result.issue(1)
+        assert outcome.final_stage == "done"
+        assert outcome.merged is True
+        assert world.hindsight._failing is True  # confirm it stayed failed
+
+
+class TestS6CIFailsFirstThenPasses:
+    """S6: Scripted CI returns failure first, then passes."""
+
+    async def test_ci_script_sequence(self, mock_world):
+        world = mock_world.add_issue(1, "Fix tests", "Flaky test suite")
+        result = await world.run_pipeline()
+
+        # With default fakes the PR should pass CI and merge — this test
+        # establishes a baseline so later tasks can script CI failure/retry.
+        outcome = result.issue(1)
+        assert outcome.final_stage == "done"


### PR DESCRIPTION
## Summary

- Adds **MockWorld** fixture that wraps `PipelineHarness` with stateful fakes (FakeGitHub, FakeLLM, FakeHindsight, FakeWorkspace, FakeSentry, FakeClock) for full pipeline scenario testing
- **47 scenario tests** across happy paths (H1-H5), sad paths (S1-S6), edge cases (E1-E5), and background loops (L1-L2)
- New `make scenario` and `make scenario-loops` CI targets with dedicated GitHub Actions job
- Scenarios added to the quality gate — `make quality` now includes them
- Sticky-repeat behavior for scripted FakeLLM results (last scripted result persists after deque exhaustion)

## Architecture

`MockWorld` wraps `PipelineHarness` (not replacing it) and swaps AsyncMock runners/PR manager with stateful fakes. Scenarios seed a world, run the pipeline, and assert on the world's final state.

```
MockWorld
├── FakeGitHub      — stateful issues, PRs, labels, CI
├── FakeLLM         — scripted per-phase per-issue results
├── FakeHindsight   — in-memory memory banks with fail mode
├── FakeWorkspace   — worktree lifecycle tracking
├── FakeSentry      — breadcrumb/event capture
└── FakeClock       — controllable time
```

## Test plan

- [x] `make scenario` — 45 passed, 2 deselected
- [x] `make scenario-loops` — 2 passed, 45 deselected
- [x] `make quality` — 10,013 passed, full pipeline green
- [x] CI workflow includes new `scenario` job

Spec: `docs/superpowers/specs/2026-04-08-scenario-testing-framework-design.md`
Plan: `docs/superpowers/plans/2026-04-08-scenario-testing-framework.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)