### PR TITLE
feat: dynamic plugin skill registry injected into every factory phase

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -730,7 +730,7 @@ Run through this checklist before your final commit:
         test_cmd = self._config.test_command  # noqa: F841 — used in f-string prompt
         tools_section = format_tools_for_prompt(discover_tools(self._config.repo_root))
         skills_section = format_skills_for_prompt(get_skills())
-        plugin_skills_section = format_plugin_skills_for_prompt(  # noqa: F841 — used in f-string prompt
+        plugin_skills_section = format_plugin_skills_for_prompt(
             discover_plugin_skills(self._config.required_plugins)
         )
 
@@ -765,7 +765,6 @@ Key rules:
 {tools_section}
 
 {skills_section}
-{plugin_skills_section}
 {feedback_section}{escalation_section}
 {self._build_self_check_checklist(escalations)}
 {self._build_requirements_gap_section(issue)}
@@ -798,6 +797,8 @@ Key rules:
   in files you are not otherwise changing for the issue. Each concern is a separate PR.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="implementation")}"""
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
         return prompt, builder.build_stats()
 
     # ------------------------------------------------------------------

--- a/src/agent.py
+++ b/src/agent.py
@@ -14,6 +14,10 @@ from base_runner import BaseRunner
 from events import EventBus, EventType, HydraFlowEvent
 from exception_classify import is_likely_bug, reraise_on_credit_or_bug
 from models import LoopResult, Task, WorkerResult, WorkerStatus, WorkerUpdatePayload
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from prompt_builder import PromptBuilder
 from review_insights import (
     ReviewInsightStore,
@@ -726,6 +730,9 @@ Run through this checklist before your final commit:
         test_cmd = self._config.test_command  # noqa: F841 — used in f-string prompt
         tools_section = format_tools_for_prompt(discover_tools(self._config.repo_root))
         skills_section = format_skills_for_prompt(get_skills())
+        plugin_skills_section = format_plugin_skills_for_prompt(  # noqa: F841 — used in f-string prompt
+            discover_plugin_skills(self._config.required_plugins)
+        )
 
         prompt = f"""You are implementing GitHub issue #{issue.id}.
 
@@ -758,6 +765,7 @@ Key rules:
 {tools_section}
 
 {skills_section}
+{plugin_skills_section}
 {feedback_section}{escalation_section}
 {self._build_self_check_checklist(escalations)}
 {self._build_requirements_gap_section(issue)}

--- a/src/config.py
+++ b/src/config.py
@@ -353,6 +353,27 @@ class HydraFlowConfig(BaseModel):
     max_hitl_workers: int = Field(
         default=1, ge=1, le=5, description="Concurrent HITL correction agents"
     )
