### PR TITLE
Fixes #6309: Code Quality: Add missing return type on store_lifecyc...

### DIFF
--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -19,7 +19,7 @@ from models import DiagnosisResult, Severity
 logger = logging.getLogger("hydraflow.diagnostic")
 
 
-def _extract_json(text: str) -> dict | None:
+def _extract_json(text: str) -> dict[str, object] | None:
     """Extract first JSON block from agent output."""
     match = re.search(r"```(?:json)?\s*\n?(.*?)```", text, re.DOTALL)
     raw = match.group(1).strip() if match else text.strip()
@@ -144,12 +144,12 @@ class DiagnosticRunner(BaseRunner):
             return DiagnosisResult.model_validate(parsed)
         except Exception:
             return DiagnosisResult(
-                root_cause=parsed.get(
-                    "root_cause", transcript[:500] if transcript else ""
+                root_cause=str(
+                    parsed.get("root_cause", transcript[:500] if transcript else "")
                 ),
                 severity=Severity.P2_FUNCTIONAL,
                 fixable=False,
-                fix_plan=parsed.get("fix_plan", ""),
+                fix_plan=str(parsed.get("fix_plan", "")),
                 human_guidance="Agent output did not validate. Manual review required.",
             )
 

--- a/src/dolt_backend.py
+++ b/src/dolt_backend.py
@@ -110,7 +110,7 @@ class DoltBackend:
 
     # --- State read/write ---
 
-    def load_state(self) -> dict | None:
+    def load_state(self) -> dict[str, object] | None:
         """Load the state JSON document. Returns ``None`` if no state stored."""
         try:
             raw = self._sql("SELECT data FROM state WHERE id = 1;")
@@ -188,7 +188,7 @@ class DoltBackend:
             logger.warning("Failed to load sessions from Dolt", exc_info=True)
             return []
 
-    def get_session(self, session_id: str) -> dict | None:
+    def get_session(self, session_id: str) -> dict[str, object] | None:
         """Load a single session by ID."""
         escaped = session_id.replace("'", "''")
         try:

--- a/src/epic.py
+++ b/src/epic.py
@@ -1005,7 +1005,7 @@ class EpicManager:
             version=version or None,
         )
 
-    def _get_release_data(self, epic_number: int) -> dict | None:
+    def _get_release_data(self, epic_number: int) -> dict[str, object] | None:
         """Return release info dict if a release exists for this epic."""
         release = self._state.get_release(epic_number)
         if release is None:

--- a/src/expert_council.py
+++ b/src/expert_council.py
@@ -69,7 +69,7 @@ class CouncilVote:
         self.confidence = max(1, min(confidence, 10))
         self.timestamp = datetime.now(UTC).isoformat()
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         return {
             "expert": self.expert_name,
             "direction": self.direction,
@@ -137,7 +137,7 @@ class CouncilResult:
             lines.append("\n**No consensus** — escalating to human for tiebreaker.\n")
         return "\n".join(lines)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         return {
             "votes": [v.to_dict() for v in self.votes],
             "consensus": self.has_consensus,

--- a/src/models.py
+++ b/src/models.py
@@ -1854,7 +1854,7 @@ class EpicDetail(BaseModel):
     merge_strategy: MergeStrategy = MergeStrategy.INDEPENDENT
     children: list[EpicChildInfo] = Field(default_factory=list)
     readiness: EpicReadiness = Field(default_factory=EpicReadiness)
-    release: dict | None = None
+    release: dict[str, object] | None = None
 
 
 # --- Changelog ---

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Callable, Coroutine, Generator
+from collections.abc import AsyncGenerator, Callable, Coroutine, Generator
 from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -314,7 +314,7 @@ async def store_lifecycle(
     store: IssueStorePort,
     issue_number: int,
     stage: str,
-):
+) -> AsyncGenerator[None, None]:
     """Mark an issue active on enter and complete on exit.
 
     Args:

--- a/src/ports.py
+++ b/src/ports.py
@@ -80,7 +80,7 @@ class StateBackendPort(Protocol):
     imported at module level.
     """
 
-    def load_state(self) -> dict | None:
+    def load_state(self) -> dict[str, object] | None:
         """Load the state JSON document. Returns ``None`` if no state stored."""
         ...
 

--- a/src/spec_match.py
+++ b/src/spec_match.py
@@ -163,7 +163,7 @@ regardless of code quality.
 """
 
 
-def extract_spec_match(transcript: str) -> dict:
+def extract_spec_match(transcript: str) -> dict[str, object]:
     """Extract spec-match assessment from agent transcript."""
     start = transcript.find(_SPEC_MATCH_START)
     end = transcript.find(_SPEC_MATCH_END)

--- a/tests/test_type_annotations.py
+++ b/tests/test_type_annotations.py
@@ -1,0 +1,166 @@
+"""Tests for type annotation tightening (issue #6309).
+
+Verifies that public functions and model fields use parameterized dict types
+instead of bare ``dict`` or ``dict | None``, and that ``store_lifecycle``
+has an explicit return type annotation.
+"""
+
+from __future__ import annotations
+
+import types
+import typing
+from collections.abc import AsyncGenerator
+
+
+class TestStoreLifecycleReturnType:
+    """store_lifecycle must be annotated -> AsyncGenerator[None, None]."""
+
+    def test_return_annotation_is_async_generator(self) -> None:
+        from phase_utils import store_lifecycle
+
+        hints = typing.get_type_hints(store_lifecycle)
+        ret = hints["return"]
+        # Should be AsyncGenerator[None, None]
+        origin = typing.get_origin(ret)
+        assert origin is AsyncGenerator, f"Expected AsyncGenerator origin, got {origin}"
+        args = typing.get_args(ret)
+        # With `from __future__ import annotations`, None resolves as the
+        # value None rather than NoneType — accept either form.
+        expected = ((type(None), type(None)), (None, None))
+        assert args in expected, f"Expected None type args, got {args}"
+
+
+class TestPortsLoadStateReturnType:
+    """StateBackendPort.load_state must return dict[str, object] | None."""
+
+    def test_load_state_return_is_parameterized_dict_or_none(self) -> None:
+        from ports import StateBackendPort
+
+        hints = typing.get_type_hints(StateBackendPort.load_state)
+        ret = hints["return"]
+        # Should be dict[str, object] | None  (a Union)
+        origin = typing.get_origin(ret)
+        assert origin is types.UnionType, f"Expected UnionType, got {origin}"
+        args = typing.get_args(ret)
+        # One arm is dict[str, object], the other is NoneType
+        dict_args = [a for a in args if typing.get_origin(a) is dict]
+        none_args = [a for a in args if a is type(None)]
+        assert len(dict_args) == 1, f"Expected one dict arm, got {dict_args}"
+        assert len(none_args) == 1, f"Expected one NoneType arm, got {none_args}"
+        assert typing.get_args(dict_args[0]) == (str, object), (
+            f"Expected dict[str, object], got dict{typing.get_args(dict_args[0])}"
+        )
+
+
+class TestDoltBackendReturnTypes:
+    """DoltBackend.load_state and get_session must return dict[str, object] | None."""
+
+    def test_load_state_return_is_parameterized(self) -> None:
+        from dolt_backend import DoltBackend
+
+        hints = typing.get_type_hints(DoltBackend.load_state)
+        ret = hints["return"]
+        origin = typing.get_origin(ret)
+        assert origin is types.UnionType
+        dict_args = [a for a in typing.get_args(ret) if typing.get_origin(a) is dict]
+        assert len(dict_args) == 1
+        assert typing.get_args(dict_args[0]) == (str, object)
+
+    def test_get_session_return_is_parameterized(self) -> None:
+        from dolt_backend import DoltBackend
+
+        hints = typing.get_type_hints(DoltBackend.get_session)
+        ret = hints["return"]
+        origin = typing.get_origin(ret)
+        assert origin is types.UnionType
+        dict_args = [a for a in typing.get_args(ret) if typing.get_origin(a) is dict]
+        assert len(dict_args) == 1
+        assert typing.get_args(dict_args[0]) == (str, object)
+
+
+class TestDiagnosticRunnerReturnType:
+    """_extract_json must return dict[str, object] | None."""
+
+    def test_extract_json_return_is_parameterized(self) -> None:
+        from diagnostic_runner import _extract_json
+
+        hints = typing.get_type_hints(_extract_json)
+        ret = hints["return"]
+        origin = typing.get_origin(ret)
+        assert origin is types.UnionType
+        dict_args = [a for a in typing.get_args(ret) if typing.get_origin(a) is dict]
+        assert len(dict_args) == 1
+        assert typing.get_args(dict_args[0]) == (str, object)
+
+
+class TestEpicReturnType:
+    """_get_release_data must return dict[str, object] | None."""
+
+    def test_get_release_data_return_is_parameterized(self) -> None:
+        from epic import EpicManager
+
+        hints = typing.get_type_hints(EpicManager._get_release_data)
+        ret = hints["return"]
+        origin = typing.get_origin(ret)
+        assert origin is types.UnionType
+        dict_args = [a for a in typing.get_args(ret) if typing.get_origin(a) is dict]
+        assert len(dict_args) == 1
+        assert typing.get_args(dict_args[0]) == (str, object)
+
+
+class TestModelsReleaseField:
+    """EpicDetail.release field must be dict[str, object] | None."""
+
+    def test_release_field_is_parameterized(self) -> None:
+        from models import EpicDetail
+
+        field_info = EpicDetail.model_fields["release"]
+        annotation = field_info.annotation
+        # Should be dict[str, object] | None
+        origin = typing.get_origin(annotation)
+        assert origin is types.UnionType, f"Expected UnionType, got {origin}"
+        dict_args = [
+            a for a in typing.get_args(annotation) if typing.get_origin(a) is dict
+        ]
+        assert len(dict_args) == 1
+        assert typing.get_args(dict_args[0]) == (str, object)
+
+
+class TestExpertCouncilReturnTypes:
+    """to_dict methods must return dict[str, object]."""
+
+    def test_expert_vote_to_dict_return_is_parameterized(self) -> None:
+        from expert_council import CouncilVote
+
+        hints = typing.get_type_hints(CouncilVote.to_dict)
+        ret = hints["return"]
+        assert typing.get_origin(ret) is dict, (
+            f"Expected dict origin, got {typing.get_origin(ret)}"
+        )
+        assert typing.get_args(ret) == (str, object), (
+            f"Expected (str, object), got {typing.get_args(ret)}"
+        )
+
+    def test_council_result_to_dict_return_is_parameterized(self) -> None:
+        from expert_council import CouncilResult
+
+        hints = typing.get_type_hints(CouncilResult.to_dict)
+        ret = hints["return"]
+        assert typing.get_origin(ret) is dict
+        assert typing.get_args(ret) == (str, object)
+
+
+class TestSpecMatchReturnType:
+    """extract_spec_match must return dict[str, object]."""
+
+    def test_extract_spec_match_return_is_parameterized(self) -> None:
+        from spec_match import extract_spec_match
+
+        hints = typing.get_type_hints(extract_spec_match)
+        ret = hints["return"]
+        assert typing.get_origin(ret) is dict, (
+            f"Expected dict origin, got {typing.get_origin(ret)}"
+        )
+        assert typing.get_args(ret) == (str, object), (
+            f"Expected (str, object), got {typing.get_args(ret)}"
+        )


### PR DESCRIPTION
## Summary

Closes #6309.

## Issue

Code Quality: Add missing return type on store_lifecycle and tighten bare dict | None in ports and dolt_backend

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow