### PR TITLE
fix(hindsight_wal): serialize file ops with threading.RLock

### DIFF
--- a/src/hindsight_wal.py
+++ b/src/hindsight_wal.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -45,69 +46,84 @@ class HindsightWAL:
         self._path = wal_path
         self._max_entries = max_entries
         self._max_retries = max_retries
+        # Re-entrant lock so internal callers (e.g. append → _trim → load/
+        # write_all) don't deadlock on the same lock. Serializes all file
+        # operations so concurrent append() and replay() can't duplicate or
+        # lose entries.
+        self._lock = threading.RLock()
 
     def append(self, entry: WALEntry) -> None:
         """Append a failed retain to the WAL (sync, crash-safe)."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with self._path.open("a") as f:
-                f.write(entry.model_dump_json() + "\n")
-                f.flush()
-            self._trim()
+        with self._lock:
             try:
-                import sentry_sdk as _sentry
+                with self._path.open("a") as f:
+                    f.write(entry.model_dump_json() + "\n")
+                    f.flush()
+                self._trim()
+                try:
+                    import sentry_sdk as _sentry
 
-                _sentry.add_breadcrumb(
-                    category="hindsight_wal.buffered",
-                    message=f"WAL entry buffered for bank={entry.bank}",
-                    level="info",
-                    data={"bank": entry.bank, "entry_count": self.count},
+                    _sentry.add_breadcrumb(
+                        category="hindsight_wal.buffered",
+                        message=f"WAL entry buffered for bank={entry.bank}",
+                        level="info",
+                        data={"bank": entry.bank, "entry_count": self.count},
+                    )
+                except ImportError:
+                    pass
+            except OSError:
+                logger.warning(
+                    "Could not write to WAL at %s", self._path, exc_info=True
                 )
-            except ImportError:
-                pass
-        except OSError:
-            logger.warning("Could not write to WAL at %s", self._path, exc_info=True)
 
     def load(self) -> list[WALEntry]:
         """Load all pending WAL entries."""
-        if not self._path.is_file():
-            return []
-        entries: list[WALEntry] = []
-        for line in self._path.read_text().splitlines():
-            stripped = line.strip()
-            if not stripped:
-                continue
-            try:
-                entries.append(WALEntry.model_validate_json(stripped))
-            except (ValueError, KeyError):
-                logger.warning("Skipping corrupt WAL entry: %s", stripped[:80])
-        return entries
+        with self._lock:
+            if not self._path.is_file():
+                return []
+            entries: list[WALEntry] = []
+            for line in self._path.read_text().splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    entries.append(WALEntry.model_validate_json(stripped))
+                except (ValueError, KeyError):
+                    logger.warning("Skipping corrupt WAL entry: %s", stripped[:80])
+            return entries
 
     def write_all(self, entries: list[WALEntry]) -> None:
         """Rewrite the WAL with the given entries (atomic replace)."""
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            content = "\n".join(e.model_dump_json() for e in entries)
-            if content:
-                content += "\n"
-            self._path.write_text(content)
-        except OSError:
-            logger.warning("Could not rewrite WAL at %s", self._path, exc_info=True)
+        with self._lock:
+            try:
+                content = "\n".join(e.model_dump_json() for e in entries)
+                if content:
+                    content += "\n"
+                self._path.write_text(content)
+            except OSError:
+                logger.warning("Could not rewrite WAL at %s", self._path, exc_info=True)
 
     def clear(self) -> None:
         """Remove all WAL entries."""
-        if self._path.is_file():
-            self._path.write_text("")
+        with self._lock:
+            if self._path.is_file():
+                self._path.write_text("")
 
     @property
     def count(self) -> int:
         """Number of pending entries."""
-        if not self._path.is_file():
-            return 0
-        return sum(1 for line in self._path.read_text().splitlines() if line.strip())
+        with self._lock:
+            if not self._path.is_file():
+                return 0
+            return sum(
+                1 for line in self._path.read_text().splitlines() if line.strip()
+            )
 
     def _trim(self) -> None:
         """Drop oldest entries if WAL exceeds max_entries."""
+        # Caller holds self._lock; load/write_all re-acquire via RLock.
         entries = self.load()
         if len(entries) > self._max_entries:
             dropped = len(entries) - self._max_entries
@@ -119,39 +135,45 @@ class HindsightWAL:
         """Replay all pending entries against Hindsight.
 
         Returns ``{"replayed": N, "failed": N, "dropped": N}``.
