### PR TITLE
test(scenarios): Tier 2 — FakeBeads + bead workflow + 5 caretaker loops

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -648,7 +648,14 @@ class CredentialsFactory:
 class PipelineHarness:
     """Utility for wiring all phases with shared real stores in tests."""
 
-    def __init__(self, tmp_path: Path, *, config=None, wiki_store: Any = None):
+    def __init__(
+        self,
+        tmp_path: Path,
+        *,
+        config=None,
+        wiki_store: Any = None,
+        beads_manager: Any = None,
+    ):
         from events import EventBus
         from hitl_phase import HITLPhase
         from implement_phase import ImplementPhase
@@ -659,6 +666,7 @@ class PipelineHarness:
         from state import StateTracker
         from triage_phase import TriagePhase
 
+        self._beads_manager = beads_manager
         self.config = config or ConfigFactory.create(
             repo_root=tmp_path / "repo",
             workspace_base=tmp_path / "worktrees",
@@ -739,6 +747,7 @@ class PipelineHarness:
             self.bus,
             self.stop_event,
             wiki_store=wiki_store,
+            beads_manager=beads_manager,
         )
         self._implement_phase_base_kwargs: dict[str, Any] = {
             "config": self.config,
@@ -747,6 +756,7 @@ class PipelineHarness:
             "prs": self.prs,
             "store": self.store,
             "stop_event": self.stop_event,
+            "beads_manager": beads_manager,
         }
         self.implement_phase = ImplementPhase(
             agents=self.agents,

--- a/tests/scenarios/fakes/fake_beads.py
+++ b/tests/scenarios/fakes/fake_beads.py
@@ -1,0 +1,169 @@
+"""FakeBeads — in-memory mock of BeadsManager's bd CLI surface.
+
+Stores tasks in a dict keyed by task_id. Dependencies tracked as a
+parallel adjacency dict. No subprocess spawned — scenarios exercise
+the bead workflow entirely against in-memory state.
+
+Matches BeadsManager's async API signatures exactly so phases that
+accept a BeadsManager can accept FakeBeads without modification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from beads_manager import BeadTask
+
+
+@dataclass
+class _FakeTask:
+    task_id: str
+    title: str
+    status: str = "open"
+    priority: int = 2
+    depends_on: list[str] = field(default_factory=list)
+
+
+class FakeBeads:
+    """In-memory BeadsManager lookalike.
+
+    Implements the same async API surface as ``BeadsManager`` so that
+    scenario tests can drive the bead workflow (create → claim → close →
+    list_ready → show) without spawning a real ``bd`` process.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: dict[str, _FakeTask] = {}
+        self._next_id: int = 1
+        self._initialized: bool = False
+
+    # ------------------------------------------------------------------
+    # Script / test-helper API
+    # ------------------------------------------------------------------
+
+    def task_ids(self) -> list[str]:
+        """Return all task IDs currently tracked."""
+        return list(self._tasks)
+
+    def task_count(self) -> int:
+        return len(self._tasks)
+
+    # ------------------------------------------------------------------
+    # BeadsManager public async API (mirror signatures exactly)
+    # ------------------------------------------------------------------
+
+    async def ensure_installed(self) -> None:
+        """Always succeeds — no real CLI in the fake."""
+        return
+
+    async def init(self, cwd: Path) -> None:
+        """Mark the fake as initialised (idempotent)."""
+        _ = cwd
+        self._initialized = True
+
+    async def create_task(self, title: str, priority: str, cwd: Path) -> str:
+        """Create an in-memory bead task and return its generated ID."""
+        _ = cwd
+        task_id = f"bd-fake-{self._next_id}"
+        self._next_id += 1
+        self._tasks[task_id] = _FakeTask(
+            task_id=task_id,
+            title=title,
+            priority=int(priority),
+        )
+        return task_id
+
+    async def add_dependency(self, child: str, parent: str, cwd: Path) -> None:
+        """Record that *child* depends on *parent*.
+
+        Raises ``KeyError`` if either task does not exist.
+        """
+        _ = cwd
+        if child not in self._tasks:
+            msg = f"FakeBeads: unknown task {child!r}"
+            raise KeyError(msg)
+        if parent not in self._tasks:
+            msg = f"FakeBeads: unknown task {parent!r}"
+            raise KeyError(msg)
+        self._tasks[child].depends_on.append(parent)
+
+    async def claim(self, bead_id: str, cwd: Path) -> None:
+        """Set task status to ``'in_progress'`` (claimed)."""
+        _ = cwd
+        task = self._tasks[bead_id]
+        task.status = "in_progress"
+
+    async def close(self, bead_id: str, reason: str, cwd: Path) -> None:
+        """Set task status to ``'closed'``."""
+        _ = (cwd, reason)
+        task = self._tasks[bead_id]
+        task.status = "closed"
+
+    async def list_ready(self, cwd: Path) -> list[BeadTask]:
+        """Return tasks whose dependencies are all closed and are not yet closed."""
+        _ = cwd
+        ready: list[BeadTask] = []
+        for task in self._tasks.values():
+            if task.status == "closed":
+                continue
+            deps_done = all(
+                self._tasks[dep].status == "closed"
+                for dep in task.depends_on
+                if dep in self._tasks
+            )
+            if deps_done:
+                ready.append(self._to_bead_task(task))
+        return ready
+
+    async def show(self, bead_id: str, cwd: Path) -> BeadTask:
+        """Return a :class:`BeadTask` for the requested ID.
+
+        Raises ``KeyError`` if the task does not exist.
+        """
+        _ = cwd
+        task = self._tasks[bead_id]
+        return self._to_bead_task(task)
+
+    async def create_from_phases(
+        self,
+        phases: list,  # list[TaskGraphPhase] — avoid import cycle in tests
+        issue_number: int,
+        cwd: Path,
+    ) -> dict[str, str]:
+        """Create bead tasks from Task Graph phases with dependency wiring.
+
+        Returns ``{phase_id: bead_id}``.  Mirrors ``BeadsManager.create_from_phases``
+        exactly — same two-pass algorithm (create then wire deps).
+        """
+        from beads_manager import _PRIORITY_HAS_DEPS, _PRIORITY_NO_DEPS  # noqa: PLC0415
+
+        mapping: dict[str, str] = {}
+
+        for phase in phases:
+            title = f"Issue #{issue_number} — {phase.name}"
+            priority = _PRIORITY_NO_DEPS if not phase.depends_on else _PRIORITY_HAS_DEPS
+            bead_id = await self.create_task(title, priority, cwd)
+            mapping[phase.id] = bead_id
+
+        for phase in phases:
+            child_bead = mapping[phase.id]
+            for dep_id in phase.depends_on:
+                parent_bead = mapping[dep_id]
+                await self.add_dependency(child_bead, parent_bead, cwd)
+
+        return mapping
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_bead_task(task: _FakeTask) -> BeadTask:
+        return BeadTask(
+            id=task.task_id,
+            title=task.title,
+            status=task.status,
+            priority=task.priority,
+            depends_on=list(task.depends_on),
+        )

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -42,11 +42,18 @@ class MockWorld:
         install_subprocess_clock: bool = False,
         use_real_agent_runner: bool = False,
         wiki_store: Any = None,
+        beads_manager: Any = None,
     ) -> None:
         self._tmp_path = tmp_path
         self._use_real_agent = use_real_agent_runner
         self._wiki_store = wiki_store
