### PR TITLE
fix: batch 2 code quality — Literal types, TimeoutExpired, no-op removal

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -923,9 +923,11 @@ class HydraFlowConfig(BaseModel):
         le=86400,
         description="Seconds between Dependabot alert polls",
     )
-    security_patch_severity_threshold: str = Field(
-        default="high",
-        description="Minimum severity to file issues for (critical, high, medium, low)",
+    security_patch_severity_threshold: Literal["critical", "high", "medium", "low"] = (
+        Field(
+            default="high",
+            description="Minimum severity to file issues for",
+        )
     )
     # Sensor enrichment — positive prompt injection on captured tool output.
     # See src/sensor_enricher.py and docs/agents/avoided-patterns.md.

--- a/src/dashboard_routes/_memory_routes.py
+++ b/src/dashboard_routes/_memory_routes.py
@@ -145,7 +145,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             )
 
         # Recall from troubleshooting + learnings banks for HITL context
-        hitl_banks = [Bank.TROUBLESHOOTING, Bank.LEARNINGS, Bank.REVIEW_INSIGHTS]
+        hitl_banks = [Bank.TROUBLESHOOTING, Bank.TRIBAL, Bank.REVIEW_INSIGHTS]
         try:
             bank_results = await ctx.hindsight_client.recall_banks(
                 query,

--- a/src/dolt_backend.py
+++ b/src/dolt_backend.py
@@ -123,6 +123,7 @@ class DoltBackend:
             return data_str
         except (
             subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
             json.JSONDecodeError,
             KeyError,
             IndexError,
@@ -184,7 +185,11 @@ class DoltBackend:
                 else:
                     results.append(d)
             return results
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+        ):
             logger.warning("Failed to load sessions from Dolt", exc_info=True)
             return []
 
@@ -202,6 +207,7 @@ class DoltBackend:
             return json.loads(d) if isinstance(d, str) else d
         except (
             subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
             json.JSONDecodeError,
             KeyError,
             IndexError,
@@ -214,7 +220,7 @@ class DoltBackend:
         try:
             self._sql_exec(f"DELETE FROM sessions WHERE session_id = '{escaped}';")  # nosec B608
             return True
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return False
 
     # --- Dedup sets (replaces JSON array files) ---
@@ -227,7 +233,11 @@ class DoltBackend:
             )
             rows = json.loads(raw)
             return {row["value"] for row in rows.get("rows", [])}
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+        ):
             return set()
 
     def add_to_dedup_set(self, set_name: str, value: str) -> None:
@@ -254,5 +264,9 @@ class DoltBackend:
                 f"FROM dolt_log LIMIT {limit};"
             )
             return json.loads(raw).get("rows", [])
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+        ):
             return []

--- a/src/merge_conflict_resolver.py
+++ b/src/merge_conflict_resolver.py
@@ -360,20 +360,7 @@ class MergeConflictResolver:
     async def _maybe_summarize_conflict(
         self, transcript: str, issue_number: int, pr_number: int
     ) -> None:
