### PR TITLE
docs(env.sample): document background worker model overrides

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -89,6 +89,14 @@ HYDRAFLOW_LABEL_FIXED=hydraflow-fixed
 # HYDRAFLOW_AC_MODEL=sonnet
 # HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL=haiku
 
+# Background worker models (defaults shown — opus by default, override for cost)
+# HYDRAFLOW_REPORT_ISSUE_MODEL=opus   # also pins sentry_loop (shared field)
+# HYDRAFLOW_ADR_REVIEW_MODEL=sonnet
+# HYDRAFLOW_MEMORY_JUDGE_MODEL=haiku
+# HYDRAFLOW_WIKI_COMPILATION_MODEL=haiku
+# HYDRAFLOW_MEMORY_COMPACTION_MODEL=haiku
+# HYDRAFLOW_BACKGROUND_MODEL=            # empty = keep per-worker defaults
+
 # Token-saver profile (~50% less prompt context payload)
 # HYDRAFLOW_PLANNER_TOOL=claude
 # HYDRAFLOW_PLANNER_MODEL=opus


### PR DESCRIPTION
Adds commented-out HYDRAFLOW_*_MODEL entries for background workers to .env.sample (report_issue_loop, adr_reviewer_loop, memory_judge, wiki_compilation, memory_compaction, background_model). Previously only pipeline-stage models were documented; operators had to read config.py to find bg-worker overrides. Notable call-out: HYDRAFLOW_REPORT_ISSUE_MODEL also pins sentry_loop (shared field).