### PR TITLE
Fixes #6299: Code Quality: Break down runner_utils.stream_claude_pr...

### DIFF
--- a/src/acceptance_criteria.py
+++ b/src/acceptance_criteria.py
@@ -12,7 +12,7 @@ from agent_cli import build_agent_command
 from execution import get_default_runner
 from models import VerificationCriteria
 from precheck import run_precheck_context
-from runner_utils import stream_claude_process, terminate_processes
+from runner_utils import StreamConfig, stream_claude_process, terminate_processes
 
 if TYPE_CHECKING:
     from config import Credentials, HydraFlowConfig
@@ -96,9 +96,11 @@ class AcceptanceCriteriaGenerator:
                 "source": "ac_generator",
             },
             logger=logger,
-            timeout=self._config.agent_timeout,
-            runner=self._runner,
-            gh_token=self._credentials.gh_token,
+            config=StreamConfig(
+                timeout=self._config.agent_timeout,
+                runner=self._runner,
+                gh_token=self._credentials.gh_token,
+            ),
         )
 
         criteria = self._extract_criteria(transcript, issue_number, pr_number)
@@ -211,6 +213,12 @@ Diff summary:
             issue, issue_number, pr_number, diff_summary
         )
 
+        _cfg = StreamConfig(
+            timeout=self._config.agent_timeout,
+            runner=self._runner,
+            gh_token=self._credentials.gh_token,
+        )
+
         async def execute(cmd: list[str], p: str) -> str:
             return await stream_claude_process(
                 cmd=cmd,
@@ -224,9 +232,7 @@ Diff summary:
                     "source": "ac_precheck",
                 },
                 logger=logger,
-                timeout=self._config.agent_timeout,
-                runner=self._runner,
-                gh_token=self._credentials.gh_token,
+                config=_cfg,
             )
 
         async def execute_debug(cmd: list[str], p: str) -> str:
@@ -242,9 +248,7 @@ Diff summary:
                     "source": "ac_precheck_debug",
                 },
                 logger=logger,
-                timeout=self._config.agent_timeout,
-                runner=self._runner,
-                gh_token=self._credentials.gh_token,
+                config=_cfg,
             )
 
         return await run_precheck_context(

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -17,6 +17,7 @@ from models import LoopResult, TranscriptEventData
 from prompt_telemetry import PromptTelemetry, parse_command_tool_model
 from runner_utils import (
     AuthenticationRetryError,
+    StreamConfig,
     stream_claude_process,
     terminate_processes,
 )
@@ -171,12 +172,14 @@ class BaseRunner:
                         event_bus=self._bus,
                         event_data=event_data,
                         logger=self._log,
-                        on_output=on_output,
-                        timeout=self._config.agent_timeout,
-                        runner=self._runner,
-                        usage_stats=usage_stats,
-                        gh_token=self._credentials.gh_token,
-                        trace_collector=trace_collector,
+                        config=StreamConfig(
+                            on_output=on_output,
+                            timeout=self._config.agent_timeout,
+                            runner=self._runner,
+                            usage_stats=usage_stats,
+                            gh_token=self._credentials.gh_token,
+                            trace_collector=trace_collector,
+                        ),
                     )
                     succeeded = True
                     if trace_collector is not None:

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -11,7 +11,7 @@ from agent_cli import build_agent_command
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
 from dedup_store import DedupStore
-from runner_utils import stream_claude_process
+from runner_utils import StreamConfig, stream_claude_process
 
 if TYPE_CHECKING:
     from ports import PRPort
@@ -76,7 +76,7 @@ class CodeGroomingLoop(BaseBackgroundLoop):
             event_bus=self._bus,
             event_data={"source": "code_grooming"},
             logger=logger,
-            gh_token=self._credentials.gh_token,
+            config=StreamConfig(gh_token=self._credentials.gh_token),
         )
 
         return self._parse_findings(transcript)

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -25,7 +25,7 @@ from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
 from execution import SubprocessRunner
 from models import PendingReport, TranscriptEventData
-from runner_utils import AuthenticationRetryError, stream_claude_process
+from runner_utils import AuthenticationRetryError, StreamConfig, stream_claude_process
 from screenshot_scanner import scan_base64_for_secrets
 from state import StateTracker
 
@@ -318,8 +318,10 @@ class ReportIssueLoop(BaseBackgroundLoop):
                 event_bus=self._bus,
                 event_data=event_data,
                 logger=logger,
-                runner=self._runner,
-                gh_token=self._credentials.gh_token,
+                config=StreamConfig(
+                    runner=self._runner,
+                    gh_token=self._credentials.gh_token,
+                ),
             )
             issue_number = self._extract_issue_number_from_transcript(transcript)
         except AuthenticationRetryError:

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -8,10 +8,11 @@ import logging
 import os
 import signal
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from activity_parser import get_activity_parser
+from activity_parser import ActivityParser, get_activity_parser
 from events import EventBus, EventType, HydraFlowEvent
 from execution import SubprocessRunner, get_default_runner
 from models import TranscriptEventData, TranscriptLinePayload
