### PR TITLE
fix: two latent bugs — shape_phase hindsight check, memory_sync breadcrumb key

### DIFF
--- a/src/memory_sync_loop.py
+++ b/src/memory_sync_loop.py
@@ -38,7 +38,7 @@ class MemorySyncLoop(BaseBackgroundLoop):
                 message="Memory sync completed",
                 level="info",
                 data={
-                    "item_count": result.get("processed", 0),
+                    "item_count": result.get("item_count", 0),
                     "compacted": result.get("compacted", False),
                 },
             )

--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -721,7 +721,7 @@ class ShapePhase:
 
             query = f"product direction preferences scope decisions for {issue.title}"
             hindsight = getattr(self._runner, "_hindsight", None)
-            if not hindsight:
+            if hindsight is None:
                 return ""
             memories = await recall_safe(hindsight, Bank.TRIBAL, query, limit=5)
             from recall_tracker import log_recall  # noqa: PLC0415

--- a/tests/test_memory_sync_loop.py
+++ b/tests/test_memory_sync_loop.py
@@ -185,3 +185,22 @@ class TestMemorySyncSentryBreadcrumbs:
             kw = sentry_mock.add_breadcrumb.call_args[1]
             assert kw["category"] == "memory.sync_completed"
             assert kw["level"] == "info"
+
+    @pytest.mark.asyncio
+    async def test_breadcrumb_reads_item_count_from_sync_result(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression: breadcrumb data must read MemorySyncResult['item_count'],
+        not the nonexistent 'processed' key which always returned 0."""
+        from unittest.mock import patch
+
+        loop, _ = _make_loop(tmp_path)
+        loop._memory_sync.sync = AsyncMock(
+            return_value={"action": "sync", "item_count": 7, "compacted": True}
+        )
+        sentry_mock = MagicMock()
+        with patch.dict("sys.modules", {"sentry_sdk": sentry_mock}):
+            await loop._do_work()
+            kw = sentry_mock.add_breadcrumb.call_args[1]
+            assert kw["data"]["item_count"] == 7
+            assert kw["data"]["compacted"] is True


### PR DESCRIPTION
## Summary

Two real bugs from the P0-audit survivor list. Single PR because each is a one-liner.

### #6198 — \`shape_phase._recall_preferences\` uses truthy check instead of \`is None\`
- \`if not hindsight:\` → \`if hindsight is None:\`
- \`getattr(self._runner, \"_hindsight\", None)\` already yields None on absence; the truthy check could incorrectly reject hindsight mocks or objects that happen to evaluate falsy.
- Matches the rest of the codebase's convention for optional-client checks.

### #6204 — \`memory_sync_loop\` Sentry breadcrumb reads wrong key
- \`result.get(\"processed\", 0)\` → \`result.get(\"item_count\", 0)\`
- \`MemorySyncResult\` TypedDict has no \`processed\` field (see \`src/models.py:2563\`) — the actual count key is \`item_count\`. The breadcrumb was silently reporting 0 every sync, masking real activity from Sentry.
- **Regression test added** — asserts breadcrumb data picks up \`item_count\` from a realistic sync result.

## Test plan

- [x] \`pytest tests/test_shape_phase.py tests/test_memory_sync_loop.py\` — 23 pass, 0 fail
- [x] ruff + pre-commit clean
- [x] Regression test for #6204 exercises the actual key, using a sync result with \`item_count=7\`

Closes #6198
Closes #6204