### PR TITLE
refactor(agent-cli): scan /opt/plugins dynamically + verify Skill tool chain

### DIFF
--- a/docs/adr/0043-dynamic-plugin-skill-loading.md
+++ b/docs/adr/0043-dynamic-plugin-skill-loading.md
@@ -56,6 +56,12 @@ Marketplace is expressed inline in `required_plugins` (`"name@marketplace"`), de
 
 **Per-phase allowlist as metadata in each `SKILL.md`.** Requires patching upstream plugins or shadowing their frontmatter. Our allowlist is a HydraFlow opinion, so it belongs in HydraFlow config, not in plugin metadata.
 
+## Verification
+
+**Host mode (2026-04-21):** probed by running `claude -p --output-format stream-json --verbose --permission-mode bypassPermissions --model claude-sonnet-4-6 --max-turns 3` with a prompt instructing the model to invoke `superpowers:systematic-debugging` via the `Skill` tool. Output stream included a `tool_use` event with `"name":"Skill","input":{"skill":"superpowers:systematic-debugging"}`, confirming the Skill tool is exposed in `-p` mode and routes to installed plugins discovered from `~/.claude/plugins/cache/`.
+
+**Docker mode (not separately probed):** `src/docker_runner.py:430-435` mounts the host's `~/.claude/` into the container at `/home/hydraflow/.claude/` (rw) and sets `CLAUDE_CONFIG_DIR=/home/hydraflow/.claude`. Claude's plugin discovery reads the same filesystem layout via that env var, so the host probe's conclusions extend to Docker subagents. Additional `--plugin-dir /opt/plugins/*` flags are emitted dynamically by `agent_cli._plugin_dir_flags()` (see test `tests/test_agent_cli_plugin_dirs.py`) for plugins pre-cloned at image build time.
+
 ## References
 
 - Spec: [`docs/superpowers/specs/2026-04-20-dynamic-skill-loading-design.md`](../superpowers/specs/2026-04-20-dynamic-skill-loading-design.md)

--- a/src/agent_cli.py
+++ b/src/agent_cli.py
@@ -7,21 +7,27 @@ from typing import Literal
 
 AgentTool = Literal["claude", "codex", "pi"]
 
-# Pre-cloned plugin directories baked into the Docker image.
-# Each entry becomes a ``--plugin-dir <path>`` flag on Claude CLI invocations.
-_DOCKER_PLUGIN_DIRS: tuple[str, ...] = (
-    "/opt/plugins/claude-plugins-official",
-    "/opt/plugins/superpowers",
-    "/opt/plugins/lightfactory",
-)
+# Base directory for plugins pre-cloned into the Docker image at build time
+# (see Dockerfile.agent-base). Each subdirectory is passed as ``--plugin-dir``
+# so the Claude CLI loads it for the session. On host machines this path
+# doesn't exist and no flags are emitted — host-installed plugins are
+# discovered via the default ``~/.claude/plugins/cache/`` path.
+_PRE_CLONED_PLUGIN_ROOT = Path("/opt/plugins")
 
 
 def _plugin_dir_flags() -> list[str]:
-    """Return ``--plugin-dir`` flags for plugin dirs that exist on disk."""
+    """Return ``--plugin-dir`` flags for every pre-cloned plugin directory.
+
+    Scans ``/opt/plugins/*`` dynamically so new plugins added to
+    ``Dockerfile.agent-base`` don't require a parallel edit here. Returns
+    an empty list when the root doesn't exist (host machines).
+    """
+    if not _PRE_CLONED_PLUGIN_ROOT.is_dir():
+        return []
     flags: list[str] = []
-    for d in _DOCKER_PLUGIN_DIRS:
-        if Path(d).is_dir():
-            flags.extend(["--plugin-dir", d])
+    for entry in sorted(_PRE_CLONED_PLUGIN_ROOT.iterdir()):
+        if entry.is_dir():
+            flags.extend(["--plugin-dir", str(entry)])
     return flags
 
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -293,65 +293,77 @@ class TestBuildLightweightCommand:
 class TestPluginDirFlags:
     """Tests for plugin directory injection into Claude commands."""
 
-    def test_plugin_dir_flags_returns_empty_when_dirs_missing(self) -> None:
-        """No flags when plugin directories don't exist on disk."""
+    def test_plugin_dir_flags_returns_empty_when_root_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """No flags when plugin root directory doesn't exist on disk."""
         from unittest.mock import patch
 
-        from agent_cli import _plugin_dir_flags
+        import agent_cli
 
-        with patch("agent_cli.Path.is_dir", return_value=False):
-            assert _plugin_dir_flags() == []
+        with patch.object(
+            agent_cli, "_PRE_CLONED_PLUGIN_ROOT", tmp_path / "does-not-exist"
+        ):
+            assert agent_cli._plugin_dir_flags() == []
 
