### PR TITLE
feat(knowledge): Phase 1 foundation — temporal wiki + contradiction detector + ADR indexer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "websockets>=12.0",
     "httpx>=0.27.0",
     "python-dotenv>=1.0",
+    "python-ulid>=3.0.0",
     "sentry-sdk[fastapi]>=2.0",
 ]
 

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -1,0 +1,109 @@
+"""ADR runtime indexer.
+
+Parses docs/adr/*.md at runtime, renders compact summaries for prompt
+injection. Load-bearing facts — we want agents to know what's been
+decided before they plan.
+
+File format (from docs/adr/0001-five-concurrent-async-loops.md):
+
+    # ADR-0001: Five Concurrent Async Loops
+
+    **Status:** Accepted
+    **Date:** 2026-02-26
+
+    ## Context
+
+    HydraFlow must process GitHub issues through five distinct stages...
+
+Status is normalized to one of: "Accepted", "Proposed", "Superseded",
+"Deprecated". "Superseded by ADR-NNNN" populates ``superseded_by``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_TITLE_RE = re.compile(r"^#\s*ADR-(\d{4}):\s*(.+?)\s*$", re.MULTILINE)
+_STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(.+?)\s*$", re.MULTILINE)
+_CONTEXT_RE = re.compile(r"##\s+Context\s*\n\s*\n(.+?)(?=\n\s*\n|\n##\s|\Z)", re.DOTALL)
+_SUPERSEDED_RE = re.compile(r"Superseded\s+by\s+(ADR-\d{4})", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ADR:
+    number: int
+    title: str
+    status: str  # normalized: Accepted | Proposed | Superseded | Deprecated | Unknown
+    summary: str  # first paragraph of ## Context, flattened
+    superseded_by: str | None = None
+
+
+def parse_adr_file(path: Path) -> ADR:
+    """Parse a single ADR markdown file. Never raises on malformed input."""
+    text = path.read_text()
+
+    title_match = _TITLE_RE.search(text)
+    if title_match is None:
+        # Fallback: use filename stem
+        number = _extract_number_from_filename(path)
+        title = path.stem
+    else:
+        number = int(title_match.group(1))
+        title = title_match.group(2)
+
+    status_raw = ""
+    status_match = _STATUS_RE.search(text)
+    if status_match:
+        status_raw = status_match.group(1).strip()
+
+    superseded_by = None
+    sup_match = _SUPERSEDED_RE.search(status_raw)
+    if sup_match:
+        superseded_by = sup_match.group(1)
+        status_norm = "Superseded"
+    else:
+        status_norm = _normalize_status(status_raw)
+
+    summary = ""
+    ctx_match = _CONTEXT_RE.search(text)
+    if ctx_match:
+        summary = " ".join(ctx_match.group(1).split())[:300]
+
+    return ADR(
+        number=number,
+        title=title,
+        status=status_norm,
+        summary=summary,
+        superseded_by=superseded_by,
+    )
+
+
+def scan_adr_directory(adr_dir: Path) -> list[ADR]:
+    """Parse every ADR file in the directory, sorted by number."""
+    if not adr_dir.exists() or not adr_dir.is_dir():
+        return []
+    adrs: list[ADR] = []
+    for p in adr_dir.iterdir():
+        if p.is_file() and p.suffix == ".md" and _TITLE_RE.search(p.read_text()):
+            adrs.append(parse_adr_file(p))
+    return sorted(adrs, key=lambda a: a.number)
+
+
+def _normalize_status(raw: str) -> str:
+    low = raw.lower()
+    if "accepted" in low:
+        return "Accepted"
+    if "proposed" in low or "draft" in low:
+        return "Proposed"
+    if "superseded" in low:
+        return "Superseded"
+    if "deprecated" in low:
+        return "Deprecated"
+    return "Unknown"
+
+
+def _extract_number_from_filename(path: Path) -> int:
+    m = re.match(r"(\d{4})-", path.name)
+    return int(m.group(1)) if m else 0

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -107,3 +107,50 @@ def _normalize_status(raw: str) -> str:
 def _extract_number_from_filename(path: Path) -> int:
     m = re.match(r"(\d{4})-", path.name)
     return int(m.group(1)) if m else 0
+
+
+def render_full(adrs: list[ADR]) -> str:
+    """Render the full ADR index for injection into plan-phase prompts."""
+    if not adrs:
+        return ""
+
+    accepted = [a for a in adrs if a.status == "Accepted"]
+    proposed = [a for a in adrs if a.status == "Proposed"]
+    superseded = [a for a in adrs if a.status == "Superseded"]
+
+    parts: list[str] = ["# Architecture Decisions (ADRs)"]
+
+    if accepted:
+        parts.append("\n## Accepted (load-bearing)")
+        for a in accepted:
+            parts.append(f"- ADR-{a.number:04d} {a.title} — {a.summary}")
+
+    if proposed:
+        parts.append("\n## Proposed (drafted, not yet accepted)")
+        for a in proposed:
+            parts.append(f"- ADR-{a.number:04d} {a.title} — {a.summary}")
+
+    if superseded:
+        parts.append("\n## Superseded")
+        for a in superseded:
+            ref = f" (superseded by {a.superseded_by})" if a.superseded_by else ""
+            parts.append(f"- ADR-{a.number:04d} {a.title}{ref}")
+
+    return "\n".join(parts)
+
+
+def render_titles_only(adrs: list[ADR]) -> str:
+    """Titles-only view for implement/review prompts (prompt-size conscious).
+
+    Excludes Superseded entries to reduce noise. Agents working in
+    implement/review shouldn't be reminded of rules that have been replaced.
+    """
+    accepted = [a for a in adrs if a.status == "Accepted"]
+    proposed = [a for a in adrs if a.status == "Proposed"]
+    visible = accepted + proposed
+    if not visible:
+        return ""
+    lines = ["# Architecture Decisions (titles only)"]
+    for a in visible:
+        lines.append(f"- ADR-{a.number:04d} {a.title}")
+    return "\n".join(lines)

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -154,3 +154,32 @@ def render_titles_only(adrs: list[ADR]) -> str:
     for a in visible:
         lines.append(f"- ADR-{a.number:04d} {a.title}")
     return "\n".join(lines)
+
+
+class ADRIndex:
+    """Mtime-based cache over the ADR directory.
+
+    Scans lazily on first ``adrs()`` call. Re-scans only when the directory
+    or any ADR file's mtime has changed. Cheap for hot callers.
+    """
+
+    def __init__(self, adr_dir: Path) -> None:
+        self._adr_dir = adr_dir
+        self._cached: list[ADR] | None = None
+        self._fingerprint: tuple[float, ...] = ()
+
+    def adrs(self) -> list[ADR]:
+        fingerprint = self._compute_fingerprint()
+        if self._cached is None or fingerprint != self._fingerprint:
+            self._cached = scan_adr_directory(self._adr_dir)
+            self._fingerprint = fingerprint
+        return self._cached
+
+    def _compute_fingerprint(self) -> tuple[float, ...]:
+        if not self._adr_dir.exists():
+            return ()
+        mtimes: list[float] = [self._adr_dir.stat().st_mtime]
+        for p in self._adr_dir.iterdir():
+            if p.is_file() and p.suffix == ".md":
+                mtimes.append(p.stat().st_mtime)
+        return tuple(sorted(mtimes))

--- a/src/agent.py
+++ b/src/agent.py
@@ -7,7 +7,7 @@ import logging
 import re
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
@@ -55,6 +55,7 @@ class AgentRunner(BaseRunner):
     """
 
     _log = logger
+    _phase_name: ClassVar[str] = "implement"
 
     _SELF_CHECK_CHECKLIST = """
 ## Self-Check Before Committing

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -542,10 +542,11 @@ class BaseRunner:
         Implement/review: titles-only (prompt-size conscious; excludes Superseded).
         Other phases: empty.
         """
-        if self._adr_index is None:
+        adr_index = getattr(self, "_adr_index", None)
+        if adr_index is None:
             return ""
 
-        adrs = self._adr_index.adrs()
+        adrs = adr_index.adrs()
         if not adrs:
             return ""
 

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -9,6 +9,11 @@ from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
+from adr_index import (  # noqa: F401 — used in _inject_adr_index
+    ADRIndex,
+    render_full,
+    render_titles_only,
+)
 from agent_cli import build_agent_command
 from config import Credentials, HydraFlowConfig
 from events import EventBus