+
+        The lock is held across the entire replay so concurrent append()
+        calls serialize behind replay. This trades latency on failing
+        appends (rare — only during Hindsight outages) for correctness:
+        no duplicate retains, no lost appends from read/write races.
         """
-        entries = self.load()
-        if not entries:
-            return {"replayed": 0, "failed": 0, "dropped": 0}
+        with self._lock:
+            entries = self.load()
+            if not entries:
+                return {"replayed": 0, "failed": 0, "dropped": 0}
 
-        remaining: list[WALEntry] = []
-        replayed = 0
-        dropped = 0
+            remaining: list[WALEntry] = []
+            replayed = 0
+            dropped = 0
 
-        for entry in entries:
-            try:
-                await client.retain(
-                    entry.bank,
-                    entry.content,
-                    context=entry.context,
-                    metadata=entry.metadata or None,
-                )
-                replayed += 1
-            except Exception:
-                entry.retries += 1
-                if entry.retries >= self._max_retries:
-                    dropped += 1
-                    logger.warning(
-                        "WAL entry dropped after %d retries: bank=%s content=%s",
-                        entry.retries,
+            for entry in entries:
+                try:
+                    await client.retain(
                         entry.bank,
-                        entry.content[:60],
+                        entry.content,
+                        context=entry.context,
+                        metadata=entry.metadata or None,
                     )
-                else:
-                    remaining.append(entry)
+                    replayed += 1
+                except Exception:
+                    entry.retries += 1
+                    if entry.retries >= self._max_retries:
+                        dropped += 1
+                        logger.warning(
+                            "WAL entry dropped after %d retries: bank=%s content=%s",
+                            entry.retries,
+                            entry.bank,
+                            entry.content[:60],
+                        )
+                    else:
+                        remaining.append(entry)
 
-        self.write_all(remaining)
-        failed = len(remaining)
+            self.write_all(remaining)
+            failed = len(remaining)
 
         if failed > 0:
             try:

--- a/tests/test_hindsight_wal.py
+++ b/tests/test_hindsight_wal.py
@@ -335,3 +335,76 @@ class TestWALSentryBreadcrumbs:
                 if c[1].get("category") == "hindsight_wal.replay_failed"
             ]
             assert len(replay_call) == 1
+
+
+# ---------------------------------------------------------------------------
+# Concurrency regression — #6142
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentAppendReplaySafety:
+    """Regression tests for issue #6142.
+
+    HindsightWAL file ops (append / _trim / load / write_all) had no locking.
+    append() (sync, called from async code) and replay() (async) could race:
+    an append between replay's load() and write_all() would be overwritten
+    and silently lost. The RLock fix serializes file ops.
+    """
+
+    @pytest.mark.asyncio
+    async def test_append_during_replay_is_not_lost(self, tmp_path: Path) -> None:
+        """An append() racing replay() must survive the write_all that rebuilds the WAL."""
+        import threading
+
+        wal = HindsightWAL(tmp_path / "wal.jsonl")
+        # Seed with 5 entries that will replay successfully (client.retain stub OK)
+        for i in range(5):
+            wal.append(WALEntry(bank="seed", content=f"seed-{i}"))
+        assert wal.count == 5
+
+        # Gate the replay's retain so we can append mid-flight
+        first_retain_seen = threading.Event()
+        gate = threading.Event()
+
+        async def _gated_retain(*args: object, **kwargs: object) -> None:
+            first_retain_seen.set()
+            # Hold the replay in-progress until the appender has had time
+            # to race us; gate.wait is blocking so we let the event loop
+            # handle the appender thread via asyncio.to_thread-free sleep.
+            while not gate.is_set():
+                await asyncio.sleep(0.01)
+
+        client = MagicMock()
+        client.retain = AsyncMock(side_effect=_gated_retain)
+
+        appended_count = 0
+
+        def _append_new() -> None:
+            """Runs in a separate thread. Blocks on the RLock until replay finishes."""
+            nonlocal appended_count
+            first_retain_seen.wait()
+            # The RLock in append() will make this block until replay() releases.
+            for i in range(3):
+                wal.append(WALEntry(bank="new", content=f"new-{i}"))
+                appended_count += 1
+
+        appender = threading.Thread(target=_append_new)
+        appender.start()
+
+        replay_task = asyncio.create_task(wal.replay(client))
+        # Let replay get past its first retain so first_retain_seen fires
+        await asyncio.sleep(0.05)
+        # Release the gate so replay can finish its remaining retains
+        gate.set()
+        result = await replay_task
+        appender.join(timeout=2.0)
+
+        # All 5 seeds replayed → 0 remaining from replay, plus 3 appends = 3 total
+        assert result == {"replayed": 5, "failed": 0, "dropped": 0}
+        assert appended_count == 3
+        entries = wal.load()
+        new_entries = [e for e in entries if e.bank == "new"]
+        assert len(new_entries) == 3, (
+            f"All 3 appends during replay must survive the terminal write_all; "
+            f"got {len(new_entries)} new entries in final WAL: {entries}"
+        )


### PR DESCRIPTION
## Summary

Closes #6142 — the last of the Group B queue.

\`HindsightWAL\` had no locking. \`append()\` (sync, called from async failure paths in \`retain_safe\`) and \`replay()\` (async, every 60s via \`run_wal_replay_loop\`) could race:

- \`append()\` calls \`_trim\` which does \`load → write_all\`. Concurrent with \`replay\`'s \`load → network → write_all\`, either side could overwrite the other.
- An append landing between \`replay\`'s \`load()\` and its terminal \`write_all()\` was the concrete data-loss scenario — the new entry would be silently dropped when replay rewrote with just its remaining set.

## Fix

Add \`threading.RLock\` to \`HindsightWAL\`. Every public method (\`append\`, \`load\`, \`write_all\`, \`clear\`, \`count\`, \`replay\`) wraps its file ops in \`with self._lock:\`.

\`replay\` holds the lock across its entire body, including the \`await client.retain()\` calls. Acceptable: failing retains only append during Hindsight outages; normal replays are fast.

**RLock** (not plain Lock) because \`append → _trim → load/write_all\` re-enters from within the same thread.

## Regression test

\`test_append_during_replay_is_not_lost\`:
1. Seeds WAL with 5 entries
2. Starts replay against a gated retain stub
3. Spawns a thread that calls \`append()\` 3 times once replay's first retain is in flight
4. Asserts all 3 new entries survive replay's final \`write_all\`

Without the lock, the 3 appends would be overwritten and lost.

## Test plan

- [x] \`pytest tests/test_hindsight_wal.py\` — 24 pass, 0 fail (23 existing + 1 new)
- [x] ruff + pyright clean
- [x] Re-entrant calls (append → _trim → load/write_all) don't deadlock

Closes #6142