### PR TITLE
fix: repair 51 pre-existing test failures from prior refactors

### DIFF
--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -148,6 +148,11 @@ class DiagnosticRunner(BaseRunner):
                 issue_number,
                 exc_info=True,
             )
+            logger.debug(
+                "raw parsed diagnosis dict for issue #%d: %s",
+                issue_number,
+                parsed,
+            )
             return DiagnosisResult(
                 root_cause=str(
                     parsed.get("root_cause", transcript[:500] if transcript else "")

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -164,6 +164,30 @@ class PostMergeHandler:
                     exc_info=True,
                 )
 
+    async def _run_visual_gate(self, ctx: MergeApprovalContext) -> bool:
+        """Run the visual validation gate; return True if merge may proceed."""
+        if not self._config.visual_gate_enabled:
+            return True
+        if ctx.visual_gate_fn is None:
+            logger.warning(
+                "PR #%d: visual_gate_enabled but no visual_gate_fn provided — blocking merge",
+                ctx.pr.number,
+            )
+            await self._bus.publish(
+                HydraFlowEvent(
+                    type=EventType.VISUAL_GATE,
+                    data=VisualGatePayload(
+                        pr=ctx.pr.number,
+                        issue=ctx.issue.id,
+                        worker=ctx.worker_id,
+                        verdict="blocked",
+                        reason="no visual_gate_fn provided to handle_approved",
+                    ),
+                )
+            )
+            return False
+        return await ctx.visual_gate_fn(ctx.pr, ctx.issue, ctx.result, ctx.worker_id)
+
     async def _run_ci_gate(self, ctx: MergeApprovalContext) -> bool:
         """Run CI gate if configured; return True to proceed, False to abort."""
         if self._config.max_ci_fix_attempts > 0:
@@ -193,7 +217,6 @@ class PostMergeHandler:
         worker_id = ctx.worker_id
         escalate_fn = ctx.escalate_fn
         publish_fn = ctx.publish_fn
-        visual_gate_fn = ctx.visual_gate_fn
         visual_decision = ctx.visual_decision
         merge_conflict_fix_fn = ctx.merge_conflict_fix_fn
 
@@ -214,30 +237,8 @@ class PostMergeHandler:
         if not await self._run_ci_gate(ctx):
             return
 
-        # Visual validation gate
-        if self._config.visual_gate_enabled:
-            if visual_gate_fn is None:
-                logger.warning(
-                    "PR #%d: visual_gate_enabled but no visual_gate_fn provided — blocking merge",
-                    pr.number,
-                )
-                await self._bus.publish(
-                    HydraFlowEvent(
-                        type=EventType.VISUAL_GATE,
-                        data=VisualGatePayload(
-                            pr=pr.number,
-                            issue=issue.id,
-                            worker=worker_id,
-                            verdict="blocked",
-                            reason="no visual_gate_fn provided to handle_approved",
-                        ),
-                    )
-                )
-                return
-            else:
-                visual_ok = await visual_gate_fn(pr, issue, result, worker_id)
-                if not visual_ok:
-                    return
+        if not await self._run_visual_gate(ctx):
+            return
 
         # Normalize PR title to canonical "Fixes #N: title" before merge
         # so the merge commit and event history show a consistent format.

--- a/tests/test_acceptance_criteria.py
+++ b/tests/test_acceptance_criteria.py
@@ -545,7 +545,7 @@ class TestGenerate:
                 issue_number=42, pr_number=101, issue=issue, diff=SAMPLE_DIFF
             )
 
-        assert mock_stream.call_args[1]["gh_token"] == gen._credentials.gh_token
+        assert mock_stream.call_args[1]["config"].gh_token == gen._credentials.gh_token
         mock_prs.post_comment.assert_awaited_once()
         call_args = mock_prs.post_comment.call_args
         assert call_args[0][0] == 42  # issue number
@@ -746,7 +746,7 @@ class TestRunPrecheckContext:
         assert call_kwargs["cmd"] == ["cmd"]
         assert call_kwargs["prompt"] == "prompt"
         assert call_kwargs["event_data"]["source"] == "ac_precheck"