+    # Plugin skill registry — see docs/superpowers/specs/2026-04-18-dynamic-plugin-skill-registry-design.md
+    required_plugins: list[str] = Field(
+        default_factory=lambda: [
+            "superpowers",
+            "code-review",
+            "code-simplifier",
+            "frontend-design",
+            "playwright",
+        ],
+        description="Plugins that must be installed under ~/.claude/plugins/cache/ at startup",
+    )
+    language_plugins: dict[str, list[str]] = Field(
+        default_factory=lambda: {
+            "python": ["pyright-lsp"],
+            "typescript": ["typescript-lsp"],
+            "csharp": ["csharp-lsp"],
+            "go": ["gopls"],
+            "rust": ["rust-analyzer"],
+        },
+        description="Language-conditional plugins loaded only when the language is detected in a target repo",
+    )
     system_tool: Literal["inherit", "claude", "codex", "pi"] = Field(
         default="inherit",
         description="Optional global default tool for system agents; 'inherit' keeps per-agent defaults",

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -11,6 +11,10 @@ from agent_cli import build_agent_command
 from base_runner import BaseRunner
 from exception_classify import reraise_on_credit_or_bug
 from models import DiscoverResult
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 
 if TYPE_CHECKING:
@@ -130,7 +134,7 @@ class DiscoverRunner(BaseRunner):
 
     def _build_prompt(self, task: Task) -> str:
         """Build the product discovery prompt with deep product thinking frameworks."""
-        return f"""You are a senior product strategist conducting deep discovery research.
+        prompt = f"""You are a senior product strategist conducting deep discovery research.
 Think through the tradeoffs carefully before producing your analysis.
 
 ## Issue #{task.id}: {task.title}
@@ -229,6 +233,13 @@ Each opportunity should be:
 
 {MEMORY_SUGGESTION_PROMPT}
 """
+        cfg = getattr(self, "_config", None)
+        plugin_skills_section = format_plugin_skills_for_prompt(
+            discover_plugin_skills(cfg.required_plugins if cfg is not None else [])
+        )
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
+        return prompt
 
     def _extract_result(
         self, transcript: str, issue_number: int

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -233,9 +233,8 @@ Each opportunity should be:
 
 {MEMORY_SUGGESTION_PROMPT}
 """
-        cfg = getattr(self, "_config", None)
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(cfg.required_plugins if cfg is not None else [])
+            discover_plugin_skills(self._config.required_plugins)
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/src/language_detector.py
+++ b/src/language_detector.py
@@ -1,0 +1,71 @@
+"""Detect programming languages in a target-repo worktree from marker files.
+
+Used by the plugin skill registry to decide which Tier-2 language-conditional
+plugins to load for a given repo. See
+``docs/superpowers/specs/2026-04-18-dynamic-plugin-skill-registry-design.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger("hydraflow.language_detector")
+
+# Language → list of literal marker filenames that indicate the language.
+_LITERAL_MARKERS: dict[str, tuple[str, ...]] = {
+    "python": ("pyproject.toml", "setup.py", "requirements.txt"),
+    "typescript": ("tsconfig.json",),
+    "go": ("go.mod",),
+    "rust": ("Cargo.toml",),
+}
+
+# Language → list of glob patterns to match (for files like *.csproj).
+_GLOB_MARKERS: dict[str, tuple[str, ...]] = {
+    "csharp": ("*.csproj", "*.sln"),
+}
+
+
+def detect_languages(repo_root: Path) -> set[str]:
+    """Return the set of languages detected in ``repo_root``.
+
+    Detection is marker-based and non-recursive (top-level only).
+    Returns an empty set if ``repo_root`` does not exist.
+    """
+    if not repo_root.is_dir():
+        return set()
+
+    detected: set[str] = set()
+
+    for language, markers in _LITERAL_MARKERS.items():
+        for marker in markers:
+            if (repo_root / marker).is_file():
+                detected.add(language)
+                break
+
+    for language, patterns in _GLOB_MARKERS.items():
+        for pattern in patterns:
+            if any(repo_root.glob(pattern)):
+                detected.add(language)
+                break
+
+    if (repo_root / "package.json").is_file() and _package_json_uses_typescript(
+        repo_root / "package.json"
+    ):
+        detected.add("typescript")
+
+    return detected
+
+
+def _package_json_uses_typescript(path: Path) -> bool:
+    """Return True if package.json declares typescript in deps or devDeps."""
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    for key in ("dependencies", "devDependencies"):
+        deps = data.get(key, {})
+        if isinstance(deps, dict) and "typescript" in deps:
+            return True
+    return False

--- a/src/planner.py
+++ b/src/planner.py
@@ -23,6 +23,10 @@ from plan_constants import (
 )
 from plan_scoring import score_actionability
 from plan_validation import run_phase_gates, validate_plan
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from prompt_builder import PromptBuilder
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 
@@ -542,6 +546,12 @@ ALREADY_SATISFIED_END
 This closes the issue automatically. False positives waste significant human time.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="planning")}"""
+        plugin_skills_section = format_plugin_skills_for_prompt(
+            discover_plugin_skills(self._config.required_plugins)
+        )
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
+
         return prompt, builder.build_stats()
 
     def _detect_plan_scale(self, issue: Task) -> PlanScale:

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -66,28 +66,40 @@ def discover_plugin_skills(
 
 
 def _discover_plugin(plugin_dir: Path) -> list[PluginSkill]:
-    skills_dir = plugin_dir / "skills"
-    if not skills_dir.is_dir():
-        return []
+    """Scan a plugin directory for skills.
 
+    The cache layout is ``<marketplace>/<plugin>/<version_or_hash>/skills/<skill>/SKILL.md``.
+    A single plugin can have multiple sibling version directories (e.g. a semver
+    tag and an ``unknown`` alias). We scan all of them and dedupe by skill name,
+    keeping the first occurrence in sorted directory order.
+    """
     out: list[PluginSkill] = []
-    for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
-        if skill_dir.name in _EXCLUDED_SKILL_NAMES:
+    seen: set[str] = set()
+
+    for version_dir in sorted(p for p in plugin_dir.iterdir() if p.is_dir()):
+        skills_dir = version_dir / "skills"
+        if not skills_dir.is_dir():
             continue
-        skill_md = skill_dir / "SKILL.md"
-        if not skill_md.is_file():
-            continue
-        parsed = _parse_skill_md(skill_md)
-        if parsed is None:
-            logger.warning(
-                "Skipping %s — malformed or missing frontmatter",
-                skill_md,
+        for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
+            if skill_dir.name in _EXCLUDED_SKILL_NAMES:
+                continue
+            skill_md = skill_dir / "SKILL.md"
+            if not skill_md.is_file():
+                continue
+            parsed = _parse_skill_md(skill_md)
+            if parsed is None:
+                logger.warning(
+                    "Skipping %s — malformed or missing frontmatter",
+                    skill_md,
+                )
+                continue
+            name, description = parsed
+            if name in seen:
+                continue
+            seen.add(name)
+            out.append(
+                PluginSkill(plugin=plugin_dir.name, name=name, description=description)
             )
-            continue
-        name, description = parsed
-        out.append(
-            PluginSkill(plugin=plugin_dir.name, name=name, description=description)
-        )
     return out
 
 

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -142,8 +142,9 @@ def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:
         "## Available Skills",
         "",
         "You have these Claude Code skills available via the `Skill` tool. "
-        'Invoke a skill with `Skill({skill: "plugin:name"})` when its '
-        "description matches your current task.",
+        "Invoke one by calling the `Skill` tool with its qualified name "
+        '(e.g. `skill: "superpowers:brainstorming"`) when its description '
+        "matches your current task.",
         "",
     ]
     for skill in skills:

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -1,0 +1,130 @@
+"""Discover and format installed Claude Code plugin skills for factory prompts.
+
+Scans ``~/.claude/plugins/cache/<marketplace>/<plugin>/skills/<skill>/SKILL.md``
+for frontmatter (``name`` + ``description``), builds a list of
+:class:`PluginSkill`, and formats them as a ``## Available Skills`` section
+injected into factory phase prompts.
+
+See ``docs/superpowers/specs/2026-04-18-dynamic-plugin-skill-registry-design.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger("hydraflow.plugin_skill_registry")
+
+_DEFAULT_CACHE_ROOT = Path.home() / ".claude" / "plugins" / "cache"
+
+# Meta-skills that route to other skills — excluded from factory prompts
+# because the factory advertises skills directly.
+_EXCLUDED_SKILL_NAMES: frozenset[str] = frozenset({"using-superpowers"})
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class PluginSkill:
+    """A Claude Code skill discovered from an installed plugin."""
+
+    plugin: str
+    name: str
+    description: str
+
+    @property
+    def qualified_name(self) -> str:
+        return f"{self.plugin}:{self.name}"
+
+
+def discover_plugin_skills(
+    plugins: list[str],
+    cache_root: Path | None = None,
+) -> list[PluginSkill]:
+    """Discover skills from allowlisted plugins under ``cache_root``.
+
+    Returns an empty list if ``cache_root`` is missing. Skills with malformed
+    frontmatter are skipped with a warning. The ``using-superpowers``
+    meta-skill is always excluded.
+    """
+    root = cache_root or _DEFAULT_CACHE_ROOT
+    if not root.is_dir():
+        return []
+
+    allowlist = set(plugins)
+    skills: list[PluginSkill] = []
+
+    for marketplace_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        for plugin_dir in sorted(p for p in marketplace_dir.iterdir() if p.is_dir()):
+            if plugin_dir.name not in allowlist:
+                continue
+            skills.extend(_discover_plugin(plugin_dir))
+
+    return skills
+
+
+def _discover_plugin(plugin_dir: Path) -> list[PluginSkill]:
+    skills_dir = plugin_dir / "skills"
+    if not skills_dir.is_dir():
+        return []
+
+    out: list[PluginSkill] = []
+    for skill_dir in sorted(p for p in skills_dir.iterdir() if p.is_dir()):
+        if skill_dir.name in _EXCLUDED_SKILL_NAMES:
+            continue
+        skill_md = skill_dir / "SKILL.md"
+        if not skill_md.is_file():
+            continue
+        parsed = _parse_skill_md(skill_md)
+        if parsed is None:
+            logger.warning(
+                "Skipping %s — malformed or missing frontmatter",
+                skill_md,
+            )
+            continue
+        name, description = parsed
+        out.append(
+            PluginSkill(plugin=plugin_dir.name, name=name, description=description)
+        )
+    return out
+
+
+def _parse_skill_md(path: Path) -> tuple[str, str] | None:
+    """Return (name, description) parsed from SKILL.md frontmatter.
+
+    Returns ``None`` if the file can't be read, has no frontmatter, or is
+    missing either the ``name`` or ``description`` key.
+    """
+    try:
+        text = path.read_text()
+    except OSError:
+        return None
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return None
+    name = _extract_key(match.group(1), "name")
+    description = _extract_key(match.group(1), "description")
+    if not name or not description:
+        return None
+    return name, description
+
+
+def _extract_key(frontmatter: str, key: str) -> str | None:
+    """Extract a top-level key value from simple YAML frontmatter.
+
+    Intentionally does NOT depend on a YAML library — SKILL.md frontmatter is
+    always flat key/value pairs. Multi-line values use the folded-on-next-line
+    convention and are joined with spaces.
+    """
+    lines = frontmatter.splitlines()
+    for i, line in enumerate(lines):
+        if line.startswith(f"{key}:"):
+            value = line[len(key) + 1 :].strip()
+            j = i + 1
+            while j < len(lines) and lines[j].startswith(("  ", "\t")):
+                value = f"{value} {lines[j].strip()}"
+                j += 1
+            return value or None
+    return None

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -24,6 +24,7 @@ _DEFAULT_CACHE_ROOT = Path.home() / ".claude" / "plugins" / "cache"
 _EXCLUDED_SKILL_NAMES: frozenset[str] = frozenset({"using-superpowers"})
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+_KEY_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$")
 
 
 @dataclass(frozen=True)
@@ -139,17 +140,20 @@ def _extract_key(frontmatter: str, key: str) -> str | None:
 
     Intentionally does NOT depend on a YAML library — SKILL.md frontmatter is
     always flat key/value pairs. Multi-line values use the folded-on-next-line
-    convention and are joined with spaces.
+    convention and are joined with spaces. Prefix-match collisions are avoided
+    by requiring an exact key match via ``_KEY_PREFIX_RE``.
     """
     lines = frontmatter.splitlines()
     for i, line in enumerate(lines):
-        if line.startswith(f"{key}:"):
-            value = line[len(key) + 1 :].strip()
-            j = i + 1
-            while j < len(lines) and lines[j].startswith(("  ", "\t")):
-                value = f"{value} {lines[j].strip()}"
-                j += 1
-            return value or None
+        match = _KEY_PREFIX_RE.match(line)
+        if match is None or match.group(1) != key:
+            continue
+        value = match.group(2).strip()
+        j = i + 1
+        while j < len(lines) and lines[j].startswith(("  ", "\t")):
+            value = f"{value} {lines[j].strip()}"
+            j += 1
+        return value or None
     return None
 
 

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -128,3 +128,25 @@ def _extract_key(frontmatter: str, key: str) -> str | None:
                 j += 1
             return value or None
     return None
+
+
+def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:
+    """Format discovered skills as a prompt section for a factory agent.
+
+    Returns an empty string when ``skills`` is empty so callers can
+    unconditionally concatenate the result.
+    """
+    if not skills:
+        return ""
+    lines = [
+        "## Available Skills",
+        "",
+        "You have these Claude Code skills available via the `Skill` tool. "
+        'Invoke a skill with `Skill({skill: "plugin:name"})` when its '
+        "description matches your current task.",
+        "",
+    ]
+    for skill in skills:
+        lines.append(f"- **{skill.qualified_name}** — {skill.description}")
+    lines.append("")
+    return "\n".join(lines)

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -45,12 +45,22 @@ def discover_plugin_skills(
 ) -> list[PluginSkill]:
     """Discover skills from allowlisted plugins under ``cache_root``.
 
+    Results are cached in memory keyed by ``(frozenset(plugins), resolved_root)``
+    so repeated calls within a process do not re-scan the filesystem. Tests
+    must call :func:`clear_plugin_skill_cache` between cases to avoid leakage.
+
     Returns an empty list if ``cache_root`` is missing. Skills with malformed
     frontmatter are skipped with a warning. The ``using-superpowers``
     meta-skill is always excluded.
     """
     root = cache_root or _DEFAULT_CACHE_ROOT
+    key = (frozenset(plugins), root)
+    cached = _skill_cache.get(key)
+    if cached is not None:
+        return list(cached)
+
     if not root.is_dir():
+        _skill_cache[key] = ()
         return []
 
     allowlist = set(plugins)
@@ -62,6 +72,7 @@ def discover_plugin_skills(
                 continue
             skills.extend(_discover_plugin(plugin_dir))
 
+    _skill_cache[key] = tuple(skills)
     return skills
 
 
@@ -140,6 +151,19 @@ def _extract_key(frontmatter: str, key: str) -> str | None:
                 j += 1
             return value or None
     return None
+
+
+# ---------------------------------------------------------------------------
+# Discovery cache — keyed by (frozenset(plugins), resolved cache root).
+# Cleared via clear_plugin_skill_cache() in tests.
+# ---------------------------------------------------------------------------
+
+_skill_cache: dict[tuple[frozenset[str], Path], tuple[PluginSkill, ...]] = {}
+
+
+def clear_plugin_skill_cache() -> None:
+    """Clear the in-memory discovery cache. Intended for tests."""
+    _skill_cache.clear()
 
 
 def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -202,20 +202,32 @@ def _check_plugins(
         if not _plugin_exists(root, plugin):
             missing_tier1.append(plugin)
 
+    if root.exists() and not root.is_dir():
+        return CheckResult(
+            "plugins",
+            CheckStatus.FAIL,
+            f"Plugin cache path exists but is not a directory: {root}",
+        )
+
     if missing_tier1:
         return CheckResult(
             "plugins",
             CheckStatus.FAIL,
-            f"Required plugins missing from {root}: {', '.join(missing_tier1)}",
+            (
+                f"Required plugins missing from {root}: "
+                f"{', '.join(missing_tier1)} — "
+                "install the missing plugins via Claude Code (`/plugin install <name>`) "
+                "or verify the cache path"
+            ),
         )
 
     required_tier2: list[str] = []
-    missing_tier2: list[str] = []
+    missing_tier2: list[tuple[str, str]] = []  # (language, plugin)
     for lang in langs:
         for plugin in config.language_plugins.get(lang, []):
             required_tier2.append(plugin)
             if not _plugin_exists(root, plugin):
-                missing_tier2.append(plugin)
+                missing_tier2.append((lang, plugin))
 
     all_plugins = config.required_plugins + required_tier2
     skills = discover_plugin_skills(all_plugins, cache_root=root)
@@ -227,10 +239,13 @@ def _check_plugins(
         )
 
     if missing_tier2:
+        formatted = ", ".join(
+            f"{plugin} (for {lang})" for lang, plugin in missing_tier2
+        )
         return CheckResult(
             "plugins",
             CheckStatus.WARN,
-            f"Language-conditional plugins missing: {', '.join(missing_tier2)}",
+            f"Language-conditional plugins missing: {formatted}",
         )
 
     return CheckResult(

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -197,9 +197,12 @@ def _check_plugins(
     - Tier 2 plugin missing for a detected language → WARN.
     - Everything present → PASS.
     """
-    from plugin_skill_registry import discover_plugin_skills  # noqa: PLC0415
+    from plugin_skill_registry import (
+        _DEFAULT_CACHE_ROOT,  # noqa: PLC0415
+        discover_plugin_skills,  # noqa: PLC0415
+    )
 
-    root = cache_root or (Path.home() / ".claude" / "plugins" / "cache")
+    root = cache_root or _DEFAULT_CACHE_ROOT
     langs = detected_languages or set()
 
     missing_tier1: list[str] = []

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -42,6 +42,11 @@ async def run_preflight_checks(config: HydraFlowConfig) -> list[CheckResult]:
         tool = getattr(config, tool_field)
         if tool != "inherit":
             results.append(_check_agent_cli(tool))
+
+    # Plugin skill registry — verify required plugins are installed.
+    # Language detection runs per-repo later; at preflight we only check Tier 1.
+    results.append(_check_plugins(config, detected_languages=set()))
+
     return results
 
 

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -177,3 +177,74 @@ def log_preflight_results(results: list[CheckResult]) -> bool:
         else:
             logger.error("[FAIL] %s — %s", r.name, r.message)
     return not any(r.status == CheckStatus.FAIL for r in results)
+
+
+def _check_plugins(
+    config: HydraFlowConfig,
+    *,
+    cache_root: Path | None = None,
+    detected_languages: set[str] | None = None,
+) -> CheckResult:
+    """Verify required plugins are installed under the plugin cache.
+
+    - Tier 1 (``config.required_plugins``) missing → FAIL.
+    - Zero total skills discovered → FAIL.
+    - Tier 2 plugin missing for a detected language → WARN.
+    - Everything present → PASS.
+    """
+    from plugin_skill_registry import discover_plugin_skills  # noqa: PLC0415
+
+    root = cache_root or (Path.home() / ".claude" / "plugins" / "cache")
+    langs = detected_languages or set()
+
+    missing_tier1: list[str] = []
+    for plugin in config.required_plugins:
+        if not _plugin_exists(root, plugin):
+            missing_tier1.append(plugin)
+
+    if missing_tier1:
+        return CheckResult(
+            "plugins",
+            CheckStatus.FAIL,
+            f"Required plugins missing from {root}: {', '.join(missing_tier1)}",
+        )
+
+    required_tier2: list[str] = []
+    missing_tier2: list[str] = []
+    for lang in langs:
+        for plugin in config.language_plugins.get(lang, []):
+            required_tier2.append(plugin)
+            if not _plugin_exists(root, plugin):
+                missing_tier2.append(plugin)
+
+    all_plugins = config.required_plugins + required_tier2
+    skills = discover_plugin_skills(all_plugins, cache_root=root)
+    if not skills:
+        return CheckResult(
+            "plugins",
+            CheckStatus.FAIL,
+            f"Plugin allowlist yielded 0 skills under {root}",
+        )
+
+    if missing_tier2:
+        return CheckResult(
+            "plugins",
+            CheckStatus.WARN,
+            f"Language-conditional plugins missing: {', '.join(missing_tier2)}",
+        )
+
+    return CheckResult(
+        "plugins",
+        CheckStatus.PASS,
+        f"{len(skills)} plugin skills discovered",
+    )
+
+
+def _plugin_exists(cache_root: Path, plugin: str) -> bool:
+    """Return True if ``plugin`` directory exists under any marketplace in ``cache_root``."""
+    if not cache_root.is_dir():
+        return False
+    for marketplace_dir in cache_root.iterdir():
+        if (marketplace_dir / plugin).is_dir():
+            return True
+    return False

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -21,6 +21,10 @@ from models import (
     ReviewVerdict,
     Task,
 )
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from precheck import run_precheck_context
 from prompt_builder import PromptBuilder
 from runner_constants import MEMORY_SUGGESTION_PROMPT
@@ -846,6 +850,12 @@ VERDICT: APPROVE
 SUMMARY: Implementation looks good, tests are comprehensive, all checks pass.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="review")}"""
+        plugin_skills_section = format_plugin_skills_for_prompt(
+            discover_plugin_skills(self._config.required_plugins)
+        )
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
+
         review_builder = PromptBuilder()
         review_builder.record_context("Issue body", issue.body or "", issue_body)
         review_builder.record_context("Diff", diff, diff_context)

--- a/src/shape_runner.py
+++ b/src/shape_runner.py
@@ -11,6 +11,10 @@ from agent_cli import build_agent_command
 from base_runner import BaseRunner
 from exception_classify import reraise_on_credit_or_bug
 from models import ProductDirection, ShapeConversation, ShapeResult, ShapeTurnResult
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 
 if TYPE_CHECKING:
@@ -238,7 +242,7 @@ We're deep in the conversation. Time to converge:
 {history}
 """
 
-        return f"""You are a product design agent having a conversation about GitHub issue #{task.id}.
+        prompt = f"""You are a product design agent having a conversation about GitHub issue #{task.id}.
 
 ## Issue: {task.title}
 
@@ -291,6 +295,14 @@ a final specification for the engineering team:
 
 {MEMORY_SUGGESTION_PROMPT}
 """
+
+        plugin_skills_section = format_plugin_skills_for_prompt(
+            discover_plugin_skills(self._config.required_plugins)
+        )
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
+
+        return prompt
 
     @staticmethod
     def _extract_between(text: str, start_marker: str, end_marker: str) -> str:

--- a/src/triage.py
+++ b/src/triage.py
@@ -21,6 +21,10 @@ from models import (
     TriageStatus,
     TriageUpdatePayload,
 )
+from plugin_skill_registry import (
+    discover_plugin_skills,
+    format_plugin_skills_for_prompt,
+)
 from prompt_builder import PromptBuilder
 
 logger = logging.getLogger("hydraflow.triage")
@@ -187,9 +191,8 @@ class TriageRunner(BaseRunner):
             max_turns=1,
         )
 
-    @staticmethod
     def _build_prompt_with_stats(
-        issue: Task, max_body: int = 5000
+        self, issue: Task, max_body: int = 5000
     ) -> tuple[str, dict[str, object]]:
         """Build the triage evaluation prompt and pruning stats."""
         builder = PromptBuilder()
@@ -255,6 +258,11 @@ or for truly insufficient issues:
 {{"ready": false, "reasons": ["Specific reason why this cannot proceed"], "issue_type": "bug", "clarity_score": 0, "needs_discovery": false, "enrichment": ""}}
 ```
 """
+        plugin_skills_section = format_plugin_skills_for_prompt(
+            discover_plugin_skills(self._config.required_plugins)
+        )
+        if plugin_skills_section:
+            prompt = f"{prompt}\n\n{plugin_skills_section}"
         stats = builder.build_stats()
         return prompt, stats
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1133,3 +1133,35 @@ class ReviewMockBuilder:
         wt.mkdir(parents=True, exist_ok=True)
 
         return mock_reviewers, mock_prs, mock_wt
+
+
+def write_plugin_skill(
+    cache_root: Path,
+    marketplace: str,
+    plugin: str,
+    skill: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    frontmatter: str | None = None,
+    version: str = "1.0.0",
+) -> Path:
+    """Create a SKILL.md under the real cache layout and return its path.
+
+    Layout: ``<cache_root>/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``.
+    Shared helper used by plugin-skill-registry and preflight-plugins tests.
+    """
+    skill_dir = cache_root / marketplace / plugin / version / "skills" / skill
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    if frontmatter is not None:
+        content = f"---\n{frontmatter}\n---\n\nBody here.\n"
+    else:
+        content = (
+            "---\n"
+            f"name: {name or skill}\n"
+            f"description: {description or f'{skill} description'}\n"
+            "---\n\nBody here.\n"
+        )
+    skill_md.write_text(content)
+    return skill_md

--- a/tests/test_config_plugins.py
+++ b/tests/test_config_plugins.py
@@ -5,38 +5,37 @@ from __future__ import annotations
 from config import HydraFlowConfig
 
 
-def test_required_plugins_has_tier1_defaults() -> None:
-    config = HydraFlowConfig()
-    assert config.required_plugins == [
-        "superpowers",
-        "code-review",
-        "code-simplifier",
-        "frontend-design",
-        "playwright",
-    ]
+class TestPluginFields:
+    """Tests for the required_plugins and language_plugins fields on HydraFlowConfig."""
 
+    def test_required_plugins_defaults(self) -> None:
+        """required_plugins should default to the five tier-1 plugin names."""
+        config = HydraFlowConfig()
+        assert config.required_plugins == [
+            "superpowers",
+            "code-review",
+            "code-simplifier",
+            "frontend-design",
+            "playwright",
+        ]
 
-def test_language_plugins_has_all_five_languages() -> None:
-    config = HydraFlowConfig()
-    assert set(config.language_plugins.keys()) == {
-        "python",
-        "typescript",
-        "csharp",
-        "go",
-        "rust",
-    }
+    def test_language_plugins_defaults(self) -> None:
+        """language_plugins should default to all five language-to-plugin mappings."""
+        config = HydraFlowConfig()
+        assert config.language_plugins == {
+            "python": ["pyright-lsp"],
+            "typescript": ["typescript-lsp"],
+            "csharp": ["csharp-lsp"],
+            "go": ["gopls"],
+            "rust": ["rust-analyzer"],
+        }
 
+    def test_required_plugins_override(self) -> None:
+        """required_plugins should accept a custom list at construction time."""
+        config = HydraFlowConfig(required_plugins=["superpowers"])
+        assert config.required_plugins == ["superpowers"]
 
-def test_language_plugins_python_maps_to_pyright_lsp() -> None:
-    config = HydraFlowConfig()
-    assert config.language_plugins["python"] == ["pyright-lsp"]
-
-
-def test_required_plugins_override() -> None:
-    config = HydraFlowConfig(required_plugins=["superpowers"])
-    assert config.required_plugins == ["superpowers"]
-
-
-def test_language_plugins_override() -> None:
-    config = HydraFlowConfig(language_plugins={"python": ["mypy-lsp"]})
-    assert config.language_plugins == {"python": ["mypy-lsp"]}
+    def test_language_plugins_override(self) -> None:
+        """language_plugins should accept a custom mapping at construction time."""
+        config = HydraFlowConfig(language_plugins={"python": ["mypy-lsp"]})
+        assert config.language_plugins == {"python": ["mypy-lsp"]}

--- a/tests/test_config_plugins.py
+++ b/tests/test_config_plugins.py
@@ -1,0 +1,42 @@
+"""Tests for plugin-related fields on HydraFlowConfig."""
+
+from __future__ import annotations
+
+from config import HydraFlowConfig
+
+
+def test_required_plugins_has_tier1_defaults() -> None:
+    config = HydraFlowConfig()
+    assert config.required_plugins == [
+        "superpowers",
+        "code-review",
+        "code-simplifier",
+        "frontend-design",
+        "playwright",
+    ]
+
+
+def test_language_plugins_has_all_five_languages() -> None:
+    config = HydraFlowConfig()
+    assert set(config.language_plugins.keys()) == {
+        "python",
+        "typescript",
+        "csharp",
+        "go",
+        "rust",
+    }
+
+
+def test_language_plugins_python_maps_to_pyright_lsp() -> None:
+    config = HydraFlowConfig()
+    assert config.language_plugins["python"] == ["pyright-lsp"]
+
+
+def test_required_plugins_override() -> None:
+    config = HydraFlowConfig(required_plugins=["superpowers"])
+    assert config.required_plugins == ["superpowers"]
+
+
+def test_language_plugins_override() -> None:
+    config = HydraFlowConfig(language_plugins={"python": ["mypy-lsp"]})
+    assert config.language_plugins == {"python": ["mypy-lsp"]}

--- a/tests/test_discover_runner.py
+++ b/tests/test_discover_runner.py
@@ -67,10 +67,10 @@ class TestExtractRawBrief:
 class TestBuildPrompt:
     """Tests for DiscoverRunner._build_prompt."""
 
-    def test_prompt_includes_issue_details(self) -> None:
+    def test_prompt_includes_issue_details(self, config, event_bus) -> None:
         from unittest.mock import MagicMock
 
-        runner = DiscoverRunner.__new__(DiscoverRunner)
+        runner = DiscoverRunner(config, event_bus)
         task = MagicMock()
         task.id = 42
         task.title = "Build a better Calendly"

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -1,0 +1,91 @@
+"""Tests for target-repo language detection via marker files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from language_detector import detect_languages
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+class TestDetectLanguages:
+    """Tests for detect_languages() — marker-based language detection."""
+
+    def test_python_from_pyproject_toml(self, repo: Path) -> None:
+        """pyproject.toml presence should detect python."""
+        (repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        assert detect_languages(repo) == {"python"}
+
+    def test_python_from_setup_py(self, repo: Path) -> None:
+        """setup.py presence should detect python."""
+        (repo / "setup.py").write_text("from setuptools import setup\n")
+        assert detect_languages(repo) == {"python"}
+
+    def test_python_from_requirements_txt(self, repo: Path) -> None:
+        """requirements.txt presence should detect python."""
+        (repo / "requirements.txt").write_text("requests==2.0\n")
+        assert detect_languages(repo) == {"python"}
+
+    def test_typescript_from_tsconfig(self, repo: Path) -> None:
+        """tsconfig.json presence should detect typescript."""
+        (repo / "tsconfig.json").write_text("{}\n")
+        assert detect_languages(repo) == {"typescript"}
+
+    def test_typescript_from_package_json_with_ts_dep(self, repo: Path) -> None:
+        """package.json with typescript in devDependencies should detect typescript."""
+        (repo / "package.json").write_text(
+            '{"devDependencies": {"typescript": "^5.0.0"}}\n'
+        )
+        assert detect_languages(repo) == {"typescript"}
+
+    def test_package_json_without_typescript_dep_is_not_typescript(
+        self, repo: Path
+    ) -> None:
+        """package.json without typescript dependency should not detect typescript."""
+        (repo / "package.json").write_text('{"dependencies": {"react": "^18.0.0"}}\n')
+        assert detect_languages(repo) == set()
+
+    def test_csharp_from_csproj(self, repo: Path) -> None:
+        """A .csproj file should detect csharp."""
+        (repo / "MyApp.csproj").write_text("<Project></Project>\n")
+        assert detect_languages(repo) == {"csharp"}
+
+    def test_csharp_from_sln(self, repo: Path) -> None:
+        """A .sln file should detect csharp."""
+        (repo / "MyApp.sln").write_text("Microsoft Visual Studio Solution\n")
+        assert detect_languages(repo) == {"csharp"}
+
+    def test_go_from_go_mod(self, repo: Path) -> None:
+        """go.mod presence should detect go."""
+        (repo / "go.mod").write_text("module example.com/foo\n")
+        assert detect_languages(repo) == {"go"}
+
+    def test_rust_from_cargo_toml(self, repo: Path) -> None:
+        """Cargo.toml presence should detect rust."""
+        (repo / "Cargo.toml").write_text("[package]\nname = 'x'\n")
+        assert detect_languages(repo) == {"rust"}
+
+    def test_multi_language_returns_all(self, repo: Path) -> None:
+        """Multiple marker files should return all detected languages."""
+        (repo / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        (repo / "tsconfig.json").write_text("{}\n")
+        assert detect_languages(repo) == {"python", "typescript"}
+
+    def test_empty_repo_returns_empty_set(self, repo: Path) -> None:
+        """A directory with no marker files should return an empty set."""
+        assert detect_languages(repo) == set()
+
+    def test_nonexistent_path_returns_empty_set(self, repo: Path) -> None:
+        """A nonexistent path should return an empty set, not raise."""
+        assert detect_languages(repo / "does-not-exist") == set()
+
+    def test_malformed_package_json_is_not_typescript(self, repo: Path) -> None:
+        """Malformed package.json should be treated as no typescript dependency."""
+        (repo / "package.json").write_text("{not valid json")
+        assert detect_languages(repo) == set()

--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -44,6 +44,13 @@ class TestDetectLanguages:
         )
         assert detect_languages(repo) == {"typescript"}
 
+    def test_typescript_from_package_json_dependencies(self, repo: Path) -> None:
+        """Return typescript when package.json declares typescript under dependencies."""
+        (repo / "package.json").write_text(
+            '{"dependencies": {"typescript": "^5.0.0"}}\n'
+        )
+        assert detect_languages(repo) == {"typescript"}
+
     def test_package_json_without_typescript_dep_is_not_typescript(
         self, repo: Path
     ) -> None:

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -163,3 +163,28 @@ class TestPlannerSkillInjection:
 
         assert "superpowers:writing-plans" in prompt
         assert "## Available Skills" in prompt
+
+
+class TestDiscoverSkillInjection:
+    """Verify plugin skills are injected into the discover prompt."""
+
+    def test_plugin_skills_appear_in_discover_prompt(self, config, event_bus) -> None:
+        """The formatted skills section appears in the discover prompt."""
+        from discover_runner import DiscoverRunner
+        from plugin_skill_registry import PluginSkill
+        from tests.conftest import TaskFactory
+
+        fake_skills = [
+            PluginSkill(
+                "superpowers", "brainstorming", "Use when starting creative work"
+            )
+        ]
+
+        issue = TaskFactory.create(id=1, title="build something", body="vague")
+        runner = DiscoverRunner(config, event_bus)
+
+        with patch("discover_runner.discover_plugin_skills", return_value=fake_skills):
+            prompt = runner._build_prompt(issue)
+
+        assert "superpowers:brainstorming" in prompt
+        assert "## Available Skills" in prompt

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -112,3 +112,28 @@ class TestReviewSkillInjection:
             )
 
         assert "## Available Skills" not in prompt
+
+
+class TestTriageSkillInjection:
+    """Verify plugin skills are injected into the triage prompt."""
+
+    def test_plugin_skills_appear_in_triage_prompt(self, config, event_bus) -> None:
+        """The formatted skills section appears in the triage prompt."""
+        from plugin_skill_registry import PluginSkill
+        from tests.conftest import TaskFactory
+        from triage import TriageRunner
+
+        fake_skills = [
+            PluginSkill(
+                "superpowers", "brainstorming", "Use when starting creative work"
+            )
+        ]
+
+        issue = TaskFactory.create(id=1, title="Vague idea", body="do stuff")
+        triager = TriageRunner(config, event_bus)
+
+        with patch("triage.discover_plugin_skills", return_value=fake_skills):
+            prompt, _ = triager._build_prompt_with_stats(issue)
+
+        assert "superpowers:brainstorming" in prompt
+        assert "## Available Skills" in prompt

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -1,0 +1,60 @@
+"""Integration tests — plugin skills appear in each factory phase prompt.
+
+Mirrors ``tests/test_beads_manager.py::TestAgentBeadPromptIntegration`` — the
+existing pattern for asserting that a runtime-built registry lands in the
+final prompt string sent to Claude.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestImplementSkillInjection:
+    """Verify plugin skills are injected into the implement prompt."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_skills_appear_in_implement_prompt(
+        self, config, event_bus
+    ) -> None:
+        """The formatted skills section and qualified names appear in the prompt."""
+        from agent import AgentRunner
+        from plugin_skill_registry import PluginSkill
+        from tests.conftest import TaskFactory
+
+        fake_skills = [
+            PluginSkill(
+                "superpowers",
+                "test-driven-development",
+                "Use when implementing a feature",
+            ),
+            PluginSkill("code-review", "code-review", "Review a PR"),
+        ]
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        runner = AgentRunner(config, event_bus)
+
+        with patch("agent.discover_plugin_skills", return_value=fake_skills):
+            prompt, _ = await runner._build_prompt_with_stats(issue)
+
+        assert "superpowers:test-driven-development" in prompt
+        assert "code-review:code-review" in prompt
+        assert "## Available Skills" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_skills_section_when_registry_empty(
+        self, config, event_bus
+    ) -> None:
+        """Empty skill list produces no '## Available Skills' section."""
+        from agent import AgentRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        runner = AgentRunner(config, event_bus)
+
+        with patch("agent.discover_plugin_skills", return_value=[]):
+            prompt, _ = await runner._build_prompt_with_stats(issue)
+
+        assert "## Available Skills" not in prompt

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -58,3 +58,57 @@ class TestImplementSkillInjection:
             prompt, _ = await runner._build_prompt_with_stats(issue)
 
         assert "## Available Skills" not in prompt
+
+
+class TestReviewSkillInjection:
+    """Verify plugin skills are injected into the review prompt."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_skills_appear_in_review_prompt(
+        self, config, event_bus
+    ) -> None:
+        """The formatted skills section and qualified names appear in the review prompt."""
+        from models import PRInfo
+        from plugin_skill_registry import PluginSkill
+        from reviewer import ReviewRunner
+        from tests.conftest import TaskFactory
+
+        fake_skills = [
+            PluginSkill("code-review", "code-review", "Review a PR"),
+            PluginSkill(
+                "superpowers",
+                "receiving-code-review",
+                "Use when receiving review feedback",
+            ),
+        ]
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        pr = PRInfo(number=1, issue_number=1, branch="feat/test")
+        reviewer = ReviewRunner(config, event_bus)
+
+        with patch("reviewer.discover_plugin_skills", return_value=fake_skills):
+            prompt, _ = await reviewer._build_review_prompt_with_stats(
+                pr, issue, diff="diff --git a/x b/x\n+foo\n"
+            )
+
+        assert "code-review:code-review" in prompt
+        assert "superpowers:receiving-code-review" in prompt
+        assert "## Available Skills" in prompt
+
+    @pytest.mark.asyncio
+    async def test_no_skills_section_when_review_empty(self, config, event_bus) -> None:
+        """Empty skill list in review phase produces no header."""
+        from models import PRInfo
+        from reviewer import ReviewRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        pr = PRInfo(number=1, issue_number=1, branch="feat/test")
+        reviewer = ReviewRunner(config, event_bus)
+
+        with patch("reviewer.discover_plugin_skills", return_value=[]):
+            prompt, _ = await reviewer._build_review_prompt_with_stats(
+                pr, issue, diff=""
+            )
+
+        assert "## Available Skills" not in prompt

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -137,3 +137,29 @@ class TestTriageSkillInjection:
 
         assert "superpowers:brainstorming" in prompt
         assert "## Available Skills" in prompt
+
+
+class TestPlannerSkillInjection:
+    """Verify plugin skills are injected into the planner prompt."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_skills_appear_in_planner_prompt(
+        self, config, event_bus
+    ) -> None:
+        """The formatted skills section appears in the planner prompt."""
+        from planner import PlannerRunner
+        from plugin_skill_registry import PluginSkill
+        from tests.conftest import TaskFactory
+
+        fake_skills = [
+            PluginSkill("superpowers", "writing-plans", "Use when writing a plan")
+        ]
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        planner = PlannerRunner(config, event_bus)
+
+        with patch("planner.discover_plugin_skills", return_value=fake_skills):
+            prompt, _ = await planner._build_prompt_with_stats(issue)
+
+        assert "superpowers:writing-plans" in prompt
+        assert "## Available Skills" in prompt

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -12,6 +12,16 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _reset_skill_cache():
+    """Clear the discovery cache before every test to prevent cross-test leakage."""
+    from plugin_skill_registry import clear_plugin_skill_cache
+
+    clear_plugin_skill_cache()
+    yield
+    clear_plugin_skill_cache()
+
+
 class TestImplementSkillInjection:
     """Verify plugin skills are injected into the implement prompt."""
 

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -188,3 +188,30 @@ class TestDiscoverSkillInjection:
 
         assert "superpowers:brainstorming" in prompt
         assert "## Available Skills" in prompt
+
+
+class TestShapeSkillInjection:
+    """Verify plugin skills are injected into the shape turn prompt."""
+
+    def test_plugin_skills_appear_in_shape_prompt(self, config, event_bus) -> None:
+        """The formatted skills section appears in the shape turn prompt."""
+        from models import ShapeConversation
+        from plugin_skill_registry import PluginSkill
+        from shape_runner import ShapeRunner
+        from tests.conftest import TaskFactory
+
+        fake_skills = [
+            PluginSkill(
+                "superpowers", "brainstorming", "Use when starting creative work"
+            )
+        ]
+
+        issue = TaskFactory.create(id=1, title="shape this", body="rough idea")
+        conversation = ShapeConversation(issue_number=1)
+        runner = ShapeRunner(config, event_bus)
+
+        with patch("shape_runner.discover_plugin_skills", return_value=fake_skills):
+            prompt = runner._build_turn_prompt(issue, conversation)
+
+        assert "superpowers:brainstorming" in prompt
+        assert "## Available Skills" in prompt

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -1,0 +1,124 @@
+"""Tests for plugin skill discovery and prompt formatting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from plugin_skill_registry import (
+    PluginSkill,
+    discover_plugin_skills,
+)
+
+
+def _write_skill(
+    cache_root: Path,
+    marketplace: str,
+    plugin: str,
+    skill: str,
+    *,
+    name: str | None = None,
+    description: str | None = None,
+    frontmatter: str | None = None,
+) -> Path:
+    """Create a SKILL.md under the cache layout and return its path."""
+    skill_dir = cache_root / marketplace / plugin / "skills" / skill
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    skill_md = skill_dir / "SKILL.md"
+    if frontmatter is not None:
+        content = f"---\n{frontmatter}\n---\n\nBody here.\n"
+    else:
+        content = (
+            "---\n"
+            f"name: {name or skill}\n"
+            f"description: {description or f'{skill} description'}\n"
+            "---\n\nBody here.\n"
+        )
+    skill_md.write_text(content)
+    return skill_md
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path) -> Path:
+    root = tmp_path / "cache"
+    root.mkdir()
+    return root
+
+
+class TestDiscoverPluginSkills:
+    """Verify discover_plugin_skills scans the cache correctly."""
+
+    def test_finds_skills_in_allowlisted_plugins(self, cache_root: Path) -> None:
+        """Return skills from allowlisted plugins with qualified names."""
+        _write_skill(cache_root, "official", "superpowers", "brainstorming")
+        _write_skill(cache_root, "official", "superpowers", "writing-plans")
+
+        result = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        names = {s.qualified_name for s in result}
+        assert names == {"superpowers:brainstorming", "superpowers:writing-plans"}
+
+    def test_skips_non_allowlisted_plugins(self, cache_root: Path) -> None:
+        """Omit plugins that are not in the allowlist."""
+        _write_skill(cache_root, "official", "superpowers", "brainstorming")
+        _write_skill(cache_root, "official", "other-plugin", "some-skill")
+
+        result = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        assert {s.plugin for s in result} == {"superpowers"}
+
+    def test_skips_malformed_frontmatter(
+        self, cache_root: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Skip skills whose SKILL.md lacks name or description and warn."""
+        _write_skill(cache_root, "official", "superpowers", "good")
+        _write_skill(
+            cache_root,
+            "official",
+            "superpowers",
+            "missing-desc",
+            frontmatter="name: broken",
+        )
+
+        with caplog.at_level("WARNING"):
+            result = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        assert {s.name for s in result} == {"good"}
+        assert any("missing-desc" in record.message for record in caplog.records)
+
+    def test_filters_using_superpowers_meta_skill(self, cache_root: Path) -> None:
+        """Always exclude the using-superpowers meta-skill."""
+        _write_skill(cache_root, "official", "superpowers", "brainstorming")
+        _write_skill(cache_root, "official", "superpowers", "using-superpowers")
+
+        result = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        assert {s.name for s in result} == {"brainstorming"}
+
+    def test_returns_empty_when_cache_root_missing(self, tmp_path: Path) -> None:
+        """Do not raise when the cache root does not exist."""
+        missing = tmp_path / "does-not-exist"
+        assert discover_plugin_skills(["superpowers"], cache_root=missing) == []
+
+    def test_returns_empty_when_plugin_dir_missing(self, cache_root: Path) -> None:
+        """Return empty list when the allowlisted plugin is not installed."""
+        assert discover_plugin_skills(["superpowers"], cache_root=cache_root) == []
+
+    def test_handles_plugin_with_no_skills_dir(self, cache_root: Path) -> None:
+        """Return empty list when a plugin has no skills/ subdirectory."""
+        (cache_root / "official" / "empty-plugin").mkdir(parents=True)
+        assert discover_plugin_skills(["empty-plugin"], cache_root=cache_root) == []
+
+
+class TestPluginSkillQualifiedName:
+    """Verify the qualified_name property formats correctly."""
+
+    def test_qualified_name_format(self) -> None:
+        """qualified_name is 'plugin:name' with a colon separator."""
+        skill = PluginSkill(
+            plugin="superpowers",
+            name="brainstorming",
+            description="Use when...",
+        )
+        assert skill.qualified_name == "superpowers:brainstorming"

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -13,6 +13,16 @@ from plugin_skill_registry import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _reset_skill_cache():
+    """Clear the discovery cache before every test to prevent cross-test leakage."""
+    from plugin_skill_registry import clear_plugin_skill_cache
+
+    clear_plugin_skill_cache()
+    yield
+    clear_plugin_skill_cache()
+
+
 def _write_skill(
     cache_root: Path,
     marketplace: str,
@@ -228,3 +238,53 @@ class TestFormatPluginSkillsForPrompt:
         output = format_plugin_skills_for_prompt(skills)
         assert "`Skill` tool" in output
         assert "qualified name" in output
+
+
+class TestDiscoveryCache:
+    """Verify discover_plugin_skills caches results and clear_plugin_skill_cache resets state."""
+
+    def test_second_call_is_cached(self, cache_root: Path) -> None:
+        """Repeated calls with the same args do not re-scan the filesystem."""
+        from plugin_skill_registry import clear_plugin_skill_cache
+
+        clear_plugin_skill_cache()
+        _write_skill(cache_root, "official", "superpowers", "brainstorming")
+
+        first = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+        assert len(first) == 1
+
+        # Remove the SKILL.md — cache should still serve the old result.
+        (
+            cache_root
+            / "official"
+            / "superpowers"
+            / "1.0.0"
+            / "skills"
+            / "brainstorming"
+            / "SKILL.md"
+        ).unlink()
+
+        second = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+        assert second == first  # cache hit
+
+    def test_clear_cache_forces_rescan(self, cache_root: Path) -> None:
+        """clear_plugin_skill_cache drops the cache so next call rescans."""
+        from plugin_skill_registry import clear_plugin_skill_cache
+
+        clear_plugin_skill_cache()
+        _write_skill(cache_root, "official", "superpowers", "brainstorming")
+        discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        # Drop the file and clear the cache — now we should see 0.
+        (
+            cache_root
+            / "official"
+            / "superpowers"
+            / "1.0.0"
+            / "skills"
+            / "brainstorming"
+            / "SKILL.md"
+        ).unlink()
+        clear_plugin_skill_cache()
+
+        assert discover_plugin_skills(["superpowers"], cache_root=cache_root) == []

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -22,9 +22,15 @@ def _write_skill(
     name: str | None = None,
     description: str | None = None,
     frontmatter: str | None = None,
+    version: str = "1.0.0",
 ) -> Path:
-    """Create a SKILL.md under the cache layout and return its path."""
-    skill_dir = cache_root / marketplace / plugin / "skills" / skill
+    """Create a SKILL.md under the cache layout and return its path.
+
+    Real cache layout: ``<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``.
+    ``version`` parameter defaults to ``"1.0.0"`` — override to simulate multiple
+    versions of the same plugin (used by the dedup test).
+    """
+    skill_dir = cache_root / marketplace / plugin / version / "skills" / skill
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_md = skill_dir / "SKILL.md"
     if frontmatter is not None:
@@ -129,9 +135,41 @@ class TestDiscoverPluginSkills:
         assert discover_plugin_skills(["superpowers"], cache_root=cache_root) == []
 
     def test_handles_plugin_with_no_skills_dir(self, cache_root: Path) -> None:
-        """Return empty list when a plugin has no skills/ subdirectory."""
+        """Return empty list when a plugin has no version/skills subdirectory."""
         (cache_root / "official" / "empty-plugin").mkdir(parents=True)
         assert discover_plugin_skills(["empty-plugin"], cache_root=cache_root) == []
+
+    def test_dedupes_skills_across_plugin_versions(self, cache_root: Path) -> None:
+        """Return one entry per skill name even when multiple versions exist."""
+        _write_skill(
+            cache_root,
+            "official",
+            "frontend-design",
+            "frontend-design",
+            version="1.0.0",
+        )
+        _write_skill(
+            cache_root,
+            "official",
+            "frontend-design",
+            "frontend-design",
+            version="unknown",
+        )
+
+        result = discover_plugin_skills(["frontend-design"], cache_root=cache_root)
+
+        assert len(result) == 1
+        assert result[0].qualified_name == "frontend-design:frontend-design"
+
+    def test_skips_plugin_version_without_skills_dir(self, cache_root: Path) -> None:
+        """Skip version directories that have no skills/ (e.g. commands-only)."""
+        # Create one version without skills/ and one with.
+        (cache_root / "official" / "multi" / "unknown" / "commands").mkdir(parents=True)
+        _write_skill(cache_root, "official", "multi", "real-skill", version="2.0.0")
+
+        result = discover_plugin_skills(["multi"], cache_root=cache_root)
+
+        assert {s.name for s in result} == {"real-skill"}
 
 
 class TestPluginSkillQualifiedName:

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -68,6 +68,28 @@ class TestDiscoverPluginSkills:
 
         assert {s.plugin for s in result} == {"superpowers"}
 
+    def test_parses_folded_multiline_description(self, cache_root: Path) -> None:
+        """Join indented continuation lines of a description with spaces."""
+        _write_skill(
+            cache_root,
+            "official",
+            "superpowers",
+            "multi",
+            frontmatter=(
+                "name: multi\n"
+                "description: First line of description\n"
+                "  continues here\n"
+                "  and here"
+            ),
+        )
+
+        result = discover_plugin_skills(["superpowers"], cache_root=cache_root)
+
+        assert len(result) == 1
+        assert (
+            result[0].description == "First line of description continues here and here"
+        )
+
     def test_skips_malformed_frontmatter(
         self, cache_root: Path, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -185,7 +185,8 @@ class TestFormatPluginSkillsForPrompt:
         assert format_plugin_skills_for_prompt([]) == ""
 
     def test_mentions_skill_tool_usage(self) -> None:
-        """Output instructs the agent to invoke via the Skill tool."""
+        """Output tells the agent to invoke the Skill tool by qualified name."""
         skills = [PluginSkill("superpowers", "brainstorming", "Use when...")]
         output = format_plugin_skills_for_prompt(skills)
-        assert "Skill" in output
+        assert "`Skill` tool" in output
+        assert "qualified name" in output

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -9,6 +9,7 @@ import pytest
 from plugin_skill_registry import (
     PluginSkill,
     discover_plugin_skills,
+    format_plugin_skills_for_prompt,
 )
 
 
@@ -144,3 +145,47 @@ class TestPluginSkillQualifiedName:
             description="Use when...",
         )
         assert skill.qualified_name == "superpowers:brainstorming"
+
+
+class TestFormatPluginSkillsForPrompt:
+    """Verify format_plugin_skills_for_prompt emits the expected prompt section."""
+
+    def test_contains_skills_header(self) -> None:
+        """Output begins with a markdown section header."""
+        skills = [PluginSkill("superpowers", "brainstorming", "Use when...")]
+        assert "## Available Skills" in format_plugin_skills_for_prompt(skills)
+
+    def test_contains_qualified_names(self) -> None:
+        """Each skill's qualified_name appears verbatim."""
+        skills = [
+            PluginSkill(
+                "superpowers", "brainstorming", "Use when starting creative work"
+            ),
+            PluginSkill("code-review", "code-review", "Review a PR"),
+        ]
+        output = format_plugin_skills_for_prompt(skills)
+        assert "superpowers:brainstorming" in output
+        assert "code-review:code-review" in output
+
+    def test_contains_descriptions(self) -> None:
+        """Each skill's description appears in the output."""
+        skills = [
+            PluginSkill(
+                "superpowers",
+                "brainstorming",
+                "Use when starting creative work",
+            )
+        ]
+        assert "Use when starting creative work" in format_plugin_skills_for_prompt(
+            skills
+        )
+
+    def test_empty_list_returns_empty_string(self) -> None:
+        """Empty skill list produces an empty string (no header)."""
+        assert format_plugin_skills_for_prompt([]) == ""
+
+    def test_mentions_skill_tool_usage(self) -> None:
+        """Output instructs the agent to invoke via the Skill tool."""
+        skills = [PluginSkill("superpowers", "brainstorming", "Use when...")]
+        output = format_plugin_skills_for_prompt(skills)
+        assert "Skill" in output

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -11,6 +11,7 @@ from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
 )
+from tests.conftest import write_plugin_skill as _write_skill
 
 
 @pytest.fixture(autouse=True)
@@ -21,39 +22,6 @@ def _reset_skill_cache():
     clear_plugin_skill_cache()
     yield
     clear_plugin_skill_cache()
-
-
-def _write_skill(
-    cache_root: Path,
-    marketplace: str,
-    plugin: str,
-    skill: str,
-    *,
-    name: str | None = None,
-    description: str | None = None,
-    frontmatter: str | None = None,
-    version: str = "1.0.0",
-) -> Path:
-    """Create a SKILL.md under the cache layout and return its path.
-
-    Real cache layout: ``<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``.
-    ``version`` parameter defaults to ``"1.0.0"`` — override to simulate multiple
-    versions of the same plugin (used by the dedup test).
-    """
-    skill_dir = cache_root / marketplace / plugin / version / "skills" / skill
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    skill_md = skill_dir / "SKILL.md"
-    if frontmatter is not None:
-        content = f"---\n{frontmatter}\n---\n\nBody here.\n"
-    else:
-        content = (
-            "---\n"
-            f"name: {name or skill}\n"
-            f"description: {description or f'{skill} description'}\n"
-            "---\n\nBody here.\n"
-        )
-    skill_md.write_text(content)
-    return skill_md
 
 
 @pytest.fixture

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -287,8 +287,8 @@ async def test_run_preflight_checks_host_mode(tmp_path: Path) -> None:
     ):
         results = await run_preflight_checks(config)
 
-    # git, gh-cli, gh-auth, repo-root, disk-space, 3x agent-cli
-    assert len(results) == 8
+    # git, gh-cli, gh-auth, repo-root, disk-space, 3x agent-cli, plugins
+    assert len(results) == 9
     # No docker check in host mode
     assert not any(r.name == "docker" for r in results)
 
@@ -319,7 +319,7 @@ async def test_run_preflight_checks_docker_mode(tmp_path: Path) -> None:
         results = await run_preflight_checks(config)
 
     assert any(r.name == "docker" for r in results)
-    assert len(results) == 9  # 8 base + docker
+    assert len(results) == 10  # 9 base + docker
 
 
 @pytest.mark.asyncio

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -148,9 +148,21 @@ class TestRunPreflightChecksWiring:
     """Verify _check_plugins is invoked by run_preflight_checks."""
 
     @pytest.mark.asyncio
-    async def test_plugin_check_appears_in_results(self, tmp_path: Path) -> None:
-        """run_preflight_checks includes a 'plugins' result entry."""
+    async def test_plugin_check_appears_in_results_with_pass_status(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_preflight_checks invokes _check_plugins with the shared default cache root.
+
+        Isolated by monkeypatching plugin_skill_registry._DEFAULT_CACHE_ROOT so the
+        test does not depend on the developer's real ~/.claude/plugins/cache.
+        """
+        import plugin_skill_registry
         from preflight import run_preflight_checks
+
+        cache_root = tmp_path / "cache"
+        cache_root.mkdir()
+        _make_plugin(cache_root, "superpowers")
+        monkeypatch.setattr(plugin_skill_registry, "_DEFAULT_CACHE_ROOT", cache_root)
 
         config = HydraFlowConfig(
             required_plugins=["superpowers"],
@@ -159,5 +171,5 @@ class TestRunPreflightChecksWiring:
             data_root=str(tmp_path),
         )
         results = await run_preflight_checks(config)
-        names = [r.name for r in results]
-        assert "plugins" in names
+        plugin_result = next(r for r in results if r.name == "plugins")
+        assert plugin_result.status == CheckStatus.PASS

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -1,0 +1,100 @@
+"""Tests for the plugin preflight check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config import HydraFlowConfig
+from preflight import CheckStatus, _check_plugins
+
+
+def _make_plugin(cache_root: Path, plugin: str, skill: str = "some-skill") -> None:
+    """Create a minimal plugin with one well-formed skill."""
+    skill_dir = cache_root / "official" / plugin / "skills" / skill
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill}\ndescription: A skill description\n---\n\nBody.\n"
+    )
+
+
+@pytest.fixture
+def cache_root(tmp_path: Path) -> Path:
+    root = tmp_path / "cache"
+    root.mkdir()
+    return root
+
+
+class TestCheckPlugins:
+    """Verify _check_plugins gates on allowlist + skill count."""
+
+    def test_passes_when_all_required_present(self, cache_root: Path) -> None:
+        """PASS when every Tier-1 plugin exists and at least one skill loads."""
+        _make_plugin(cache_root, "superpowers")
+        _make_plugin(cache_root, "code-review")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers", "code-review"],
+            language_plugins={},
+        )
+        result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
+
+        assert result.status == CheckStatus.PASS
+
+    def test_fails_when_tier1_plugin_missing(self, cache_root: Path) -> None:
+        """FAIL when a Tier-1 plugin directory is not present."""
+        _make_plugin(cache_root, "superpowers")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers", "code-review"],
+            language_plugins={},
+        )
+        result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
+
+        assert result.status == CheckStatus.FAIL
+        assert "code-review" in result.message
+
+    def test_fails_when_zero_skills_discovered(self, cache_root: Path) -> None:
+        """FAIL when the allowlisted plugin has no skills."""
+        (cache_root / "official" / "superpowers").mkdir(parents=True)
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={},
+        )
+        result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
+
+        assert result.status == CheckStatus.FAIL
+        assert "0 skills" in result.message
+
+    def test_warns_when_tier2_missing_and_language_detected(
+        self, cache_root: Path
+    ) -> None:
+        """WARN when a language-conditional plugin is missing for a detected language."""
+        _make_plugin(cache_root, "superpowers")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={"python": ["pyright-lsp"]},
+        )
+        result = _check_plugins(
+            config, cache_root=cache_root, detected_languages={"python"}
+        )
+
+        assert result.status == CheckStatus.WARN
+        assert "pyright-lsp" in result.message
+
+    def test_silent_when_tier2_missing_and_language_absent(
+        self, cache_root: Path
+    ) -> None:
+        """PASS silently when a Tier-2 plugin is missing but its language was not detected."""
+        _make_plugin(cache_root, "superpowers")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={"python": ["pyright-lsp"]},
+        )
+        result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
+
+        assert result.status == CheckStatus.PASS

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -54,6 +54,7 @@ class TestCheckPlugins:
 
         assert result.status == CheckStatus.FAIL
         assert "code-review" in result.message
+        assert "/plugin install" in result.message
 
     def test_fails_when_zero_skills_discovered(self, cache_root: Path) -> None:
         """FAIL when the allowlisted plugin has no skills."""
@@ -98,3 +99,33 @@ class TestCheckPlugins:
         result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
 
         assert result.status == CheckStatus.PASS
+
+    def test_fails_when_cache_root_is_file(self, tmp_path: Path) -> None:
+        """FAIL when cache_root exists but is a regular file, not a directory."""
+        cache_file = tmp_path / "cache"
+        cache_file.write_text("not a dir")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={},
+        )
+        result = _check_plugins(config, cache_root=cache_file, detected_languages=set())
+
+        assert result.status == CheckStatus.FAIL
+        assert "not a directory" in result.message
+
+    def test_warn_message_includes_language_context(self, cache_root: Path) -> None:
+        """WARN message identifies which language triggered the missing plugin."""
+        _make_plugin(cache_root, "superpowers")
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={"python": ["pyright-lsp"]},
+        )
+        result = _check_plugins(
+            config, cache_root=cache_root, detected_languages={"python"}
+        )
+
+        assert result.status == CheckStatus.WARN
+        assert "for python" in result.message
+        assert "pyright-lsp" in result.message

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -11,8 +11,11 @@ from preflight import CheckStatus, _check_plugins
 
 
 def _make_plugin(cache_root: Path, plugin: str, skill: str = "some-skill") -> None:
-    """Create a minimal plugin with one well-formed skill."""
-    skill_dir = cache_root / "official" / plugin / "skills" / skill
+    """Create a minimal plugin with one well-formed skill.
+
+    Mirrors the real cache layout: ``<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``.
+    """
+    skill_dir = cache_root / "official" / plugin / "1.0.0" / "skills" / skill
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         f"---\nname: {skill}\ndescription: A skill description\n---\n\nBody.\n"

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -10,6 +10,16 @@ from config import HydraFlowConfig
 from preflight import CheckStatus, _check_plugins
 
 
+@pytest.fixture(autouse=True)
+def _reset_skill_cache():
+    """Clear the discovery cache before every test to prevent cross-test leakage."""
+    from plugin_skill_registry import clear_plugin_skill_cache
+
+    clear_plugin_skill_cache()
+    yield
+    clear_plugin_skill_cache()
+
+
 def _make_plugin(cache_root: Path, plugin: str, skill: str = "some-skill") -> None:
     """Create a minimal plugin with one well-formed skill.
 

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -129,3 +129,22 @@ class TestCheckPlugins:
         assert result.status == CheckStatus.WARN
         assert "for python" in result.message
         assert "pyright-lsp" in result.message
+
+
+class TestRunPreflightChecksWiring:
+    """Verify _check_plugins is invoked by run_preflight_checks."""
+
+    @pytest.mark.asyncio
+    async def test_plugin_check_appears_in_results(self, tmp_path: Path) -> None:
+        """run_preflight_checks includes a 'plugins' result entry."""
+        from preflight import run_preflight_checks
+
+        config = HydraFlowConfig(
+            required_plugins=["superpowers"],
+            language_plugins={},
+            repo_root=str(tmp_path),
+            data_root=str(tmp_path),
+        )
+        results = await run_preflight_checks(config)
+        names = [r.name for r in results]
+        assert "plugins" in names

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -21,15 +21,10 @@ def _reset_skill_cache():
 
 
 def _make_plugin(cache_root: Path, plugin: str, skill: str = "some-skill") -> None:
-    """Create a minimal plugin with one well-formed skill.
+    """Create a minimal plugin with one well-formed skill (thin wrapper around shared helper)."""
+    from tests.conftest import write_plugin_skill
 
-    Mirrors the real cache layout: ``<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md``.
-    """
-    skill_dir = cache_root / "official" / plugin / "1.0.0" / "skills" / skill
-    skill_dir.mkdir(parents=True)
-    (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {skill}\ndescription: A skill description\n---\n\nBody.\n"
-    )
+    write_plugin_skill(cache_root, "official", plugin, skill)
 
 
 @pytest.fixture

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -557,28 +557,33 @@ class TestBuildCommand:
 class TestBuildPrompt:
     """Tests for TriageRunner._build_prompt_with_stats."""
 
-    def test_prompt_contains_issue_title_and_body(self) -> None:
+    def test_prompt_contains_issue_title_and_body(self, config, event_bus) -> None:
         issue = TaskFactory.create(
             id=42,
             title="Add dark mode toggle",
             body="The app should support dark mode in settings.",
         )
-        prompt, _ = TriageRunner._build_prompt_with_stats(issue)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
         assert "Add dark mode toggle" in prompt
         assert "dark mode in settings" in prompt
         assert "#42" in prompt
 
-    def test_prompt_contains_evaluation_criteria(self) -> None:
+    def test_prompt_contains_evaluation_criteria(self, config, event_bus) -> None:
         issue = TaskFactory.create(id=1)
-        prompt, _ = TriageRunner._build_prompt_with_stats(issue)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
         assert "Clarity" in prompt
         assert "Specificity" in prompt
         assert "Actionability" in prompt
         assert "Scope" in prompt
 
-    def test_build_prompt_with_stats_tracks_body_pruning(self) -> None:
+    def test_build_prompt_with_stats_tracks_body_pruning(
+        self, config, event_bus
+    ) -> None:
         issue = TaskFactory.create(id=9, body="a" * 200)
-        _prompt, stats = TriageRunner._build_prompt_with_stats(issue, max_body=50)
+        runner = TriageRunner(config, event_bus)
+        _prompt, stats = runner._build_prompt_with_stats(issue, max_body=50)
         assert stats["context_chars_before"] == 200
         assert stats["context_chars_after"] > 50
         assert stats["pruned_chars_total"] > 0


### PR DESCRIPTION
## Summary

Makes HydraFlow's factory phases (triage, discover, shape, plan, implement, review) dynamically discover installed Claude Code plugin skills and advertise them to child agents. Closes the gap where child Claudes had skills available via the \`Skill\` tool but didn't know what existed.

**Design spec:** \`docs/superpowers/specs/2026-04-18-dynamic-plugin-skill-registry-design.md\` (local, gitignored)
**Implementation plan:** \`docs/superpowers/plans/2026-04-18-dynamic-plugin-skill-registry.md\` (local, gitignored)

### What's in the box

- \`src/plugin_skill_registry.py\` — \`PluginSkill\` dataclass + \`discover_plugin_skills()\` that scans \`~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/<skill>/SKILL.md\`, parses frontmatter, dedupes across versions, filters \`using-superpowers\` meta-skill.
- \`src/language_detector.py\` — per-repo language detection from marker files (python/typescript/csharp/go/rust) for Tier-2 language-conditional plugins.
- \`src/preflight.py::_check_plugins\` — startup gate that FAILs if Tier-1 plugins are missing or zero skills are discovered, WARNs on missing Tier-2 for detected languages, wired into \`run_preflight_checks\`.
- \`HydraFlowConfig.required_plugins\` and \`HydraFlowConfig.language_plugins\` — the two-tier allowlist.
- All 6 factory phase prompts (\`agent.py\`, \`reviewer.py\`, \`triage.py\`, \`planner.py\`, \`discover_runner.py\`, \`shape_runner.py\`) inject \`## Available Skills\` via \`format_plugin_skills_for_prompt\`.

### Tier-1 allowlist (always required)

\`superpowers\`, \`code-review\`, \`code-simplifier\`, \`frontend-design\`, \`playwright\`

### Tier-2 (language-conditional)

\`python → pyright-lsp\`, \`typescript → typescript-lsp\`, \`csharp → csharp-lsp\`, \`go → gopls\`, \`rust → rust-analyzer\`

### Tests (49 new)

- \`tests/test_config_plugins.py\` — 4 tests for config field defaults + overrides
- \`tests/test_language_detector.py\` — 15 tests for marker-file detection
- \`tests/test_plugin_skill_registry.py\` — 16 tests for discovery, dedup, malformed-frontmatter handling, format output
- \`tests/test_preflight_plugins.py\` — 8 tests for PASS/FAIL/WARN decision table + \`run_preflight_checks\` integration
- \`tests/test_phase_skill_injection.py\` — 8 prompt-integration tests (one per factory phase + empty-list cases) asserting qualified skill names land in the final prompt string sent to Claude

Smoke-tested against the real plugin cache — discovers 14 real skills from the live allowlist.

### Commits (19)

Structured TDD-style per-task commits; each one adds tests before implementation.

## Test plan

- [x] Unit tests for config, language detector, plugin registry, preflight all pass
- [x] Prompt-integration tests assert every phase prompt contains the advertised skills
- [x] Existing test suite unbroken (triage, reviewer, planner, discover, shape, preflight, agent all regression-tested)
- [x] Smoke test: discovers 14 real plugin skills from \`~/.claude/plugins/cache/\` on dev machine
- [ ] CI runs \`make quality\` (lint + types + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)