### PR TITLE
feat(skills): boot-time install + prompt alignment + per-phase whitelist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RESET := \033[0m
 DOCKER_IMAGE ?= ghcr.io/t-rav/hydraflow-agent:latest
 DOCKER_BASE_IMAGE ?= ghcr.io/t-rav/hydraflow-agent-base:latest
 
-.PHONY: help run dev dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix typecheck security quality quality-lite install setup status ui ui-dev ui-clean ensure-labels prep scaffold hot docker-build docker-ensure docker-test deps integration soak screenshot screenshot-update check-node-ui
+.PHONY: help run dev dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels prep scaffold hot docker-build docker-ensure docker-test deps integration soak screenshot screenshot-update check-node-ui
 
 check-node-ui:
 	@cd $(HYDRAFLOW_DIR)src/ui && $(HYDRAFLOW_DIR)scripts/ui-npm.sh --version >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,11 @@ install:
 	@VIRTUAL_ENV=$(VENV) uv pip install fastapi uvicorn websockets
 	@echo "$(GREEN)Dashboard dependencies installed$(RESET)"
 
+install-plugins: deps
+	@echo "$(BLUE)Installing HydraFlow-required Claude Code plugins...$(RESET)"
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) python -m install_plugins_cli
+	@echo "$(GREEN)Plugin install complete$(RESET)"
+
 setup: deps
 	@if ! command -v gh >/dev/null 2>&1; then \
 		echo "$(BLUE)Installing gh CLI...$(RESET)"; \

--- a/docs/adr/0043-dynamic-plugin-skill-loading.md
+++ b/docs/adr/0043-dynamic-plugin-skill-loading.md
@@ -1,0 +1,64 @@
+# ADR-0043: Dynamic plugin skill loading — install at boot, discipline in the prompt, filtered per phase
+
+- **Status:** Accepted
+- **Date:** 2026-04-20
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related spec:** [`docs/superpowers/specs/2026-04-20-dynamic-skill-loading-design.md`](../superpowers/specs/2026-04-20-dynamic-skill-loading-design.md)
+
+## Context
+
+PR #8348 shipped a skill-discovery system: factory runners inject an `## Available Skills` section into their prompts listing every skill discovered from the Tier‑1 plugin allowlist. Preflight FAILs startup when a Tier‑1 plugin is missing, with the operator expected to run `/plugin install` interactively inside Claude Code.
+
+In practice the system leaks value in three ways:
+
+1. Subagents read the bland preamble and move on. The `superpowers:using-superpowers` skill loaded into main Claude sessions enforces a "1% confidence → MUST invoke" rule; subagents receive nothing of that strength.
+2. Every phase sees every skill. A `reviewer` gets `frontend-design`; a `triage` gets `playwright` tool docs. The noise competes with the skills that actually fit.
+3. A missing plugin stops the harness until a human runs the interactive slash command. Fresh clones, cleared caches, and CI boxes all pay this tax.
+
+## Decision
+
+Do three things together, in one PR:
+
+1. **Install at boot.** `_check_plugins` in `src/preflight.py` shells out to `claude plugin install <name>@<marketplace> --scope user` for each missing Tier‑1 (and language-matched Tier‑2) plugin, then re-verifies. Still FAILs — but only if the install itself fails. Toggleable via `auto_install_plugins: bool = True`.
+2. **Rewrite the preamble.** `format_plugin_skills_for_prompt` emits a condensed version of `using-superpowers`: "even at 1% confidence you MUST invoke", process-first priority, a short red-flag reminder. Descriptions still come verbatim from `SKILL.md` frontmatter.
+3. **Per-phase whitelist.** A new `phase_skills: dict[str, list[str]]` config field maps each factory phase (`triage`, `discover`, `shape`, `planner`, `agent`, `reviewer`) to a curated set of qualified skill names. Each runner filters discovery through its whitelist before formatting.
+
+Marketplace is expressed inline in `required_plugins` (`"name@marketplace"`), defaulting to `@claude-plugins-official` for bare names. No schema migration.
+
+## Consequences
+
+**Positive**
+
+- First-boot experience is now "`python -m hydraflow` and walk away" — no manual slash-command dance.
+- Subagents receive the same skill-picking discipline the main Claude session has, so the skills we ship are likelier to be used.
+- Phase-level noise drops sharply: the heaviest phase (`agent`) sees 5 skills, the lightest (`triage`) sees 1. Advertisement becomes signal again.
+- `make install-plugins` + `auto_install_plugins=False` give hermetic-CI operators a deterministic path.
+
+**Negative**
+
+- First boot on a fresh cache takes ≈ 30 s per plugin; with the 5 defaults that is ≈ 2–3 min of blocking install. Only paid once.
+- Preflight now depends on `claude` being on `$PATH` and the user having run `claude login` at some point. Today's preflight already implicitly depends on `claude` — this makes the dependency slightly more demanding. Mitigated by a clear error path pointing to `claude login` when auth is the root cause.
+- The `phase_skills` default mapping is opinionated. Users wanting every skill in every phase must explicitly override, which is a small friction cost in exchange for default-on signal-to-noise.
+
+**Neutral**
+
+- The `using-superpowers` meta-skill is still excluded from discovery; its discipline is now inlined into the preamble instead.
+- Skill *discovery* is unchanged; we only add a filter in front of it.
+
+## Alternatives considered
+
+**Declarative install via `enabledPlugins` in `~/.claude/settings.json`.** Claude Code auto-reconciles this file on startup, so writing the plugin list there would give lazy install "for free." Rejected because (a) install would happen on the *next* subagent dispatch, not at preflight, so preflight couldn't verify the result; (b) we'd be co-editing a user-owned config file.
+
+**Makefile-only install (`make install-plugins`), preflight stays validate-only.** Cleaner separation, but contradicts the user-stated goal ("install when booting") and leaves fresh machines in a broken state until someone remembers the setup step. We keep the Makefile target as the manual fallback, not the primary path.
+
+**Full `using-superpowers` body inlined in the preamble.** Would maximize discipline transfer, but costs ≈ 1 kB per prompt across six runners. Condensing to 8 lines keeps the load-bearing phrases ("1% confidence", "process first", "do not rationalize") without the bulk.
+
+**Per-phase allowlist as metadata in each `SKILL.md`.** Requires patching upstream plugins or shadowing their frontmatter. Our allowlist is a HydraFlow opinion, so it belongs in HydraFlow config, not in plugin metadata.
+
+## References
+
+- Spec: [`docs/superpowers/specs/2026-04-20-dynamic-skill-loading-design.md`](../superpowers/specs/2026-04-20-dynamic-skill-loading-design.md)
+- Prior feature PR (now being extended): #8348
+- Claude Code plugin CLI: <https://code.claude.com/docs/en/plugins-reference#plugin-install>
+- [`ADR-0001: Five concurrent async loops`](0001-five-concurrent-async-loops.md) — the factory-phase names used by `phase_skills` originate here.

