### PR TITLE
feat(wiki): Phase 5 — /api/wiki/* read + admin-enqueue endpoints

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1512,6 +1512,11 @@ def create_router(
 
     _register_crates(router, ctx)
 
+    # --- Wiki routes (Phase 5 of git-backed repo wiki) ---
+    from dashboard_routes._wiki_routes import register as _register_wiki
+
+    _register_wiki(router, ctx)
+
     # --- HITL routes (extracted to _hitl_routes.py) ---
     from dashboard_routes._hitl_routes import register as _register_hitl
 

--- a/src/dashboard_routes/_wiki_routes.py
+++ b/src/dashboard_routes/_wiki_routes.py
@@ -1,0 +1,405 @@
+"""/api/wiki/* endpoints — read + admin-enqueue routes for the git-backed repo wiki.
+
+Phase 5 of ``docs/git-backed-wiki-design.md``.  Read endpoints traverse
+the tracked ``repo_wiki/`` directory under ``config.repo_root`` (the
+per-entry layout landed by Phase 2); admin endpoints enqueue
+``MaintenanceTask`` entries that ``RepoWikiLoop`` drains on its next
+tick.  Nothing here mutates the wiki directly — every write goes
+through the single-track commit path that emits the
+``chore(wiki): maintenance`` PR.
+
+Follows the ``_memory_routes.py`` pattern: ``register(router, ctx)``
+attaches ``@router.<method>`` handlers that close over ``ctx`` for
+shared state (config, wiki queue, wiki loop).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from fastapi import HTTPException
+from pydantic import BaseModel, Field
+
+from wiki_maint_queue import MaintenanceTask
+
+if TYPE_CHECKING:
+    from fastapi import APIRouter
+
+    from dashboard_routes._routes import RouteContext
+
+logger = logging.getLogger("hydraflow.dashboard.wiki")
+
+_TOPICS: tuple[str, ...] = (
+    "architecture",
+    "patterns",
+    "gotchas",
+    "testing",
+    "dependencies",
+)
+
+# Filename pattern: ``{id:04d}-issue-{N|unknown}-{slug}.md``.  Parses both
+# the id and the issue tag so the API can filter by either.
+_ENTRY_FILENAME_RE = re.compile(r"^(\d+)-issue-(\S+?)-(.+)\.md$")
+
+
+class ForceCompilePayload(BaseModel):
+    owner: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+    topic: str = Field(min_length=1)
+
+
+class MarkStalePayload(BaseModel):
+    owner: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+    entry_id: str = Field(min_length=1)
+    reason: str = Field(default="")
+
+
+class RebuildIndexPayload(BaseModel):
+    owner: str = Field(min_length=1)
+    repo: str = Field(min_length=1)
+
+
+def _wiki_loop(ctx: RouteContext):
+    """Return the ``RepoWikiLoop`` from the running orchestrator, or None.
+
+    Services live inside ``ServiceRegistry`` on the orchestrator, which
+    is constructed after the dashboard.  Looking them up lazily keeps
+    the route module decoupled from ``service_registry`` import order.
+    """
+    orch = ctx.get_orchestrator()
+    if orch is None:
+        return None
+    svc = getattr(orch, "_svc", None)
+    if svc is None:
+        return None
+    return getattr(svc, "repo_wiki_loop", None)
+
+
+def _maintenance_queue(ctx: RouteContext):
+    """Return the loop's ``MaintenanceQueue``, or None if loop is down."""
+    loop = _wiki_loop(ctx)
+    if loop is None:
+        return None
+    return getattr(loop, "_queue", None)
+
+
+def _wiki_root(ctx: RouteContext) -> Path:
+    """Absolute path to the tracked ``repo_wiki/`` directory.
+
+    Reads from ``config.repo_root / config.repo_wiki_path`` so the API
+    sees what the migration script and phase runners wrote, not the
+    legacy ``.hydraflow/repo_wiki/`` layout.
+    """
+    return (ctx.config.repo_root / ctx.config.repo_wiki_path).resolve()
+
+
+def _repo_dir(ctx: RouteContext, owner: str, repo: str) -> Path | None:
+    """Return the tracked dir for ``{owner}/{repo}`` or None when absent.
+
+    Prevents path traversal via ``..`` or absolute paths in owner/repo.
+    """
+    if "/" in owner or "/" in repo or ".." in owner or ".." in repo:
+        return None
+    candidate = _wiki_root(ctx) / owner / repo
+    try:
+        candidate_resolved = candidate.resolve()
+    except OSError:
+        return None
+    root = _wiki_root(ctx)
+    if not str(candidate_resolved).startswith(str(root)):
+        return None
+    if not candidate_resolved.is_dir():
+        return None
+    return candidate_resolved
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Split a markdown file into (frontmatter-dict, body-str).
+
+    Tolerates missing frontmatter: returns ``({}, text)`` so downstream
+    callers still get the full text rendered as body.
+    """
+    if not text.startswith("---\n"):
+        return {}, text
+    try:
+        end = text.index("\n---\n", 4)
+    except ValueError:
+        return {}, text
+    block = text[4:end]
+    body = text[end + len("\n---\n") :]
+    frontmatter: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        frontmatter[key.strip()] = value.strip()
+    return frontmatter, body
+
+
+def _entry_summary_from_path(
+    *, topic: str, path: Path, owner: str, repo: str
+) -> dict[str, Any] | None:
+    """Cheap-to-compute summary (frontmatter only, no body) for list views."""
+    match = _ENTRY_FILENAME_RE.match(path.name)
+    if match is None:
+        return None
+    entry_id = match.group(1)
+    issue_tag = match.group(2)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    frontmatter, _ = _parse_frontmatter(text)
+    return {
+        "id": entry_id,
+        "issue": issue_tag,
+        "topic": topic,
+        "owner": owner,
+        "repo": repo,
+        "filename": path.name,
+        "status": frontmatter.get("status", "active"),
+        "source_phase": frontmatter.get("source_phase", ""),
+        "source_issue": frontmatter.get("source_issue", issue_tag),
+        "created_at": frontmatter.get("created_at", ""),
+    }
+
+
+def _match_filters(
+    summary: dict[str, Any],
+    *,
+    status: str | None,
+    q: str | None,
+    body_fetcher,
+) -> bool:
+    """Apply status + substring filters.  ``body_fetcher`` is a 0-arg
+    callable that returns the markdown body (lazily — free-text ``q``
+    search loads body text only when status filter is satisfied)."""
+    if status and summary["status"] != status:
+        return False
+    if q:
+        needle = q.lower()
+        if needle in summary["filename"].lower():
+            return True
+        if needle in summary.get("source_phase", "").lower():
+            return True
+        try:
+            return needle in body_fetcher().lower()
+        except OSError:
+            return False
+    return True
+
+
+def register(router: APIRouter, ctx: RouteContext) -> None:
+    """Attach /api/wiki/* handlers to ``router``.
+
+    All reads go through the tracked ``repo_wiki/`` layout under
+    ``config.repo_root``.  All writes happen via ``MaintenanceQueue``
+    drains inside ``RepoWikiLoop`` — the admin endpoints here never
+    mutate the wiki directly.
+    """
+
+    @router.get("/api/wiki/repos")
+    def list_wiki_repos() -> list[dict[str, str]]:
+        root = _wiki_root(ctx)
+        if not root.is_dir():
+            return []
+        out: list[dict[str, str]] = []
+        for owner_dir in sorted(root.iterdir()):
+            if not owner_dir.is_dir():
+                continue
+            for repo_dir in sorted(owner_dir.iterdir()):
+                if not repo_dir.is_dir():
+                    continue
+                if (repo_dir / "index.md").exists() or (
+                    repo_dir / "index.json"
+                ).exists():
+                    out.append({"owner": owner_dir.name, "repo": repo_dir.name})
+        return out
+
+    @router.get("/api/wiki/repos/{owner}/{repo}/entries")
+    def list_wiki_entries(
+        owner: str,
+        repo: str,
+        topic: str | None = None,
+        status: str | None = None,
+        q: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        repo_dir = _repo_dir(ctx, owner, repo)
+        if repo_dir is None:
+            return []
+        topics: tuple[str, ...] = (topic,) if topic else _TOPICS
+        out: list[dict[str, Any]] = []
+        for t in topics:
+            topic_dir = repo_dir / t
+            if not topic_dir.is_dir():
+                continue
+            for entry_path in sorted(topic_dir.glob("*.md")):
+                summary = _entry_summary_from_path(
+                    topic=t, path=entry_path, owner=owner, repo=repo
+                )
+                if summary is None:
+                    continue
+                if not _match_filters(
+                    summary,
+                    status=status,
+                    q=q,
+                    body_fetcher=lambda p=entry_path: p.read_text(encoding="utf-8"),
+                ):
+                    continue
+                out.append(summary)
+        offset = max(offset, 0)
+        limit = max(limit, 0)
+        return out[offset : offset + limit]
+
+    @router.get("/api/wiki/repos/{owner}/{repo}/entries/{entry_id}")
+    def get_wiki_entry(owner: str, repo: str, entry_id: str) -> dict[str, Any]:
+        repo_dir = _repo_dir(ctx, owner, repo)
+        if repo_dir is None:
+            raise HTTPException(status_code=404, detail="repo not found")
+        if not re.fullmatch(r"\d{1,6}", entry_id):
+            raise HTTPException(status_code=400, detail="invalid entry id")
+        prefix = f"{int(entry_id):04d}-"
+        for topic in _TOPICS:
+            topic_dir = repo_dir / topic
+            if not topic_dir.is_dir():
+                continue
+            for match in topic_dir.glob(f"{prefix}*.md"):
+                text = match.read_text(encoding="utf-8")
+                frontmatter, body = _parse_frontmatter(text)
+                return {
+                    "id": entry_id,
+                    "topic": topic,
+                    "owner": owner,
+                    "repo": repo,
+                    "filename": match.name,
+                    "frontmatter": frontmatter,
+                    "body": body,
+                }
+        raise HTTPException(status_code=404, detail="entry not found")
+
+    @router.get("/api/wiki/repos/{owner}/{repo}/log")
+    def get_wiki_log(
+        owner: str,
+        repo: str,
+        issue: int | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        repo_dir = _repo_dir(ctx, owner, repo)
+        if repo_dir is None:
+            return []
+        log_dir = repo_dir / "log"
+        if not log_dir.is_dir():
+            return []
+        if issue is not None:
+            candidates = [log_dir / f"{issue}.jsonl"]
+        else:
+            candidates = sorted(log_dir.glob("*.jsonl"))
+        records: list[dict[str, Any]] = []
+        for path in candidates:
+            if not path.is_file():
+                continue
+            for line in path.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    import json  # noqa: PLC0415
+
+                    records.append(json.loads(stripped))
+                except ValueError:
+                    continue
+        limit = max(limit, 0)
+        return records[-limit:] if limit else []
+
+    @router.get("/api/wiki/maintenance/status")
+    def get_maintenance_status() -> dict[str, Any]:
+        loop = _wiki_loop(ctx)
+        queue = _maintenance_queue(ctx)
+        queue_path = (
+            queue._path  # noqa: SLF001 — read-only diagnostics
+            if queue is not None
+            else None
+        )
+        return {
+            "open_pr_url": getattr(loop, "_open_pr_url", None) if loop else None,
+            "open_pr_branch": getattr(loop, "_open_pr_branch", None) if loop else None,
+            "queue_depth": len(queue.peek()) if queue is not None else 0,
+            "queue_path": str(queue_path) if queue_path else None,
+            "interval_seconds": ctx.config.repo_wiki_interval,
+            "auto_merge": ctx.config.repo_wiki_maintenance_auto_merge,
+            "coalesce": ctx.config.repo_wiki_maintenance_pr_coalesce,
+        }
+
+    @router.post("/api/wiki/admin/force-compile")
+    def admin_force_compile(payload: ForceCompilePayload) -> dict[str, str]:
+        queue = _maintenance_queue(ctx)
+        if queue is None:
+            raise HTTPException(status_code=503, detail="wiki queue unavailable")
+        queue.enqueue(
+            MaintenanceTask(
+                kind="force-compile",
+                repo_slug=f"{payload.owner}/{payload.repo}",
+                params={"topic": payload.topic},
+            )
+        )
+        return {"status": "queued"}
+
+    @router.post("/api/wiki/admin/mark-stale")
+    def admin_mark_stale(payload: MarkStalePayload) -> dict[str, str]:
+        queue = _maintenance_queue(ctx)
+        if queue is None:
+            raise HTTPException(status_code=503, detail="wiki queue unavailable")
+        queue.enqueue(
+            MaintenanceTask(
+                kind="mark-stale",
+                repo_slug=f"{payload.owner}/{payload.repo}",
+                params={
+                    "entry_id": payload.entry_id,
+                    "reason": payload.reason,
+                },
+            )
+        )
+        return {"status": "queued"}
+
+    @router.post("/api/wiki/admin/rebuild-index")
+    def admin_rebuild_index(payload: RebuildIndexPayload) -> dict[str, str]:
+        queue = _maintenance_queue(ctx)
+        if queue is None:
+            raise HTTPException(status_code=503, detail="wiki queue unavailable")
+        queue.enqueue(
+            MaintenanceTask(
+                kind="rebuild-index",
+                repo_slug=f"{payload.owner}/{payload.repo}",
+                params={},
+            )
+        )
+        return {"status": "queued"}
+
+    @router.post("/api/wiki/admin/run-now")
+    def admin_run_now() -> dict[str, str]:
+        """Request that ``RepoWikiLoop`` runs on the next event-loop iteration.
+
+        The loop itself decides timing — this endpoint only flips a flag
+        the loop observes; it does not bypass the interval directly.
+        Phase 5 delivers the queued-for-soon semantics; Phase 6 may add
+        an interrupt path.
+        """
+        loop = _wiki_loop(ctx)
+        if loop is None:
+            raise HTTPException(status_code=503, detail="wiki loop unavailable")
+        # BaseBackgroundLoop exposes ``trigger_now`` / ``force_tick`` on
+        # some loops; fall through to a log-only response if not.
+        trigger = getattr(loop, "trigger_now", None) or getattr(
+            loop, "force_tick", None
+        )
+        if callable(trigger):
+            trigger()
+            return {"status": "triggered"}
+        logger.info("Wiki admin run-now received; loop has no trigger hook")
+        return {"status": "acknowledged"}

--- a/tests/test_wiki_routes.py
+++ b/tests/test_wiki_routes.py
@@ -1,0 +1,335 @@
+"""Tests for /api/wiki/* routes (Phase 5 of the git-backed repo wiki).
+
+Covers:
+
+- Read endpoints traverse the tracked ``repo_wiki/`` layout and return
+  the expected fields / 404s.
+- Admin endpoints enqueue ``MaintenanceTask`` entries into the orchestrator's
+  ``RepoWikiLoop._queue`` when present, 503 otherwise.
+- ``/api/wiki/maintenance/status`` reports queue depth + open-PR state.
+
+Tests use the ``make_dashboard_router`` helper + ``find_endpoint`` to
+reach handlers directly — no FastAPI TestClient required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from config import HydraFlowConfig
+from events import EventBus
+from state import StateTracker
+from tests.helpers import find_endpoint, make_dashboard_router
+from wiki_maint_queue import MaintenanceQueue, MaintenanceTask
+
+REPO = "acme/widget"
+
+
+@pytest.fixture
+def wiki_root(tmp_path: Path) -> Path:
+    """A tracked ``repo_wiki/`` tree with two entries + index.md + log."""
+    root = tmp_path / "repo_wiki"
+    repo_dir = root / "acme" / "widget"
+    (repo_dir / "patterns").mkdir(parents=True)
+    (repo_dir / "gotchas").mkdir()
+    (repo_dir / "log").mkdir()
+
+    (repo_dir / "index.md").write_text("# Wiki: acme/widget\n")
+
+    (repo_dir / "patterns" / "0001-issue-10-first-pattern.md").write_text(
+        "---\n"
+        "id: 0001\n"
+        "topic: patterns\n"
+        "source_issue: 10\n"
+        "source_phase: plan\n"
+        "created_at: 2026-04-01T00:00:00Z\n"
+        "status: active\n"
+        "---\n"
+        "\n"
+        "# First pattern\n"
+        "\n"
+        "Pattern body content.\n"
+    )
+    (repo_dir / "gotchas" / "0001-issue-11-watch-out.md").write_text(
+        "---\n"
+        "id: 0001\n"
+        "topic: gotchas\n"
+        "source_issue: 11\n"
+        "source_phase: review\n"
+        "created_at: 2026-04-02T00:00:00Z\n"
+        "status: stale\n"
+        "---\n"
+        "\n"
+        "# Watch out\n"
+        "\n"
+        "Gotcha body.\n"
+    )
+    (repo_dir / "log" / "10.jsonl").write_text(
+        json.dumps({"issue_number": 10, "phase": "plan", "action": "ingest"}) + "\n"
+    )
+    (repo_dir / "log" / "11.jsonl").write_text(
+        json.dumps({"issue_number": 11, "phase": "review", "action": "ingest"}) + "\n"
+    )
+    return root
+
+
+@pytest.fixture
+def config(tmp_path: Path, wiki_root: Path) -> HydraFlowConfig:
+    return HydraFlowConfig(
+        repo=REPO,
+        repo_root=wiki_root.parent,  # wiki_root is <repo_root>/repo_wiki
+        repo_wiki_git_backed=True,
+        repo_wiki_path="repo_wiki",
+    )
+
+
+@pytest.fixture
+def maintenance_queue(tmp_path: Path) -> MaintenanceQueue:
+    return MaintenanceQueue(path=tmp_path / "queue.json")
+
+
+@pytest.fixture
+def fake_orchestrator(maintenance_queue: MaintenanceQueue) -> MagicMock:
+    """A mock orchestrator whose ``_svc.repo_wiki_loop._queue`` is the fixture."""
+    loop = MagicMock()
+    loop._queue = maintenance_queue
+    loop._open_pr_url = "https://github.com/x/y/pull/99"
+    loop._open_pr_branch = "hydraflow/wiki-maint-abc"
+
+    svc = MagicMock()
+    svc.repo_wiki_loop = loop
+
+    orch = MagicMock()
+    orch._svc = svc
+    return orch
+
+
+@pytest.fixture
+def router(
+    config: HydraFlowConfig,
+    tmp_path: Path,
+    fake_orchestrator: MagicMock,
+) -> Any:
+    bus = EventBus()
+    state = StateTracker(tmp_path / "state.json")
+    r, _pr = make_dashboard_router(
+        config=config,
+        event_bus=bus,
+        state=state,
+        tmp_path=tmp_path,
+        get_orch=lambda: fake_orchestrator,
+    )
+    return r
+
+
+class TestReadEndpoints:
+    def test_list_repos(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos", "GET")
+        assert handler is not None
+        result = handler()
+        assert result == [{"owner": "acme", "repo": "widget"}]
+
+    def test_list_entries_returns_all_by_default(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
+        assert handler is not None
+        entries = handler(owner="acme", repo="widget")
+        assert len(entries) == 2
+        topics = {e["topic"] for e in entries}
+        assert topics == {"patterns", "gotchas"}
+
+    def test_list_entries_filters_by_topic(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
+        entries = handler(owner="acme", repo="widget", topic="patterns")
+        assert len(entries) == 1
+        assert entries[0]["topic"] == "patterns"
+
+    def test_list_entries_filters_by_status(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
+        stale = handler(owner="acme", repo="widget", status="stale")
+        assert len(stale) == 1
+        assert stale[0]["topic"] == "gotchas"
+
+    def test_list_entries_rejects_path_traversal_in_owner(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
+        assert handler(owner="../evil", repo="widget") == []
+
+    def test_get_entry_returns_frontmatter_plus_body(self, router: Any) -> None:
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+        )
+        result = handler(owner="acme", repo="widget", entry_id="0001")
+        assert result["frontmatter"]["source_phase"] in {"plan", "review"}
+        assert "# " in result["body"] or result["body"].strip()
+
+    def test_get_entry_404_for_unknown_id(self, router: Any) -> None:
+        from fastapi import HTTPException
+
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+        )
+        with pytest.raises(HTTPException) as exc:
+            handler(owner="acme", repo="widget", entry_id="9999")
+        assert exc.value.status_code == 404
+
+    def test_get_entry_400_for_non_numeric_id(self, router: Any) -> None:
+        from fastapi import HTTPException
+
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+        )
+        with pytest.raises(HTTPException) as exc:
+            handler(owner="acme", repo="widget", entry_id="../passwd")
+        assert exc.value.status_code == 400
+
+    def test_get_log_filters_by_issue(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/log", "GET")
+        records = handler(owner="acme", repo="widget", issue=10)
+        assert len(records) == 1
+        assert records[0]["issue_number"] == 10
+
+    def test_get_log_empty_for_unknown_repo(self, router: Any) -> None:
+        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/log", "GET")
+        assert handler(owner="ghost", repo="ghost") == []
+
+
+class TestMaintenanceStatus:
+    def test_reports_open_pr_and_queue_depth(
+        self, router: Any, maintenance_queue: MaintenanceQueue
+    ) -> None:
+        maintenance_queue.enqueue(
+            MaintenanceTask(kind="rebuild-index", repo_slug=REPO, params={})
+        )
+        handler = find_endpoint(router, "/api/wiki/maintenance/status", "GET")
+        status = handler()
+        assert status["open_pr_url"] == "https://github.com/x/y/pull/99"
+        assert status["open_pr_branch"] == "hydraflow/wiki-maint-abc"
+        assert status["queue_depth"] == 1
+
+
+class TestAdminEndpoints:
+    def test_force_compile_enqueues(
+        self, router: Any, maintenance_queue: MaintenanceQueue
+    ) -> None:
+        handler = find_endpoint(router, "/api/wiki/admin/force-compile", "POST")
+        from dashboard_routes._wiki_routes import ForceCompilePayload
+
+        response = handler(
+            ForceCompilePayload(owner="acme", repo="widget", topic="patterns")
+        )
+        assert response == {"status": "queued"}
+        queued = maintenance_queue.peek()
+        assert len(queued) == 1
+        assert queued[0].kind == "force-compile"
+        assert queued[0].params == {"topic": "patterns"}
+
+    def test_mark_stale_enqueues(
+        self, router: Any, maintenance_queue: MaintenanceQueue
+    ) -> None:
+        handler = find_endpoint(router, "/api/wiki/admin/mark-stale", "POST")
+        from dashboard_routes._wiki_routes import MarkStalePayload
+
+        handler(
+            MarkStalePayload(
+                owner="acme",
+                repo="widget",
+                entry_id="0042",
+                reason="superseded",
+            )
+        )
+        queued = maintenance_queue.peek()
+        assert queued[0].kind == "mark-stale"
+        assert queued[0].params["entry_id"] == "0042"
+
+    def test_rebuild_index_enqueues(
+        self, router: Any, maintenance_queue: MaintenanceQueue
+    ) -> None:
+        handler = find_endpoint(router, "/api/wiki/admin/rebuild-index", "POST")
+        from dashboard_routes._wiki_routes import RebuildIndexPayload
+
+        handler(RebuildIndexPayload(owner="acme", repo="widget"))
+        queued = maintenance_queue.peek()
+        assert queued[0].kind == "rebuild-index"
+
+    def test_admin_503_when_queue_unavailable(
+        self,
+        config: HydraFlowConfig,
+        tmp_path: Path,
+    ) -> None:
+        """When the orchestrator is not up yet, admin endpoints return 503."""
+        from fastapi import HTTPException
+
+        bus = EventBus()
+        state = StateTracker(tmp_path / "state.json")
+        r, _ = make_dashboard_router(
+            config=config,
+            event_bus=bus,
+            state=state,
+            tmp_path=tmp_path,
+            get_orch=lambda: None,
+        )
+        handler = find_endpoint(r, "/api/wiki/admin/force-compile", "POST")
+        from dashboard_routes._wiki_routes import ForceCompilePayload
+
+        with pytest.raises(HTTPException) as exc:
+            handler(ForceCompilePayload(owner="acme", repo="widget", topic="patterns"))
+        assert exc.value.status_code == 503
+
+    def test_run_now_calls_trigger_hook_when_available(
+        self,
+        config: HydraFlowConfig,
+        tmp_path: Path,
+        maintenance_queue: MaintenanceQueue,
+    ) -> None:
+        loop = MagicMock()
+        loop._queue = maintenance_queue
+        loop.trigger_now = MagicMock()
+
+        svc = MagicMock()
+        svc.repo_wiki_loop = loop
+
+        orch = MagicMock()
+        orch._svc = svc
+
+        bus = EventBus()
+        state = StateTracker(tmp_path / "state.json")
+        r, _ = make_dashboard_router(
+            config=config,
+            event_bus=bus,
+            state=state,
+            tmp_path=tmp_path,
+            get_orch=lambda: orch,
+        )
+        handler = find_endpoint(r, "/api/wiki/admin/run-now", "POST")
+        response = handler()
+
+        loop.trigger_now.assert_called_once()
+        assert response["status"] == "triggered"
+
+    def test_run_now_acknowledges_when_no_trigger(
+        self,
+        config: HydraFlowConfig,
+        tmp_path: Path,
+        fake_orchestrator: MagicMock,
+    ) -> None:
+        """When the loop exposes no ``trigger_now`` / ``force_tick`` hook,
+        the endpoint returns an acknowledgement rather than 503."""
+        # The default fake_orchestrator's loop has no trigger_* attrs.
+        del fake_orchestrator._svc.repo_wiki_loop.trigger_now
+        del fake_orchestrator._svc.repo_wiki_loop.force_tick
+
+        bus = EventBus()
+        state = StateTracker(tmp_path / "state.json")
+        r, _ = make_dashboard_router(
+            config=config,
+            event_bus=bus,
+            state=state,
+            tmp_path=tmp_path,
+            get_orch=lambda: fake_orchestrator,
+        )
+        handler = find_endpoint(r, "/api/wiki/admin/run-now", "POST")
+        assert handler()["status"] == "acknowledged"


### PR DESCRIPTION
## Summary

Phase 5 of the [git-backed repo wiki](../blob/main/docs/git-backed-wiki-design.md). Adds the dashboard API surface. Read endpoints traverse the tracked ``repo_wiki/`` layout (Phase 2); admin endpoints enqueue ``MaintenanceTask`` entries into ``RepoWikiLoop._queue`` so every edit rides the single-track commit path that Phase 4 ships via ``chore(wiki): maintenance`` PRs. Nothing here mutates the wiki directly.

## Routes

| Method | Path | Purpose |
|--------|------|---------|
| GET  | `/api/wiki/repos` | list repos with a wiki |
| GET  | `/api/wiki/repos/{owner}/{repo}/entries` | filter by topic/status/q, paginated |
| GET  | `/api/wiki/repos/{owner}/{repo}/entries/{entry_id}` | full entry + frontmatter |
| GET  | `/api/wiki/repos/{owner}/{repo}/log` | merged per-issue audit log |
| GET  | `/api/wiki/maintenance/status` | queue depth + open PR |
| POST | `/api/wiki/admin/force-compile` | enqueue synthesis task |
| POST | `/api/wiki/admin/mark-stale` | enqueue stale flag write |
| POST | `/api/wiki/admin/rebuild-index` | enqueue index rebuild |
| POST | `/api/wiki/admin/run-now` | trigger loop (soft-fallback when no hook) |

## Security

- `owner` / `repo` path params reject `..` or `/` before any filesystem lookup (path-traversal guard).
- `entry_id` validated as 1–6 digits.
- No authentication added — follows the existing dashboard-route pattern (matches memory routes).

## Wiring

- Registered in `src/dashboard_routes/_routes.py` alongside the other sub-routers.
- Admin/status endpoints look up `RepoWikiLoop` and its `MaintenanceQueue` lazily via `ctx.get_orchestrator()._svc` — the orchestrator is constructed after the dashboard, so lazy lookup is the only option. All admin handlers return **503** when the loop isn't up yet.

## Tests

17 tests across 3 classes (`tests/test_wiki_routes.py`) use `make_dashboard_router` + `find_endpoint` to call handlers directly:

- **Read** — list, filter by topic, filter by status, path-traversal rejection, 404 on unknown id, 400 on non-numeric id, log filter by issue.
- **Maintenance status** — reports queue depth + open PR URL/branch.
- **Admin** — force-compile / mark-stale / rebuild-index enqueue correct kinds + params; 503 when orchestrator is None; run-now calls `trigger_now` when available and falls back to acknowledged otherwise.

## Test plan

- [x] `uv run pytest tests/test_wiki_routes.py` — 17 passed.
- [x] `make lint-check` clean.
- [x] `make quality-lite` clean.
- [ ] CI `make quality`.
- [ ] Phase 6 — the UI console that consumes these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)