### PR TITLE
fix(auto-pr): empty commit_author falls back to ambient git config

### DIFF
--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -7,9 +7,11 @@ wiki maintenance, etc.).
 
 Callers write the desired file contents into `repo_root` *before* invoking
 `open_automated_pr`; the helper copies each file (preserving relative path)
-into a fresh worktree branched off `origin/{base}`, commits it with a bot
-identity, pushes, and opens the PR via `gh`.  The worktree is always
-removed in a `finally` block, even on failure.
+into a fresh worktree branched off `origin/{base}`, commits it with the
+caller-supplied identity (defaulting to the HydraFlow bot, or falling back
+to ambient git config when both name and email are empty), pushes, and
+opens the PR via `gh`.  The worktree is always removed in a `finally`
+block, even on failure.
 
 See `src/adr_reviewer.py::_commit_acceptance` for the original pattern this
 helper generalizes.
@@ -139,6 +141,23 @@ def _remove_worktree(
 # ---------------------------------------------------------------------------
 
 
+def _build_commit_args(author_name: str, author_email: str, message: str) -> list[str]:
+    """Build the arg list for `git commit`, skipping identity overrides when
+    the caller-supplied name or email is empty.
+
+    Empty values mean "fall back to git's ambient config" per the
+    `HydraFlowConfig.git_user_name/email` contract. Passing `-c user.email=`
+    to git would instead force an empty identity and fail with
+    "Author identity unknown".
+    """
+    args: list[str] = []
+    if author_name and author_email:
+        args.extend(["-c", f"user.email={author_email}"])
+        args.extend(["-c", f"user.name={author_name}"])
+    args.extend(["commit", "-m", message])
+    return args
+
+
 def open_automated_pr(
     *,
     repo_root: Path,
@@ -173,12 +192,23 @@ def open_automated_pr(
         auto_merge: If True, attempt to enable auto-merge via
             ``gh pr merge --auto --squash``.  Best-effort — failure here is
             logged but does not raise.
+        worktree_parent: Directory to create the ephemeral worktree under.
+            Defaults to ``repo_root.parent``. Callers that keep worktrees in
+            a dedicated workspace (e.g. HydraFlow's ``workspace_base``) pass
+            that path here.
+        commit_author_name: Name for ``git -c user.name`` on the commit.
+            Defaults to the HydraFlow bot. When both name and email are
+            empty strings, the ``-c`` overrides are omitted and git uses
+            the ambient worktree/global config instead.
+        commit_author_email: Email for ``git -c user.email``. See above
+            regarding empty-string fallback.
 
     Returns:
         ``AutoPrResult`` describing the outcome.
 
     Raises:
-        AutoPrError: If the push or ``gh pr create`` step fails.
+        AutoPrError: If the worktree-add, stage, commit, push, or
+            ``gh pr create`` step fails.
     """
     repo_root = repo_root.resolve()
     timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
@@ -245,23 +275,14 @@ def open_automated_pr(
             )
             return AutoPrResult(status="no-diff", pr_url=None, branch=branch)
 
-        # Commit with the caller-supplied identity (defaults to the HydraFlow
-        # bot). Explicit `-c user.email/user.name` ensures the commit succeeds
-        # even when the worktree's git config is empty (e.g. fresh containers).
+        # Commit with the caller-supplied identity when provided; when either
+        # value is empty, omit the `-c user.*` overrides so git falls back to
+        # ambient config (worktree → user global → system). This matches the
+        # documented `HydraFlowConfig.git_user_name/email` contract that an
+        # empty config value falls back to global git config.
+        commit_args = _build_commit_args(commit_author_name, commit_author_email, title)
         try:
-            _run_git(
-                [
-                    "-c",
-                    f"user.email={commit_author_email}",
-                    "-c",
-                    f"user.name={commit_author_name}",
-                    "commit",
-                    "-m",
-                    title,
-                ],
-                cwd=worktree_path,
-                check=True,
-            )
+            _run_git(commit_args, cwd=worktree_path, check=True)
         except subprocess.CalledProcessError as exc:
             raise AutoPrError(f"git commit failed: {exc.stderr}") from exc
 
@@ -391,6 +412,14 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
         gh_token: Value injected as GH_TOKEN for each subprocess call.
         raise_on_failure: If False, failures become
             ``AutoPrResult(status="failed")`` instead of raising.
+        worktree_parent: Directory to create the ephemeral worktree under.
+            Defaults to ``repo_root.parent``.
+        commit_author_name: Name for ``git -c user.name`` on the commit.
+            Defaults to the HydraFlow bot. When both name and email are
+            empty strings, the ``-c`` overrides are omitted and git uses
+            the ambient worktree/global config instead.
+        commit_author_email: Email for ``git -c user.email``. See above
+            regarding empty-string fallback.
 
     Returns:
         ``AutoPrResult`` describing the outcome.
@@ -499,21 +528,14 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
             # Non-zero exit means there IS a diff. Proceed.
             pass
 
-        # Commit with the caller-supplied identity (defaults to the HydraFlow
-        # bot). Explicit `-c user.email/user.name` ensures the commit succeeds
-        # even when the worktree's git config is empty (e.g. fresh containers).
+        # Commit with the caller-supplied identity when provided; when either
+        # value is empty, omit the `-c user.*` overrides so git falls back to
+        # ambient config per the `HydraFlowConfig.git_user_name/email`
+        # contract.
+        commit_args = _build_commit_args(commit_author_name, commit_author_email, msg)
         try:
             await run_subprocess(
-                "git",
-                "-c",
-                f"user.email={commit_author_email}",
-                "-c",
-                f"user.name={commit_author_name}",
-                "commit",
-                "-m",
-                msg,
-                cwd=worktree_path,
-                gh_token=gh_token,
+                "git", *commit_args, cwd=worktree_path, gh_token=gh_token
             )
         except RuntimeError as exc:
             return _fail(f"git commit failed: {exc}")

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -22,21 +22,16 @@ def local_repo(tmp_path: Path, bare_remote: Path) -> Path:
     local = tmp_path / "local"
     subprocess.run(["git", "clone", str(bare_remote), str(local)], check=True)
     subprocess.run(["git", "-C", str(local), "checkout", "-b", "main"], check=True)
+    # Persist identity in the repo-local config so worktrees created from this
+    # repo inherit it via the shared git dir. Tests that exercise the
+    # empty-commit-author fallback rely on this ambient config existing — CI
+    # runners have no global git config.
+    subprocess.run(["git", "-C", str(local), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(local), "config", "user.name", "t"], check=True)
     (local / "README.md").write_text("init\n")
     subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True)
     subprocess.run(
-        [
-            "git",
-            "-C",
-            str(local),
-            "-c",
-            "user.email=t@t",
-            "-c",
-            "user.name=t",
-            "commit",
-            "-m",
-            "init",
-        ],
+        ["git", "-C", str(local), "commit", "-m", "init"],
         check=True,
     )
     subprocess.run(

--- a/tests/test_auto_pr.py
+++ b/tests/test_auto_pr.py
@@ -473,6 +473,103 @@ async def test_async_commit_author_is_forwarded(
 
 
 @pytest.mark.asyncio
+async def test_async_empty_commit_author_omits_c_overrides(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty commit_author_name/email must NOT emit `-c user.email= -c user.name=`.
+
+    An empty `-c user.email=` override would force git to use an empty identity
+    and fail with 'Author identity unknown', contradicting the documented
+    `HydraFlowConfig.git_user_name/email` contract ('falls back to global git
+    config if empty'). The helper should instead omit the overrides so git
+    falls back to ambient config.
+    """
+    from auto_pr import open_automated_pr_async
+
+    commit_cmds: list[tuple[str, ...]] = []
+
+    def on_cmd(cmd: tuple[str, ...]) -> None:
+        if "commit" in cmd and "-m" in cmd:
+            commit_cmds.append(cmd)
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/44\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler, on_cmd=on_cmd),
+    )
+
+    target = local_repo / "empty-id.txt"
+    target.write_text("content\n")
+
+    await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/empty-id",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        commit_author_name="",
+        commit_author_email="",
+    )
+
+    assert len(commit_cmds) == 1
+    cmd = commit_cmds[0]
+    # No `-c user.email=` or `-c user.name=` in the git invocation.
+    assert not any(arg.startswith("user.email=") for arg in cmd), cmd
+    assert not any(arg.startswith("user.name=") for arg in cmd), cmd
+
+
+@pytest.mark.asyncio
+async def test_async_partial_empty_commit_author_omits_c_overrides(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If either name OR email is empty, skip both overrides (don't mix).
+
+    Mixing a real name with an empty email (or vice versa) would still break
+    the commit, so `_build_commit_args` only emits overrides when both values
+    are non-empty.
+    """
+    from auto_pr import open_automated_pr_async
+
+    commit_cmds: list[tuple[str, ...]] = []
+
+    def on_cmd(cmd: tuple[str, ...]) -> None:
+        if "commit" in cmd and "-m" in cmd:
+            commit_cmds.append(cmd)
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[2] == "create":
+            return "https://github.com/x/y/pull/45\n"
+        return ""
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _real_run_subprocess_stub(gh_handler=gh_handler, on_cmd=on_cmd),
+    )
+
+    target = local_repo / "partial.txt"
+    target.write_text("p\n")
+
+    await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="feature/partial-id",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        commit_author_name="Only Name",
+        commit_author_email="",
+    )
+
+    assert len(commit_cmds) == 1
+    cmd = commit_cmds[0]
+    assert not any(arg.startswith("user.name=") for arg in cmd), cmd
+    assert not any(arg.startswith("user.email=") for arg in cmd), cmd
+
+
+@pytest.mark.asyncio
 async def test_async_fetch_failure_is_non_fatal(
     local_repo: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Summary

Post-merge code review of [PR #8353](https://github.com/T-rav/hydraflow/pull/8353) caught a real regression: `HydraFlowConfig.git_user_name` / `.git_user_email` default to \`\"\"\`, and #8353 started threading those values into \`open_automated_pr(_async)\`. Empty strings become \`git -c user.email= -c user.name= commit …\`, which **fails with \"Author identity unknown\"** — even when the user has valid global git config.

The [config docstring](../blob/main/src/config.py#L1323-L1330) says *\"falls back to global git config if empty\"*, so this was a silent breakage of the documented contract.

## Fix

New `_build_commit_args(name, email, message)` helper in `src/auto_pr.py`. When either name or email is empty, it omits the `-c user.*` overrides entirely so git uses its normal fallback chain (worktree → user global → system). Both the sync and async helpers route through it.

Tests:
- `test_async_empty_commit_author_omits_c_overrides` — both values `\"\"` → no `-c user.email=` / `-c user.name=` in the git invocation.
- `test_async_partial_empty_commit_author_omits_c_overrides` — one set, one empty → still omits both (never half-override).

Also refreshes the module docstring + `Args:` blocks on both public functions to document the new `commit_author_name`, `commit_author_email`, and `worktree_parent` parameters.

121 tests pass locally; lint clean. No behavioral change when both values are non-empty (existing callers and tests unaffected).

## Test plan

- [x] `uv run pytest tests/test_auto_pr.py tests/test_adr_reviewer.py` — 121 passed.
- [x] `make lint-check` — clean.
- [ ] CI `make quality`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)