-        """Summarize a conflict resolution transcript if summarizer is available."""
-        if self._summarizer is None:
-            return
-        try:
-            await self._summarizer.summarize_and_publish(
-                transcript=transcript,
-                issue_number=issue_number,
-                phase="conflict_resolution",
-            )
-        except (RuntimeError, OSError):
-            logger.exception(
-                "Failed to file transcript summary for conflict resolution on PR #%d",
-                pr_number,
-            )
+        """No-op — transcript summary as issue feature was removed."""
 
     def save_conflict_transcript(
         self,

--- a/src/models.py
+++ b/src/models.py
@@ -434,16 +434,14 @@ class ShapeResult(BaseModel):
 class ConversationTurn(BaseModel):
     """A single turn in a shape design conversation."""
 
-    role: str = Field(description="Who spoke: 'agent' or 'human'")
+    role: Literal["agent", "human"] = Field(description="Who spoke")
     content: str = Field(description="The message content")
     timestamp: str = Field(default="", description="ISO 8601 timestamp")
     signal: str = Field(
         default="",
         description="Classified learning signal (e.g. scope_narrow, positive)",
     )
-    source: str = Field(
-        default="", description="Response source: github, dashboard, whatsapp"
-    )
+    source: str = Field(default="", description="Response source identifier")
 
 
 class ShapeConversation(BaseModel):
@@ -451,8 +449,8 @@ class ShapeConversation(BaseModel):
 
     issue_number: int = Field(description="GitHub issue number")
     turns: list[ConversationTurn] = Field(default_factory=list)
-    status: str = Field(
-        default="exploring", description="exploring, finalizing, done, timed_out"
+    status: Literal["exploring", "finalizing", "done", "timed_out"] = Field(
+        default="exploring", description="Shape conversation lifecycle status"
     )
     started_at: str = Field(default="", description="ISO 8601")
     last_activity_at: str = Field(default="", description="ISO 8601")
@@ -667,11 +665,6 @@ class ReproductionResult(BaseModel):
     error: str | None = Field(default=None)
 
 
-# ---------------------------------------------------------------------------
-# Stage preconditions and route-back (#6423)
-# ---------------------------------------------------------------------------
-
-
 class RouteBackRecord(BaseModel):
     """Record of a stage route-back transition (#6423).
 
@@ -691,6 +684,11 @@ class RouteBackRecord(BaseModel):
     timestamp: IsoTimestamp = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),
     )
+
+
+# ---------------------------------------------------------------------------
+# Stage preconditions and route-back (#6423)
+# ---------------------------------------------------------------------------
 
 
 class ResearchResult(BaseModel):
@@ -2293,16 +2291,6 @@ class TranscriptLinePayload(TypedDict, total=False):
     source: str
     line: str
     repo: str
-
-
-class ActivityType(StrEnum):
-    """Kind of agent activity detected from CLI output."""
-
-    TOOL_CALL = "tool_call"
-    TOOL_RESULT = "tool_result"
-    THINKING = "thinking"
-    TEXT = "text"
-    ERROR = "error"
 
 
 class AgentActivityPayload(TypedDict, total=False):

--- a/src/stream_parser.py
+++ b/src/stream_parser.py
@@ -462,7 +462,7 @@ def _pick_usage_extractor(
     return current
 
 
-def _map_usage_payload(obj: Any) -> dict[str, int]:
+def _map_usage_payload(obj: dict[str, Any] | list[Any] | object) -> dict[str, int]:
     """Return canonical usage totals from arbitrary payload object."""
     totals: dict[str, int] = {}
     for key, value in _iter_numeric_fields(obj):
@@ -487,7 +487,9 @@ def _map_top_level_usage_scalars(event: dict[str, Any]) -> dict[str, int]:
     return totals
 
 
-def _iter_numeric_fields(obj: Any) -> list[tuple[str, int]]:
+def _iter_numeric_fields(
+    obj: dict[str, Any] | list[Any] | object,
+) -> list[tuple[str, int]]:
     """Return nested ``(key, int_value)`` numeric fields for a usage payload."""
     out: list[tuple[str, int]] = []
     if isinstance(obj, dict):

--- a/src/transcript_summarizer.py
+++ b/src/transcript_summarizer.py
@@ -255,25 +255,6 @@ class TranscriptSummarizer:
 
     # --- Issue-based summaries (legacy, configurable) ---
 
-    async def summarize_and_publish(
-        self,
-        transcript: str,
-        issue_number: int,
-        phase: str,
-        issue_title: str = "",
-        duration_seconds: float = 0.0,
-    ) -> int | None:
-        """Summarize a transcript and publish as a GitHub issue.
-
-        Returns the created issue number, or ``None`` if skipped/failed.
-        Never raises — all errors are logged and swallowed.
-
-        .. deprecated::
-            The ``transcript_summary_as_issue`` feature was removed. This method
-            is now a permanent no-op and always returns ``None``.
-        """
-        return None
-
     async def _call_model(self, prompt: str) -> str | None:
         """Call the configured CLI backend to summarize.
 

--- a/tests/test_transcript_summarizer.py
+++ b/tests/test_transcript_summarizer.py
@@ -427,30 +427,7 @@ class TestSummarizeAndComment:
         assert call_kwargs["input"] is None
 
 
-# --- TranscriptSummarizer.summarize_and_publish tests ---
-
-
-class TestSummarizeAndPublish:
-    """Tests for issue-based transcript summaries (deprecated no-op)."""
-
-    @pytest.mark.asyncio
-    async def test_always_returns_none(self, tmp_path: Path) -> None:
-        """summarize_and_publish is a permanent no-op after feature removal."""
-        config = ConfigFactory.create(repo_root=tmp_path)
-        prs = MagicMock()
-        prs.create_issue = AsyncMock()
-        bus = MagicMock()
-        state = MagicMock()
-
-        summarizer = TranscriptSummarizer(config, prs, bus, state)
-        result = await summarizer.summarize_and_publish(
-            transcript="x" * 1000, issue_number=42, phase="implement"
-        )
-
-        assert result is None
-        prs.create_issue.assert_not_called()
-
-
+# Note: TestSummarizeAndPublish removed — method was a deprecated no-op, now deleted.
 # Note: TestExtractAndFileMemoryItems was removed in the tribal-memory rollout
 # (2026-04-07). Transcript-summary auto-filing was removed because the bullets
 # routinely produced implementation-detail noise below the tribal-knowledge bar.


### PR DESCRIPTION
## Summary
- Remove dead `ActivityType` enum from models.py (#6312)
- `ConversationTurn.role` → `Literal["agent", "human"]`, `ShapeConversation.status` → Literal enum (#6310, #6320)
- `security_patch_severity_threshold` → `Literal["critical", "high", "medium", "low"]` (#6310)
- `stream_parser` `_map_usage_payload`/`_iter_numeric_fields`: `Any` → specific types (#6316)
- `dolt_backend`: add `subprocess.TimeoutExpired` to all except clauses (#6328)
- Remove deprecated no-op `TranscriptSummarizer.summarize_and_publish` (#6315)
- Fix pre-existing `Bank.LEARNINGS` → `Bank.TRIBAL` pyright error in memory routes

Closes #6312, #6310, #6320, #6316, #6328, #6315

## Test plan
- [x] `make lint` clean
- [x] Pre-commit + pre-push hooks pass (lint-check, typecheck, security)
- [x] Removed test for deleted `summarize_and_publish`
- [x] All new test failures verified as pre-existing on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)