@@ -36,6 +37,142 @@ class AuthenticationRetryError(RuntimeError):
     """
 
 
+@dataclass(frozen=True, slots=True)
+class StreamConfig:
+    """Rarely-varying options for :func:`stream_claude_process`."""
+
+    on_output: Callable[[str], bool] | None = None
+    timeout: float = 3600.0
+    runner: SubprocessRunner | None = None
+    usage_stats: dict[str, object] | None = field(default=None)
+    gh_token: str = ""
+    trace_collector: TraceCollector | None = None
+
+
+def _route_prompt_to_cmd(cmd: list[str], prompt: str) -> tuple[list[str], int]:
+    """Decide how to deliver *prompt* to the CLI subprocess.
+
+    Returns ``(cmd_to_run, stdin_mode)`` where *stdin_mode* is either
+    ``asyncio.subprocess.DEVNULL`` (prompt embedded in *cmd_to_run*) or
+    ``asyncio.subprocess.PIPE`` (caller must write *prompt* to stdin).
+    """
+    use_codex_exec = len(cmd) >= 2 and cmd[0] == "codex" and cmd[1] == "exec"
+    use_pi_print = cmd and cmd[0] == "pi" and ("-p" in cmd or "--print" in cmd)
+    use_claude_print = cmd and cmd[0] == "claude" and "-p" in cmd
+    use_prompt_arg = use_codex_exec or use_pi_print or use_claude_print
+    if use_prompt_arg:
+        if use_claude_print or use_pi_print:
+            # Claude/Pi CLI require the prompt immediately after -p/--print;
+            # placing it at the end causes "Input must be provided" errors.
+            flag = "-p" if "-p" in cmd else "--print"
+            idx = cmd.index(flag)
+            cmd_to_run = [*cmd[: idx + 1], prompt, *cmd[idx + 1 :]]
+        else:
+            # Codex exec: prompt is a trailing positional argument.
+            cmd_to_run = [*cmd, prompt]
+        return cmd_to_run, asyncio.subprocess.DEVNULL
+    return cmd, asyncio.subprocess.PIPE
+
+
+async def _stream_and_collect(
+    proc: asyncio.subprocess.Process,
+    stderr_task: asyncio.Task[bytes],
+    event_bus: EventBus,
+    event_data: TranscriptEventData,
+    parser: StreamParser,
+    activity_parser: ActivityParser,
+    logger: logging.Logger,
+    config: StreamConfig,
+) -> str:
+    """Read *proc* stdout, publish events, and assemble the transcript."""
+    raw_lines: list[str] = []
+    result_text = ""
+    accumulated_text = ""
+    early_killed = False
+
+    assert proc.stdout is not None
+    async for raw in proc.stdout:
+        line = raw.decode(errors="replace").rstrip("\n")
+        raw_lines.append(line)
+        if not line.strip():
+            continue
+
+        display, result = parser.parse(line)
+        if result is not None:
+            result_text = result
+
+        if display.strip():
+            accumulated_text += display + "\n"
+            line_data: TranscriptLinePayload = {**event_data, "line": display}
+            await event_bus.publish(
+                HydraFlowEvent(type=EventType.TRANSCRIPT_LINE, data=line_data)
+            )
+
+        if (
+            config.on_output is not None
+            and not early_killed
+            and config.on_output(accumulated_text)
+        ):
+            early_killed = True
+            proc.kill()
+            break
+
+        # Emit structured activity event (additive — does not replace TRANSCRIPT_LINE)
+        try:
+            activity = activity_parser.parse(line)
+            if activity is not None:
+                activity["issue"] = event_data.get("issue", 0)
+                activity["source"] = event_data.get("source", "unknown")
+                await event_bus.publish(
+                    HydraFlowEvent(type=EventType.AGENT_ACTIVITY, data=activity)
+                )
+        except Exception:
+            logger.warning("Activity parsing failed", exc_info=True)
+
+        if config.trace_collector is not None:
+            config.trace_collector.record(line)
+
+    # --- Post-stream validation and result assembly ---
+    stderr_bytes = await stderr_task
+    await proc.wait()
+    stderr_text = stderr_bytes.decode(errors="replace").strip()
+
+    if not early_killed and proc.returncode != 0:
+        logger.warning(
+            "Process exited with code %d: %s",
+            proc.returncode,
+            stderr_text[:500],
+        )
+
+    # Skip auth/credit checks when early_killed — killing the process can cause
+    # in-flight API requests to fail with spurious errors.
+    raw_output = "\n".join(raw_lines)
+    if not early_killed and "authentication_failed" in raw_output:
+        raise AuthenticationRetryError(
+            "Agent CLI authentication failed — check "
+            "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
+        )
+
+    combined = f"{stderr_text}\n{accumulated_text}"
+    if not early_killed and is_credit_exhaustion(combined):
+        resume_at = parse_credit_resume_time(combined)
+        raise CreditExhaustedError("API credit limit reached", resume_at=resume_at)
+
+    if config.usage_stats is not None:
+        config.usage_stats.update(parser.usage_snapshot)
+
+    transcript = result_text or accumulated_text.rstrip("\n") or "\n".join(raw_lines)
+
+    if not transcript.strip() and stderr_text:
+        logger.warning(
+            "Process produced empty stdout (rc=%d), stderr: %s",
+            proc.returncode or 0,
+            stderr_text[:500],
+        )
+
+    return transcript
+
+
 async def stream_claude_process(
     *,
     cmd: list[str],
@@ -45,12 +182,7 @@ async def stream_claude_process(
     event_bus: EventBus,
     event_data: TranscriptEventData,
     logger: logging.Logger,
-    on_output: Callable[[str], bool] | None = None,
-    timeout: float = 3600.0,
-    runner: SubprocessRunner | None = None,
-    usage_stats: dict[str, object] | None = None,
-    gh_token: str = "",
-    trace_collector: TraceCollector | None = None,
+    config: StreamConfig = StreamConfig(),
 ) -> str:
     """Run an agent subprocess and stream its output.
 