-        assert call_kwargs["gh_token"] == gen._credentials.gh_token
+        assert call_kwargs["config"].gh_token == gen._credentials.gh_token
 
     @pytest.mark.asyncio
     async def test_execute_debug_closure_uses_ac_precheck_debug_source(
@@ -786,7 +786,7 @@ class TestRunPrecheckContext:
 
         mock_stream.assert_called_once()
         assert mock_stream.call_args[1]["event_data"]["source"] == "ac_precheck_debug"
-        assert mock_stream.call_args[1]["gh_token"] == gen._credentials.gh_token
+        assert mock_stream.call_args[1]["config"].gh_token == gen._credentials.gh_token
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agent_execution.py
+++ b/tests/test_agent_execution.py
@@ -1014,7 +1014,7 @@ class TestScopeCheckLoop:
         config.max_scope_check_attempts = 0
         runner = AgentRunner(config, event_bus)
         result = await runner._run_skill(
-            BUILTIN_SKILLS[1], agent_task, tmp_path, "branch", worker_id=0
+            BUILTIN_SKILLS[2], agent_task, tmp_path, "branch", worker_id=0
         )
         assert result.passed is True
         assert "disabled" in result.summary
@@ -1043,7 +1043,7 @@ class TestScopeCheckLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[1],
+                BUILTIN_SKILLS[2],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1080,7 +1080,7 @@ class TestScopeCheckLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[1],
+                BUILTIN_SKILLS[2],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1115,7 +1115,7 @@ class TestScopeCheckLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[1],
+                BUILTIN_SKILLS[2],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1135,7 +1135,7 @@ class TestPlanComplianceLoop:
         config.max_plan_compliance_attempts = 0
         runner = AgentRunner(config, event_bus)
         result = await runner._run_skill(
-            BUILTIN_SKILLS[2], agent_task, tmp_path, "branch", worker_id=0
+            BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
         )
         assert result.passed is True
         assert "disabled" in result.summary
@@ -1160,7 +1160,7 @@ class TestPlanComplianceLoop:
             patch.object(runner, "_execute", new_callable=AsyncMock) as mock_execute,
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[2],
+                BUILTIN_SKILLS[3],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1195,7 +1195,7 @@ class TestPlanComplianceLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[2],
+                BUILTIN_SKILLS[3],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1228,7 +1228,7 @@ class TestPlanComplianceLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[2],
+                BUILTIN_SKILLS[3],
                 agent_task,
                 tmp_path,
                 "branch",
@@ -1249,7 +1249,7 @@ class TestTestAdequacyLoop:
         config.max_test_adequacy_attempts = 0
         runner = AgentRunner(config, event_bus)
         result = await runner._run_skill(
-            BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
+            BUILTIN_SKILLS[4], agent_task, tmp_path, "branch", worker_id=0
         )
         assert result.passed is True
         assert "disabled" in result.summary
@@ -1264,7 +1264,7 @@ class TestTestAdequacyLoop:
             runner, "_count_commits", new_callable=AsyncMock, return_value=0
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
+                BUILTIN_SKILLS[4], agent_task, tmp_path, "branch", worker_id=0
             )
         assert result.passed is True
         assert "No commits" in result.summary
@@ -1293,7 +1293,7 @@ class TestTestAdequacyLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
+                BUILTIN_SKILLS[4], agent_task, tmp_path, "branch", worker_id=0
             )
         assert result.passed is True
 
@@ -1321,7 +1321,7 @@ class TestTestAdequacyLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
+                BUILTIN_SKILLS[4], agent_task, tmp_path, "branch", worker_id=0
             )
         assert result.passed is False
         assert "missing tests" in result.summary
@@ -1355,7 +1355,7 @@ class TestTestAdequacyLoop:
             ),
         ):
             result = await runner._run_skill(
-                BUILTIN_SKILLS[3], agent_task, tmp_path, "branch", worker_id=0
+                BUILTIN_SKILLS[4], agent_task, tmp_path, "branch", worker_id=0
             )
         assert result.passed is True
         assert result.attempts == 2

--- a/tests/test_base_runner.py
+++ b/tests/test_base_runner.py
@@ -178,15 +178,12 @@ class TestExecute:
         assert result == "transcript output"
         mock.assert_awaited_once()
         call_kwargs = mock.call_args[1]
