### PR TITLE
chore(code-grooming): default the audit loop off

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -92,6 +92,7 @@ HYDRAFLOW_LABEL_FIXED=hydraflow-fixed
 # Background worker models (defaults shown — each worker is independently tunable)
 # HYDRAFLOW_REPORT_ISSUE_MODEL=opus       # report_issue_loop (codebase research)
 # HYDRAFLOW_SENTRY_MODEL=opus             # sentry_loop (Sentry event triage/filing)
+# HYDRAFLOW_CODE_GROOMING_ENABLED=false   # opt in to the code grooming loop (default off — noisy)
 # HYDRAFLOW_CODE_GROOMING_MODEL=sonnet    # code_grooming_loop (daily code audit)
 # HYDRAFLOW_ADR_REVIEW_MODEL=sonnet       # adr_reviewer council
 # HYDRAFLOW_MEMORY_JUDGE_MODEL=haiku      # tribal-memory candidate judge

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -100,6 +100,9 @@ class CodeGroomingLoop(BaseBackgroundLoop):
         if self._config.dry_run:
             return None
 
+        if not self._config.code_grooming_enabled:
+            return {"skipped": "disabled"}
+
         try:
             findings = await self._run_audit()
         except Exception:

--- a/src/config.py
+++ b/src/config.py
@@ -235,6 +235,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         "HYDRAFLOW_PRECONDITION_GATE_ENABLED",
         False,
     ),
+    ("code_grooming_enabled", "HYDRAFLOW_CODE_GROOMING_ENABLED", False),
     ("docker_read_only_root", "HYDRAFLOW_DOCKER_READ_ONLY_ROOT", True),
     ("docker_no_new_privileges", "HYDRAFLOW_DOCKER_NO_NEW_PRIVILEGES", True),
     (
@@ -981,6 +982,14 @@ class HydraFlowConfig(BaseModel):
     )
 
     # Code grooming
+    code_grooming_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable the daily code grooming audit worker. Defaults to "
+            "False because the audit tends to surface noisy, low-signal "
+            "findings; operators opt in explicitly when they want it."
+        ),
+    )
     code_grooming_interval: int = Field(
         default=86400,
         ge=3600,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -387,6 +387,7 @@ class ConfigFactory:
         security_patch_interval: int = 3600,
         security_patch_severity_threshold: str = "high",
         code_grooming_interval: int = 86400,
+        code_grooming_enabled: bool = False,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -612,6 +613,7 @@ class ConfigFactory:
                 security_patch_interval=security_patch_interval,
                 security_patch_severity_threshold=security_patch_severity_threshold,
                 code_grooming_interval=code_grooming_interval,
+                code_grooming_enabled=code_grooming_enabled,
             )
 
 

--- a/tests/regressions/test_issue_6830.py
+++ b/tests/regressions/test_issue_6830.py
@@ -33,7 +33,11 @@ def _make_loop(
     tmp_path: Path,
 ) -> tuple[CodeGroomingLoop, AsyncMock, asyncio.Event]:
     """Build a CodeGroomingLoop with test-friendly defaults."""
-    deps = make_bg_loop_deps(tmp_path, code_grooming_interval=86400)
+    deps = make_bg_loop_deps(
+        tmp_path,
+        code_grooming_interval=86400,
+        code_grooming_enabled=True,
+    )
     pr_manager = AsyncMock()
     pr_manager.create_issue = AsyncMock(return_value=42)
     loop = CodeGroomingLoop(
@@ -57,7 +61,9 @@ class TestDoWorkPropagatesFatalErrors:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6830 — fix not yet landed", strict=False)
+    @pytest.mark.xfail(
+        reason="Regression for issue #6830 — fix not yet landed", strict=False
+    )
     async def test_authentication_error_propagates(self, tmp_path: Path) -> None:
         """_do_work must let AuthenticationError escape.
 
@@ -78,7 +84,9 @@ class TestDoWorkPropagatesFatalErrors:
             await loop._do_work()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6830 — fix not yet landed", strict=False)
+    @pytest.mark.xfail(
+        reason="Regression for issue #6830 — fix not yet landed", strict=False
+    )
     async def test_credit_exhausted_error_propagates(self, tmp_path: Path) -> None:
         """_do_work must let CreditExhaustedError escape.
 

--- a/tests/test_code_grooming_loop.py
+++ b/tests/test_code_grooming_loop.py
@@ -25,6 +25,7 @@ def _make_loop(
     *,
     enabled: bool = True,
     dry_run: bool = False,
+    code_grooming_enabled: bool = True,
     code_grooming_interval: int = 86400,
     existing_dedup: list[str] | None = None,
 ) -> tuple[CodeGroomingLoop, AsyncMock, asyncio.Event]:
@@ -33,6 +34,7 @@ def _make_loop(
         tmp_path,
         enabled=enabled,
         dry_run=dry_run,
+        code_grooming_enabled=code_grooming_enabled,
         code_grooming_interval=code_grooming_interval,
     )
     pr_manager = AsyncMock()
@@ -124,6 +126,15 @@ class TestCodeGroomingLoopWork:
         loop, pm, _stop = _make_loop(tmp_path, dry_run=True)
         result = await loop._do_work()
         assert result is None
+        pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_disabled_skips_audit(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(tmp_path, code_grooming_enabled=False)
+        with patch.object(loop, "_run_audit", new_callable=AsyncMock) as run_audit:
+            result = await loop._do_work()
+        assert result == {"skipped": "disabled"}
+        run_audit.assert_not_called()
         pm.create_issue.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `code_grooming_enabled` config flag (default `False`) and env override `HYDRAFLOW_CODE_GROOMING_ENABLED`
- Short-circuit `CodeGroomingLoop._do_work` with `{"skipped": "disabled"}` when the flag is off
- Loop still registers and heartbeats normally; operators opt in explicitly

Motivation: the audit has been surfacing noisy, low-signal findings. Defaulting it off stops the flood; anyone who wants it can flip the env var.

## Test plan
- [x] `pytest tests/test_code_grooming_loop.py tests/test_config_consistency.py tests/test_bg_worker_manager.py tests/test_state_tracking.py tests/test_caretaker_loop_wiring.py tests/scenarios/catalog/test_loop_instantiation.py tests/scenarios/catalog/test_loop_registrations.py tests/regressions/test_issue_6571.py tests/regressions/test_issue_6363.py`
- [x] `ruff check` + `pyright` on touched files
- [ ] Manual: confirm dashboard shows code_grooming worker idle (`skipped: disabled`) with default config

🤖 Generated with [Claude Code](https://claude.com/claude-code)