### PR TITLE
refactor(auto-pr): extract shared worktree+PR helper

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -15,7 +15,7 @@ from adr_utils import ADR_FILE_RE
 from agent_cli import build_lightweight_command
 from file_util import append_jsonl
 from models import ADRCouncilResult, CouncilVerdict, CouncilVote
-from subprocess_util import make_clean_env, run_subprocess
+from subprocess_util import make_clean_env
 
 if TYPE_CHECKING:
     from config import Credentials, HydraFlowConfig
@@ -804,7 +804,13 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
         readme_path: Path,
         result: ADRCouncilResult,
     ) -> None:
-        """Create worktree, commit status update, push, and create PR."""
+        """Create worktree, commit status update, push, and create PR.
+
+        Delegates the worktree/commit/push/PR lifecycle to
+        :func:`auto_pr.open_automated_pr_async`.
+        """
+        from auto_pr import open_automated_pr_async  # noqa: PLC0415
+
         if self._config.dry_run:
             logger.info(
                 "[dry-run] Would commit acceptance for ADR-%04d", result.adr_number
@@ -813,100 +819,26 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
 
         repo_root = Path(self._config.repo_root)
         branch = f"adr/accept-{result.adr_number:04d}"
-        worktree_path = (
-            Path(self._config.workspace_base) / f"adr-accept-{result.adr_number:04d}"
+
+        files = [adr_path]
+        if readme_path.exists():
+            files.append(readme_path)
+
+        minority = (
+            f"\n\nMinority note: {result.minority_note}"
+            if result.minority_note and result.minority_note != "none"
+            else ""
+        )
+        commit_message = (
+            f"Accept ADR-{result.adr_number:04d}: {result.adr_title}"
+            f"\n\nCouncil decision: {result.summary}{minority}"
         )
 
-        try:
-            # Create an isolated worktree to avoid corrupting the primary checkout
-            await run_subprocess(
-                "git",
-                "worktree",
-                "add",
-                "-b",
-                branch,
-                str(worktree_path),
-                cwd=repo_root,
-                gh_token=self._credentials.gh_token,
-            )
-
-            # Copy updated files into the worktree
-            wt_adr_path = worktree_path / adr_path.relative_to(repo_root)
-            wt_adr_path.parent.mkdir(parents=True, exist_ok=True)
-            wt_adr_path.write_text(
-                adr_path.read_text(encoding="utf-8"), encoding="utf-8"
-            )
-            await run_subprocess(
-                "git",
-                "add",
-                str(wt_adr_path.relative_to(worktree_path)),
-                cwd=worktree_path,
-                gh_token=self._credentials.gh_token,
-            )
-
-            if readme_path.exists():
-                wt_readme = worktree_path / readme_path.relative_to(repo_root)
-                wt_readme.parent.mkdir(parents=True, exist_ok=True)
-                wt_readme.write_text(
-                    readme_path.read_text(encoding="utf-8"), encoding="utf-8"
-                )
-                await run_subprocess(
-                    "git",
-                    "add",
-                    str(wt_readme.relative_to(worktree_path)),
-                    cwd=worktree_path,
-                    gh_token=self._credentials.gh_token,
-                )
-
-            minority = (
-                f"\n\nMinority note: {result.minority_note}"
-                if result.minority_note and result.minority_note != "none"
-                else ""
-            )
-            message = (
-                f"Accept ADR-{result.adr_number:04d}: {result.adr_title}"
-                f"\n\nCouncil decision: {result.summary}{minority}"
-            )
-            await run_subprocess(
-                "git",
-                "commit",
-                "-m",
-                message,
-                cwd=worktree_path,
-                gh_token=self._credentials.gh_token,
-            )
-            await run_subprocess(
-                "git",
-                "push",
-                "-u",
-                "origin",
-                branch,
-                cwd=worktree_path,
-                gh_token=self._credentials.gh_token,
-            )
-        except RuntimeError:
-            logger.exception("Failed to commit ADR-%04d acceptance", result.adr_number)
-            return
-        finally:
-            # Always clean up the worktree
-            try:
-                await run_subprocess(
-                    "git",
-                    "worktree",
-                    "remove",
-                    str(worktree_path),
-                    "--force",
-                    cwd=repo_root,
-                    gh_token=self._credentials.gh_token,
-                )
-            except RuntimeError:
-                logger.debug("Worktree cleanup failed for %s", worktree_path)
-
         summary = self._build_council_summary(result)
-        title = f"Accept ADR-{result.adr_number:04d}: {result.adr_title}"
-        if len(title) > 70:
-            title = title[:67] + "..."
-        body = (
+        pr_title = f"Accept ADR-{result.adr_number:04d}: {result.adr_title}"
+        if len(pr_title) > 70:
+            pr_title = pr_title[:67] + "..."
+        pr_body = (
             f"## ADR Council Review\n\n"
             f"The ADR review council has voted to **accept** "
             f"ADR-{result.adr_number:04d}.\n\n"
@@ -915,24 +847,19 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             f"Generated by HydraFlow ADR Council"
         )
 
-        try:
-            await run_subprocess(
-                "gh",
-                "pr",
-                "create",
-                "--title",
-                title,
-                "--body",
-                body,
-                "--base",
-                self._config.base_branch(),
-                "--head",
-                branch,
-                cwd=repo_root,
-                gh_token=self._credentials.gh_token,
-            )
-        except RuntimeError:
-            logger.exception("Failed to create PR for ADR-%04d", result.adr_number)
+        await open_automated_pr_async(
+            repo_root=repo_root,
+            branch=branch,
+            files=files,
+            pr_title=pr_title,
+            pr_body=pr_body,
+            commit_message=commit_message,
+            base=self._config.base_branch(),
+            auto_merge=False,
+            gh_token=self._credentials.gh_token,
+            raise_on_failure=False,
+            worktree_parent=Path(self._config.workspace_base),
+        )
 
     async def _escalate_to_hitl(self, result: ADRCouncilResult, *, reason: str) -> None:
         """Record a HITL escalation decision to adr_decisions.jsonl."""

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -101,8 +101,14 @@ def _run_gh(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _remove_worktree(repo_root: Path, worktree_path: Path) -> None:
-    """Best-effort worktree cleanup. Never raises."""
+def _remove_worktree(
+    repo_root: Path, worktree_path: Path, branch: str | None = None
+) -> None:
+    """Best-effort worktree cleanup. Never raises.
+
+    When `branch` is provided, also deletes the local branch so a retry with
+    the same branch name doesn't hit "branch already exists".
+    """
     try:
         _run_git(
             ["worktree", "remove", str(worktree_path), "--force"],
@@ -114,6 +120,11 @@ def _remove_worktree(repo_root: Path, worktree_path: Path) -> None:
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path, ignore_errors=True)
+
+    if branch is not None:
+        # Best-effort: delete the local branch. Harmless if it was already
+        # removed by `git worktree remove`.
+        _run_git(["branch", "-D", branch], cwd=repo_root, check=False)
 
 
 # ---------------------------------------------------------------------------
@@ -193,16 +204,21 @@ def open_automated_pr(
             return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
 
         # Copy each file into the worktree and stage it by relative path.
-        for src_path in files:
-            rel = src_path.resolve().relative_to(repo_root)
-            dst_path = worktree_path / rel
-            dst_path.parent.mkdir(parents=True, exist_ok=True)
-            dst_path.write_bytes(src_path.read_bytes())
-            _run_git(
-                ["add", str(rel)],
-                cwd=worktree_path,
-                check=True,
-            )
+        try:
+            for src_path in files:
+                rel = src_path.resolve().relative_to(repo_root)
+                dst_path = worktree_path / rel
+                dst_path.parent.mkdir(parents=True, exist_ok=True)
+                dst_path.write_bytes(src_path.read_bytes())
+                _run_git(
+                    ["add", str(rel)],
+                    cwd=worktree_path,
+                    check=True,
+                )
+        except (subprocess.CalledProcessError, OSError, ValueError) as exc:
+            raise AutoPrError(
+                f"failed to stage files for branch {branch!r}: {exc}"
+            ) from exc
 
         # Detect empty staged diff — e.g. the file contents matched origin.
         diff_check = _run_git(
@@ -270,6 +286,12 @@ def open_automated_pr(
             )
 
         pr_url = _extract_pr_url(create_proc.stdout)
+        if pr_url is None:
+            logger.warning(
+                "gh pr create succeeded for %s but no URL was parsed from stdout: %r",
+                branch,
+                create_proc.stdout,
+            )
 
         if auto_merge and pr_url is not None:
             merge_proc = _run_gh(
@@ -288,13 +310,17 @@ def open_automated_pr(
         return AutoPrResult(status="opened", pr_url=pr_url, branch=branch)
 
     finally:
-        _remove_worktree(repo_root, worktree_path)
+        _remove_worktree(repo_root, worktree_path, branch=branch)
 
 
 def _extract_pr_url(stdout: str) -> str | None:
-    """Pull the PR URL from the last non-empty line of `gh pr create` stdout."""
+    """Pull the PR URL from `gh pr create` stdout.
+
+    `gh` may emit warnings after the URL; scan from the end for the first
+    non-empty line that looks like an HTTPS URL.
+    """
     for line in reversed(stdout.splitlines()):
         stripped = line.strip()
-        if stripped:
+        if stripped.startswith("https://"):
             return stripped
     return None

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -400,10 +400,15 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
     def _fail(err: str) -> AutoPrResult:
         if raise_on_failure:
             raise AutoPrError(err)
-        logger.exception("open_automated_pr_async failed for %s: %s", branch, err)
+        # Plain .error — not .exception — because we may be called outside an
+        # except handler; .exception would attach a misleading `NoneType: None`
+        # traceback in Sentry (see docs/agents/sentry.md).
+        logger.error("open_automated_pr_async failed for %s: %s", branch, err)
         return AutoPrResult(status="failed", pr_url=None, branch=branch, error=err)
 
-    # Fetch base so origin/{base} is current.
+    # Fetch base so origin/{base} is current. Failures before the worktree
+    # is created don't need cleanup; handle them separately from the main
+    # try/finally below.
     try:
         await run_subprocess(
             "git",
@@ -417,23 +422,23 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
     except RuntimeError as exc:
         return _fail(f"git fetch failed: {exc}")
 
-    # Create worktree on new branch.
+    # From here on every exit path must go through `finally` so the worktree
+    # + branch are torn down regardless of outcome.
     try:
-        await run_subprocess(
-            "git",
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            str(worktree_path),
-            f"origin/{base}",
-            cwd=repo_root,
-            gh_token=gh_token,
-        )
-    except RuntimeError as exc:
-        return _fail(f"git worktree add failed for {branch!r}: {exc}")
-
-    try:
+        try:
+            await run_subprocess(
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                f"origin/{base}",
+                cwd=repo_root,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            return _fail(f"git worktree add failed for {branch!r}: {exc}")
         if not files:
             logger.info("open_automated_pr_async: no files supplied for %s", branch)
             return AutoPrResult(status="no-diff", pr_url=None, branch=branch)

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -53,9 +53,10 @@ class AutoPrError(RuntimeError):
 class AutoPrResult:
     """Outcome of an `open_automated_pr` call."""
 
-    status: Literal["opened", "no-diff"]
+    status: Literal["opened", "no-diff", "failed"]
     pr_url: str | None
     branch: str
+    error: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +142,7 @@ def open_automated_pr(
     body: str,
     base: str = "main",
     auto_merge: bool = True,
+    worktree_parent: Path | None = None,
 ) -> AutoPrResult:
     """Open a PR for `files` on a fresh worktree branched from `origin/{base}`.
 
@@ -173,7 +175,9 @@ def open_automated_pr(
     repo_root = repo_root.resolve()
     timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     wt_name = f"autopr-{_sanitize_branch_for_path(branch)}-{timestamp}"
-    worktree_path = repo_root.parent / wt_name
+    wt_parent = (worktree_parent or repo_root.parent).resolve()
+    wt_parent.mkdir(parents=True, exist_ok=True)
+    worktree_path = wt_parent / wt_name
 
     # Ensure we have an up-to-date origin ref for the base branch.
     _run_git(["fetch", "origin", base, "--quiet"], cwd=repo_root, check=False)
@@ -324,3 +328,262 @@ def _extract_pr_url(stdout: str) -> str | None:
         if stripped.startswith("https://"):
             return stripped
     return None
+
+
+# ---------------------------------------------------------------------------
+# Async API — used from HydraFlow's async call sites (ADR reviewer, etc.)
+# ---------------------------------------------------------------------------
+
+
+async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guards, each with its own fail path
+    *,
+    repo_root: Path,
+    branch: str,
+    files: list[Path],
+    pr_title: str,
+    pr_body: str,
+    commit_message: str | None = None,
+    base: str = "main",
+    auto_merge: bool = True,
+    gh_token: str = "",
+    raise_on_failure: bool = True,
+    worktree_parent: Path | None = None,
+) -> AutoPrResult:
+    """Async variant that routes subprocess calls through `run_subprocess`.
+
+    Same high-level behavior as the sync `open_automated_pr`:
+    worktree → copy files → stage → commit → push → gh pr create → gh pr merge
+    → clean up.
+
+    Differences from the sync version:
+
+    - Uses :func:`subprocess_util.run_subprocess` so it participates in the
+      HydraFlow async loop and the `gh/git` concurrency semaphore.
+    - Accepts an explicit `gh_token` that's threaded through every call.
+    - Accepts an independent `commit_message` for callers where the commit
+      message differs from the PR title (e.g. the ADR reviewer embeds the
+      council summary in the commit).
+    - When `raise_on_failure=False`, logs + returns an
+      ``AutoPrResult(status="failed", error=...)`` instead of raising —
+      matching the ADR reviewer's "log and continue" contract.
+
+    Args:
+        repo_root: Root of the primary git checkout.
+        branch: New branch name (must not already exist on origin).
+        files: Paths under `repo_root` whose current contents should be
+            staged into the PR. Empty → no-diff short-circuit.
+        pr_title: Title for the PR.
+        pr_body: Body for the PR.
+        commit_message: Commit message; defaults to `pr_title` when None.
+        base: Base branch. Defaults to ``"main"``.
+        auto_merge: If True, attempt `gh pr merge --auto --squash`.
+        gh_token: Value injected as GH_TOKEN for each subprocess call.
+        raise_on_failure: If False, failures become
+            ``AutoPrResult(status="failed")`` instead of raising.
+
+    Returns:
+        ``AutoPrResult`` describing the outcome.
+
+    Raises:
+        AutoPrError: If a step fails and `raise_on_failure` is True.
+    """
+    from subprocess_util import run_subprocess  # local import: avoids cycles
+
+    repo_root = repo_root.resolve()
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    wt_name = f"autopr-{_sanitize_branch_for_path(branch)}-{timestamp}"
+    wt_parent = (worktree_parent or repo_root.parent).resolve()
+    wt_parent.mkdir(parents=True, exist_ok=True)
+    worktree_path = wt_parent / wt_name
+    msg = commit_message if commit_message is not None else pr_title
+
+    def _fail(err: str) -> AutoPrResult:
+        if raise_on_failure:
+            raise AutoPrError(err)
+        logger.exception("open_automated_pr_async failed for %s: %s", branch, err)
+        return AutoPrResult(status="failed", pr_url=None, branch=branch, error=err)
+
+    # Fetch base so origin/{base} is current.
+    try:
+        await run_subprocess(
+            "git",
+            "fetch",
+            "origin",
+            base,
+            "--quiet",
+            cwd=repo_root,
+            gh_token=gh_token,
+        )
+    except RuntimeError as exc:
+        return _fail(f"git fetch failed: {exc}")
+
+    # Create worktree on new branch.
+    try:
+        await run_subprocess(
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            branch,
+            str(worktree_path),
+            f"origin/{base}",
+            cwd=repo_root,
+            gh_token=gh_token,
+        )
+    except RuntimeError as exc:
+        return _fail(f"git worktree add failed for {branch!r}: {exc}")
+
+    try:
+        if not files:
+            logger.info("open_automated_pr_async: no files supplied for %s", branch)
+            return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
+
+        # Copy each file, stage by relative path (targeted; no `git add -A`).
+        try:
+            for src_path in files:
+                rel = src_path.resolve().relative_to(repo_root)
+                dst_path = worktree_path / rel
+                dst_path.parent.mkdir(parents=True, exist_ok=True)
+                dst_path.write_bytes(src_path.read_bytes())
+                await run_subprocess(
+                    "git",
+                    "add",
+                    str(rel),
+                    cwd=worktree_path,
+                    gh_token=gh_token,
+                )
+        except (RuntimeError, OSError, ValueError) as exc:
+            return _fail(f"failed to stage files for {branch!r}: {exc}")
+
+        # Detect empty staged diff.
+        try:
+            await run_subprocess(
+                "git",
+                "diff",
+                "--cached",
+                "--quiet",
+                cwd=worktree_path,
+                gh_token=gh_token,
+            )
+            # exit 0 → no staged diff
+            logger.info("open_automated_pr_async: empty staged diff for %s", branch)
+            return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
+        except RuntimeError:
+            # Non-zero exit means there IS a diff. Proceed.
+            pass
+
+        # Commit with stable bot identity.
+        try:
+            await run_subprocess(
+                "git",
+                "-c",
+                f"user.email={BOT_EMAIL}",
+                "-c",
+                f"user.name={BOT_NAME}",
+                "commit",
+                "-m",
+                msg,
+                cwd=worktree_path,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            return _fail(f"git commit failed: {exc}")
+
+        try:
+            await run_subprocess(
+                "git",
+                "push",
+                "-u",
+                "origin",
+                branch,
+                cwd=worktree_path,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            return _fail(f"git push failed for {branch!r}: {exc}")
+
+        # Create the PR.
+        try:
+            create_stdout = await run_subprocess(
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                pr_title,
+                "--body",
+                pr_body,
+                "--base",
+                base,
+                "--head",
+                branch,
+                cwd=worktree_path,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            return _fail(f"gh pr create failed for {branch!r}: {exc}")
+
+        pr_url = _extract_pr_url(create_stdout)
+        if pr_url is None:
+            logger.warning(
+                "gh pr create succeeded for %s but no URL parsed: %r",
+                branch,
+                create_stdout,
+            )
+
+        if auto_merge and pr_url is not None:
+            try:
+                await run_subprocess(
+                    "gh",
+                    "pr",
+                    "merge",
+                    pr_url,
+                    "--auto",
+                    "--squash",
+                    cwd=worktree_path,
+                    gh_token=gh_token,
+                )
+            except RuntimeError as exc:
+                logger.warning("gh pr merge --auto failed for %s: %s", pr_url, exc)
+
+        return AutoPrResult(status="opened", pr_url=pr_url, branch=branch)
+
+    finally:
+        await _remove_worktree_async(repo_root, worktree_path, branch, gh_token)
+
+
+async def _remove_worktree_async(
+    repo_root: Path,
+    worktree_path: Path,
+    branch: str,
+    gh_token: str,
+) -> None:
+    """Best-effort async worktree cleanup. Never raises."""
+    from subprocess_util import run_subprocess  # local import: avoids cycles
+
+    try:
+        await run_subprocess(
+            "git",
+            "worktree",
+            "remove",
+            str(worktree_path),
+            "--force",
+            cwd=repo_root,
+            gh_token=gh_token,
+        )
+    except RuntimeError:
+        logger.debug("git worktree remove failed for %s", worktree_path)
+
+    if worktree_path.exists():
+        shutil.rmtree(worktree_path, ignore_errors=True)
+
+    try:
+        await run_subprocess(
+            "git",
+            "branch",
+            "-D",
+            branch,
+            cwd=repo_root,
+            gh_token=gh_token,
+        )
+    except RuntimeError:
+        logger.debug("git branch -D failed for %s", branch)

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -1,0 +1,300 @@
+"""Auto PR — shared helper for automated worktree+commit+push+PR flows.
+
+This module encapsulates the repeated "create an ephemeral worktree, stage
+a set of files, commit, push the branch, open a PR, and clean up" pattern
+used by agents that emit PRs on behalf of HydraFlow (ADR acceptance, repo
+wiki maintenance, etc.).
+
+Callers write the desired file contents into `repo_root` *before* invoking
+`open_automated_pr`; the helper copies each file (preserving relative path)
+into a fresh worktree branched off `origin/{base}`, commits it with a bot
+identity, pushes, and opens the PR via `gh`.  The worktree is always
+removed in a `finally` block, even on failure.
+
+See `src/adr_reviewer.py::_commit_acceptance` for the original pattern this
+helper generalizes.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BOT_EMAIL = "hydraflow@noreply"
+BOT_NAME = "HydraFlow"
+
+# Characters that are not safe for a filesystem path component. Branch names
+# may contain "/" and other characters; sanitize for the worktree dir name.
+_SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class AutoPrError(RuntimeError):
+    """Raised when the automated PR flow fails (push, gh create, etc.)."""
+
+
+@dataclass(frozen=True)
+class AutoPrResult:
+    """Outcome of an `open_automated_pr` call."""
+
+    status: Literal["opened", "no-diff"]
+    pr_url: str | None
+    branch: str
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_branch_for_path(branch: str) -> str:
+    """Return a filesystem-safe version of a branch name."""
+    cleaned = _SANITIZE_RE.sub("-", branch).strip("-")
+    return cleaned or "autopr"
+
+
+def _run_git(
+    args: list[str], *, cwd: Path, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return the completed process.
+
+    Separated from `_run_gh` so test code can stub `gh` without also stubbing
+    the many git calls this module makes against a real repo.
+    """
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_gh(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Thin wrapper around `subprocess.run` for `gh` invocations.
+
+    Kept as a module-level function so tests can monkeypatch
+    `auto_pr._run_gh` without intercepting every `subprocess.run` call.
+    """
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _remove_worktree(repo_root: Path, worktree_path: Path) -> None:
+    """Best-effort worktree cleanup. Never raises."""
+    try:
+        _run_git(
+            ["worktree", "remove", str(worktree_path), "--force"],
+            cwd=repo_root,
+            check=False,
+        )
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("git worktree remove failed for %s", worktree_path)
+
+    if worktree_path.exists():
+        shutil.rmtree(worktree_path, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def open_automated_pr(
+    *,
+    repo_root: Path,
+    branch: str,
+    files: list[Path],
+    title: str,
+    body: str,
+    base: str = "main",
+    auto_merge: bool = True,
+) -> AutoPrResult:
+    """Open a PR for `files` on a fresh worktree branched from `origin/{base}`.
+
+    Callers write the desired contents to each path under `repo_root` before
+    calling; the helper copies each file into a new worktree (preserving
+    the path relative to `repo_root`), commits with the HydraFlow bot
+    identity, pushes, and opens the PR via `gh`.
+
+    If `files` is empty or the staged diff is empty, returns an
+    ``AutoPrResult`` with ``status="no-diff"`` and no push/PR side effects.
+
+    Args:
+        repo_root: Root of the primary git checkout.
+        branch: New branch name to create (must not already exist on origin).
+        files: Paths (under `repo_root`) whose current contents should be
+            staged into the PR.  An empty list short-circuits to no-diff.
+        title: PR title (also used as the commit message).
+        body: PR body.
+        base: Base branch the PR targets. Defaults to ``"main"``.
+        auto_merge: If True, attempt to enable auto-merge via
+            ``gh pr merge --auto --squash``.  Best-effort — failure here is
+            logged but does not raise.
+
+    Returns:
+        ``AutoPrResult`` describing the outcome.
+
+    Raises:
+        AutoPrError: If the push or ``gh pr create`` step fails.
+    """
+    repo_root = repo_root.resolve()
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
+    wt_name = f"autopr-{_sanitize_branch_for_path(branch)}-{timestamp}"
+    worktree_path = repo_root.parent / wt_name
+
+    # Ensure we have an up-to-date origin ref for the base branch.
+    _run_git(["fetch", "origin", base, "--quiet"], cwd=repo_root, check=False)
+
+    # Create the worktree on a new branch that starts from origin/{base}.
+    try:
+        _run_git(
+            [
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                f"origin/{base}",
+            ],
+            cwd=repo_root,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise AutoPrError(
+            f"git worktree add failed for branch {branch!r}: {exc.stderr}"
+        ) from exc
+
+    try:
+        # Short-circuit when the caller supplied no files to stage.
+        if not files:
+            logger.info("open_automated_pr: no files supplied for %s, skipping", branch)
+            return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
+
+        # Copy each file into the worktree and stage it by relative path.
+        for src_path in files:
+            rel = src_path.resolve().relative_to(repo_root)
+            dst_path = worktree_path / rel
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            dst_path.write_bytes(src_path.read_bytes())
+            _run_git(
+                ["add", str(rel)],
+                cwd=worktree_path,
+                check=True,
+            )
+
+        # Detect empty staged diff — e.g. the file contents matched origin.
+        diff_check = _run_git(
+            ["diff", "--cached", "--quiet"],
+            cwd=worktree_path,
+            check=False,
+        )
+        if diff_check.returncode == 0:
+            logger.info(
+                "open_automated_pr: staged diff is empty for %s, skipping",
+                branch,
+            )
+            return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
+
+        # Commit with a stable bot identity — do not rely on the user's git
+        # config, which may not be set in automation contexts.
+        try:
+            _run_git(
+                [
+                    "-c",
+                    f"user.email={BOT_EMAIL}",
+                    "-c",
+                    f"user.name={BOT_NAME}",
+                    "commit",
+                    "-m",
+                    title,
+                ],
+                cwd=worktree_path,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise AutoPrError(f"git commit failed: {exc.stderr}") from exc
+
+        try:
+            _run_git(
+                ["push", "-u", "origin", branch],
+                cwd=worktree_path,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise AutoPrError(
+                f"git push failed for branch {branch!r}: {exc.stderr}"
+            ) from exc
+
+        create_proc = _run_gh(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--base",
+                base,
+                "--head",
+                branch,
+            ],
+            cwd=worktree_path,
+        )
+        if create_proc.returncode != 0:
+            raise AutoPrError(
+                f"gh pr create failed for branch {branch!r}: "
+                f"{create_proc.stderr or create_proc.stdout}"
+            )
+
+        pr_url = _extract_pr_url(create_proc.stdout)
+
+        if auto_merge and pr_url is not None:
+            merge_proc = _run_gh(
+                ["gh", "pr", "merge", pr_url, "--auto", "--squash"],
+                cwd=worktree_path,
+            )
+            if merge_proc.returncode != 0:
+                # Auto-merge is best-effort; many repos disallow it and that
+                # shouldn't fail the whole flow.
+                logger.warning(
+                    "gh pr merge --auto failed for %s: %s",
+                    pr_url,
+                    merge_proc.stderr or merge_proc.stdout,
+                )
+
+        return AutoPrResult(status="opened", pr_url=pr_url, branch=branch)
+
+    finally:
+        _remove_worktree(repo_root, worktree_path)
+
+
+def _extract_pr_url(stdout: str) -> str | None:
+    """Pull the PR URL from the last non-empty line of `gh pr create` stdout."""
+    for line in reversed(stdout.splitlines()):
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -910,7 +910,7 @@ class TestAcceptADR:
             ],
         )
 
-        with patch("adr_reviewer.run_subprocess", new_callable=AsyncMock):
+        with patch("auto_pr.open_automated_pr_async", new_callable=AsyncMock):
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
         content = adr_path.read_text(encoding="utf-8")
@@ -940,7 +940,7 @@ class TestAcceptADR:
             ],
         )
 
-        with patch("adr_reviewer.run_subprocess", new_callable=AsyncMock):
+        with patch("auto_pr.open_automated_pr_async", new_callable=AsyncMock):
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
         readme_content = readme.read_text(encoding="utf-8")
@@ -974,19 +974,15 @@ class TestAcceptADR:
             ],
         )
 
-        mock_run = AsyncMock()
-        with patch("adr_reviewer.run_subprocess", mock_run):
+        mock_open_pr = AsyncMock()
+        with patch("auto_pr.open_automated_pr_async", mock_open_pr):
             await reviewer._accept_adr(result, adr_path, adr_dir)
 
-        # Check commit message includes minority note
-        commit_calls = [
-            c
-            for c in mock_run.await_args_list
-            if c.args[0] == "git" and c.args[1] == "commit"
-        ]
-        assert len(commit_calls) == 1
-        commit_msg = commit_calls[0].args[3]
-        assert "Minority note:" in commit_msg
+        # Helper called once; commit_message kwarg carries the minority note.
+        assert mock_open_pr.await_count == 1
+        assert mock_open_pr.await_args is not None
+        kwargs = mock_open_pr.await_args.kwargs
+        assert "Minority note:" in kwargs["commit_message"]
 
 
 class TestEscalateToHITL:
@@ -1602,10 +1598,12 @@ class TestAcceptADREdgeCases:
         )
 
         # Should not raise
-        with patch("adr_reviewer.run_subprocess", new_callable=AsyncMock) as mock_run:
+        with patch(
+            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+        ) as mock_open_pr:
             await reviewer._accept_adr(result, adr_path, adr_dir)
             # Should not reach commit since file couldn't be read
-            mock_run.assert_not_awaited()
+            mock_open_pr.assert_not_awaited()
 
 
 class TestCommitAcceptance:
@@ -1625,15 +1623,20 @@ class TestCommitAcceptance:
             adr_number=1, adr_title="Test", final_decision="ACCEPT", summary="OK"
         )
 
-        with patch("adr_reviewer.run_subprocess", new_callable=AsyncMock) as mock_run:
+        with patch(
+            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+        ) as mock_open_pr:
             await reviewer._commit_acceptance(
                 tmp_path / "adr.md", tmp_path / "README.md", result
             )
-            mock_run.assert_not_awaited()
+            mock_open_pr.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_git_failure_logs_and_returns(self, tmp_path: Path) -> None:
-        """Worktree creation failure should be caught and logged."""
+    async def test_commit_acceptance_passes_raise_on_failure_false(
+        self, tmp_path: Path
+    ) -> None:
+        """_commit_acceptance delegates to the helper with raise_on_failure=False
+        so transient git/gh failures don't crash the reviewer loop."""
         reviewer = _make_reviewer(tmp_path)
         result = ADRCouncilResult(
             adr_number=1, adr_title="Test", final_decision="ACCEPT", summary="OK"
@@ -1643,44 +1646,17 @@ class TestCommitAcceptance:
         adr_path.write_text("**Status:** Accepted")
 
         with patch(
-            "adr_reviewer.run_subprocess",
-            new_callable=AsyncMock,
-            side_effect=RuntimeError("git worktree add failed"),
-        ) as mock_run:
-            # Should not raise
+            "auto_pr.open_automated_pr_async", new_callable=AsyncMock
+        ) as mock_open_pr:
             await reviewer._commit_acceptance(
                 adr_path, tmp_path / "repo" / "docs" / "adr" / "README.md", result
             )
-        # Verify the error-raising subprocess was invoked
-        mock_run.assert_awaited()
-
-    @pytest.mark.asyncio
-    async def test_pr_creation_failure_does_not_crash(self, tmp_path: Path) -> None:
-        """PR creation failure after successful commit should be caught."""
-        reviewer = _make_reviewer(tmp_path)
-        result = ADRCouncilResult(
-            adr_number=1, adr_title="Test", final_decision="ACCEPT", summary="OK"
-        )
-        adr_path = tmp_path / "repo" / "docs" / "adr" / "0001-test.md"
-        adr_path.parent.mkdir(parents=True)
-        adr_path.write_text("**Status:** Accepted")
-
-        call_count = 0
-
-        async def _mock_run(*args: object, **kwargs: object) -> None:
-            nonlocal call_count
-            call_count += 1
-            # Last call is `gh pr create` — make it fail
-            if call_count >= 6 and args[0] == "gh":
-                raise RuntimeError("gh pr create failed")
-
-        with patch("adr_reviewer.run_subprocess", new_callable=AsyncMock) as mock_run:
-            mock_run.side_effect = _mock_run
-            # Should not raise
-            await reviewer._commit_acceptance(
-                adr_path, tmp_path / "repo" / "docs" / "adr" / "README.md", result
-            )
-        assert call_count >= 6  # confirms PR creation step was reached
+        assert mock_open_pr.await_count == 1
+        assert mock_open_pr.await_args is not None
+        kwargs = mock_open_pr.await_args.kwargs
+        assert kwargs["raise_on_failure"] is False
+        assert kwargs["auto_merge"] is False
+        assert kwargs["branch"] == "adr/accept-0001"
 
 
 class TestTitleTruncation:

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -197,3 +197,234 @@ def test_remove_worktree_deletes_local_branch(local_repo: Path) -> None:
         body="b",
     )
     assert result.status == "no-diff"
+
+
+# ---------------------------------------------------------------------------
+# Async API tests
+# ---------------------------------------------------------------------------
+
+
+import subprocess as _sp
+from collections.abc import Awaitable, Callable
+from pathlib import Path as _Path
+
+GhHandler = Callable[[tuple[str, ...]], str | None]
+OnCmd = Callable[[tuple[str, ...]], None]
+FailOn = Callable[[tuple[str, ...]], str | None]
+
+
+def _real_run_subprocess_stub(
+    gh_handler: GhHandler | None = None,
+    on_cmd: OnCmd | None = None,
+    fail_on: FailOn | None = None,
+) -> Callable[..., Awaitable[str]]:
+    """Build a fake `run_subprocess` that matches the real contract:
+
+    - Raises RuntimeError on non-zero exit (not CalledProcessError).
+    - Returns stripped stdout on success.
+    - `gh pr` calls route through `gh_handler` so tests never hit real `gh`.
+    - `on_cmd` is a side-effect hook.
+    - `fail_on` returning a non-None string raises RuntimeError with that msg.
+    """
+
+    async def fake_run(
+        *cmd: str,
+        cwd: _Path | None = None,
+        gh_token: str = "",
+        timeout: float = 120.0,
+        runner: object = None,
+    ) -> str:
+        del gh_token, timeout, runner
+        if on_cmd is not None:
+            on_cmd(cmd)
+        if fail_on is not None:
+            err = fail_on(cmd)
+            if err is not None:
+                raise RuntimeError(err)
+        if cmd[:2] == ("gh", "pr") and gh_handler is not None:
+            stdout = gh_handler(cmd)
+            if stdout is None:
+                raise RuntimeError(f"gh command failed: {cmd}")
+            return stdout.strip()
+        try:
+            return _sp.run(
+                list(cmd),
+                cwd=str(cwd) if cwd is not None else None,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except _sp.CalledProcessError as exc:
+            raise RuntimeError(exc.stderr or str(exc)) from exc
+
+    return fake_run
+
+
+@pytest.mark.asyncio
+async def test_async_happy_path_opens_pr(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """open_automated_pr_async: file written, committed, pushed, gh pr create called."""
+    from auto_pr import open_automated_pr_async
+
+    gh_calls: list[tuple[str, ...]] = []
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        gh_calls.append(cmd)
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/42\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler),
+    )
+
+    target = local_repo / "note.txt"
+    target.write_text("hi\n")
+
+    result = await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/a",
+        files=[target],
+        pr_title="feat: a",
+        pr_body="b",
+        auto_merge=True,
+    )
+
+    assert result.status == "opened"
+    assert result.pr_url == "https://github.com/x/y/pull/42"
+    assert any(c[:3] == ("gh", "pr", "create") for c in gh_calls)
+    assert any(c[:3] == ("gh", "pr", "merge") for c in gh_calls)
+
+
+@pytest.mark.asyncio
+async def test_async_uses_separate_commit_message(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When commit_message is supplied, it's used for the commit (not pr_title)."""
+    from auto_pr import open_automated_pr_async
+
+    commit_msgs: list[str] = []
+
+    def on_cmd(cmd: tuple[str, ...]) -> None:
+        if "commit" in cmd and "-m" in cmd:
+            idx = cmd.index("-m")
+            commit_msgs.append(cmd[idx + 1])
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/1\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler, on_cmd=on_cmd),
+    )
+
+    target = local_repo / "x.txt"
+    target.write_text("x\n")
+
+    await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/msg",
+        files=[target],
+        pr_title="short title",
+        pr_body="body",
+        commit_message="long commit message\n\nDetails here.",
+    )
+
+    assert "long commit message" in commit_msgs[0]
+    assert "short title" not in commit_msgs[0]
+
+
+@pytest.mark.asyncio
+async def test_async_raise_on_failure_false_returns_failed_status(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With raise_on_failure=False, push failure returns status='failed' instead of raising."""
+    from auto_pr import open_automated_pr_async
+
+    def fail_on(cmd: tuple[str, ...]) -> str | None:
+        if cmd[:2] == ("git", "push"):
+            return "push rejected"
+        return None
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(fail_on=fail_on),
+    )
+
+    target = local_repo / "f.txt"
+    target.write_text("f\n")
+
+    result = await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/nofail",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        raise_on_failure=False,
+    )
+
+    assert result.status == "failed"
+    assert result.error is not None
+    assert "push" in result.error.lower()
+
+
+@pytest.mark.asyncio
+async def test_async_gh_token_is_forwarded(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The gh_token kwarg is forwarded to every subprocess call."""
+    from auto_pr import open_automated_pr_async
+
+    tokens_seen: list[str] = []
+
+    # We need the raw gh_token that was passed — go direct rather than via
+    # the stub factory so we can capture it.
+    import subprocess as _spmod
+
+    async def capturing_run(
+        *cmd: str,
+        cwd: Path | None = None,
+        gh_token: str = "",
+        timeout: float = 120.0,
+        runner: object = None,
+    ) -> str:
+        del timeout, runner
+        tokens_seen.append(gh_token)
+        if cmd[:3] == ("gh", "pr", "create"):
+            return "https://github.com/x/y/pull/7"
+        if cmd[:2] == ("gh", "pr"):
+            return ""
+        try:
+            return _spmod.run(
+                list(cmd),
+                cwd=str(cwd) if cwd is not None else None,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except _spmod.CalledProcessError as exc:
+            raise RuntimeError(exc.stderr or str(exc)) from exc
+
+    monkeypatch.setattr("subprocess_util.run_subprocess", capturing_run)
+
+    target = local_repo / "t.txt"
+    target.write_text("t\n")
+
+    await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/tok",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        gh_token="ghs_TESTTOKEN",
+    )
+
+    # Every captured call received the same token (ignore the rare empty
+    # no-op entries for edge paths if any).
+    relevant = [t for t in tokens_seen if t]
+    assert relevant, "no subprocess calls observed"
+    assert all(t == "ghs_TESTTOKEN" for t in relevant)

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -136,3 +136,64 @@ def test_open_automated_pr_skips_when_no_diff(local_repo: Path) -> None:
 
     assert result.pr_url is None
     assert result.status == "no-diff"
+
+
+def test_open_automated_pr_skips_when_file_matches_base(local_repo: Path) -> None:
+    """A file whose content matches origin produces an empty staged diff → no-diff."""
+    from auto_pr import open_automated_pr
+
+    # README.md already exists on origin/main with content "init\n".
+    # Pass it unchanged — the staged diff will be empty.
+    result = open_automated_pr(
+        repo_root=local_repo,
+        branch="feature/identical",
+        files=[local_repo / "README.md"],
+        title="t",
+        body="b",
+    )
+
+    assert result.pr_url is None
+    assert result.status == "no-diff"
+
+
+def test_open_automated_pr_wraps_git_add_failure_in_autoprerror(
+    local_repo: Path,
+) -> None:
+    """A file outside repo_root triggers a ValueError in relative_to; must surface as AutoPrError."""
+    from auto_pr import AutoPrError, open_automated_pr
+
+    outside = local_repo.parent / "outside.txt"
+    outside.write_text("x\n")
+
+    with pytest.raises(AutoPrError, match="failed to stage files"):
+        open_automated_pr(
+            repo_root=local_repo,
+            branch="feature/bad-path",
+            files=[outside],
+            title="t",
+            body="b",
+        )
+
+
+def test_remove_worktree_deletes_local_branch(local_repo: Path) -> None:
+    """After open_automated_pr returns no-diff, the local branch is cleaned up so retries work."""
+    from auto_pr import open_automated_pr
+
+    branch = "feature/retry-me"
+    # First call: no-diff (files=[]).
+    open_automated_pr(
+        repo_root=local_repo,
+        branch=branch,
+        files=[],
+        title="t",
+        body="b",
+    )
+    # Second call with the same branch must not fail with "branch already exists".
+    result = open_automated_pr(
+        repo_root=local_repo,
+        branch=branch,
+        files=[],
+        title="t",
+        body="b",
+    )
+    assert result.status == "no-diff"

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -1,0 +1,138 @@
+"""Tests for src/auto_pr.py — shared worktree+commit+push+PR helper."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def bare_remote(tmp_path: Path) -> Path:
+    """A bare git repo that acts as 'origin' for tests."""
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote)], check=True)
+    return remote
+
+
+@pytest.fixture
+def local_repo(tmp_path: Path, bare_remote: Path) -> Path:
+    """A checkout of the bare remote, with one initial commit on main."""
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare_remote), str(local)], check=True)
+    subprocess.run(["git", "-C", str(local), "checkout", "-b", "main"], check=True)
+    (local / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(local),
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "init",
+        ],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"], check=True
+    )
+    return local
+
+
+def test_open_automated_pr_creates_worktree_commits_and_cleans_up(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Happy path: worktree created, file committed, pushed, PR command invoked, worktree removed."""
+    from auto_pr import open_automated_pr
+
+    gh_calls: list[list[str]] = []
+
+    def fake_gh(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        gh_calls.append(cmd)
+        return subprocess.CompletedProcess(
+            cmd, 0, stdout="https://github.com/x/y/pull/1\n", stderr=""
+        )
+
+    monkeypatch.setattr("auto_pr._run_gh", fake_gh)
+
+    target_file = local_repo / "new.txt"
+    # Caller writes the file content BEFORE calling open_automated_pr.
+    target_file.write_text("hello\n")
+
+    result = open_automated_pr(
+        repo_root=local_repo,
+        branch="feature/x",
+        files=[target_file],
+        title="feat: x",
+        body="body",
+        base="main",
+        auto_merge=True,
+    )
+
+    # PR command invoked exactly once, with correct title/body/branch
+    assert any(("pr" in c and "create" in c) for c in gh_calls)
+    # Auto-merge enabled
+    assert any(("pr" in c and "merge" in c and "--auto" in c) for c in gh_calls)
+    # Result carries the PR URL
+    assert result.pr_url == "https://github.com/x/y/pull/1"
+    # No leftover worktrees
+    wt_list = subprocess.run(
+        ["git", "-C", str(local_repo), "worktree", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert wt_list.count("\n") == 1  # only main checkout remains
+
+
+def test_open_automated_pr_cleans_up_worktree_on_failure(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Worktree is removed even when the gh call fails."""
+    from auto_pr import AutoPrError, open_automated_pr
+
+    def failing_gh(cmd: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="gh failed")
+
+    monkeypatch.setattr("auto_pr._run_gh", failing_gh)
+
+    (local_repo / "f.txt").write_text("x\n")
+    with pytest.raises(AutoPrError):
+        open_automated_pr(
+            repo_root=local_repo,
+            branch="feature/fail",
+            files=[local_repo / "f.txt"],
+            title="t",
+            body="b",
+        )
+
+    wt_list = subprocess.run(
+        ["git", "-C", str(local_repo), "worktree", "list"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert wt_list.count("\n") == 1  # only main checkout remains
+
+
+def test_open_automated_pr_skips_when_no_diff(local_repo: Path) -> None:
+    """If the caller passes no files, the function returns a 'no-diff' result without pushing."""
+    from auto_pr import open_automated_pr
+
+    # files=[] short-circuits before any gh call is made, so no monkeypatching needed.
+    result = open_automated_pr(
+        repo_root=local_repo,
+        branch="feature/empty",
+        files=[],
+        title="t",
+        body="b",
+    )
+
+    assert result.pr_url is None
+    assert result.status == "no-diff"


### PR DESCRIPTION
## Summary

Factors the "create worktree → stage files → commit → push → open PR → clean up" pattern out of `ADRReviewerAgent._commit_acceptance()` into a reusable `src/auto_pr.py`. Both sync (`open_automated_pr`) and async (`open_automated_pr_async`) variants are provided; the ADR reviewer is refactored to use the async variant while preserving its existing behavior (no auto-merge, log-and-continue on failure, worktree under `workspace_base`).

Part 1 of 6 in the **git-backed repo wiki** initiative (see [`docs/git-backed-wiki-design.md`](../blob/spec/git-backed-wiki/docs/git-backed-wiki-design.md) on branch `spec/git-backed-wiki`). Phase 4 (`RepoWikiLoop` maintenance PRs) will reuse `open_automated_pr` for wiki commits.

## What's new

- **`src/auto_pr.py`**
  - `AutoPrError`, `AutoPrResult(status, pr_url, branch, error)` — public types.
  - `open_automated_pr(...)` — sync, plain `subprocess.run`. Takes keyword-only args: `repo_root, branch, files, title, body, base="main", auto_merge=True, worktree_parent=None`.
  - `open_automated_pr_async(...)` — routes through HydraFlow's `run_subprocess` (respects the gh/git concurrency semaphore; threads `gh_token` through every call). Additional params: `commit_message` (so callers can embed a detailed commit that differs from the PR title), `raise_on_failure` (False → log + return `status="failed"`).
  - Robustness: targeted `git add` by relative path (never `-A`); worktree **and** local branch cleaned up in a `finally`; empty-file lists and empty staged diffs short-circuit to `status="no-diff"` without pushing; PR URL parsed by `https://` prefix so trailing `gh` warnings don't confuse extraction.

- **`src/adr_reviewer.py`** — `_commit_acceptance` is now a thin wrapper that assembles `commit_message` / `pr_title` / `pr_body` / `files` and calls `open_automated_pr_async(..., auto_merge=False, raise_on_failure=False, worktree_parent=self._config.workspace_base)`. Dry-run short-circuit preserved; method signature unchanged.

- **`tests/test_auto_pr.py`** — 10 tests covering sync + async paths: happy path, gh-failure cleanup, empty-files short-circuit, file-content-matches-base short-circuit, file outside repo_root wrapped as `AutoPrError`, retry after no-diff (branch cleanup), async happy path, commit_message separate from pr_title, `raise_on_failure=False` returns `status="failed"`, gh_token forwarded to every subprocess call.

- **`tests/test_adr_reviewer.py`** — 5 existing tests updated to patch `auto_pr.open_automated_pr_async` instead of `adr_reviewer.run_subprocess`. `test_pr_creation_failure_does_not_crash` collapsed into `test_commit_acceptance_passes_raise_on_failure_false` since the failure handling is exercised at the helper level.

## Behavior preserved for ADR

- ADR PRs remain NOT auto-merged (`auto_merge=False`).
- Transient git/gh failures log and continue (`raise_on_failure=False`).
- Worktrees stay under `self._config.workspace_base` (`worktree_parent=...`).
- Commit message keeps the "Accept ADR-XXXX … Council decision: …" multi-line form distinct from the truncated 70-char PR title.
- `gh_token` threaded through every subprocess call via `run_subprocess`.

## Test plan

- [x] `uv run pytest tests/test_auto_pr.py tests/test_adr_reviewer.py` — 116 tests pass locally.
- [x] `make lint-check` — clean.
- [ ] CI runs `make quality` (ruff, pyright, bandit, full pytest + coverage).
- [ ] Manual smoke: next ADR acceptance cycle should open a PR identical to the pre-refactor flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)