### PR TITLE
fix(telemetry): detect Anthropic spend-cap rejections + zero phantom cost

### DIFF
--- a/scripts/cleanup_phantom_cost.py
+++ b/scripts/cleanup_phantom_cost.py
@@ -1,0 +1,264 @@
+"""Backfill the zero-usage-anomaly guard onto historical telemetry records.
+
+Rewrites ``.hydraflow/metrics/prompt/inferences.jsonl`` so that any record
+matching the zero-usage anomaly signature (success=True, zero actual tokens,
+usage_available=False, prompt_chars > threshold) is reclassified as
+status="failed", estimated_cost_usd=0.0, and tagged with
+usage_anomaly="zero_usage_with_prompt".
+
+Then rebuilds ``pr_stats.json`` from the cleaned record stream so lifetime,
+per-PR, per-issue, per-session, and per-source rollups reflect honest spend.
+
+Idempotent: records already tagged ``usage_anomaly`` are left alone. The
+original files are copied to ``inferences.jsonl.bak`` / ``pr_stats.json.bak``
+before rewriting.
+
+Usage:
+    python scripts/cleanup_phantom_cost.py                # dry-run report
+    python scripts/cleanup_phantom_cost.py --apply        # rewrite files
+    python scripts/cleanup_phantom_cost.py --path <jsonl> # custom location
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+# Must match src/prompt_telemetry.py::_ZERO_USAGE_PROMPT_THRESHOLD
+_ZERO_USAGE_PROMPT_THRESHOLD = 500
+
+
+def _is_anomaly(record: dict[str, object]) -> bool:
+    """Match the same signature as the runtime guard in PromptTelemetry.record."""
+    if record.get("usage_anomaly"):
+        return False  # already cleaned
+    if record.get("status") != "success":
+        return False
+    if record.get("usage_available"):
+        return False
+    if _as_int(record.get("input_tokens")) + _as_int(record.get("output_tokens")) > 0:
+        return False
+    return _as_int(record.get("prompt_chars")) > _ZERO_USAGE_PROMPT_THRESHOLD
+
+
+def _reclassify(record: dict[str, object]) -> dict[str, object]:
+    fixed = dict(record)
+    fixed["status"] = "failed"
+    fixed["estimated_cost_usd"] = 0.0
+    fixed["usage_anomaly"] = "zero_usage_with_prompt"
+    return fixed
+
+
+def _as_int(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _as_float(value: object) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0
+
+
+def _new_counter() -> dict[str, object]:
+    # Must match src/prompt_telemetry.py::_new_counter exactly — notably
+    # estimated_cost_usd is NOT seeded here; it appears only on first
+    # non-zero contribution, matching production counter shape.
+    return {
+        "inference_calls": 0,
+        "prompt_est_tokens": 0,
+        "total_est_tokens": 0,
+        "total_tokens": 0,
+        "history_chars_saved": 0,
+        "context_chars_saved": 0,
+        "cache_hits": 0,
+        "cache_misses": 0,
+        "actual_usage_calls": 0,
+        "usage_unavailable_calls": 0,
+        "pruned_chars_total": 0,
+        "last_updated": "",
+    }
+
+
+def _accumulate(target: dict[str, object], record: dict[str, object]) -> None:
+    """Mirror PromptTelemetry._accumulate_counter exactly."""
+    target["inference_calls"] = _as_int(target.get("inference_calls", 0)) + 1
+    for key in (
+        "prompt_est_tokens",
+        "total_est_tokens",
+        "total_tokens",
+        "history_chars_saved",
+        "context_chars_saved",
+        "cache_hits",
+        "cache_misses",
+        "pruned_chars_total",
+    ):
+        target[key] = _as_int(target.get(key, 0)) + _as_int(record.get(key, 0))
+    if record.get("token_source") == "actual":
+        target["actual_usage_calls"] = _as_int(target.get("actual_usage_calls", 0)) + 1
+    if record.get("usage_status") == "unavailable":
+        target["usage_unavailable_calls"] = (
+            _as_int(target.get("usage_unavailable_calls", 0)) + 1
+        )
+    record_cost = record.get("estimated_cost_usd")
+    if isinstance(record_cost, int | float) and record_cost > 0:
+        target["estimated_cost_usd"] = round(
+            _as_float(target.get("estimated_cost_usd", 0.0)) + float(record_cost),
+            6,
+        )
+    target["last_updated"] = str(record.get("timestamp", ""))
+
+
+def _rebuild_rollup(records: list[dict[str, object]]) -> dict[str, object]:
+    """Reconstruct pr_stats.json from a clean record stream."""
+    data: dict[str, object] = {
+        "lifetime": _new_counter(),
+        "sessions": {},
+        "prs": {},
+        "issues": {},
+        "sources": {},
+    }
+    for rec in records:
+        _accumulate(data["lifetime"], rec)  # type: ignore[arg-type]
+        session_id = str(rec.get("session_id", "")).strip()
+        if session_id:
+            sessions = data["sessions"]
+            assert isinstance(sessions, dict)
+            sessions.setdefault(session_id, _new_counter())
+            _accumulate(sessions[session_id], rec)
+        pr_number = rec.get("pr_number")
+        if isinstance(pr_number, int) and pr_number > 0:
+            prs = data["prs"]
+            assert isinstance(prs, dict)
+            key = str(pr_number)
+            prs.setdefault(key, _new_counter())
+            _accumulate(prs[key], rec)
+        issue_number = rec.get("issue_number")
+        if isinstance(issue_number, int) and issue_number > 0:
+            issues = data["issues"]
+            assert isinstance(issues, dict)
+            key = str(issue_number)
+            issues.setdefault(key, _new_counter())
+            _accumulate(issues[key], rec)
+        source = str(rec.get("source", "")).strip()
+        if source:
+            sources = data["sources"]
+            assert isinstance(sources, dict)
+            sources.setdefault(source, _new_counter())
+            _accumulate(sources[source], rec)
+    if records:
+        data["updated_at"] = str(records[-1].get("timestamp", ""))
+    return data
+
+
+def _load_jsonl(path: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    with path.open() as f:
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                rec = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict):
+                records.append(rec)
+    return records
+
+
+def _write_jsonl_atomic(path: Path, records: list[dict[str, object]]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w") as f:
+        for rec in records:
+            f.write(json.dumps(rec, sort_keys=True) + "\n")
+    tmp.replace(path)
+
+
+def run(jsonl_path: Path, *, apply: bool) -> int:
+    if not jsonl_path.is_file():
+        print(f"error: {jsonl_path} not found", file=sys.stderr)
+        return 1
+    pr_stats_path = jsonl_path.parent / "pr_stats.json"
+
+    records = _load_jsonl(jsonl_path)
+    total = len(records)
+    scanned, reclassified, phantom_cost = 0, 0, 0.0
+    cleaned: list[dict[str, object]] = []
+    for rec in records:
+        scanned += 1
+        if _is_anomaly(rec):
+            reclassified += 1
+            phantom_cost += _as_float(rec.get("estimated_cost_usd"))
+            cleaned.append(_reclassify(rec))
+        else:
+            cleaned.append(rec)
+
+    print(f"scanned:        {scanned}/{total}")
+    print(f"reclassified:   {reclassified}")
+    print(f"phantom cost:   ${phantom_cost:.4f} removed")
+
+    if not apply:
+        print("\nDRY-RUN — rerun with --apply to write changes.")
+        return 0
+
+    if reclassified == 0:
+        print("\nno changes to apply.")
+        return 0
+
+    bak = jsonl_path.with_suffix(jsonl_path.suffix + ".bak")
+    shutil.copy2(jsonl_path, bak)
+    print(f"\nbacked up:      {bak}")
+    _write_jsonl_atomic(jsonl_path, cleaned)
+    print(f"rewrote:        {jsonl_path} ({len(cleaned)} records)")
+
+    if pr_stats_path.is_file():
+        pr_bak = pr_stats_path.with_suffix(pr_stats_path.suffix + ".bak")
+        shutil.copy2(pr_stats_path, pr_bak)
+        print(f"backed up:      {pr_bak}")
+
+    rebuilt = _rebuild_rollup(cleaned)
+    pr_stats_path.write_text(json.dumps(rebuilt, indent=2, sort_keys=True))
+    print(f"rebuilt rollup: {pr_stats_path}")
+    lifetime = rebuilt["lifetime"]
+    assert isinstance(lifetime, dict)
+    print(f"lifetime cost:  ${_as_float(lifetime.get('estimated_cost_usd')):.4f}")
+    return 0
+
+
+def main() -> int:
+    default_path = (
+        Path(__file__).resolve().parent.parent
+        / ".hydraflow"
+        / "metrics"
+        / "prompt"
+        / "inferences.jsonl"
+    )
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=default_path,
+        help="Path to inferences.jsonl (default: repo-local .hydraflow)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually rewrite files; otherwise prints a dry-run report.",
+    )
+    args = parser.parse_args()
+    return run(args.path, apply=args.apply)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cost_report.py
+++ b/scripts/cost_report.py
@@ -1,0 +1,189 @@
+"""Print HydraFlow API spend breakdown from prompt telemetry.
+
+Reads ``.hydraflow/metrics/prompt/pr_stats.json`` for lifetime and per-source
+aggregates and, when available, ``inferences.jsonl`` for a per-(source, model)
+breakdown that exposes where Opus vs Sonnet cost actually lands.
+
+Usage:
+    python scripts/cost_report.py
+    python scripts/cost_report.py --data-root /custom/.hydraflow
+    python scripts/cost_report.py --top 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        print(f"error: {path} not found", file=sys.stderr)
+        sys.exit(1)
+    with path.open() as f:
+        return json.load(f)
+
+
+def _iter_jsonl(path: Path):
+    if not path.is_file():
+        return
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _fmt_money(x: float) -> str:
+    return f"${x:>10,.2f}"
+
+
+def _fmt_int(x: int) -> str:
+    return f"{x:>10,}"
+
+
+def _print_lifetime(lifetime: dict[str, Any]) -> None:
+    print("=" * 72)
+    print("LIFETIME TOTALS")
+    print("=" * 72)
+    cost = float(lifetime.get("estimated_cost_usd", 0.0) or 0.0)
+    calls = int(lifetime.get("inference_calls", 0) or 0)
+    tokens = int(lifetime.get("total_tokens", 0) or 0)
+    cache_hits = int(lifetime.get("cache_hits", 0) or 0)
+    cache_misses = int(lifetime.get("cache_misses", 0) or 0)
+    cache_total = cache_hits + cache_misses
+    hit_rate = (cache_hits / cache_total * 100) if cache_total else 0.0
+    print(f"  total spend         {_fmt_money(cost)}")
+    print(f"  inference calls     {_fmt_int(calls)}")
+    print(f"  total tokens        {_fmt_int(tokens)}")
+    print(
+        f"  cache hit rate      {hit_rate:>9.1f}%  ({cache_hits:,} hits / {cache_misses:,} misses)"
+    )
+    if calls:
+        print(f"  avg $/call          ${cost / calls:>9.4f}")
+    print()
+
+
+def _print_sources(sources: dict[str, Any], top: int) -> None:
+    print("=" * 72)
+    print(f"COST BY SOURCE (top {top})")
+    print("=" * 72)
+    rows = []
+    total_cost = 0.0
+    for name, payload in sources.items():
+        if not isinstance(payload, dict):
+            continue
+        cost = float(payload.get("estimated_cost_usd", 0.0) or 0.0)
+        calls = int(payload.get("inference_calls", 0) or 0)
+        rows.append((name, cost, calls))
+        total_cost += cost
+    rows.sort(key=lambda r: -r[1])
+    print(
+        f"  {'source':<22} {'cost':>12} {'% of total':>11} {'calls':>10} {'$/call':>10}"
+    )
+    print(f"  {'-' * 22} {'-' * 12} {'-' * 11} {'-' * 10} {'-' * 10}")
+    for name, cost, calls in rows[:top]:
+        pct = (cost / total_cost * 100) if total_cost else 0.0
+        per_call = (cost / calls) if calls else 0.0
+        print(
+            f"  {name:<22} {_fmt_money(cost)} {pct:>10.1f}% {_fmt_int(calls)} ${per_call:>9.4f}"
+        )
+    print()
+
+
+def _print_source_model_breakdown(inferences_path: Path, top: int) -> None:
+    if not inferences_path.is_file():
+        print(f"note: {inferences_path} not found — skipping per-model breakdown\n")
+        return
+    agg: dict[tuple[str, str], dict[str, float]] = defaultdict(
+        lambda: {"cost": 0.0, "calls": 0, "tokens": 0, "prompt_chars": 0}
+    )
+    for record in _iter_jsonl(inferences_path):
+        source = str(record.get("source", "?"))
+        model = str(record.get("model", "?"))
+        key = (source, model)
+        agg[key]["cost"] += float(record.get("estimated_cost_usd") or 0.0)
+        agg[key]["calls"] += 1
+        agg[key]["tokens"] += int(record.get("total_tokens") or 0)
+        agg[key]["prompt_chars"] += int(record.get("prompt_chars") or 0)
+
+    rows = [
+        (
+            source,
+            model,
+            v["cost"],
+            int(v["calls"]),
+            int(v["prompt_chars"]),
+        )
+        for (source, model), v in agg.items()
+    ]
+    rows.sort(key=lambda r: -r[2])
+
+    print("=" * 72)
+    print(f"COST BY SOURCE x MODEL (top {top})")
+    print("=" * 72)
+    print(
+        f"  {'source':<22} {'model':<14} {'cost':>12} {'calls':>8} "
+        f"{'$/call':>10} {'avg chars':>11}"
+    )
+    print(f"  {'-' * 22} {'-' * 14} {'-' * 12} {'-' * 8} {'-' * 10} {'-' * 11}")
+    for source, model, cost, calls, chars in rows[:top]:
+        per_call = (cost / calls) if calls else 0.0
+        avg_chars = (chars // calls) if calls else 0
+        print(
+            f"  {source:<22} {model:<14} {_fmt_money(cost)} "
+            f"{_fmt_int(calls).strip():>8} ${per_call:>9.4f} {avg_chars:>11,}"
+        )
+    print()
+
+
+def _default_data_root() -> Path:
+    return Path.cwd() / ".hydraflow"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Print HydraFlow API spend breakdown from prompt telemetry."
+    )
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=_default_data_root(),
+        help="HydraFlow data root (defaults to ./.hydraflow)",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=15,
+        help="Rows to show in each breakdown table",
+    )
+    args = parser.parse_args()
+
+    stats_path = args.data_root / "metrics" / "prompt" / "pr_stats.json"
+    inferences_path = args.data_root / "metrics" / "prompt" / "inferences.jsonl"
+
+    data = _load_json(stats_path)
+    updated = data.get("updated_at") or "unknown"
+    print(f"\nhydraflow cost report — stats as of {updated}\n")
+
+    lifetime = data.get("lifetime", {})
+    if isinstance(lifetime, dict):
+        _print_lifetime(lifetime)
+
+    sources = data.get("sources", {})
+    if isinstance(sources, dict) and sources:
+        _print_sources(sources, args.top)
+
+    _print_source_model_breakdown(inferences_path, args.top)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prompt_telemetry.py
+++ b/src/prompt_telemetry.py
@@ -19,6 +19,12 @@ _MODEL_CHARS_PER_TOKEN: tuple[tuple[tuple[str, ...], float, str], ...] = (
     (("claude", "sonnet", "opus"), 3.9, "medium"),
 )
 
