### PR TITLE
fix(ui): silence vite ws-proxy EPIPE noise + stop force-closing WS on error

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1542,7 +1542,10 @@ export function HydraFlowProvider({ children }) {
       reconnectTimer.current = setTimeout(connect, 2000)
     }
 
-    ws.onerror = () => ws.close()
+    // Don't force-close on error — browsers fire `close` after `error`
+    // automatically, and calling close() here races a frame still in flight
+    // through the Vite dev proxy, producing EPIPE noise during reconnect.
+    ws.onerror = () => {}
     wsRef.current = ws
   }, [state.selectedRepoSlug, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
 

--- a/src/ui/vite.config.mjs
+++ b/src/ui/vite.config.mjs
@@ -1,7 +1,24 @@
-import { defineConfig } from 'vite'
+import { defineConfig, createLogger } from 'vite'
 import react from '@vitejs/plugin-react'
 
+// Vite attaches its own `error` handler to the proxy EventEmitter after the
+// user's `configure` runs, so `proxy.on('error', ...)` can't suppress the
+// "ws proxy error" / "ws proxy socket error" messages; the socket-level
+// error is per-request and unreachable from config entirely. The only lever
+// is the logger. These errors fire when a browser socket tears down
+// mid-write (HMR reload, StrictMode remount, backgrounded tab) — the
+// frontend reconnects on its own.
+const logger = createLogger()
+const originalError = logger.error.bind(logger)
+logger.error = (msg, options) => {
+  if (typeof msg === 'string' && /ws proxy (?:socket )?error/.test(msg)) {
+    return
+  }
+  originalError(msg, options)
+}
+
 export default defineConfig({
+  customLogger: logger,
   plugins: [react()],
   base: '/',
   optimizeDeps: {
@@ -25,12 +42,6 @@ export default defineConfig({
       '/ws': {
         target: 'ws://localhost:5555',
         ws: true,
-        configure: (proxy) => {
-          proxy.on('error', () => {
-            // Silently handle expected proxy errors (ECONNRESET/EPIPE)
-            // Frontend auto-reconnects via useHydraFlowSocket
-          })
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- `proxy.on('error', ...)` in `vite.config.mjs` was dead code: Vite registers its own `error` handler on the proxy EventEmitter *after* user `configure()` runs, and the per-socket `error` listener is attached inside `proxyReqWs` where user config can't reach it. Replaced with a `customLogger` that filters the two noise patterns (`ws proxy error` / `ws proxy socket error`).
- Dropped `ws.onerror = () => ws.close()` in `HydraFlowContext.jsx`. Browsers fire `close` after `error` automatically; force-closing here races a frame still in flight through the Vite proxy — that's what actually generated the EPIPE errors the user was seeing.

## Why the old approach didn't work
Vite 7's `proxyMiddleware` ([source][1]):
```js
const proxy = createProxyServer(opts)
if (opts.configure) opts.configure(proxy, opts)   // user handler attached first
proxy.on('error', ...)                            // Vite's logger attached AFTER — both fire
proxy.on('proxyReqWs', (req, res, socket) => {
  socket.on('error', ...)                         // per-socket, unreachable from config
})
```
EventEmitter fires both listeners. The user's no-op handler didn't suppress anything; Vite's internal logger always ran.

## Evidence of the zombie connection pattern
Observed during investigation: 2 browser→Vite WS established, only 1 Vite→backend tunnel established, 12 CLOSED sockets piled up from past reconnects. StrictMode double-mount + `onerror` force-close was producing the churn.

## Why no backend ping
Uvicorn already sends protocol-level pings (`ws_ping_interval=20` default), so an app-level heartbeat would be redundant.

## Test plan
- [x] `npx vitest run` — 1061 UI tests pass
- [x] `pytest tests/test_dashboard_websocket.py` — 11 WS tests pass
- [ ] Manual: start `make ui-dev`, open 2 tabs, background one for a minute, confirm no `ws proxy (socket) error` messages in terminal
- [ ] Manual: trigger HMR reload (edit a file), confirm WS reconnects without EPIPE noise

[1]: https://github.com/vitejs/vite/blob/v7.3.2/packages/vite/src/node/server/middlewares/proxy.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)