### PR TITLE
test(scenarios): phase 3a — behavior decorators + fidelity scenarios

### DIFF
--- a/tests/scenarios/behaviors/__init__.py
+++ b/tests/scenarios/behaviors/__init__.py
@@ -1,6 +1,7 @@
 from tests.scenarios.behaviors.eventual_consistency import EventuallyConsistent
 from tests.scenarios.behaviors.flaky import Flaky, FlakyError
 from tests.scenarios.behaviors.latency import Latency
+from tests.scenarios.behaviors.quota import Quota, QuotaExceeded
 from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
 
 __all__ = [
@@ -8,6 +9,8 @@ __all__ = [
     "Flaky",
     "FlakyError",
     "Latency",
+    "Quota",
+    "QuotaExceeded",
     "RateLimitExceeded",
     "RateLimited",
 ]

--- a/tests/scenarios/behaviors/__init__.py
+++ b/tests/scenarios/behaviors/__init__.py
@@ -1,11 +1,13 @@
 from tests.scenarios.behaviors.eventual_consistency import EventuallyConsistent
 from tests.scenarios.behaviors.flaky import Flaky, FlakyError
+from tests.scenarios.behaviors.latency import Latency
 from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
 
 __all__ = [
     "EventuallyConsistent",
     "Flaky",
     "FlakyError",
+    "Latency",
     "RateLimitExceeded",
     "RateLimited",
 ]

--- a/tests/scenarios/behaviors/__init__.py
+++ b/tests/scenarios/behaviors/__init__.py
@@ -1,3 +1,4 @@
+from tests.scenarios.behaviors.eventual_consistency import EventuallyConsistent
 from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
 
-__all__ = ["RateLimitExceeded", "RateLimited"]
+__all__ = ["EventuallyConsistent", "RateLimitExceeded", "RateLimited"]

--- a/tests/scenarios/behaviors/__init__.py
+++ b/tests/scenarios/behaviors/__init__.py
@@ -1,0 +1,3 @@
+from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
+
+__all__ = ["RateLimitExceeded", "RateLimited"]

--- a/tests/scenarios/behaviors/__init__.py
+++ b/tests/scenarios/behaviors/__init__.py
@@ -1,4 +1,11 @@
 from tests.scenarios.behaviors.eventual_consistency import EventuallyConsistent
+from tests.scenarios.behaviors.flaky import Flaky, FlakyError
 from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
 
-__all__ = ["EventuallyConsistent", "RateLimitExceeded", "RateLimited"]
+__all__ = [
+    "EventuallyConsistent",
+    "Flaky",
+    "FlakyError",
+    "RateLimitExceeded",
+    "RateLimited",
+]

--- a/tests/scenarios/behaviors/eventual_consistency.py
+++ b/tests/scenarios/behaviors/eventual_consistency.py
@@ -1,0 +1,63 @@
+"""EventuallyConsistent — simulates read-after-write staleness.
+
+Strategy: snapshot state before a watched write; serve the snapshot for the
+next N watched reads, then flip to current state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+from typing import Any
+
+
+class EventuallyConsistent:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        delay_reads: int,
+        watch_writes: list[str],
+        watch_reads: list[str],
+    ) -> None:
+        self._wrapped = wrapped
+        self._delay_reads = delay_reads
+        self._watch_writes = set(watch_writes)
+        self._watch_reads = set(watch_reads)
+        self._pending_reads = 0
+        self._snapshot: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._wrapped, name)
+
+        if name in self._watch_writes and callable(attr):
+            if asyncio.iscoroutinefunction(attr):
+
+                async def _async_write_wrapper(*args: Any, **kwargs: Any) -> Any:
+                    # Snapshot BEFORE applying the write.
+                    self._snapshot = copy.deepcopy(self._wrapped)
+                    self._pending_reads = self._delay_reads
+                    return await attr(*args, **kwargs)
+
+                return _async_write_wrapper
+
+            def _write_wrapper(*args: Any, **kwargs: Any) -> Any:
+                # Snapshot BEFORE applying the write.
+                self._snapshot = copy.deepcopy(self._wrapped)
+                self._pending_reads = self._delay_reads
+                return attr(*args, **kwargs)
+
+            return _write_wrapper
+
+        if name in self._watch_reads and callable(attr):
+
+            def _read_wrapper(*args: Any, **kwargs: Any) -> Any:
+                if self._pending_reads > 0 and self._snapshot is not None:
+                    self._pending_reads -= 1
+                    stale_attr = getattr(self._snapshot, name)
+                    return stale_attr(*args, **kwargs)
+                return attr(*args, **kwargs)
+
+            return _read_wrapper
+
+        return attr

--- a/tests/scenarios/behaviors/flaky.py
+++ b/tests/scenarios/behaviors/flaky.py
@@ -1,0 +1,49 @@
+"""Flaky — deterministic failure injection for the first N calls of listed methods."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class FlakyError(Exception):
+    """Raised by Flaky decorator on scripted failure calls."""
+
+
+class Flaky:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        fail_first: int,
+        methods: list[str] | None = None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._fail_first = fail_first
+        self._failed_so_far = 0
+        self._methods = set(methods or [])
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._wrapped, name)
+        if name not in self._methods or not callable(attr):
+            return attr
+
+        if asyncio.iscoroutinefunction(attr):
+
+            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                if self._failed_so_far < self._fail_first:
+                    self._failed_so_far += 1
+                    msg = f"flaky failure #{self._failed_so_far} on {name!r}"
+                    raise FlakyError(msg)
+                return await attr(*args, **kwargs)  # pyright: ignore[reportGeneralTypeIssues]
+
+            return _async_wrapper
+
+        def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            if self._failed_so_far < self._fail_first:
+                self._failed_so_far += 1
+                msg = f"flaky failure #{self._failed_so_far} on {name!r}"
+                raise FlakyError(msg)
+            return attr(*args, **kwargs)
+
+        return _sync_wrapper

