### PR TITLE
test(scenarios): phase 4 — hypothesis fuzz over builders

### DIFF
--- a/tests/scenarios/fuzz/__init__.py
+++ b/tests/scenarios/fuzz/__init__.py
@@ -1,0 +1,1 @@
+"""Hypothesis-based fuzz tests for the scenario framework."""

--- a/tests/scenarios/fuzz/strategies.py
+++ b/tests/scenarios/fuzz/strategies.py
@@ -1,0 +1,111 @@
+"""Hypothesis strategies that produce builder instances.
+
+Strategies compose over the existing builders (IssueBuilder, PRBuilder,
+RepoStateBuilder) so fuzz tests reuse phase-1 seed plumbing. Each strategy
+draws structural fields only — values stay inside legal domains (e.g. label
+names from the state-machine set).
+"""
+
+from __future__ import annotations
+
+from hypothesis import strategies as st
+
+from tests.scenarios.builders.issue import IssueBuilder
+from tests.scenarios.builders.pr import PRBuilder
+from tests.scenarios.builders.repo import RepoStateBuilder
+
+# Valid labels from the hydraflow state machine (subset — extend as needed).
+_VALID_LABELS = [
+    "hydraflow-find",
+    "hydraflow-ready",
+    "hydraflow-planning",
+    "hydraflow-implementing",
+    "hydraflow-reviewing",
+    "hydraflow-done",
+    "hydraflow-hitl",
+    "hydraflow-ci-failure",
+]
+
+_CI_STATUSES = ["success", "failure", "pending"]
+
+
+def issue_numbers() -> st.SearchStrategy[int]:
+    return st.integers(min_value=1, max_value=9_999)
+
+
+def labels() -> st.SearchStrategy[list[str]]:
+    return st.lists(st.sampled_from(_VALID_LABELS), min_size=1, max_size=3, unique=True)
+
+
+def issue_titles() -> st.SearchStrategy[str]:
+    return st.text(
+        alphabet=st.characters(
+            min_codepoint=0x20, max_codepoint=0x7E, blacklist_characters=["`", '"']
+        ),
+        min_size=1,
+        max_size=80,
+    )
+
+
+@st.composite
+def issue_builders(draw: st.DrawFn) -> IssueBuilder:
+    """Strategy that draws a seeded IssueBuilder (not yet .at()-ed)."""
+    builder = (
+        IssueBuilder()
+        .numbered(draw(issue_numbers()))
+        .titled(draw(issue_titles()))
+        .bodied(draw(st.text(max_size=200)))
+        .labeled(*draw(labels()))
+    )
+    return builder
+
+
+@st.composite
+def pr_builders(draw: st.DrawFn) -> PRBuilder:
+    """Strategy that draws a PRBuilder for a given issue number."""
+    return (
+        PRBuilder()
+        .for_issue(draw(issue_numbers()))
+        .on_branch(f"hydraflow/{draw(issue_numbers())}-test")
+        .with_ci_status(draw(st.sampled_from(_CI_STATUSES)))
+    )
+
+
+@st.composite
+def repo_states(draw: st.DrawFn) -> RepoStateBuilder:
+    """Composite: a RepoStateBuilder with 1-5 issues and 0-3 PRs.
+
+    Deduplicates issue numbers within the batch so .at() doesn't hit the
+    FakeGitHub add_issue duplicate-number path.
+    """
+    issues = draw(st.lists(issue_builders(), min_size=1, max_size=5))
+    # Dedupe by number — strategy-level fix for the FakeGitHub constraint.
+    seen: set[int] = set()
+    deduped: list[IssueBuilder] = []
+    for ib in issues:
+        n = ib._number
+        if n is None or n in seen:
+            continue
+        seen.add(n)
+        deduped.append(ib)
+    if not deduped:
+        deduped = [draw(issue_builders())]
+
+    issue_numbers_in_state = [ib._number for ib in deduped if ib._number is not None]
+    prs = draw(
+        st.lists(
+            st.builds(
+                lambda n, status: (
+                    PRBuilder()
+                    .for_issue(n)
+                    .on_branch(f"hydraflow/{n}-test")
+                    .with_ci_status(status)
+                ),
+                st.sampled_from(issue_numbers_in_state or [1]),
+                st.sampled_from(_CI_STATUSES),
+            ),
+            min_size=0,
+            max_size=3,
+        )
+    )
+    return RepoStateBuilder().with_issues(deduped).with_prs(prs)