-    def test_plugin_dir_flags_includes_existing_dirs(self, tmp_path: Path) -> None:
-        """Flags should include only directories that exist."""
+    def test_plugin_dir_flags_includes_existing_subdirs(self, tmp_path: Path) -> None:
+        """Flags should include subdirectories that exist under the root."""
         from unittest.mock import patch
 
-        from agent_cli import _plugin_dir_flags
+        import agent_cli
 
-        fake_dir = str(tmp_path / "lightfactory")
-        (tmp_path / "lightfactory").mkdir()
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "lightfactory").mkdir()
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (fake_dir,)):
-            flags = _plugin_dir_flags()
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
+            flags = agent_cli._plugin_dir_flags()
 
-        assert flags == ["--plugin-dir", fake_dir]
+        assert flags == ["--plugin-dir", str(root / "lightfactory")]
 
-    def test_plugin_dir_flags_skips_missing_dirs(self, tmp_path: Path) -> None:
-        """Directories that don't exist should be skipped."""
+    def test_plugin_dir_flags_excludes_files(self, tmp_path: Path) -> None:
+        """Non-directory entries (files) under the root should be skipped."""
         from unittest.mock import patch
 
-        from agent_cli import _plugin_dir_flags
+        import agent_cli
 
-        existing = str(tmp_path / "exists")
-        (tmp_path / "exists").mkdir()
-        missing = str(tmp_path / "missing")
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "real-plugin").mkdir()
+        (root / "README.md").write_text("not a plugin dir")
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (existing, missing)):
-            flags = _plugin_dir_flags()
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
+            flags = agent_cli._plugin_dir_flags()
 
-        assert flags == ["--plugin-dir", existing]
+        assert flags == ["--plugin-dir", str(root / "real-plugin")]
 
     def test_claude_agent_command_includes_plugin_dirs(self, tmp_path: Path) -> None:
         """build_agent_command for claude should include --plugin-dir flags."""
         from unittest.mock import patch
 
-        fake_dir = str(tmp_path / "superpowers")
-        (tmp_path / "superpowers").mkdir()
+        import agent_cli
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (fake_dir,)):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "superpowers").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
             cmd = build_agent_command(tool="claude", model="sonnet")
 
         assert "--plugin-dir" in cmd
-        assert cmd[cmd.index("--plugin-dir") + 1] == fake_dir
+        assert cmd[cmd.index("--plugin-dir") + 1] == str(root / "superpowers")
 
     def test_codex_command_does_not_include_plugin_dirs(self, tmp_path: Path) -> None:
         """Codex commands should not include --plugin-dir flags."""
         from unittest.mock import patch
 
-        fake_dir = str(tmp_path / "superpowers")
-        (tmp_path / "superpowers").mkdir()
+        import agent_cli
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (fake_dir,)):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "superpowers").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
             cmd = build_agent_command(tool="codex", model="o4-mini")
 
         assert "--plugin-dir" not in cmd
@@ -360,33 +372,37 @@ class TestPluginDirFlags:
         """build_lightweight_command for claude should include --plugin-dir flags."""
         from unittest.mock import patch
 
-        fake_dir = str(tmp_path / "lightfactory")
-        (tmp_path / "lightfactory").mkdir()
+        import agent_cli
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (fake_dir,)):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "lightfactory").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
             cmd, _ = build_lightweight_command(
                 tool="claude", model="sonnet", prompt="test"
             )
 
         assert "--plugin-dir" in cmd
-        assert cmd[cmd.index("--plugin-dir") + 1] == fake_dir
+        assert cmd[cmd.index("--plugin-dir") + 1] == str(root / "lightfactory")
 
     def test_lightweight_pi_excludes_plugin_dirs(self, tmp_path: Path) -> None:
         """build_lightweight_command for pi should not include --plugin-dir flags."""
         from unittest.mock import patch
 
-        fake_dir = str(tmp_path / "lightfactory")
-        (tmp_path / "lightfactory").mkdir()
+        import agent_cli
 
-        with patch("agent_cli._DOCKER_PLUGIN_DIRS", (fake_dir,)):
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "lightfactory").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
             cmd, _ = build_lightweight_command(tool="pi", model="pi-max", prompt="test")
 
         assert "--plugin-dir" not in cmd
 
-    def test_docker_plugin_dirs_constant_has_expected_entries(self) -> None:
-        """The constant should list all three plugin repos."""
-        from agent_cli import _DOCKER_PLUGIN_DIRS
+    def test_pre_cloned_plugin_root_points_at_opt_plugins(self) -> None:
+        """The constant should point at /opt/plugins (where Dockerfile bakes plugins)."""
+        from agent_cli import _PRE_CLONED_PLUGIN_ROOT
 