--- a/tests/scenarios/behaviors/latency.py
+++ b/tests/scenarios/behaviors/latency.py
@@ -1,0 +1,40 @@
+"""Latency — advances a test clock for each call to a listed method."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class Latency:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        clock: Any,
+        delay_seconds: float,
+        methods: list[str] | None = None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._clock = clock
+        self._delay = delay_seconds
+        self._methods = set(methods or [])
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._wrapped, name)
+        if name not in self._methods or not callable(attr):
+            return attr
+
+        if asyncio.iscoroutinefunction(attr):
+
+            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                self._clock.advance(self._delay)
+                return await attr(*args, **kwargs)  # pyright: ignore[reportGeneralTypeIssues]
+
+            return _async_wrapper
+
+        def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            self._clock.advance(self._delay)
+            return attr(*args, **kwargs)
+
+        return _sync_wrapper

--- a/tests/scenarios/behaviors/quota.py
+++ b/tests/scenarios/behaviors/quota.py
@@ -1,0 +1,61 @@
+"""Quota — simulates Anthropic credit exhaustion.
+
+Decrements a budget per listed method call. On exhaustion, raises
+``QuotaExceeded`` with a ``resume_at`` attribute (future timestamp string).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class QuotaExceeded(Exception):
+    def __init__(self, message: str, *, resume_at: str) -> None:
+        super().__init__(message)
+        self.resume_at = resume_at
+
+
+class Quota:
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        budget: int,
+        methods: list[str] | None = None,
+        resume_at: str = "2099-01-01T00:00:00Z",
+    ) -> None:
+        self._wrapped = wrapped
+        self._initial_budget = budget
+        self._remaining = budget
+        self._methods = set(methods or [])
+        self._resume_at = resume_at
+
+    @property
+    def remaining(self) -> int:
+        return self._remaining
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._wrapped, name)
+        if name not in self._methods or not callable(attr):
+            return attr
+
+        if asyncio.iscoroutinefunction(attr):
+
+            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                if self._remaining <= 0:
+                    msg = f"quota exhausted on {name!r} (resume_at={self._resume_at})"
+                    raise QuotaExceeded(msg, resume_at=self._resume_at)
+                self._remaining -= 1
+                return await attr(*args, **kwargs)  # pyright: ignore[reportGeneralTypeIssues]
+
+            return _async_wrapper
+
+        def _sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            if self._remaining <= 0:
+                msg = f"quota exhausted on {name!r} (resume_at={self._resume_at})"
+                raise QuotaExceeded(msg, resume_at=self._resume_at)
+            self._remaining -= 1
+            return attr(*args, **kwargs)
+
+        return _sync_wrapper

