### PR TITLE
fix(auto-pr): address PR #8352 post-merge review findings

### DIFF
--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -859,6 +859,8 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
             gh_token=self._credentials.gh_token,
             raise_on_failure=False,
             worktree_parent=Path(self._config.workspace_base),
+            commit_author_name=self._config.git_user_name,
+            commit_author_email=self._config.git_user_email,
         )
 
     async def _escalate_to_hitl(self, result: ADRCouncilResult, *, reason: str) -> None:

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -34,6 +34,10 @@ logger = logging.getLogger(__name__)
 
 BOT_EMAIL = "hydraflow@noreply"
 BOT_NAME = "HydraFlow"
+# ^^ Defaults used when the caller does not supply
+# `commit_author_name` / `commit_author_email`.  HydraFlow callers should
+# pass `self._config.git_user_name` / `self._config.git_user_email` so a
+# user-configured identity is respected.
 
 # Characters that are not safe for a filesystem path component. Branch names
 # may contain "/" and other characters; sanitize for the worktree dir name.
@@ -117,7 +121,9 @@ def _remove_worktree(
             check=False,
         )
     except Exception:  # pragma: no cover - defensive
-        logger.debug("git worktree remove failed for %s", worktree_path)
+        # Per docs/agents/sentry.md: handled cleanup failures log at
+        # `warning` minimum — never bare `except: pass` or debug-silent.
+        logger.warning("git worktree remove failed for %s", worktree_path)
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path, ignore_errors=True)
@@ -143,6 +149,8 @@ def open_automated_pr(
     base: str = "main",
     auto_merge: bool = True,
     worktree_parent: Path | None = None,
+    commit_author_name: str = BOT_NAME,
+    commit_author_email: str = BOT_EMAIL,
 ) -> AutoPrResult:
     """Open a PR for `files` on a fresh worktree branched from `origin/{base}`.
 
@@ -237,15 +245,16 @@ def open_automated_pr(
             )
             return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
 
-        # Commit with a stable bot identity — do not rely on the user's git
-        # config, which may not be set in automation contexts.
+        # Commit with the caller-supplied identity (defaults to the HydraFlow
+        # bot). Explicit `-c user.email/user.name` ensures the commit succeeds
+        # even when the worktree's git config is empty (e.g. fresh containers).
         try:
             _run_git(
                 [
                     "-c",
-                    f"user.email={BOT_EMAIL}",
+                    f"user.email={commit_author_email}",
                     "-c",
-                    f"user.name={BOT_NAME}",
+                    f"user.name={commit_author_name}",
                     "commit",
                     "-m",
                     title,
@@ -348,6 +357,8 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
     gh_token: str = "",
     raise_on_failure: bool = True,
     worktree_parent: Path | None = None,
+    commit_author_name: str = BOT_NAME,
+    commit_author_email: str = BOT_EMAIL,
 ) -> AutoPrResult:
     """Async variant that routes subprocess calls through `run_subprocess`.
 
@@ -400,15 +411,21 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
     def _fail(err: str) -> AutoPrResult:
         if raise_on_failure:
             raise AutoPrError(err)
-        # Plain .error — not .exception — because we may be called outside an
-        # except handler; .exception would attach a misleading `NoneType: None`
-        # traceback in Sentry (see docs/agents/sentry.md).
-        logger.error("open_automated_pr_async failed for %s: %s", branch, err)
+        # These are transient subprocess failures (git/gh network, auth, race
+        # conditions) — operational, not code bugs. Per docs/agents/sentry.md,
+        # handled transient failures log at `warning`, not `error`.
+        # Plain .warning (not .exception) because we may be called outside an
+        # except handler; .exception would attach a misleading
+        # `NoneType: None` traceback in Sentry.
+        logger.warning("open_automated_pr_async failed for %s: %s", branch, err)
         return AutoPrResult(status="failed", pr_url=None, branch=branch, error=err)
 
-    # Fetch base so origin/{base} is current. Failures before the worktree
-    # is created don't need cleanup; handle them separately from the main
-    # try/finally below.
+    # Best-effort fetch of the base ref. If the fetch fails (offline,
+    # transient auth hiccup), fall through: the subsequent `git worktree add`
+    # will use whatever cached `origin/{base}` the local repo already has,
+    # which is usually recent enough. Only a missing local `origin/{base}`
+    # ref will fail, at which point `git worktree add` surfaces a clear
+    # error and we route through `_fail` like any other failure.
     try:
         await run_subprocess(
             "git",
@@ -420,7 +437,12 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
             gh_token=gh_token,
         )
     except RuntimeError as exc:
-        return _fail(f"git fetch failed: {exc}")
+        logger.warning(
+            "git fetch origin %s failed for %s; continuing with cached ref: %s",
+            base,
+            branch,
+            exc,
+        )
 
     # From here on every exit path must go through `finally` so the worktree
     # + branch are torn down regardless of outcome.
@@ -477,14 +499,16 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
             # Non-zero exit means there IS a diff. Proceed.
             pass
 
-        # Commit with stable bot identity.
+        # Commit with the caller-supplied identity (defaults to the HydraFlow
+        # bot). Explicit `-c user.email/user.name` ensures the commit succeeds
+        # even when the worktree's git config is empty (e.g. fresh containers).
         try:
             await run_subprocess(
                 "git",
                 "-c",
-                f"user.email={BOT_EMAIL}",
+                f"user.email={commit_author_email}",
                 "-c",
-                f"user.name={BOT_NAME}",
+                f"user.name={commit_author_name}",
                 "commit",
                 "-m",
                 msg,
@@ -576,7 +600,9 @@ async def _remove_worktree_async(
             gh_token=gh_token,
         )
     except RuntimeError:
-        logger.debug("git worktree remove failed for %s", worktree_path)
+        # Per docs/agents/sentry.md: handled cleanup failures log at
+        # `warning` minimum.
+        logger.warning("git worktree remove failed for %s", worktree_path)
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path, ignore_errors=True)
@@ -591,4 +617,4 @@ async def _remove_worktree_async(
             gh_token=gh_token,
         )
     except RuntimeError:
-        logger.debug("git branch -D failed for %s", branch)
+        logger.warning("git branch -D failed for %s", branch)

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -1657,6 +1657,9 @@ class TestCommitAcceptance:
         assert kwargs["raise_on_failure"] is False
         assert kwargs["auto_merge"] is False
         assert kwargs["branch"] == "adr/accept-0001"
