### PR TITLE
fix(wiki): post-merge review — stats overcount + atomic frontmatter rewrites

### DIFF
--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -328,7 +328,14 @@ def _write_tracked_synthesis_entry(
 def _mark_tracked_entry_superseded(entry_path: Path, *, superseded_by: str) -> None:
     """Flip ``status`` → ``superseded`` and add ``superseded_by`` in the
     frontmatter.  No-op when the file has no frontmatter block.
+
+    Uses ``file_util.atomic_write`` so an interrupted rewrite can't
+    leave the file as a half-frontmatter block that ``_split_tracked_entry``
+    would then silently drop (which would cost us both the
+    ``superseded_by`` pointer and the entry body).
     """
+    from file_util import atomic_write  # noqa: PLC0415
+
     try:
         text = entry_path.read_text(encoding="utf-8")
     except OSError:
@@ -342,7 +349,7 @@ def _mark_tracked_entry_superseded(entry_path: Path, *, superseded_by: str) -> N
         "---\n" + "\n".join(f"{k}: {v}" for k, v in fields.items()) + "\n---\n" + body
     )
     try:
-        entry_path.write_text(rebuilt, encoding="utf-8")
+        atomic_write(entry_path, rebuilt)
     except OSError:
         logger.warning(
             "mark_tracked_entry_superseded: failed to rewrite %s", entry_path
@@ -427,7 +434,12 @@ def active_lint_tracked(
                     stale_reason=f"source issue #{source_issue} closed",
                 )
                 if updated is not None:
-                    entry_path.write_text(updated, encoding="utf-8")
+                    # Atomic rewrite: an interrupted write would leave a
+                    # half-frontmatter block that _split_tracked_entry
+                    # silently drops, losing the entry entirely.
+                    from file_util import atomic_write  # noqa: PLC0415
+
+                    atomic_write(entry_path, updated)
                     result.entries_marked_stale += 1
                     status = "stale"
 

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -193,8 +193,15 @@ class RepoWikiLoop(BaseBackgroundLoop):
                                     tracked_root, slug, topic
                                 )
                             )
+                            # Report the post-synthesis count — matches the
+                            # legacy ``compile_topic`` semantic and keeps
+                            # ``total_compiled`` comparable across legacy
+                            # and tracked ticks.  Using ``active_count``
+                            # here (pre-synthesis) would inflate the stat
+                            # roughly 5-10× because synthesis typically
+                            # collapses many entries into one or two.
                             if synthesized:
-                                total_compiled += active_count
+                                total_compiled += synthesized
                         except Exception:  # noqa: BLE001
                             logger.warning(
                                 "Wiki compile_tracked failed for %s/%s",

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -711,3 +711,8 @@ class TestTrackedCompileStatsReporting:
         assert stats is not None
         # Must be 2 (post-synthesis), not 8 (active_count pre-fix).
         assert stats["entries_compiled"] == 2
+        # Defence-in-depth: if the 5-entry threshold is ever raised above
+        # our 8-entry fixture, the outer assertion would still pass with
+        # entries_compiled == 0 (0 != 2 → fail, but for the wrong reason).
+        # Pinning await_count guarantees the compiler was actually invoked.
+        compiler.compile_topic_tracked.assert_awaited_once()

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -646,3 +646,68 @@ class TestTrackedActiveLintIntegration:
 
         # Tracked file untouched — lint only scans when the flag is on.
         assert "status: active" in entry_path.read_text(encoding="utf-8")
+
+
+class TestTrackedCompileStatsReporting:
+    """Regression for the ``total_compiled`` overcount: the loop must
+    report the *post-synthesis* count returned by
+    ``compile_topic_tracked`` rather than the pre-synthesis active
+    count.  Using ``active_count`` would inflate ``entries_compiled``
+    ~5-10× vs. the legacy ``compile_topic`` branch that aggregates
+    into the same field.
+    """
+
+    @pytest.mark.asyncio
+    async def test_adds_post_synthesis_count_not_active_count(
+        self, git_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from datetime import UTC, datetime
+        from unittest.mock import AsyncMock, MagicMock
+
+        from repo_wiki import RepoWikiStore
+
+        # 8 active entries in patterns, above the 5-entry threshold.
+        tracked_root = git_repo / "repo_wiki"
+        topic_dir = tracked_root / "acme" / "widget" / "patterns"
+        topic_dir.mkdir(parents=True)
+        for i in range(8):
+            (topic_dir / f"000{i}-issue-{i}-x.md").write_text(
+                "---\n"
+                f"id: 000{i}\n"
+                "topic: patterns\n"
+                f"source_issue: {i}\n"
+                "source_phase: plan\n"
+                f"created_at: {datetime.now(UTC).isoformat()}\n"
+                "status: active\n"
+                "---\n\n# Entry\n",
+                encoding="utf-8",
+            )
+        (tracked_root / "acme" / "widget" / "index.md").write_text(
+            "# index\n", encoding="utf-8"
+        )
+
+        legacy_store = MagicMock(spec=RepoWikiStore)
+        legacy_store.list_repos.return_value = []
+        legacy_store.active_lint.return_value = MagicMock(
+            stale_entries=0,
+            orphan_entries=0,
+            total_entries=0,
+            entries_marked_stale=0,
+            orphans_pruned=0,
+            empty_topics=[],
+        )
+
+        compiler = MagicMock()
+        compiler.compile_topic_tracked = AsyncMock(return_value=2)
+
+        loop = _stub_loop(_make_config(git_repo))
+        loop._wiki_store = legacy_store
+        loop._wiki_compiler = compiler
+        loop._state = None
+        monkeypatch.setattr(loop, "_maybe_open_maintenance_pr", AsyncMock())
+
+        stats = await loop._do_work()
+
+        assert stats is not None
+        # Must be 2 (post-synthesis), not 8 (active_count pre-fix).
+        assert stats["entries_compiled"] == 2


### PR DESCRIPTION
## Summary

Post-merge holistic review of the wiki subsystem surfaced two bugs the individual-PR reviews missed.

## U — ``total_compiled`` overcount (metric bug)

``RepoWikiLoop._do_work`` added ``active_count`` (pre-synthesis, ≥5) to ``total_compiled`` on a successful ``compile_topic_tracked`` call.  But the legacy ``compile_topic`` branch it aggregates into reports the *post-synthesis* count (typically 1-2).  Synthesis collapses many entries into few, so ``entries_compiled`` was inflated ~5-10× vs. legacy ticks.  Fix: use ``synthesized`` (the return value) instead of ``active_count``.

Regression test: ``TestTrackedCompileStatsReporting::test_adds_post_synthesis_count_not_active_count`` seeds 8 active entries, stubs the compiler to return 2, asserts ``stats["entries_compiled"] == 2``.

## V — non-atomic frontmatter rewrites (corruption risk)

``_mark_tracked_entry_superseded`` and the rewrite path in ``active_lint_tracked`` both used ``Path.write_text`` — a non-atomic write on an existing file.  A crash mid-write leaves a half-frontmatter block, which ``_split_tracked_entry`` then silently drops — losing the ``superseded_by`` / ``stale_reason`` field **and** the entry body.

Fix: route both rewrites through ``file_util.atomic_write`` (temp file + ``os.replace`` on the same filesystem — same pattern the rest of the codebase uses for state files and the hindsight WAL).

## Tests

46 pass, no regressions (``tests/test_repo_wiki_loop_pr.py`` gains the U regression; ``tests/test_active_lint_tracked.py`` and ``tests/test_compile_topic_tracked.py`` unchanged — the switch to atomic_write is observationally identical under success).

## Test plan

- [x] ``uv run pytest tests/test_repo_wiki_loop_pr.py tests/test_active_lint_tracked.py tests/test_compile_topic_tracked.py`` — 46 pass.
- [x] ``make lint-check`` clean.
- [ ] CI ``make quality``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)