--- a/tests/scenarios/behaviors/rate_limit.py
+++ b/tests/scenarios/behaviors/rate_limit.py
@@ -55,7 +55,7 @@ class RateLimited:
                         )
                         raise RateLimitExceeded(msg)
                     self_ref._remaining -= 1
-                    return await attr(*args, **kwargs)
+                    return await attr(*args, **kwargs)  # pyright: ignore[reportGeneralTypeIssues]
 
                 return _gated_async
 

--- a/tests/scenarios/behaviors/rate_limit.py
+++ b/tests/scenarios/behaviors/rate_limit.py
@@ -1,0 +1,80 @@
+"""RateLimited — wraps any port and injects RateLimitExceeded after budget exhaustion.
+
+Scoped to methods listed in the ``methods`` kwarg. Other methods pass through
+unchanged. Call ``refill()`` to reset the budget in tests.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RateLimitExceeded(Exception):
+    """Raised when the wrapped port exhausts its rate-limit budget."""
+
+
+class RateLimited:
+    """Budget-bounded wrapper that passes calls through to a wrapped port.
+
+    ``RateLimited(port, budget=5, methods=["get_pr_diff"])`` decrements the
+    budget on each listed method call; raises ``RateLimitExceeded`` when
+    budget hits zero. Unlisted methods are not metered.
+    """
+
+    def __init__(
+        self,
+        wrapped: Any,
+        *,
+        budget: int,
+        methods: list[str] | None = None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._initial_budget = budget
+        self._remaining = budget
+        self._methods = set(methods or [])
+
+    def refill(self) -> None:
+        self._remaining = self._initial_budget
+
+    def __getattr__(self, name: str) -> Any:
+        attr = getattr(self._wrapped, name)
+        if name not in self._methods:
+            return attr
+        # Intercept — decrement budget before delegating.
+        if callable(attr):
+            remaining = self._remaining
+            self_ref = self
+
+            if _is_coroutine_method(attr):
+
+                async def _gated_async(*args: Any, **kwargs: Any) -> Any:
+                    if self_ref._remaining <= 0:
+                        msg = (
+                            f"rate-limit budget exhausted on {name!r} "
+                            f"(initial={self_ref._initial_budget})"
+                        )
+                        raise RateLimitExceeded(msg)
+                    self_ref._remaining -= 1
+                    return await attr(*args, **kwargs)
+
+                return _gated_async
+
+            def _gated_sync(*args: Any, **kwargs: Any) -> Any:
+                if self_ref._remaining <= 0:
+                    msg = (
+                        f"rate-limit budget exhausted on {name!r} "
+                        f"(initial={self_ref._initial_budget})"
+                    )
+                    raise RateLimitExceeded(msg)
+                self_ref._remaining -= 1
+                return attr(*args, **kwargs)
+
+            _ = remaining  # silence unused
+            return _gated_sync
+        return attr
+
+
+def _is_coroutine_method(fn: Any) -> bool:
+    import asyncio  # noqa: PLC0415
+
+    return asyncio.iscoroutinefunction(fn)

--- a/tests/scenarios/behaviors/test_eventual_consistency.py
+++ b/tests/scenarios/behaviors/test_eventual_consistency.py
@@ -1,0 +1,32 @@
+"""EventuallyConsistent — delays visibility of writes for N subsequent reads."""
+
+from __future__ import annotations
+
+from tests.scenarios.behaviors.eventual_consistency import EventuallyConsistent
+from tests.scenarios.fakes.fake_github import FakeGitHub
+
+
+async def test_write_visible_after_N_reads() -> None:
+    gh = FakeGitHub()
+    gh.add_issue(1, "A", "body")
+    wrapped = EventuallyConsistent(
+        gh, delay_reads=2, watch_writes=["add_labels"], watch_reads=["issue"]
+    )
+    # Stage a "write" via the pass-through then assert stale views for N reads.
+    await wrapped.add_labels(1, ["fresh"])
+    # Immediate reads see stale state (0 labels before "fresh").
+    snap1 = wrapped.issue(1)
+    snap2 = wrapped.issue(1)
+    # After N (2) stale reads, the label is visible.
+    snap3 = wrapped.issue(1)
+    assert "fresh" not in snap1.labels
+    assert "fresh" not in snap2.labels
+    assert "fresh" in snap3.labels
+
+
+def test_unwatched_methods_pass_through() -> None:
+    gh = FakeGitHub()
+    gh.add_issue(1, "A", "body")
+    wrapped = EventuallyConsistent(gh, delay_reads=2, watch_writes=[], watch_reads=[])
+    # No methods watched: behaves identical to underlying.
+    assert wrapped.issue(1).title == "A"

--- a/tests/scenarios/behaviors/test_flaky.py
+++ b/tests/scenarios/behaviors/test_flaky.py
@@ -1,0 +1,26 @@
+"""Flaky — injects deterministic failures for N of M calls."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.behaviors.flaky import Flaky, FlakyError
+from tests.scenarios.fakes.fake_github import FakeGitHub
+
+
+async def test_first_n_calls_fail_then_succeed() -> None:
+    gh = FakeGitHub()
+    wrapped = Flaky(gh, fail_first=2, methods=["get_pr_diff"])
+    with pytest.raises(FlakyError):
+        await wrapped.get_pr_diff(1)
+    with pytest.raises(FlakyError):
+        await wrapped.get_pr_diff(1)
+    # Third call succeeds.
+    assert await wrapped.get_pr_diff(1) == "diff --git a/x b/x"
+
+
+async def test_unwatched_methods_pass_through() -> None:
+    gh = FakeGitHub()
+    gh.add_issue(1, "A", "B")
+    wrapped = Flaky(gh, fail_first=5, methods=["get_pr_diff"])
+    assert wrapped.issue(1).title == "A"