@@ -72,12 +204,8 @@ async def stream_claude_process(
         ``"line"`` is added automatically per output line.
     logger:
         Caller's logger for warnings (preserves per-runner log context).
-    on_output:
-        Optional callback receiving accumulated display text.
-        Return ``True`` to kill the process early.
-    usage_stats:
-        Optional dict populated with normalized usage totals and metadata
-        (availability status, backend, and raw usage blobs when emitted).
+    config:
+        Optional streaming configuration (callbacks, timeout, runner, etc.).
 
     Returns
     -------
@@ -85,29 +213,9 @@ async def stream_claude_process(
         The transcript string, using the fallback chain:
         result_text → accumulated_text → raw_lines.
     """
-    env = make_clean_env(gh_token)
-
-    if runner is None:
-        runner = get_default_runner()
-    use_codex_exec = len(cmd) >= 2 and cmd[0] == "codex" and cmd[1] == "exec"
-    use_pi_print = cmd and cmd[0] == "pi" and ("-p" in cmd or "--print" in cmd)
-    use_claude_print = cmd and cmd[0] == "claude" and "-p" in cmd
-    use_prompt_arg = use_codex_exec or use_pi_print or use_claude_print
-    if use_prompt_arg:
-        if use_claude_print or use_pi_print:
-            # Claude/Pi CLI require the prompt immediately after -p/--print;
-            # placing it at the end causes "Input must be provided" errors.
-            flag = "-p" if "-p" in cmd else "--print"
-            idx = cmd.index(flag)
-            cmd_to_run = [*cmd[: idx + 1], prompt, *cmd[idx + 1 :]]
-        else:
-            # Codex exec: prompt is a trailing positional argument.
-            cmd_to_run = [*cmd, prompt]
-    else:
-        cmd_to_run = cmd
-    stdin_mode = (
-        asyncio.subprocess.DEVNULL if use_prompt_arg else asyncio.subprocess.PIPE
-    )
+    env = make_clean_env(config.gh_token)
+    runner = config.runner or get_default_runner()
+    cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
 
     proc = await runner.create_streaming_process(
         cmd_to_run,
@@ -126,144 +234,39 @@ async def stream_claude_process(
         assert proc.stdout is not None
         assert proc.stderr is not None
 
-        stdout_stream = proc.stdout  # capture for nested function
-
-        if not use_prompt_arg:
+        if stdin_mode == asyncio.subprocess.PIPE:
             assert proc.stdin is not None
             proc.stdin.write(prompt.encode())
             await proc.stdin.drain()
             proc.stdin.close()
 
-        # Drain stderr in background to prevent deadlock
         stderr_task = asyncio.create_task(proc.stderr.read())
 
         parser = StreamParser()
-        # Determine CLI backend from command for activity parsing
         _backend = "claude"
-        if len(cmd) >= 1:
-            if cmd[0] == "codex":
-                _backend = "codex"
-            elif cmd[0] == "pi":
-                _backend = "pi"
+        if cmd and cmd[0] == "codex":
+            _backend = "codex"
+        elif cmd and cmd[0] == "pi":
+            _backend = "pi"
         activity_parser = get_activity_parser(_backend)
-        raw_lines: list[str] = []
-        result_text = ""
-        accumulated_text = ""
-        early_killed = False
 
-        async def _stream_body() -> str:
-            nonlocal result_text, accumulated_text, early_killed
-
-            async for raw in stdout_stream:
-                line = raw.decode(errors="replace").rstrip("\n")
-                raw_lines.append(line)
-                if not line.strip():
-                    continue
-
-                display, result = parser.parse(line)
-                if result is not None:
-                    result_text = result
-
-                if display.strip():
-                    accumulated_text += display + "\n"
-                    line_data: TranscriptLinePayload = {**event_data, "line": display}
-                    await event_bus.publish(
-                        HydraFlowEvent(
-                            type=EventType.TRANSCRIPT_LINE,
-                            data=line_data,
-                        )
-                    )
-
-                if (
-                    on_output is not None
-                    and not early_killed
-                    and on_output(accumulated_text)
-                ):
-                    early_killed = True
-                    proc.kill()
-                    break
-
-                # Emit structured activity event (additive — does not replace TRANSCRIPT_LINE)
-                try:
-                    activity = activity_parser.parse(line)
-                    if activity is not None:
-                        activity["issue"] = event_data.get("issue", 0)
-                        activity["source"] = event_data.get("source", "unknown")
-                        await event_bus.publish(
-                            HydraFlowEvent(
-                                type=EventType.AGENT_ACTIVITY,
-                                data=activity,
-                            )
-                        )
-                except Exception:
-                    logger.warning("Activity parsing failed", exc_info=True)
-
-                # Feed the in-process trace collector if one was provided.
-                # TraceCollector.record is fail-open (wraps its own exceptions),
-                # so no try/except needed here.
-                if trace_collector is not None:
-                    trace_collector.record(line)
-
-            stderr_bytes = await stderr_task
-            await proc.wait()
-
-            stderr_text = stderr_bytes.decode(errors="replace").strip()
-
-            if not early_killed and proc.returncode != 0:
-                logger.warning(
-                    "Process exited with code %d: %s",
-                    proc.returncode,
-                    stderr_text[:500],
-                )
-
-            # Detect authentication failures from stream-json output.
-            # Claude CLI emits '"error":"authentication_failed"' when it
-            # cannot authenticate — this can be a transient OAuth token
-            # refresh failure, so the caller retries with backoff.
-            # Skip when early_killed=True — killing the process can cause
-            # in-flight API requests to fail with auth errors as a side effect.
-            raw_output = "\n".join(raw_lines)
-            if not early_killed and "authentication_failed" in raw_output:
-                raise AuthenticationRetryError(
-                    "Agent CLI authentication failed — check "
-                    "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
-                )
-
-            # Check for credit exhaustion in both stderr and transcript.
-            # Skip when early_killed=True — the process was intentionally killed by us
-            # because it produced its expected output; credit phrases in legitimate
-            # transcript content would otherwise cause false-positive pauses.
-            combined = f"{stderr_text}\n{accumulated_text}"
-            if not early_killed and is_credit_exhaustion(combined):
-                resume_at = parse_credit_resume_time(combined)
-                raise CreditExhaustedError(
-                    "API credit limit reached", resume_at=resume_at
-                )
-
-            if usage_stats is not None:
-                usage_stats.update(parser.usage_snapshot)
-
-            transcript = (
-                result_text or accumulated_text.rstrip("\n") or "\n".join(raw_lines)
-            )
-
-            # Log stderr when transcript is empty — this is the only place
-            # stderr content is available and it's critical for diagnosing
-            # silent subprocess failures (e.g. CLI auth errors, missing flags).
-            if not transcript.strip() and stderr_text:
-                logger.warning(
-                    "Process produced empty stdout (rc=%d), stderr: %s",
-                    proc.returncode or 0,
-                    stderr_text[:500],
-                )
-
-            return transcript
-
-        return await asyncio.wait_for(_stream_body(), timeout=timeout)
+        return await asyncio.wait_for(
+            _stream_and_collect(
+                proc,
+                stderr_task,
+                event_bus,
+                event_data,
+                parser,
+                activity_parser,
+                logger,
+                config,
+            ),
+            timeout=config.timeout,
+        )
     except TimeoutError as exc:
         proc.kill()
         await proc.wait()
-        raise RuntimeError(f"Agent process timed out after {timeout}s") from exc
+        raise RuntimeError(f"Agent process timed out after {config.timeout}s") from exc
     except asyncio.CancelledError:
         proc.kill()
         raise

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -74,6 +74,60 @@ def _route_prompt_to_cmd(cmd: list[str], prompt: str) -> tuple[list[str], int]:
     return cmd, asyncio.subprocess.PIPE
 
 
+def _post_stream_result(
+    *,
+    raw_lines: list[str],
+    accumulated_text: str,
+    result_text: str,
+    early_killed: bool,
+    returncode: int | None,
+    stderr_text: str,
+    parser: StreamParser,
+    config: StreamConfig,
+    logger: logging.Logger,
+) -> str:
+    """Validate post-stream state, check for errors, and assemble the transcript.
+
+    Raises :class:`AuthenticationRetryError` or :class:`CreditExhaustedError`
+    when the raw output indicates a retryable auth or billing failure
+    (skipped when *early_killed* is ``True``).
+    """
+    if not early_killed and returncode != 0:
+        logger.warning(
+            "Process exited with code %d: %s",
+            returncode,
+            stderr_text[:500],
+        )
+
+    # Skip auth/credit checks when early_killed — killing the process can cause
+    # in-flight API requests to fail with spurious errors.
+    raw_output = "\n".join(raw_lines)
+    if not early_killed and "authentication_failed" in raw_output:
+        raise AuthenticationRetryError(
+            "Agent CLI authentication failed — check "
+            "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
+        )
+
+    combined = f"{stderr_text}\n{accumulated_text}"
+    if not early_killed and is_credit_exhaustion(combined):
+        resume_at = parse_credit_resume_time(combined)
+        raise CreditExhaustedError("API credit limit reached", resume_at=resume_at)
+
+    if config.usage_stats is not None:
+        config.usage_stats.update(parser.usage_snapshot)
+
+    transcript = result_text or accumulated_text.rstrip("\n") or "\n".join(raw_lines)
+
+    if not transcript.strip() and stderr_text:
+        logger.warning(
+            "Process produced empty stdout (rc=%d), stderr: %s",
+            returncode or 0,
+            stderr_text[:500],
+        )
+
+    return transcript
+
+
 async def _stream_and_collect(
     proc: asyncio.subprocess.Process,
     stderr_task: asyncio.Task[bytes],
@@ -137,40 +191,17 @@ async def _stream_and_collect(
     await proc.wait()
     stderr_text = stderr_bytes.decode(errors="replace").strip()
 
-    if not early_killed and proc.returncode != 0:
-        logger.warning(
-            "Process exited with code %d: %s",
-            proc.returncode,
-            stderr_text[:500],
-        )
-
-    # Skip auth/credit checks when early_killed — killing the process can cause
-    # in-flight API requests to fail with spurious errors.
-    raw_output = "\n".join(raw_lines)
-    if not early_killed and "authentication_failed" in raw_output:
-        raise AuthenticationRetryError(
-            "Agent CLI authentication failed — check "
-            "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
-        )
-
-    combined = f"{stderr_text}\n{accumulated_text}"
-    if not early_killed and is_credit_exhaustion(combined):
-        resume_at = parse_credit_resume_time(combined)
-        raise CreditExhaustedError("API credit limit reached", resume_at=resume_at)
-
-    if config.usage_stats is not None:
-        config.usage_stats.update(parser.usage_snapshot)
-
-    transcript = result_text or accumulated_text.rstrip("\n") or "\n".join(raw_lines)
-
-    if not transcript.strip() and stderr_text:
-        logger.warning(
-            "Process produced empty stdout (rc=%d), stderr: %s",
-            proc.returncode or 0,
-            stderr_text[:500],
-        )
-
-    return transcript
+    return _post_stream_result(
+        raw_lines=raw_lines,
+        accumulated_text=accumulated_text,
+        result_text=result_text,
+        early_killed=early_killed,
+        returncode=proc.returncode,
+        stderr_text=stderr_text,
+        parser=parser,
+        config=config,
+        logger=logger,
+    )
 
 
 async def stream_claude_process(

--- a/src/sentry_loop.py
+++ b/src/sentry_loop.py
@@ -328,7 +328,7 @@ class SentryLoop(BaseBackgroundLoop):
 
         from agent_cli import build_agent_command  # noqa: PLC0415
         from models import TranscriptEventData  # noqa: PLC0415
-        from runner_utils import stream_claude_process  # noqa: PLC0415
+        from runner_utils import StreamConfig, stream_claude_process  # noqa: PLC0415
 
         cmd = build_agent_command(
             tool=self._config.report_issue_tool,
@@ -347,8 +347,10 @@ class SentryLoop(BaseBackgroundLoop):
                 event_bus=self._bus,
                 event_data=event_data,
                 logger=logger,
-                runner=self._runner,
-                gh_token=self._credentials.gh_token,
+                config=StreamConfig(
+                    runner=self._runner,
+                    gh_token=self._credentials.gh_token,
+                ),
             )
             match = _ISSUE_URL_RE.search(transcript)
             if match:

--- a/src/verification_judge.py
+++ b/src/verification_judge.py
@@ -22,7 +22,7 @@ from models import (
     VerificationJudgePayload,
 )
 from precheck import run_precheck_context
-from runner_utils import stream_claude_process, terminate_processes
+from runner_utils import StreamConfig, stream_claude_process, terminate_processes
 
 if TYPE_CHECKING:
     from execution import SubprocessRunner
@@ -559,9 +559,11 @@ Diff excerpt:
             event_bus=self._bus,
             event_data={"issue": issue_number, "source": "verification_judge"},
             logger=logger,
-            timeout=self._config.agent_timeout,
-            runner=self._runner,
-            gh_token=self._credentials.gh_token,
+            config=StreamConfig(
+                timeout=self._config.agent_timeout,
+                runner=self._runner,
+                gh_token=self._credentials.gh_token,
+            ),
         )
 
     def terminate(self) -> None:

--- a/tests/test_credit_pause.py
+++ b/tests/test_credit_pause.py
@@ -29,7 +29,7 @@ from tests.helpers import ConfigFactory, make_streaming_proc, mock_fetcher_noop
 if TYPE_CHECKING:
     from config import HydraFlowConfig
 
-from runner_utils import stream_claude_process
+from runner_utils import StreamConfig, stream_claude_process
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -38,6 +38,17 @@ from runner_utils import stream_claude_process
 
 def _default_stream_kwargs(event_bus, **overrides):
     """Build default kwargs for stream_claude_process."""
+    _CONFIG_KEYS = {
+        "on_output",
+        "timeout",
+        "runner",
+        "usage_stats",
+        "gh_token",
+        "trace_collector",
+    }
+    config_overrides = {
+        k: overrides.pop(k) for k in list(overrides) if k in _CONFIG_KEYS
+    }
     defaults = {
         "cmd": ["claude", "-p"],
         "prompt": "test prompt",
@@ -48,6 +59,8 @@ def _default_stream_kwargs(event_bus, **overrides):
         "logger": logging.getLogger("test"),
     }
     defaults.update(overrides)
+    if config_overrides:
+        defaults["config"] = StreamConfig(**config_overrides)
     return defaults
 
 

--- a/tests/test_route_prompt_to_cmd.py
+++ b/tests/test_route_prompt_to_cmd.py
@@ -1,0 +1,87 @@
+"""Tests for _route_prompt_to_cmd — pure function extracted from stream_claude_process."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from runner_utils import _route_prompt_to_cmd
+
+
+class TestClaudePrintMode:
+    """Claude -p flag: prompt inserted immediately after -p."""
+
+    def test_prompt_inserted_after_p_flag(self) -> None:
+        cmd = ["claude", "-p", "--output-format", "stream-json"]
+        prompt = "evaluate this"
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        p_idx = result_cmd.index("-p")
+        assert result_cmd[p_idx + 1] == prompt
+        assert stdin_mode == asyncio.subprocess.DEVNULL
+
+    def test_prompt_does_not_corrupt_disallowed_tools(self) -> None:
+        cmd = [
+            "claude",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--disallowedTools",
+            "Write,Edit,NotebookEdit",
+        ]
+        prompt = "Plan this issue: " + "x" * 100
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        p_idx = result_cmd.index("-p")
+        assert result_cmd[p_idx + 1] == prompt
+        dt_idx = result_cmd.index("--disallowedTools")
+        assert result_cmd[dt_idx + 1] == "Write,Edit,NotebookEdit"
+        assert stdin_mode == asyncio.subprocess.DEVNULL
+
+
+class TestPiPrintMode:
+    """Pi -p / --print flag: prompt inserted immediately after flag."""
+
+    def test_pi_p_flag_inserts_prompt(self) -> None:
+        cmd = ["pi", "-p", "--mode", "json"]
+        prompt = "do the thing"
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        p_idx = result_cmd.index("-p")
+        assert result_cmd[p_idx + 1] == prompt
+        assert stdin_mode == asyncio.subprocess.DEVNULL
+
+    def test_pi_print_flag_inserts_prompt(self) -> None:
+        cmd = ["pi", "--print", "--mode", "json"]
+        prompt = "do the thing"
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        p_idx = result_cmd.index("--print")
+        assert result_cmd[p_idx + 1] == prompt
+        assert stdin_mode == asyncio.subprocess.DEVNULL
+
+
+class TestCodexExecMode:
+    """Codex exec: prompt appended as trailing positional argument."""
+
+    def test_codex_exec_appends_prompt(self) -> None:
+        cmd = ["codex", "exec", "--json", "--model", "gpt-5.3"]
+        prompt = "do the thing"
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        assert result_cmd[-1] == prompt
+        assert stdin_mode == asyncio.subprocess.DEVNULL
+
+
+class TestStdinFallback:
+    """No recognized flag: cmd unchanged, stdin=PIPE."""
+
+    def test_stdin_fallback_for_unknown_command(self) -> None:
+        cmd = ["claude", "--verbose"]
+        prompt = "hello"
+        result_cmd, stdin_mode = _route_prompt_to_cmd(cmd, prompt)
+        assert result_cmd == cmd
+        assert stdin_mode == asyncio.subprocess.PIPE
+
+    def test_empty_cmd_returns_pipe(self) -> None:
+        result_cmd, stdin_mode = _route_prompt_to_cmd([], "hello")
+        assert result_cmd == []
+        assert stdin_mode == asyncio.subprocess.PIPE

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -16,7 +16,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from events import EventType
-from runner_utils import StreamConfig, stream_claude_process, terminate_processes
+from runner_utils import (
+    StreamConfig,
+    _post_stream_result,
+    stream_claude_process,
+    terminate_processes,
+)
 from tests.helpers import make_streaming_proc
 
 # ---------------------------------------------------------------------------
@@ -917,3 +922,167 @@ class TestStreamConfig:
         assert cfg.timeout == 120.0
         assert cfg.usage_stats is stats
         assert cfg.gh_token == "ghp_test"
+
+
+# ---------------------------------------------------------------------------
+# _post_stream_result — post-loop validation and transcript assembly
+# ---------------------------------------------------------------------------
+
+
+class TestPostStreamResult:
+    """Tests for _post_stream_result extracted helper."""
+
+    def _make_parser_with_snapshot(
+        self, snapshot: dict[str, object] | None = None
+    ) -> MagicMock:
+        parser = MagicMock()
+        parser.usage_snapshot = snapshot or {}
+        return parser
+
+    def test_returns_result_text_when_available(self) -> None:
+        """result_text takes priority over accumulated and raw lines."""
+        transcript = _post_stream_result(
+            raw_lines=["raw"],
+            accumulated_text="accumulated",
+            result_text="final result",
+            early_killed=False,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=logging.getLogger("test"),
+        )
+        assert transcript == "final result"
+
+    def test_falls_back_to_accumulated_text(self) -> None:
+        """When no result_text, accumulated display text is used."""
+        transcript = _post_stream_result(
+            raw_lines=["raw"],
+            accumulated_text="display line\n",
+            result_text="",
+            early_killed=False,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=logging.getLogger("test"),
+        )
+        assert transcript == "display line"
+
+    def test_falls_back_to_raw_lines(self) -> None:
+        """When no result_text and no accumulated text, raw lines are joined."""
+        transcript = _post_stream_result(
+            raw_lines=["line1", "line2"],
+            accumulated_text="",
+            result_text="",
+            early_killed=False,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=logging.getLogger("test"),
+        )
+        assert transcript == "line1\nline2"
+
+    def test_raises_auth_error_when_auth_failed(self) -> None:
+        """authentication_failed in raw output raises AuthenticationRetryError."""
+        from runner_utils import AuthenticationRetryError
+
+        with pytest.raises(AuthenticationRetryError):
+            _post_stream_result(
+                raw_lines=['{"error": "authentication_failed"}'],
+                accumulated_text="",
+                result_text="",
+                early_killed=False,
+                returncode=1,
+                stderr_text="",
+                parser=self._make_parser_with_snapshot(),
+                config=StreamConfig(),
+                logger=logging.getLogger("test"),
+            )
+
+    def test_skips_auth_check_when_early_killed(self) -> None:
+        """Auth check is skipped when early_killed=True."""
+        transcript = _post_stream_result(
+            raw_lines=['{"error": "authentication_failed"}'],
+            accumulated_text="good output\n",
+            result_text="",
+            early_killed=True,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=logging.getLogger("test"),
+        )
+        assert "good output" in transcript
+
+    def test_raises_credit_error_when_exhausted(self) -> None:
+        """Credit exhaustion in combined output raises CreditExhaustedError."""
+        from subprocess_util import CreditExhaustedError
+
+        with pytest.raises(CreditExhaustedError):
+            _post_stream_result(
+                raw_lines=["output"],
+                accumulated_text="Your credit balance is too low\n",
+                result_text="",
+                early_killed=False,
+                returncode=0,
+                stderr_text="",
+                parser=self._make_parser_with_snapshot(),
+                config=StreamConfig(),
+                logger=logging.getLogger("test"),
+            )
+
+    def test_skips_credit_check_when_early_killed(self) -> None:
+        """Credit check is skipped when early_killed=True."""
+        transcript = _post_stream_result(
+            raw_lines=["output"],
+            accumulated_text="Your credit balance is too low\n",
+            result_text="",
+            early_killed=True,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=logging.getLogger("test"),
+        )
+        assert "credit balance" in transcript
+
+    def test_updates_usage_stats(self) -> None:
+        """usage_stats dict is updated from parser snapshot when provided."""
+        stats: dict[str, object] = {}
+        snapshot = {"input_tokens": 50, "usage_status": "available"}
+        _post_stream_result(
+            raw_lines=["line"],
+            accumulated_text="line\n",
+            result_text="",
+            early_killed=False,
+            returncode=0,
+            stderr_text="",
+            parser=self._make_parser_with_snapshot(snapshot),
+            config=StreamConfig(usage_stats=stats),
+            logger=logging.getLogger("test"),
+        )
+        assert stats["input_tokens"] == 50
+        assert stats["usage_status"] == "available"
+
+    def test_logs_warning_on_nonzero_exit(self) -> None:
+        """Non-zero exit code logs a warning."""
+        mock_logger = MagicMock()
+        _post_stream_result(
+            raw_lines=["output"],
+            accumulated_text="output\n",
+            result_text="",
+            early_killed=False,
+            returncode=1,
+            stderr_text="error details",
+            parser=self._make_parser_with_snapshot(),
+            config=StreamConfig(),
+            logger=mock_logger,
+        )
+        mock_logger.warning.assert_called_once()
+        assert (
+            "code 1"
+            in mock_logger.warning.call_args[0][0]
+            % mock_logger.warning.call_args[0][1:]
+        )

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -16,7 +16,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from events import EventType
-from runner_utils import stream_claude_process, terminate_processes
+from runner_utils import StreamConfig, stream_claude_process, terminate_processes
 from tests.helpers import make_streaming_proc
 
 # ---------------------------------------------------------------------------
@@ -25,7 +25,23 @@ from tests.helpers import make_streaming_proc
 
 
 def _default_kwargs(event_bus, **overrides):
-    """Build default kwargs for stream_claude_process."""
+    """Build default kwargs for stream_claude_process.
+
+    Keys that belong on :class:`StreamConfig` (``on_output``, ``timeout``,
+    ``runner``, ``usage_stats``, ``gh_token``, ``trace_collector``) are
+    extracted and bundled into a ``config`` kwarg automatically.
+    """
+    _CONFIG_KEYS = {
+        "on_output",
+        "timeout",
+        "runner",
+        "usage_stats",
+        "gh_token",
+        "trace_collector",
+    }
+    config_overrides = {
+        k: overrides.pop(k) for k in list(overrides) if k in _CONFIG_KEYS
+    }
     defaults = {
         "cmd": ["claude", "-p"],
         "prompt": "test prompt",
@@ -36,6 +52,8 @@ def _default_kwargs(event_bus, **overrides):
         "logger": logging.getLogger("test"),
     }
     defaults.update(overrides)
+    if config_overrides:
+        defaults["config"] = StreamConfig(**config_overrides)
     return defaults
 
 
@@ -492,7 +510,9 @@ class TestStreamClaudeProcessLifecycle:
             patch("asyncio.create_subprocess_exec", mock_create),
             pytest.raises(RuntimeError, match="timed out"),
         ):
-            await stream_claude_process(**_default_kwargs(event_bus), timeout=0.01)
+            await stream_claude_process(
+                **_default_kwargs(event_bus), config=StreamConfig(timeout=0.01)
+            )
 
         # The finally block in stream_claude_process already cancelled and awaited
         # stderr_task before raising, so no sleep(0) is needed here.
@@ -538,7 +558,9 @@ class TestStreamClaudeProcessLifecycle:
             patch("asyncio.create_subprocess_exec", mock_create),
             pytest.raises(RuntimeError, match="timed out") as exc_info,
         ):
-            await stream_claude_process(**_default_kwargs(event_bus), timeout=0.01)
+            await stream_claude_process(
+                **_default_kwargs(event_bus), config=StreamConfig(timeout=0.01)
+            )
 
         assert exc_info.value.__cause__ is not None
         assert isinstance(exc_info.value.__cause__, TimeoutError)
@@ -764,7 +786,7 @@ class TestStreamClaudeProcessTimeout:
         ):
             await stream_claude_process(
                 **_default_kwargs(event_bus, active_procs=active_procs),
-                timeout=0.01,
+                config=StreamConfig(timeout=0.01),
             )
 
         mock_proc.kill.assert_called_once()
@@ -802,7 +824,7 @@ class TestStreamClaudeProcessTimeout:
         ):
             await stream_claude_process(
                 **_default_kwargs(event_bus, active_procs=active_procs),
-                timeout=0.01,
+                config=StreamConfig(timeout=0.01),
             )
 
         assert len(active_procs) == 0
@@ -830,7 +852,8 @@ class TestStreamClaudeProcessGhToken:
 
         with patch("asyncio.create_subprocess_exec", side_effect=capture_env):
             await stream_claude_process(
-                **_default_kwargs(event_bus), gh_token="ghp_bot_token"
+                **_default_kwargs(event_bus),
+                config=StreamConfig(gh_token="ghp_bot_token"),
             )
 
         assert captured_env.get("GH_TOKEN") == "ghp_bot_token"