--- a/src/agent.py
+++ b/src/agent.py
@@ -17,6 +17,7 @@ from models import LoopResult, Task, WorkerResult, WorkerStatus, WorkerUpdatePay
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from prompt_builder import PromptBuilder
 from review_insights import (
@@ -731,7 +732,11 @@ Run through this checklist before your final commit:
         tools_section = format_tools_for_prompt(discover_tools(self._config.repo_root))
         skills_section = format_skills_for_prompt(get_skills())
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "agent",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
 
         prompt = f"""You are implementing GitHub issue #{issue.id}.

--- a/src/config.py
+++ b/src/config.py
@@ -381,6 +381,9 @@ class HydraFlowConfig(BaseModel):
             "for missing Tier-1/Tier-2 plugins before failing."
         ),
     )
+    # Per-phase whitelist. See ADR-0043 for rationale behind which skills are
+    # included/excluded per phase (e.g., dialog-only and human-author skills
+    # are excluded from every subagent phase).
     phase_skills: dict[str, list[str]] = Field(
         default_factory=lambda: {
             "triage": ["superpowers:systematic-debugging"],

--- a/src/config.py
+++ b/src/config.py
@@ -374,6 +374,53 @@ class HydraFlowConfig(BaseModel):
         },
         description="Language-conditional plugins loaded only when the language is detected in a target repo",
     )
+    auto_install_plugins: bool = Field(
+        default=True,
+        description=(
+            "When True, preflight attempts `claude plugin install name@marketplace --scope user` "
+            "for missing Tier-1/Tier-2 plugins before failing."
+        ),
+    )
+    phase_skills: dict[str, list[str]] = Field(
+        default_factory=lambda: {
+            "triage": ["superpowers:systematic-debugging"],
+            "discover": ["superpowers:systematic-debugging"],
+            "shape": ["superpowers:writing-plans"],
+            "planner": [
+                "superpowers:writing-plans",
+                "superpowers:systematic-debugging",
+            ],
+            "agent": [
+                "superpowers:test-driven-development",
+                "superpowers:systematic-debugging",
+                "superpowers:verification-before-completion",
+                "code-simplifier:simplify",
+                "frontend-design:frontend-design",
+            ],
+            "reviewer": [
+                "code-review:code-review",
+                "superpowers:systematic-debugging",
+            ],
+        },
+        description=(
+            "Per-phase whitelist of qualified skill names (`plugin:skill`) "
+            "rendered into each runner's prompt."
+        ),
+    )
+
+    @field_validator("phase_skills")
+    @classmethod
+    def _validate_phase_names(cls, v: dict[str, list[str]]) -> dict[str, list[str]]:
+        from plugin_skill_registry import PHASE_NAMES  # noqa: PLC0415
+
+        unknown = set(v) - PHASE_NAMES
+        if unknown:
+            raise ValueError(
+                f"unknown phase name(s) in phase_skills: {sorted(unknown)}; "
+                f"expected subset of {sorted(PHASE_NAMES)}"
+            )
+        return v
+
     system_tool: Literal["inherit", "claude", "codex", "pi"] = Field(
         default="inherit",
         description="Optional global default tool for system agents; 'inherit' keeps per-agent defaults",

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -14,6 +14,7 @@ from models import DiscoverResult
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 
@@ -234,7 +235,11 @@ Each opportunity should be:
 {MEMORY_SUGGESTION_PROMPT}
 """
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "discover",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/src/install_plugins_cli.py
+++ b/src/install_plugins_cli.py
@@ -21,15 +21,36 @@ logger = logging.getLogger("hydraflow.install_plugins_cli")
 def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
     """Install every plugin in ``config`` not yet present in ``cache_root``.
 
-    Returns process exit code: 0 on success, non-zero if any install failed.
+    Returns 0 on success or when only Tier-2 (language-conditional) plugins
+    fail; returns 1 if any Tier-1 (``required_plugins``) plugin fails.
+    Mirrors preflight's Tier-1 FAIL / Tier-2 WARN distinction.
     """
     root = cache_root or DEFAULT_CACHE_ROOT
-    all_entries = list(config.required_plugins)
-    for plugins in config.language_plugins.values():
-        all_entries.extend(plugins)
 
+    tier2_entries: list[str] = []
+    for plugins in config.language_plugins.values():
+        tier2_entries.extend(plugins)
+
+    tier1_failures = _install_tier(list(config.required_plugins), root)
+    tier2_failures = _install_tier(tier2_entries, root)
+
+    for failure in tier1_failures:
+        logger.error("%s", failure)
+    for failure in tier2_failures:
+        logger.warning("%s", failure)
+
+    return 1 if tier1_failures else 0
+
+
+def _install_tier(entries: list[str], root: Path) -> list[str]:
+    """Install every entry in ``entries`` not yet present in ``root``.
+
+    Returns a list of ``"name@marketplace: detail"`` strings for each
+    entry that failed to parse or install. Already-installed plugins are
+    logged at INFO and omitted from the failures list.
+    """
     failures: list[str] = []
-    for entry in all_entries:
+    for entry in entries:
         try:
             name, marketplace = parse_plugin_spec(entry)
         except ValueError as exc:
@@ -43,12 +64,7 @@ def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
             logger.info("installed %s@%s", name, marketplace)
         else:
             failures.append(f"{name}@{marketplace}: {detail}")
-
-    if failures:
-        for failure in failures:
-            logger.error("%s", failure)
-        return 1
-    return 0
+    return failures
 
 
 def main() -> int:

--- a/src/install_plugins_cli.py
+++ b/src/install_plugins_cli.py
@@ -1,0 +1,101 @@
+"""CLI: install all Tier-1 + Tier-2 plugins declared in the active HydraFlow config.
+
+Invoked by ``make install-plugins``. Reads the same config HydraFlow boots
+with and runs ``claude plugin install`` for each missing plugin.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+from config import HydraFlowConfig
+from plugin_skill_registry import DEFAULT_CACHE_ROOT, parse_plugin_spec
+from preflight import _plugin_exists
+
+logger = logging.getLogger("hydraflow.install_plugins_cli")
+
+_INSTALL_TIMEOUT_S = 120
+
+
+def _install_plugin(
+    name: str, marketplace: str, *, timeout_s: int = _INSTALL_TIMEOUT_S
+) -> tuple[bool, str]:
+    """Attempt ``claude plugin install name@marketplace --scope user``.
+
+    Uses this module's ``subprocess.run`` so tests can patch it via
+    ``patch("install_plugins_cli.subprocess.run", ...)``.
+
+    Returns ``(success, detail)`` where ``detail`` is the tail of stderr
+    (or a human-readable error string) for logging.
+    """
+    argv = [
+        "claude",
+        "plugin",
+        "install",
+        f"{name}@{marketplace}",
+        "--scope",
+        "user",
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, "`claude` binary not found on PATH"
+    except subprocess.TimeoutExpired:
+        return False, f"install timed out after {timeout_s}s"
+
+    if result.returncode == 0:
+        return True, result.stdout.strip()
+    return False, (result.stderr or result.stdout or "non-zero exit").strip()
+
+
+def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
+    """Install every plugin in ``config`` not yet present in ``cache_root``.
+
+    Returns process exit code: 0 on success, non-zero if any install failed.
+    """
+    root = cache_root or DEFAULT_CACHE_ROOT
+    all_entries = list(config.required_plugins)
+    for plugins in config.language_plugins.values():
+        all_entries.extend(plugins)
+
+    failures: list[str] = []
+    for entry in all_entries:
+        try:
+            name, marketplace = parse_plugin_spec(entry)
+        except ValueError as exc:
+            failures.append(str(exc))
+            continue
+        if _plugin_exists(root, name):
+            logger.info("already installed: %s@%s", name, marketplace)
+            continue
+        ok, detail = _install_plugin(name, marketplace)
+        if ok:
+            logger.info("installed %s@%s", name, marketplace)
+        else:
+            failures.append(f"{name}@{marketplace}: {detail}")
+
+    if failures:
+        for f in failures:
+            logger.error(f)
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m install_plugins_cli``."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    cfg = HydraFlowConfig()  # defaults; no CLI args — matches make target expectations
+    return run(cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/install_plugins_cli.py
+++ b/src/install_plugins_cli.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 from config import HydraFlowConfig
 from plugin_skill_registry import DEFAULT_CACHE_ROOT, parse_plugin_spec
-from preflight import _plugin_exists, install_plugin
+from preflight import install_plugin, plugin_exists
 
 logger = logging.getLogger("hydraflow.install_plugins_cli")
 
@@ -35,7 +35,7 @@ def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
         except ValueError as exc:
             failures.append(str(exc))
             continue
-        if _plugin_exists(root, name):
+        if plugin_exists(root, name):
             logger.info("already installed: %s@%s", name, marketplace)
             continue
         ok, detail = install_plugin(name, marketplace)
@@ -45,8 +45,8 @@ def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
             failures.append(f"{name}@{marketplace}: {detail}")
 
     if failures:
-        for f in failures:
-            logger.error(f)
+        for failure in failures:
+            logger.error("%s", failure)
         return 1
     return 0
 

--- a/src/install_plugins_cli.py
+++ b/src/install_plugins_cli.py
@@ -1,60 +1,21 @@
 """CLI: install all Tier-1 + Tier-2 plugins declared in the active HydraFlow config.
 
 Invoked by ``make install-plugins``. Reads the same config HydraFlow boots
-with and runs ``claude plugin install`` for each missing plugin.
+with and runs ``claude plugin install`` for each missing plugin via the
+shared :func:`preflight.install_plugin` helper.
 """
 
 from __future__ import annotations
 
 import logging
-import subprocess
 import sys
 from pathlib import Path
 
 from config import HydraFlowConfig
 from plugin_skill_registry import DEFAULT_CACHE_ROOT, parse_plugin_spec
-from preflight import _plugin_exists
+from preflight import _plugin_exists, install_plugin
 
 logger = logging.getLogger("hydraflow.install_plugins_cli")
-
-_INSTALL_TIMEOUT_S = 120
-
-
-def _install_plugin(
-    name: str, marketplace: str, *, timeout_s: int = _INSTALL_TIMEOUT_S
-) -> tuple[bool, str]:
-    """Attempt ``claude plugin install name@marketplace --scope user``.
-
-    Uses this module's ``subprocess.run`` so tests can patch it via
-    ``patch("install_plugins_cli.subprocess.run", ...)``.
-
-    Returns ``(success, detail)`` where ``detail`` is the tail of stderr
-    (or a human-readable error string) for logging.
-    """
-    argv = [
-        "claude",
-        "plugin",
-        "install",
-        f"{name}@{marketplace}",
-        "--scope",
-        "user",
-    ]
-    try:
-        result = subprocess.run(  # noqa: S603
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=timeout_s,
-            check=False,
-        )
-    except FileNotFoundError:
-        return False, "`claude` binary not found on PATH"
-    except subprocess.TimeoutExpired:
-        return False, f"install timed out after {timeout_s}s"
-
-    if result.returncode == 0:
-        return True, result.stdout.strip()
-    return False, (result.stderr or result.stdout or "non-zero exit").strip()
 
 
 def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
@@ -77,7 +38,7 @@ def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
         if _plugin_exists(root, name):
             logger.info("already installed: %s@%s", name, marketplace)
             continue
-        ok, detail = _install_plugin(name, marketplace)
+        ok, detail = install_plugin(name, marketplace)
         if ok:
             logger.info("installed %s@%s", name, marketplace)
         else:
@@ -90,7 +51,7 @@ def run(config: HydraFlowConfig, *, cache_root: Path | None = None) -> int:
     return 0
 
 
-def main(argv: list[str] | None = None) -> int:
+def main() -> int:
     """Entry point for ``python -m install_plugins_cli``."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     cfg = HydraFlowConfig()  # defaults; no CLI args — matches make target expectations

--- a/src/planner.py
+++ b/src/planner.py
@@ -26,6 +26,7 @@ from plan_validation import run_phase_gates, validate_plan
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from prompt_builder import PromptBuilder
 from runner_constants import MEMORY_SUGGESTION_PROMPT
@@ -547,7 +548,11 @@ This closes the issue automatically. False positives waste significant human tim
 
 {MEMORY_SUGGESTION_PROMPT.format(context="planning")}"""
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "planner",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -215,7 +215,7 @@ def skills_for_phase(
 
 
 def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:
-    """Format discovered skills as a prompt section for a factory agent.
+    """Format discovered skills as a prompt section carrying the skill-use discipline.
 
     Returns an empty string when ``skills`` is empty so callers can
     unconditionally concatenate the result.
@@ -225,10 +225,22 @@ def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:
     lines = [
         "## Available Skills",
         "",
-        "You have these Claude Code skills available via the `Skill` tool. "
-        "Invoke one by calling the `Skill` tool with its qualified name "
-        '(e.g. `skill: "superpowers:brainstorming"`) when its description '
-        "matches your current task.",
+        (
+            "You have Claude Code skills available via the `Skill` tool. "
+            "**If any skill's description may apply to your current task — "
+            "even at 1% confidence — you MUST invoke it before proceeding.** "
+            "Skills encode proven discipline you would otherwise skip."
+        ),
+        "",
+        "Priority when multiple apply:",
+        "1. **Process skills first** (debugging, planning) — they shape *how* you work.",
+        "2. **Implementation skills second** (TDD, simplify) — they shape *what* you build.",
+        "",
+        (
+            "Do not rationalize past a skill because the task feels simple, "
+            'because you "remember" the skill, or because invoking it feels '
+            "like overhead. Invoke it."
+        ),
         "",
     ]
     for skill in skills:

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -26,6 +26,25 @@ _EXCLUDED_SKILL_NAMES: frozenset[str] = frozenset({"using-superpowers"})
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _KEY_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$")
 
+_DEFAULT_MARKETPLACE = "claude-plugins-official"
+
+
+def _parse_plugin_spec(spec: str) -> tuple[str, str]:
+    """Parse a plugin spec into ``(name, marketplace)``.
+
+    Accepts ``"name"`` (default marketplace) or ``"name@marketplace"``.
+    Raises :class:`ValueError` on empty, double-``@``, or empty halves.
+    """
+    cleaned = spec.strip()
+    if not cleaned:
+        raise ValueError(f"Empty plugin spec: {spec!r}")
+    parts = [p.strip() for p in cleaned.split("@")]
+    if len(parts) == 1:
+        return parts[0], _DEFAULT_MARKETPLACE
+    if len(parts) == 2 and parts[0] and parts[1]:
+        return parts[0], parts[1]
+    raise ValueError(f"Malformed plugin spec: {spec!r}")
+
 
 @dataclass(frozen=True)
 class PluginSkill:

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -28,6 +28,10 @@ _KEY_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$")
 
 DEFAULT_MARKETPLACE = "claude-plugins-official"
 
+PHASE_NAMES: frozenset[str] = frozenset(
+    {"triage", "discover", "shape", "planner", "agent", "reviewer"}
+)
+
 
 def parse_plugin_spec(spec: str) -> tuple[str, str]:
     """Parse a plugin spec into ``(name, marketplace)``.
@@ -187,6 +191,27 @@ _skill_cache: dict[tuple[frozenset[str], Path], tuple[PluginSkill, ...]] = {}
 def clear_plugin_skill_cache() -> None:
     """Clear the in-memory discovery cache. Intended for tests."""
     _skill_cache.clear()
+
+
+def skills_for_phase(
+    phase: str,
+    discovered: list[PluginSkill],
+    phase_skills: dict[str, list[str]],
+) -> list[PluginSkill]:
+    """Return the subset of ``discovered`` whitelisted for ``phase``.
+
+    Order follows the whitelist's declaration order. Qualified names
+    ``<plugin>:<skill>`` not present in ``discovered`` are silently
+    omitted (allows disabling a plugin without synchronous config edits).
+    Raises :class:`ValueError` if ``phase`` is not a known factory phase.
+    """
+    if phase not in PHASE_NAMES:
+        raise ValueError(
+            f"unknown phase {phase!r}; expected one of {sorted(PHASE_NAMES)}"
+        )
+    allowed = phase_skills.get(phase, [])
+    by_qualified = {s.qualified_name: s for s in discovered}
+    return [by_qualified[q] for q in allowed if q in by_qualified]
 
 
 def format_plugin_skills_for_prompt(skills: list[PluginSkill]) -> str:

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -26,10 +26,10 @@ _EXCLUDED_SKILL_NAMES: frozenset[str] = frozenset({"using-superpowers"})
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _KEY_PREFIX_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_-]*):\s*(.*)$")
 