-        expected_kwargs = {
-            "cmd": ["claude", "-p"],
-            "prompt": "prompt",
-            "cwd": tmp_path,
-            "event_data": {"issue": 42},
-            "on_output": None,
-            "gh_token": runner._credentials.gh_token,
-        }
-        assert {k: call_kwargs[k] for k in expected_kwargs} == expected_kwargs
+        assert call_kwargs["cmd"] == ["claude", "-p"]
+        assert call_kwargs["prompt"] == "prompt"
+        assert call_kwargs["cwd"] == tmp_path
+        assert call_kwargs["event_data"] == {"issue": 42}
+        assert call_kwargs["config"].on_output is None
+        assert call_kwargs["config"].gh_token == runner._credentials.gh_token
 
     @pytest.mark.asyncio
     async def test_passes_on_output_callback(
@@ -208,7 +205,7 @@ class TestExecute:
             )
 
         call_kwargs = mock.call_args[1]
-        assert call_kwargs["on_output"] is callback
+        assert call_kwargs["config"].on_output is callback
 
     @pytest.mark.asyncio
     async def test_auth_failure_retries_with_backoff(

--- a/tests/test_base_runner_execute_trace.py
+++ b/tests/test_base_runner_execute_trace.py
@@ -61,9 +61,9 @@ async def test_execute_passes_collector_when_ctx_set(tmp_path: Path):
             event_data={"issue": 42, "source": "implementer"},
         )
 
-    assert captured_kwargs.get("trace_collector") is not None
+    collector = captured_kwargs["config"].trace_collector
+    assert collector is not None
     # The collector instance should be built from the context values
-    collector = captured_kwargs["trace_collector"]
     assert collector._issue_number == 42
     assert collector._phase == "implement"
     assert collector._run_id == 1
@@ -88,7 +88,7 @@ async def test_execute_passes_no_collector_when_ctx_unset(tmp_path: Path):
             event_data={"issue": 42, "source": "implementer"},
         )
 
-    assert captured_kwargs.get("trace_collector") is None
+    assert captured_kwargs["config"].trace_collector is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_base_runner_subprocess_counter.py
+++ b/tests/test_base_runner_subprocess_counter.py
@@ -89,7 +89,7 @@ class TestSubprocessCounter:
         captured_indices: list[int] = []
 
         async def fake_stream(**kwargs):
-            collector = kwargs["trace_collector"]
+            collector = kwargs["config"].trace_collector
             captured_indices.append(collector._subprocess_idx)
             return "transcript"
 
@@ -113,7 +113,7 @@ class TestSubprocessCounter:
         # No context set
 
         async def fake_stream(**kwargs):