+# Prompts smaller than this may legitimately return zero tokens (stubs,
+# no-ops, cached identity responses). Above the threshold, a zero-usage
+# "success" is almost always a CLI-swallowed API rejection (spend cap,
+# 400 invalid_request_error, etc.) and should not contribute phantom cost.
+_ZERO_USAGE_PROMPT_THRESHOLD = 500
+
 
 def _estimate_tokens(chars: int, model: str) -> tuple[int, float, str]:
     """Estimate token count from character count with model-aware heuristics."""
@@ -114,7 +120,18 @@ class PromptTelemetry:
             actual_total_tokens if actual_total_tokens > 0 else estimated_total_tokens
         )
 
-        record = {
+        # Zero-usage sanity guard: a "successful" CLI run that reports zero
+        # tokens on a non-trivial prompt is almost always a silently-swallowed
+        # API rejection. Reclassify as failed and zero the estimated cost so
+        # the dashboard does not attribute phantom spend.
+        zero_usage_anomaly = (
+            not usage_available
+            and actual_total_tokens == 0
+            and prompt_chars > _ZERO_USAGE_PROMPT_THRESHOLD
+        )
+        effective_success = success and not zero_usage_anomaly
+
+        record: dict[str, object] = {
             "timestamp": datetime.now(UTC).isoformat(),
             "source": source,
             "tool": tool,
@@ -136,7 +153,7 @@ class PromptTelemetry:
             "usage_status": usage_status,
             "usage_available": usage_available,
             "duration_seconds": round(duration_seconds, 3),
-            "status": "success" if success else "failed",
+            "status": "success" if effective_success else "failed",
             "token_estimation_mode": "model-aware-chars-per-token",
             "token_estimation_chars_per_token": chars_per_token,
             "token_estimation_confidence": estimate_confidence,
@@ -170,15 +187,31 @@ class PromptTelemetry:
             "unique_suffix_chars": unique_suffix_chars,
             "prefix_cache_reuse_ratio": prefix_cache_reuse_ratio,
         }
-        # Estimate cost from pricing table
-        cost = self._pricing.estimate_cost(
-            model,
-            input_tokens=actual_input_tokens or prompt_tokens,
-            output_tokens=actual_output_tokens or transcript_tokens,
-            cache_write_tokens=actual_cache_creation_tokens,
-            cache_read_tokens=actual_cache_read_tokens,
-        )
-        record["estimated_cost_usd"] = round(cost, 6) if cost is not None else None
+        # Estimate cost from pricing table. Two cases produce zero cost:
+        # - Zero-usage anomaly: API rejected before billing, so any estimate
+        #   from prompt_chars would be phantom spend.
+        # - Genuine failure with no actual tokens reported AND nothing streamed:
+        #   nothing plausibly billed, so we skip the char-based estimate.
+        # A genuine failure that DID report real tokens (e.g. mid-stream error
+        # after partial billing) must still reflect that spend.
+        if (
+            zero_usage_anomaly
+            or not success
+            and actual_total_tokens == 0
+            and transcript_chars == 0
+        ):
+            record["estimated_cost_usd"] = 0.0
+        else:
+            cost = self._pricing.estimate_cost(
+                model,
+                input_tokens=actual_input_tokens or prompt_tokens,
+                output_tokens=actual_output_tokens or transcript_tokens,
+                cache_write_tokens=actual_cache_creation_tokens,
+                cache_read_tokens=actual_cache_read_tokens,
+            )
+            record["estimated_cost_usd"] = round(cost, 6) if cost is not None else None
+        if zero_usage_anomaly:
+            record["usage_anomaly"] = "zero_usage_with_prompt"
         section_chars = st.get("section_chars")
         if isinstance(section_chars, dict):
             clean_sections: dict[str, int] = {}

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -152,6 +152,12 @@ _CREDIT_PATTERNS = (
     "credit balance is too low",
     "you've hit your limit",
     "hit your usage limit",
+    # Anthropic API spend-cap rejection (HTTP 400 invalid_request_error).
+    # Full phrase — narrower patterns would false-match conversational
+    # transcript text like "reached your specified goals" and trigger a
+    # non-retryable halt on every run.
+    "reached your specified api usage limits",
+    "reached your specified usage limits",
 )
 
 # Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",
@@ -159,6 +165,18 @@ _CREDIT_PATTERNS = (
 _RESET_TIME_RE = re.compile(
     r"resets?\s+(?:at\s+)?(\d{1,2})\s*(am|pm)"
     r"(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+
+# Matches Anthropic's ISO-style spend-cap resume format:
+# "regain access on 2026-05-01 at 00:00 UTC"
+# UTC is REQUIRED — if Anthropic ever changes the timezone (or omits it),
+# we'd rather fail-to-parse than silently misinterpret the resume time.
+_ISO_RESUME_TIME_RE = re.compile(
+    r"regain\s+access\s+on\s+"
+    r"(\d{4})-(\d{2})-(\d{2})"
+    r"\s+at\s+(\d{1,2}):(\d{2})"
+    r"\s+UTC\b",
     re.IGNORECASE,
 )
 
@@ -243,7 +261,25 @@ def parse_credit_resume_time(text: str) -> datetime | None:
 
     When the parsed time is already past, we assume the reset is
     tomorrow at the same time.
+
+    Also recognizes Anthropic's spend-cap format
+    ``"regain access on 2026-05-01 at 00:00 UTC"`` and returns the exact
+    UTC datetime without the past-time roll-forward (the date is explicit).
     """
+    iso_match = _ISO_RESUME_TIME_RE.search(text)
+    if iso_match:
+        year, month, day, hour, minute = (
+            int(iso_match.group(1)),
+            int(iso_match.group(2)),
+            int(iso_match.group(3)),
+            int(iso_match.group(4)),
+            int(iso_match.group(5)),
+        )
+        try:
+            return datetime(year, month, day, hour, minute, tzinfo=UTC)
+        except ValueError:
+            return None
+
     match = _RESET_TIME_RE.search(text)
     if not match:
         return None

--- a/tests/test_prompt_telemetry.py
+++ b/tests/test_prompt_telemetry.py
@@ -503,3 +503,159 @@ class TestAsFloat:
 
     def test_none_value(self):
         assert _as_float(None) == 0.0
+
+
+class TestZeroUsageSanityGuard:
+    """A 'successful' run that produced zero actual tokens with a non-trivial
+    prompt is almost always a CLI-swallowed API rejection (spend cap, 400
+    error, etc.). Guard: do not estimate phantom cost, re-classify as failed,
+    and tag the record so it is observable.
+    """
+
+    def test_reclassifies_success_with_zero_usage_as_failed(self, telemetry):
+        """success=True + all actual tokens zero + prompt_chars > 500 => status='failed'."""
+        telemetry.record(
+            source="triage",
+            tool="claude",
+            model="sonnet",
+            issue_number=9001,
+            pr_number=None,
+            session_id="sess-zero",
+            prompt_chars=21404,
+            transcript_chars=229,
+            duration_seconds=1.9,
+            success=True,
+            stats={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "total_tokens": 0,
+                "usage_available": False,
+                "usage_status": "unavailable",
+            },
+        )
+        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(
+            [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
+        )
+        assert row["status"] == "failed"
+        assert row["estimated_cost_usd"] == 0.0
+        assert row["usage_anomaly"] == "zero_usage_with_prompt"
+
+    def test_leaves_legitimate_successful_run_untouched(self, telemetry):
+        """success=True with actual tokens reported is a real call — no reclassification."""
+        telemetry.record(
+            source="implementer",
+            tool="claude",
+            model="opus",
+            issue_number=9002,
+            pr_number=None,
+            session_id="sess-ok",
+            prompt_chars=5000,
+            transcript_chars=2000,
+            duration_seconds=10.0,
+            success=True,
+            stats={
+                "input_tokens": 1200,
+                "output_tokens": 400,
+                "total_tokens": 1600,
+                "usage_available": True,
+                "usage_status": "available",
+            },
+        )
+        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(
+            [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
+        )
+        assert row["status"] == "success"
+        assert row.get("usage_anomaly") is None
+        assert row["estimated_cost_usd"] > 0
+
+    def test_leaves_tiny_prompt_runs_alone(self, telemetry):
+        """Prompts under the threshold may legitimately return zero tokens (stub/no-op); don't touch them."""
+        telemetry.record(
+            source="triage",
+            tool="claude",
+            model="sonnet",
+            issue_number=9003,
+            pr_number=None,
+            session_id="sess-tiny",
+            prompt_chars=100,
+            transcript_chars=0,
+            duration_seconds=0.5,
+            success=True,
+            stats={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "usage_available": False,
+                "usage_status": "unavailable",
+            },
+        )
+        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(
+            [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
+        )
+        assert row["status"] == "success"
+        assert row.get("usage_anomaly") is None
+
+    def test_already_failed_runs_not_relabeled_but_still_zero_cost(self, telemetry):
+        """Failed runs stay failed; no phantom estimated cost either."""
+        telemetry.record(
+            source="reviewer",
+            tool="claude",
+            model="sonnet",
+            issue_number=9004,
+            pr_number=None,
+            session_id="sess-fail",
+            prompt_chars=8000,
+            transcript_chars=0,
+            duration_seconds=5.0,
+            success=False,
+            stats={
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "usage_available": False,
+                "usage_status": "unavailable",
+            },
+        )
+        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(
+            [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
+        )
+        assert row["status"] == "failed"
+        assert row["estimated_cost_usd"] == 0.0
+
+    def test_failed_run_with_real_tokens_preserves_cost(self, telemetry):
+        """A genuine failure after partial billing must preserve real-token cost.
+        The spend-cap guard zeroes cost ONLY when the API emitted zero tokens
+        (rejected before billing). A network error after streaming 50k tokens
+        must keep its real cost in the record.
+        """
+        telemetry.record(
+            source="implementer",
+            tool="claude",
+            model="sonnet",
+            issue_number=9005,
+            pr_number=None,
+            session_id="sess-partial",
+            prompt_chars=30000,
+            transcript_chars=5000,
+            duration_seconds=60.0,
+            success=False,  # genuine failure
+            stats={
+                "input_tokens": 50000,  # but tokens were already billed
+                "output_tokens": 8000,
+                "total_tokens": 58000,
+                "usage_available": True,
+                "usage_status": "available",
+            },
+        )
+        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        row = json.loads(
+            [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
+        )
+        assert row["status"] == "failed"
+        assert row.get("usage_anomaly") is None
+        # Real tokens were billed — cost must reflect that, not be zeroed out.
+        assert row["estimated_cost_usd"] > 0

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -1033,6 +1033,31 @@ class TestPostStreamResult:
                 logger=logging.getLogger("test"),
             )
 
+    def test_raises_credit_error_on_anthropic_spend_cap_rejection(self) -> None:
+        """Anthropic's 400 invalid_request_error for a hit spend-cap raises with parsed resume_at."""
+        from datetime import UTC, datetime
+
+        from subprocess_util import CreditExhaustedError
+
+        transcript = (
+            'API Error: 400 {"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"You have reached your specified API usage limits. '
+            'You will regain access on 2026-05-01 at 00:00 UTC."}}'
+        )
+        with pytest.raises(CreditExhaustedError) as exc_info:
+            _post_stream_result(
+                raw_lines=[transcript],
+                accumulated_text=transcript + "\n",
+                result_text="",
+                early_killed=False,
+                returncode=0,
+                stderr_text="",
+                parser=self._make_parser_with_snapshot(),
+                config=StreamConfig(),
+                logger=logging.getLogger("test"),
+            )
+        assert exc_info.value.resume_at == datetime(2026, 5, 1, 0, 0, tzinfo=UTC)
+
     def test_skips_credit_check_when_early_killed(self) -> None:
         """Credit check is skipped when early_killed=True."""
         transcript = _post_stream_result(

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -17,8 +17,10 @@ from subprocess_util import (
     _is_auth_error,
     _is_retryable_error,
     configure_gh_concurrency,
+    is_credit_exhaustion,
     make_clean_env,
     make_docker_env,
+    parse_credit_resume_time,
     run_subprocess,
     run_subprocess_with_retry,
 )
@@ -999,3 +1001,101 @@ class TestRateLimitCooldown:
             await run_subprocess("gh", "api", "test", runner=runner)
 
         assert subprocess_util._rate_limit_until is None
+
+
+# ---------------------------------------------------------------------------
+# Credit exhaustion detection — Anthropic API spend-cap rejections
+# ---------------------------------------------------------------------------
+
+
+class TestIsCreditExhaustion:
+    """is_credit_exhaustion must match all current Anthropic rejection phrasings."""
+
+    def test_matches_specified_api_usage_limits_phrasing(self) -> None:
+        """Anthropic's 400 error: 'reached your specified API usage limits'."""
+        msg = (
+            'API Error: 400 {"type":"error","error":{"type":"invalid_request_error",'
+            '"message":"You have reached your specified API usage limits. '
+            'You will regain access on 2026-05-01 at 00:00 UTC."}}'
+        )
+        assert is_credit_exhaustion(msg)
+
+    def test_matches_embedded_in_invalid_request_error_json(self) -> None:
+        """Anthropic's wording may also appear inside a JSON envelope."""
+        msg = (
+            '{"type":"invalid_request_error","message":'
+            '"You have reached your specified API usage limits."}'
+        )
+        assert is_credit_exhaustion(msg)
+
+    def test_still_matches_legacy_phrasings(self) -> None:
+        """Existing patterns must continue to match — no regression."""
+        assert is_credit_exhaustion("Your credit balance is too low")
+        assert is_credit_exhaustion("you've hit your limit")
+        assert is_credit_exhaustion("usage limit reached")
+
+    def test_does_not_match_unrelated_text(self) -> None:
+        """Generic successful transcripts must not trip the detector."""
+        assert not is_credit_exhaustion("All tests passed.")
+        assert not is_credit_exhaustion("")
+
+    def test_does_not_false_match_benign_phrasings(self) -> None:
+        """Tightened patterns must not trigger on conversational output that
+        happens to contain substrings of the error wording. CreditExhaustedError
+        is non-retryable and halts all work — false positives are costly.
+        """
+        # 'reached your specified' used to be overly permissive
+        assert not is_credit_exhaustion(
+            "I've reached your specified goals for this sprint."
+        )
+        assert not is_credit_exhaustion(
+            "We reached your specified target of 95% coverage."
+        )
+        # 'reached your usage limits' in a config/docs context
+        assert not is_credit_exhaustion(
+            "You reached your usage limits set in the test config."
+        )
+
+
+class TestParseCreditResumeTime:
+    """parse_credit_resume_time must recognize Anthropic's ISO-style resume format."""
+
+    def test_parses_iso_date_with_utc(self) -> None:
+        """'regain access on 2026-05-01 at 00:00 UTC' → May 1 2026 00:00 UTC."""
+        msg = "You will regain access on 2026-05-01 at 00:00 UTC."
+        resume = parse_credit_resume_time(msg)
+        assert resume is not None
+        assert resume.year == 2026
+        assert resume.month == 5
+        assert resume.day == 1
+        assert resume.hour == 0
+        assert resume.minute == 0
+
+    def test_parses_iso_date_with_nonzero_time(self) -> None:
+        """'regain access on 2026-06-15 at 14:30 UTC'."""
+        msg = "you will regain access on 2026-06-15 at 14:30 UTC."
+        resume = parse_credit_resume_time(msg)
+        assert resume is not None
+        assert (resume.year, resume.month, resume.day) == (2026, 6, 15)
+        assert (resume.hour, resume.minute) == (14, 30)
+
+    def test_still_parses_legacy_am_pm_format(self) -> None:
+        """Existing 'reset at 3pm' phrasings must still parse — no regression."""
+        resume = parse_credit_resume_time("resets at 3pm")
+        assert resume is not None
+        assert resume.hour in {15, 22, 23, 0, 1, 2, 7, 8}  # tz-dependent
+
+    def test_returns_none_for_non_matching_text(self) -> None:
+        assert parse_credit_resume_time("no date here") is None
+
+    def test_requires_utc_suffix_on_iso_format(self) -> None:
+        """If UTC is absent or replaced (e.g. PST), we must NOT silently
+        interpret the time as UTC — fail-to-parse is safer than silent
+        misinterpretation for cooldown scheduling.
+        """
+        # No timezone suffix: must not parse
+        assert parse_credit_resume_time("regain access on 2026-05-01 at 00:00") is None
+        # Non-UTC timezone: must not parse
+        assert (
+            parse_credit_resume_time("regain access on 2026-05-01 at 00:00 PST") is None
+        )


### PR DESCRIPTION
## Summary

- The \`claude\` CLI emits \`status=success\` with a zero-token \`result\` event whenever Anthropic's API returns HTTP 400 \`"You have reached your specified API usage limits"\`. HydraFlow recorded these as successful inferences and fell back to char-based token estimation, producing phantom cost on the dashboard.
- Across 21,665 historical records, **2,736 were affected — ~\$195 of phantom spend**. Triage loop was the worst hit (10,423 zero-token records, 3 in 4 of the anomaly set).
- Three layers of defense: pattern matching, zero-usage sanity guard, and honest resume-time parsing.

## Changes

**\`src/subprocess_util.py\`**
- Extended \`_CREDIT_PATTERNS\` with full-phrase matches for Anthropic's current spend-cap wording. Patterns are intentionally narrow — \`"reached your specified"\` on its own would false-match conversational output like \`"reached your specified goals"\` and trigger a non-retryable halt on every run.
- New \`_ISO_RESUME_TIME_RE\` + branch in \`parse_credit_resume_time()\` for \`"regain access on 2026-05-01 at 00:00 UTC"\`. UTC is required; fail-to-parse is safer than silently misinterpreting a future non-UTC format.

**\`src/prompt_telemetry.py\`**
- New \`_ZERO_USAGE_PROMPT_THRESHOLD=500\`.
- Zero-usage sanity guard in \`PromptTelemetry.record()\`: when a \`success=True\` run reports zero actual tokens on a non-trivial prompt, reclassify as \`failed\`, zero \`estimated_cost_usd\`, and tag \`usage_anomaly="zero_usage_with_prompt"\`. Genuine failures that *did* bill tokens (mid-stream errors after partial billing) still report real cost — the guard is scoped to the phantom-cost signature only.

**\`scripts/cleanup_phantom_cost.py\`** (new)
- One-shot backfill for historical \`inferences.jsonl\`. Idempotent, dry-run by default, \`--apply\` to write with automatic \`.bak\` backups. Rebuilds \`pr_stats.json\` from the cleaned record stream; counter shape matches production \`_new_counter\` exactly (\`estimated_cost_usd\` key only appears on non-zero buckets).
- Ran locally: 2,736 records reclassified, \$195.31 phantom cost removed, lifetime stabilized at \$5,090.62 across 21,665 calls.

**\`scripts/cost_report.py\`** (new, was untracked)
- Per-\`(source, model)\` spend breakdown reading \`pr_stats.json\` + \`inferences.jsonl\`. Telemetry-adjacent and already in tree untracked; rolled in with this work since the numbers now mean something honest.

## Test plan

- [x] 12 new tests added:
  - \`TestIsCreditExhaustion\` — new patterns match, legacy patterns still match, **benign phrasings do NOT false-match** (\`"reached your specified goals"\`, etc.)
  - \`TestParseCreditResumeTime\` — ISO format with/without non-zero minutes, legacy am/pm still parses, **UTC-required negative test**
  - \`TestPostStreamResult\` — end-to-end integration: Anthropic 400 raises \`CreditExhaustedError\` with parsed \`resume_at\`
  - \`TestZeroUsageSanityGuard\` — reclassification fires on anomaly signature, legitimate success untouched, tiny-prompt runs untouched, **genuine failures with real tokens preserve cost**
- [x] 174/174 tests passing across the three affected modules
- [x] \`ruff check\` + \`pyright\` clean on all modified files
- [x] Independent code review pass addressed 4 issues (cost regression for partial-billing failures, overly-broad patterns, silent UTC fallback, counter shape drift)
- [ ] Dashboard rendering post-merge (phantom cost should drop; failure-rate column will rise reflecting the real CLI-rejection rate)

## Notes for reviewer

- **Historical data has already been cleaned** on my local repo via \`scripts/cleanup_phantom_cost.py --apply\`. You'll want to run this once on each deployment's \`inferences.jsonl\` to backfill the guard. Script is idempotent.
- Failure-rate on dashboards will visibly increase — this is honest reclassification, not new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)