-        self._harness = PipelineHarness(tmp_path, config=config, wiki_store=wiki_store)
+        self._beads_manager = beads_manager
+        self._harness = PipelineHarness(
+            tmp_path,
+            config=config,
+            wiki_store=wiki_store,
+            beads_manager=beads_manager,
+        )
         self._llm = FakeLLM()
         self._github = FakeGitHub()
         self._hindsight = FakeHindsight()

--- a/tests/scenarios/fakes/test_fake_beads.py
+++ b/tests/scenarios/fakes/test_fake_beads.py
@@ -1,0 +1,186 @@
+"""Unit tests for FakeBeads — verifies it faithfully mirrors BeadsManager's API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.scenarios.fakes.fake_beads import FakeBeads
+
+_CWD = Path("/tmp/fake-beads-test")
+
+
+# ---------------------------------------------------------------------------
+# ensure_installed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_ensure_installed_returns_none() -> None:
+    beads = FakeBeads()
+    result = await beads.ensure_installed()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# init
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_init_is_idempotent() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    await beads.init(cwd=_CWD)  # calling twice must not raise
+    assert beads._initialized is True
+
+
+# ---------------------------------------------------------------------------
+# create_task
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_create_task_returns_unique_ids() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    id1 = await beads.create_task(title="alpha", priority="0", cwd=_CWD)
+    id2 = await beads.create_task(title="beta", priority="1", cwd=_CWD)
+    assert id1 != id2
+
+
+@pytest.mark.asyncio()
+async def test_create_task_stores_title_and_priority() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    bead_id = await beads.create_task(title="my task", priority="1", cwd=_CWD)
+    task = await beads.show(bead_id, cwd=_CWD)
+    assert task.title == "my task"
+    assert task.priority == 1
+
+
+# ---------------------------------------------------------------------------
+# add_dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_add_dependency_records_edge() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    parent = await beads.create_task(title="parent", priority="0", cwd=_CWD)
+    child = await beads.create_task(title="child", priority="1", cwd=_CWD)
+    await beads.add_dependency(child, parent, cwd=_CWD)
+    shown = await beads.show(child, cwd=_CWD)
+    assert parent in shown.depends_on
+
+
+@pytest.mark.asyncio()
+async def test_add_dependency_unknown_child_raises() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    parent = await beads.create_task(title="p", priority="0", cwd=_CWD)
+    with pytest.raises(KeyError):
+        await beads.add_dependency("bd-fake-999", parent, cwd=_CWD)
+
+
+@pytest.mark.asyncio()
+async def test_add_dependency_unknown_parent_raises() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    child = await beads.create_task(title="c", priority="1", cwd=_CWD)
+    with pytest.raises(KeyError):
+        await beads.add_dependency(child, "bd-fake-999", cwd=_CWD)
+
+
+# ---------------------------------------------------------------------------
+# claim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_claim_sets_status_in_progress() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    bead_id = await beads.create_task(title="claimable", priority="0", cwd=_CWD)
+    await beads.claim(bead_id, cwd=_CWD)
+    task = await beads.show(bead_id, cwd=_CWD)
+    assert task.status == "in_progress"
+
+
+# ---------------------------------------------------------------------------
+# close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_close_sets_status_closed() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    bead_id = await beads.create_task(title="closeable", priority="0", cwd=_CWD)
+    await beads.close(bead_id, reason="done", cwd=_CWD)
+    task = await beads.show(bead_id, cwd=_CWD)
+    assert task.status == "closed"
+
+
+# ---------------------------------------------------------------------------
+# list_ready
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_list_ready_excludes_tasks_with_open_deps() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    parent = await beads.create_task(title="parent", priority="0", cwd=_CWD)
+    child = await beads.create_task(title="child", priority="1", cwd=_CWD)
+    await beads.add_dependency(child, parent, cwd=_CWD)
+
+    ready = await beads.list_ready(cwd=_CWD)
+    ready_ids = [t.id for t in ready]
+    assert parent in ready_ids
+    assert child not in ready_ids
+
+
+@pytest.mark.asyncio()
+async def test_list_ready_includes_task_once_dep_closed() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    parent = await beads.create_task(title="parent", priority="0", cwd=_CWD)
+    child = await beads.create_task(title="child", priority="1", cwd=_CWD)
+    await beads.add_dependency(child, parent, cwd=_CWD)
+
+    await beads.close(parent, reason="done", cwd=_CWD)
+    ready = await beads.list_ready(cwd=_CWD)
+    ready_ids = [t.id for t in ready]
+    assert child in ready_ids
+
+
+@pytest.mark.asyncio()
+async def test_list_ready_excludes_closed_tasks() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    bead_id = await beads.create_task(title="t", priority="0", cwd=_CWD)
+    await beads.close(bead_id, reason="done", cwd=_CWD)
+
+    ready = await beads.list_ready(cwd=_CWD)
+    assert not any(t.id == bead_id for t in ready)
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_show_returns_bead_task_shape() -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=_CWD)
+    bead_id = await beads.create_task(title="show me", priority="0", cwd=_CWD)
+    task = await beads.show(bead_id, cwd=_CWD)
+    assert task.id == bead_id
+    assert task.title == "show me"
+    assert task.priority == 0
+    assert task.status == "open"
+    assert task.depends_on == []

--- a/tests/scenarios/fakes/test_mock_world.py
+++ b/tests/scenarios/fakes/test_mock_world.py
@@ -189,3 +189,36 @@ async def test_mockworld_default_wiki_store_is_none(tmp_path) -> None:
     plan_phase = world.harness.plan_phase
     stored = getattr(plan_phase, "_wiki_store", getattr(plan_phase, "wiki_store", None))
     assert stored is None
+
+
+async def test_mockworld_wires_beads_manager_to_phases(tmp_path) -> None:
+    """MockWorld threads beads_manager through PipelineHarness to plan + implement phases."""
+    from tests.scenarios.fakes.fake_beads import FakeBeads
+    from tests.scenarios.fakes.mock_world import MockWorld
+
+    beads = FakeBeads()
+    world = MockWorld(tmp_path, beads_manager=beads)
+
+    assert world.harness.plan_phase._beads_manager is beads
+    assert world.harness.implement_phase._beads_manager is beads
+
+
+async def test_mockworld_default_beads_manager_is_none(tmp_path) -> None:
+    from tests.scenarios.fakes.mock_world import MockWorld
+
+    world = MockWorld(tmp_path)
+    assert world.harness.plan_phase._beads_manager is None
+    assert world.harness.implement_phase._beads_manager is None
+
+
+async def test_mockworld_set_agents_preserves_beads_manager(tmp_path) -> None:
+    """PipelineHarness.set_agents must not drop the beads_manager binding."""
+    from tests.scenarios.fakes.fake_beads import FakeBeads
+    from tests.scenarios.fakes.mock_world import MockWorld
+
+    beads = FakeBeads()
+    world = MockWorld(tmp_path, beads_manager=beads)
+    # set_agents rebuilds ImplementPhase — make sure beads_manager survives
+    sentinel = object()
+    world.harness.set_agents(sentinel)  # type: ignore[arg-type]
+    assert world.harness.implement_phase._beads_manager is beads

--- a/tests/scenarios/test_bead_workflow.py
+++ b/tests/scenarios/test_bead_workflow.py
@@ -1,0 +1,201 @@
+"""End-to-end bead workflow scenarios using FakeBeads.
+
+Prod-code bead lifecycle
+------------------------
+- **Plan phase** (`plan_phase.py:283`): if ``beads_manager`` is set and
+  ``result.plan`` is non-empty, calls ``_create_beads_from_plan``.
+  That method calls ``extract_phases(plan)`` from ``task_graph``; if phases
+  are found it calls ``create_from_phases`` which creates one bead per phase
+  and wires dependencies.  The ``{phase_id: bead_id}`` mapping is stored in
+  state via ``set_bead_mapping``.
+- **Implement phase** (`implement_phase.py:577-580`): reads the bead mapping
+  from state.  If a mapping exists, calls ``beads_manager.init(wt_path)`` and
+  passes ``bead_mapping`` to the agent runner.  ``claim``/``close`` are NOT
+  called by prod code — those are executed by the real ``bd`` CLI subprocess
+  inside the container.  ``FakeDocker`` does not emulate CLI bead calls, so
+  tasks stay in their created state after the pipeline.
+- **Review phase** (`review_phase.py:1082-1113`): reads the mapping from
+  state and builds a ``bead_tasks`` context list (hardcoded ``status='closed'``
+  — an assumption, not a real query).  No ``BeadsManager`` methods are called.
+
+The plan text **must** contain phase headers matching the regex
+``### P{N} — Name`` for ``extract_phases`` to return phases.  The default
+``PlanResultFactory`` plan string does NOT contain these headers, so the plan
+must be explicitly set.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.conftest import PlanResultFactory
+from tests.scenarios.fakes.fake_beads import FakeBeads
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.git_worktree_fixture import init_test_worktree
+
+pytestmark = pytest.mark.scenario
+
+# ---------------------------------------------------------------------------
+# A valid Task Graph plan — two phases with a dependency chain.
+# extract_phases() requires "### P{N} — <name>" headers.
+# ---------------------------------------------------------------------------
+_TASK_GRAPH_PLAN = """\
+## Plan
+
+Add feature X in two phases.
+
+## Task Graph
+
+### P1 — Data model
+**Files:** src/models.py
+**Tests:**
+- model fields are correct
+**Depends on:** none
+
+### P2 — API endpoint
+**Files:** src/api.py
+**Tests:**
+- endpoint returns 200
+**Depends on:** P1
+"""
+
+
+async def test_B1_bead_workflow_end_to_end(tmp_path) -> None:
+    """Plan creates beads → implement init fires → bead mapping in state.
+
+    Pipeline bead behaviour (matched to prod reality):
+
+    1. FakeBeads is wired into MockWorld/PipelineHarness.
+    2. Plan phase detects Task Graph phases in the plan text and calls
+       ``create_from_phases`` → one bead per phase is stored in FakeBeads.
+    3. Implement phase calls ``beads_manager.init`` (because a bead mapping
+       now exists in state).
+    4. ``claim``/``close`` are NOT called by prod code — those are agent
+       subprocess concerns.  After the pipeline the tasks remain in their
+       created state.
+    5. Review phase reads the mapping from state but calls no FakeBeads
+       methods, so bead state is unchanged.
+
+    If any of the three invariants above break, the corresponding assertion
+    fails with a diagnostic message pointing to the relevant prod-code site.
+    """
+    beads = FakeBeads()
+    world = MockWorld(tmp_path, use_real_agent_runner=True, beads_manager=beads)
+    world.add_issue(1, "add feature X", "body", labels=["hydraflow-ready"])
+
+    worktree_cwd = tmp_path / "worktrees" / "issue-1"
+    init_test_worktree(worktree_cwd)
+
+    # Provide a plan whose text contains Task Graph phase headers.
+    plan = PlanResultFactory.create(
+        issue_number=1,
+        success=True,
+        plan=_TASK_GRAPH_PLAN,
+    )
+    world._llm.script_plan(1, [plan])
+
+    # Script the Docker fake so the agent runner sees a successful run with
+    # at least one commit (required by AgentRunner._verify_result).
+    world.docker.script_run_with_commits(
+        events=[{"type": "result", "success": True, "exit_code": 0}],
+        commits=[("x.py", "ok")],
+        cwd=worktree_cwd,
+    )
+
+    result = await world.run_pipeline()
+
+    # ------------------------------------------------------------------
+    # Assertion 1: FakeBeads was initialised by the implement phase.
+    # Triggered at implement_phase.py:580 when a bead mapping is in state.
+    # If False, the plan phase may not have stored a mapping (check A2).
+    # ------------------------------------------------------------------
+    assert beads._initialized is True, (
+        "FakeBeads.init was never called — implement phase only calls init "
+        "when a bead mapping exists in state (implement_phase.py:577-580). "
+        "This means plan phase did not produce a mapping (check A2 below)."
+    )
+
+    # ------------------------------------------------------------------
+    # Assertion 2: Two beads were created (one per Task Graph phase).
+    # Triggered by plan_phase._create_beads_from_plan via create_from_phases.
+    # The plan text above has two P{N} headers → two phases → two beads.
+    # ------------------------------------------------------------------
+    assert beads.task_count() == 2, (
+        f"Expected 2 bead tasks (one per plan phase), got {beads.task_count()}. "
+        "plan_phase.py:411 calls create_from_phases only when extract_phases "
+        "finds '### P{N} — Name' headers. Check the plan text format."
+    )
+
+    # ------------------------------------------------------------------
+    # Assertion 3: Dependency wiring — P2 depends on P1.
+    # FakeBeads.add_dependency records the edge; verify by inspecting the
+    # internal _tasks dict.  P2 is the second bead created (bd-fake-2).
+    # ------------------------------------------------------------------
+    task_ids = beads.task_ids()
+    assert len(task_ids) == 2  # matches A2
+    p1_bead_id, p2_bead_id = task_ids[0], task_ids[1]
+    p2_internal = beads._tasks[p2_bead_id]
+    assert p1_bead_id in p2_internal.depends_on, (
+        f"P2 bead ({p2_bead_id}) should depend on P1 bead ({p1_bead_id}). "
+        f"Actual depends_on: {p2_internal.depends_on}"
+    )
+
+    # ------------------------------------------------------------------
+    # Assertion 4: Tasks remain in 'open' state after the pipeline.
+    # claim/close are NOT called by prod pipeline code — they are bd CLI
+    # subprocess calls made inside the container, which FakeDocker does not
+    # emulate.  If status is not 'open', the fake or prod code changed.
+    # ------------------------------------------------------------------
+    for tid, task in beads._tasks.items():
+        assert task.status == "open", (
+            f"Bead {tid} status is {task.status!r}; expected 'open' because "
+            "prod code never calls BeadsManager.claim/close — those are agent "
+            "subprocess calls (bd CLI inside container)."
+        )
+
+    # ------------------------------------------------------------------
+    # Assertion 5: Pipeline completed (issue is tracked in result).
+    # ------------------------------------------------------------------
+    assert result.issue(1) is not None, "Pipeline returned no outcome for issue #1"
+
+
+async def test_B1_no_beads_without_task_graph_headers(tmp_path) -> None:
+    """Plan text without Task Graph headers → no beads created, no crash.
+
+    Validates the guard at plan_phase.py:401 — if extract_phases returns []
+    the method returns early; FakeBeads.create_from_phases is never called so
+    task_count() stays at 0 and _initialized stays False.
+    """
+    beads = FakeBeads()
+    world = MockWorld(tmp_path, use_real_agent_runner=True, beads_manager=beads)
+    world.add_issue(2, "plain task", "body", labels=["hydraflow-ready"])
+
+    worktree_cwd = tmp_path / "worktrees" / "issue-2"
+    init_test_worktree(worktree_cwd)
+
+    # Default plan text — no "### P{N} — ..." headers → extract_phases → []
+    plain_plan = PlanResultFactory.create(
+        issue_number=2,
+        success=True,
+        plan="## Plan\n\n1. Do the thing\n2. Test the thing",
+    )
+    world._llm.script_plan(2, [plain_plan])
+
+    world.docker.script_run_with_commits(
+        events=[{"type": "result", "success": True, "exit_code": 0}],
+        commits=[("y.py", "ok")],
+        cwd=worktree_cwd,
+    )
+
+    result = await world.run_pipeline()
+
+    # No phases → no beads → no init
+    assert beads.task_count() == 0, (
+        "Expected 0 beads when plan text has no Task Graph headers. "
+        f"Got {beads.task_count()} — check plan_phase._create_beads_from_plan."
+    )
+    assert beads._initialized is False, (
+        "FakeBeads.init should not be called when no bead mapping was stored. "
+        "implement_phase.py:577 gates init on get_bead_mapping returning truthy."
+    )
+    assert result.issue(2) is not None, "Pipeline returned no outcome for issue #2"

--- a/tests/scenarios/test_caretaker_loops.py
+++ b/tests/scenarios/test_caretaker_loops.py
@@ -1,0 +1,402 @@
+"""Caretaker loop scenarios L9–L13 — covers loops beyond L1–L8 in test_loops.py.
+
+Each scenario seeds a MockWorld, runs one real BaseBackgroundLoop subclass via
+``run_with_loops()``, and asserts on the observable result or mock call counts.
+
+Because the inner delegates (adr_reviewer, memory_sync, etc.) are injected as
+AsyncMock / MagicMock objects through ``world._loop_ports``, the loops exercise
+their full _do_work() dispatch path without touching real I/O.
+
+Strategy for injecting port mocks before the catalog creates its defaults:
+    world._loop_ports is initialised lazily on the first run_with_loops() call.
+    We pre-seed it ourselves so the catalog's ``ports.get(key) or MagicMock()``
+    finds our mock and uses it instead of creating a bare MagicMock().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _seed_ports(world: MockWorld, extra: dict) -> None:
+    """Pre-initialise world._loop_ports with base fakes + caller-supplied mocks.
+
+    MockWorld lazily creates _loop_ports on the first run_with_loops() call.
+    By seeding it here we ensure our AsyncMocks are in place before the catalog
+    builder runs ``ports.get(key) or MagicMock()``.
+    """
+    if not hasattr(world, "_loop_ports"):
+        world._loop_ports = {
+            "github": world.github,
+            "workspace": world._workspace,
+            "hindsight": world._hindsight,
+            "sentry": world._sentry,
+            "clock": world._clock,
+        }
+    world._loop_ports.update(extra)
+
+
+# ---------------------------------------------------------------------------
+# L9: ADR Reviewer loop invokes reviewer delegate
+# ---------------------------------------------------------------------------
+
+
+class TestL9ADRReviewerLoop:
+    """L9: adr_reviewer_loop calls review_proposed_adrs on its delegate."""
+
+    async def test_adr_reviewer_loop_invokes_reviewer(self, tmp_path) -> None:
+        """ADRReviewerLoop._do_work delegates entirely to adr_reviewer.review_proposed_adrs.
+
+        We inject an AsyncMock as the adr_reviewer port before the catalog
+        builds the loop, so the await inside _do_work succeeds.  The return
+        value propagates back as the loop's stats dict.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_reviewer = AsyncMock()
+        fake_reviewer.review_proposed_adrs.return_value = {
+            "reviewed": 2,
+            "accepted": 1,
+            "deferred": 1,
+        }
+        _seed_ports(world, {"adr_reviewer": fake_reviewer})
+
+        stats = await world.run_with_loops(["adr_reviewer"], cycles=1)
+
+        assert stats["adr_reviewer"] is not None
+        assert stats["adr_reviewer"]["reviewed"] == 2
+        assert stats["adr_reviewer"]["accepted"] == 1
+        fake_reviewer.review_proposed_adrs.assert_called_once()
+
+    async def test_adr_reviewer_loop_returns_none_passthrough(self, tmp_path) -> None:
+        """ADRReviewerLoop passes through None if reviewer returns None.
+
+        Verifies the loop does not wrap or mutate a None result.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_reviewer = AsyncMock()
+        fake_reviewer.review_proposed_adrs.return_value = None
+        _seed_ports(world, {"adr_reviewer": fake_reviewer})
+
+        stats = await world.run_with_loops(["adr_reviewer"], cycles=1)
+
+        assert stats["adr_reviewer"] is None
+        fake_reviewer.review_proposed_adrs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# L10: Memory Sync loop reconciles drift via delegate
+# ---------------------------------------------------------------------------
+
+
+class TestL10MemorySyncLoop:
+    """L10: memory_sync_loop calls sync() then publish_sync_event() on its delegate."""
+
+    async def test_memory_sync_loop_calls_sync_and_publish(self, tmp_path) -> None:
+        """MemorySyncLoop._do_work calls sync(), then publish_sync_event(result).
+
+        Both methods are async on the real MemorySyncWorker.  We inject an
+        AsyncMock so the awaits succeed, and assert both calls happened with
+        the expected arguments.  The stats dict is a copy of the sync result.
+        """
+        world = MockWorld(tmp_path)
+
+        sync_result = {"item_count": 42, "compacted": True, "evicted": 3}
+        fake_memory_sync = AsyncMock()
+        fake_memory_sync.sync.return_value = sync_result
+        fake_memory_sync.publish_sync_event.return_value = None
+        _seed_ports(world, {"memory_sync": fake_memory_sync})
+
+        stats = await world.run_with_loops(["memory_sync"], cycles=1)
+
+        assert stats["memory_sync"] is not None
+        assert stats["memory_sync"]["item_count"] == 42
+        assert stats["memory_sync"]["compacted"] is True
+        fake_memory_sync.sync.assert_called_once()
+        fake_memory_sync.publish_sync_event.assert_called_once_with(sync_result)
+
+    async def test_memory_sync_loop_stats_is_copy_of_result(self, tmp_path) -> None:
+        """Stats dict returned by the loop is a fresh copy of the sync result.
+
+        The loop does ``return dict(result)`` so mutating stats should not
+        affect the original dict held by the mock.
+        """
+        world = MockWorld(tmp_path)
+
+        sync_result = {"item_count": 5, "compacted": False}
+        fake_memory_sync = AsyncMock()
+        fake_memory_sync.sync.return_value = sync_result
+        fake_memory_sync.publish_sync_event.return_value = None
+        _seed_ports(world, {"memory_sync": fake_memory_sync})
+
+        stats = await world.run_with_loops(["memory_sync"], cycles=1)
+
+        # Mutating the returned stats must not affect the original
+        stats["memory_sync"]["item_count"] = 999
+        assert sync_result["item_count"] == 5
+
+
+# ---------------------------------------------------------------------------
+# L11: Retrospective loop processes queue items
+# ---------------------------------------------------------------------------
+
+
+class TestL11RetrospectiveLoop:
+    """L11: retrospective_loop drains its queue and records stats."""
+
+    async def test_empty_queue_returns_zero_processed(self, tmp_path) -> None:
+        """With an empty queue, the loop returns zero processed/patterns/stale.
+
+        queue.load() is sync on RetrospectiveQueue so a plain MagicMock works.
+        We configure it to return [] to exercise the early-return branch.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_queue = MagicMock()
+        fake_queue.load.return_value = []
+        _seed_ports(world, {"retrospective_queue": fake_queue})
+
+        stats = await world.run_with_loops(["retrospective"], cycles=1)
+
+        assert stats["retrospective"] == {
+            "processed": 0,
+            "patterns_filed": 0,
+            "stale_proposals": 0,
+        }
+        fake_queue.load.assert_called_once()
+
+    async def test_retro_patterns_item_processed_and_acknowledged(
+        self, tmp_path
+    ) -> None:
+        """A RETRO_PATTERNS queue item causes _handle_retro_patterns to run.
+
+        The retrospective collector's _load_recent and _detect_patterns are
+        called.  The item id is acknowledged and processed count == 1.
+        """
+        from retrospective_queue import QueueItem, QueueKind  # noqa: PLC0415
+
+        world = MockWorld(tmp_path)
+
+        item = QueueItem(kind=QueueKind.RETRO_PATTERNS, issue_number=77, pr_number=88)
+
+        fake_queue = MagicMock()
+        fake_queue.load.return_value = [item]
+
+        fake_retro = MagicMock()
+        fake_retro._load_recent.return_value = []
+        fake_retro._detect_patterns = AsyncMock(return_value=None)
+
+        _seed_ports(
+            world,
+            {
+                "retrospective_queue": fake_queue,
+                "retrospective": fake_retro,
+            },
+        )
+
+        stats = await world.run_with_loops(["retrospective"], cycles=1)
+
+        assert stats["retrospective"]["processed"] == 1
+        fake_queue.acknowledge.assert_called_once_with([item.id])
+        fake_retro._load_recent.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# L12: Epic Sweeper verifies done-epic children closed
+# ---------------------------------------------------------------------------
+
+
+class TestL12EpicSweeperLoop:
+    """L12: epic_sweeper_loop sweeps open epics and auto-closes completed ones."""
+
+    async def test_no_epics_returns_zero_counts(self, tmp_path) -> None:
+        """When no open epics exist, the loop reports zero checked and swept.
+
+        IssueFetcherPort.fetch_issues_by_labels is async so we need AsyncMock.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_fetcher = AsyncMock()
+        fake_fetcher.fetch_issues_by_labels.return_value = []
+        fake_state = MagicMock()
+        fake_state.get_epic_state.return_value = None
+        _seed_ports(
+            world,
+            {
+                "issue_fetcher": fake_fetcher,
+                "epic_sweeper_state": fake_state,
+            },
+        )
+
+        stats = await world.run_with_loops(["epic_sweeper"], cycles=1)
+
+        assert stats["epic_sweeper"] is not None
+        assert stats["epic_sweeper"]["checked"] == 0
+        assert stats["epic_sweeper"]["swept"] == 0
+        assert stats["epic_sweeper"]["total_open_epics"] == 0
+
+    async def test_epic_with_all_closed_sub_issues_is_swept(self, tmp_path) -> None:
+        """An epic whose sub-issues are all closed gets auto-closed by the sweeper.
+
+        The epic body contains a checkbox reference to issue #200.  Issue #200
+        is closed.  After one cycle: epic closed, comment posted via FakeGitHub.
+        """
+        from models import GitHubIssue  # noqa: PLC0415
+
+        world = MockWorld(tmp_path)
+
+        # Epic issue with a checkbox ref to sub-issue #200
+        epic_body = "## Tasks\n- [x] #200 — implement feature\n"
+        epic = GitHubIssue(
+            number=100,
+            title="Epic: Implement feature",
+            body=epic_body,
+            state="open",
+            labels=["hydraflow-epic"],
+        )
+
+        # Sub-issue that is already closed
+        sub_issue = GitHubIssue(
+            number=200,
+            title="Implement feature",
+            body="",
+            state="closed",
+            labels=[],
+        )
+
+        # Pre-seed FakeGitHub so close_issue / post_comment have a real target
+        world.github.add_issue(100, epic.title, epic.body, labels=epic.labels)
+        world.github.add_issue(200, sub_issue.title, sub_issue.body, labels=[])
+        world.github.issue(200).state = "closed"
+
+        fake_fetcher = AsyncMock()
+        fake_fetcher.fetch_issues_by_labels.return_value = [epic]
+        fake_fetcher.fetch_issue_by_number.return_value = sub_issue
+
+        fake_state = MagicMock()
+        fake_state.get_epic_state.return_value = None  # no formal EpicState children
+
+        _seed_ports(
+            world,
+            {
+                "issue_fetcher": fake_fetcher,
+                "epic_sweeper_state": fake_state,
+            },
+        )
+
+        stats = await world.run_with_loops(["epic_sweeper"], cycles=1)
+
+        assert stats["epic_sweeper"]["swept"] == 1
+        assert stats["epic_sweeper"]["checked"] == 1
+        # FakeGitHub close_issue should have been called
+        assert world.github.issue(100).state == "closed"
+
+
+# ---------------------------------------------------------------------------
+# L13: Security Patch loop files issues from Dependabot alerts
+# ---------------------------------------------------------------------------
+
+
+class TestL13SecurityPatchLoop:
+    """L13: security_patch_loop creates patch issues from dependabot alerts."""
+
+    async def test_no_alerts_returns_zero_filed(self, tmp_path) -> None:
+        """When Dependabot returns no alerts, filed == 0 and no issues created.
+
+        FakeGitHub.get_dependabot_alerts returns [] by default, so no extra
+        setup is required.
+        """
+        world = MockWorld(tmp_path)
+
+        stats = await world.run_with_loops(["security_patch"], cycles=1)
+
+        assert stats["security_patch"] is not None
+        assert stats["security_patch"]["filed"] == 0
+        assert stats["security_patch"]["total_alerts"] == 0
+
+    async def test_fixable_high_severity_alert_files_issue(self, tmp_path) -> None:
+        """A fixable, high-severity alert causes the loop to file a GitHub issue.
+
+        We monkeypatch FakeGitHub.get_dependabot_alerts to return one alert
+        matching the default severity threshold (high).  After one cycle the
+        loop should have filed exactly one issue.
+        """
+        world = MockWorld(tmp_path)
+
+        alert = {
+            "number": 1,
+            "security_vulnerability": {
+                "package": {"name": "requests"},
+                "severity": "high",
+                "first_patched_version": {"identifier": "2.32.0"},
+            },
+            "security_advisory": {
+                "summary": "SSRF vulnerability in requests",
+            },
+        }
+
+        async def _fake_alerts(**_kw):
+            return [alert]
+
+        world.github.get_dependabot_alerts = _fake_alerts
+
+        initial_issue_count = len(world.github._issues)
+
+        stats = await world.run_with_loops(["security_patch"], cycles=1)
+
+        assert stats["security_patch"]["filed"] == 1
+        assert stats["security_patch"]["total_alerts"] == 1
+        assert stats["security_patch"]["skipped_dedup"] == 0
+        assert len(world.github._issues) == initial_issue_count + 1
+
+    async def test_dry_run_skips_all_alerts(self, tmp_path) -> None:
+        """When dry_run=True, the loop returns None without filing any issues.
+
+        We instantiate SecurityPatchLoop directly with a dry-run config rather
+        than going through run_with_loops, which cannot pass dry_run=True.
+        """
+        from base_background_loop import LoopDeps  # noqa: PLC0415
+        from security_patch_loop import SecurityPatchLoop  # noqa: PLC0415
+        from tests.helpers import make_bg_loop_deps  # noqa: PLC0415
+
+        world = MockWorld(tmp_path)
+
+        alert = {
+            "number": 2,
+            "security_vulnerability": {
+                "package": {"name": "urllib3"},
+                "severity": "critical",
+                "first_patched_version": {"identifier": "2.2.0"},
+            },
+            "security_advisory": {"summary": "Critical vuln"},
+        }
+
+        async def _fake_alerts(**_kw):
+            return [alert]
+
+        world.github.get_dependabot_alerts = _fake_alerts
+
+        bg = make_bg_loop_deps(tmp_path, dry_run=True)
+        loop_deps = LoopDeps(
+            event_bus=bg.bus,
+            stop_event=bg.stop_event,
+            status_cb=bg.status_cb,
+            enabled_cb=bg.enabled_cb,
+            sleep_fn=bg.sleep_fn,
+        )
+
+        loop = SecurityPatchLoop(
+            config=bg.config,
+            pr_manager=world.github,
+            deps=loop_deps,
+        )
+        result = await loop._do_work()
+
+        assert result is None


### PR DESCRIPTION
## Summary

Tier 2 of the MockWorld scenario coverage expansion. New `FakeBeads` in-memory mock of the `bd` CLI, bead-workflow end-to-end scenario, and 5 caretaker loop scenarios (L9–L13). Zero production-code changes.

Builds on Tier 1 (PR #8356). Can land independently — touches different files.

**Spec:** `docs/superpowers/specs/2026-04-18-mockworld-scenario-expansion-design.md` (gitignored)
**Plan:** `docs/superpowers/plans/2026-04-18-mockworld-scenario-expansion-all-tiers.md` (gitignored)

## What this delivers

### FakeBeads infrastructure
- `tests/scenarios/fakes/fake_beads.py` — in-memory mirror of all 9 `BeadsManager` async methods (`ensure_installed`, `init`, `create_task`, `add_dependency`, `claim`, `close`, `list_ready`, `show`, `create_from_phases`).
- Returns real `BeadTask` Pydantic models (imported from `beads_manager`), not plain dicts — matches what `BeadsManager._parse_show_json` produces.
- `MockWorld(tmp_path, beads_manager=FakeBeads())` threads through `PipelineHarness` to both `PlanPhase` and `ImplementPhase`.
- `PipelineHarness.set_agents()` preserves the `beads_manager` binding via `_implement_phase_base_kwargs`.

### Scenarios

**B1 — bead workflow end-to-end** (`test_bead_workflow.py`):
- Plan produces a multi-phase plan with `### P1 —` / `### P2 —` headers.
- `PlanPhase._create_beads_from_plan` parses phases and calls `create_from_phases`.
- `ImplementPhase` calls `init`; beads created with P2 depending on P1.

**L9–L13 — caretaker loops** (`test_caretaker_loops.py`):
- **L9** — `adr_reviewer_loop` invokes `review_proposed_adrs`.
- **L10** — `memory_sync_loop` calls `sync()` + `publish_sync_event(result)`.
- **L11** — `retrospective_loop` drains queue, dispatches to collector on `RETRO_PATTERNS` match.
- **L12** — `epic_sweeper_loop` closes done epics with all children done.
- **L13** — `security_patch_loop` files patch issues for fixable dependabot alerts; dedup tracked.

11 tests total in `test_caretaker_loops.py` (2 per loop, 3 for security_patch).

## Findings

- `claim`/`close` aren't called from the pipeline itself — those happen inside the agent Docker container. FakeBeads tasks stay `'open'` after a pipeline run.
- Plan text must include `### P{N} — <name>` headers (em-dash or hyphen) for `extract_phases` to recognize them. The default `PlanResultFactory` plan string doesn't trigger bead creation — B1 explicitly crafts a conforming plan.
- Caretaker loops' inner delegates (`adr_reviewer`, `memory_sync`, etc.) are `MagicMock` by default in the loop catalog. A new `_seed_ports()` helper in `test_caretaker_loops.py` pre-seeds `AsyncMock` variants to avoid `TypeError` when loops `await` mock methods.

## Pre-existing failure

`tests/test_planner.py::test_build_prompt_truncates_long_body` fails on `origin/main` and on this branch identically (11991 > 10000). Not caused by this PR.

## Test plan
- [x] Full scenarios suite: 262 passed (scenario + scenario_loops markers), 0 regressions
- [x] `make quality`: 10834 passed + 1 pre-existing failure unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)