-_DEFAULT_MARKETPLACE = "claude-plugins-official"
+DEFAULT_MARKETPLACE = "claude-plugins-official"
 
 
-def _parse_plugin_spec(spec: str) -> tuple[str, str]:
+def parse_plugin_spec(spec: str) -> tuple[str, str]:
     """Parse a plugin spec into ``(name, marketplace)``.
 
     Accepts ``"name"`` (default marketplace) or ``"name@marketplace"``.
@@ -40,7 +40,7 @@ def _parse_plugin_spec(spec: str) -> tuple[str, str]:
         raise ValueError(f"Empty plugin spec: {spec!r}")
     parts = [p.strip() for p in cleaned.split("@")]
     if len(parts) == 1:
-        return parts[0], _DEFAULT_MARKETPLACE
+        return parts[0], DEFAULT_MARKETPLACE
     if len(parts) == 2 and parts[0] and parts[1]:
         return parts[0], parts[1]
     raise ValueError(f"Malformed plugin spec: {spec!r}")

--- a/src/plugin_skill_registry.py
+++ b/src/plugin_skill_registry.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 logger = logging.getLogger("hydraflow.plugin_skill_registry")
 
-_DEFAULT_CACHE_ROOT = Path.home() / ".claude" / "plugins" / "cache"
+DEFAULT_CACHE_ROOT = Path.home() / ".claude" / "plugins" / "cache"
 
 # Meta-skills that route to other skills — excluded from factory prompts
 # because the factory advertises skills directly.
@@ -77,7 +77,7 @@ def discover_plugin_skills(
     frontmatter are skipped with a warning. The ``using-superpowers``
     meta-skill is always excluded.
     """
-    root = cache_root or _DEFAULT_CACHE_ROOT
+    root = cache_root or DEFAULT_CACHE_ROOT
     key = (frozenset(plugins), root)
     cached = _skill_cache.get(key)
     if cached is not None:

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -184,7 +184,7 @@ def log_preflight_results(results: list[CheckResult]) -> bool:
     return not any(r.status == CheckStatus.FAIL for r in results)
 
 