+        # Commit author threaded through from HydraFlowConfig, not hardcoded.
+        assert kwargs["commit_author_name"] == reviewer._config.git_user_name
+        assert kwargs["commit_author_email"] == reviewer._config.git_user_email
 
 
 class TestTitleTruncation:

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -428,3 +428,132 @@ async def test_async_gh_token_is_forwarded(
     relevant = [t for t in tokens_seen if t]
     assert relevant, "no subprocess calls observed"
     assert all(t == "ghs_TESTTOKEN" for t in relevant)
+
+
+@pytest.mark.asyncio
+async def test_async_commit_author_is_forwarded(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """commit_author_name / commit_author_email appear in the git commit -c args."""
+    from auto_pr import open_automated_pr_async
+
+    commit_cmds: list[tuple[str, ...]] = []
+
+    def on_cmd(cmd: tuple[str, ...]) -> None:
+        if "commit" in cmd and "-m" in cmd:
+            commit_cmds.append(cmd)
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/11\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler, on_cmd=on_cmd),
+    )
+
+    target = local_repo / "author.txt"
+    target.write_text("hi\n")
+
+    await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/author",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        commit_author_name="Jane Dev",
+        commit_author_email="jane@example.com",
+    )
+
+    assert len(commit_cmds) == 1
+    cmd = commit_cmds[0]
+    assert "user.email=jane@example.com" in cmd
+    assert "user.name=Jane Dev" in cmd
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_failure_is_non_fatal(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """git fetch failures log a warning but don't abort the flow.
+
+    The subsequent worktree add proceeds against the cached `origin/{base}`.
+    """
+    from auto_pr import open_automated_pr_async
+
+    def fail_on(cmd: tuple[str, ...]) -> str | None:
+        if cmd[:3] == ("git", "fetch", "origin"):
+            return "network unreachable"
+        return None
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/12\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler, fail_on=fail_on),
+    )
+
+    target = local_repo / "offline.txt"
+    target.write_text("offline\n")
+
+    with caplog.at_level("WARNING", logger="auto_pr"):
+        result = await open_automated_pr_async(
+            repo_root=local_repo,
+            branch="feature/offline",
+            files=[target],
+            pr_title="t",
+            pr_body="b",
+        )
+
+    assert result.status == "opened"
+    assert any(
+        "git fetch origin main failed" in rec.message and rec.levelname == "WARNING"
+        for rec in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_fail_logs_at_warning_not_error(
+    local_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Transient subprocess failures with raise_on_failure=False log at WARNING,
+    not ERROR, to avoid flooding Sentry (docs/agents/sentry.md).
+    """
+    from auto_pr import open_automated_pr_async
+
+    def fail_on(cmd: tuple[str, ...]) -> str | None:
+        if cmd[:2] == ("git", "push"):
+            return "push rejected"
+        return None
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(fail_on=fail_on),
+    )
+
+    target = local_repo / "x.txt"
+    target.write_text("x\n")
+
+    with caplog.at_level("WARNING", logger="auto_pr"):
+        result = await open_automated_pr_async(
+            repo_root=local_repo,
+            branch="feature/warn",
+            files=[target],
+            pr_title="t",
+            pr_body="b",
+            raise_on_failure=False,
+        )
+
+    assert result.status == "failed"
+    # The failure message must log at WARNING, never ERROR.
+    failure_logs = [
+        rec for rec in caplog.records if "open_automated_pr_async failed" in rec.message
+    ]
+    assert failure_logs, "expected a failure log line"
+    assert all(rec.levelname == "WARNING" for rec in failure_logs)


### PR DESCRIPTION
## Summary

Four targeted follow-ups to [PR #8352](https://github.com/T-rav/hydraflow/pull/8352) surfaced by a post-merge code-review pass. Each fix cites the specific guidance it resolves. No behavioral change for the happy path.

## Fixes

### A. `_fail` logs at WARNING (was ERROR)

`src/auto_pr.py:_fail` inside `open_automated_pr_async` wraps transient subprocess failures (git fetch / worktree / commit / push / gh pr create). These are operational errors — network, auth, race — not code bugs. Per [`docs/agents/sentry.md`](../blob/main/docs/agents/sentry.md): *"Use logger.warning() for expected or transient failures."* Error-level would flood Sentry.

### B. Cleanup helpers log at WARNING (was DEBUG)

`_remove_worktree` (sync) and `_remove_worktree_async` log caught `RuntimeError` at DEBUG. [`docs/agents/sentry.md`](../blob/main/docs/agents/sentry.md) mandates a **warning minimum** for any handled exception: *"Never use bare except: pass — always log at warning level minimum."*

### C. Commit author respects `HydraFlowConfig`

`open_automated_pr` and `open_automated_pr_async` now accept `commit_author_name` / `commit_author_email` kwargs (defaults preserve `HydraFlow <hydraflow@noreply>`). `ADRReviewerAgent._commit_acceptance` threads `self._config.git_user_name` / `.git_user_email` through, so a user-configured git identity is respected instead of silently overridden. The pre-refactor ADR code inherited the ambient git config; this restores that contract while keeping the explicit `-c user.email/user.name` fallback for empty-config environments (containers).

### D. `git fetch` is best-effort

`open_automated_pr_async` previously aborted on `git fetch origin <base>` failure. Now a fetch failure logs a warning and falls through to `git worktree add origin/{base}` against whatever cached ref is present locally. Offline and transient fetch errors no longer abort the whole flow; a truly missing local ref still surfaces via the subsequent worktree-add failure.

## Tests

- `test_async_commit_author_is_forwarded` — asserts `-c user.email/name` carries the caller-supplied identity.
- `test_async_fetch_failure_is_non_fatal` — fetch failure → warning log + successful PR against cached ref.
- `test_async_fail_logs_at_warning_not_error` — failure logging stays at WARNING.
- `test_commit_acceptance_passes_raise_on_failure_false` (extended) — also asserts `commit_author_name/email` flow from `HydraFlowConfig`.

119 tests pass locally (`uv run pytest tests/test_auto_pr.py tests/test_adr_reviewer.py`). `make lint-check` clean.

## Test plan

- [x] `uv run pytest tests/test_auto_pr.py tests/test_adr_reviewer.py` — 119 passed.
- [x] `make lint-check` — clean.
- [ ] CI `make quality`.
- [ ] Next ADR acceptance cycle opens a PR authored by the configured `HYDRAFLOW_GIT_USER_NAME` / `..._EMAIL` rather than `HydraFlow <hydraflow@noreply>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)