-        assert len(_DOCKER_PLUGIN_DIRS) == 3
-        paths = {d.rsplit("/", 1)[-1] for d in _DOCKER_PLUGIN_DIRS}
-        assert paths == {"claude-plugins-official", "superpowers", "lightfactory"}
+        assert Path("/opt/plugins") == _PRE_CLONED_PLUGIN_ROOT

--- a/tests/test_agent_cli_plugin_dirs.py
+++ b/tests/test_agent_cli_plugin_dirs.py
@@ -1,0 +1,68 @@
+"""Tests for agent_cli._plugin_dir_flags — dynamic --plugin-dir emission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import agent_cli
+
+
+def _with_plugin_root(root: Path):
+    """Patch the module's _PRE_CLONED_PLUGIN_ROOT to point at ``root``."""
+    return patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root)
+
+
+def test_missing_root_emits_no_flags(tmp_path: Path):
+    # tmp_path exists but we point at a child that doesn't.
+    with _with_plugin_root(tmp_path / "does-not-exist"):
+        assert agent_cli._plugin_dir_flags() == []
+
+
+def test_root_not_a_directory_emits_no_flags(tmp_path: Path):
+    # Path exists but is a file, not a directory.
+    file_path = tmp_path / "plugins-not-dir"
+    file_path.write_text("")
+    with _with_plugin_root(file_path):
+        assert agent_cli._plugin_dir_flags() == []
+
+
+def test_empty_root_emits_no_flags(tmp_path: Path):
+    root = tmp_path / "plugins"
+    root.mkdir()
+    with _with_plugin_root(root):
+        assert agent_cli._plugin_dir_flags() == []
+
+
+def test_emits_flag_for_each_subdirectory_sorted(tmp_path: Path):
+    root = tmp_path / "plugins"
+    root.mkdir()
+    for name in ["superpowers", "claude-plugins-official", "lightfactory"]:
+        (root / name).mkdir()
+    with _with_plugin_root(root):
+        flags = agent_cli._plugin_dir_flags()
+    # Alphabetical order, two tokens per plugin (--plugin-dir PATH).
+    assert flags == [
+        "--plugin-dir",
+        str(root / "claude-plugins-official"),
+        "--plugin-dir",
+        str(root / "lightfactory"),
+        "--plugin-dir",
+        str(root / "superpowers"),
+    ]
+
+
+def test_non_directory_entries_ignored(tmp_path: Path):
+    root = tmp_path / "plugins"
+    root.mkdir()
+    (root / "real-plugin").mkdir()
+    (root / "README.md").write_text("not a plugin dir")
+    with _with_plugin_root(root):
+        flags = agent_cli._plugin_dir_flags()
+    assert flags == ["--plugin-dir", str(root / "real-plugin")]
+
+
+def test_pre_cloned_root_constant_points_at_opt_plugins():
+    # Regression guard: Dockerfile.agent-base places plugins at /opt/plugins.
+    # Any change to that baked-in path must also update this constant.
+    assert Path("/opt/plugins") == agent_cli._PRE_CLONED_PLUGIN_ROOT


### PR DESCRIPTION
Follow-up to #8374. Two small improvements:

## 1. Dynamic scan of `/opt/plugins/*`

`agent_cli._DOCKER_PLUGIN_DIRS` was a hardcoded tuple of three pre-cloned plugin paths. Adding a new plugin to `Dockerfile.agent-base` required a parallel edit here — easy to forget. Replaced with a single `_PRE_CLONED_PLUGIN_ROOT = Path("/opt/plugins")` constant + dynamic `iterdir()` scan. No API changes.

## 2. End-to-end verification of the Skill-tool chain

Probed the merged #8374 feature against real `claude -p`:

\`\`\`
echo 'Use the Skill tool to invoke "superpowers:systematic-debugging"…' \
  | claude -p --output-format stream-json --verbose --permission-mode bypassPermissions …
\`\`\`

Stream included `"tool_use","name":"Skill","input":{"skill":"superpowers:systematic-debugging"}` — the Skill tool IS exposed in `-p` mode and routes to plugins discovered from `~/.claude/plugins/cache/`. Docker mode uses the same mechanism via host `~/.claude/` mount + `CLAUDE_CONFIG_DIR`. Documented in ADR-0043's new Verification section.

## Test plan
- [x] 6 new unit tests in \`tests/test_agent_cli_plugin_dirs.py\` (flag emission on various filesystem states).
- [x] 8 existing \`test_agent_cli.py\` plugin-dir tests updated for the new constant name.
- [x] \`make quality\` green: 11,038 passed, 0 failures, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)