### PR TITLE
docs(agents): 5 new avoided patterns + planner self-audit step

### DIFF
--- a/docs/agents/avoided-patterns.md
+++ b/docs/agents/avoided-patterns.md
@@ -103,6 +103,143 @@ if self._hindsight is None:
 
 **Why:** `Mock()` objects are truthy by default, but a `Mock()` configured with `spec=SomeClass` that has `__bool__` can be falsy, and ordinary values like empty lists or dicts trigger the wrong branch. Explicit `is None` makes the intent unambiguous and matches the type annotation contract (`X | None`).
 
+## Underscore-prefixed names imported across modules
+
+If a symbol is imported from another module, it is part of that module's public API and must not start with `_`. The leading underscore is Python's "module-internal" convention; crossing the boundary lies about the contract and trips pyright's `reportPrivateUsage` / unused-symbol warnings.
+
+**Wrong:**
+
+```python
+# src/plugin_skill_registry.py
+def _parse_plugin_spec(spec: str) -> tuple[str, str]: ...
+
+# src/preflight.py
+from plugin_skill_registry import _parse_plugin_spec  # crosses the boundary
+```
+
+**Right:**
+
+```python
+# src/plugin_skill_registry.py
+def parse_plugin_spec(spec: str) -> tuple[str, str]: ...
+
+# src/preflight.py
+from plugin_skill_registry import parse_plugin_spec
+```
+
+**Why:** Pyright flags private-symbol imports and "defined but not used" warnings for `_`-prefixed names whose only consumers are other modules. Promotion to public is also a signal to future readers that the symbol is a load-bearing contract, not an implementation detail.
+
+**How to check:** Any symbol imported across module boundaries must not start with `_`. If it does, rename or refactor in the same change.
+
+## Writing a new test helper without checking conftest
+
+Before adding a helper function to a test file, grep `tests/conftest.py` (and any `tests/helpers*.py`) for similar helpers. Shared test fixtures belong in conftest; duplicating a helper locally causes drift when one copy is updated and the other is not.
+
+**Wrong:**
+
+```python
+# tests/test_my_feature.py
+def _write_fake_skill(cache_root, marketplace, plugin, skill):
+    skill_dir = cache_root / marketplace / plugin / "1.0.0" / "skills" / skill
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {skill}\n---\nbody\n")
+```
+
+(while `tests/conftest.py:write_plugin_skill` already does exactly this.)
+
+**Right:**
+
+```python
+# tests/test_my_feature.py
+from tests.conftest import write_plugin_skill
+```
+
+**Why:** Duplicated helpers drift silently. If `write_plugin_skill` in conftest gains a new parameter or changes its on-disk layout, the local copy stays stale and tests pass against a fiction.
+
+**How to check:** Before adding any `def _<something>` in a test file, run `rg "def <name>" tests/conftest.py tests/helpers*.py` for semantically-similar helpers.
+
+## `logger.error(value)` without a format string
+
+Logging calls must pass a format string as the first argument and the variable as the second. Passing a variable directly treats the variable as the format template — if it ever contains `%s`, `%d`, or `{...}`, logging either misformats or raises `TypeError` at runtime.
+
+**Wrong:**
+
+```python
+for failure in failures:
+    logger.error(failure)  # failure is the format string — unsafe
+```
+
+**Right:**
+
+```python
+for failure in failures:
+    logger.error("%s", failure)
+```
+
+**Why:** Latent logging-injection bug. `logger.error("got error: %s")` with a user-controlled string containing `%d` raises `TypeError: not enough arguments for format string` at runtime, not during testing. The `logger.error("%s", value)` form defers formatting to the logging machinery which handles it safely.
+
+**How to check:** `rg "logger\.(error|warning|info|debug)\(\w+\)" src/` — every match should have a literal string as the first argument.
+
+## Hardcoded path lists that duplicate filesystem state
+
+When multiple files (Dockerfile, Python constant, documentation) must agree on a list of paths or names, scan the authoritative source at runtime instead of hardcoding a parallel list that can drift.
+
+**Wrong:**
+
+```python
+# src/agent_cli.py
+_DOCKER_PLUGIN_DIRS: tuple[str, ...] = (
+    "/opt/plugins/claude-plugins-official",
+    "/opt/plugins/superpowers",
+    "/opt/plugins/lightfactory",
+)
+# Dockerfile.agent-base clones these three — but if a fourth is added
+# there, this tuple silently stays wrong.
+```
+
+**Right:**
+
+```python
+# src/agent_cli.py
+_PRE_CLONED_PLUGIN_ROOT = Path("/opt/plugins")
+
+def _plugin_dir_flags() -> list[str]:
+    if not _PRE_CLONED_PLUGIN_ROOT.is_dir():
+        return []
+    flags: list[str] = []
+    for entry in sorted(_PRE_CLONED_PLUGIN_ROOT.iterdir()):
+        if entry.is_dir():
+            flags.extend(["--plugin-dir", str(entry)])
+    return flags
+```
+
+**Why:** Two sources of truth decay. Every time someone edits the Dockerfile, CI passes but the Python list falls behind. Dynamic enumeration of the filesystem (or a single config source) eliminates the drift.
+
+**How to check:** Any hardcoded list that mirrors filesystem layout, Dockerfile state, or config file contents should raise a flag — can it be computed at runtime from the source of truth?
+
+## `_name` for unused loop variables (prefer bare `_`)
+
+Python's informal "unused by intent" convention is a bare `_`, not `_name`. Pyright and some strict linters treat `_name` as a named variable that happens to start with `_` and flag it as unused regardless.
+
+**Wrong:**
+
+```python
+for _lang, name, marketplace in specs:
+    install(name, marketplace)
+# Pyright: "_lang" is not accessed
+```
+
+**Right:**
+
+```python
+for _, name, marketplace in specs:
+    install(name, marketplace)
+```
+
+**Why:** Bare `_` is universally understood as "throwaway"; `_name` is not. Reserve `_name` only when documentation value is meaningful enough to keep a name alive. Otherwise use bare `_`.
+
+**How to check:** `rg "for _[a-z]" src/` — each match should justify why the underscore-prefixed name is more readable than bare `_`.
+
 ---
 
 ## Adding a new avoided pattern

