### PR TITLE
feat(wiki): Phase 3.5 — wire plan/review phases to git-backed writes

### DIFF
--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -45,6 +45,36 @@ logger = logging.getLogger("hydraflow.plan_phase")
 _MIN_ISSUE_BODY_CHARS: int = 50
 
 
+def _run_fallback_ingest_plan(
+    *,
+    tracked_store: RepoWikiStore,
+    worktree_path: Path,
+    repo: str,
+    issue_number: int,
+    plan_text: str,
+    path_prefix: str,
+) -> None:
+    """Sync wrapper for the fallback plan-ingest path.
+
+    Module-level so it can be dispatched via ``asyncio.to_thread`` without
+    binding a bound-method reference to the loop.  See ADR-0001 — the
+    sync ``git commit`` call under ``commit_pending_entries`` must not
+    run on the event loop.
+    """
+    from repo_wiki_ingest import ingest_from_plan  # noqa: PLC0415
+
+    count = ingest_from_plan(
+        tracked_store, repo, issue_number, plan_text, git_backed=True
+    )
+    if count:
+        tracked_store.commit_pending_entries(
+            worktree_path=worktree_path,
+            phase="plan",
+            issue_number=issue_number,
+            path_prefix=path_prefix,
+        )
+
+
 class PlanPhase:
     """Runs planning agents on issues and posts results."""
 
@@ -392,7 +422,11 @@ class PlanPhase:
                 )
                 if entries:
                     if tracked_store is not None and worktree_path is not None:
-                        self._wiki_commit_compiler_entries(
+                        # Offload the sync file + git-subprocess work off the
+                        # event loop so the other four concurrent phase loops
+                        # (ADR-0001) don't stall on `git commit`.
+                        await asyncio.to_thread(
+                            self._wiki_commit_compiler_entries,
                             tracked_store=tracked_store,
                             worktree_path=worktree_path,
                             repo=repo,
@@ -409,20 +443,16 @@ class PlanPhase:
             from repo_wiki_ingest import ingest_from_plan  # noqa: PLC0415
 
             if tracked_store is not None and worktree_path is not None:
-                count = ingest_from_plan(
-                    tracked_store,
-                    repo,
-                    issue_number,
-                    plan_text,
-                    git_backed=True,
+                # Offload the sync write + commit.
+                await asyncio.to_thread(
+                    _run_fallback_ingest_plan,
+                    tracked_store=tracked_store,
+                    worktree_path=worktree_path,
+                    repo=repo,
+                    issue_number=issue_number,
+                    plan_text=plan_text,
+                    path_prefix=self._config.repo_wiki_path,
                 )
-                if count:
-                    tracked_store.commit_pending_entries(
-                        worktree_path=worktree_path,
-                        phase="plan",
-                        issue_number=issue_number,
-                        path_prefix=self._config.repo_wiki_path,
-                    )
             else:
                 ingest_from_plan(self._wiki_store, repo, issue_number, plan_text)
             self._wiki_store.mark_ingested(repo, issue_number, "plan")

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from analysis import PlanAnalyzer
@@ -22,6 +23,7 @@ from phase_utils import (
     store_lifecycle,
 )
 from planner import PlannerRunner
+from repo_wiki import RepoWikiStore, WikiEntry, classify_topic
 from research_runner import ResearchRunner
 from state import StateTracker
 from task_source import TaskTransitioner
@@ -35,7 +37,6 @@ if TYPE_CHECKING:
     from memory_judge import MemoryJudge  # noqa: TCH004
     from plan_reviewer import PlanReviewer
     from ports import IssueStorePort, PRPort
-    from repo_wiki import RepoWikiStore  # noqa: TCH004
     from wiki_compiler import WikiCompiler  # noqa: TCH004
 
 logger = logging.getLogger("hydraflow.plan_phase")
@@ -363,12 +364,23 @@ class PlanPhase:
         Uses the LLM compiler for synthesis when available, falling back
         to mechanical section extraction.  Skips if already ingested.
         Never raises.
+
+        When ``config.repo_wiki_git_backed`` is True and the issue
+        worktree exists, per-entry markdown files are written under the
+        worktree's ``repo_wiki/`` directory and committed by
+        ``commit_pending_entries`` so the wiki updates ride the issue's
+        PR.  Dedup state (``is_ingested`` / ``mark_ingested``) still
+        lives on the main host's legacy wiki path regardless — the
+        tracked writes are an additional artifact, not a replacement
+        for dedup bookkeeping.
         """
         if self._wiki_store is None or not self._config.repo:
             return
         repo = self._config.repo
         if self._wiki_store.is_ingested(repo, issue_number, "plan"):
             return
+
+        tracked_store, worktree_path = self._wiki_tracked_store(issue_number)
         try:
             # Prefer LLM synthesis when compiler is available
             if self._wiki_compiler is not None:
@@ -379,19 +391,106 @@ class PlanPhase:
                     plan_text[: self._WIKI_INGEST_MAX_CHARS],
                 )
                 if entries:
-                    self._wiki_store.ingest(repo, entries)
+                    if tracked_store is not None and worktree_path is not None:
+                        self._wiki_commit_compiler_entries(
+                            tracked_store=tracked_store,
+                            worktree_path=worktree_path,
+                            repo=repo,
+                            issue_number=issue_number,
+                            phase="plan",
+                            entries=entries,
+                        )
+                    else:
+                        self._wiki_store.ingest(repo, entries)
                     self._wiki_store.mark_ingested(repo, issue_number, "plan")
                     return
 
             # Fallback: mechanical section extraction
             from repo_wiki_ingest import ingest_from_plan  # noqa: PLC0415
 
-            ingest_from_plan(self._wiki_store, repo, issue_number, plan_text)
+            if tracked_store is not None and worktree_path is not None:
+                count = ingest_from_plan(
+                    tracked_store,
+                    repo,
+                    issue_number,
+                    plan_text,
+                    git_backed=True,
+                )
+                if count:
+                    tracked_store.commit_pending_entries(
+                        worktree_path=worktree_path,
+                        phase="plan",
+                        issue_number=issue_number,
+                        path_prefix=self._config.repo_wiki_path,
+                    )
+            else:
+                ingest_from_plan(self._wiki_store, repo, issue_number, plan_text)
             self._wiki_store.mark_ingested(repo, issue_number, "plan")
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Wiki ingest failed for plan #%d", issue_number, exc_info=True
             )
+
+    def _wiki_tracked_store(
+        self, issue_number: int
+    ) -> tuple[RepoWikiStore | None, Path | None]:
+        """Build a RepoWikiStore pointed at the issue worktree's tracked
+        ``repo_wiki/`` directory, or ``(None, None)`` when git-backed writes
+        are disabled / the worktree is missing.
+        """
+        if not self._config.repo_wiki_git_backed:
+            return None, None
+        worktree_path = self._config.workspace_path_for_issue(issue_number)
+        if not worktree_path.is_dir():
+            logger.debug(
+                "Wiki git-backed write skipped for #%d: worktree %s missing",
+                issue_number,
+                worktree_path,
+            )
+            return None, None
+        tracked_root = worktree_path / self._config.repo_wiki_path
+        return RepoWikiStore(tracked_root), worktree_path
+
+    def _wiki_commit_compiler_entries(
+        self,
+        *,
+        tracked_store: RepoWikiStore,
+        worktree_path: Path,
+        repo: str,
+        issue_number: int,
+        phase: str,
+        entries: list[WikiEntry],
+    ) -> None:
+        """Route compiler-synthesized entries through ``write_entry`` then
+        commit. Topic classification mirrors ``RepoWikiStore.ingest``.
+        Rolls back any files written before a mid-batch failure.
+        """
+        # Classification uses the module-level helper — same keyword
+        # scheme the legacy layout used, so synthesized entries land in
+        # the expected topic directory.
+        written: list[Path] = []
+        try:
+            for entry in entries:
+                topic = classify_topic(entry)
+                written.append(tracked_store.write_entry(repo, entry, topic=topic))
+            tracked_store.append_log(
+                repo,
+                issue_number,
+                {"phase": phase, "action": "ingest", "entries": len(entries)},
+            )
+            tracked_store.commit_pending_entries(
+                worktree_path=worktree_path,
+                phase=phase,
+                issue_number=issue_number,
+                path_prefix=self._config.repo_wiki_path,
+            )
+        except Exception:
+            for p in written:
+                try:
+                    p.unlink()
+                except OSError:
+                    logger.warning("wiki ingest rollback: failed to unlink %s", p)
+            raise
 
     async def _create_beads_from_plan(self, issue: Task, plan: str) -> None:
         """Create bead tasks from a Task Graph plan and post mapping comment."""

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -89,6 +89,86 @@ def _next_entry_id(topic_dir: Path) -> int:
     return max(ids) + 1 if ids else 1
 
 
+_TOPIC_KEYWORDS: dict[str, list[str]] = {
+    "architecture": [
+        "architect",
+        "structure",
+        "module",
+        "layer",
+        "service",
+        "component",
+        "design",
+        "pattern",
+        "directory",
+        "layout",
+    ],
+    "patterns": [
+        "pattern",
+        "convention",
+        "idiom",
+        "style",
+        "approach",
+        "best practice",
+        "anti-pattern",
+        "refactor",
+    ],
+    "gotchas": [
+        "gotcha",
+        "pitfall",
+        "bug",
+        "issue",
+        "error",
+        "fail",
+        "careful",
+        "watch out",
+        "caveat",
+        "workaround",
+        "edge case",
+    ],
+    "testing": [
+        "test",
+        "fixture",
+        "mock",
+        "assert",
+        "coverage",
+        "pytest",
+        "spec",
+        "integration test",
+        "unit test",
+    ],
+    "dependencies": [
+        "dependency",
+        "package",
+        "import",
+        "library",
+        "version",
+        "requirement",
+        "pip",
+        "npm",
+        "uv",
+        "cargo",
+    ],
+}
+
+
+def classify_topic(entry: WikiEntry) -> str:
+    """Classify a ``WikiEntry`` into a topic based on title/content keywords.
+
+    Public module-level helper so phase runners can classify compiler-
+    produced entries without poking at private store methods.  Defaults
+    to ``"patterns"`` when no topic-specific keywords match.
+    """
+    text = f"{entry.title} {entry.content}".lower()
+    best_topic = "patterns"
+    best_score = 0
+    for topic, keywords in _TOPIC_KEYWORDS.items():
+        score = sum(1 for kw in keywords if kw in text)
+        if score > best_score:
+            best_score = score
+            best_topic = topic
+    return best_topic
+
+
 def _sanitize_body_for_frontmatter(content: str) -> str:
     """Prevent a leading ``---`` in body content from being parsed as a
     second YAML document.
@@ -684,80 +764,8 @@ class RepoWikiStore:
         return repo_dir
 
     def _classify_topic(self, entry: WikiEntry) -> str:
-        """Classify an entry into a topic based on keywords in title/content."""
-        text = f"{entry.title} {entry.content}".lower()
-
-        topic_keywords: dict[str, list[str]] = {
-            "architecture": [
-                "architect",
-                "structure",
-                "module",
-                "layer",
-                "service",
-                "component",
-                "design",
-                "pattern",
-                "directory",
-                "layout",
-            ],
-            "patterns": [
-                "pattern",
-                "convention",
-                "idiom",
-                "style",
-                "approach",
-                "best practice",
-                "anti-pattern",
-                "refactor",
-            ],
-            "gotchas": [
-                "gotcha",
-                "pitfall",
-                "bug",
-                "issue",
-                "error",
-                "fail",
-                "careful",
-                "watch out",
-                "caveat",
-                "workaround",
-                "edge case",
-            ],
-            "testing": [
-                "test",
-                "fixture",
-                "mock",
-                "assert",
-                "coverage",
-                "pytest",
-                "spec",
-                "integration test",
-                "unit test",
-            ],
-            "dependencies": [
-                "dependency",
-                "package",
-                "import",
-                "library",
-                "version",
-                "requirement",
-                "pip",
-                "npm",
-                "uv",
-                "cargo",
-            ],
-        }
-
-        best_topic = "patterns"  # default
-        best_score = 0
-
-        for topic, keywords in topic_keywords.items():
-            score = sum(1 for kw in keywords if kw in text)
-            if score > best_score:
-                best_score = score
-                best_topic = topic
-
-        return best_topic
+        """Backward-compat: classify via the module-level `classify_topic`."""
+        return classify_topic(entry)
 
     def _load_topic_entries(self, topic_path: Path) -> list[WikiEntry]:
         """Parse a topic markdown file back into entries.

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from memory_judge import MemoryJudge  # noqa: TCH004
     from ports import IssueStorePort, PRPort, ReviewInsightStorePort, WorkspacePort
     from precondition_gate import PreconditionGate
-    from repo_wiki import RepoWikiStore  # noqa: TCH004 — used in __init__ signature
     from retrospective_queue import RetrospectiveQueue
     from visual_validator import VisualValidator
     from wiki_compiler import WikiCompiler  # noqa: TCH004 — used in __init__ signature
@@ -68,6 +67,7 @@ from phase_utils import (
     store_lifecycle,
 )
 from post_merge_handler import PostMergeHandler
+from repo_wiki import RepoWikiStore, WikiEntry, classify_topic
 from review_insights import (
     _PROPOSAL_STALE_DAYS,
     CATEGORY_DESCRIPTIONS,
@@ -215,12 +215,20 @@ class ReviewPhase:
         for richer synthesis.  Falls back to *summary* for mechanical
         extraction.  Skips if this issue+review was already ingested.
         Never raises.
+
+        When ``config.repo_wiki_git_backed`` is True and the issue
+        worktree exists, per-entry markdown files are written under the
+        worktree's ``repo_wiki/`` directory and committed so the wiki
+        updates ride the issue's PR.  Dedup state still lives on the
+        main host's legacy wiki path.
         """
         if self._wiki_store is None or not self._config.repo:
             return
         repo = self._config.repo
         if self._wiki_store.is_ingested(repo, issue_number, "review"):
             return
+
+        tracked_store, worktree_path = self._wiki_tracked_store(issue_number)
         try:
             # Prefer LLM synthesis from transcript when compiler is available
             if self._wiki_compiler is not None and transcript:
@@ -231,19 +239,104 @@ class ReviewPhase:
                     transcript[: self._WIKI_INGEST_MAX_CHARS],
                 )
                 if entries:
-                    self._wiki_store.ingest(repo, entries)
+                    if tracked_store is not None and worktree_path is not None:
+                        self._wiki_commit_compiler_entries(
+                            tracked_store=tracked_store,
+                            worktree_path=worktree_path,
+                            repo=repo,
+                            issue_number=issue_number,
+                            phase="review",
+                            entries=entries,
+                        )
+                    else:
+                        self._wiki_store.ingest(repo, entries)
                     self._wiki_store.mark_ingested(repo, issue_number, "review")
                     return
 
             # Fallback: mechanical extraction from structured summary
             from repo_wiki_ingest import ingest_from_review  # noqa: PLC0415
 
-            ingest_from_review(self._wiki_store, repo, issue_number, summary)
+            if tracked_store is not None and worktree_path is not None:
+                count = ingest_from_review(
+                    tracked_store,
+                    repo,
+                    issue_number,
+                    summary,
+                    git_backed=True,
+                )
+                if count:
+                    tracked_store.commit_pending_entries(
+                        worktree_path=worktree_path,
+                        phase="review",
+                        issue_number=issue_number,
+                        path_prefix=self._config.repo_wiki_path,
+                    )
+            else:
+                ingest_from_review(self._wiki_store, repo, issue_number, summary)
             self._wiki_store.mark_ingested(repo, issue_number, "review")
         except Exception:  # noqa: BLE001
             logger.warning(
                 "Wiki ingest failed for review #%d", issue_number, exc_info=True
             )
+
+    def _wiki_tracked_store(
+        self, issue_number: int
+    ) -> tuple[RepoWikiStore | None, Path | None]:
+        """Build a ``RepoWikiStore`` pointed at the issue worktree's
+        tracked ``repo_wiki/`` directory, or ``(None, None)`` when
+        git-backed writes are disabled / the worktree is missing.
+        """
+        if not self._config.repo_wiki_git_backed:
+            return None, None
+        worktree_path = self._config.workspace_path_for_issue(issue_number)
+        if not worktree_path.is_dir():
+            logger.debug(
+                "Wiki git-backed write skipped for #%d: worktree %s missing",
+                issue_number,
+                worktree_path,
+            )
+            return None, None
+        return (
+            RepoWikiStore(worktree_path / self._config.repo_wiki_path),
+            worktree_path,
+        )
+
+    def _wiki_commit_compiler_entries(
+        self,
+        *,
+        tracked_store: RepoWikiStore,
+        worktree_path: Path,
+        repo: str,
+        issue_number: int,
+        phase: str,
+        entries: list[WikiEntry],
+    ) -> None:
+        """Route compiler-synthesized entries through ``write_entry`` then
+        commit.  Rolls back any files written before a mid-batch failure.
+        """
+        written: list[Path] = []
+        try:
+            for entry in entries:
+                topic = classify_topic(entry)
+                written.append(tracked_store.write_entry(repo, entry, topic=topic))
+            tracked_store.append_log(
+                repo,
+                issue_number,
+                {"phase": phase, "action": "ingest", "entries": len(entries)},
+            )
+            tracked_store.commit_pending_entries(
+                worktree_path=worktree_path,
+                phase=phase,
+                issue_number=issue_number,
+                path_prefix=self._config.repo_wiki_path,
+            )
+        except Exception:
+            for p in written:
+                try:
+                    p.unlink()
+                except OSError:
+                    logger.warning("wiki ingest rollback: failed to unlink %s", p)
+            raise
 
     @property
     def active_issues(self) -> set[int]:

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -85,6 +85,35 @@ from transcript_summarizer import TranscriptSummarizer
 logger = logging.getLogger("hydraflow.review_phase")
 
 
+def _run_fallback_ingest_review(
+    *,
+    tracked_store: RepoWikiStore,
+    worktree_path: Path,
+    repo: str,
+    issue_number: int,
+    summary: str,
+    path_prefix: str,
+) -> None:
+    """Sync wrapper for the fallback review-ingest path.
+
+    Module-level so it can be dispatched via ``asyncio.to_thread`` — the
+    sync ``git commit`` in ``commit_pending_entries`` would otherwise
+    stall the event loop (ADR-0001).
+    """
+    from repo_wiki_ingest import ingest_from_review  # noqa: PLC0415
+
+    count = ingest_from_review(
+        tracked_store, repo, issue_number, summary, git_backed=True
+    )
+    if count:
+        tracked_store.commit_pending_entries(
+            worktree_path=worktree_path,
+            phase="review",
+            issue_number=issue_number,
+            path_prefix=path_prefix,
+        )
+
+
 @dataclass(slots=True)
 class ReviewGuardContext:
     """Successful result from _run_initial_guards."""
@@ -240,7 +269,11 @@ class ReviewPhase:
                 )
                 if entries:
                     if tracked_store is not None and worktree_path is not None:
-                        self._wiki_commit_compiler_entries(
+                        # Offload sync file + git-subprocess work off the
+                        # event loop — ADR-0001 — so other concurrent
+                        # phase loops don't stall on ``git commit``.
+                        await asyncio.to_thread(
+                            self._wiki_commit_compiler_entries,
                             tracked_store=tracked_store,
                             worktree_path=worktree_path,
                             repo=repo,
@@ -257,20 +290,15 @@ class ReviewPhase:
             from repo_wiki_ingest import ingest_from_review  # noqa: PLC0415
 
             if tracked_store is not None and worktree_path is not None:
-                count = ingest_from_review(
-                    tracked_store,
-                    repo,
-                    issue_number,
-                    summary,
-                    git_backed=True,
+                await asyncio.to_thread(
+                    _run_fallback_ingest_review,
+                    tracked_store=tracked_store,
+                    worktree_path=worktree_path,
+                    repo=repo,
+                    issue_number=issue_number,
+                    summary=summary,
+                    path_prefix=self._config.repo_wiki_path,
                 )
-                if count:
-                    tracked_store.commit_pending_entries(
-                        worktree_path=worktree_path,
-                        phase="review",
-                        issue_number=issue_number,
-                        path_prefix=self._config.repo_wiki_path,
-                    )
             else:
                 ingest_from_review(self._wiki_store, repo, issue_number, summary)
             self._wiki_store.mark_ingested(repo, issue_number, "review")

--- a/tests/test_phase_wiki_wiring.py
+++ b/tests/test_phase_wiki_wiring.py
@@ -1,0 +1,230 @@
+"""Tests for the Phase 3.5 wiki-ingest wiring in plan_phase / review_phase.
+
+Exercises the ``_wiki_tracked_store`` decision helper on both phases —
+verifying it respects ``config.repo_wiki_git_backed`` and the existence
+of the issue worktree — and the ``_wiki_commit_compiler_entries`` rollback
+path.  Avoids reconstructing the full phase object; instead builds a
+minimal stub that exposes just the attributes the helper reads.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from config import HydraFlowConfig
+from plan_phase import PlanPhase
+from repo_wiki import RepoWikiStore, WikiEntry
+from review_phase import ReviewPhase
+
+
+@pytest.fixture
+def git_worktree(tmp_path: Path) -> Path:
+    # Path must match HydraFlowConfig.workspace_path_for_issue:
+    # workspace_base / repo_slug / issue-{n} where repo_slug replaces `/`→`-`.
+    wt = tmp_path / "workspaces" / "acme-widget" / "issue-42"
+    wt.mkdir(parents=True)
+    subprocess.run(["git", "init", str(wt)], check=True)
+    (wt / "seed").write_text("seed\n")
+    subprocess.run(["git", "-C", str(wt), "add", "."], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(wt),
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-m",
+            "init",
+        ],
+        check=True,
+    )
+    return wt
+
+
+def _make_config(tmp_path: Path, *, git_backed: bool) -> HydraFlowConfig:
+    """Minimal config — only the fields the wiki wiring reads."""
+    return HydraFlowConfig(
+        repo="acme/widget",
+        workspace_base=tmp_path / "workspaces",
+        repo_wiki_git_backed=git_backed,
+        repo_wiki_path="repo_wiki",
+    )
+
+
+def _stub_phase(
+    cls: type[PlanPhase] | type[ReviewPhase],
+    config: HydraFlowConfig,
+    wiki_store: RepoWikiStore,
+) -> PlanPhase | ReviewPhase:
+    """Construct a phase instance bypassing full __init__ — sets just
+    the attributes the wiki helpers read.
+    """
+    obj = cls.__new__(cls)  # type: ignore[call-overload]
+    obj._config = config
+    obj._wiki_store = wiki_store
+    obj._wiki_compiler = None
+    return obj
+
+
+@pytest.mark.parametrize("phase_cls", [PlanPhase, ReviewPhase])
+class TestWikiTrackedStore:
+    def test_returns_none_when_git_backed_disabled(
+        self, phase_cls: type, tmp_path: Path, git_worktree: Path
+    ) -> None:
+        del git_worktree  # created but the helper skips on the config flag
+        config = _make_config(tmp_path, git_backed=False)
+        store = RepoWikiStore(tmp_path / "legacy")
+
+        phase = _stub_phase(phase_cls, config, store)
+        tracked, path = phase._wiki_tracked_store(42)
+
+        assert tracked is None
+        assert path is None
+
+    def test_returns_none_when_worktree_missing(
+        self, phase_cls: type, tmp_path: Path
+    ) -> None:
+        config = _make_config(tmp_path, git_backed=True)
+        store = RepoWikiStore(tmp_path / "legacy")
+
+        phase = _stub_phase(phase_cls, config, store)
+        tracked, path = phase._wiki_tracked_store(999)  # no worktree for 999
+
+        assert tracked is None
+        assert path is None
+
+    def test_returns_tracked_store_when_worktree_exists(
+        self, phase_cls: type, tmp_path: Path, git_worktree: Path
+    ) -> None:
+        config = _make_config(tmp_path, git_backed=True)
+        store = RepoWikiStore(tmp_path / "legacy")
+
+        phase = _stub_phase(phase_cls, config, store)
+        tracked, path = phase._wiki_tracked_store(42)
+
+        assert tracked is not None
+        assert path == git_worktree
+        # Tracked store's root points at worktree/repo_wiki/.
+        assert tracked._wiki_root == git_worktree / "repo_wiki"
+
+
+@pytest.mark.parametrize("phase_cls", [PlanPhase, ReviewPhase])
+class TestWikiCommitCompilerEntries:
+    def test_writes_commits_and_respects_path_prefix(
+        self, phase_cls: type, tmp_path: Path, git_worktree: Path
+    ) -> None:
+        config = _make_config(tmp_path, git_backed=True)
+        legacy_store = RepoWikiStore(tmp_path / "legacy")
+        tracked_store = RepoWikiStore(git_worktree / "repo_wiki")
+
+        phase = _stub_phase(phase_cls, config, legacy_store)
+        entries = [
+            WikiEntry(
+                title="Architecture of the queue",
+                content="service A talks to service B via a queue" * 3,
+                source_type="plan",
+                source_issue=42,
+            ),
+            WikiEntry(
+                title="Test strategy for the queue",
+                content="run unit tests before integration tests" * 3,
+                source_type="plan",
+                source_issue=42,
+            ),
+        ]
+
+        phase._wiki_commit_compiler_entries(
+            tracked_store=tracked_store,
+            worktree_path=git_worktree,
+            repo="acme/widget",
+            issue_number=42,
+            phase="plan",
+            entries=entries,
+        )
+
+        log = subprocess.run(
+            ["git", "-C", str(git_worktree), "log", "--oneline"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert "wiki: ingest plan for #42" in log
+
+        show = subprocess.run(
+            ["git", "-C", str(git_worktree), "show", "--name-only", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        assert "repo_wiki/" in show
+        # Two per-entry markdown files (one per topic via classify_topic) + a log jsonl.
+        assert show.count(".md") == 2
+        assert "log/42.jsonl" in show
+
+    def test_rollback_on_partial_failure(
+        self,
+        phase_cls: type,
+        tmp_path: Path,
+        git_worktree: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When one write_entry raises, every prior write is removed."""
+        config = _make_config(tmp_path, git_backed=True)
+        legacy_store = RepoWikiStore(tmp_path / "legacy")
+        tracked_store = RepoWikiStore(git_worktree / "repo_wiki")
+
+        phase = _stub_phase(phase_cls, config, legacy_store)
+
+        call_count = {"n": 0}
+        original = tracked_store.write_entry
+
+        def flaky_write_entry(repo_slug: str, entry: WikiEntry, *, topic: str) -> Path:
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise OSError("simulated disk full")
+            return original(repo_slug, entry, topic=topic)
+
+        monkeypatch.setattr(tracked_store, "write_entry", flaky_write_entry)
+
+        entries = [
+            WikiEntry(
+                title=f"Entry {i}",
+                content=f"content {i}" * 10,
+                source_type="plan",
+                source_issue=42,
+            )
+            for i in range(3)
+        ]
+
+        with pytest.raises(OSError, match="simulated disk full"):
+            phase._wiki_commit_compiler_entries(
+                tracked_store=tracked_store,
+                worktree_path=git_worktree,
+                repo="acme/widget",
+                issue_number=42,
+                phase="plan",
+                entries=entries,
+            )
+
+        # No wiki files remain — the first successful write was rolled back.
+        remaining = list((git_worktree / "repo_wiki").rglob("*.md"))
+        assert remaining == [], f"orphaned after rollback: {remaining}"
+
+        # No commit landed.
+        log = (
+            subprocess.run(
+                ["git", "-C", str(git_worktree), "log", "--oneline"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        assert len(log) == 1  # only the initial seed commit

--- a/tests/test_phase_wiki_wiring.py
+++ b/tests/test_phase_wiki_wiring.py
@@ -110,8 +110,15 @@ class TestWikiTrackedStore:
 
         assert tracked is not None
         assert path == git_worktree
-        # Tracked store's root points at worktree/repo_wiki/.
-        assert tracked._wiki_root == git_worktree / "repo_wiki"
+
+        # Observe-behaviour check instead of peeking at the private
+        # `_wiki_root`: writing an entry should land a file under
+        # `worktree/repo_wiki/<topic>/`.
+        entry = WikiEntry(
+            title="sanity", content="x", source_type="plan", source_issue=42
+        )
+        out = tracked.write_entry("acme/widget", entry, topic="patterns")
+        assert out.is_relative_to(git_worktree / "repo_wiki")
 
 
 @pytest.mark.parametrize("phase_cls", [PlanPhase, ReviewPhase])


### PR DESCRIPTION
## Summary

Phase 3.5 of the [git-backed repo wiki](../blob/main/docs/git-backed-wiki-design.md). Turns on the Phase 3 per-entry write path from inside the running phase runners. Stacked on [#8357](https://github.com/T-rav/hydraflow/pull/8357).

## What happens at runtime

When `config.repo_wiki_git_backed` is True **and** the issue worktree exists, `PlanPhase._wiki_ingest_plan` and `ReviewPhase._wiki_ingest_review`:

1. Construct a worktree-scoped `RepoWikiStore` pointed at `{worktree}/{repo_wiki_path}/`.
2. Write each entry as a per-entry markdown file via `write_entry` (compiler path uses `classify_topic` per entry; fallback path uses `ingest_from_plan/review(..., git_backed=True)`).
3. Append a per-issue log record via `append_log`.
4. Commit the new files via `commit_pending_entries` — targeted `git add`, message `wiki: ingest {phase} for #{issue}`.

When the flag is False or the worktree is missing, the legacy topic-level ingest path runs unchanged.

Dedup state (`is_ingested` / `mark_ingested`) keeps living on the main host's legacy wiki path regardless — the tracked writes are an additional artifact. Errors leave the legacy dedup mark unset so the next cycle retries.

## What changed

- **`src/plan_phase.py`** — `_wiki_ingest_plan` gains `_wiki_tracked_store` + `_wiki_commit_compiler_entries` helpers; both compiler and fallback paths route through the tracked store when applicable.
- **`src/review_phase.py`** — mirror changes for `_wiki_ingest_review`.
- **`src/repo_wiki.py`** — promotes `_classify_topic` to a module-level `classify_topic` (the store's method stays as a backward-compat shim).

## Rollback discipline

Compiler-synthesized entries are written in a batch; if any write raises mid-loop, every prior file in that batch is unlinked before the exception re-raises (log append never runs; no commit lands). Matches `ingest_from_plan`'s `_write_pairs_or_rollback`.

## Tests

`tests/test_phase_wiki_wiring.py` — 10 new parametrized tests covering both phases:

- `_wiki_tracked_store` returns None when `git_backed=False`
- `_wiki_tracked_store` returns None when the worktree is missing
- `_wiki_tracked_store` returns a worktree-rooted store when both conditions hold
- `_wiki_commit_compiler_entries` writes files, commits, respects `path_prefix`
- Rollback removes all prior writes when one raises mid-batch

255 tests pass locally (includes the full plan/review/wiki suites). `make lint-check` clean.

## Test plan

- [x] `uv run pytest tests/test_plan_phase.py tests/test_review_phase_core.py tests/test_phase_wiki_wiring.py tests/test_repo_wiki*.py tests/test_wiki_migration.py` — 255 passed.
- [x] `make lint-check` — clean.
- [ ] CI `make quality`.
- [ ] After merge, next plan/review cycle on any managed repo should produce a `wiki: ingest {phase} for #{N}` commit in the issue's PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)