### PR TITLE
fix: batch 5 — ReviewInsightStorePort, WorkCycleResult type alias

### DIFF
--- a/src/base_background_loop.py
+++ b/src/base_background_loop.py
@@ -18,7 +18,12 @@ from typing import Any
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
-from models import BackgroundWorkerStatusPayload, ErrorPayload, StatusCallback
+from models import (
+    BackgroundWorkerStatusPayload,
+    ErrorPayload,
+    StatusCallback,
+    WorkCycleResult,  # noqa: TCH002
+)
 from runner_utils import AuthenticationRetryError
 from subprocess_util import AuthenticationError, CreditExhaustedError
 
@@ -87,7 +92,7 @@ class BaseBackgroundLoop(abc.ABC):
         self._trigger_event = asyncio.Event()
 
     @abc.abstractmethod
-    async def _do_work(self) -> dict[str, Any] | None:
+    async def _do_work(self) -> WorkCycleResult:
         """Execute one cycle of domain-specific work.
 
         Returns an optional stats/details dict to include in the

--- a/src/models.py
+++ b/src/models.py
@@ -59,6 +59,10 @@ def _check_iso_timestamp(v: str) -> str:
 HttpUrl = Annotated[str, AfterValidator(_check_url)]
 IsoTimestamp = Annotated[str, AfterValidator(_check_iso_timestamp)]
 
+#: Return type for ``BaseBackgroundLoop._do_work()`` — an optional dict
+#: of stats/details included in the ``BACKGROUND_WORKER_STATUS`` event.
+WorkCycleResult = dict[str, Any] | None
+
 # --- Enumerations for constrained fields ---
 
 

--- a/src/ports.py
+++ b/src/ports.py
@@ -44,9 +44,12 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import runtime_checkable
+from typing import TYPE_CHECKING, runtime_checkable
 
 from typing_extensions import Protocol
+
+if TYPE_CHECKING:
+    from review_insights import ProposalMetadata, ReviewRecord  # noqa: TCH004
 
 from models import (
     CodeScanningAlert,
@@ -502,3 +505,27 @@ class AgentPort(Protocol):
     async def _verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
         """Verify the agent produced valid commits and quality passes."""
         ...
+
+
+@runtime_checkable
+class ReviewInsightStorePort(Protocol):
+    """Port for review insight persistence.
+
+    Implemented by: ``review_insights.ReviewInsightStore``
+
+    Decouples ``ReviewPhase`` from the concrete file/Dolt storage backend.
+    """
+
+    def append_review(self, record: ReviewRecord) -> None: ...
+
+    def load_recent(self, n: int = 10) -> list[ReviewRecord]: ...
+
+    def get_proposed_categories(self) -> set[str]: ...
+
+    def mark_category_proposed(self, category: str) -> None: ...
+
+    def record_proposal(self, category: str, pre_count: int) -> None: ...
+
+    def load_proposal_metadata(self) -> dict[str, ProposalMetadata]: ...
+
+    def update_proposal_verified(self, category: str, *, verified: bool) -> None: ...

--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from dolt_backend import DoltBackend
     from hindsight import HindsightClient
     from hindsight_wal import HindsightWAL
+    from ports import ReviewInsightStorePort  # noqa: TCH004
 
 logger = logging.getLogger("hydraflow.review_insights")
 
@@ -550,7 +551,7 @@ _PROPOSAL_IMPROVEMENT_THRESHOLD = 0.5  # >50% reduction marks as verified
 
 
 def verify_proposals(
-    store: ReviewInsightStore,
+    store: ReviewInsightStore | ReviewInsightStorePort,
     records: list[ReviewRecord],
 ) -> list[str]:
     """Check filed improvement proposals and classify outcomes.

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from hindsight_wal import HindsightWAL
     from issue_cache import IssueCache
     from memory_judge import MemoryJudge  # noqa: TCH004
-    from ports import IssueStorePort, PRPort, WorkspacePort
+    from ports import IssueStorePort, PRPort, ReviewInsightStorePort, WorkspacePort
     from precondition_gate import PreconditionGate
     from repo_wiki import RepoWikiStore  # noqa: TCH004 — used in __init__ signature
     from retrospective_queue import RetrospectiveQueue
@@ -71,7 +71,6 @@ from post_merge_handler import PostMergeHandler
 from review_insights import (
     _PROPOSAL_STALE_DAYS,
     CATEGORY_DESCRIPTIONS,
-    ReviewInsightStore,
     ReviewRecord,
     analyze_patterns,
     build_insight_issue_body,
@@ -152,7 +151,7 @@ class ReviewPhase:
         post_merge: PostMergeHandler,
         event_bus: EventBus | None = None,
         harness_insights: HarnessInsightStore | None = None,
-        review_insights: ReviewInsightStore | None = None,
+        review_insights: ReviewInsightStorePort | None = None,
         update_bg_worker_status: StatusCallback | None = None,
         baseline_policy: BaselinePolicy | None = None,
         hindsight: HindsightClient | None = None,
@@ -182,9 +181,12 @@ class ReviewPhase:
         self._wiki_compiler = wiki_compiler
         self._update_bg_worker_status = update_bg_worker_status
         self._harness_insights = harness_insights
-        self._insights = review_insights or ReviewInsightStore(
-            config.memory_dir, dolt=dolt, wal=wal
-        )
+        if review_insights is not None:
+            self._insights = review_insights
+        else:
+            from review_insights import ReviewInsightStore  # noqa: PLC0415
+
+            self._insights = ReviewInsightStore(config.memory_dir, dolt=dolt, wal=wal)
         self._wal = wal
         self._active_issues_cb = active_issues_cb
         self._active_issues: set[int] = set()


### PR DESCRIPTION
## Summary
- Add `ReviewInsightStorePort` Protocol to decouple ReviewPhase from concrete store (#5948)
- Add `WorkCycleResult` type alias for `BaseBackgroundLoop._do_work()` return type (#6331)

Closes #5948, #6331

## Test plan
- [x] `make lint` clean
- [x] Pre-push hooks pass
- [x] Targeted tests pass (test_epic_manager, test_orchestrator_core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)