-            assert kwargs["trace_collector"] is None
+            assert kwargs["config"].trace_collector is None
             return "transcript"
 
         with patch("base_runner.stream_claude_process", side_effect=fake_stream):

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -24,7 +24,6 @@ SRC = Path(__file__).resolve().parent.parent / "src"
 # ---------------------------------------------------------------------------
 _INTERVAL_BOUNDS_SKIP: set[str] = {
     "data_poll_interval",
-    "state_backup_interval",
     "dependabot_merge_interval",
     "report_issue_interval",
     "epic_monitor_interval",

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -123,6 +123,7 @@ class TestEnvVarOverrideTable:
     # Generic tests can't use arbitrary strings for these fields.
     _EXPLICIT_VALUES: dict[str, str] = {
         "execution_mode": "docker",
+        "security_patch_severity_threshold": "critical",
     }
 
     @pytest.mark.parametrize(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1242,7 +1242,7 @@ class TestLabelValidation:
 
 
 class TestTimeoutConfigFields:
-    """Tests for agent_timeout, transcript_summary_timeout, memory_compaction_timeout."""
+    """Tests for agent_timeout and transcript_summary_timeout."""
 
     def test_agent_timeout_default(self) -> None:
         config = HydraFlowConfig(repo="test/repo")
@@ -1251,10 +1251,6 @@ class TestTimeoutConfigFields:
     def test_transcript_summary_timeout_default(self) -> None:
         config = HydraFlowConfig(repo="test/repo")
         assert config.transcript_summary_timeout == 120
-
-    def test_memory_compaction_timeout_default(self) -> None:
-        config = HydraFlowConfig(repo="test/repo")
-        assert config.memory_compaction_timeout == 60
 
     def test_agent_timeout_bounds_too_low(self) -> None:
         from pydantic import ValidationError
@@ -1280,18 +1276,6 @@ class TestTimeoutConfigFields:
         with pytest.raises(ValidationError):
             HydraFlowConfig(repo="test/repo", transcript_summary_timeout=999)
 
-    def test_memory_compaction_timeout_bounds_too_low(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            HydraFlowConfig(repo="test/repo", memory_compaction_timeout=5)
-
-    def test_memory_compaction_timeout_bounds_too_high(self) -> None:
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            HydraFlowConfig(repo="test/repo", memory_compaction_timeout=999)
-
     def test_agent_timeout_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HYDRAFLOW_AGENT_TIMEOUT", "7200")
         config = HydraFlowConfig(repo="test/repo")
@@ -1303,13 +1287,6 @@ class TestTimeoutConfigFields:
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_TIMEOUT", "300")
         config = HydraFlowConfig(repo="test/repo")
         assert config.transcript_summary_timeout == 300
-
-    def test_memory_compaction_timeout_env_override(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_MEMORY_COMPACTION_TIMEOUT", "90")
-        config = HydraFlowConfig(repo="test/repo")
-        assert config.memory_compaction_timeout == 90
 
 
 # ---------------------------------------------------------------------------
@@ -1688,7 +1665,6 @@ class TestAgentToolFields:
         assert cfg.planner_tool == "claude"
         assert cfg.triage_tool == "claude"
         assert cfg.transcript_summary_tool == "claude"
-        assert cfg.memory_compaction_tool == "claude"
         assert cfg.ac_tool == "claude"
         assert cfg.verification_judge_tool == "claude"
         assert cfg.system_tool == "inherit"
@@ -1702,7 +1678,6 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_PLANNER_TOOL", "codex")
         monkeypatch.setenv("HYDRAFLOW_TRIAGE_TOOL", "codex")
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_MEMORY_COMPACTION_TOOL", "codex")
         monkeypatch.setenv("HYDRAFLOW_AC_TOOL", "codex")
         monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE_TOOL", "codex")
         cfg = HydraFlowConfig(
@@ -1716,7 +1691,6 @@ class TestAgentToolFields:
         assert cfg.planner_tool == "codex"
         assert cfg.triage_tool == "codex"
         assert cfg.transcript_summary_tool == "codex"
-        assert cfg.memory_compaction_tool == "codex"
         assert cfg.ac_tool == "codex"
         assert cfg.verification_judge_tool == "codex"
 
@@ -1728,7 +1702,6 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_PLANNER_TOOL", "pi")
         monkeypatch.setenv("HYDRAFLOW_TRIAGE_TOOL", "pi")
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_MEMORY_COMPACTION_TOOL", "pi")
         monkeypatch.setenv("HYDRAFLOW_AC_TOOL", "pi")
         monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE_TOOL", "pi")
         monkeypatch.setenv("HYDRAFLOW_SUBSKILL_TOOL", "pi")
@@ -1745,7 +1718,6 @@ class TestAgentToolFields:
         assert cfg.planner_tool == "pi"
         assert cfg.triage_tool == "pi"
         assert cfg.transcript_summary_tool == "pi"
-        assert cfg.memory_compaction_tool == "pi"
         assert cfg.ac_tool == "pi"
         assert cfg.verification_judge_tool == "pi"
         assert cfg.subskill_tool == "pi"
@@ -1771,7 +1743,6 @@ class TestAgentToolFields:
         assert cfg.debug_tool == "codex"
         assert cfg.triage_tool == "codex"
         assert cfg.transcript_summary_tool == "codex"
-        assert cfg.memory_compaction_tool == "codex"
 
     def test_profile_model_overrides_apply_to_defaults(self, tmp_path: Path) -> None:
         cfg = HydraFlowConfig(
@@ -1789,7 +1760,6 @@ class TestAgentToolFields:
         assert cfg.debug_model == "gpt-5-codex"
         assert cfg.triage_model == "gpt-5-codex"
         assert cfg.transcript_summary_model == "gpt-5-codex"
-        assert cfg.memory_compaction_model == "gpt-5-codex"
 
     def test_profile_overrides_do_not_clobber_explicit_per_field(
         self, tmp_path: Path

--- a/tests/test_exception_chaining.py
+++ b/tests/test_exception_chaining.py
@@ -396,17 +396,14 @@ class TestMergeConflictResolverExceptionChaining:
         assert result.success is False
 
     @pytest.mark.asyncio
-    async def test_summarize_narrows_to_runtime_os_error(self) -> None:
-        """_maybe_summarize_conflict should only catch RuntimeError/OSError."""
+    async def test_maybe_summarize_conflict_is_noop(self) -> None:
+        """_maybe_summarize_conflict is a retained no-op — transcript summarization was removed."""
         from merge_conflict_resolver import MergeConflictResolver
 
         resolver = MergeConflictResolver.__new__(MergeConflictResolver)
-        resolver._summarizer = AsyncMock()
-        resolver._summarizer.summarize_and_publish.side_effect = TypeError(
-            "bug in summarizer"
-        )
-        with pytest.raises(TypeError, match="bug in summarizer"):
-            await resolver._maybe_summarize_conflict("transcript", 1, 2)
+        # Should return cleanly even without any wiring — proves the method is a no-op
+        result = await resolver._maybe_summarize_conflict("transcript", 1, 2)
+        assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -1326,12 +1326,15 @@ class TestRunLogIngestionCycle:
 
     @pytest.mark.asyncio
     async def test_returns_none_on_import_error(self, tmp_path: Path) -> None:
-        """Returns None when log_ingestion module is not available."""
+        """Returns None when log_ingestion import fails mid-cycle."""
         loop = _make_loop(tmp_path)
-        # Even with a log dir, if log_ingestion is missing, returns None
         log_dir = loop._config.data_root / "logs"
         log_dir.mkdir(parents=True, exist_ok=True)
-        result = await loop._run_log_ingestion_cycle()
+        # Force the function-local import to fail by patching the source module.
+        with patch(
+            "log_ingestion.parse_log_files", side_effect=ImportError("simulated")
+        ):
+            result = await loop._run_log_ingestion_cycle()
         assert result is None
 
     @pytest.mark.asyncio
@@ -1348,24 +1351,15 @@ class TestRunLogIngestionCycle:
         mock_result.escalated = 1
 
         with (
-            patch("health_monitor_loop.parse_log_files", create=True, return_value=[]),
+            patch("log_ingestion.parse_log_files", return_value=[]),
+            patch("log_ingestion.detect_log_patterns", return_value=[]),
+            patch("log_ingestion.load_known_patterns", return_value={}),
             patch(
-                "health_monitor_loop.detect_log_patterns", create=True, return_value=[]
-            ),
-            patch(
-                "health_monitor_loop.load_known_patterns", create=True, return_value={}
-            ),
-            patch(
-                "health_monitor_loop.file_log_patterns",
-                create=True,
+                "log_ingestion.file_log_patterns",
                 new_callable=AsyncMock,
                 return_value=mock_result,
             ),
-            patch(
-                "health_monitor_loop.save_known_patterns",
-                create=True,
-                return_value=None,
-            ),
+            patch("log_ingestion.save_known_patterns", return_value=None),
         ):
             result = await loop._run_log_ingestion_cycle()
 
@@ -1394,16 +1388,8 @@ class TestRunHarnessAutoFileCycle:
         mock_store_cls.return_value = mock_store_instance
 
         with (
-            patch(
-                "health_monitor_loop.HarnessInsightStore",
-                create=True,
-                new=mock_store_cls,
-            ),
-            patch(
-                "health_monitor_loop.auto_file_suggestions",
-                create=True,
-                new=mock_auto_file,
-            ),
+            patch("harness_insights.HarnessInsightStore", new=mock_store_cls),
+            patch("harness_insights.auto_file_suggestions", new=mock_auto_file),
         ):
             await loop._run_harness_auto_file_cycle()
 
@@ -1491,16 +1477,8 @@ class TestRunCrossProjectPatternCycle:
         mock_detect = MagicMock(return_value=[{"pattern": "timeout"}])
 
         with (
-            patch(
-                "health_monitor_loop.detect_cross_project_log_patterns",
-                create=True,
-                new=mock_detect,
-            ),
-            patch(
-                "health_monitor_loop.load_known_patterns",
-                create=True,
-                return_value={"p1": "v1"},
-            ),
+            patch("log_ingestion.detect_cross_project_log_patterns", new=mock_detect),
+            patch("log_ingestion.load_known_patterns", return_value={"p1": "v1"}),
         ):
             loop._run_cross_project_pattern_cycle()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -994,23 +994,6 @@ class TestMemoryModels:
         assert issue.created_at == "2024-01-01"
 
 
-# --- Config: memory_compaction_model tests ---
-
-
-class TestMemoryCompactionModelConfig:
-    """Tests for the memory_compaction_model config field."""
-
-    def test_default_is_haiku(self) -> None:
-        from config import HydraFlowConfig
-
-        config = HydraFlowConfig(repo="test/repo")
-        assert config.memory_compaction_model == "haiku"
-
-    def test_custom_model(self) -> None:
-        config = ConfigFactory.create(memory_compaction_model="sonnet")
-        assert config.memory_compaction_model == "sonnet"
-
-
 # --- PR Manager tests ---
 
 

--- a/tests/test_memory_routes.py
+++ b/tests/test_memory_routes.py
@@ -167,7 +167,7 @@ class TestMemorySearchEndpoint:
     async def test_search_with_results(self, router_with_hindsight):
         router, mock_hs, _ = router_with_hindsight
         mock_hs.recall_banks.return_value = {
-            Bank.LEARNINGS: [
+            Bank.TRIBAL: [
                 HindsightMemory(
                     text="CI timeout fix: increase timeout to 300s",
                     content="CI timeout fix",
@@ -200,7 +200,7 @@ class TestMemorySearchEndpoint:
     async def test_search_with_bank_filter(self, router_with_hindsight):
         router, mock_hs, _ = router_with_hindsight
         mock_hs.recall_banks.return_value = {
-            Bank.LEARNINGS: [
+            Bank.TRIBAL: [
                 HindsightMemory(
                     text="something", content="something", relevance_score=0.5
                 ),
@@ -208,14 +208,14 @@ class TestMemorySearchEndpoint:
         }
 
         handler = find_endpoint(router, "/api/memory/search", "GET")
-        resp = await handler(q="test", bank=str(Bank.LEARNINGS), limit=10)
+        resp = await handler(q="test", bank=str(Bank.TRIBAL), limit=10)
 
         payload = json.loads(resp.body)
-        assert payload["bank_filter"] == str(Bank.LEARNINGS)
+        assert payload["bank_filter"] == str(Bank.TRIBAL)
         # recall_banks should have been called with specific bank
         mock_hs.recall_banks.assert_called_once()
         call_args = mock_hs.recall_banks.call_args
-        assert call_args[0][1] == [Bank.LEARNINGS]
+        assert call_args[0][1] == [Bank.TRIBAL]
 
     @pytest.mark.asyncio
     async def test_search_invalid_bank_returns_empty(self, router_with_hindsight):
@@ -280,7 +280,7 @@ class TestMemoryForIssueEndpoint:
     async def test_returns_context_for_issue(self, router_with_hindsight):
         router, mock_hs, _ = router_with_hindsight
         mock_hs.recall_banks.return_value = {
-            Bank.LEARNINGS: [
+            Bank.TRIBAL: [
                 HindsightMemory(
                     text="Relevant learning",
                     content="Relevant learning",
@@ -376,7 +376,7 @@ class TestMemoryForHITLEndpoint:
         call_args = mock_hs.recall_banks.call_args
         banks_arg = call_args[0][1]
         assert Bank.TROUBLESHOOTING in banks_arg
-        assert Bank.LEARNINGS in banks_arg
+        assert Bank.TRIBAL in banks_arg
         assert Bank.REVIEW_INSIGHTS in banks_arg
 
     @pytest.mark.asyncio
@@ -444,10 +444,10 @@ class TestRecallBanks:
 
         results = await client.recall_banks(
             "test",
-            [Bank.LEARNINGS, Bank.TROUBLESHOOTING],
+            [Bank.TRIBAL, Bank.TROUBLESHOOTING],
         )
         assert len(results) == 2
-        assert Bank.LEARNINGS in results
+        assert Bank.TRIBAL in results
         assert Bank.TROUBLESHOOTING in results
         assert client.recall.call_count == 2
         await client.close()
@@ -464,7 +464,7 @@ class TestRecallBanks:
         async def mock_recall(bank, query, *, limit=10):
             nonlocal call_count
             call_count += 1
-            if bank == Bank.LEARNINGS:
+            if bank == Bank.TRIBAL:
                 raise Exception("timeout")
             return [HindsightMemory(text="ok", content="ok", relevance_score=0.5)]
 
@@ -472,8 +472,8 @@ class TestRecallBanks:
 
         results = await client.recall_banks(
             "test",
-            [Bank.LEARNINGS, Bank.TROUBLESHOOTING],
+            [Bank.TRIBAL, Bank.TROUBLESHOOTING],
         )
-        assert results[Bank.LEARNINGS] == []
+        assert results[Bank.TRIBAL] == []
         assert len(results[Bank.TROUBLESHOOTING]) == 1
         await client.close()

--- a/tests/test_models_core.py
+++ b/tests/test_models_core.py
@@ -1083,20 +1083,13 @@ class TestHITLItem:
 
 def test_agent_activity_payload_keys():
     """AgentActivityPayload has the expected keys."""
-    from models import ActivityType, AgentActivityPayload
-
-    # Verify enum values
-    assert ActivityType.TOOL_CALL == "tool_call"
-    assert ActivityType.TOOL_RESULT == "tool_result"
-    assert ActivityType.THINKING == "thinking"
-    assert ActivityType.TEXT == "text"
-    assert ActivityType.ERROR == "error"
+    from models import AgentActivityPayload
 
     # Verify TypedDict accepts all fields
     payload: AgentActivityPayload = {
         "issue": 42,
         "source": "implementer",
-        "activity_type": ActivityType.TOOL_CALL,
+        "activity_type": "tool_call",
         "tool_name": "Read",
         "summary": "Reading src/config.py",
         "detail": "file_path: src/config.py",

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -95,7 +95,7 @@ class TestReportIssueLoopDoWork:
         assert result["issue_number"] == 77
         mock_stream.assert_awaited_once()
         _pr.create_issue.assert_not_awaited()
-        assert mock_stream.call_args[1]["gh_token"] == loop._credentials.gh_token
+        assert mock_stream.call_args[1]["config"].gh_token == loop._credentials.gh_token
         # Queue should be empty after successful processing
         assert state.peek_report() is None
 

--- a/tests/test_runner_utils_activity.py
+++ b/tests/test_runner_utils_activity.py
@@ -7,6 +7,7 @@ import json
 import pytest
 
 from events import EventBus, EventType, HydraFlowEvent
+from runner_utils import StreamConfig
 
 
 @pytest.mark.asyncio
@@ -70,7 +71,7 @@ async def test_activity_event_emitted_for_tool_use(tmp_path):
         event_bus=bus,
         event_data={"issue": 42, "source": "implementer"},
         logger=__import__("logging").getLogger("test"),
-        runner=runner_mock,
+        config=StreamConfig(runner=runner_mock),
     )
 
     activity_events = [e for e in collected if e.type == EventType.AGENT_ACTIVITY]
@@ -137,7 +138,7 @@ async def test_no_activity_event_for_session_lines(tmp_path):
         event_bus=bus,
         event_data={"issue": 99, "source": "planner"},
         logger=__import__("logging").getLogger("test"),
-        runner=runner_mock,
+        config=StreamConfig(runner=runner_mock),
     )
 
     activity_events = [e for e in collected if e.type == EventType.AGENT_ACTIVITY]
@@ -216,7 +217,7 @@ async def test_codex_backend_detection(tmp_path):
         event_bus=bus,
         event_data={"issue": 10, "source": "implementer"},
         logger=__import__("logging").getLogger("test"),
-        runner=runner,
+        config=StreamConfig(runner=runner),
     )
 
     activity_events = [e for e in collected if e.type == EventType.AGENT_ACTIVITY]
@@ -267,7 +268,7 @@ async def test_activity_parser_exception_does_not_crash_stream(tmp_path):
             event_bus=bus,
             event_data={"issue": 1, "source": "implementer"},
             logger=__import__("logging").getLogger("test"),
-            runner=runner,
+            config=StreamConfig(runner=runner),
         )
 
     # TRANSCRIPT_LINE should still be emitted even if activity parsing exploded

--- a/tests/test_runner_utils_trace.py
+++ b/tests/test_runner_utils_trace.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 import pytest  # noqa: E402
 
 from events import EventBus  # noqa: E402
-from runner_utils import stream_claude_process  # noqa: E402
+from runner_utils import StreamConfig, stream_claude_process  # noqa: E402
 from trace_collector import TraceCollector  # noqa: E402
 
 
@@ -87,8 +87,7 @@ async def test_trace_collector_receives_each_line(tmp_path: Path):
         event_bus=bus,
         event_data={"issue": 42, "source": "implementer"},
         logger=logging.getLogger("test"),
-        runner=runner,
-        trace_collector=collector,
+        config=StreamConfig(runner=runner, trace_collector=collector),
     )
 
     # Collector should have processed the assistant event
@@ -118,5 +117,5 @@ async def test_no_collector_does_not_break_existing_flow(tmp_path: Path):
         event_bus=bus,
         event_data={"issue": 42, "source": "implementer"},
         logger=logging.getLogger("test"),
-        runner=runner,
+        config=StreamConfig(runner=runner),
     )

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -1388,4 +1388,4 @@ class TestExecuteGhToken:
         ) as mock_stream:
             await judge._execute(["claude", "-p"], "prompt", 42)
 
-        assert mock_stream.call_args[1]["gh_token"] == "ghp_bot_judge"
+        assert mock_stream.call_args[1]["config"].gh_token == "ghp_bot_judge"


### PR DESCRIPTION
## Summary

Sweeps 51 failing tests back into alignment with source after several recent refactors (stream_claude_process signature change, BUILTIN_SKILLS reordering, Bank.LEARNINGS→TRIBAL rename, memory_compaction field removal, etc.). No new features, no behavior changes beyond extracting one inlined helper (\`_run_visual_gate\`) that existing tests already expected.

## Root causes addressed

1. **\`stream_claude_process\` signature refactor** — \`runner\` / \`gh_token\` / \`on_output\` / \`trace_collector\` / \`timeout\` / \`usage_stats\` moved into \`StreamConfig\`; 14 tests updated across 8 files to wrap kwargs or assert on \`config.*\`.
2. **\`Bank.LEARNINGS\` → \`Bank.TRIBAL\`** rename — 12 refs updated in \`test_memory_routes.py\`.
3. **\`BUILTIN_SKILLS\` list grew** — \`diff-sanity\` + \`arch-compliance\` prepended; \`test_agent_execution.py\` indices shifted +1 for the three downstream skill loops.
4. **\`post_merge_handler\`** — extracted \`_run_visual_gate\` from \`handle_approved\` (tests already expected this method; source never had it). Semantically equivalent to inlined logic.
5. **\`diagnostic_runner\`** — added debug log for raw parsed dict on validation failure (test expected this diagnostic surface).
6. **\`ActivityType\` enum removed** — \`test_models_core\` updated to test the \`AgentActivityPayload\` TypedDict shape only.
7. **\`_maybe_summarize_conflict\` is now a no-op** (transcript summary feature removed); \`test_exception_chaining\` assertion updated to match.
8. **\`security_patch_severity_threshold\` is now a Literal** — \`test_config_env\` parametrized entry uses \"critical\" (non-default, valid literal).
9. **\`health_monitor_loop\` uses function-local imports** — 4 tests updated to patch the source module (\`log_ingestion.*\`, \`harness_insights.*\`) instead of \`health_monitor_loop.*\` which was never read.
10. **\`memory_compaction_timeout/tool/model\` fields removed** in batches 3+4; stale tests and the \`state_backup_interval\` skip-list entry removed.

## Verification

- Full suite: **10,152 passed, 0 failed** (was 51 failed, 10,146 passed on \`origin/main\` before this branch).
- Ruff / ruff-format / pyright clean on changed files.

## Test plan

- [x] \`PYTHONPATH=src uv run pytest\` — 10,152 passed, 0 failed
- [x] Root causes verified against \`origin/main\` (stashed this branch's changes, confirmed same failures reproduce, stashed pop)