-def _install_plugin(
+def install_plugin(
     name: str, marketplace: str, *, timeout_s: int = 120
 ) -> tuple[bool, str]:
     """Attempt ``claude plugin install name@marketplace --scope user``.
@@ -278,7 +278,7 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     install_errors: list[str] = []
     if missing_tier1 and config.auto_install_plugins:
         for name, marketplace in missing_tier1:
-            ok, detail = _install_plugin(name, marketplace)
+            ok, detail = install_plugin(name, marketplace)
             if ok:
                 logger.info("installed %s@%s", name, marketplace)
             else:
@@ -319,7 +319,7 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     if config.auto_install_plugins:
         for _, name, marketplace in tier2_specs:
             if not _plugin_exists(root, name):
-                ok, detail = _install_plugin(name, marketplace)
+                ok, detail = install_plugin(name, marketplace)
                 if not ok:
                     tier2_install_errors[name] = detail
 

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -236,12 +236,12 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     - Everything present → PASS.
     """
     from plugin_skill_registry import (
-        _DEFAULT_CACHE_ROOT,  # noqa: PLC0415 — private but already imported elsewhere
+        DEFAULT_CACHE_ROOT,  # noqa: PLC0415
         discover_plugin_skills,  # noqa: PLC0415
         parse_plugin_spec,  # noqa: PLC0415
     )
 
-    root = cache_root or _DEFAULT_CACHE_ROOT
+    root = cache_root or DEFAULT_CACHE_ROOT
     langs = detected_languages or set()
 
     if root.exists() and not root.is_dir():
@@ -288,15 +288,22 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     still_missing = [(n, m) for n, m in tier1_specs if not _plugin_exists(root, n)]
     if still_missing:
         pretty = ", ".join(f"{n}@{m}" for n, m in still_missing)
-        errors_block = (
-            "\n".join(f"  {e}" for e in install_errors) or "  (auto-install disabled)"
-        )
+        if config.auto_install_plugins:
+            header = f"Plugin install failed for: {pretty}"
+            errors_block = (
+                "\n".join(f"  {e}" for e in install_errors)
+                or "  (no install errors captured)"
+            )
+            middle = f"Last errors:\n{errors_block}\n"
+        else:
+            header = f"Required plugins missing: {pretty}"
+            middle = "Auto-install disabled (auto_install_plugins=False).\n"
         return CheckResult(
             "plugins",
             CheckStatus.FAIL,
             (
-                f"Plugin install failed for: {pretty}\n"
-                f"Last errors:\n{errors_block}\n"
+                f"{header}\n"
+                f"{middle}"
                 "Manual fix:\n"
                 "  make install-plugins          # preferred — reads config, installs all missing\n"
                 "  # or per-plugin:\n"
@@ -306,11 +313,15 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
             ),
         )
 
-    # Tier-2 install (best effort).
+    # Tier-2 install (best effort). Capture per-plugin errors so the WARN
+    # message can report WHY an install failed, not just that it's missing.
+    tier2_install_errors: dict[str, str] = {}  # plugin_name → detail
     if config.auto_install_plugins:
         for _, name, marketplace in tier2_specs:
             if not _plugin_exists(root, name):
-                _install_plugin(name, marketplace)  # errors recorded in WARN below
+                ok, detail = _install_plugin(name, marketplace)
+                if not ok:
+                    tier2_install_errors[name] = detail
 
     missing_tier2 = [
         (lang, n) for lang, n, _ in tier2_specs if not _plugin_exists(root, n)
@@ -326,11 +337,17 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
         )
 
     if missing_tier2:
-        formatted = ", ".join(f"{n} (for {lang})" for lang, n in missing_tier2)
+        parts: list[str] = []
+        for lang, name in missing_tier2:
+            detail = tier2_install_errors.get(name)
+            if detail:
+                parts.append(f"{name} (for {lang}: {detail})")
+            else:
+                parts.append(f"{name} (for {lang})")
         return CheckResult(
             "plugins",
             CheckStatus.WARN,
-            f"Language-conditional plugins missing: {formatted}",
+            f"Language-conditional plugins missing: {', '.join(parts)}",
         )
 
     return CheckResult(

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -308,12 +308,12 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
 
     # Tier-2 install (best effort).
     if config.auto_install_plugins:
-        for _lang, name, marketplace in tier2_specs:
+        for _, name, marketplace in tier2_specs:
             if not _plugin_exists(root, name):
                 _install_plugin(name, marketplace)  # errors recorded in WARN below
 
     missing_tier2 = [
-        (lang, n) for lang, n, _m in tier2_specs if not _plugin_exists(root, n)
+        (lang, n) for lang, n, _ in tier2_specs if not _plugin_exists(root, n)
     ]
 
     all_plugin_names = [n for n, _ in tier1_specs] + [n for _, n, _ in tier2_specs]

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -273,7 +273,7 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
             tier2_specs.append((lang, name, marketplace))
 
     # Identify missing Tier-1 before any install attempt.
-    missing_tier1 = [(n, m) for n, m in tier1_specs if not _plugin_exists(root, n)]
+    missing_tier1 = [(n, m) for n, m in tier1_specs if not plugin_exists(root, n)]
 
     install_errors: list[str] = []
     if missing_tier1 and config.auto_install_plugins:
@@ -285,7 +285,7 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
                 install_errors.append(f"{name}@{marketplace}: {detail}")
 
     # Re-check after install attempt.
-    still_missing = [(n, m) for n, m in tier1_specs if not _plugin_exists(root, n)]
+    still_missing = [(n, m) for n, m in tier1_specs if not plugin_exists(root, n)]
     if still_missing:
         pretty = ", ".join(f"{n}@{m}" for n, m in still_missing)
         if config.auto_install_plugins:
@@ -318,13 +318,13 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     tier2_install_errors: dict[str, str] = {}  # plugin_name → detail
     if config.auto_install_plugins:
         for _, name, marketplace in tier2_specs:
-            if not _plugin_exists(root, name):
+            if not plugin_exists(root, name):
                 ok, detail = install_plugin(name, marketplace)
                 if not ok:
                     tier2_install_errors[name] = detail
 
     missing_tier2 = [
-        (lang, n) for lang, n, _ in tier2_specs if not _plugin_exists(root, n)
+        (lang, n) for lang, n, _ in tier2_specs if not plugin_exists(root, n)
     ]
 
     all_plugin_names = [n for n, _ in tier1_specs] + [n for _, n, _ in tier2_specs]
@@ -357,7 +357,7 @@ def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own r
     )
 
 
-def _plugin_exists(cache_root: Path, plugin: str) -> bool:
+def plugin_exists(cache_root: Path, plugin: str) -> bool:
     """Return True if ``plugin`` directory exists under any marketplace in ``cache_root``."""
     if not cache_root.is_dir():
         return False

--- a/src/preflight.py
+++ b/src/preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
+import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -142,7 +143,6 @@ def _check_docker() -> CheckResult:
     """Check that Docker is available and responsive."""
     if not shutil.which("docker"):
         return CheckResult("docker", CheckStatus.FAIL, "docker not found on PATH")
-    import subprocess  # noqa: PLC0415
 
     try:
         result = subprocess.run(  # noqa: S603, S607
@@ -184,7 +184,42 @@ def log_preflight_results(results: list[CheckResult]) -> bool:
     return not any(r.status == CheckStatus.FAIL for r in results)
 
 
-def _check_plugins(
+def _install_plugin(
+    name: str, marketplace: str, *, timeout_s: int = 120
+) -> tuple[bool, str]:
+    """Attempt ``claude plugin install name@marketplace --scope user``.
+
+    Returns ``(success, detail)`` where ``detail`` is the tail of stderr
+    (or a human-readable error string) for logging.
+    """
+
+    argv = [
+        "claude",
+        "plugin",
+        "install",
+        f"{name}@{marketplace}",
+        "--scope",
+        "user",
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False, "`claude` binary not found on PATH"
+    except subprocess.TimeoutExpired:
+        return False, f"install timed out after {timeout_s}s"
+
+    if result.returncode == 0:
+        return True, result.stdout.strip()
+    return False, (result.stderr or result.stdout or "non-zero exit").strip()
+
+
+def _check_plugins(  # noqa: PLR0911 — linear gate checks, each with its own return path
     config: HydraFlowConfig,
     *,
     cache_root: Path | None = None,
@@ -192,23 +227,22 @@ def _check_plugins(
 ) -> CheckResult:
     """Verify required plugins are installed under the plugin cache.
 
-    - Tier 1 (``config.required_plugins``) missing → FAIL.
+    - Tier 1 (``config.required_plugins``) missing → attempt auto-install when
+      ``config.auto_install_plugins`` is True; otherwise FAIL immediately. FAIL
+      with a rich error message if still missing after install.
     - Zero total skills discovered → FAIL.
-    - Tier 2 plugin missing for a detected language → WARN.
+    - Tier 2 plugin missing for a detected language → best-effort install, then
+      WARN if still missing.
     - Everything present → PASS.
     """
     from plugin_skill_registry import (
-        _DEFAULT_CACHE_ROOT,  # noqa: PLC0415
+        _DEFAULT_CACHE_ROOT,  # noqa: PLC0415 — private but already imported elsewhere
         discover_plugin_skills,  # noqa: PLC0415
+        parse_plugin_spec,  # noqa: PLC0415
     )
 
     root = cache_root or _DEFAULT_CACHE_ROOT
     langs = detected_languages or set()
-
-    missing_tier1: list[str] = []
-    for plugin in config.required_plugins:
-        if not _plugin_exists(root, plugin):
-            missing_tier1.append(plugin)
 
     if root.exists() and not root.is_dir():
         return CheckResult(
@@ -217,28 +251,73 @@ def _check_plugins(
             f"Plugin cache path exists but is not a directory: {root}",
         )
 
-    if missing_tier1:
+    # Collect Tier-1 + Tier-2 specs.
+    tier1_specs: list[tuple[str, str]] = []
+    for entry in config.required_plugins:
+        try:
+            tier1_specs.append(parse_plugin_spec(entry))
+        except ValueError as exc:
+            return CheckResult(
+                "plugins", CheckStatus.FAIL, f"Bad required_plugins entry: {exc}"
+            )
+
+    tier2_specs: list[tuple[str, str, str]] = []  # (lang, name, marketplace)
+    for lang in langs:
+        for entry in config.language_plugins.get(lang, []):
+            try:
+                name, marketplace = parse_plugin_spec(entry)
+            except ValueError as exc:
+                return CheckResult(
+                    "plugins", CheckStatus.FAIL, f"Bad language_plugins entry: {exc}"
+                )
+            tier2_specs.append((lang, name, marketplace))
+
+    # Identify missing Tier-1 before any install attempt.
+    missing_tier1 = [(n, m) for n, m in tier1_specs if not _plugin_exists(root, n)]
+
+    install_errors: list[str] = []
+    if missing_tier1 and config.auto_install_plugins:
+        for name, marketplace in missing_tier1:
+            ok, detail = _install_plugin(name, marketplace)
+            if ok:
+                logger.info("installed %s@%s", name, marketplace)
+            else:
+                install_errors.append(f"{name}@{marketplace}: {detail}")
+
+    # Re-check after install attempt.
+    still_missing = [(n, m) for n, m in tier1_specs if not _plugin_exists(root, n)]
+    if still_missing:
+        pretty = ", ".join(f"{n}@{m}" for n, m in still_missing)
+        errors_block = (
+            "\n".join(f"  {e}" for e in install_errors) or "  (auto-install disabled)"
+        )
         return CheckResult(
             "plugins",
             CheckStatus.FAIL,
             (
-                f"Required plugins missing from {root}: "
-                f"{', '.join(missing_tier1)} — "
-                "install the missing plugins via Claude Code (`/plugin install <name>`) "
-                "or verify the cache path"
+                f"Plugin install failed for: {pretty}\n"
+                f"Last errors:\n{errors_block}\n"
+                "Manual fix:\n"
+                "  make install-plugins          # preferred — reads config, installs all missing\n"
+                "  # or per-plugin:\n"
+                "  claude plugin install <name>@<marketplace> --scope user\n"
+                "\nIf `claude plugin install` reports a login error, run:\n"
+                "  claude login"
             ),
         )
 
-    required_tier2: list[str] = []
-    missing_tier2: list[tuple[str, str]] = []  # (language, plugin)
-    for lang in langs:
-        for plugin in config.language_plugins.get(lang, []):
-            required_tier2.append(plugin)
-            if not _plugin_exists(root, plugin):
-                missing_tier2.append((lang, plugin))
+    # Tier-2 install (best effort).
+    if config.auto_install_plugins:
+        for _lang, name, marketplace in tier2_specs:
+            if not _plugin_exists(root, name):
+                _install_plugin(name, marketplace)  # errors recorded in WARN below
 
-    all_plugins = config.required_plugins + required_tier2
-    skills = discover_plugin_skills(all_plugins, cache_root=root)
+    missing_tier2 = [
+        (lang, n) for lang, n, _m in tier2_specs if not _plugin_exists(root, n)
+    ]
+
+    all_plugin_names = [n for n, _ in tier1_specs] + [n for _, n, _ in tier2_specs]
+    skills = discover_plugin_skills(all_plugin_names, cache_root=root)
     if not skills:
         return CheckResult(
             "plugins",
@@ -247,9 +326,7 @@ def _check_plugins(
         )
 
     if missing_tier2:
-        formatted = ", ".join(
-            f"{plugin} (for {lang})" for lang, plugin in missing_tier2
-        )
+        formatted = ", ".join(f"{n} (for {lang})" for lang, n in missing_tier2)
         return CheckResult(
             "plugins",
             CheckStatus.WARN,

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -24,6 +24,7 @@ from models import (
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from precheck import run_precheck_context
 from prompt_builder import PromptBuilder
@@ -851,7 +852,11 @@ SUMMARY: Implementation looks good, tests are comprehensive, all checks pass.
 
 {MEMORY_SUGGESTION_PROMPT.format(context="review")}"""
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "reviewer",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/src/shape_runner.py
+++ b/src/shape_runner.py
@@ -14,6 +14,7 @@ from models import ProductDirection, ShapeConversation, ShapeResult, ShapeTurnRe
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from runner_constants import MEMORY_SUGGESTION_PROMPT
 
@@ -297,7 +298,11 @@ a final specification for the engineering team:
 """
 
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "shape",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/src/triage.py
+++ b/src/triage.py
@@ -24,6 +24,7 @@ from models import (
 from plugin_skill_registry import (
     discover_plugin_skills,
     format_plugin_skills_for_prompt,
+    skills_for_phase,
 )
 from prompt_builder import PromptBuilder
 
@@ -259,7 +260,11 @@ or for truly insufficient issues:
 ```
 """
         plugin_skills_section = format_plugin_skills_for_prompt(
-            discover_plugin_skills(self._config.required_plugins)
+            skills_for_phase(
+                "triage",
+                discover_plugin_skills(self._config.required_plugins),
+                self._config.phase_skills,
+            )
         )
         if plugin_skills_section:
             prompt = f"{prompt}\n\n{plugin_skills_section}"

--- a/tests/test_config_phase_skills.py
+++ b/tests/test_config_phase_skills.py
@@ -1,0 +1,48 @@
+"""Tests for the auto_install_plugins and phase_skills config fields."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from config import HydraFlowConfig
+
+
+def test_auto_install_plugins_defaults_true():
+    cfg = HydraFlowConfig()
+    assert cfg.auto_install_plugins is True
+
+
+def test_phase_skills_defaults_contain_all_six_phases():
+    cfg = HydraFlowConfig()
+    assert set(cfg.phase_skills.keys()) == {
+        "triage",
+        "discover",
+        "shape",
+        "planner",
+        "agent",
+        "reviewer",
+    }
+
+
+def test_phase_skills_default_agent_contents():
+    cfg = HydraFlowConfig()
+    assert cfg.phase_skills["agent"] == [
+        "superpowers:test-driven-development",
+        "superpowers:systematic-debugging",
+        "superpowers:verification-before-completion",
+        "code-simplifier:simplify",
+        "frontend-design:frontend-design",
+    ]
+
+
+def test_unknown_phase_name_rejected():
+    with pytest.raises(ValidationError, match="unknown phase"):
+        HydraFlowConfig(phase_skills={"bogus_phase": []})
+
+
+def test_override_preserves_other_phases():
+    cfg = HydraFlowConfig(phase_skills={"triage": ["superpowers:systematic-debugging"]})
+    # Overriding one phase replaces the entire dict (pydantic default semantics)
+    # — the test documents and locks in this behavior.
+    assert cfg.phase_skills == {"triage": ["superpowers:systematic-debugging"]}

--- a/tests/test_install_plugins_cli.py
+++ b/tests/test_install_plugins_cli.py
@@ -1,0 +1,71 @@
+"""Tests for install_plugins_cli.run()."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from config import HydraFlowConfig
+from install_plugins_cli import run
+
+
+def test_installs_all_missing_tier1_plugins(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers", "code-review"],
+        language_plugins={},
+    )
+    called_argvs: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        called_argvs.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with patch("install_plugins_cli.subprocess.run", side_effect=fake_run):
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code == 0
+    assert called_argvs == [
+        [
+            "claude",
+            "plugin",
+            "install",
+            "superpowers@claude-plugins-official",
+            "--scope",
+            "user",
+        ],
+        [
+            "claude",
+            "plugin",
+            "install",
+            "code-review@claude-plugins-official",
+            "--scope",
+            "user",
+        ],
+    ]
+
+
+def test_skips_already_installed_plugins(tmp_path: Path):
+    cfg = HydraFlowConfig(required_plugins=["superpowers"], language_plugins={})
+    # Pre-populate cache so the plugin is "already installed"
+    (tmp_path / "claude-plugins-official" / "superpowers" / "1.0.0" / "skills").mkdir(
+        parents=True
+    )
+
+    with patch("install_plugins_cli.subprocess.run") as mock_run:
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code == 0
+    assert mock_run.call_count == 0
+
+
+def test_nonzero_exit_on_any_install_failure(tmp_path: Path):
+    cfg = HydraFlowConfig(required_plugins=["superpowers"], language_plugins={})
+
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+
+    with patch("install_plugins_cli.subprocess.run", side_effect=fake_run):
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code != 0

--- a/tests/test_install_plugins_cli.py
+++ b/tests/test_install_plugins_cli.py
@@ -59,7 +59,7 @@ def test_skips_already_installed_plugins(tmp_path: Path):
     assert mock_run.call_count == 0
 
 
-def test_nonzero_exit_on_any_install_failure(tmp_path: Path):
+def test_nonzero_exit_on_tier1_install_failure(tmp_path: Path):
     cfg = HydraFlowConfig(required_plugins=["superpowers"], language_plugins={})
 
     def fake_run(argv, **kwargs):
@@ -69,3 +69,72 @@ def test_nonzero_exit_on_any_install_failure(tmp_path: Path):
         exit_code = run(cfg, cache_root=tmp_path)
 
     assert exit_code != 0
+
+
+def test_zero_exit_when_only_tier2_install_fails(tmp_path: Path):
+    """Tier-2 (language-conditional) failures are warnings, not errors."""
+    cfg = HydraFlowConfig(
+        required_plugins=[],
+        language_plugins={"python": ["bogus-lsp"]},
+    )
+
+    def fake_run(argv, **_kwargs):
+        return subprocess.CompletedProcess(
+            argv, 1, stdout="", stderr="marketplace unknown"
+        )
+
+    with patch("preflight.subprocess.run", side_effect=fake_run):
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code == 0
+
+
+def test_nonzero_when_tier1_fails_even_if_tier2_succeeds(tmp_path: Path):
+    """Tier-1 failure is still fatal regardless of Tier-2 outcome."""
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        language_plugins={"python": ["pyright-lsp"]},
+    )
+
+    def fake_run(argv, **_kwargs):
+        # Fail tier-1 superpowers; succeed tier-2 pyright-lsp by populating cache
+        if "superpowers" in argv[3]:
+            return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+        # pyright-lsp succeeds
+        (
+            tmp_path / "claude-plugins-official" / "pyright-lsp" / "1.0.0" / "skills"
+        ).mkdir(parents=True, exist_ok=True)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with patch("preflight.subprocess.run", side_effect=fake_run):
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code == 1
+
+
+def test_tier2_entries_always_attempted_when_missing(tmp_path: Path):
+    """Tier-2 entries are attempted even if Tier-1 is empty."""
+    cfg = HydraFlowConfig(
+        required_plugins=[],
+        language_plugins={"python": ["pyright-lsp"]},
+    )
+    called_argvs: list[list[str]] = []
+
+    def fake_run(argv, **_kwargs):
+        called_argvs.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with patch("preflight.subprocess.run", side_effect=fake_run):
+        exit_code = run(cfg, cache_root=tmp_path)
+
+    assert exit_code == 0
+    assert called_argvs == [
+        [
+            "claude",
+            "plugin",
+            "install",
+            "pyright-lsp@claude-plugins-official",
+            "--scope",
+            "user",
+        ],
+    ]

--- a/tests/test_install_plugins_cli.py
+++ b/tests/test_install_plugins_cli.py
@@ -21,7 +21,7 @@ def test_installs_all_missing_tier1_plugins(tmp_path: Path):
         called_argvs.append(argv)
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
-    with patch("install_plugins_cli.subprocess.run", side_effect=fake_run):
+    with patch("preflight.subprocess.run", side_effect=fake_run):
         exit_code = run(cfg, cache_root=tmp_path)
 
     assert exit_code == 0
@@ -52,7 +52,7 @@ def test_skips_already_installed_plugins(tmp_path: Path):
         parents=True
     )
 
-    with patch("install_plugins_cli.subprocess.run") as mock_run:
+    with patch("preflight.subprocess.run") as mock_run:
         exit_code = run(cfg, cache_root=tmp_path)
 
     assert exit_code == 0
@@ -65,7 +65,7 @@ def test_nonzero_exit_on_any_install_failure(tmp_path: Path):
     def fake_run(argv, **kwargs):
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
 
-    with patch("install_plugins_cli.subprocess.run", side_effect=fake_run):
+    with patch("preflight.subprocess.run", side_effect=fake_run):
         exit_code = run(cfg, cache_root=tmp_path)
 
     assert exit_code != 0

--- a/tests/test_phase_skill_filter.py
+++ b/tests/test_phase_skill_filter.py
@@ -1,0 +1,73 @@
+"""Tests for plugin_skill_registry.skills_for_phase."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugin_skill_registry import PHASE_NAMES, PluginSkill, skills_for_phase
+
+
+def _make_skills() -> list[PluginSkill]:
+    return [
+        PluginSkill(
+            plugin="superpowers", name="test-driven-development", description="TDD"
+        ),
+        PluginSkill(
+            plugin="superpowers", name="systematic-debugging", description="Debug"
+        ),
+        PluginSkill(plugin="code-review", name="code-review", description="Review"),
+    ]
+
+
+def test_phase_names_are_frozen():
+    assert (
+        frozenset({"triage", "discover", "shape", "planner", "agent", "reviewer"})
+        == PHASE_NAMES
+    )
+
+
+def test_intersection_returns_only_whitelisted():
+    phase_skills = {"agent": ["superpowers:test-driven-development"]}
+    out = skills_for_phase("agent", _make_skills(), phase_skills)
+    assert [s.qualified_name for s in out] == ["superpowers:test-driven-development"]
+
+
+def test_preserves_whitelist_order_not_discovery_order():
+    phase_skills = {
+        "agent": [
+            "code-review:code-review",
+            "superpowers:test-driven-development",
+        ]
+    }
+    out = skills_for_phase("agent", _make_skills(), phase_skills)
+    assert [s.qualified_name for s in out] == [
+        "code-review:code-review",
+        "superpowers:test-driven-development",
+    ]
+
+
+def test_missing_from_discovery_silently_omitted():
+    phase_skills = {
+        "agent": [
+            "superpowers:test-driven-development",
+            "nonexistent:skill",
+        ]
+    }
+    out = skills_for_phase("agent", _make_skills(), phase_skills)
+    assert [s.qualified_name for s in out] == ["superpowers:test-driven-development"]
+
+
+def test_empty_whitelist_returns_empty_list():
+    out = skills_for_phase("triage", _make_skills(), {"triage": []})
+    assert out == []
+
+
+def test_missing_phase_key_returns_empty_list():
+    # Phase is valid but config omits it → empty, don't crash.
+    out = skills_for_phase("agent", _make_skills(), {})
+    assert out == []
+
+
+def test_unknown_phase_name_raises():
+    with pytest.raises(ValueError, match="unknown phase"):
+        skills_for_phase("bogus", _make_skills(), {"bogus": []})

--- a/tests/test_phase_skill_filter.py
+++ b/tests/test_phase_skill_filter.py
@@ -19,7 +19,14 @@ def _make_skills() -> list[PluginSkill]:
     ]
 
 
-def test_phase_names_are_frozen():
+def test_phase_names_locks_the_six_factory_phases():
+    """Locks PHASE_NAMES at exactly the six factory phases.
+
+    Adding a phase is a deliberate change that must update PHASE_NAMES,
+    the default ``phase_skills`` config in ``src/config.py``, and this
+    test together — breaking one and not the others should fail loudly.
+    """
+    assert isinstance(PHASE_NAMES, frozenset)
     assert (
         frozenset({"triage", "discover", "shape", "planner", "agent", "reviewer"})
         == PHASE_NAMES
@@ -65,6 +72,16 @@ def test_empty_whitelist_returns_empty_list():
 def test_missing_phase_key_returns_empty_list():
     # Phase is valid but config omits it → empty, don't crash.
     out = skills_for_phase("agent", _make_skills(), {})
+    assert out == []
+
+
+def test_empty_discovered_with_non_empty_whitelist_returns_empty():
+    # Nothing discovered → even a well-populated whitelist yields nothing.
+    out = skills_for_phase(
+        "agent",
+        [],
+        {"agent": ["superpowers:test-driven-development"]},
+    )
     assert out == []
 
 

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -28,6 +28,10 @@ def _reset_skill_cache():
 # ---------------------------------------------------------------------------
 
 
+# Mirror of the skills in the src/config.py phase_skills default, used to
+# populate the test cache with every phase's expected skills. Keep in sync
+# when the default whitelist changes — no automated enforcement (the tests
+# must exercise actual filtering, which requires a concrete list here).
 def _all_phase_skills():
     """Return a PluginSkill list covering every whitelisted skill across phases."""
     from plugin_skill_registry import PluginSkill

--- a/tests/test_phase_skill_injection.py
+++ b/tests/test_phase_skill_injection.py
@@ -22,6 +22,29 @@ def _reset_skill_cache():
     clear_plugin_skill_cache()
 
 
+# ---------------------------------------------------------------------------
+# Shared helper: a cross-phase skill list covering all whitelists.
+# Used by whitelist-filtering tests to ensure cross-phase leak detection.
+# ---------------------------------------------------------------------------
+
+
+def _all_phase_skills():
+    """Return a PluginSkill list covering every whitelisted skill across phases."""
+    from plugin_skill_registry import PluginSkill
+
+    return [
+        PluginSkill("superpowers", "test-driven-development", "TDD discipline"),
+        PluginSkill("superpowers", "systematic-debugging", "Debug systematically"),
+        PluginSkill(
+            "superpowers", "verification-before-completion", "Verify before done"
+        ),
+        PluginSkill("superpowers", "writing-plans", "Write structured plans"),
+        PluginSkill("code-review", "code-review", "Review a PR"),
+        PluginSkill("code-simplifier", "simplify", "Simplify code"),
+        PluginSkill("frontend-design", "frontend-design", "Design frontend"),
+    ]
+
+
 class TestImplementSkillInjection:
     """Verify plugin skills are injected into the implement prompt."""
 
@@ -34,13 +57,18 @@ class TestImplementSkillInjection:
         from plugin_skill_registry import PluginSkill
         from tests.conftest import TaskFactory
 
+        # Use skills that are in the agent whitelist
         fake_skills = [
             PluginSkill(
                 "superpowers",
                 "test-driven-development",
                 "Use when implementing a feature",
             ),
-            PluginSkill("code-review", "code-review", "Review a PR"),
+            PluginSkill(
+                "superpowers",
+                "systematic-debugging",
+                "Debug systematically",
+            ),
         ]
 
         issue = TaskFactory.create(id=1, title="t", body="b")
@@ -50,7 +78,7 @@ class TestImplementSkillInjection:
             prompt, _ = await runner._build_prompt_with_stats(issue)
 
         assert "superpowers:test-driven-development" in prompt
-        assert "code-review:code-review" in prompt
+        assert "superpowers:systematic-debugging" in prompt
         assert "## Available Skills" in prompt
 
     @pytest.mark.asyncio
@@ -69,6 +97,32 @@ class TestImplementSkillInjection:
 
         assert "## Available Skills" not in prompt
 
+    @pytest.mark.asyncio
+    async def test_agent_prompt_includes_only_agent_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Agent prompt shows its whitelist and excludes reviewer-only skills."""
+        from agent import AgentRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        runner = AgentRunner(config, event_bus)
+
+        with patch("agent.discover_plugin_skills", return_value=_all_phase_skills()):
+            prompt, _ = await runner._build_prompt_with_stats(issue)
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # agent whitelist skills present
+        assert "superpowers:test-driven-development" in prompt
+        assert "superpowers:systematic-debugging" in prompt
+        assert "superpowers:verification-before-completion" in prompt
+        assert "code-simplifier:simplify" in prompt
+        assert "frontend-design:frontend-design" in prompt
+        # reviewer-only skill must NOT appear
+        assert "code-review:code-review" not in prompt
+
 
 class TestReviewSkillInjection:
     """Verify plugin skills are injected into the review prompt."""
@@ -83,12 +137,13 @@ class TestReviewSkillInjection:
         from reviewer import ReviewRunner
         from tests.conftest import TaskFactory
 
+        # Use skills that are in the reviewer whitelist
         fake_skills = [
             PluginSkill("code-review", "code-review", "Review a PR"),
             PluginSkill(
                 "superpowers",
-                "receiving-code-review",
-                "Use when receiving review feedback",
+                "systematic-debugging",
+                "Debug systematically",
             ),
         ]
 
@@ -102,7 +157,7 @@ class TestReviewSkillInjection:
             )
 
         assert "code-review:code-review" in prompt
-        assert "superpowers:receiving-code-review" in prompt
+        assert "superpowers:systematic-debugging" in prompt
         assert "## Available Skills" in prompt
 
     @pytest.mark.asyncio
@@ -123,6 +178,33 @@ class TestReviewSkillInjection:
 
         assert "## Available Skills" not in prompt
 
+    @pytest.mark.asyncio
+    async def test_reviewer_prompt_includes_only_reviewer_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Reviewer prompt shows its whitelist and excludes agent-only skills."""
+        from models import PRInfo
+        from reviewer import ReviewRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        pr = PRInfo(number=1, issue_number=1, branch="feat/test")
+        reviewer = ReviewRunner(config, event_bus)
+
+        with patch("reviewer.discover_plugin_skills", return_value=_all_phase_skills()):
+            prompt, _ = await reviewer._build_review_prompt_with_stats(
+                pr, issue, diff="diff --git a/x b/x\n+foo\n"
+            )
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # reviewer whitelist skills present
+        assert "code-review:code-review" in prompt
+        assert "superpowers:systematic-debugging" in prompt
+        # agent-only skill must NOT appear
+        assert "superpowers:test-driven-development" not in prompt
+
 
 class TestTriageSkillInjection:
     """Verify plugin skills are injected into the triage prompt."""
@@ -133,10 +215,9 @@ class TestTriageSkillInjection:
         from tests.conftest import TaskFactory
         from triage import TriageRunner
 
+        # Use a skill that is in the triage whitelist
         fake_skills = [
-            PluginSkill(
-                "superpowers", "brainstorming", "Use when starting creative work"
-            )
+            PluginSkill("superpowers", "systematic-debugging", "Debug systematically")
         ]
 
         issue = TaskFactory.create(id=1, title="Vague idea", body="do stuff")
@@ -145,8 +226,29 @@ class TestTriageSkillInjection:
         with patch("triage.discover_plugin_skills", return_value=fake_skills):
             prompt, _ = triager._build_prompt_with_stats(issue)
 
-        assert "superpowers:brainstorming" in prompt
+        assert "superpowers:systematic-debugging" in prompt
         assert "## Available Skills" in prompt
+
+    def test_triage_prompt_includes_only_triage_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Triage prompt shows its whitelist and excludes agent-only skills."""
+        from tests.conftest import TaskFactory
+        from triage import TriageRunner
+
+        issue = TaskFactory.create(id=1, title="Vague idea", body="do stuff")
+        triager = TriageRunner(config, event_bus)
+
+        with patch("triage.discover_plugin_skills", return_value=_all_phase_skills()):
+            prompt, _ = triager._build_prompt_with_stats(issue)
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # triage whitelist skill present
+        assert "superpowers:systematic-debugging" in prompt
+        # agent-only skill must NOT appear
+        assert "superpowers:test-driven-development" not in prompt
 
 
 class TestPlannerSkillInjection:
@@ -174,6 +276,29 @@ class TestPlannerSkillInjection:
         assert "superpowers:writing-plans" in prompt
         assert "## Available Skills" in prompt
 
+    @pytest.mark.asyncio
+    async def test_planner_prompt_includes_only_planner_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Planner prompt shows its whitelist and excludes reviewer-only skills."""
+        from planner import PlannerRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="t", body="b")
+        planner = PlannerRunner(config, event_bus)
+
+        with patch("planner.discover_plugin_skills", return_value=_all_phase_skills()):
+            prompt, _ = await planner._build_prompt_with_stats(issue)
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # planner whitelist skills present
+        assert "superpowers:writing-plans" in prompt
+        assert "superpowers:systematic-debugging" in prompt
+        # reviewer-only skill must NOT appear
+        assert "code-review:code-review" not in prompt
+
 
 class TestDiscoverSkillInjection:
     """Verify plugin skills are injected into the discover prompt."""
@@ -184,10 +309,9 @@ class TestDiscoverSkillInjection:
         from plugin_skill_registry import PluginSkill
         from tests.conftest import TaskFactory
 
+        # Use a skill that is in the discover whitelist
         fake_skills = [
-            PluginSkill(
-                "superpowers", "brainstorming", "Use when starting creative work"
-            )
+            PluginSkill("superpowers", "systematic-debugging", "Debug systematically")
         ]
 
         issue = TaskFactory.create(id=1, title="build something", body="vague")
@@ -196,8 +320,31 @@ class TestDiscoverSkillInjection:
         with patch("discover_runner.discover_plugin_skills", return_value=fake_skills):
             prompt = runner._build_prompt(issue)
 
-        assert "superpowers:brainstorming" in prompt
+        assert "superpowers:systematic-debugging" in prompt
         assert "## Available Skills" in prompt
+
+    def test_discover_prompt_includes_only_discover_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Discover prompt shows its whitelist and excludes agent-only skills."""
+        from discover_runner import DiscoverRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="build something", body="vague")
+        runner = DiscoverRunner(config, event_bus)
+
+        with patch(
+            "discover_runner.discover_plugin_skills", return_value=_all_phase_skills()
+        ):
+            prompt = runner._build_prompt(issue)
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # discover whitelist skill present
+        assert "superpowers:systematic-debugging" in prompt
+        # agent-only skill must NOT appear
+        assert "superpowers:test-driven-development" not in prompt
 
 
 class TestShapeSkillInjection:
@@ -210,10 +357,9 @@ class TestShapeSkillInjection:
         from shape_runner import ShapeRunner
         from tests.conftest import TaskFactory
 
+        # Use a skill that is in the shape whitelist
         fake_skills = [
-            PluginSkill(
-                "superpowers", "brainstorming", "Use when starting creative work"
-            )
+            PluginSkill("superpowers", "writing-plans", "Use when writing a plan")
         ]
 
         issue = TaskFactory.create(id=1, title="shape this", body="rough idea")
@@ -223,5 +369,30 @@ class TestShapeSkillInjection:
         with patch("shape_runner.discover_plugin_skills", return_value=fake_skills):
             prompt = runner._build_turn_prompt(issue, conversation)
 
-        assert "superpowers:brainstorming" in prompt
+        assert "superpowers:writing-plans" in prompt
         assert "## Available Skills" in prompt
+
+    def test_shape_prompt_includes_only_shape_whitelisted_skills(
+        self, config, event_bus
+    ) -> None:
+        """Shape prompt shows its whitelist and excludes reviewer-only skills."""
+        from models import ShapeConversation
+        from shape_runner import ShapeRunner
+        from tests.conftest import TaskFactory
+
+        issue = TaskFactory.create(id=1, title="shape this", body="rough idea")
+        conversation = ShapeConversation(issue_number=1)
+        runner = ShapeRunner(config, event_bus)
+
+        with patch(
+            "shape_runner.discover_plugin_skills", return_value=_all_phase_skills()
+        ):
+            prompt = runner._build_turn_prompt(issue, conversation)
+
+        assert "## Available Skills" in prompt
+        # 1% confidence preamble
+        assert "1% confidence" in prompt
+        # shape whitelist skill present
+        assert "superpowers:writing-plans" in prompt
+        # reviewer-only skill must NOT appear
+        assert "code-review:code-review" not in prompt

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -189,6 +189,28 @@ def test_format_plugin_skills_for_prompt_empty_returns_empty_string():
     assert format_plugin_skills_for_prompt([]) == ""
 
 
+def test_format_plugin_skills_for_prompt_renders_every_skill_as_bullet():
+    skills = [
+        PluginSkill(
+            plugin="superpowers",
+            name="test-driven-development",
+            description="Use when implementing any feature or bugfix",
+        ),
+        PluginSkill(
+            plugin="code-review",
+            name="code-review",
+            description="Review a pull request",
+        ),
+    ]
+    out = format_plugin_skills_for_prompt(skills)
+    # Both qualified names rendered as bullets.
+    assert "- **superpowers:test-driven-development** —" in out
+    assert "- **code-review:code-review** —" in out
+    # Descriptions passed through verbatim (not reordered, not rewritten).
+    assert "Use when implementing any feature or bugfix" in out
+    assert "Review a pull request" in out
+
+
 class TestDiscoveryCache:
     """Verify discover_plugin_skills caches results and clear_plugin_skill_cache resets state."""
 

--- a/tests/test_plugin_skill_registry.py
+++ b/tests/test_plugin_skill_registry.py
@@ -163,49 +163,30 @@ class TestPluginSkillQualifiedName:
         assert skill.qualified_name == "superpowers:brainstorming"
 
 
-class TestFormatPluginSkillsForPrompt:
-    """Verify format_plugin_skills_for_prompt emits the expected prompt section."""
+def test_format_plugin_skills_for_prompt_carries_discipline_preamble():
+    skills = [
+        PluginSkill(
+            plugin="superpowers",
+            name="test-driven-development",
+            description="Use when implementing any feature or bugfix",
+        ),
+    ]
+    out = format_plugin_skills_for_prompt(skills)
+    assert "## Available Skills" in out
+    # Discipline phrasing — subagents need the 1% rule.
+    assert "1% confidence" in out
+    assert "MUST invoke" in out
+    assert "Process skills first" in out
+    assert "Implementation skills second" in out
+    # Skill body still rendered verbatim from frontmatter.
+    assert (
+        "**superpowers:test-driven-development** — Use when implementing any feature or bugfix"
+        in out
+    )
 
-    def test_contains_skills_header(self) -> None:
-        """Output begins with a markdown section header."""
-        skills = [PluginSkill("superpowers", "brainstorming", "Use when...")]
-        assert "## Available Skills" in format_plugin_skills_for_prompt(skills)
 
-    def test_contains_qualified_names(self) -> None:
-        """Each skill's qualified_name appears verbatim."""
-        skills = [
-            PluginSkill(
-                "superpowers", "brainstorming", "Use when starting creative work"
-            ),
-            PluginSkill("code-review", "code-review", "Review a PR"),
-        ]
-        output = format_plugin_skills_for_prompt(skills)
-        assert "superpowers:brainstorming" in output
-        assert "code-review:code-review" in output
-
-    def test_contains_descriptions(self) -> None:
-        """Each skill's description appears in the output."""
-        skills = [
-            PluginSkill(
-                "superpowers",
-                "brainstorming",
-                "Use when starting creative work",
-            )
-        ]
-        assert "Use when starting creative work" in format_plugin_skills_for_prompt(
-            skills
-        )
-
-    def test_empty_list_returns_empty_string(self) -> None:
-        """Empty skill list produces an empty string (no header)."""
-        assert format_plugin_skills_for_prompt([]) == ""
-
-    def test_mentions_skill_tool_usage(self) -> None:
-        """Output tells the agent to invoke the Skill tool by qualified name."""
-        skills = [PluginSkill("superpowers", "brainstorming", "Use when...")]
-        output = format_plugin_skills_for_prompt(skills)
-        assert "`Skill` tool" in output
-        assert "qualified name" in output
+def test_format_plugin_skills_for_prompt_empty_returns_empty_string():
+    assert format_plugin_skills_for_prompt([]) == ""
 
 
 class TestDiscoveryCache:

--- a/tests/test_plugin_spec_parser.py
+++ b/tests/test_plugin_spec_parser.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from plugin_skill_registry import parse_plugin_spec
-
-DEFAULT_MARKETPLACE = "claude-plugins-official"
+from plugin_skill_registry import DEFAULT_MARKETPLACE, parse_plugin_spec
 
 
 def test_bare_name_gets_default_marketplace():

--- a/tests/test_plugin_spec_parser.py
+++ b/tests/test_plugin_spec_parser.py
@@ -1,28 +1,28 @@
-"""Tests for plugin_skill_registry._parse_plugin_spec."""
+"""Tests for plugin_skill_registry.parse_plugin_spec."""
 
 from __future__ import annotations
 
 import pytest
 
-from plugin_skill_registry import _parse_plugin_spec
+from plugin_skill_registry import parse_plugin_spec
 
 DEFAULT_MARKETPLACE = "claude-plugins-official"
 
 
 def test_bare_name_gets_default_marketplace():
-    assert _parse_plugin_spec("superpowers") == ("superpowers", DEFAULT_MARKETPLACE)
+    assert parse_plugin_spec("superpowers") == ("superpowers", DEFAULT_MARKETPLACE)
 
 
 def test_explicit_marketplace():
-    assert _parse_plugin_spec("craft-plugin@craft") == ("craft-plugin", "craft")
+    assert parse_plugin_spec("craft-plugin@craft") == ("craft-plugin", "craft")
 
 
 def test_whitespace_stripped():
-    assert _parse_plugin_spec("  superpowers  ") == ("superpowers", DEFAULT_MARKETPLACE)
-    assert _parse_plugin_spec("foo @ bar") == ("foo", "bar")
+    assert parse_plugin_spec("  superpowers  ") == ("superpowers", DEFAULT_MARKETPLACE)
+    assert parse_plugin_spec("foo @ bar") == ("foo", "bar")
 
 
 @pytest.mark.parametrize("spec", ["", "@market", "name@", "a@b@c"])
 def test_malformed_raises(spec: str):
     with pytest.raises(ValueError):
-        _parse_plugin_spec(spec)
+        parse_plugin_spec(spec)

--- a/tests/test_plugin_spec_parser.py
+++ b/tests/test_plugin_spec_parser.py
@@ -1,0 +1,28 @@
+"""Tests for plugin_skill_registry._parse_plugin_spec."""
+
+from __future__ import annotations
+
+import pytest
+
+from plugin_skill_registry import _parse_plugin_spec
+
+DEFAULT_MARKETPLACE = "claude-plugins-official"
+
+
+def test_bare_name_gets_default_marketplace():
+    assert _parse_plugin_spec("superpowers") == ("superpowers", DEFAULT_MARKETPLACE)
+
+
+def test_explicit_marketplace():
+    assert _parse_plugin_spec("craft-plugin@craft") == ("craft-plugin", "craft")
+
+
+def test_whitespace_stripped():
+    assert _parse_plugin_spec("  superpowers  ") == ("superpowers", DEFAULT_MARKETPLACE)
+    assert _parse_plugin_spec("foo @ bar") == ("foo", "bar")
+
+
+@pytest.mark.parametrize("spec", ["", "@market", "name@", "a@b@c"])
+def test_malformed_raises(spec: str):
+    with pytest.raises(ValueError):
+        _parse_plugin_spec(spec)

--- a/tests/test_preflight_install.py
+++ b/tests/test_preflight_install.py
@@ -36,7 +36,7 @@ def test_auto_install_runs_claude_for_missing_plugin(tmp_path: Path):
         auto_install_plugins=True,
     )
 
-    def fake_run(argv, **kwargs):
+    def fake_run(argv, **_kwargs):
         # Simulate install by populating the cache, then return success.
         assert argv == [
             "claude",
@@ -62,7 +62,7 @@ def test_auto_install_failure_falls_through_to_rich_fail(tmp_path: Path):
         auto_install_plugins=True,
     )
 
-    def fake_run(argv, **kwargs):
+    def fake_run(argv, **_kwargs):
         # Install "succeeds" but plugin still isn't in the cache.
         return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
 
@@ -122,7 +122,7 @@ def test_explicit_marketplace_in_spec(tmp_path: Path):
         auto_install_plugins=True,
     )
 
-    def fake_run(argv, **kwargs):
+    def fake_run(argv, **_kwargs):
         assert argv == [
             "claude",
             "plugin",

--- a/tests/test_preflight_install.py
+++ b/tests/test_preflight_install.py
@@ -11,6 +11,7 @@ import pytest
 from config import HydraFlowConfig
 from plugin_skill_registry import clear_plugin_skill_cache
 from preflight import CheckStatus, _check_plugins
+from tests.conftest import write_plugin_skill as _write_skill
 
 
 @pytest.fixture(autouse=True)
@@ -18,16 +19,6 @@ def _clear_caches():
     clear_plugin_skill_cache()
     yield
     clear_plugin_skill_cache()
-
-
-def _write_fake_skill(
-    cache_root: Path, marketplace: str, plugin: str, skill: str
-) -> None:
-    skill_dir = cache_root / marketplace / plugin / "1.0.0" / "skills" / skill
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    (skill_dir / "SKILL.md").write_text(
-        f"---\nname: {skill}\ndescription: test skill\n---\nbody\n"
-    )
 
 
 def test_auto_install_runs_claude_for_missing_plugin(tmp_path: Path):
@@ -46,7 +37,7 @@ def test_auto_install_runs_claude_for_missing_plugin(tmp_path: Path):
             "--scope",
             "user",
         ]
-        _write_fake_skill(tmp_path, "claude-plugins-official", "superpowers", "tdd")
+        _write_skill(tmp_path, "claude-plugins-official", "superpowers", "tdd")
         return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
 
     with patch("preflight.subprocess.run", side_effect=fake_run) as mock_run:
@@ -131,7 +122,7 @@ def test_explicit_marketplace_in_spec(tmp_path: Path):
             "--scope",
             "user",
         ]
-        _write_fake_skill(tmp_path, "custom-marketplace", "foo", "bar")
+        _write_skill(tmp_path, "custom-marketplace", "foo", "bar")
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
     with patch("preflight.subprocess.run", side_effect=fake_run):

--- a/tests/test_preflight_install.py
+++ b/tests/test_preflight_install.py
@@ -1,0 +1,140 @@
+"""Tests for the boot-time install branch of preflight._check_plugins."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from config import HydraFlowConfig
+from plugin_skill_registry import clear_plugin_skill_cache
+from preflight import CheckStatus, _check_plugins
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    clear_plugin_skill_cache()
+    yield
+    clear_plugin_skill_cache()
+
+
+def _write_fake_skill(
+    cache_root: Path, marketplace: str, plugin: str, skill: str
+) -> None:
+    skill_dir = cache_root / marketplace / plugin / "1.0.0" / "skills" / skill
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {skill}\ndescription: test skill\n---\nbody\n"
+    )
+
+
+def test_auto_install_runs_claude_for_missing_plugin(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        auto_install_plugins=True,
+    )
+
+    def fake_run(argv, **kwargs):
+        # Simulate install by populating the cache, then return success.
+        assert argv == [
+            "claude",
+            "plugin",
+            "install",
+            "superpowers@claude-plugins-official",
+            "--scope",
+            "user",
+        ]
+        _write_fake_skill(tmp_path, "claude-plugins-official", "superpowers", "tdd")
+        return subprocess.CompletedProcess(argv, 0, stdout="ok", stderr="")
+
+    with patch("preflight.subprocess.run", side_effect=fake_run) as mock_run:
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.PASS
+    assert mock_run.call_count == 1
+
+
+def test_auto_install_failure_falls_through_to_rich_fail(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        auto_install_plugins=True,
+    )
+
+    def fake_run(argv, **kwargs):
+        # Install "succeeds" but plugin still isn't in the cache.
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+
+    with patch("preflight.subprocess.run", side_effect=fake_run):
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.FAIL
+    assert "make install-plugins" in result.message
+    assert "claude login" in result.message
+
+
+def test_install_timeout_treated_as_failure(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        auto_install_plugins=True,
+    )
+
+    with patch(
+        "preflight.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=120),
+    ):
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.FAIL
+    assert "timed out" in result.message.lower()
+
+
+def test_claude_binary_missing_skips_install_and_fails(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        auto_install_plugins=True,
+    )
+
+    with patch("preflight.subprocess.run", side_effect=FileNotFoundError):
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.FAIL
+    assert "claude" in result.message.lower()
+
+
+def test_auto_install_disabled_matches_legacy_behavior(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["superpowers"],
+        auto_install_plugins=False,
+    )
+
+    with patch("preflight.subprocess.run") as mock_run:
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.FAIL
+    assert mock_run.call_count == 0  # never touched subprocess
+
+
+def test_explicit_marketplace_in_spec(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        required_plugins=["foo@custom-marketplace"],
+        auto_install_plugins=True,
+    )
+
+    def fake_run(argv, **kwargs):
+        assert argv == [
+            "claude",
+            "plugin",
+            "install",
+            "foo@custom-marketplace",
+            "--scope",
+            "user",
+        ]
+        _write_fake_skill(tmp_path, "custom-marketplace", "foo", "bar")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    with patch("preflight.subprocess.run", side_effect=fake_run):
+        result = _check_plugins(cfg, cache_root=tmp_path)
+
+    assert result.status == CheckStatus.PASS

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -163,7 +163,7 @@ class TestRunPreflightChecksWiring:
     ) -> None:
         """run_preflight_checks invokes _check_plugins with the shared default cache root.
 
-        Isolated by monkeypatching plugin_skill_registry._DEFAULT_CACHE_ROOT so the
+        Isolated by monkeypatching plugin_skill_registry.DEFAULT_CACHE_ROOT so the
         test does not depend on the developer's real ~/.claude/plugins/cache.
         """
         import plugin_skill_registry
@@ -172,7 +172,7 @@ class TestRunPreflightChecksWiring:
         cache_root = tmp_path / "cache"
         cache_root.mkdir()
         _make_plugin(cache_root, "superpowers")
-        monkeypatch.setattr(plugin_skill_registry, "_DEFAULT_CACHE_ROOT", cache_root)
+        monkeypatch.setattr(plugin_skill_registry, "DEFAULT_CACHE_ROOT", cache_root)
 
         config = HydraFlowConfig(
             required_plugins=["superpowers"],

--- a/tests/test_preflight_plugins.py
+++ b/tests/test_preflight_plugins.py
@@ -51,18 +51,23 @@ class TestCheckPlugins:
         assert result.status == CheckStatus.PASS
 
     def test_fails_when_tier1_plugin_missing(self, cache_root: Path) -> None:
-        """FAIL when a Tier-1 plugin directory is not present."""
+        """FAIL when a Tier-1 plugin directory is not present.
+
+        With ``auto_install_plugins=False`` the check must not touch subprocess
+        and falls through to the rich manual-fix FAIL message.
+        """
         _make_plugin(cache_root, "superpowers")
 
         config = HydraFlowConfig(
             required_plugins=["superpowers", "code-review"],
             language_plugins={},
+            auto_install_plugins=False,
         )
         result = _check_plugins(config, cache_root=cache_root, detected_languages=set())
 
         assert result.status == CheckStatus.FAIL
         assert "code-review" in result.message
-        assert "/plugin install" in result.message
+        assert "claude plugin install" in result.message
 
     def test_fails_when_zero_skills_discovered(self, cache_root: Path) -> None:
         """FAIL when the allowlisted plugin has no skills."""
@@ -80,12 +85,17 @@ class TestCheckPlugins:
     def test_warns_when_tier2_missing_and_language_detected(
         self, cache_root: Path
     ) -> None:
-        """WARN when a language-conditional plugin is missing for a detected language."""
+        """WARN when a language-conditional plugin is missing for a detected language.
+
+        ``auto_install_plugins=False`` keeps this a pure unit test — we do not
+        want to shell out to ``claude plugin install`` here.
+        """
         _make_plugin(cache_root, "superpowers")
 
         config = HydraFlowConfig(
             required_plugins=["superpowers"],
             language_plugins={"python": ["pyright-lsp"]},
+            auto_install_plugins=False,
         )
         result = _check_plugins(
             config, cache_root=cache_root, detected_languages={"python"}
@@ -123,12 +133,17 @@ class TestCheckPlugins:
         assert "not a directory" in result.message
 
     def test_warn_message_includes_language_context(self, cache_root: Path) -> None:
-        """WARN message identifies which language triggered the missing plugin."""
+        """WARN message identifies which language triggered the missing plugin.
+
+        ``auto_install_plugins=False`` keeps this a pure unit test — we do not
+        want to shell out to ``claude plugin install`` here.
+        """
         _make_plugin(cache_root, "superpowers")
 
         config = HydraFlowConfig(
             required_plugins=["superpowers"],
             language_plugins={"python": ["pyright-lsp"]},
+            auto_install_plugins=False,
         )
         result = _check_plugins(
             config, cache_root=cache_root, detected_languages={"python"}


### PR DESCRIPTION
## Summary

Three coordinated extensions to PR #8348's plugin skill registry, landing together because they depend on each other. Full rationale in [ADR-0043](docs/adr/0043-dynamic-plugin-skill-loading.md).

- **Boot-time install** — `preflight._check_plugins` now runs `claude plugin install name@marketplace --scope user` for missing Tier-1/Tier-2 plugins before failing. Gated by new `auto_install_plugins: bool = True` config flag. Falls through to a rich FAIL (with `make install-plugins` + `claude login` hints) only if install itself fails.
- **Prompt alignment** — `format_plugin_skills_for_prompt` now carries a condensed `superpowers:using-superpowers` discipline preamble: "even at 1% confidence you MUST invoke", process-before-implementation priority, explicit rationalization warning. Subagents now apply the same skill-picking rigor the main Claude session has.
- **Per-phase whitelist** — new `phase_skills: dict[str, list[str]]` config field; each of six runners (`agent`, `planner`, `reviewer`, `triage`, `discover`, `shape`) filters discovery through its whitelist via a new `skills_for_phase` helper. `PHASE_NAMES` frozenset + pydantic validator reject unknown phase keys.

Also: `src/install_plugins_cli.py` + `make install-plugins` target as the deterministic manual fallback. CLI distinguishes Tier-1 (required → exit 1) from Tier-2 (language-conditional → warning only), matching preflight semantics.

## Module API changes

Three symbols promoted from module-private to public (cross-module consumers need them):
- `_parse_plugin_spec` → `parse_plugin_spec`
- `_install_plugin` → `install_plugin`
- `_plugin_exists` → `plugin_exists`
- `_DEFAULT_CACHE_ROOT` → `DEFAULT_CACHE_ROOT`
- New exports: `DEFAULT_MARKETPLACE`, `PHASE_NAMES`, `skills_for_phase`

## Test plan

- [x] \`make quality\` passes: 11,017 tests / 3 skipped / 231 xfailed / 0 failures, exit 0.
- [x] New test files (all green): \`test_plugin_spec_parser.py\`, \`test_phase_skill_filter.py\`, \`test_config_phase_skills.py\`, \`test_preflight_install.py\`, \`test_install_plugins_cli.py\`.
- [x] Updated: \`test_phase_skill_injection.py\` (per-runner whitelist + cross-phase exclusion), \`test_plugin_skill_registry.py\` (new preamble assertions), \`test_preflight_plugins.py\` (explicit \`auto_install_plugins=False\` where previously implicit).

Manual verification (for reviewer):
- [ ] Fresh \`~/.claude/plugins/cache/claude-plugins-official/\` → \`python -m server\` installs plugins and starts.
- [ ] \`auto_install_plugins=False\` + missing plugin → FAIL with \`make install-plugins\` hint (new header: \"Required plugins missing\" not \"Plugin install failed\").
- [ ] \`claude\` binary absent from \$PATH → FAIL includes \"claude binary not found\".
- [ ] Dump a runner's prompt (via \`HYDRAFLOW_DEBUG_PROMPTS=1\` or equivalent) and confirm the phase-filtered skill list + \"1% confidence\" preamble.

## Known follow-ups (out of scope)

- Version pinning (\`name@marketplace@version\`) — deferred per ADR-0043.
- Auto-marketplace add — deferred per ADR-0043.
- Scenario-framework coverage proving subagents actually invoke advertised skills — belongs in \`docs/scenarios/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)