--- a/tests/scenarios/behaviors/test_latency.py
+++ b/tests/scenarios/behaviors/test_latency.py
@@ -1,0 +1,25 @@
+"""Latency — adds clock-driven delay to listed methods."""
+
+from __future__ import annotations
+
+from tests.scenarios.behaviors.latency import Latency
+from tests.scenarios.fakes.fake_clock import FakeClock
+from tests.scenarios.fakes.fake_github import FakeGitHub
+
+
+async def test_latency_advances_clock() -> None:
+    gh = FakeGitHub()
+    clock = FakeClock(start=1000.0)
+    wrapped = Latency(gh, clock=clock, delay_seconds=0.5, methods=["get_pr_diff"])
+    assert clock.now() == 1000.0
+    await wrapped.get_pr_diff(1)
+    assert clock.now() == 1000.5
+
+
+async def test_unwatched_method_does_not_advance() -> None:
+    gh = FakeGitHub()
+    gh.add_issue(1, "A", "B")
+    clock = FakeClock(start=500.0)
+    wrapped = Latency(gh, clock=clock, delay_seconds=0.1, methods=["get_pr_diff"])
+    _ = wrapped.issue(1)
+    assert clock.now() == 500.0

--- a/tests/scenarios/behaviors/test_quota.py
+++ b/tests/scenarios/behaviors/test_quota.py
@@ -1,0 +1,32 @@
+"""Quota — Anthropic credit-exhaustion simulation."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.behaviors.quota import Quota, QuotaExceeded
+from tests.scenarios.fakes.fake_llm import FakeLLM
+
+
+async def test_quota_decrements_on_each_call() -> None:
+    llm = FakeLLM()
+    wrapped = Quota(llm.agents, budget=2, methods=["run"])
+    assert wrapped.remaining == 2
+
+    class _Task:
+        id = 1
+
+    await wrapped.run(_Task(), worktree_path="/tmp", branch="b")
+    assert wrapped.remaining == 1
+
+
+async def test_quota_exhausted_raises() -> None:
+    llm = FakeLLM()
+    wrapped = Quota(llm.agents, budget=1, methods=["run"])
+
+    class _Task:
+        id = 1
+
+    await wrapped.run(_Task(), worktree_path="/tmp", branch="b")
+    with pytest.raises(QuotaExceeded, match="resume_at"):
+        await wrapped.run(_Task(), worktree_path="/tmp", branch="b")

--- a/tests/scenarios/behaviors/test_rate_limit.py
+++ b/tests/scenarios/behaviors/test_rate_limit.py
@@ -1,0 +1,35 @@
+"""RateLimited behavior decorator — wraps any port and injects 403 after budget exhaustion."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.behaviors.rate_limit import RateLimited, RateLimitExceeded
+from tests.scenarios.fakes.fake_github import FakeGitHub
+
+
+async def test_under_budget_passes_through() -> None:
+    gh = FakeGitHub()
+    gh.add_issue(1, "x", "y")
+    wrapped = RateLimited(gh, budget=5, methods=["get_pr_diff"])
+    # Port method still callable; doesn't touch budget for unlisted methods.
+    assert wrapped.issue(1).title == "x"
+
+
+async def test_exceeds_budget_raises() -> None:
+    gh = FakeGitHub()
+    wrapped = RateLimited(gh, budget=2, methods=["get_pr_diff"])
+    await wrapped.get_pr_diff(1)
+    await wrapped.get_pr_diff(1)
+    with pytest.raises(RateLimitExceeded, match="budget"):
+        await wrapped.get_pr_diff(1)
+
+
+async def test_budget_refill_restores() -> None:
+    gh = FakeGitHub()
+    wrapped = RateLimited(gh, budget=1, methods=["get_pr_diff"])
+    await wrapped.get_pr_diff(1)
+    with pytest.raises(RateLimitExceeded):
+        await wrapped.get_pr_diff(1)
+    wrapped.refill()
+    await wrapped.get_pr_diff(1)  # no raise