@@ -39,6 +44,7 @@ class BaseRunner:
     """
 
     _log: ClassVar[logging.Logger]
+    _phase_name: ClassVar[str] = "unknown"
 
     def __init__(
         self,
@@ -69,6 +75,9 @@ class BaseRunner:
         self._trace_subprocess_counter: int = 0
         self._credentials = credentials or Credentials()
         self._wiki_store = wiki_store
+        # ADR runtime index — injected into plan/implement/review prompts.
+        # Relative path from the worktree cwd. None-safe at read time.
+        self._adr_index: ADRIndex | None = ADRIndex(Path("docs/adr"))
 
     @property
     def active_count(self) -> int:
@@ -469,6 +478,11 @@ class BaseRunner:
         if wiki_section:
             memory_section += wiki_section
 
+        # Append ADR index (load-bearing architectural decisions)
+        adr_section = self._inject_adr_index()
+        if adr_section:
+            memory_section += adr_section
+
         self._last_context_stats = {
             "cache_hits": 0,
             "cache_misses": 0,
@@ -480,6 +494,7 @@ class BaseRunner:
                 + len(harness_insights_raw)
             ),
             "context_chars_after": len(memory_section),
+            "adr_chars": len(adr_section),
             "dedup_items_removed": dedup_items_removed,
             "dedup_chars_saved": dedup_chars_saved,
         }
@@ -512,6 +527,39 @@ class BaseRunner:
         if wiki_section:
             return f"\n\n{wiki_section}"
         return ""
+
+    #: Prompt-size budget for the rendered ADR index section. If render_full
+    #: exceeds this, we fall back to the titles-only view (which is bounded by
+    #: ADR count, not summary length). Prevents large ADR corpora from
+    #: dominating the plan prompt.
+    _MAX_ADR_SECTION_CHARS: ClassVar[int] = 4000
+
+    def _inject_adr_index(self) -> str:
+        """Inject the ADR index into the current phase's prompt.
+
+        Plan phase: full index (with summaries) — or titles-only if the full
+        view would exceed ``_MAX_ADR_SECTION_CHARS``.
+        Implement/review: titles-only (prompt-size conscious; excludes Superseded).
+        Other phases: empty.
+        """
+        if self._adr_index is None:
+            return ""
+
+        adrs = self._adr_index.adrs()
+        if not adrs:
+            return ""
+
+        phase = self._phase_name
+        if phase == "plan":
+            body = render_full(adrs)
+            if len(body) > self._MAX_ADR_SECTION_CHARS:
+                body = render_titles_only(adrs)
+        elif phase in ("implement", "review"):
+            body = render_titles_only(adrs)
+        else:
+            return ""
+
+        return f"\n\n{body}" if body else ""
 
     def _consume_context_stats(self) -> dict[str, int]:
         stats = dict(self._last_context_stats)

--- a/src/events.py
+++ b/src/events.py
@@ -93,6 +93,7 @@ class EventType(StrEnum):
     SYSTEM_REROUTE = "system_reroute"
     DIAGNOSTIC_UPDATE = "diagnostic_update"
     RETROSPECTIVE_UPDATE = "retrospective_update"
+    WIKI_SUPERSEDES = "wiki_supersedes"
 
 
 _T = TypeVar("_T")

--- a/src/planner.py
+++ b/src/planner.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import time
 from pathlib import Path
+from typing import ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
@@ -42,6 +43,7 @@ class PlannerRunner(BaseRunner):
     """
 
     _log = logger