@@ -847,7 +870,9 @@ class TestStreamClaudeProcessGhToken:
             return await original_create(*args, **kwargs)
 
         with patch("asyncio.create_subprocess_exec", side_effect=capture_env):
-            await stream_claude_process(**_default_kwargs(event_bus), gh_token="")
+            await stream_claude_process(
+                **_default_kwargs(event_bus), config=StreamConfig(gh_token="")
+            )
 
         # GH_TOKEN is only set if it was already in os.environ (inherited),
         # not explicitly injected by make_clean_env.
@@ -858,3 +883,37 @@ class TestStreamClaudeProcessGhToken:
         if "GH_TOKEN" in captured_env:
             # If present, it was inherited from os.environ, not injected
             assert captured_env["GH_TOKEN"] == os.environ.get("GH_TOKEN", "")
+
+
+# ---------------------------------------------------------------------------
+# StreamConfig — dataclass for rarely-varying options
+# ---------------------------------------------------------------------------
+
+
+class TestStreamConfig:
+    """Tests for StreamConfig dataclass."""
+
+    def test_defaults(self) -> None:
+        """All optional fields default to sensible values."""
+        cfg = StreamConfig()
+        assert cfg.on_output is None
+        assert cfg.timeout == 3600.0
+        assert cfg.runner is None
+        assert cfg.usage_stats is None
+        assert cfg.gh_token == ""
+        assert cfg.trace_collector is None
+
+    def test_custom_values(self) -> None:
+        """StreamConfig accepts overrides for every field."""
+        cb = lambda _: False  # noqa: E731
+        stats: dict[str, object] = {}
+        cfg = StreamConfig(
+            on_output=cb,
+            timeout=120.0,
+            usage_stats=stats,
+            gh_token="ghp_test",
+        )
+        assert cfg.on_output is cb
+        assert cfg.timeout == 120.0
+        assert cfg.usage_stats is stats
+        assert cfg.gh_token == "ghp_test"


### PR DESCRIPTION
## Summary

Closes #6299.

## Issue

Code Quality: Break down runner_utils.stream_claude_process — 141 lines, 13 parameters

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow