### PR TITLE
feat(wiki): Phase 8 — compile_topic_tracked + loop integration

### DIFF
--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -246,6 +246,109 @@ def _tracked_entry_age_days(fields: dict[str, str], now: datetime) -> int:
     return max(0, (now - ts).days)
 
 
+def _load_tracked_active_entries(topic_dir: Path) -> list[dict[str, Any]]:
+    """Return ``[{id, title, body, source_issue, source_phase, created_at,
+    path}]`` for every ``status: active`` entry in ``topic_dir``.
+
+    Used by ``WikiCompiler.compile_topic_tracked`` to build the LLM
+    prompt and to remember which files to mark superseded after the
+    synthesis output lands.
+    """
+    if not topic_dir.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for path in sorted(topic_dir.glob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        fields, _block, body = _split_tracked_entry(text)
+        if not fields or fields.get("status", "active") != "active":
+            continue
+        title = body.lstrip().split("\n", 1)[0].lstrip("# ").strip() or path.stem
+        out.append(
+            {
+                "id": fields.get("id", ""),
+                "title": title,
+                "body": body.strip(),
+                "source_issue": fields.get("source_issue", ""),
+                "source_phase": fields.get("source_phase", ""),
+                "created_at": fields.get("created_at", ""),
+                "path": str(path),
+            }
+        )
+    return out
+
+
+def _write_tracked_synthesis_entry(
+    topic_dir: Path,
+    *,
+    entry: WikiEntry,
+    topic: str,
+    supersedes: list[str],
+) -> Path:
+    """Write a compiler-synthesized per-entry file with
+    ``source_phase: synthesis`` and a ``supersedes`` list in frontmatter.
+
+    The filename embeds ``issue-synthesis`` (not ``issue-{N}``) so
+    synthesis outputs are distinguishable from ingest entries at a
+    glance.  Returns the written path.
+    """
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    next_id = _next_entry_id(topic_dir)
+    slug = _slugify(entry.title)
+    if slug == "untitled":
+        slug = "synthesis"
+    filename = f"{next_id:04d}-issue-synthesis-{slug}.md"
+    path = topic_dir / filename
+
+    now = datetime.now(UTC).isoformat()
+    safe_content = _sanitize_body_for_frontmatter(entry.content)
+    lines = [
+        "---",
+        f"id: {next_id:04d}",
+        f"topic: {topic}",
+        "source_issue: synthesis",
+        "source_phase: synthesis",
+        f"created_at: {now}",
+        "status: active",
+    ]
+    if supersedes:
+        lines.append("supersedes: " + ",".join(supersedes))
+    lines.append("---")
+    lines.append("")
+    lines.append(f"# {entry.title}")
+    lines.append("")
+    lines.append(safe_content)
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _mark_tracked_entry_superseded(entry_path: Path, *, superseded_by: str) -> None:
+    """Flip ``status`` → ``superseded`` and add ``superseded_by`` in the
+    frontmatter.  No-op when the file has no frontmatter block.
+    """
+    try:
+        text = entry_path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    fields, _block, body = _split_tracked_entry(text)
+    if not fields:
+        return
+    fields["status"] = "superseded"
+    fields["superseded_by"] = superseded_by
+    rebuilt = (
+        "---\n" + "\n".join(f"{k}: {v}" for k, v in fields.items()) + "\n---\n" + body
+    )
+    try:
+        entry_path.write_text(rebuilt, encoding="utf-8")
+    except OSError:
+        logger.warning(
+            "mark_tracked_entry_superseded: failed to rewrite %s", entry_path
+        )
+
+
 def active_lint_tracked(
     tracked_root: Path,
     repo_slug: str,

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -173,6 +173,36 @@ class RepoWikiLoop(BaseBackgroundLoop):
                                 exc_info=True,
                             )
 
+                # Phase 8: tracked-layout compilation — produces
+                # ``source_phase: synthesis`` per-entry files and marks
+                # their sources ``superseded`` under
+                # ``{repo_root}/{repo_wiki_path}/{slug}/{topic}/``.  When
+                # the layout has ≥ 5 active entries, LLM synthesis runs
+                # and its diffs surface in the next maintenance PR.
+                if tracked_root is not None:
+                    for topic in DEFAULT_TOPICS:
+                        topic_dir = tracked_root / slug / topic
+                        active_count = sum(
+                            1 for _ in _iter_tracked_active_files(topic_dir)
+                        )
+                        if active_count < 5:
+                            continue
+                        try:
+                            synthesized = (
+                                await self._wiki_compiler.compile_topic_tracked(
+                                    tracked_root, slug, topic
+                                )
+                            )
+                            if synthesized:
+                                total_compiled += active_count
+                        except Exception:  # noqa: BLE001
+                            logger.warning(
+                                "Wiki compile_tracked failed for %s/%s",
+                                slug,
+                                topic,
+                                exc_info=True,
+                            )
+
         stats = {
             "repos": len(repos),
             "total_entries": total_entries,
@@ -419,6 +449,35 @@ def _list_tracked_repos(tracked_root: Path) -> list[str]:
             if (repo_dir / "index.md").exists() or (repo_dir / "index.json").exists():
                 slugs.append(f"{owner_dir.name}/{repo_dir.name}")
     return slugs
+
+
+def _iter_tracked_active_files(topic_dir: Path):
+    """Yield per-entry file paths whose frontmatter ``status`` is
+    ``active``.  Used to count active entries before deciding to run
+    ``compile_topic_tracked`` — LLM calls are expensive, so we cap the
+    work at topics with a meaningful backlog.
+    """
+    if not topic_dir.is_dir():
+        return
+    for path in topic_dir.glob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if not text.startswith("---\n"):
+            continue
+        try:
+            end = text.index("\n---\n", 4)
+        except ValueError:
+            continue
+        block = text[4:end]
+        status = "active"
+        for line in block.splitlines():
+            if line.startswith("status:"):
+                status = line.split(":", 1)[1].strip() or "active"
+                break
+        if status == "active":
+            yield path
 
 
 def _ci_rollup_state(rollup: list[dict[str, Any]]) -> str:

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -15,9 +15,13 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from repo_wiki import WikiEntry
+
+_SYNTHESIS_ID_RE = re.compile(r"^(\d+)-")
 
 if TYPE_CHECKING:
     from config import Credentials, HydraFlowConfig
@@ -186,6 +190,107 @@ class WikiCompiler:
             repo,
             topic,
             len(entries),
+            len(compiled),
+        )
+        return len(compiled)
+
+    async def compile_topic_tracked(
+        self,
+        tracked_root: Path,
+        repo: str,
+        topic: str,
+        *,
+        other_topics: list[str] | None = None,
+    ) -> int:
+        """Tracked-layout counterpart of ``compile_topic``.
+
+        Reads ``status: active`` per-entry files in
+        ``{tracked_root}/{repo}/{topic}/*.md``, asks the LLM to
+        synthesize / deduplicate, then:
+
+        - Writes each compiled entry as a new per-entry file with
+          ``source_phase: synthesis`` under a ``synthesis-<timestamp>``
+          suffix so the filename doesn't collide with issue-tagged
+          entries.
+        - Flips every input entry's ``status`` to ``superseded`` with a
+          ``superseded_by`` pointer to the first synthesis id (operators
+          looking at a superseded entry can find the replacement).
+
+        Returns the number of compiled entries written (0 if the LLM
+        call failed or the topic had fewer than 2 active entries).
+
+        The stale-flag path already writes to the tracked layout (Phase
+        7), so combining this method with ``_maybe_open_maintenance_pr``
+        lets ``RepoWikiLoop`` emit complete maintenance PRs without
+        needing a separate synthesis sub-loop.
+        """
+        from repo_wiki import (  # noqa: PLC0415
+            DEFAULT_TOPICS,
+            _load_tracked_active_entries,
+            _mark_tracked_entry_superseded,
+            _write_tracked_synthesis_entry,
+        )
+
+        topic_dir = tracked_root / repo / topic
+        active_entries = _load_tracked_active_entries(topic_dir)
+        if len(active_entries) < 2:
+            return 0
+
+        entries_text = "\n\n".join(
+            f"### {e['title']}\n{e['body']}\n"
+            f"Source: #{e['source_issue'] or 'N/A'} ({e['source_phase']})\n"
+            f"Created: {e['created_at']}"
+            for e in active_entries
+        )
+
+        if other_topics is None:
+            other_topics = [t for t in DEFAULT_TOPICS if t != topic]
+
+        prompt = _COMPILE_TOPIC_PROMPT.format(
+            topic=topic,
+            repo=repo,
+            entries_text=entries_text,
+            other_topics=", ".join(other_topics),
+        )
+
+        raw = await self._call_model(prompt)
+        if raw is None:
+            return 0
+
+        compiled = self._parse_entries(raw)
+        if not compiled:
+            logger.warning(
+                "Wiki compile_tracked for %s/%s produced no valid entries — "
+                "keeping originals",
+                repo,
+                topic,
+            )
+            return 0
+
+        superseded_ids = [e["id"] for e in active_entries]
+        synthesis_paths: list[Path] = []
+        for entry in compiled:
+            path = _write_tracked_synthesis_entry(
+                topic_dir,
+                entry=entry,
+                topic=topic,
+                supersedes=superseded_ids,
+            )
+            synthesis_paths.append(path)
+
+        if synthesis_paths:
+            m = _SYNTHESIS_ID_RE.match(synthesis_paths[0].name)
+            primary_id = m.group(1) if m else "unknown"
+            for entry in active_entries:
+                _mark_tracked_entry_superseded(
+                    Path(entry["path"]), superseded_by=primary_id
+                )
+
+        logger.info(
+            "Wiki compile_tracked %s/%s: %d active → %d synthesis",
+            repo,
+            topic,
+            len(active_entries),
             len(compiled),
         )
         return len(compiled)

--- a/tests/test_compile_topic_tracked.py
+++ b/tests/test_compile_topic_tracked.py
@@ -1,0 +1,287 @@
+"""Tests for ``WikiCompiler.compile_topic_tracked`` and its helpers.
+
+Phase 8 — reads tracked per-entry files, calls the LLM, writes a
+synthesis per-entry file, and marks every input ``superseded`` so the
+next ``RepoWikiLoop`` tick emits a ``chore(wiki): maintenance`` PR
+with both the new synthesis entry and the updated statuses.
+
+Tests cover the tracked-layout helpers directly plus the compiler
+method with a stubbed ``_call_model`` so the suite never touches the
+real LLM backend.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repo_wiki import (
+    WikiEntry,
+    _load_tracked_active_entries,
+    _mark_tracked_entry_superseded,
+    _write_tracked_synthesis_entry,
+)
+from wiki_compiler import WikiCompiler
+
+REPO = "acme/widget"
+
+
+def _write_entry_file(
+    path: Path,
+    *,
+    entry_id: str,
+    topic: str,
+    status: str = "active",
+    source_issue: str | int = 1,
+    title: str = "Existing entry",
+    body: str = "Content body.",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: plan\n"
+        f"created_at: {now}\n"
+        f"status: {status}\n"
+        "---\n"
+        "\n"
+        f"# {title}\n\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+class TestLoadTrackedActiveEntries:
+    def test_returns_only_active(self, tmp_path: Path) -> None:
+        topic_dir = tmp_path / "topic"
+        _write_entry_file(
+            topic_dir / "0001-issue-1-a.md",
+            entry_id="0001",
+            topic="patterns",
+            title="A",
+        )
+        _write_entry_file(
+            topic_dir / "0002-issue-2-b.md",
+            entry_id="0002",
+            topic="patterns",
+            status="stale",
+            title="B",
+        )
+        _write_entry_file(
+            topic_dir / "0003-issue-3-c.md",
+            entry_id="0003",
+            topic="patterns",
+            status="superseded",
+            title="C",
+        )
+
+        entries = _load_tracked_active_entries(topic_dir)
+
+        ids = [e["id"] for e in entries]
+        assert ids == ["0001"]
+        assert entries[0]["title"] == "A"
+
+    def test_missing_dir_returns_empty(self, tmp_path: Path) -> None:
+        assert _load_tracked_active_entries(tmp_path / "missing") == []
+
+    def test_skips_files_without_frontmatter(self, tmp_path: Path) -> None:
+        topic_dir = tmp_path / "topic"
+        topic_dir.mkdir()
+        (topic_dir / "0001-issue-1-x.md").write_text("# no frontmatter\n")
+        assert _load_tracked_active_entries(topic_dir) == []
+
+
+class TestWriteTrackedSynthesisEntry:
+    def test_writes_file_with_expected_frontmatter(self, tmp_path: Path) -> None:
+        topic_dir = tmp_path / "patterns"
+        entry = WikiEntry(
+            title="Consolidated insight",
+            content="Merged content.",
+            source_type="synthesis",
+            source_issue=None,
+        )
+
+        path = _write_tracked_synthesis_entry(
+            topic_dir,
+            entry=entry,
+            topic="patterns",
+            supersedes=["0001", "0002", "0003"],
+        )
+
+        assert path.exists()
+        text = path.read_text()
+        assert "source_phase: synthesis" in text
+        assert "source_issue: synthesis" in text
+        assert "supersedes: 0001,0002,0003" in text
+        assert "# Consolidated insight" in text
+        assert "issue-synthesis" in path.name
+
+    def test_id_is_monotonic_within_topic(self, tmp_path: Path) -> None:
+        topic_dir = tmp_path / "patterns"
+        _write_entry_file(
+            topic_dir / "0001-issue-1-prior.md",
+            entry_id="0001",
+            topic="patterns",
+            title="prior",
+        )
+
+        path = _write_tracked_synthesis_entry(
+            topic_dir,
+            entry=WikiEntry(
+                title="merged",
+                content="merged body",
+                source_type="synthesis",
+                source_issue=None,
+            ),
+            topic="patterns",
+            supersedes=["0001"],
+        )
+        assert path.name.startswith("0002-")
+
+
+class TestMarkTrackedEntrySuperseded:
+    def test_flips_status_and_adds_pointer(self, tmp_path: Path) -> None:
+        entry_path = tmp_path / "0001-issue-1-x.md"
+        _write_entry_file(entry_path, entry_id="0001", topic="patterns", title="X")
+
+        _mark_tracked_entry_superseded(entry_path, superseded_by="0042")
+
+        text = entry_path.read_text()
+        assert "status: superseded" in text
+        assert "superseded_by: 0042" in text
+
+    def test_noop_when_no_frontmatter(self, tmp_path: Path) -> None:
+        entry_path = tmp_path / "0001-bad.md"
+        entry_path.write_text("just a markdown file\n")
+
+        _mark_tracked_entry_superseded(entry_path, superseded_by="0042")
+
+        # Left untouched.
+        assert entry_path.read_text() == "just a markdown file\n"
+
+
+class TestCompileTopicTracked:
+    @pytest.fixture
+    def compiler_with_active_entries(self, tmp_path: Path) -> tuple[WikiCompiler, Path]:
+        """Build a WikiCompiler + seed 3 active entries in one topic."""
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "patterns"
+        for i in range(3):
+            _write_entry_file(
+                topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md",
+                entry_id=f"000{i + 1}",
+                topic="patterns",
+                source_issue=i + 1,
+                title=f"Original {i + 1}",
+            )
+
+        compiler = WikiCompiler.__new__(WikiCompiler)
+        compiler._config = MagicMock()
+        compiler._config.wiki_compilation_tool = "stub"
+        compiler._config.wiki_compilation_model = "stub"
+        compiler._config.wiki_compilation_timeout = 60
+        compiler._credentials = MagicMock()
+        compiler._credentials.gh_token = ""
+        compiler._runner = MagicMock()
+        return compiler, tracked_root
+
+    @pytest.mark.asyncio
+    async def test_writes_synthesis_and_marks_inputs_superseded(
+        self,
+        compiler_with_active_entries: tuple[WikiCompiler, Path],
+    ) -> None:
+        compiler, tracked_root = compiler_with_active_entries
+
+        compiler._call_model = AsyncMock(
+            return_value='[{"title":"Merged","content":"Unified body.",'
+            '"source_type":"synthesis"}]'
+        )
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "patterns")
+
+        assert count == 1
+        topic_dir = tracked_root / REPO / "patterns"
+        synthesis = list(topic_dir.glob("*-issue-synthesis-*.md"))
+        assert len(synthesis) == 1
+        synth_text = synthesis[0].read_text()
+        assert "supersedes: 0001,0002,0003" in synth_text
+
+        for i in range(3):
+            original = topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md"
+            assert "status: superseded" in original.read_text()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_fewer_than_two_active_entries(
+        self, tmp_path: Path
+    ) -> None:
+        tracked_root = tmp_path / "repo_wiki"
+        topic_dir = tracked_root / REPO / "patterns"
+        _write_entry_file(
+            topic_dir / "0001-issue-1-solo.md",
+            entry_id="0001",
+            topic="patterns",
+            title="Solo",
+        )
+
+        compiler = WikiCompiler.__new__(WikiCompiler)
+        compiler._config = MagicMock()
+        compiler._credentials = MagicMock()
+        compiler._credentials.gh_token = ""
+        compiler._runner = MagicMock()
+        compiler._call_model = AsyncMock(
+            side_effect=AssertionError("should not be called")
+        )
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "patterns")
+
+        assert count == 0
+        # Solo entry untouched.
+        assert "status: active" in (topic_dir / "0001-issue-1-solo.md").read_text()
+
+    @pytest.mark.asyncio
+    async def test_model_failure_keeps_originals(
+        self,
+        compiler_with_active_entries: tuple[WikiCompiler, Path],
+    ) -> None:
+        compiler, tracked_root = compiler_with_active_entries
+
+        # _call_model returning None simulates rc != 0 / timeout / parse fail.
+        compiler._call_model = AsyncMock(return_value=None)
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "patterns")
+
+        assert count == 0
+        topic_dir = tracked_root / REPO / "patterns"
+        synthesis = list(topic_dir.glob("*-issue-synthesis-*.md"))
+        assert synthesis == []
+        # Originals stay active.
+        for i in range(3):
+            assert (
+                "status: active"
+                in (topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md").read_text()
+            )
+
+    @pytest.mark.asyncio
+    async def test_llm_returned_no_entries_keeps_originals(
+        self,
+        compiler_with_active_entries: tuple[WikiCompiler, Path],
+    ) -> None:
+        compiler, tracked_root = compiler_with_active_entries
+
+        # Valid JSON but empty list → no new entries, don't supersede.
+        compiler._call_model = AsyncMock(return_value="[]")
+
+        count = await compiler.compile_topic_tracked(tracked_root, REPO, "patterns")
+
+        assert count == 0
+        topic_dir = tracked_root / REPO / "patterns"
+        for i in range(3):
+            assert (
+                "status: active"
+                in (topic_dir / f"000{i + 1}-issue-{i + 1}-orig.md").read_text()
+            )


### PR DESCRIPTION
## Summary

Closes the last piece of loop-side behaviour that hadn't been ported to the tracked layout. Once a topic has ≥ 5 ``status: active`` entries, ``RepoWikiLoop`` now calls ``WikiCompiler.compile_topic_tracked``: LLM synthesis runs against per-entry files, and the resulting synthesis entries + ``superseded`` flag rewrites land in the next ``chore(wiki): maintenance`` PR. Stacked on [#8371](https://github.com/T-rav/hydraflow/pull/8371).

## What's in

**`src/repo_wiki.py` helpers**

- `_load_tracked_active_entries(topic_dir)` — dicts with id / title / body / source fields / path.
- `_write_tracked_synthesis_entry(topic_dir, *, entry, topic, supersedes)` — emits per-entry file with `source_issue: synthesis`, `source_phase: synthesis`, `supersedes: id1,id2,…`, filename `{id:04d}-issue-synthesis-{slug}.md`.
- `_mark_tracked_entry_superseded(entry_path, *, superseded_by)` — flips status + adds pointer; no-op on files without frontmatter.

**`WikiCompiler.compile_topic_tracked`**

Tracked counterpart of `compile_topic`. Reuses `_COMPILE_TOPIC_PROMPT` + `_parse_entries`. Returns 0 when < 2 active entries, LLM call fails, or parse returns empty.

**`RepoWikiLoop._do_work`**

Legacy compile pass unchanged. New tracked compile pass runs when `tracked_root` is set and topic has ≥ 5 active entries. Errors log at `warning` and don't crash the tick. Module-level `_iter_tracked_active_files` streams active files for the count check without the pydantic round-trip.

## Tests (11 new, 45 total)

- `tests/test_compile_topic_tracked.py`:
  - `_load_tracked_active_entries` returns only active (filters stale / superseded), missing dir, no-frontmatter tolerance
  - `_write_tracked_synthesis_entry` frontmatter shape + monotonic id
  - `_mark_tracked_entry_superseded` status flip + pointer + no-op on files without frontmatter
  - `compile_topic_tracked` writes synthesis + supersedes originals, skips < 2 active, LLM None keeps originals, LLM `[]` keeps originals

Stubs `WikiCompiler._call_model` via `AsyncMock` so the suite never touches a real LLM backend.

## Test plan

- [x] `uv run pytest tests/test_compile_topic_tracked.py tests/test_active_lint_tracked.py tests/test_repo_wiki_loop_pr.py` — 45 pass.
- [x] `make lint-check` clean.
- [ ] CI `make quality`.
- [ ] After merge, the next wiki tick with a qualifying topic produces a PR with both the new synthesis entry and the superseded-flag rewrites bundled together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)