### PR TITLE
feat(wiki): Phase 6 — Wiki console under System tab

### DIFF
--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -8,6 +8,7 @@ import { WorkerLogStream } from './WorkerLogStream'
 import { MetricsPanel } from './MetricsPanel'
 import { InsightsPanel } from './InsightsPanel'
 import { MemoryExplorer } from './memory/MemoryExplorer'
+import { WikiExplorer } from './wiki/WikiExplorer'
 
 const DiagnosticsTab = lazy(() =>
   import('./diagnostics/DiagnosticsTab').then(m => ({ default: m.DiagnosticsTab }))
@@ -19,6 +20,7 @@ const SUB_TABS = [
   { key: 'metrics', label: 'Metrics' },
   { key: 'insights', label: 'Insights' },
   { key: 'memory', label: 'Memory' },
+  { key: 'wiki', label: 'Wiki' },
   { key: 'diagnostics', label: 'Diagnostics' },
   { key: 'livestream', label: 'Livestream' },
 ]
@@ -792,6 +794,7 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
         )}
         {activeSubTab === 'insights' && <InsightsPanel />}
         {activeSubTab === 'memory' && <MemoryExplorer />}
+        {activeSubTab === 'wiki' && <WikiExplorer />}
         {activeSubTab === 'diagnostics' && (
           <Suspense fallback={<div style={styles.diagnosticsLoading}>Loading diagnostics…</div>}>
             <DiagnosticsTab />

--- a/src/ui/src/components/wiki/WikiEntryDetail.jsx
+++ b/src/ui/src/components/wiki/WikiEntryDetail.jsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { theme } from '../../theme'
+
+export function WikiEntryDetail({ entry, selectedRepo, onAdminAction }) {
+  const styles = {
+    empty: {
+      color: theme.textMuted,
+      fontSize: 13,
+      padding: '24px 0',
+    },
+    heading: {
+      fontSize: 15,
+      color: theme.textBright,
+      margin: 0,
+      marginBottom: 8,
+      wordBreak: 'break-all',
+    },
+    metaTable: {
+      borderCollapse: 'collapse',
+      fontSize: 12,
+      marginBottom: 12,
+    },
+    metaKey: {
+      color: theme.textMuted,
+      padding: '2px 12px 2px 0',
+      verticalAlign: 'top',
+      width: 120,
+    },
+    metaVal: {
+      color: theme.text,
+      padding: '2px 0',
+      fontFamily:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+    },
+    body: {
+      fontSize: 13,
+      lineHeight: 1.5,
+      whiteSpace: 'pre-wrap',
+      wordBreak: 'break-word',
+      color: theme.text,
+      background: theme.surfaceInset,
+      border: `1px solid ${theme.border}`,
+      borderRadius: 4,
+      padding: 12,
+    },
+    actions: {
+      display: 'flex',
+      gap: 8,
+      marginTop: 12,
+    },
+    actionBtn: {
+      fontSize: 12,
+      padding: '4px 10px',
+      borderRadius: 4,
+      border: `1px solid ${theme.border}`,
+      background: theme.surface,
+      color: theme.text,
+      cursor: 'pointer',
+    },
+  }
+
+  if (!entry) {
+    return <div style={styles.empty}>Select an entry to see its contents.</div>
+  }
+
+  const frontmatter = entry.frontmatter || {}
+
+  const handleMarkStale = () => {
+    if (!selectedRepo || !entry) return
+    onAdminAction('mark-stale', {
+      owner: selectedRepo.owner,
+      repo: selectedRepo.repo,
+      entry_id: entry.id,
+      reason: 'manual via console',
+    })
+  }
+
+  return (
+    <div>
+      <h3 style={styles.heading}>{entry.filename}</h3>
+      <table style={styles.metaTable}>
+        <tbody>
+          {Object.entries(frontmatter).map(([key, value]) => (
+            <tr key={key}>
+              <td style={styles.metaKey}>{key}</td>
+              <td style={styles.metaVal}>{String(value)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <pre style={styles.body}>{entry.body || ''}</pre>
+      <div style={styles.actions}>
+        <button
+          type="button"
+          style={styles.actionBtn}
+          onClick={handleMarkStale}
+          disabled={!selectedRepo}
+        >
+          Mark stale
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default WikiEntryDetail

--- a/src/ui/src/components/wiki/WikiEntryList.jsx
+++ b/src/ui/src/components/wiki/WikiEntryList.jsx
@@ -1,0 +1,106 @@
+import React from 'react'
+import { theme } from '../../theme'
+
+const STATUS_COLORS = {
+  active: theme.green,
+  stale: theme.orange,
+  superseded: theme.textMuted,
+}
+
+export function WikiEntryList({ entries, selectedId, onSelect }) {
+  const styles = {
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      padding: '4px 0',
+    },
+    empty: {
+      padding: '24px 16px',
+      color: theme.textMuted,
+      fontSize: 13,
+      textAlign: 'center',
+    },
+    item: (isSelected) => ({
+      padding: '8px 16px',
+      cursor: 'pointer',
+      borderLeft: `3px solid ${isSelected ? theme.accent : 'transparent'}`,
+      background: isSelected ? theme.surfaceInset : 'transparent',
+      color: theme.text,
+    }),
+    row: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      fontSize: 13,
+    },
+    topicChip: {
+      fontSize: 10,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      padding: '1px 6px',
+      borderRadius: 3,
+      background: theme.surface,
+      color: theme.textMuted,
+      border: `1px solid ${theme.border}`,
+    },
+    filename: {
+      flex: 1,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      color: theme.textBright,
+    },
+    statusDot: (status) => ({
+      width: 8,
+      height: 8,
+      borderRadius: '50%',
+      background: STATUS_COLORS[status] || theme.textMuted,
+      flexShrink: 0,
+    }),
+    meta: {
+      marginTop: 2,
+      fontSize: 11,
+      color: theme.textMuted,
+    },
+  }
+
+  if (!entries || entries.length === 0) {
+    return (
+      <div style={styles.root}>
+        <div style={styles.empty}>No entries</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.root}>
+      {entries.map((entry) => {
+        const isSelected = entry.id === selectedId
+        return (
+          <div
+            key={`${entry.topic}-${entry.id}`}
+            style={styles.item(isSelected)}
+            onClick={() => onSelect(entry)}
+            role="button"
+            tabIndex={0}
+          >
+            <div style={styles.row}>
+              <span
+                style={styles.statusDot(entry.status)}
+                aria-label={`status ${entry.status}`}
+              />
+              <span style={styles.topicChip}>{entry.topic}</span>
+              <span style={styles.filename}>{entry.filename}</span>
+            </div>
+            <div style={styles.meta}>
+              #{entry.source_issue ?? 'unknown'} · {entry.source_phase || '—'} ·{' '}
+              {entry.status}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+export default WikiEntryList

--- a/src/ui/src/components/wiki/WikiExplorer.jsx
+++ b/src/ui/src/components/wiki/WikiExplorer.jsx
@@ -1,0 +1,149 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { theme } from '../../theme'
+import { WikiTopBar } from './WikiTopBar'
+import { WikiEntryList } from './WikiEntryList'
+import { WikiEntryDetail } from './WikiEntryDetail'
+import { WikiMaintenancePanel } from './WikiMaintenancePanel'
+
+export function WikiExplorer() {
+  const [repos, setRepos] = useState([])
+  const [selectedRepo, setSelectedRepo] = useState(null)
+  const [filters, setFilters] = useState({ topic: '', status: '', q: '' })
+  const [entries, setEntries] = useState([])
+  const [selectedEntry, setSelectedEntry] = useState(null)
+  const [entryDetail, setEntryDetail] = useState(null)
+
+  useEffect(() => {
+    fetch('/api/wiki/repos')
+      .then((r) => {
+        if (!r.ok) {
+          console.warn('wiki/repos fetch non-ok:', r.status)
+          return []
+        }
+        return r.json()
+      })
+      .then((data) => {
+        const list = Array.isArray(data) ? data : []
+        setRepos(list)
+        if (list.length > 0 && selectedRepo === null) {
+          setSelectedRepo(list[0])
+        }
+      })
+      .catch((err) => {
+        console.warn('wiki/repos fetch failed:', err)
+        setRepos([])
+      })
+    // We want this to fire exactly once on mount; selectedRepo is intentionally
+    // outside the dep array so we don't overwrite a user-chosen repo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (!selectedRepo) {
+      setEntries([])
+      return
+    }
+    const qs = new URLSearchParams()
+    if (filters.topic) qs.set('topic', filters.topic)
+    if (filters.status) qs.set('status', filters.status)
+    if (filters.q) qs.set('q', filters.q)
+    qs.set('limit', '200')
+    fetch(
+      `/api/wiki/repos/${selectedRepo.owner}/${selectedRepo.repo}/entries?${qs}`,
+    )
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setEntries(Array.isArray(data) ? data : []))
+      .catch(() => setEntries([]))
+  }, [selectedRepo, filters.topic, filters.status, filters.q])
+
+  useEffect(() => {
+    if (!selectedEntry || !selectedRepo) {
+      setEntryDetail(null)
+      return
+    }
+    fetch(
+      `/api/wiki/repos/${selectedRepo.owner}/${selectedRepo.repo}/entries/${selectedEntry.id}`,
+    )
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setEntryDetail(data))
+      .catch(() => setEntryDetail(null))
+  }, [selectedEntry, selectedRepo])
+
+  const handleAdminAction = useCallback(
+    async (path, payload) => {
+      try {
+        const response = await fetch(`/api/wiki/admin/${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!response.ok) {
+          console.warn(`wiki/admin/${path} returned ${response.status}`)
+        }
+      } catch (err) {
+        console.warn(`wiki/admin/${path} failed:`, err)
+      }
+    },
+    [],
+  )
+
+  const styles = {
+    root: {
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      background: theme.bg,
+      color: theme.text,
+      minHeight: 0,
+    },
+    panes: {
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'row',
+      minHeight: 0,
+      borderTop: `1px solid ${theme.border}`,
+    },
+    leftPane: {
+      width: '40%',
+      minWidth: 280,
+      borderRight: `1px solid ${theme.border}`,
+      overflowY: 'auto',
+    },
+    rightPane: {
+      flex: 1,
+      overflowY: 'auto',
+      padding: '12px 16px',
+    },
+  }
+
+  return (
+    <div style={styles.root}>
+      <WikiTopBar
+        repos={repos}
+        selectedRepo={selectedRepo}
+        onRepoChange={setSelectedRepo}
+        filters={filters}
+        onFiltersChange={setFilters}
+      />
+      <div style={styles.panes}>
+        <div style={styles.leftPane}>
+          <WikiEntryList
+            entries={entries}
+            selectedId={selectedEntry?.id ?? null}
+            onSelect={setSelectedEntry}
+          />
+        </div>
+        <div style={styles.rightPane}>
+          <WikiEntryDetail
+            entry={entryDetail}
+            selectedRepo={selectedRepo}
+            onAdminAction={handleAdminAction}
+          />
+        </div>
+      </div>
+      <WikiMaintenancePanel onAdminAction={handleAdminAction} />
+    </div>
+  )
+}
+
+export default WikiExplorer

--- a/src/ui/src/components/wiki/WikiMaintenancePanel.jsx
+++ b/src/ui/src/components/wiki/WikiMaintenancePanel.jsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useEffect, useState } from 'react'
+import { theme } from '../../theme'
+
+export function WikiMaintenancePanel({ onAdminAction }) {
+  const [status, setStatus] = useState(null)
+
+  const refresh = useCallback(() => {
+    fetch('/api/wiki/maintenance/status')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setStatus(data))
+      .catch(() => setStatus(null))
+  }, [])
+
+  useEffect(() => {
+    refresh()
+    const iv = setInterval(refresh, 30_000)
+    return () => clearInterval(iv)
+  }, [refresh])
+
+  const handleRunNow = async () => {
+    await onAdminAction('run-now', {})
+    refresh()
+  }
+
+  const styles = {
+    root: {
+      display: 'flex',
+      alignItems: 'center',
+      gap: 16,
+      padding: '8px 16px',
+      background: theme.surfaceInset,
+      borderTop: `1px solid ${theme.border}`,
+      color: theme.text,
+      fontSize: 12,
+      flexWrap: 'wrap',
+    },
+    label: {
+      color: theme.textMuted,
+      textTransform: 'uppercase',
+      fontSize: 10,
+      letterSpacing: 0.5,
+    },
+    value: {
+      color: theme.textBright,
+      fontFamily:
+        'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+    },
+    prLink: {
+      color: theme.accent,
+      textDecoration: 'none',
+    },
+    runBtn: {
+      marginLeft: 'auto',
+      fontSize: 12,
+      padding: '4px 10px',
+      borderRadius: 4,
+      border: `1px solid ${theme.border}`,
+      background: theme.surface,
+      color: theme.text,
+      cursor: 'pointer',
+    },
+  }
+
+  const prUrl = status?.open_pr_url
+  const queueDepth = status?.queue_depth ?? 0
+  const intervalSeconds = status?.interval_seconds ?? '—'
+
+  return (
+    <div style={styles.root}>
+      <span style={styles.label}>Queue</span>
+      <span style={styles.value}>{queueDepth}</span>
+
+      <span style={styles.label}>Open PR</span>
+      <span style={styles.value}>
+        {prUrl ? (
+          <a href={prUrl} target="_blank" rel="noreferrer" style={styles.prLink}>
+            {prUrl.split('/').slice(-2).join('/')}
+          </a>
+        ) : (
+          '—'
+        )}
+      </span>
+
+      <span style={styles.label}>Interval</span>
+      <span style={styles.value}>{intervalSeconds}s</span>
+
+      <button type="button" onClick={handleRunNow} style={styles.runBtn}>
+        Run now
+      </button>
+    </div>
+  )
+}
+
+export default WikiMaintenancePanel

--- a/src/ui/src/components/wiki/WikiTopBar.jsx
+++ b/src/ui/src/components/wiki/WikiTopBar.jsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { theme } from '../../theme'
+
+const TOPICS = ['architecture', 'patterns', 'gotchas', 'testing', 'dependencies']
+const STATUSES = ['active', 'stale', 'superseded']
+
+export function WikiTopBar({
+  repos,
+  selectedRepo,
+  onRepoChange,
+  filters,
+  onFiltersChange,
+}) {
+  const styles = {
+    bar: {
+      display: 'flex',
+      gap: 12,
+      alignItems: 'center',
+      padding: '10px 16px',
+      background: theme.surface,
+      color: theme.text,
+      flexWrap: 'wrap',
+    },
+    label: {
+      fontSize: 12,
+      color: theme.textMuted,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+    },
+    select: {
+      background: theme.surfaceInset,
+      color: theme.text,
+      border: `1px solid ${theme.border}`,
+      borderRadius: 4,
+      padding: '4px 8px',
+      fontSize: 13,
+      minWidth: 140,
+    },
+    input: {
+      background: theme.surfaceInset,
+      color: theme.text,
+      border: `1px solid ${theme.border}`,
+      borderRadius: 4,
+      padding: '4px 8px',
+      fontSize: 13,
+      flex: 1,
+      minWidth: 160,
+    },
+  }
+
+  const repoValue = selectedRepo
+    ? `${selectedRepo.owner}/${selectedRepo.repo}`
+    : ''
+
+  const handleRepoChange = (e) => {
+    const [owner, repo] = e.target.value.split('/')
+    if (owner && repo) {
+      onRepoChange({ owner, repo })
+    }
+  }
+
+  const setFilter = (key, value) => {
+    onFiltersChange({ ...filters, [key]: value })
+  }
+
+  return (
+    <div style={styles.bar}>
+      <span style={styles.label}>Repo</span>
+      <select
+        aria-label="Wiki repo"
+        style={styles.select}
+        value={repoValue}
+        onChange={handleRepoChange}
+      >
+        <option value="">Select repo…</option>
+        {repos.map((r) => (
+          <option key={`${r.owner}/${r.repo}`} value={`${r.owner}/${r.repo}`}>
+            {r.owner}/{r.repo}
+          </option>
+        ))}
+      </select>
+
+      <span style={styles.label}>Topic</span>
+      <select
+        aria-label="Topic filter"
+        style={styles.select}
+        value={filters.topic}
+        onChange={(e) => setFilter('topic', e.target.value)}
+      >
+        <option value="">All topics</option>
+        {TOPICS.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </select>
+
+      <span style={styles.label}>Status</span>
+      <select
+        aria-label="Status filter"
+        style={styles.select}
+        value={filters.status}
+        onChange={(e) => setFilter('status', e.target.value)}
+      >
+        <option value="">All statuses</option>
+        {STATUSES.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+
+      <input
+        type="search"
+        aria-label="Search entries"
+        placeholder="Search…"
+        style={styles.input}
+        value={filters.q}
+        onChange={(e) => setFilter('q', e.target.value)}
+      />
+    </div>
+  )
+}
+
+export default WikiTopBar

--- a/src/ui/src/components/wiki/__tests__/WikiExplorer.test.jsx
+++ b/src/ui/src/components/wiki/__tests__/WikiExplorer.test.jsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from '@testing-library/react'
+
+const { WikiExplorer } = await import('../WikiExplorer')
+
+function mockJsonResponse(data, { ok = true } = {}) {
+  return { ok, json: async () => data }
+}
+
+function setupFetch({
+  repos = [{ owner: 'acme', repo: 'widget' }],
+  entries = [
+    {
+      id: '0001',
+      issue: '10',
+      topic: 'patterns',
+      filename: '0001-issue-10-first-pattern.md',
+      status: 'active',
+      source_phase: 'plan',
+      source_issue: '10',
+      created_at: '2026-04-01T00:00:00Z',
+    },
+  ],
+  entry = {
+    id: '0001',
+    topic: 'patterns',
+    filename: '0001-issue-10-first-pattern.md',
+    frontmatter: { id: '0001', topic: 'patterns', status: 'active' },
+    body: '# First pattern\n\nBody content.',
+  },
+  status = {
+    open_pr_url: 'https://github.com/x/y/pull/99',
+    open_pr_branch: 'hydraflow/wiki-maint-abc',
+    queue_depth: 2,
+    interval_seconds: 3600,
+    auto_merge: false,
+    coalesce: true,
+  },
+  adminCapture,
+} = {}) {
+  global.fetch = vi.fn().mockImplementation((url, init) => {
+    const u = String(url)
+    const method = init?.method || 'GET'
+    if (u === '/api/wiki/repos') {
+      return Promise.resolve(mockJsonResponse(repos))
+    }
+    if (u.match(/\/api\/wiki\/repos\/[^/]+\/[^/]+\/entries\?/)) {
+      return Promise.resolve(mockJsonResponse(entries))
+    }
+    if (u.match(/\/api\/wiki\/repos\/[^/]+\/[^/]+\/entries\/\d+$/)) {
+      return Promise.resolve(mockJsonResponse(entry))
+    }
+    if (u === '/api/wiki/maintenance/status') {
+      return Promise.resolve(mockJsonResponse(status))
+    }
+    if (u.startsWith('/api/wiki/admin/') && method === 'POST') {
+      if (adminCapture) {
+        adminCapture.push({ url: u, body: init?.body })
+      }
+      return Promise.resolve(mockJsonResponse({ status: 'queued' }))
+    }
+    return Promise.resolve(mockJsonResponse([]))
+  })
+}
+
+beforeEach(() => {
+  setupFetch()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('WikiExplorer', () => {
+  it('auto-selects the first repo and renders its entries', async () => {
+    render(<WikiExplorer />)
+    await waitFor(() => {
+      expect(
+        screen.getByText('0001-issue-10-first-pattern.md'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('selecting an entry loads and displays its body', async () => {
+    render(<WikiExplorer />)
+    const filename = await screen.findByText(
+      '0001-issue-10-first-pattern.md',
+    )
+    fireEvent.click(filename)
+    await waitFor(() => {
+      expect(screen.getByText(/First pattern/)).toBeInTheDocument()
+    })
+  })
+
+  it('topic filter requeries entries with the topic query param', async () => {
+    render(<WikiExplorer />)
+    await screen.findByText('0001-issue-10-first-pattern.md')
+
+    global.fetch.mockClear()
+
+    const topicSelect = screen.getByLabelText('Topic filter')
+    fireEvent.change(topicSelect, { target: { value: 'gotchas' } })
+
+    await waitFor(() => {
+      const entriesCalls = global.fetch.mock.calls.filter(([u]) =>
+        String(u).includes('/entries?'),
+      )
+      expect(entriesCalls.length).toBeGreaterThanOrEqual(1)
+      const lastCall = entriesCalls[entriesCalls.length - 1]
+      expect(String(lastCall[0])).toContain('topic=gotchas')
+    })
+  })
+
+  it('mark-stale button fires the admin POST with the entry id', async () => {
+    const captured = []
+    setupFetch({ adminCapture: captured })
+
+    render(<WikiExplorer />)
+    fireEvent.click(
+      await screen.findByText('0001-issue-10-first-pattern.md'),
+    )
+    await screen.findByText(/First pattern/)
+
+    fireEvent.click(screen.getByRole('button', { name: /mark stale/i }))
+
+    await waitFor(() => {
+      expect(captured.length).toBeGreaterThanOrEqual(1)
+    })
+    const call = captured.find((c) => c.url.endsWith('/admin/mark-stale'))
+    expect(call).toBeDefined()
+    const body = JSON.parse(call.body)
+    expect(body).toMatchObject({
+      owner: 'acme',
+      repo: 'widget',
+      entry_id: '0001',
+    })
+  })
+
+  it('maintenance panel renders the open PR link and queue depth', async () => {
+    render(<WikiExplorer />)
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: /pull\/99/ })
+      expect(link.getAttribute('href')).toBe(
+        'https://github.com/x/y/pull/99',
+      )
+    })
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('Run now button triggers the admin run-now POST', async () => {
+    const captured = []
+    setupFetch({ adminCapture: captured })
+
+    render(<WikiExplorer />)
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /run now/i }),
+      ).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /run now/i }))
+    await waitFor(() => {
+      expect(
+        captured.some((c) => c.url.endsWith('/admin/run-now')),
+      ).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Phase 6 of the [git-backed repo wiki](../blob/main/docs/git-backed-wiki-design.md). Adds the dashboard UI surface — a new **Wiki** subtab under the System tab that talks to the Phase 5 \`/api/wiki/*\` endpoints. Stacked on [#8362](https://github.com/T-rav/hydraflow/pull/8362).

## Components (src/ui/src/components/wiki/)

- **\`WikiExplorer.jsx\`** — two-pane shell + maintenance panel. Auto-selects first repo, refetches entries when filters change, refetches entry body when selection changes.
- **\`WikiTopBar.jsx\`** — repo selector, topic filter, status filter, free-text search. Drives the entries fetch via query params.
- **\`WikiEntryList.jsx\`** — left pane rows: status dot (green / orange / muted) · topic chip · filename · ``#issue · phase · status\`` meta line.
- **\`WikiEntryDetail.jsx\`** — right pane: frontmatter table + rendered body + **Mark stale** button that POSTs \`/api/wiki/admin/mark-stale\`.
- **\`WikiMaintenancePanel.jsx\`** — footer: queue depth, open PR link (shows \`{owner}/{repo}/pull/{N}\`), interval, **Run now** button that POSTs \`/api/wiki/admin/run-now\`.

## Registration

Added \`{ key: 'wiki', label: 'Wiki' }\` to \`SUB_TABS\` in \`SystemPanel.jsx\` (between Memory and Diagnostics) and a matching conditional render.

## Styling

Follows MemoryExplorer: inline style objects + CSS custom properties from \`src/theme.js\`. No new CSS files.

## Tests

6 vitest cases (\`WikiExplorer.test.jsx\`):

1. Auto-selects the first repo on mount and renders its entries
2. Clicking an entry loads and displays the body
3. Topic filter requeries with \`topic=\` query param
4. Mark-stale POSTs \`/admin/mark-stale\` with the correct \`entry_id\` payload
5. Maintenance panel shows the open PR link + queue depth
6. Run-now POSTs \`/admin/run-now\`

\`make lint-check\` clean; full dashboard-backend quality pipeline stays green.

## Test plan

- [x] \`npm test -- --run wiki\` — 6 passed.
- [x] \`make lint-check\` — clean.
- [ ] CI \`make quality\`.
- [ ] Manual smoke: open the dashboard → System → Wiki → select a repo → click an entry → click Mark stale → verify the task lands in \`MaintenanceQueue\` via \`/api/wiki/maintenance/status\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)