--- a/tests/scenarios/test_fidelity.py
+++ b/tests/scenarios/test_fidelity.py
@@ -1,0 +1,148 @@
+"""Fidelity scenarios — behavior decorators against FakeGitHub / FakeLLM."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.behaviors import (
+    EventuallyConsistent,
+    Flaky,
+    FlakyError,
+    Latency,
+    Quota,
+    QuotaExceeded,
+    RateLimited,
+    RateLimitExceeded,
+)
+from tests.scenarios.fakes.fake_clock import FakeClock
+from tests.scenarios.fakes.fake_github import FakeGitHub
+from tests.scenarios.fakes.fake_llm import FakeLLM
+
+pytestmark = pytest.mark.scenario
+
+
+class TestF1RateLimitBudget:
+    async def test_primary_rate_limit_blocks_after_budget(self) -> None:
+        gh = RateLimited(FakeGitHub(), budget=2, methods=["get_pr_diff"])
+        await gh.get_pr_diff(1)
+        await gh.get_pr_diff(1)
+        with pytest.raises(RateLimitExceeded):
+            await gh.get_pr_diff(1)
+
+
+class TestF2RateLimitRefill:
+    async def test_refill_restores_access(self) -> None:
+        gh = RateLimited(FakeGitHub(), budget=1, methods=["get_pr_diff"])
+        await gh.get_pr_diff(1)
+        with pytest.raises(RateLimitExceeded):
+            await gh.get_pr_diff(1)
+        gh.refill()
+        await gh.get_pr_diff(1)  # ok
+
+
+class TestF3EventualConsistency:
+    async def test_write_is_stale_for_N_reads(self) -> None:
+        base = FakeGitHub()
+        base.add_issue(1, "A", "body")
+        gh = EventuallyConsistent(
+            base,
+            delay_reads=2,
+            watch_writes=["add_labels"],
+            watch_reads=["issue"],
+        )
+        await gh.add_labels(1, ["new"])
+        # N stale reads before catch-up
+        assert "new" not in gh.issue(1).labels
+        assert "new" not in gh.issue(1).labels
+        assert "new" in gh.issue(1).labels
+
+
+class TestF4FlakyRecovery:
+    async def test_first_two_fail_third_succeeds(self) -> None:
+        gh = Flaky(FakeGitHub(), fail_first=2, methods=["get_pr_diff"])
+        for _ in range(2):
+            with pytest.raises(FlakyError):
+                await gh.get_pr_diff(1)
+        assert await gh.get_pr_diff(1) == "diff --git a/x b/x"
+
+
+class TestF5LatencyAdvancesClock:
+    async def test_method_call_advances_fake_clock(self) -> None:
+        clock = FakeClock(start=0.0)
+        gh = Latency(
+            FakeGitHub(), clock=clock, delay_seconds=1.5, methods=["get_pr_diff"]
+        )
+        await gh.get_pr_diff(1)
+        assert clock.now() == 1.5
+
+
+class TestF6QuotaExhaustion:
+    async def test_llm_quota_exhausts_after_budget(self) -> None:
+        llm = FakeLLM()
+        wrapped = Quota(llm.agents, budget=1, methods=["run"])
+
+        class _Task:
+            id = 42
+
+        await wrapped.run(_Task(), worktree_path="/tmp", branch="b")
+        with pytest.raises(QuotaExceeded) as exc:
+            await wrapped.run(_Task(), worktree_path="/tmp", branch="b")
+        assert exc.value.resume_at  # has a resume timestamp
+
+
+class TestF7StackedRateAndLatency:
+    async def test_latency_then_rate_limit(self) -> None:
+        # Order: Latency outside, RateLimited inside
+        clock = FakeClock(start=0.0)
+        gh = Latency(
+            RateLimited(FakeGitHub(), budget=2, methods=["get_pr_diff"]),
+            clock=clock,
+            delay_seconds=0.25,
+            methods=["get_pr_diff"],
+        )
+        await gh.get_pr_diff(1)
+        await gh.get_pr_diff(1)
+        assert clock.now() == 0.5
+        with pytest.raises(RateLimitExceeded):
+            await gh.get_pr_diff(1)
+
+
+class TestF8StackedReverseOrder:
+    async def test_rate_limit_then_latency(self) -> None:
+        # Order: RateLimited outside, Latency inside
+        clock = FakeClock(start=0.0)
+        gh = RateLimited(
+            Latency(
+                FakeGitHub(),
+                clock=clock,
+                delay_seconds=0.1,
+                methods=["get_pr_diff"],
+            ),
+            budget=1,
+            methods=["get_pr_diff"],
+        )
+        await gh.get_pr_diff(1)
+        assert clock.now() == 0.1
+        with pytest.raises(RateLimitExceeded):
+            await gh.get_pr_diff(1)
+        # Latency did NOT advance because outer rate-limit short-circuited.
+        assert clock.now() == 0.1
+
+
+class TestF9UnwatchedPassesThrough:
+    async def test_decorators_ignore_unlisted_methods(self) -> None:
+        gh = RateLimited(FakeGitHub(), budget=0, methods=["get_pr_diff"])
+        gh.add_issue(1, "A", "B")
+        assert gh.issue(1).title == "A"
+
+
+class TestF10FlakyOnlyAffectsListedMethod:
+    async def test_flaky_does_not_fail_other_methods(self) -> None:
+        base = FakeGitHub()
+        base.add_issue(1, "A", "B")
+        gh = Flaky(base, fail_first=10, methods=["get_pr_diff"])
+        # issue() is unlisted — always succeeds.
+        assert gh.issue(1).title == "A"
+        # get_pr_diff() fails per budget
+        with pytest.raises(FlakyError):
+            await gh.get_pr_diff(1)


### PR DESCRIPTION
## Summary

Phase 3A of the mock-the-world gap audit. **Base branch: `mock-world-phase2` (PR #7512).** Stacked on phases 1+2.

### Behavior decorators (5)

Each wraps any port via `__getattr__` and intercepts listed methods. Stackable: `RateLimited(Latency(FakeGitHub()))` composes cleanly.

- **`RateLimited(port, budget, methods)`** — raises `RateLimitExceeded` after budget exhaustion; `.refill()` resets
- **`EventuallyConsistent(port, delay_reads, watch_writes, watch_reads)`** — post-write reads see stale snapshot for N calls; async writes routed through async wrapper
- **`Flaky(port, fail_first, methods)`** — first N calls raise `FlakyError`; subsequent succeed
- **`Latency(port, clock, delay_seconds, methods)`** — advances a `FakeClock` on each listed call
- **`Quota(port, budget, methods, resume_at)`** — Anthropic credit exhaustion; raises `QuotaExceeded` with `resume_at`

### Scenarios

`tests/scenarios/test_fidelity.py` — 10 scenarios: rate-limit exhaustion + refill, eventual consistency staleness, flaky recovery, latency clock advance, quota exhaustion, **2 stack-order tests** (F7 `Latency(RateLimited(...))` + F8 reversed), 2 unwatched-pass-through tests.

## Test plan

- [x] `pytest tests/scenarios/ -v` — 141 passing (phase 1+2 baseline 120 + 10 fidelity + 11 decorator unit tests); 0 regressions
- [x] Each decorator independently unit-tested (5 test files)
- [x] Stack-order verified (F7/F8) — decorators compose in either direction with observable outer-wins semantics

## Out of scope (Phase 3B)

- 14 remaining loop registrations (RunsGC, Retrospective, ADRReviewer, GitHubCache, RepoWiki, Sentry, MemorySync, Diagnostic, CodeGrooming, ReportIssue, EpicSweeper, SecurityPatch, StaleIssue, EpicMonitor)
- 22 loop scenarios
- 7 concurrency/race scenarios for `test_edge.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)