### PR TITLE
feat(config): dedicated model env var per LLM-calling background worker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -89,13 +89,17 @@ HYDRAFLOW_LABEL_FIXED=hydraflow-fixed
 # HYDRAFLOW_AC_MODEL=sonnet
 # HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL=haiku
 
-# Background worker models (defaults shown — opus by default, override for cost)
-# HYDRAFLOW_REPORT_ISSUE_MODEL=opus   # also pins sentry_loop (shared field)
-# HYDRAFLOW_ADR_REVIEW_MODEL=sonnet
-# HYDRAFLOW_MEMORY_JUDGE_MODEL=haiku
-# HYDRAFLOW_WIKI_COMPILATION_MODEL=haiku
-# HYDRAFLOW_MEMORY_COMPACTION_MODEL=haiku
-# HYDRAFLOW_BACKGROUND_MODEL=            # empty = keep per-worker defaults
+# Background worker models (defaults shown — each worker is independently tunable)
+# HYDRAFLOW_REPORT_ISSUE_MODEL=opus       # report_issue_loop (codebase research)
+# HYDRAFLOW_SENTRY_MODEL=opus             # sentry_loop (Sentry event triage/filing)
+# HYDRAFLOW_CODE_GROOMING_MODEL=sonnet    # code_grooming_loop (daily code audit)
+# HYDRAFLOW_ADR_REVIEW_MODEL=sonnet       # adr_reviewer council
+# HYDRAFLOW_MEMORY_JUDGE_MODEL=haiku      # tribal-memory candidate judge
+# HYDRAFLOW_WIKI_COMPILATION_MODEL=haiku  # per-repo wiki compactor
+# HYDRAFLOW_MEMORY_COMPACTION_MODEL=haiku # memory_sync compaction
+# HYDRAFLOW_BACKGROUND_MODEL=             # empty = keep per-worker defaults;
+                                          # set to cascade to triage/transcript/
+                                          # report_issue/sentry/code_grooming
 
 # Token-saver profile (~50% less prompt context payload)
 # HYDRAFLOW_PLANNER_TOOL=claude

--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Beyond the five pipeline stages, HydraFlow runs background loops for operational
 - **ADR reviewer** — council-based Architecture Decision Record reviews
 - **Report issue** — processes bug reports with screenshot scanning
 
+Each loop that dispatches an LLM call has its own `HYDRAFLOW_*_MODEL` env var for cost tuning (report_issue, sentry, code_grooming, adr_review, memory_judge, memory_compaction, wiki_compilation, transcript_summary). See [docs/agents/background-loops.md](docs/agents/background-loops.md) for the full table and the `HYDRAFLOW_BACKGROUND_MODEL` cascade behavior.
+
 ### Self-improving harness
 
 This repo includes a harnessed self-improvement loop (observation + session retro + memory candidate artifacts).

--- a/docs/agents/background-loops.md
+++ b/docs/agents/background-loops.md
@@ -18,6 +18,25 @@ When creating a new background loop (`BaseBackgroundLoop` subclass):
 
 Missing any of these five entries will cause `test_loop_wiring_completeness` to fail. Add them all in the same commit.
 
+## Per-worker model overrides
+
+Each background worker that dispatches an LLM call has its own `HYDRAFLOW_*_MODEL` env var so it can be tuned independently for cost. Most loops are logic-only (no LLM call) and don't appear here.
+
+| Loop | Config field | Env var | Default |
+|------|--------------|---------|---------|
+| `report_issue_loop` | `report_issue_model` | `HYDRAFLOW_REPORT_ISSUE_MODEL` | `opus` |
+| `sentry_loop` | `sentry_model` | `HYDRAFLOW_SENTRY_MODEL` | `opus` |
+| `code_grooming_loop` | `code_grooming_model` | `HYDRAFLOW_CODE_GROOMING_MODEL` | `sonnet` |
+| `adr_reviewer_loop` (council) | `adr_review_model` | `HYDRAFLOW_ADR_REVIEW_MODEL` | `sonnet` |
+| tribal-memory judge | `memory_judge_model` | `HYDRAFLOW_MEMORY_JUDGE_MODEL` | `haiku` |
+| memory_sync compaction | `memory_compaction_model` | `HYDRAFLOW_MEMORY_COMPACTION_MODEL` | `haiku` |
+| wiki compaction | `wiki_compilation_model` | `HYDRAFLOW_WIKI_COMPILATION_MODEL` | `haiku` |
+| transcript summarizer | `transcript_summary_model` | `HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL` | `haiku` |
+
+`HYDRAFLOW_BACKGROUND_MODEL` is a cascade: when non-empty it applies to every field above that still equals its own default (`triage_model`, `transcript_summary_model`, `report_issue_model`, `sentry_model`, `code_grooming_model`). Per-worker overrides always win over the cascade.
+
+When adding a new loop that makes LLM calls, add its own `HYDRAFLOW_<NAME>_MODEL` field to `src/config.py` and `_ENV_STR_OVERRIDES` — don't reuse an existing loop's field.
+
 ## Design rationale
 
 See [`docs/adr/0029-caretaker-loop-pattern.md`](../adr/0029-caretaker-loop-pattern.md) for the caretaker loop pattern, and [`docs/adr/0019-background-task-delegation-abstraction-layer.md`](../adr/0019-background-task-delegation-abstraction-layer.md) for the delegation abstraction.

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -66,7 +66,7 @@ class CodeGroomingLoop(BaseBackgroundLoop):
             tool=self._config.background_tool
             if self._config.background_tool != "inherit"
             else "claude",
