### PR TITLE
chore(code-grooming): file issues only for critical severity findings

### DIFF
--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -18,8 +18,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.code_grooming_loop")
 
-# Severities that warrant filing an issue.
-_ACTIONABLE_SEVERITIES = frozenset({"critical", "high"})
+# Severities that warrant filing an issue. P0-only by policy: "high" findings
+# are deliberately ignored — code is fluid, over-investing in non-critical
+# cleanup crowds the factory out of work that actually ships.
+_ACTIONABLE_SEVERITIES = frozenset({"critical"})
 
 
 class CodeGroomingLoop(BaseBackgroundLoop):

--- a/tests/test_code_grooming_loop.py
+++ b/tests/test_code_grooming_loop.py
@@ -105,7 +105,7 @@ class TestCodeGroomingLoopWork:
     async def test_duplicate_finding_skipped(self, tmp_path: Path) -> None:
         finding = {
             "id": "dead-code-auth-module",
-            "severity": "high",
+            "severity": "critical",
             "title": "Dead code in auth module",
             "description": "Unused function",
         }
@@ -157,3 +157,21 @@ class TestCodeGroomingLoopWork:
         assert result is not None
         assert result["filed"] == 0
         assert result["skipped_severity"] == 1
+
+    @pytest.mark.asyncio
+    async def test_high_severity_finding_skipped(self, tmp_path: Path) -> None:
+        finding = {
+            "id": "refactor-opportunity",
+            "severity": "high",
+            "title": "Duplicate logic across helpers",
+            "description": "Two helpers share near-identical branches",
+        }
+        loop, pm, _stop = _make_loop(tmp_path)
+        with patch.object(
+            loop, "_run_audit", new_callable=AsyncMock, return_value=[finding]
+        ):
+            result = await loop._do_work()
+        assert result is not None
+        assert result["filed"] == 0
+        assert result["skipped_severity"] == 1
+        pm.create_issue.assert_not_called()


### PR DESCRIPTION
## Summary

- Tightens `CodeGroomingLoop` to only file issues for `severity=critical` — "high" findings are now deliberately skipped.
- Rationale: "code is fluid" — over-investing in non-critical cleanup before code stabilizes crowds the factory out of work that actually ships.
- Cost angle: the loop itself is cheap to run, but the issues it used to file then get worked on by the full plan→implement→review pipeline. Tightening the filter at the source cuts downstream spend on work nobody asked for.

## Change

- `src/code_grooming_loop.py` — `_ACTIONABLE_SEVERITIES = frozenset({"critical", "high"})` → `frozenset({"critical"})`
- `tests/test_code_grooming_loop.py` — existing dedup test now uses critical severity (still exercises the filing path), and a new `test_high_severity_finding_skipped` locks in the new filter behavior.

## Test plan

- [x] `pytest tests/test_code_grooming_loop.py` — **10/10 pass**
- [x] `ruff check` + `ruff format --check` on changed files — **clean**
- [x] `pyright` on changed files — **0 errors, 0 warnings**

## Note on CI

**The full `make quality` run will show 42 failing tests on this PR.** I verified those failures reproduce on clean `origin/main` with this branch's changes stashed — they are **pre-existing on main** and entirely unrelated to this change (they span `test_base_runner`, `test_memory_routes`, `test_health_monitor`, `test_runner_utils_*`, `test_verification_judge`, etc. — none touch `code_grooming_loop`). A separate fix branch is being prepared to address them.