### PR TITLE
fix: credential exclusion in run artifacts + handle_approved idempotency

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -329,7 +329,20 @@ class ImplementPhase:
                 plan_text = self._read_plan_for_recording(issue.id)
                 if plan_text:
                     ctx.save_plan(plan_text)
-                ctx.save_config(self._config.model_dump(mode="json"))
+                ctx.save_config(
+                    self._config.model_dump(
+                        mode="json",
+                        exclude={
+                            "gh_token",
+                            "hindsight_api_key",
+                            "sentry_auth_token",
+                            "whatsapp_token",
+                            "whatsapp_phone_id",
+                            "whatsapp_recipient",
+                            "whatsapp_verify_token",
+                        },
+                    )
+                )
             except (RuntimeError, OSError):
                 logger.debug("Run recording setup failed", exc_info=True)
                 ctx = None

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -21,6 +21,7 @@ from models import (
     CriterionVerdict,
     GitHubIssue,
     HitlEscalation,
+    IssueOutcomeType,
     JudgeResult,
     JudgeVerdict,
     MergeApprovalContext,
@@ -211,6 +212,19 @@ class PostMergeHandler:
         but merge is deferred until all siblings are ready.
         """
         pr = ctx.pr
+        # Idempotency guard: don't re-run post-merge side effects if this
+        # issue has already been recorded as merged. Protects against retries,
+        # race conditions, and duplicate approval events.
+        existing = self._state.get_outcome(pr.issue_number)
+        if existing is not None and existing.outcome == IssueOutcomeType.MERGED:
+            logger.info(
+                "PR #%d (issue #%d): skipping handle_approved — "
+                "already recorded as MERGED at %s",
+                pr.number,
+                pr.issue_number,
+                existing.closed_at,
+            )
+            return
         issue = ctx.issue
         result = ctx.result
         diff = ctx.diff

--- a/tests/test_post_merge_handler.py
+++ b/tests/test_post_merge_handler.py
@@ -130,6 +130,32 @@ class TestPostMergeHandler:
         s.handler._prs.close_issue.assert_awaited_once_with(s.pr.issue_number)
 
     @pytest.mark.asyncio
+    async def test_handle_approved_is_idempotent_for_already_merged_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """If the issue is already recorded as MERGED, handle_approved must no-op.
+
+        Protects against duplicate post-merge side effects (counters,
+        label swaps, retrospectives, hooks) when handle_approved is
+        invoked twice for the same issue via retry or race.
+        """
+        from models import IssueOutcomeType
+
+        s = _setup_approved(config)
+        s.handler._state.record_outcome(
+            s.pr.issue_number,
+            IssueOutcomeType.MERGED,
+            reason="previous run",
+            pr_number=s.pr.number,
+        )
+
+        await s.call()
+
+        s.handler._prs.merge_pr.assert_not_awaited()
+        s.handler._prs.swap_pipeline_labels.assert_not_awaited()
+        s.handler._prs.close_issue.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_handle_approved_closes_issue_after_merge(
         self, config: HydraFlowConfig
     ) -> None:

--- a/tests/test_run_recorder.py
+++ b/tests/test_run_recorder.py
@@ -37,6 +37,47 @@ class TestRunContext:
         assert data["model"] == "opus"
         assert data["max_workers"] == 3
 
+    def test_config_dump_excludes_secrets(self, tmp_path: Path) -> None:
+        """Regression for #5971: implement_phase's model_dump(exclude=...) call
+        must strip credentials before they hit disk in run_dir/config.json."""
+        from config import HydraFlowConfig
+
+        config = HydraFlowConfig(
+            repo="test/repo",
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+            gh_token="ghp_SECRET",
+            hindsight_api_key="sk-SECRET",
+            sentry_auth_token="sntrys_SECRET",
+            whatsapp_token="wa_SECRET",
+            whatsapp_phone_id="123456",
+            whatsapp_recipient="+27123456789",
+            whatsapp_verify_token="wvt_SECRET",
+        )
+        # The exact same exclude set used in implement_phase.py:332
+        dumped = config.model_dump(
+            mode="json",
+            exclude={
+                "gh_token",
+                "hindsight_api_key",
+                "sentry_auth_token",
+                "whatsapp_token",
+                "whatsapp_phone_id",
+                "whatsapp_recipient",
+                "whatsapp_verify_token",
+            },
+        )
+        assert "gh_token" not in dumped
+        assert "hindsight_api_key" not in dumped
+        assert "sentry_auth_token" not in dumped
+        assert "whatsapp_token" not in dumped
+        assert "whatsapp_phone_id" not in dumped
+        assert "whatsapp_recipient" not in dumped
+        assert "whatsapp_verify_token" not in dumped
+        # Non-secret fields should still be present
+        assert dumped["repo"] == "test/repo"
+
     def test_append_transcript_buffers_lines(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run1"
         run_dir.mkdir()


### PR DESCRIPTION
## Summary

Two fixes from the Group B queue.

### #5971 — credentials leaking to disk
\`implement_phase.py:332\` calls \`self._config.model_dump(mode=\"json\")\` and passes it to \`run_recorder.save_config()\` which persists to \`run_dir/config.json\`. The dump included \`gh_token\`, \`hindsight_api_key\`, \`sentry_auth_token\`, and the full \`whatsapp_*\` set in plaintext on every run.

Fix: pass \`exclude={...}\` of all credential fields to \`model_dump\`. Regression test in \`test_run_recorder.py\` constructs a config with non-empty secrets and asserts the excluded dump has none of them.

### #6180 — handle_approved is now idempotent
\`PostMergeHandler.handle_approved\` had no guard against re-entry for an already-merged issue. A retry or race condition could cause duplicate counter increments, redundant label swaps, and re-execution of post-merge hooks/retrospectives.

Fix: early-return at the top of \`handle_approved\` when \`state.get_outcome(issue_number)\` already shows \`IssueOutcomeType.MERGED\`, with an info log. Regression test pre-seeds a MERGED outcome and asserts \`merge_pr\`, \`swap_pipeline_labels\`, and \`close_issue\` are NOT invoked.

## Note on #6155

Also queued in Group B was #6155 (merge scoring getattr bug). Investigation showed the current code at \`post_merge_handler.py:276\` already uses \`self._state.get_worker_result_meta()\` — exactly what the issue recommended. Closing #6155 separately as obsolete.

## Test plan

- [x] \`pytest tests/test_run_recorder.py tests/test_post_merge_handler.py tests/test_implement_phase.py\` — 199 pass, 0 fail
- [x] ruff + pyright clean on changed files
- [x] New regression tests cover both fixes

Closes #5971
Closes #6180