-            model=self._config.background_model or "sonnet",
+            model=self._config.code_grooming_model,
             max_turns=10,
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -189,6 +189,8 @@ _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
     ("subskill_model", "HYDRAFLOW_SUBSKILL_MODEL", "haiku"),
     ("debug_model", "HYDRAFLOW_DEBUG_MODEL", "opus"),
     ("report_issue_model", "HYDRAFLOW_REPORT_ISSUE_MODEL", "opus"),
+    ("sentry_model", "HYDRAFLOW_SENTRY_MODEL", "opus"),
+    ("code_grooming_model", "HYDRAFLOW_CODE_GROOMING_MODEL", "sonnet"),
     ("adr_review_model", "HYDRAFLOW_ADR_REVIEW_MODEL", "sonnet"),
     ("memory_judge_model", "HYDRAFLOW_MEMORY_JUDGE_MODEL", "haiku"),
     ("changelog_file", "HYDRAFLOW_CHANGELOG_FILE", ""),
@@ -1226,6 +1228,14 @@ class HydraFlowConfig(BaseModel):
         default="opus",
         description="Model for report-issue worker (codebase research + structured issue creation)",
     )
+    sentry_model: str = Field(
+        default="opus",
+        description="Model for sentry_loop ingestion worker (issue triage + filing from Sentry events)",
+    )
+    code_grooming_model: str = Field(
+        default="sonnet",
+        description="Model for code_grooming_loop audit worker (daily code-quality scan)",
+    )
     report_issue_interval: int = Field(
         default=30,
         ge=10,
@@ -1805,6 +1815,8 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
             "triage_model",
             "transcript_summary_model",
             "report_issue_model",
+            "sentry_model",
+            "code_grooming_model",
         ):
             _apply_if_default(field, config.background_model)
 

--- a/src/sentry_loop.py
+++ b/src/sentry_loop.py
@@ -344,7 +344,7 @@ class SentryLoop(BaseBackgroundLoop):
 
         cmd = build_agent_command(
             tool=self._config.report_issue_tool,
-            model=self._config.report_issue_model,
+            model=self._config.sentry_model,
             max_turns=10,
         )
 


### PR DESCRIPTION
## Summary

Each background worker that dispatches an LLM call now has its own HYDRAFLOW_*_MODEL env var. Previously \`sentry_loop\` and \`code_grooming_loop\` shared or fell back to other fields, which made independent cost tuning awkward.

## Changes

### New env vars (new fields on HydraFlowConfig)

- \`HYDRAFLOW_SENTRY_MODEL\` (default \`opus\`) — was sharing \`report_issue_model\`
- \`HYDRAFLOW_CODE_GROOMING_MODEL\` (default \`sonnet\`) — was using \`background_model or \"sonnet\"\` fallback

Both defaults match the previous effective value, so behavior is unchanged unless overridden.

### Cascade extended

\`HYDRAFLOW_BACKGROUND_MODEL\` now cascades to \`sentry_model\` and \`code_grooming_model\` in addition to the prior \`triage_model\`, \`transcript_summary_model\`, and \`report_issue_model\`. Per-worker env vars still win.

### Docs

- \`docs/agents/background-loops.md\` — new operator table listing every LLM-calling loop → field → env var → default, plus the cascade rule
- \`README.md\` — pointer to the table from the Background Loops section
- \`.env.sample\` — per-worker block updated with the two new vars

## Non-goals

17 other bg loops are logic-only (no LLM call) — giving them model env vars would be cruft. \`pr_unsticker\` and \`diagnostic_runner\` ride the pipeline's \`HYDRAFLOW_MODEL\` via the implementation agent; separating those would be a bigger refactor and isn't in scope here.

## Test plan

- [x] \`pytest tests/test_sentry_loop.py tests/test_code_grooming_loop.py tests/test_config_env.py tests/test_config_validation.py tests/test_config_consistency.py tests/test_loop_wiring_completeness.py\` — 710 pass, 0 fail
- [x] ruff + ruff-format + pyright clean on changed source files
- [x] Defaults preserve prior effective model per worker