--- a/tests/scenarios/fuzz/test_invariants.py
+++ b/tests/scenarios/fuzz/test_invariants.py
@@ -1,0 +1,97 @@
+"""Property-based invariant tests.
+
+Each test draws 50-100 generated world states and asserts a framework-level
+invariant. Failures reveal builder or fake bugs that single hand-rolled
+scenarios wouldn't catch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+
+from tests.scenarios.builders.issue import IssueBuilder
+from tests.scenarios.builders.pr import PRBuilder
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.fuzz.strategies import (
+    issue_builders,
+    pr_builders,
+    repo_states,
+)
+
+pytestmark = pytest.mark.scenario
+
+_DEFAULT_SETTINGS = settings(
+    max_examples=50,
+    deadline=None,  # disabled — async seeding varies per example
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+
+@given(builder=issue_builders())
+@_DEFAULT_SETTINGS
+async def test_issue_builder_never_raises(
+    tmp_path: Path, builder: IssueBuilder
+) -> None:
+    """IssueBuilder.at(world) should seed successfully for any valid draw."""
+    world = MockWorld(tmp_path)
+    issue = builder.at(world)
+    # Structural invariants: issue has a number and at least one label
+    assert issue.number >= 1
+    assert len(issue.labels) >= 1
+
+
+@given(builder=pr_builders())
+@_DEFAULT_SETTINGS
+async def test_pr_builder_links_to_issue(tmp_path: Path, builder: PRBuilder) -> None:
+    """For any PR draw, seeding its referenced issue then .at() seeds the PR."""
+    world = MockWorld(tmp_path)
+    issue_num = builder._issue_number
+    assert issue_num is not None  # strategy always sets it
+    IssueBuilder().numbered(issue_num).at(world)
+    pr = await builder.at(world)
+    assert pr.issue_number == issue_num
+
+
+@given(repo=repo_states())
+@_DEFAULT_SETTINGS
+async def test_repo_state_has_no_orphan_prs(tmp_path: Path, repo) -> None:
+    """For any repo state, every PR seeded references a seeded issue.
+
+    Strategy guarantees PRs only point at issues in the same state,
+    so this is a tautology — if it EVER fails, the strategy is broken.
+    """
+    world = MockWorld(tmp_path)
+    await repo.at(world)
+    # Every PR has a FakePR linked via issue_number
+    for pr_builder in repo._prs:
+        issue_num = pr_builder._issue_number
+        assert world.github.issue(issue_num).number == issue_num
+
+
+@given(repo=repo_states())
+@_DEFAULT_SETTINGS
+async def test_repo_state_labels_are_valid(tmp_path: Path, repo) -> None:
+    """Every seeded issue carries labels from the valid set."""
+    world = MockWorld(tmp_path)
+    await repo.at(world)
+    valid_labels = {
+        "hydraflow-find",
+        "hydraflow-ready",
+        "hydraflow-planning",
+        "hydraflow-implementing",
+        "hydraflow-reviewing",
+        "hydraflow-done",
+        "hydraflow-hitl",
+        "hydraflow-ci-failure",
+    }
+    for issue_builder in repo._issues:
+        num = issue_builder._number
+        if num is None:
+            continue
+        got = set(world.github.issue(num).labels)
+        assert got.issubset(valid_labels), (
+            f"unknown labels on {num}: {got - valid_labels}"
+        )


### PR DESCRIPTION
## Summary

Phase 4 of the mock-the-world gap audit. **Base: `mock-world-phase3b` (PR #7515).** Top of the 5-PR stack.

### Hypothesis strategies (`tests/scenarios/fuzz/strategies.py`)

Composes over existing builders:
- `issue_builders()` — draws `IssueBuilder` with numbered/titled/bodied/labeled fields
- `pr_builders()` — draws `PRBuilder` for a given issue number
- `repo_states()` — draws `RepoStateBuilder` with 1-5 issues + 0-3 PRs (dedup'd numbers)

### Invariant properties (`tests/scenarios/fuzz/test_invariants.py`)

Each property draws 50 examples:
- `test_issue_builder_never_raises` — any valid IssueBuilder draw seeds without exception
- `test_pr_builder_links_to_issue` — seeded PR always links to a seeded issue
- `test_repo_state_has_no_orphan_prs` — strategy-level tautology, canary
- `test_repo_state_labels_are_valid` — seeded labels always from the state-machine set

### Deferred

Golden-trace replay (design spec §4.6) deferred until a production trace-recorder lands. The MockWorld API already supports the replay pattern; just needs the recorder.

## Test plan

- [x] `pytest tests/scenarios/ -v` — 187 passing (phase 3b 183 + 4 fuzz properties × 50 examples = 200+ effective cases)
- [x] Hypothesis finds no counterexamples (all 4 properties hold across all draws)
- [x] Pre-existing suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)