+    _phase_name: ClassVar[str] = "plan"
 
     async def plan(
         self,

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -831,6 +831,48 @@ class RepoWikiStore:
         self._append_log(repo_slug, "active_lint", result.model_dump())
         return result
 
+    def mark_superseded(
+        self,
+        repo_slug: str,
+        entry_id: str,
+        *,
+        superseded_by: str,
+        reason: str,
+    ) -> bool:
+        """Set superseded_by/superseded_reason on an existing entry.
+
+        Searches all topic pages for the entry by id. Returns True if the
+        entry was found and updated; False otherwise. Does not delete or
+        move the entry. Callers emit events.
+        """
+        repo_dir = self._repo_dir(repo_slug)
+        if not repo_dir.exists():
+            return False
+
+        now = datetime.now(UTC).isoformat()
+        for topic_name in DEFAULT_TOPICS:
+            topic_path = repo_dir / f"{topic_name}.md"
+            if not topic_path.exists():
+                continue
+            entries = self._load_topic_entries(topic_path)
+            for i, e in enumerate(entries):
+                if e.id == entry_id:
+                    entries[i] = e.model_copy(
+                        update={
+                            "superseded_by": superseded_by,
+                            "superseded_reason": reason,
+                            "updated_at": now,
+                        }
+                    )
+                    self._write_topic_page(topic_path, topic_name, entries)
+                    self._append_log(
+                        repo_slug,
+                        "mark_superseded",
+                        {"entry_id": entry_id, "superseded_by": superseded_by},
+                    )
+                    return True
+        return False
+
     def list_repos(self) -> list[str]:
         """Return slugs for all repos with wikis.
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -26,6 +26,8 @@ from typing import TYPE_CHECKING, Any, Literal
 from pydantic import BaseModel, Field, model_validator
 from ulid import ULID
 
+from staleness import evaluate as evaluate_staleness
+
 if TYPE_CHECKING:
     from dedup_store import DedupStore
 
@@ -662,6 +664,12 @@ class RepoWikiStore:
             entries = self._load_topic_entries(topic_path)
             if not entries:
                 continue
+
+            # Staleness filtering — only inject current entries into prompts
+            now = datetime.now(UTC)
+            entries = [
+                e for e in entries if evaluate_staleness(e, now=now) == "current"
+            ]
 
             # Keyword filtering within topic
             if keywords:

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -538,6 +538,7 @@ class LintResult(BaseModel):
     total_entries: int = 0
     entries_marked_stale: int = 0
     orphans_pruned: int = 0
+    review_candidates_flagged: int = 0  # stale + age > 90d (no longer pruned)
     index_rebuilt: bool = False
 
 
@@ -797,16 +798,15 @@ class RepoWikiStore:
 
                 if current.stale:
                     result.stale_entries += 1
-                    # Prune stale entries older than threshold
                     try:
                         created = datetime.fromisoformat(current.created_at)
                         age_days = (now - created).days
                     except (ValueError, TypeError):
                         age_days = 0
                     if age_days > _STALE_PRUNE_DAYS:
-                        result.orphans_pruned += 1
-                        topic_modified = True
-                        continue  # skip — don't keep this entry
+                        # Phase 1 change: flag as review candidate; do NOT prune.
+                        # Staleness is now content-based (superseded_by), not time-based.
+                        result.review_candidates_flagged += 1
 
                 new_entries.append(current)
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
+from ulid import ULID
 
 if TYPE_CHECKING:
     from dedup_store import DedupStore
@@ -461,13 +462,25 @@ def active_lint_tracked(
 class WikiEntry(BaseModel):
     """A single knowledge entry within a topic page."""
 
+    id: str = Field(
+        default_factory=lambda: str(ULID()),
+        description="Stable ULID used for supersedes references",
+    )
     title: str = Field(description="Short summary of the insight")
     content: str = Field(description="Full explanation")
+    topic: str | None = Field(
+        default=None,
+        description="Which topic page this entry lives under (architecture/patterns/gotchas/testing/dependencies/harness)",
+    )
     source_type: str = Field(
-        description="Where the knowledge came from: plan, implement, review, hitl"
+        description="Where the knowledge came from: plan, implement, review, hitl, reflection, librarian, manual"
     )
     source_issue: int | None = Field(
         default=None, description="GitHub issue number, if applicable"
+    )
+    source_repo: str | None = Field(
+        default=None,
+        description="owner/repo slug, or 'global' for tribal entries",
     )
     created_at: str = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),
@@ -475,7 +488,10 @@ class WikiEntry(BaseModel):
     updated_at: str = Field(
         default_factory=lambda: datetime.now(UTC).isoformat(),
     )
-    stale: bool = Field(default=False, description="Flagged as potentially outdated")
+    stale: bool = Field(
+        default=False,
+        description="Flagged as potentially outdated (legacy; see superseded_by)",
+    )
 
 
 class WikiIndex(BaseModel):

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -21,9 +21,9 @@ import logging
 import re
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from ulid import ULID
 
 if TYPE_CHECKING:
@@ -468,30 +468,37 @@ class WikiEntry(BaseModel):
     )
     title: str = Field(description="Short summary of the insight")
     content: str = Field(description="Full explanation")
-    topic: str | None = Field(
-        default=None,
-        description="Which topic page this entry lives under (architecture/patterns/gotchas/testing/dependencies/harness)",
-    )
+    topic: str | None = Field(default=None)
     source_type: str = Field(
-        description="Where the knowledge came from: plan, implement, review, hitl, reflection, librarian, manual"
+        description="plan|implement|review|hitl|reflection|librarian|manual"
     )
-    source_issue: int | None = Field(
-        default=None, description="GitHub issue number, if applicable"
-    )
-    source_repo: str | None = Field(
+    source_issue: int | None = Field(default=None)
+    source_repo: str | None = Field(default=None)
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    valid_from: str | None = Field(
         default=None,
-        description="owner/repo slug, or 'global' for tribal entries",
+        description="ISO8601; defaults to created_at if unset",
     )
-    created_at: str = Field(
-        default_factory=lambda: datetime.now(UTC).isoformat(),
+    valid_to: str | None = Field(
+        default=None,
+        description="ISO8601 absolute date OR null=indefinite. Durations resolved at ingest.",
     )
-    updated_at: str = Field(
-        default_factory=lambda: datetime.now(UTC).isoformat(),
+    superseded_by: str | None = Field(
+        default=None, description="id of newer entry that replaces this one"
     )
+    superseded_reason: str | None = Field(default=None)
+    confidence: Literal["high", "medium", "low"] = Field(default="medium")
     stale: bool = Field(
         default=False,
-        description="Flagged as potentially outdated (legacy; see superseded_by)",
+        description="Legacy marker; see superseded_by for canonical staleness",
     )
+
+    @model_validator(mode="after")
+    def _default_valid_from(self) -> WikiEntry:
+        if self.valid_from is None:
+            self.valid_from = self.created_at
+        return self
 
 
 class WikiIndex(BaseModel):

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -468,12 +468,20 @@ class WikiEntry(BaseModel):
     )
     title: str = Field(description="Short summary of the insight")
     content: str = Field(description="Full explanation")
-    topic: str | None = Field(default=None)
+    topic: str | None = Field(
+        default=None,
+        description="Which topic page this entry lives under (architecture/patterns/gotchas/testing/dependencies/harness)",
+    )
     source_type: str = Field(
         description="plan|implement|review|hitl|reflection|librarian|manual"
     )
-    source_issue: int | None = Field(default=None)
-    source_repo: str | None = Field(default=None)
+    source_issue: int | None = Field(
+        default=None, description="GitHub issue number, if applicable"
+    )
+    source_repo: str | None = Field(
+        default=None,
+        description="owner/repo slug, or 'global' for tribal entries",
+    )
     created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
     updated_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
     valid_from: str | None = Field(

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -473,7 +473,7 @@ class WikiEntry(BaseModel):
         description="Which topic page this entry lives under (architecture/patterns/gotchas/testing/dependencies/harness)",
     )
     source_type: str = Field(
-        description="plan|implement|review|hitl|reflection|librarian|manual"
+        description="Where the knowledge came from: plan, implement, review, hitl, reflection, librarian, manual"
     )
     source_issue: int | None = Field(
         default=None, description="GitHub issue number, if applicable"
@@ -495,7 +495,10 @@ class WikiEntry(BaseModel):
     superseded_by: str | None = Field(
         default=None, description="id of newer entry that replaces this one"
     )
-    superseded_reason: str | None = Field(default=None)
+    superseded_reason: str | None = Field(
+        default=None,
+        description="Freeform reason paired with superseded_by",
+    )
     confidence: Literal["high", "medium", "low"] = Field(default="medium")
     stale: bool = Field(
         default=False,

--- a/src/repo_wiki_ingest.py
+++ b/src/repo_wiki_ingest.py
@@ -8,15 +8,31 @@ output and produces ``WikiEntry`` objects for the store.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel
+
 from repo_wiki import WikiEntry
+from staleness import evaluate as evaluate_staleness
 
 if TYPE_CHECKING:
     from repo_wiki import RepoWikiStore
+    from wiki_compiler import WikiCompiler
 
 logger = logging.getLogger("hydraflow.repo_wiki_ingest")
+
+
+# ---------------------------------------------------------------------------
+# Result model for ingest_phase_output
+# ---------------------------------------------------------------------------
+
+
+class IngestWithContradictionsResult(BaseModel):
+    entries_added: int = 0
+    entries_updated: int = 0
+    contradictions_marked: int = 0
 
 
 def ingest_from_plan(
@@ -220,3 +236,59 @@ def _extract_sections(text: str) -> dict[str, str]:
         sections[current_heading] = "\n".join(current_lines).strip()
 
     return sections
+
+
+# ---------------------------------------------------------------------------
+# Async helper: ingest with contradiction detection
+# ---------------------------------------------------------------------------
+
+
+async def ingest_phase_output(
+    *,
+    store: RepoWikiStore,
+    repo: str,
+    entries: list[WikiEntry],
+    compiler: WikiCompiler,
+) -> IngestWithContradictionsResult:
+    """Ingest entries and run contradiction detection on each.
+
+    Contradicted siblings have their ``superseded_by``/``superseded_reason``
+    set via :meth:`RepoWikiStore.mark_superseded`. Entries are never deleted.
+    """
+    ingest_result = store.ingest(repo, entries)
+    result = IngestWithContradictionsResult(
+        entries_added=ingest_result.entries_added,
+        entries_updated=ingest_result.entries_updated,
+    )
+
+    now = datetime.now(UTC)
+    for new_entry in entries:
+        if new_entry.topic is None:
+            continue
+        topic_path = store._repo_dir(repo) / f"{new_entry.topic}.md"
+        if not topic_path.exists():
+            continue
+        all_entries = store._load_topic_entries(topic_path)
+        siblings = [
+            e
+            for e in all_entries
+            if e.id != new_entry.id and evaluate_staleness(e, now=now) == "current"
+        ]
+        if not siblings:
+            continue
+
+        check = await compiler.detect_contradictions(
+            new_entry=new_entry,
+            siblings=siblings,
+            repo=repo,
+        )
+        for flagged in check.contradicts:
+            if store.mark_superseded(
+                repo,
+                entry_id=flagged.id,
+                superseded_by=new_entry.id,
+                reason=flagged.reason,
+            ):
+                result.contradictions_marked += 1
+
+    return result

--- a/src/repo_wiki_ingest.py
+++ b/src/repo_wiki_ingest.py
@@ -14,10 +14,12 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from events import EventType, HydraFlowEvent
 from repo_wiki import WikiEntry
 from staleness import evaluate as evaluate_staleness
 
 if TYPE_CHECKING:
+    from events import EventBus
     from repo_wiki import RepoWikiStore
     from wiki_compiler import WikiCompiler
 
@@ -249,11 +251,16 @@ async def ingest_phase_output(
     repo: str,
     entries: list[WikiEntry],
     compiler: WikiCompiler,
+    event_bus: EventBus | None = None,
 ) -> IngestWithContradictionsResult:
     """Ingest entries and run contradiction detection on each.
 
     Contradicted siblings have their ``superseded_by``/``superseded_reason``
     set via :meth:`RepoWikiStore.mark_superseded`. Entries are never deleted.
+
+    When ``event_bus`` is provided, a ``WIKI_SUPERSEDES`` event is published
+    for every contradiction marked. Publish failures are swallowed — wiki
+    events are non-critical.
     """
     ingest_result = store.ingest(repo, entries)
     result = IngestWithContradictionsResult(
@@ -290,5 +297,37 @@ async def ingest_phase_output(
                 reason=flagged.reason,
             ):
                 result.contradictions_marked += 1
+                if event_bus is not None:
+                    await _emit_wiki_supersedes(
+                        event_bus=event_bus,
+                        repo=repo,
+                        superseded_id=flagged.id,
+                        superseded_by=new_entry.id,
+                        reason=flagged.reason,
+                    )
 
     return result
+
+
+async def _emit_wiki_supersedes(
+    *,
+    event_bus: EventBus,
+    repo: str,
+    superseded_id: str,
+    superseded_by: str,
+    reason: str,
+) -> None:
+    """Publish a WIKI_SUPERSEDES event. Swallows errors."""
+    event = HydraFlowEvent(
+        type=EventType.WIKI_SUPERSEDES,
+        data={
+            "repo": repo,
+            "superseded_id": superseded_id,
+            "superseded_by": superseded_by,
+            "reason": reason,
+        },
+    )
+    try:
+        await event_bus.publish(event)
+    except Exception:  # noqa: BLE001
+        logger.debug("wiki event publish failed; continuing")

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -6,6 +6,7 @@ import logging
 import re
 import time
 from pathlib import Path
+from typing import ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
@@ -54,6 +55,7 @@ class ReviewRunner(BaseRunner):
     """
 
     _log = logger
+    _phase_name: ClassVar[str] = "review"
 
     @staticmethod
     def _format_code_scanning_alerts(

--- a/src/staleness.py
+++ b/src/staleness.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from repo_wiki import WikiEntry
 
 
 class ParseError(ValueError):
@@ -52,3 +56,45 @@ def parse_valid_to(raw: str | None, *, now: datetime) -> str | None:
         return parsed.isoformat()
     except ValueError as exc:
         raise ParseError(f"valid_to must be ISO8601 or duration: {raw!r}") from exc
+
+
+Status = Literal["current", "pending", "expired", "superseded"]
+
+
+def evaluate(entry: WikiEntry, *, now: datetime) -> Status:
+    """Classify an entry's validity at ``now``.
+
+    Precedence (highest first):
+      1. superseded_by set → "superseded"
+      2. now < valid_from → "pending"
+      3. valid_to set and now >= valid_to → "expired"
+      4. otherwise → "current"
+
+    ``pending`` and ``expired`` entries are excluded from prompt injection
+    but kept on disk for audit. ``superseded`` entries are likewise excluded
+    but may be browsed in the wiki UI with a badge.
+    """
+    if entry.superseded_by:
+        return "superseded"
+
+    if entry.valid_from:
+        valid_from = _parse_iso(entry.valid_from)
+        if valid_from is not None and now < valid_from:
+            return "pending"
+
+    if entry.valid_to:
+        valid_to = _parse_iso(entry.valid_to)
+        if valid_to is not None and now >= valid_to:
+            return "expired"
+
+    return "current"
+
+
+def _parse_iso(raw: str) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed

--- a/src/staleness.py
+++ b/src/staleness.py
@@ -1,0 +1,54 @@
+"""Staleness evaluator for wiki entries.
+
+Pure functions — no I/O, no LLM calls. Resolves valid_to expressions
+and classifies entries as current / expired / superseded.
+
+valid_to grammar (V1 — intentionally minimal, no DSL):
+  - ISO8601 date (2026-12-31) or datetime (2026-12-31T00:00:00+00:00)
+  - Relative duration: Nd (days), Nmo (months≈30d), Ny (years≈365d)
+  - None — indefinite
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+
+class ParseError(ValueError):
+    """Raised when valid_to cannot be parsed."""
+
+
+_DURATION_RE = re.compile(r"^(\d+)(d|mo|y)$")
+
+
+def parse_valid_to(raw: str | None, *, now: datetime) -> str | None:
+    """Resolve a valid_to expression to an absolute ISO8601 string.
+
+    Returns None if raw is None or empty (indefinite).
+    Raises ParseError if raw cannot be parsed.
+    """
+    if raw is None or raw == "":
+        return None
+
+    match = _DURATION_RE.match(raw)
+    if match:
+        n = int(match.group(1))
+        unit = match.group(2)
+        if n <= 0:
+            raise ParseError(f"valid_to duration must be positive: {raw!r}")
+        days = {"d": n, "mo": n * 30, "y": n * 365}[unit]
+        return (now + timedelta(days=days)).isoformat()
+
+    # Try parsing as ISO8601
+    try:
+        candidate = raw
+        # Accept plain date (2026-12-31) by appending midnight UTC
+        if "T" not in candidate and len(candidate) == 10:
+            candidate = f"{candidate}T00:00:00+00:00"
+        parsed = datetime.fromisoformat(candidate)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.isoformat()
+    except ValueError as exc:
+        raise ParseError(f"valid_to must be ISO8601 or duration: {raw!r}") from exc

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -19,9 +19,26 @@ import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pydantic import BaseModel, Field
+
 from repo_wiki import WikiEntry
 
 _SYNTHESIS_ID_RE = re.compile(r"^(\d+)-")
+
+
+# ---------------------------------------------------------------------------
+# Contradiction-check models
+# ---------------------------------------------------------------------------
+
+
+class ContradictedEntry(BaseModel):
+    id: str = Field(description="ULID of the sibling entry that is contradicted")
+    reason: str = Field(description="One-sentence explanation")
+
+
+class ContradictionCheck(BaseModel):
+    contradicts: list[ContradictedEntry] = Field(default_factory=list)
+
 
 if TYPE_CHECKING:
     from config import Credentials, HydraFlowConfig
@@ -67,6 +84,38 @@ Return a JSON array of compiled entries. Each entry must be a JSON object with t
 Return ONLY the JSON array, no other text.
 """
 
+_CONTRADICTION_PROMPT = """\
+You are a technical knowledge librarian. A new wiki entry has been written to the
+**{topic}** topic of repository **{repo}**. Identify which existing sibling entries
+(if any) it contradicts — meaning the new entry's advice is incompatible with an
+existing entry's advice, not merely different in emphasis.
+
+## New entry
+
+title: {new_title}
+content:
+{new_content}
+
+## Existing sibling entries (current only)
+
+{siblings_text}
+
+## Instructions
+
+Return a JSON object with one key, "contradicts", mapping to an array of
+{{"id": <sibling_id>, "reason": <one-sentence>}} objects.
+
+Only include a sibling if the new entry **directly contradicts** it — e.g.,
+"use X" vs "never use X", or "Python 3.11 minimum" vs "Python 3.10 minimum".
+Do NOT include siblings that are merely related or complementary.
+
+Return ONLY the JSON object, no other text.
+
+Example valid outputs:
+  {{"contradicts": []}}
+  {{"contradicts": [{{"id":"01HQ...","reason":"new entry says X, this one said not-X"}}]}}
+"""
+
 _SYNTHESIZE_INGEST_PROMPT = """\
 You are a technical knowledge librarian. A {source_type} phase just completed for \
 issue #{issue_number} in repository {repo}.
@@ -106,6 +155,32 @@ Return ONLY the JSON array, no other text.
 
 class WikiCompiler:
     """LLM-powered wiki compilation and synthesis."""
+
+    @staticmethod
+    def _parse_contradiction_output(raw: str) -> ContradictionCheck:
+        """Parse contradiction-check LLM output. Never raises."""
+        text = raw.strip()
+        if text.startswith("```"):
+            lines = text.split("\n")
+            text = "\n".join(lines[1:-1] if lines[-1].startswith("```") else lines[1:])
+
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1:
+            return ContradictionCheck()
+
+        try:
+            obj = json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            return ContradictionCheck()
+
+        if not isinstance(obj, dict) or "contradicts" not in obj:
+            return ContradictionCheck()
+
+        try:
+            return ContradictionCheck.model_validate(obj)
+        except Exception:  # noqa: BLE001
+            return ContradictionCheck()
 
     def __init__(
         self,

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -370,6 +370,38 @@ class WikiCompiler:
         )
         return len(compiled)
 
+    async def detect_contradictions(
+        self,
+        *,
+        new_entry: WikiEntry,
+        siblings: list[WikiEntry],
+        repo: str,
+    ) -> ContradictionCheck:
+        """Ask the LLM which siblings (if any) the new entry contradicts.
+
+        ``siblings`` must already be filtered to ``current`` entries on the
+        same topic. Returns an empty ContradictionCheck on LLM failure or if
+        siblings is empty — never raises.
+        """
+        if not siblings:
+            return ContradictionCheck()
+
+        siblings_text = "\n\n".join(
+            f"id: {s.id}\ntitle: {s.title}\ncontent:\n{s.content}" for s in siblings
+        )
+        prompt = _CONTRADICTION_PROMPT.format(
+            topic=new_entry.topic or "unknown",
+            repo=repo,
+            new_title=new_entry.title,
+            new_content=new_entry.content,
+            siblings_text=siblings_text,
+        )
+
+        raw = await self._call_model(prompt)
+        if raw is None:
+            return ContradictionCheck()
+        return self._parse_contradiction_output(raw)
+
     async def synthesize_ingest(
         self,
         repo: str,

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from adr_index import parse_adr_file, scan_adr_directory
+from adr_index import (
+    ADR,
+    parse_adr_file,
+    render_full,
+    render_titles_only,
+    scan_adr_directory,
+)
 
 
 def _write_adr(path: Path, number: int, title: str, status: str, context: str) -> Path:
@@ -57,3 +63,49 @@ def test_scan_adr_directory_sorts_by_number_and_filters_non_adr(tmp_path):
 def test_scan_adr_directory_missing_returns_empty(tmp_path):
     nonexistent = tmp_path / "nope"
     assert scan_adr_directory(nonexistent) == []
+
+
+def test_render_full_groups_by_status(tmp_path):
+    adrs = [
+        ADR(number=1, title="A", status="Accepted", summary="a."),
+        ADR(number=2, title="B", status="Proposed", summary="b."),
+        ADR(
+            number=7,
+            title="Old",
+            status="Superseded",
+            summary="old.",
+            superseded_by="ADR-0021",
+        ),
+    ]
+    out = render_full(adrs)
+    assert "## Accepted (load-bearing)" in out
+    assert "## Proposed (drafted, not yet accepted)" in out
+    assert "## Superseded" in out
+    assert "ADR-0001 A — a." in out
+    assert "ADR-0007" in out and "superseded by ADR-0021" in out
+
+
+def test_render_full_empty_input_returns_empty():
+    assert render_full([]) == ""
+
+
+def test_render_titles_only_excludes_summaries_and_superseded():
+    adrs = [
+        ADR(number=1, title="A", status="Accepted", summary="long summary here"),
+        ADR(
+            number=7,
+            title="Old",
+            status="Superseded",
+            summary="old.",
+            superseded_by="ADR-0021",
+        ),
+    ]
+    out = render_titles_only(adrs)
+    assert "ADR-0001 A" in out
+    assert "long summary" not in out
+    # Titles-only skips Superseded entries to avoid noise in implement/review
+    assert "ADR-0007" not in out
+
+
+def test_render_titles_only_empty_input_returns_empty():
+    assert render_titles_only([]) == ""

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -157,3 +157,34 @@ def test_cache_handles_directory_creation_after_instantiation(tmp_path):
     _write_adr(missing, 1, "A", "Accepted", "a.")
     refreshed = index.adrs()
     assert len(refreshed) == 1
+
+
+def test_scan_real_adr_directory_produces_valid_output():
+    """Smoke test against the real docs/adr/ — guards against regression
+    if an ADR file's format drifts from the expected template."""
+    import pytest
+
+    adr_dir = Path(__file__).resolve().parents[1] / "docs" / "adr"
+    if not adr_dir.exists():
+        pytest.skip("docs/adr not present in this checkout")
+
+    adrs = scan_adr_directory(adr_dir)
+    assert len(adrs) > 0
+
+    for a in adrs:
+        assert a.number > 0
+        assert a.title
+        assert a.status in {
+            "Accepted",
+            "Proposed",
+            "Superseded",
+            "Deprecated",
+            "Unknown",
+        }
+
+    full = render_full(adrs)
+    titles = render_titles_only(adrs)
+    assert full
+    assert titles
+    # Titles-only should be strictly smaller
+    assert len(titles) < len(full)

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -1,0 +1,59 @@
+"""Tests for ADR runtime indexer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adr_index import parse_adr_file, scan_adr_directory
+
+
+def _write_adr(path: Path, number: int, title: str, status: str, context: str) -> Path:
+    p = path / f"{number:04d}-{title.lower().replace(' ', '-')}.md"
+    p.write_text(
+        f"# ADR-{number:04d}: {title}\n\n"
+        f"**Status:** {status}\n"
+        f"**Date:** 2026-01-01\n\n"
+        f"## Context\n\n{context}\n"
+    )
+    return p
+
+
+def test_parse_adr_file_extracts_number_title_status(tmp_path):
+    p = _write_adr(tmp_path, 1, "Async Loops", "Accepted", "We run five loops.")
+    adr = parse_adr_file(p)
+    assert adr.number == 1
+    assert adr.title == "Async Loops"
+    assert adr.status == "Accepted"
+    assert "five loops" in adr.summary
+
+
+def test_parse_adr_file_status_is_normalized(tmp_path):
+    p = _write_adr(tmp_path, 7, "Old Thing", "Superseded by ADR-0021", "old.")
+    adr = parse_adr_file(p)
+    # Normalize to bucket: "Accepted" | "Proposed" | "Superseded"
+    assert adr.status == "Superseded"
+    assert adr.superseded_by == "ADR-0021"
+
+
+def test_parse_adr_file_handles_missing_context_section(tmp_path):
+    p = tmp_path / "0099-empty.md"
+    p.write_text("# ADR-0099: Empty\n\n**Status:** Proposed\n")
+    adr = parse_adr_file(p)
+    assert adr.number == 99
+    assert adr.summary == ""
+
+
+def test_scan_adr_directory_sorts_by_number_and_filters_non_adr(tmp_path):
+    _write_adr(tmp_path, 3, "C", "Accepted", "c.")
+    _write_adr(tmp_path, 1, "A", "Accepted", "a.")
+    _write_adr(tmp_path, 2, "B", "Proposed", "b.")
+    # A distractor: README, not an ADR
+    (tmp_path / "README.md").write_text("# README\n\nnot an ADR\n")
+
+    adrs = scan_adr_directory(tmp_path)
+    assert [a.number for a in adrs] == [1, 2, 3]
+
+
+def test_scan_adr_directory_missing_returns_empty(tmp_path):
+    nonexistent = tmp_path / "nope"
+    assert scan_adr_directory(nonexistent) == []

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -65,7 +65,7 @@ def test_scan_adr_directory_missing_returns_empty(tmp_path):
     assert scan_adr_directory(nonexistent) == []
 
 
-def test_render_full_groups_by_status(tmp_path):
+def test_render_full_groups_by_status():
     adrs = [
         ADR(number=1, title="A", status="Accepted", summary="a."),
         ADR(number=2, title="B", status="Proposed", summary="b."),

--- a/tests/test_adr_index.py
+++ b/tests/test_adr_index.py
@@ -109,3 +109,51 @@ def test_render_titles_only_excludes_summaries_and_superseded():
 
 def test_render_titles_only_empty_input_returns_empty():
     assert render_titles_only([]) == ""
+
+
+def test_cache_returns_same_result_on_repeat_call(tmp_path):
+    from adr_index import ADRIndex
+
+    _write_adr(tmp_path, 1, "A", "Accepted", "a.")
+    index = ADRIndex(tmp_path)
+    first = index.adrs()
+    second = index.adrs()
+    assert first is second  # cached reference (no re-scan)
+
+
+def test_cache_refreshes_when_file_changes(tmp_path):
+    import os
+    import time
+
+    from adr_index import ADRIndex
+
+    _write_adr(tmp_path, 1, "A", "Accepted", "a.")
+    index = ADRIndex(tmp_path)
+    first = index.adrs()
+    assert first[0].title == "A"
+
+    # Wait for mtime resolution, then rewrite with a new title
+    time.sleep(1.1)
+    target = next(tmp_path.iterdir())
+    target.write_text(
+        "# ADR-0001: Renamed\n\n**Status:** Accepted\n**Date:** 2026-01-01\n\n"
+        "## Context\n\nupdated.\n"
+    )
+    os.utime(target, None)
+
+    second = index.adrs()
+    assert second is not first
+    assert second[0].title == "Renamed"
+
+
+def test_cache_handles_directory_creation_after_instantiation(tmp_path):
+    from adr_index import ADRIndex
+
+    missing = tmp_path / "later"
+    index = ADRIndex(missing)
+    assert index.adrs() == []
+
+    missing.mkdir()
+    _write_adr(missing, 1, "A", "Accepted", "a.")
+    refreshed = index.adrs()
+    assert len(refreshed) == 1

--- a/tests/test_base_runner_memory.py
+++ b/tests/test_base_runner_memory.py
@@ -74,3 +74,71 @@ async def test_harness_insights_recalled(base_runner):
 
     assert "Known Pipeline Patterns" in memory_section
     assert "CI timeout" in memory_section
+
+
+# ---------------------------------------------------------------------------
+# ADR index injection (Task 3.4)
+# ---------------------------------------------------------------------------
+
+
+def test_inject_adr_index_full_for_plan_phase(tmp_path):
+    """Plan-phase injection contains the full ADR index with summaries."""
+    from adr_index import ADRIndex
+
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    (adr_dir / "0001-foo.md").write_text(
+        "# ADR-0001: Foo\n\n**Status:** Accepted\n\n## Context\n\nbar.\n"
+    )
+
+    runner = BaseRunner.__new__(BaseRunner)
+    runner._adr_index = ADRIndex(adr_dir)
+    runner._phase_name = "plan"  # type: ignore[misc]
+
+    section = runner._inject_adr_index()
+    assert "ADR-0001 Foo" in section
+    assert "bar." in section
+
+
+def test_inject_adr_index_titles_only_for_implement_phase(tmp_path):
+    from adr_index import ADRIndex
+
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    (adr_dir / "0001-foo.md").write_text(
+        "# ADR-0001: Foo\n\n**Status:** Accepted\n\n## Context\n\nbar.\n"
+    )
+
+    runner = BaseRunner.__new__(BaseRunner)
+    runner._adr_index = ADRIndex(adr_dir)
+    runner._phase_name = "implement"  # type: ignore[misc]
+
+    section = runner._inject_adr_index()
+    assert "ADR-0001 Foo" in section
+    assert "bar." not in section
+
+
+def test_inject_adr_index_empty_dir_returns_empty_string(tmp_path):
+    from adr_index import ADRIndex
+
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    runner = BaseRunner.__new__(BaseRunner)
+    runner._adr_index = ADRIndex(adr_dir)
+    runner._phase_name = "plan"  # type: ignore[misc]
+    assert runner._inject_adr_index() == ""
+
+
+def test_inject_adr_index_unknown_phase_returns_empty(tmp_path):
+    """Default phase (e.g. HITL) returns empty — no ADR injection."""
+    from adr_index import ADRIndex
+
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    (adr_dir / "0001-foo.md").write_text(
+        "# ADR-0001: Foo\n\n**Status:** Accepted\n\n## Context\n\nbar.\n"
+    )
+    runner = BaseRunner.__new__(BaseRunner)
+    runner._adr_index = ADRIndex(adr_dir)
+    runner._phase_name = "unknown"  # type: ignore[misc]
+    assert runner._inject_adr_index() == ""

--- a/tests/test_event_reducer_coverage.py
+++ b/tests/test_event_reducer_coverage.py
@@ -56,6 +56,9 @@ SKIP_LIST: set[str] = {
     "diagnostic_update",
     # Retrospective events are consumed server-side (post-merge learning)
     "retrospective_update",
+    # Wiki supersedes events are consumed server-side (audit log for temporal
+    # invalidation); no direct dashboard reducer case.
+    "wiki_supersedes",
 }
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,6 +49,7 @@ _EVENT_STRING_CASES: list[tuple[EventType, str]] = [
     (EventType.PIPELINE_STATS, "pipeline_stats"),
     (EventType.VISUAL_GATE, "visual_gate"),
     (EventType.BASELINE_UPDATE, "baseline_update"),
+    (EventType.WIKI_SUPERSEDES, "wiki_supersedes"),
 ]
 
 
@@ -95,6 +96,7 @@ class TestEventTypeEnum:
             "SYSTEM_REROUTE",
             "DIAGNOSTIC_UPDATE",
             "RETROSPECTIVE_UPDATE",
+            "WIKI_SUPERSEDES",
         }
         actual = {member.name for member in EventType}
         assert expected == actual

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -233,7 +233,9 @@ async def test_build_prompt_truncates_long_body(config, event_bus):
     prompt, _ = await runner._build_prompt_with_stats(task)
 
     assert "…(truncated)" in prompt
-    assert len(prompt) < 11_000  # well under original 20k body
+    # Well under original 20k body. Upper bound accommodates the ADR titles
+    # index (~2k chars for ~40 ADRs) which is now injected into plan prompts.
+    assert len(prompt) < 14_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -700,3 +700,46 @@ def test_active_lint_flags_old_entries_in_result_but_keeps_them(store):
     result = store.active_lint(REPO, closed_issues=set())
     # New semantics: report flagged count, do not prune
     assert getattr(result, "review_candidates_flagged", 0) >= 1
+
+
+def test_loads_pre_phase1_wiki_on_disk(tmp_path):
+    """Wikis written before Phase 1 lack temporal fields. They must still load."""
+    from repo_wiki import RepoWikiStore
+
+    root = tmp_path / "repo_wiki"
+    repo_dir = root / "legacy" / "repo"
+    repo_dir.mkdir(parents=True)
+
+    # Minimal pre-Phase-1 on-disk layout: index.json + one topic page.
+    (repo_dir / "index.json").write_text(
+        '{"repo_slug":"legacy/repo","topics":{"patterns":["old"]},'
+        '"total_entries":1,"last_updated":"2025-06-01T00:00:00+00:00",'
+        '"last_lint":null}'
+    )
+    # Topic page uses the current ```json:entry``` code-block format but with
+    # old-style JSON that lacks Phase-1 temporal fields (valid_from, valid_to,
+    # superseded_by, superseded_reason, confidence, id, topic, source_repo).
+    (repo_dir / "patterns.md").write_text(
+        "# Patterns\n\n"
+        "## old\n\n"
+        "x\n\n"
+        "```json:entry\n"
+        '{"title":"old","content":"x","source_type":"plan",'
+        '"source_issue":null,"created_at":"2025-06-01T00:00:00+00:00",'
+        '"updated_at":"2025-06-01T00:00:00+00:00","stale":false}\n'
+        "```\n"
+    )
+
+    store = RepoWikiStore(root)
+    # Should not raise — legacy entries gain defaulted temporal fields.
+    entries = store._load_topic_entries(repo_dir / "patterns.md")
+    assert len(entries) == 1
+    assert entries[0].title == "old"
+    assert entries[0].valid_from == entries[0].created_at
+    assert entries[0].valid_to is None
+    assert entries[0].superseded_by is None
+    assert entries[0].confidence == "medium"
+
+    # Query must work and return the entry (it's current).
+    out = store.query("legacy/repo", topics=["patterns"])
+    assert "old" in out

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -740,3 +740,63 @@ def test_loads_pre_phase1_wiki_on_disk(tmp_path):
     # Query must work and return the entry (it's current).
     out = store.query("legacy/repo", topics=["patterns"])
     assert "old" in out
+
+
+# ---------------------------------------------------------------------------
+# mark_superseded
+# ---------------------------------------------------------------------------
+
+
+def test_mark_superseded_sets_fields_and_returns_true(store):
+    store.ingest(
+        REPO,
+        [
+            WikiEntry(
+                id="01HQ9999999999999999999999",
+                title="original",
+                content="v1",
+                source_type="plan",
+                topic="patterns",
+            ),
+        ],
+    )
+    ok = store.mark_superseded(
+        REPO,
+        entry_id="01HQ9999999999999999999999",
+        superseded_by="01HQ0000000000000000000000",
+        reason="obsoleted",
+    )
+    assert ok is True
+
+    # Find the entry across topics and verify fields
+    for topic_name in [
+        "architecture",
+        "patterns",
+        "gotchas",
+        "testing",
+        "dependencies",
+    ]:
+        p = store._repo_dir(REPO) / f"{topic_name}.md"
+        if not p.exists():
+            continue
+        for e in store._load_topic_entries(p):
+            if e.id == "01HQ9999999999999999999999":
+                assert e.superseded_by == "01HQ0000000000000000000000"
+                assert e.superseded_reason == "obsoleted"
+                return
+    raise AssertionError("entry not found after mark_superseded")
+
+
+def test_mark_superseded_missing_entry_returns_false(store):
+    store.ingest(
+        REPO, [WikiEntry(title="x", content="y", source_type="plan", topic="patterns")]
+    )
+    assert (
+        store.mark_superseded(
+            REPO,
+            entry_id="01HQ_DOES_NOT_EXIST_NOPE_NOPE",
+            superseded_by="01HQ0000000000000000000000",
+            reason="x",
+        )
+        is False
+    )

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -463,6 +463,38 @@ class TestWikiIndexModel:
         assert "patterns" in data["topics"]
 
 
+import re
+
+
+def test_wiki_entry_auto_generates_id():
+    e = WikiEntry(title="t", content="c", source_type="plan")
+    assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", e.id) is not None
+
+
+def test_wiki_entry_two_entries_get_distinct_ids():
+    a = WikiEntry(title="t", content="c", source_type="plan")
+    b = WikiEntry(title="t", content="c", source_type="plan")
+    assert a.id != b.id
+
+
+def test_wiki_entry_accepts_topic_and_source_repo():
+    e = WikiEntry(
+        title="t",
+        content="c",
+        source_type="plan",
+        topic="architecture",
+        source_repo="acme/widget",
+    )
+    assert e.topic == "architecture"
+    assert e.source_repo == "acme/widget"
+
+
+def test_wiki_entry_topic_and_source_repo_default_to_none():
+    e = WikiEntry(title="t", content="c", source_type="plan")
+    assert e.topic is None
+    assert e.source_repo is None
+
+
 class TestListReposLayoutCompat:
     """list_repos must accept both legacy (index.json) and new (index.md) layouts.
 

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -577,3 +577,60 @@ def test_wiki_entry_backward_compat_loads_old_shape():
     assert e.valid_to is None
     assert e.superseded_by is None
     assert e.confidence == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Staleness filtering in query()
+# ---------------------------------------------------------------------------
+
+from datetime import UTC, datetime, timedelta
+
+
+def test_query_excludes_superseded_entries(store, tmp_path):
+    store.ingest(
+        REPO,
+        [
+            WikiEntry(
+                title="old rule", content="A", source_type="plan", topic="patterns"
+            ),
+        ],
+    )
+    # Simulate another ingest that supersedes the first (we'll wire the
+    # contradiction detector in PR 2; here we set superseded_by directly)
+    index_dir = store._repo_dir(REPO)
+    topic_path = index_dir / "patterns.md"
+    entries = store._load_topic_entries(topic_path)
+    assert len(entries) == 1
+    superseded = entries[0].model_copy(
+        update={"superseded_by": "01HQ0000000000000000000000"}
+    )
+    store._write_topic_page(topic_path, "patterns", [superseded])
+
+    out = store.query(REPO, topics=["patterns"])
+    assert "old rule" not in out
+
+
+def test_query_excludes_expired_entries(store):
+    past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    expired = WikiEntry(
+        title="expired rule",
+        content="A",
+        source_type="plan",
+        topic="patterns",
+        valid_to=past,
+    )
+    store.ingest(REPO, [expired])
+    out = store.query(REPO, topics=["patterns"])
+    assert "expired rule" not in out
+
+
+def test_query_includes_current_entries(store):
+    current = WikiEntry(
+        title="current rule",
+        content="A",
+        source_type="plan",
+        topic="patterns",
+    )
+    store.ingest(REPO, [current])
+    out = store.query(REPO, topics=["patterns"])
+    assert "current rule" in out

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -527,3 +527,53 @@ class TestListReposLayoutCompat:
 
         store = RepoWikiStore(wiki_root)
         assert store.list_repos() == []
+
+
+def test_wiki_entry_temporal_defaults():
+    e = WikiEntry(title="t", content="c", source_type="plan")
+    assert e.valid_from == e.created_at
+    assert e.valid_to is None
+    assert e.superseded_by is None
+    assert e.superseded_reason is None
+    assert e.confidence == "medium"
+
+
+def test_wiki_entry_temporal_explicit_values():
+    e = WikiEntry(
+        title="t",
+        content="c",
+        source_type="plan",
+        valid_from="2026-01-01T00:00:00+00:00",
+        valid_to="2027-01-01T00:00:00+00:00",
+        superseded_by="01HQ0000000000000000000000",
+        superseded_reason="replaced by X",
+        confidence="high",
+    )
+    assert e.valid_to == "2027-01-01T00:00:00+00:00"
+    assert e.superseded_by == "01HQ0000000000000000000000"
+    assert e.confidence == "high"
+
+
+def test_wiki_entry_confidence_rejects_invalid():
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        WikiEntry(title="t", content="c", source_type="plan", confidence="maybe")
+
+
+def test_wiki_entry_backward_compat_loads_old_shape():
+    # Simulate loading an entry missing temporal fields (old on-disk format)
+    e = WikiEntry.model_validate(
+        {
+            "title": "legacy",
+            "content": "c",
+            "source_type": "plan",
+            "created_at": "2025-06-01T00:00:00+00:00",
+            "updated_at": "2025-06-01T00:00:00+00:00",
+            "stale": False,
+        }
+    )
+    assert e.valid_from == e.created_at  # defaulted from created_at
+    assert e.valid_to is None
+    assert e.superseded_by is None
+    assert e.confidence == "medium"

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -328,7 +328,10 @@ class TestActiveLint:
         assert result.entries_marked_stale == 1
         assert result.stale_entries == 1
 
-    def test_prunes_old_stale_entries(self, store: RepoWikiStore) -> None:
+    def test_flags_old_stale_entries_instead_of_pruning(
+        self, store: RepoWikiStore
+    ) -> None:
+        # Phase 1: 90-day hard-prune replaced by review_candidates_flagged counter.
         store.ingest(
             REPO,
             [
@@ -342,7 +345,8 @@ class TestActiveLint:
             ],
         )
         result = store.active_lint(REPO)
-        assert result.orphans_pruned == 1
+        assert result.orphans_pruned == 0
+        assert result.review_candidates_flagged >= 1
 
     def test_preserves_fresh_stale_entries(self, store: RepoWikiStore) -> None:
         store.ingest(
@@ -634,3 +638,65 @@ def test_query_includes_current_entries(store):
     store.ingest(REPO, [current])
     out = store.query(REPO, topics=["patterns"])
     assert "current rule" in out
+
+
+def test_active_lint_does_not_prune_old_entries(store):
+    old_date = (datetime.now(UTC) - timedelta(days=120)).isoformat()
+    old_entry = WikiEntry(
+        title="ancient rule",
+        content="A",
+        source_type="plan",
+        topic="patterns",
+        created_at=old_date,
+        updated_at=old_date,
+        stale=True,  # stale marker set
+    )
+    store.ingest(REPO, [old_entry])
+
+    result = store.active_lint(REPO, closed_issues=set())
+    assert result.orphans_pruned == 0
+    # Entry is still on disk
+    topic_path = store._repo_dir(REPO) / "patterns.md"
+    entries = store._load_topic_entries(topic_path)
+    assert any(e.title == "ancient rule" for e in entries)
+
+
+def test_active_lint_still_marks_stale_when_source_issue_closed(store):
+    e = WikiEntry(
+        title="closed issue entry",
+        content="Architecture detail.",
+        source_type="plan",
+        topic="architecture",
+        source_issue=42,
+    )
+    store.ingest(REPO, [e])
+
+    result = store.active_lint(REPO, closed_issues={42})
+    assert result.entries_marked_stale == 1
+
+    # Find entry across all topic pages (classifier picks the actual topic)
+    repo_dir = store._repo_dir(REPO)
+    all_entries = []
+    for topic_file in repo_dir.glob("*.md"):
+        if topic_file.stem in ("index",):
+            continue
+        all_entries.extend(store._load_topic_entries(topic_file))
+    assert any(e.title == "closed issue entry" and e.stale for e in all_entries)
+
+
+def test_active_lint_flags_old_entries_in_result_but_keeps_them(store):
+    old_date = (datetime.now(UTC) - timedelta(days=120)).isoformat()
+    old_entry = WikiEntry(
+        title="ancient rule",
+        content="A",
+        source_type="plan",
+        topic="patterns",
+        created_at=old_date,
+        updated_at=old_date,
+        stale=True,
+    )
+    store.ingest(REPO, [old_entry])
+
+    result = store.active_lint(REPO, closed_issues=set())
+    # New semantics: report flagged count, do not prune
+    assert getattr(result, "review_candidates_flagged", 0) >= 1

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -467,9 +469,6 @@ class TestWikiIndexModel:
         assert "patterns" in data["topics"]
 
 
-import re
-
-
 def test_wiki_entry_auto_generates_id():
     e = WikiEntry(title="t", content="c", source_type="plan")
     assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", e.id) is not None
@@ -587,10 +586,8 @@ def test_wiki_entry_backward_compat_loads_old_shape():
 # Staleness filtering in query()
 # ---------------------------------------------------------------------------
 
-from datetime import UTC, datetime, timedelta
 
-
-def test_query_excludes_superseded_entries(store, tmp_path):
+def test_query_excludes_superseded_entries(store):
     store.ingest(
         REPO,
         [

--- a/tests/test_repo_wiki_ingest.py
+++ b/tests/test_repo_wiki_ingest.py
@@ -255,3 +255,67 @@ async def test_ingest_phase_output_marks_contradicted_siblings(tmp_path: Path) -
     out = store.query("acme/widget", topics=["patterns"])
     assert "Never use X" in out
     assert "Use X always" not in out
+
+
+async def test_ingest_phase_output_emits_wiki_supersedes_event(tmp_path):
+    """When an event_bus is provided, every contradiction publishes a WIKI_SUPERSEDES event."""
+    from unittest.mock import AsyncMock
+
+    from events import EventBus, EventType, HydraFlowEvent
+    from repo_wiki import RepoWikiStore, WikiEntry
+    from repo_wiki_ingest import ingest_phase_output
+    from wiki_compiler import ContradictedEntry, ContradictionCheck
+
+    store = RepoWikiStore(tmp_path / "wiki")
+    event_bus = EventBus()
+    published: list[HydraFlowEvent] = []
+
+    async def capture(event: HydraFlowEvent) -> None:
+        published.append(event)
+
+    event_bus.publish = capture  # type: ignore[method-assign]
+
+    entry_a = WikiEntry(
+        id="01HQ0000000000000000000000",
+        title="Use X",
+        content="Always X.",
+        source_type="plan",
+        topic="patterns",
+    )
+    compiler = AsyncMock()
+    compiler.detect_contradictions = AsyncMock(return_value=ContradictionCheck())
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[entry_a],
+        compiler=compiler,
+        event_bus=event_bus,
+    )
+    assert published == []
+
+    entry_b = WikiEntry(
+        id="01HQ1111111111111111111111",
+        title="Never X",
+        content="Never X.",
+        source_type="plan",
+        topic="patterns",
+    )
+    reply = ContradictionCheck(
+        contradicts=[ContradictedEntry(id=entry_a.id, reason="reverses")]
+    )
+    compiler.detect_contradictions = AsyncMock(return_value=reply)
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[entry_b],
+        compiler=compiler,
+        event_bus=event_bus,
+    )
+
+    assert len(published) == 1
+    event = published[0]
+    assert event.type == EventType.WIKI_SUPERSEDES
+    assert event.data["repo"] == "acme/widget"
+    assert event.data["superseded_id"] == entry_a.id
+    assert event.data["superseded_by"] == entry_b.id
+    assert event.data["reason"] == "reverses"

--- a/tests/test_repo_wiki_ingest.py
+++ b/tests/test_repo_wiki_ingest.py
@@ -185,3 +185,73 @@ class TestGitBackedIngest:
 
         # No log record should exist — log append only runs after all writes.
         assert not (store._wiki_root / REPO / "log" / "77.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# ingest_phase_output — end-to-end contradiction detection
+# ---------------------------------------------------------------------------
+
+
+async def test_ingest_phase_output_marks_contradicted_siblings(tmp_path: Path) -> None:
+    """End-to-end: ingest entry A, then ingest contradicting B → A.superseded_by = B.id."""
+    from unittest.mock import AsyncMock
+
+    from repo_wiki import RepoWikiStore, WikiEntry
+    from repo_wiki_ingest import ingest_phase_output
+    from wiki_compiler import ContradictedEntry, ContradictionCheck
+
+    store = RepoWikiStore(tmp_path / "wiki")
+
+    # First ingest: one entry, no contradictions.
+    entry_a = WikiEntry(
+        id="01HQ0000000000000000000000",
+        title="Use X always",
+        content="Always use X.",
+        source_type="plan",
+        topic="patterns",
+    )
+    compiler = AsyncMock()
+    compiler.detect_contradictions = AsyncMock(return_value=ContradictionCheck())
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[entry_a],
+        compiler=compiler,
+    )
+
+    # Second ingest: entry contradicts A.
+    contradiction_reply = ContradictionCheck(
+        contradicts=[
+            ContradictedEntry(
+                id="01HQ0000000000000000000000",
+                reason="reverses guidance",
+            )
+        ]
+    )
+    entry_b = WikiEntry(
+        id="01HQ1111111111111111111111",
+        title="Never use X",
+        content="Never use X; prefer Y.",
+        source_type="plan",
+        topic="patterns",
+    )
+    compiler.detect_contradictions = AsyncMock(return_value=contradiction_reply)
+    result = await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[entry_b],
+        compiler=compiler,
+    )
+    assert result.contradictions_marked == 1
+
+    # A now has superseded_by set.
+    topic_path = store._repo_dir("acme/widget") / "patterns.md"
+    on_disk = store._load_topic_entries(topic_path)
+    a_on_disk = next(e for e in on_disk if e.id == entry_a.id)
+    assert a_on_disk.superseded_by == entry_b.id
+    assert a_on_disk.superseded_reason == "reverses guidance"
+
+    # query() excludes superseded A, keeps current B
+    out = store.query("acme/widget", topics=["patterns"])
+    assert "Never use X" in out
+    assert "Use X always" not in out

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -66,3 +66,62 @@ def test_parse_garbage_rejected():
     now = datetime(2026, 4, 22, tzinfo=UTC)
     with pytest.raises(ParseError):
         parse_valid_to("banana", now=now)
+
+
+from staleness import evaluate
+
+
+def _entry(**overrides):
+    from repo_wiki import WikiEntry
+
+    defaults = {"title": "t", "content": "c", "source_type": "plan"}
+    defaults.update(overrides)
+    return WikiEntry(**defaults)
+
+
+NOW = datetime(2026, 4, 22, 12, 0, tzinfo=UTC)
+
+
+def test_evaluate_indefinite_entry_is_current():
+    e = _entry(valid_from=NOW.isoformat(), valid_to=None)
+    assert evaluate(e, now=NOW) == "current"
+
+
+def test_evaluate_entry_before_valid_from_is_future():
+    future = datetime(2027, 1, 1, tzinfo=UTC).isoformat()
+    e = _entry(valid_from=future, valid_to=None)
+    # Future entries are not current yet — treat as "pending" (not injected)
+    assert evaluate(e, now=NOW) == "pending"
+
+
+def test_evaluate_entry_after_valid_to_is_expired():
+    past = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+    e = _entry(valid_from=past, valid_to=datetime(2026, 3, 1, tzinfo=UTC).isoformat())
+    assert evaluate(e, now=NOW) == "expired"
+
+
+def test_evaluate_superseded_wins_over_current_window():
+    past = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+    e = _entry(
+        valid_from=past, valid_to=None, superseded_by="01HQ0000000000000000000000"
+    )
+    assert evaluate(e, now=NOW) == "superseded"
+
+
+def test_evaluate_superseded_wins_over_expired():
+    past = datetime(2026, 1, 1, tzinfo=UTC).isoformat()
+    expired = datetime(2026, 3, 1, tzinfo=UTC).isoformat()
+    e = _entry(
+        valid_from=past,
+        valid_to=expired,
+        superseded_by="01HQ0000000000000000000000",
+    )
+    # superseded classification takes precedence
+    assert evaluate(e, now=NOW) == "superseded"
+
+
+def test_evaluate_at_exact_valid_to_is_expired():
+    at = datetime(2026, 4, 22, 12, 0, tzinfo=UTC).isoformat()
+    e = _entry(valid_from="2026-01-01T00:00:00+00:00", valid_to=at)
+    # boundary: now == valid_to → expired
+    assert evaluate(e, now=NOW) == "expired"

--- a/tests/test_staleness.py
+++ b/tests/test_staleness.py
@@ -1,0 +1,68 @@
+"""Tests for staleness evaluator and valid_to duration parsing."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from staleness import ParseError, parse_valid_to
+
+
+def test_parse_none_returns_none():
+    assert parse_valid_to(None, now=datetime.now(UTC)) is None
+
+
+def test_parse_empty_string_returns_none():
+    assert parse_valid_to("", now=datetime.now(UTC)) is None
+
+
+def test_parse_iso_date_passthrough():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    result = parse_valid_to("2027-01-01", now=now)
+    assert result == "2027-01-01T00:00:00+00:00"
+
+
+def test_parse_iso_datetime_passthrough():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    result = parse_valid_to("2027-01-01T12:00:00+00:00", now=now)
+    assert result == "2027-01-01T12:00:00+00:00"
+
+
+def test_parse_duration_days():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    result = parse_valid_to("90d", now=now)
+    # 2026-04-22 + 90 days = 2026-07-21
+    assert result.startswith("2026-07-21")
+
+
+def test_parse_duration_months():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    result = parse_valid_to("6mo", now=now)
+    # 6 months treated as 6 * 30 days = 180 days
+    assert result.startswith("2026-10-19")
+
+
+def test_parse_duration_years():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    result = parse_valid_to("1y", now=now)
+    # 1 year treated as 365 days
+    assert result.startswith("2027-04-22")
+
+
+def test_parse_duration_zero_rejected():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    with pytest.raises(ParseError):
+        parse_valid_to("0d", now=now)
+
+
+def test_parse_duration_negative_rejected():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    with pytest.raises(ParseError):
+        parse_valid_to("-5d", now=now)
+
+
+def test_parse_garbage_rejected():
+    now = datetime(2026, 4, 22, tzinfo=UTC)
+    with pytest.raises(ParseError):
+        parse_valid_to("banana", now=now)

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -261,3 +261,71 @@ def test_parse_contradiction_output_missing_key_returns_empty():
     raw = '{"other":"shape"}'
     result = WikiCompiler._parse_contradiction_output(raw)
     assert result.contradicts == []
+
+
+class TestDetectContradictions:
+    @pytest.mark.asyncio
+    async def test_flags_contradicting_sibling(self, compiler: WikiCompiler) -> None:
+        sibling = WikiEntry(
+            id="01HQ0000000000000000000000",
+            title="Use X",
+            content="Always use X.",
+            source_type="plan",
+            topic="patterns",
+        )
+        new = WikiEntry(
+            id="01HQ1111111111111111111111",
+            title="Never use X",
+            content="Never use X, prefer Y.",
+            source_type="plan",
+            topic="patterns",
+        )
+        raw_output = (
+            '{"contradicts":[{"id":"01HQ0000000000000000000000",'
+            '"reason":"new entry reverses guidance"}]}'
+        )
+        compiler._call_model = AsyncMock(return_value=raw_output)
+
+        result = await compiler.detect_contradictions(
+            new_entry=new, siblings=[sibling], repo="acme/widget"
+        )
+        assert len(result.contradicts) == 1
+        assert result.contradicts[0].id == "01HQ0000000000000000000000"
+
+    @pytest.mark.asyncio
+    async def test_empty_siblings_skips_llm(self, compiler: WikiCompiler) -> None:
+        compiler._call_model = AsyncMock()
+        new = WikiEntry(
+            id="01HQ0000000000000000000000",
+            title="x",
+            content="x",
+            source_type="plan",
+            topic="patterns",
+        )
+        result = await compiler.detect_contradictions(
+            new_entry=new, siblings=[], repo="acme/widget"
+        )
+        assert result.contradicts == []
+        compiler._call_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_returns_empty(self, compiler: WikiCompiler) -> None:
+        compiler._call_model = AsyncMock(return_value=None)
+        sibling = WikiEntry(
+            id="01HQ0000000000000000000000",
+            title="x",
+            content="x",
+            source_type="plan",
+            topic="patterns",
+        )
+        new = WikiEntry(
+            id="01HQ1111111111111111111111",
+            title="y",
+            content="y",
+            source_type="plan",
+            topic="patterns",
+        )
+        result = await compiler.detect_contradictions(
+            new_entry=new, siblings=[sibling], repo="acme/widget"
+        )
+        assert result.contradicts == []

--- a/tests/test_wiki_compiler.py
+++ b/tests/test_wiki_compiler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from repo_wiki import RepoWikiStore, WikiEntry
-from wiki_compiler import WikiCompiler
+from wiki_compiler import ContradictionCheck, WikiCompiler
 
 
 @pytest.fixture
@@ -223,3 +223,41 @@ class TestSynthesizeIngest:
 
         entries = await compiler.synthesize_ingest(REPO, 1, "plan", "x" * 200)
         assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# Contradiction output parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_contradiction_output_valid():
+    raw = '{"contradicts":[{"id":"01HQ0000000000000000000000","reason":"replaced"}]}'
+    result = WikiCompiler._parse_contradiction_output(raw)
+    assert isinstance(result, ContradictionCheck)
+    assert len(result.contradicts) == 1
+    assert result.contradicts[0].id == "01HQ0000000000000000000000"
+    assert result.contradicts[0].reason == "replaced"
+
+
+def test_parse_contradiction_output_empty_list():
+    raw = '{"contradicts":[]}'
+    result = WikiCompiler._parse_contradiction_output(raw)
+    assert result.contradicts == []
+
+
+def test_parse_contradiction_output_with_markdown_fence():
+    raw = '```json\n{"contradicts":[]}\n```'
+    result = WikiCompiler._parse_contradiction_output(raw)
+    assert result.contradicts == []
+
+
+def test_parse_contradiction_output_invalid_json_returns_empty():
+    raw = "not json"
+    result = WikiCompiler._parse_contradiction_output(raw)
+    assert result.contradicts == []
+
+
+def test_parse_contradiction_output_missing_key_returns_empty():
+    raw = '{"other":"shape"}'
+    result = WikiCompiler._parse_contradiction_output(raw)
+    assert result.contradicts == []

--- a/uv.lock
+++ b/uv.lock
@@ -236,6 +236,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "python-ulid" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -287,6 +288,7 @@ requires-dist = [
     { name = "pytest-rerunfailures", marker = "extra == 'test'", specifier = ">=16.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.5.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.0" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
@@ -620,6 +622,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "python-ulid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Phase 1 of the HydraFlow knowledge-system redesign (spec: `docs/superpowers/specs/2026-04-22-knowledge-system-redesign-design.md`). Adds the temporal-invalidation foundation, LLM-judged contradiction detection at ingest, and a runtime ADR indexer. No existing behavior is removed; Hindsight remains untouched. Phases 2 (promotion: reflection bridge + tribal wiki + agent-drafted ADRs) and 3 (cutover: remove Hindsight) follow in separate plans.

## What changes

### Temporal wiki (ex-PR 1)
- `WikiEntry` gains `id` (ULID), `topic`, `source_repo`, `valid_from`, `valid_to`, `superseded_by`, `superseded_reason`, `confidence`.
- New `src/staleness.py` — pure-function duration parser (`Nd`/`Nmo`/`Ny`/ISO) + `evaluate()` classifier (current / pending / expired / superseded) with superseded taking precedence.
- `RepoWikiStore.query()` filters out non-`current` entries via the staleness evaluator.
- `RepoWikiStore.active_lint()` no longer hard-prunes 90-day-old entries; it flags them via `review_candidates_flagged`. Content-based supersedes replaces time-based expiry.
- Backward compatible: pre-Phase-1 on-disk wikis load with defaulted fields (`valid_from := created_at`, `valid_to := null`, `confidence := medium`).

### Contradiction detector (ex-PR 2)
- New `WIKI_SUPERSEDES` `EventType`.
- New `ContradictionCheck` / `ContradictedEntry` Pydantic models + `WikiCompiler._parse_contradiction_output` (tolerates markdown fences, malformed JSON, missing keys).
- New `WikiCompiler.detect_contradictions()` async method — single LLM call per ingest; empty siblings short-circuits; LLM failure returns empty.
- New `RepoWikiStore.mark_superseded()` — sets `superseded_by`/`superseded_reason` on an existing entry by id; does not delete.
- New async helper `ingest_phase_output()` in `src/repo_wiki_ingest.py` that wraps `store.ingest()` and runs contradiction detection over each entry's current topic siblings. Optional `event_bus` parameter publishes `WIKI_SUPERSEDES` per contradiction.
- Existing sync `ingest_from_plan` / `ingest_from_review` left untouched.

### ADR runtime indexer (ex-PR 3)
- New `src/adr_index.py` with `parse_adr_file`, `scan_adr_directory`, `render_full`, `render_titles_only`, and `ADRIndex` (mtime-based cache).
- `BaseRunner._inject_adr_index()` — full render on plan phase (falls back to titles-only if over 4 KB), titles-only on implement/review, nothing on other phases. `_phase_name: ClassVar[str]` overridden on `PlannerRunner` / `AgentRunner` / `ReviewRunner`.
- Smoke test against real `docs/adr/` guards against template drift.

## Spec

`docs/superpowers/specs/2026-04-22-knowledge-system-redesign-design.md`
Phase plan: `docs/superpowers/plans/2026-04-22-knowledge-system-phase1-foundation.md` (local/gitignored)

## Test plan

- [x] Unit tests for schema (46), staleness parse + evaluate (16), contradiction parser (5), `detect_contradictions` behavior (3), `mark_superseded` (2), ADR parse/render/cache (12), ADR smoke vs real docs/adr (1), `_inject_adr_index` phases (4).
- [x] Integration: ingest-then-contradict full cycle via `ingest_phase_output`; supersedes chain verified on disk and via `query()`.
- [x] Integration: `WIKI_SUPERSEDES` event payload verified end-to-end.
- [x] Backward-compat: pre-Phase-1 on-disk layout loads and queries correctly.
- [x] `test_build_prompt_truncates_long_body` budget raised from 11k→14k to reflect ADR titles section.
- [x] `make quality` green (11,161 passed, 0 failed).

## Scope explicitly NOT in this PR

- Reflection→wiki bridge (Phase 2).
- Tribal wiki + generalization pass (Phase 2).
- Agent-drafted ADRs (Phase 2).
- Hindsight recall/retain removal (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)