### PR TITLE
fix(events): serialize EventLog append/rotate with file_lock

### DIFF
--- a/src/events.py
+++ b/src/events.py
@@ -14,7 +14,7 @@ from typing import Any, TypeVar, cast
 
 from pydantic import BaseModel, Field, ValidationError
 
-from file_util import append_jsonl, atomic_write
+from file_util import append_jsonl, atomic_write, file_lock
 
 
 class _Counter:
@@ -134,6 +134,11 @@ class EventLog:
 
     def __init__(self, path: Path) -> None:
         self._path = path
+        # Sibling lock file used to serialize concurrent appends and to
+        # prevent rotate() from racing in-flight appends (events appended
+        # between rotate()'s read and os.replace() would otherwise go to
+        # the unlinked inode and be silently lost).
+        self._lock_path = path.parent / f".{path.name}.lock"
 
     @property
     def path(self) -> Path:
@@ -142,7 +147,8 @@ class EventLog:
     def _append_sync(self, line: str) -> None:
         """Synchronous append — called via ``asyncio.to_thread``."""
         try:
-            append_jsonl(self._path, line)
+            with file_lock(self._lock_path):
+                append_jsonl(self._path, line)
         except OSError:
             logger.warning(
                 "Could not append to event log %s",
@@ -213,7 +219,13 @@ class EventLog:
         return await asyncio.to_thread(self._load_sync, since, max_events)
 
     def _rotate_sync(self, max_size_bytes: int, max_age_days: int) -> None:
-        """Synchronous rotation — called via ``asyncio.to_thread``."""
+        """Synchronous rotation — called via ``asyncio.to_thread``.
+
+        Holds the lock across the entire read → filter → atomic_write cycle
+        so concurrent appends block until rotation completes. Without the
+        lock, events appended between the read and os.replace() write to
+        the old (now unlinked) inode and are silently lost.
+        """
         if not self._path.exists():
             return
 
@@ -225,40 +237,49 @@ class EventLog:
         if file_size <= max_size_bytes:
             return
 
-        cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
-        kept_lines: list[str] = []
-
         try:
-            with open(self._path) as f:
-                for raw_line in f:
-                    stripped = raw_line.strip()
-                    if not stripped:
-                        continue
-                    try:
-                        event = HydraFlowEvent.model_validate_json(stripped)
-                        ts = datetime.fromisoformat(event.timestamp)
-                        if ts >= cutoff:
-                            kept_lines.append(stripped)
-                    except (ValidationError, ValueError):
-                        logger.debug(
-                            "Dropping corrupt event line during rotation",
-                            exc_info=True,
-                        )
-                        continue
+            with file_lock(self._lock_path):
+                cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
+                kept_lines: list[str] = []
+
+                try:
+                    with open(self._path) as f:
+                        for raw_line in f:
+                            stripped = raw_line.strip()
+                            if not stripped:
+                                continue
+                            try:
+                                event = HydraFlowEvent.model_validate_json(stripped)
+                                ts = datetime.fromisoformat(event.timestamp)
+                                if ts >= cutoff:
+                                    kept_lines.append(stripped)
+                            except (ValidationError, ValueError):
+                                logger.debug(
+                                    "Dropping corrupt event line during rotation",
+                                    exc_info=True,
+                                )
+                                continue
+                except OSError:
+                    logger.warning(
+                        "Could not read event log for rotation: %s",
+                        self._path,
+                        exc_info=True,
+                    )
+                    return
+
+                content = "\n".join(kept_lines) + "\n" if kept_lines else ""
+                try:
+                    atomic_write(self._path, content)
+                except OSError:
+                    logger.warning(
+                        "Could not write rotated event log: %s",
+                        self._path,
+                        exc_info=True,
+                    )
         except OSError:
+            # file_lock acquisition failed (e.g. permissions on lock file)
             logger.warning(
                 "Could not read event log for rotation: %s",
-                self._path,
-                exc_info=True,
-            )
-            return
-
-        content = "\n".join(kept_lines) + "\n" if kept_lines else ""
-        try:
-            atomic_write(self._path, content)
-        except OSError:
-            logger.warning(
-                "Could not write rotated event log: %s",
                 self._path,
                 exc_info=True,
             )

--- a/tests/test_event_persistence.py
+++ b/tests/test_event_persistence.py
@@ -270,10 +270,13 @@ class TestEventLogRotation:
 
         await log.rotate(max_size_bytes=1, max_age_days=7)
 
-        # Only the events.jsonl file should remain
-        files = list(tmp_path.iterdir())
-        assert len(files) == 1
-        assert files[0].name == "events.jsonl"
+        # events.jsonl must remain. The .events.jsonl.lock sidecar created by
+        # the file_lock concurrency guard is expected. No atomic_write .tmp
+        # orphans should survive.
+        names = {f.name for f in tmp_path.iterdir()}
+        assert "events.jsonl" in names
+        assert names <= {"events.jsonl", ".events.jsonl.lock"}
+        assert not any(name.endswith(".tmp") for name in names)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1198,3 +1198,93 @@ class TestRotateSyncOSError:
             event_log._rotate_sync(max_size_bytes=10, max_age_days=365)
 
         assert "Could not write rotated event log" in caplog.text
+
+
+class TestConcurrentWriteSafety:
+    """Regression tests for issues #6177 and #6178.
+
+    #6177: append_jsonl() lacks file locking — concurrent appends race.
+    #6178: rotate() + concurrent appends — events written between read
+    and atomic_write's os.replace() go to the old (unlinked) inode and
+    are silently lost.
+    """
+
+    def test_concurrent_appends_all_persist(self, tmp_path: Path) -> None:
+        """All events from N threads appending concurrently must land in the file."""
+        import threading
+
+        log_path = tmp_path / "events.jsonl"
+        event_log = EventLog(log_path)
+        n_threads = 20
+        per_thread = 10
+
+        def _append_batch(worker_id: int) -> None:
+            for i in range(per_thread):
+                event = HydraFlowEvent(
+                    type=EventType.PHASE_CHANGE,
+                    data={"worker": worker_id, "i": i},
+                )
+                event_log._append_sync(event.model_dump_json())
+
+        threads = [
+            threading.Thread(target=_append_batch, args=(w,)) for w in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        lines = log_path.read_text().strip().splitlines()
+        assert len(lines) == n_threads * per_thread
+        # Each line must be valid JSON — no partial/torn writes
+        for raw in lines:
+            HydraFlowEvent.model_validate_json(raw)
+
+    def test_rotation_does_not_lose_concurrent_appends(self, tmp_path: Path) -> None:
+        """Events appended while rotation is holding the lock must survive.
+
+        The fix's file_lock() on both _append_sync and _rotate_sync
+        serializes them — appends block while rotate reads+writes, so
+        no event lands in the unlinked-post-replace inode.
+        """
+        import threading
+
+        log_path = tmp_path / "events.jsonl"
+        event_log = EventLog(log_path)
+
+        # Seed with enough data to trigger rotation (recent events, within max_age)
+        seed_event = HydraFlowEvent(type=EventType.PHASE_CHANGE, data={"seed": 1})
+        log_path.write_text((seed_event.model_dump_json() + "\n") * 500)
+
+        rotate_started = threading.Event()
+        rotate_done = threading.Event()
+
+        def _rotate() -> None:
+            rotate_started.set()
+            event_log._rotate_sync(max_size_bytes=1000, max_age_days=365)
+            rotate_done.set()
+
+        def _concurrent_appends() -> None:
+            rotate_started.wait()
+            for i in range(20):
+                event = HydraFlowEvent(
+                    type=EventType.PHASE_CHANGE,
+                    data={"concurrent": i},
+                )
+                event_log._append_sync(event.model_dump_json())
+
+        rotate_thread = threading.Thread(target=_rotate)
+        append_thread = threading.Thread(target=_concurrent_appends)
+        rotate_thread.start()
+        append_thread.start()
+        rotate_thread.join()
+        append_thread.join()
+
+        assert rotate_done.is_set()
+        lines = log_path.read_text().strip().splitlines()
+        # All 20 concurrent appends must be present in the final file,
+        # regardless of whether they landed before or after rotation.
+        concurrent_count = sum(1 for raw in lines if '"concurrent"' in raw)
+        assert concurrent_count == 20, (
+            f"Expected 20 concurrent events preserved, got {concurrent_count}"
+        )


### PR DESCRIPTION
## Summary

Two related concurrency bugs in EventLog, fixed together because they share a mechanism.

### #6177 — append_jsonl has no file locking
\`EventLog._append_sync\` called \`append_jsonl()\` without any lock. Concurrent \`asyncio.to_thread\` dispatches could race; POSIX small-append atomicity is filesystem-dependent and untested under high concurrency.

### #6178 — rotation races in-flight appends
\`EventLog._rotate_sync\` used \`atomic_write\` (temp + \`os.replace\`). Any append racing between the rotation's read and the \`os.replace\` landed in the old (now unlinked) inode and was silently lost. Classic log-rotation-during-writes problem.

## Fix

Each EventLog instance gets a sibling \`.{name}.lock\` file. Both \`_append_sync\` and \`_rotate_sync\` wrap their operations in \`file_lock(self._lock_path)\`. Appends block while rotation holds the lock and vice versa.

Pattern mirrors the existing \`prompt_telemetry\` locking.

## Regression tests

- **test_concurrent_appends_all_persist** — 20 threads × 10 events each; file must contain 200 valid JSON lines with no torn writes.
- **test_rotation_does_not_lose_concurrent_appends** — 20 appends race a rotate; all 20 must survive in the final file.
- **test_no_temp_files_left_after_rotation** updated to allow the \`.lock\` sidecar (still catches \`.tmp\` orphans from \`atomic_write\`).

## Test plan

- [x] \`pytest tests/test_events.py tests/test_event_payloads.py tests/test_event_persistence.py tests/test_event_reducer_coverage.py\` — 205 pass, 0 fail
- [x] New regression tests exercise the race conditions the fix prevents
- [x] OSError handling preserved: lock-acquisition failure logs \"Could not read event log for rotation\" and returns (matches prior semantics)

Closes #6177
Closes #6178