--- a/src/planner.py
+++ b/src/planner.py
@@ -480,6 +480,15 @@ Use semantic tools first (before grep):
 5. Build a Task Graph with dependency-ordered phases (full plans only).
 6. Write behavioral test specs for each phase — describe observable outcomes, not test code.
 7. For UI work, call out reusable components/shared modules (`constants.js`, `types.js`, `theme.js`).
+8. **Audit the plan against `docs/agents/avoided-patterns.md`.** Every code snippet,
+   test fixture, and cross-module import in your plan must avoid the anti-patterns
+   listed there. Specifically check: symbols imported across modules do not start
+   with `_`; test helpers do not duplicate ones in `tests/conftest.py` (grep first);
+   `logger.error` / `logger.warning` calls pass a literal format string, not a bare
+   variable; hardcoded path lists that mirror filesystem or Dockerfile state are
+   replaced with runtime scans; loop variables use bare `_` for throwaways, not
+   `_name`. Catching these in the plan is orders of magnitude cheaper than catching
+   them in code review.
 
 ## Required Output
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -233,7 +233,7 @@ async def test_build_prompt_truncates_long_body(config, event_bus):
     prompt, _ = await runner._build_prompt_with_stats(task)
 
     assert "…(truncated)" in prompt
-    assert len(prompt) < 10_000  # well under original 20k body
+    assert len(prompt) < 11_000  # well under original 20k body
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #8374 / #8375. Translates the session-level retrospective insights into the factory's persistent workflow.

## Why

PR #8374 went through 8 task commits + 8 fix commits (review→fix→re-review). Most fix commits addressed the same class of issues that \`docs/agents/avoided-patterns.md\` already documents — private symbols crossing modules, missing conftest reuse, unsafe logger formatting, etc. Writing these into the canonical pattern doc means the **planner phase** (and any sensor/audit agent reading the doc) catches them at plan-writing time instead of in code-review-fix loops.

## Changes

1. **\`docs/agents/avoided-patterns.md\`** — 5 new sections in the same Wrong / Right / Why / How-to-check format as existing entries:
   - Underscore-prefixed names imported across modules
   - Writing a new test helper without checking conftest
   - \`logger.error(value)\` without a format string
   - Hardcoded path lists that duplicate filesystem state
   - \`_name\` for unused loop variables (prefer bare \`_\`)

2. **\`src/planner.py\`** — add Step 8 to the planner's **Planning Steps** section, instructing it to self-audit the plan against \`avoided-patterns.md\` BEFORE emitting. Catching these in a plan is orders of magnitude cheaper than catching them in agent code review.

3. **\`tests/test_planner.py\`** — bump \`test_build_prompt_truncates_long_body\` threshold from \`< 10_000\` to \`< 11_000\`. The new Step 8 grew the planner prompt baseline by ~650 chars; the truncation semantic ("…(truncated)" marker + body dramatically smaller than original 20k) is unchanged.

## Test plan
- [x] \`make quality\` green locally (after test-threshold fix): 11,038 passed.
- [x] Planner-prompt-truncation test still asserts truncation behavior (just with the new baseline accounted for).

## Follow-ups (not in this PR)

Per \`avoided-patterns.md\`'s own "Adding a new avoided pattern" guidance, consider:
- Adding rules to \`src/sensor_rules.py\` so the sensor enricher surfaces these hints automatically on matching failures.
- Updating \`.claude/commands/hf.audit-code.md\` Agent 5 (convention drift) to check for the new patterns on sweeps.

Both are separate concerns — doing them requires understanding those subsystems in depth. Filed as mental follow-ups; happy to do either as a separate PR if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)