### PR TITLE
feat(knowledge): Phase 3 part 1 — observability + production wiring + reversible recall flag

### DIFF
--- a/docs/agents/commands.md
+++ b/docs/agents/commands.md
@@ -58,3 +58,47 @@ make lint && make test
 # Before committing
 make quality
 ```
+
+## Hindsight recall — disable / re-enable
+
+Phase 3 PR 9 ships with `hindsight_recall_enabled=True` by default. To
+flip off during the 2-week observation window while validating that the
+wiki-based system catches everything Hindsight was catching:
+
+```bash
+export HYDRAFLOW_HINDSIGHT_RECALL_ENABLED=false
+```
+
+To re-enable (rollback):
+
+```bash
+unset HYDRAFLOW_HINDSIGHT_RECALL_ENABLED
+```
+
+Retains (writes to Hindsight) remain active — only reads are gated. The
+archive keeps accumulating so nothing is lost during the observation
+window.
+
+Metrics to watch on the dashboard (`/api/wiki/metrics`):
+
+- `wiki_entries_ingested` should climb at approximately the rate of
+  plan/implement/review cycles.
+- `wiki_supersedes` should be non-zero within a few days (proves the
+  contradiction detector is active).
+- `tribal_promotions` will be zero until ≥2 active target repos share
+  a principle (may stay zero indefinitely with only one managed repo).
+- `reflections_bridged` should increment once per target-repo issue
+  merge.
+- `adr_drafts_judged` / `adr_drafts_opened` are non-zero only when
+  agents have emitted `ADR_DRAFT_SUGGESTION` blocks.
+
+Also watch `/api/wiki/health` — `store: populated` and (with ≥2 repos)
+`tribal: populated` indicate the stores are being used.
+
+Issue auto-merge rate should be stable within ±10% of the pre-change
+baseline. Error rate should not change.
+
+If divergence or regressions appear, unset the env var and file an
+issue; do not proceed to the Hindsight deletion (Phase 3 PR 10) until
+the gap is understood.
+

--- a/scripts/extract_hindsight_to_wiki.py
+++ b/scripts/extract_hindsight_to_wiki.py
@@ -1,0 +1,162 @@
+"""One-time pre-cutover extraction: Hindsight banks → wiki.
+
+Reads every memory from the configured Hindsight instance, filters to
+the subset with corroboration (≥2 citations OR tied to a closed issue),
+runs them through the librarian, and writes the survivors as WikiEntry
+objects in the appropriate wiki (per-repo or tribal).
+
+Most memories are expected to drop. This is intentional — Hindsight
+accumulated years of unstructured noise; the wiki should only carry
+what has evidence behind it.
+
+Run pre-cutover:
+
+    PYTHONPATH=src uv run python scripts/extract_hindsight_to_wiki.py \\
+        --dry-run
+
+Then without --dry-run to commit. Safe to re-run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from repo_wiki import RepoWikiStore
+    from wiki_compiler import WikiCompiler
+
+logger = logging.getLogger("extract_hindsight_to_wiki")
+
+
+def extract_corroborated_memories(memories: list[dict]) -> list[dict]:
+    """Filter memories to those with evidence.
+
+    Rules (any-of):
+      1. ≥2 citations.
+      2. Exactly 1 citation AND ``closed_issue`` truthy.
+    """
+    survivors: list[dict] = []
+    for m in memories:
+        cites = m.get("citations") or []
+        closed = bool(m.get("closed_issue", False))
+        if len(cites) >= 2 or len(cites) == 1 and closed:
+            survivors.append(m)
+    return survivors
+
+
+async def write_entries_to_wiki(
+    *,
+    store: RepoWikiStore,
+    compiler: WikiCompiler,
+    repo: str,
+    memories: list[dict],
+) -> int:
+    """Route each memory through synthesize_ingest; write what comes back.
+
+    Returns the number of entries written.
+    """
+    total = 0
+    for m in memories:
+        entries = await compiler.synthesize_ingest(
+            repo=repo,
+            issue_number=m.get("issue_number", 0),
+            source_type="librarian",
+            raw_text=m.get("text", ""),
+        )
+        if entries:
+            store.ingest(repo, entries)
+            total += len(entries)
+    return total
+
+
+async def _run(args: argparse.Namespace) -> int:
+    """Live-run path. Imports are deferred so test imports don't fail."""
+    from config import load_config  # noqa: PLC0415
+    from hindsight import HindsightClient  # noqa: PLC0415
+    from hindsight_types import Bank  # noqa: PLC0415
+    from repo_wiki import RepoWikiStore  # noqa: PLC0415
+    from tribal_wiki import TribalWikiStore  # noqa: PLC0415
+    from wiki_compiler import WikiCompiler  # noqa: PLC0415
+
+    config = load_config()
+    client = HindsightClient(config=config)
+
+    # recall_banks fetches from all banks concurrently; use a broad query to
+    # surface as many memories as possible.  The corroboration filter below
+    # discards noise.
+    banks = [
+        Bank.TRIBAL,
+        Bank.TROUBLESHOOTING,
+        Bank.HARNESS_INSIGHTS,
+        Bank.REVIEW_INSIGHTS,
+        Bank.RETROSPECTIVES,
+    ]
+    all_memories: list[dict] = []
+    try:
+        bank_results = await client.recall_banks(
+            query="*",
+            banks=banks,
+            limit=500,
+        )
+        for _bank, memories in bank_results.items():
+            for m in memories:
+                all_memories.append(
+                    {
+                        "text": m.display_text,
+                        "citations": m.metadata.get("citations", []),
+                        "closed_issue": m.metadata.get("closed_issue", False),
+                        "issue_number": m.metadata.get("issue_number", 0),
+                    }
+                )
+    except Exception:  # noqa: BLE001
+        logger.warning("recall_banks failed", exc_info=True)
+
+    survivors = extract_corroborated_memories(all_memories)
+    logger.info(
+        "extracted %d survivors out of %d raw memories",
+        len(survivors),
+        len(all_memories),
+    )
+
+    if args.dry_run:
+        return 0
+
+    if args.repo == "global":
+        store = TribalWikiStore(config.data_path("tribal"))
+        effective_repo = "global"
+    else:
+        store = RepoWikiStore(config.data_path("repo_wiki"))
+        effective_repo = args.repo
+
+    compiler = WikiCompiler(config=config, runner=None, credentials=None)
+    total = await write_entries_to_wiki(
+        store=store,
+        compiler=compiler,
+        repo=effective_repo,
+        memories=survivors,
+    )
+    logger.info("wrote %d entries to wiki (repo=%s)", total, effective_repo)
+    return 0
+
+
+async def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Filter and report counts; do not write.",
+    )
+    parser.add_argument(
+        "--repo",
+        default="global",
+        help='Target repo slug. "global" → tribal store.',
+    )
+    args = parser.parse_args(argv)
+    return await _run(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/extract_hindsight_to_wiki.py
+++ b/scripts/extract_hindsight_to_wiki.py
@@ -73,73 +73,40 @@ async def write_entries_to_wiki(
 
 
 async def _run(args: argparse.Namespace) -> int:
-    """Live-run path. Imports are deferred so test imports don't fail."""
-    from config import load_config  # noqa: PLC0415
-    from hindsight import HindsightClient  # noqa: PLC0415
-    from hindsight_types import Bank  # noqa: PLC0415
-    from repo_wiki import RepoWikiStore  # noqa: PLC0415
-    from tribal_wiki import TribalWikiStore  # noqa: PLC0415
-    from wiki_compiler import WikiCompiler  # noqa: PLC0415
+    """Live-run path. Not yet integrated.
 
-    config = load_config()
-    client = HindsightClient(config=config)
+    The pure functions above (``extract_corroborated_memories`` and
+    ``write_entries_to_wiki``) are tested and correct. This live driver
+    is a placeholder: wiring the live Hindsight API + configured stores
+    + compiler is deferred until an operator actually runs the cutover
+    extraction. They will need to:
 
-    # recall_banks fetches from all banks concurrently; use a broad query to
-    # surface as many memories as possible.  The corroboration filter below
-    # discards noise.
-    banks = [
-        Bank.TRIBAL,
-        Bank.TROUBLESHOOTING,
-        Bank.HARNESS_INSIGHTS,
-        Bank.REVIEW_INSIGHTS,
-        Bank.RETROSPECTIVES,
-    ]
-    all_memories: list[dict] = []
-    try:
-        bank_results = await client.recall_banks(
-            query="*",
-            banks=banks,
-            limit=500,
-        )
-        for _bank, memories in bank_results.items():
-            for m in memories:
-                all_memories.append(
-                    {
-                        "text": m.display_text,
-                        "citations": m.metadata.get("citations", []),
-                        "closed_issue": m.metadata.get("closed_issue", False),
-                        "issue_number": m.metadata.get("issue_number", 0),
-                    }
-                )
-    except Exception:  # noqa: BLE001
-        logger.warning("recall_banks failed", exc_info=True)
+      1. Build a ``HydraFlowConfig`` via ``load_hydraflow_config()`` or
+         equivalent.
+      2. Construct ``HindsightClient(base_url=config.hindsight_url,
+         api_key=credentials.hindsight_api_key)``.
+      3. Call ``client.recall_banks(query=..., banks=[Bank.TRIBAL, ...])``
+         and map each ``HindsightMemory`` to the dict shape accepted by
+         ``extract_corroborated_memories`` (keys: text, citations,
+         closed_issue, issue_number).
+      4. Build a ``SubprocessRunner`` + ``WikiCompiler(config, runner,
+         credentials)``.
+      5. Build the target store: ``TribalWikiStore(...)`` for
+         ``--repo global`` else ``RepoWikiStore(...)``.
+      6. ``await write_entries_to_wiki(store=..., compiler=...,
+         repo=effective_repo, memories=survivors)``.
 
-    survivors = extract_corroborated_memories(all_memories)
+    The shape of each wiring step differs slightly across HydraFlow
+    versions; writing it against a specific version is safer than
+    committing a stub that silently rots.
+    """
     logger.info(
-        "extracted %d survivors out of %d raw memories",
-        len(survivors),
-        len(all_memories),
+        "extract_hindsight_to_wiki live path is not integrated. "
+        "Call extract_corroborated_memories + write_entries_to_wiki "
+        "directly from a wired entry point."
     )
-
-    if args.dry_run:
-        return 0
-
-    if args.repo == "global":
-        store = TribalWikiStore(config.data_path("tribal"))
-        effective_repo = "global"
-    else:
-        store = RepoWikiStore(config.data_path("repo_wiki"))
-        effective_repo = args.repo
-
-    compiler = WikiCompiler(config=config, runner=None, credentials=None)
-    total = await write_entries_to_wiki(
-        store=store,
-        compiler=compiler,
-        repo=effective_repo,
-        memories=survivors,
-    )
-    logger.info("wrote %d entries to wiki (repo=%s)", total, effective_repo)
-    return 0
+    _ = args  # unused
+    return 1
 
 
 async def main(argv: list[str] | None = None) -> int:

--- a/src/adr_draft_opener.py
+++ b/src/adr_draft_opener.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from knowledge_metrics import metrics as _metrics
+
 if TYPE_CHECKING:
     from wiki_compiler import ADRDraftDecision
 
@@ -67,5 +69,6 @@ async def open_adr_draft_issue(
 
     if not isinstance(response, dict):
         return None
+    _metrics.increment("adr_drafts_opened")
     number = response.get("number")
     return int(number) if number is not None else None

--- a/src/agent.py
+++ b/src/agent.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from hindsight_wal import HindsightWAL
     from repo_wiki import RepoWikiStore
     from tracing_context import TracingContext
+    from tribal_wiki import TribalWikiStore
 
 logger = logging.getLogger("hydraflow.agent")
 
@@ -144,6 +145,7 @@ Run through this checklist before your final commit:
         wal: HindsightWAL | None = None,
         credentials: Credentials | None = None,
         wiki_store: RepoWikiStore | None = None,
+        tribal_wiki_store: TribalWikiStore | None = None,
     ) -> None:
         super().__init__(
             config,
@@ -152,6 +154,7 @@ Run through this checklist before your final commit:
             hindsight=hindsight,
             credentials=credentials,
             wiki_store=wiki_store,
+            tribal_wiki_store=tribal_wiki_store,
         )
         self._insights = ReviewInsightStore(
             config.memory_dir, hindsight=hindsight, dolt=dolt, wal=wal

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -278,6 +278,9 @@ class BaseRunner:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
+            self._log.debug(
+                "_save_transcript called outside event loop — ADR-draft pipeline skipped"
+            )
             return
         loop.create_task(self._process_transcript_for_adr_draft(transcript))
 

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -347,7 +347,11 @@ class BaseRunner:
         dedup_items_removed = 0
         dedup_chars_saved = 0
 
-        if self._hindsight is not None and query_context:
+        if (
+            self._hindsight is not None
+            and query_context
+            and getattr(self._config, "hindsight_recall_enabled", True)
+        ):
             from hindsight import Bank, format_memories_as_markdown, recall_safe
 
             max_chars = self._config.max_memory_prompt_chars

--- a/src/config.py
+++ b/src/config.py
@@ -253,6 +253,7 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ),
     ("collaborator_check_enabled", "HYDRAFLOW_COLLABORATOR_CHECK_ENABLED", True),
     ("memory_auto_approve", "HYDRAFLOW_MEMORY_AUTO_APPROVE", False),
+    ("hindsight_recall_enabled", "HYDRAFLOW_HINDSIGHT_RECALL_ENABLED", True),
     ("visual_gate_enabled", "HYDRAFLOW_VISUAL_GATE_ENABLED", False),
     ("visual_gate_bypass", "HYDRAFLOW_VISUAL_GATE_BYPASS", False),
     ("visual_validation_enabled", "HYDRAFLOW_VISUAL_VALIDATION_ENABLED", True),
@@ -1102,6 +1103,16 @@ class HydraFlowConfig(BaseModel):
         ge=5,
         le=120,
         description="HTTP timeout in seconds for Hindsight API calls",
+    )
+
+    hindsight_recall_enabled: bool = Field(
+        default=True,
+        description=(
+            "When False, base_runner skips Hindsight recall injection at "
+            "prompt-build time. Retains remain active; only reads are gated. "
+            "Phase 3 rollout knob — set to False via "
+            "HYDRAFLOW_HINDSIGHT_RECALL_ENABLED for the observation window."
+        ),
     )
 
     memory_auto_approve: bool = Field(

--- a/src/dashboard_routes/_wiki_routes.py
+++ b/src/dashboard_routes/_wiki_routes.py
@@ -202,6 +202,43 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
     mutate the wiki directly.
     """
 
+    @router.get("/api/wiki/metrics")
+    async def get_wiki_metrics() -> dict:
+        """Return current knowledge-system counters as a JSON snapshot."""
+        from knowledge_metrics import metrics as _metrics  # noqa: PLC0415
+
+        return _metrics.snapshot()
+
+    @router.get("/api/wiki/health")
+    async def get_wiki_health() -> dict:
+        """Report wiki + tribal store presence and rough sizing.
+
+        Reads the RepoWikiLoop's store and tribal_store attributes so the
+        dashboard can show whether the knowledge system is populated.
+        """
+        result: dict = {"store": "unconfigured", "tribal": "unconfigured"}
+        loop = _wiki_loop(ctx)
+        if loop is None:
+            return result
+
+        store = getattr(loop, "_wiki_store", None)
+        if store is not None:
+            try:
+                repos = store.list_repos()
+            except Exception:  # noqa: BLE001
+                repos = []
+            result["store"] = "populated" if repos else "empty"
+            result["repos"] = len(repos)
+
+        tribal = getattr(loop, "_tribal_store", None)
+        if tribal is not None:
+            try:
+                out = tribal.query()
+            except Exception:  # noqa: BLE001
+                out = ""
+            result["tribal"] = "populated" if out else "empty"
+        return result
+
     @router.get("/api/wiki/repos")
     def list_wiki_repos() -> list[dict[str, str]]:
         root = _wiki_root(ctx)

--- a/src/knowledge_metrics.py
+++ b/src/knowledge_metrics.py
@@ -1,0 +1,56 @@
+"""In-memory counters for knowledge-system activity.
+
+Lightweight Prometheus-style counters backed by a threading Lock.  Callers
+mutate via ``metrics.increment("<name>")``; dashboards read via
+``metrics.snapshot()``.  All counters are process-local — aggregation
+across workers (if any) is an open question for a future metrics bus.
+
+Reasons for an in-memory module-level singleton (vs. passing an instance):
+ - Every knowledge-system hook already runs in-process.
+ - The counter set is fixed and small (~6 values).
+ - Test isolation uses ``reset()`` at setup, not per-test instances.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+
+_COUNTER_NAMES = (
+    "wiki_entries_ingested",
+    "wiki_supersedes",
+    "tribal_promotions",
+    "adr_drafts_judged",
+    "adr_drafts_opened",
+    "reflections_bridged",
+)
+
+
+@dataclass
+class KnowledgeMetrics:
+    """Mutable counter bag for knowledge-system events."""
+
+    _values: dict[str, int] = field(
+        default_factory=lambda: dict.fromkeys(_COUNTER_NAMES, 0)
+    )
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def increment(self, name: str, amount: int = 1) -> None:
+        if name not in self._values:
+            raise KeyError(f"unknown counter: {name!r}")
+        with self._lock:
+            self._values[name] += amount
+
+    def snapshot(self) -> dict[str, int]:
+        """Return a copy of current counter values."""
+        with self._lock:
+            return dict(self._values)
+
+    def reset(self) -> None:
+        """Zero every counter (used in tests)."""
+        with self._lock:
+            for k in self._values:
+                self._values[k] = 0
+
+
+metrics = KnowledgeMetrics()

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -145,11 +145,15 @@ class PostMergeHandler:
         update_bg_worker_status: StatusCallback | None = None,
         epic_manager: EpicManager | None = None,
         store: IssueStorePort | None = None,
+        *,
+        wiki_store: RepoWikiStore | None = None,
+        wiki_compiler: WikiCompiler | None = None,
     ) -> None:
         self._config = config
         self._state = state
         self._prs = prs
         self._bus = event_bus
+        self._event_bus = event_bus  # Named exposure for reflection-bridge hook
         self._ac_generator = ac_generator
         self._retrospective = retrospective
         self._verification_judge = verification_judge
@@ -158,6 +162,8 @@ class PostMergeHandler:
         self._prompt_telemetry = PromptTelemetry(config)
         self._epic_manager = epic_manager
         self._store = store
+        self._wiki_store = wiki_store
+        self._wiki_compiler = wiki_compiler
 
     def _should_defer_merge(self, issue_number: int) -> bool:
         """Return True if merge should be deferred for bundled epic strategy."""
@@ -566,19 +572,16 @@ class PostMergeHandler:
                         exc_info=True,
                     )
 
-        if (
-            getattr(self, "_wiki_store", None) is not None
-            and getattr(self, "_wiki_compiler", None) is not None
-        ):
+        if self._wiki_store is not None and self._wiki_compiler is not None:
             await self._safe_hook(
                 "reflection bridge",
                 _bridge_reflections_to_wiki(
                     config=self._config,
                     issue_number=pr.issue_number,
                     repo=self._config.repo or "",
-                    store=getattr(self, "_wiki_store", None),
-                    compiler=getattr(self, "_wiki_compiler", None),
-                    event_bus=getattr(self, "_event_bus", None),
+                    store=self._wiki_store,
+                    compiler=self._wiki_compiler,
+                    event_bus=self._event_bus,
                 ),
                 pr.issue_number,
             )

--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -12,6 +12,7 @@ from acceptance_criteria import AcceptanceCriteriaGenerator
 from config import HydraFlowConfig
 from epic import EpicCompletionChecker
 from events import EventBus, EventType, HydraFlowEvent
+from knowledge_metrics import metrics as _metrics
 
 if TYPE_CHECKING:
     from epic import EpicManager
@@ -85,6 +86,7 @@ async def _bridge_reflections_to_wiki(
                 event_bus=event_bus,
             )
         clear_reflections(config, issue_number)
+        _metrics.increment("reflections_bridged")
     except Exception:  # noqa: BLE001
         logger.warning(
             "reflection bridge failed for issue #%d; log kept for retry",

--- a/src/repo_wiki_ingest.py
+++ b/src/repo_wiki_ingest.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from pydantic import BaseModel
 
 from events import EventType, HydraFlowEvent
+from knowledge_metrics import metrics as _metrics
 from repo_wiki import WikiEntry, classify_topic
 from staleness import evaluate as evaluate_staleness
 
@@ -270,6 +271,7 @@ async def ingest_phase_output(
             f"ingest_phase_output entries must have unique ids; duplicate: {duplicates!r}"
         )
     ingest_result = store.ingest(repo, entries)
+    _metrics.increment("wiki_entries_ingested", len(entries))
     result = IngestWithContradictionsResult(
         entries_added=ingest_result.entries_added,
         entries_updated=ingest_result.entries_updated,
@@ -325,6 +327,7 @@ async def _emit_wiki_supersedes(
     reason: str,
 ) -> None:
     """Publish a WIKI_SUPERSEDES event. Swallows errors."""
+    _metrics.increment("wiki_supersedes")
     event = HydraFlowEvent(
         type=EventType.WIKI_SUPERSEDES,
         data={

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -15,6 +15,7 @@ from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
 from events import EventType, HydraFlowEvent
+from knowledge_metrics import metrics as _metrics
 from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
 from staleness import evaluate as evaluate_staleness
 from subprocess_util import run_subprocess
@@ -106,6 +107,7 @@ async def run_generalization_pass(
                         reason="promoted to tribal wiki",
                     )
                 result.promoted += 1
+                _metrics.increment("tribal_promotions")
 
                 if event_bus is not None:
                     event = HydraFlowEvent(

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -274,7 +274,10 @@ def build_services(
     repo_wiki_store = RepoWikiStore(
         wiki_root=config.data_path("repo_wiki"),
     )
+    from tribal_wiki import TribalWikiStore  # noqa: PLC0415
     from wiki_compiler import WikiCompiler  # noqa: PLC0415
+
+    tribal_wiki_store = TribalWikiStore(config.data_path("tribal"))
 
     wiki_compiler = WikiCompiler(
         config=config,
@@ -290,6 +293,7 @@ def build_services(
         wal=hindsight_wal,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     planners = PlannerRunner(
         config,
@@ -298,6 +302,7 @@ def build_services(
         hindsight=hindsight_client,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     researcher = ResearchRunner(
         config,
@@ -306,6 +311,7 @@ def build_services(
         hindsight=hindsight_client,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     prs = PRManager(config, event_bus, credentials=credentials)
     reviewers = ReviewRunner(
@@ -315,6 +321,7 @@ def build_services(
         hindsight=hindsight_client,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     hitl_runner = HITLRunner(
         config,
@@ -323,6 +330,7 @@ def build_services(
         hindsight=hindsight_client,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     triage = TriageRunner(
         config,
@@ -331,6 +339,7 @@ def build_services(
         hindsight=hindsight_client,
         credentials=credentials,
         wiki_store=repo_wiki_store,
+        tribal_wiki_store=tribal_wiki_store,
     )
     summarizer = TranscriptSummarizer(
         config, prs, event_bus, state, runner=subprocess_runner, credentials=credentials
@@ -627,6 +636,8 @@ def build_services(
         update_bg_worker_status=callbacks.update_status,
         epic_manager=epic_manager,
         store=store,
+        wiki_store=repo_wiki_store,
+        wiki_compiler=wiki_compiler,
     )
     # ReviewInsightStore shared between AgentRunner and ReviewPhase
     review_insights = ReviewInsightStore(
@@ -781,6 +792,7 @@ def build_services(
         wiki_compiler=wiki_compiler,
         state=state,
         credentials=credentials,
+        tribal_store=tribal_wiki_store,
     )
     diagnostic_runner = DiagnosticRunner(config=config, event_bus=event_bus)
     diagnostic_loop = DiagnosticLoop(

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -29,6 +29,7 @@ export const initialState = {
   hitlEscalation: null,
   humanInputRequests: {},
   backgroundWorkers: [],
+  adrDrafts: [],
   metrics: null,
   systemAlert: null,
   intents: [],
@@ -807,6 +808,20 @@ export function reducer(state, action) {
         selectedSessionId: state.selectedSessionId === action.data.sessionId
           ? null
           : state.selectedSessionId,
+      }
+
+    case 'adr_draft_opened':
+      return {
+        ...addEvent(state, action),
+        adrDrafts: [
+          {
+            issueNumber: action.data.issue_number,
+            title: action.data.title,
+            reason: action.data.reason,
+            timestamp: action.timestamp,
+          },
+          ...(state.adrDrafts || []).slice(0, 19),
+        ],
       }
 
     default:

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, Field
 
+from knowledge_metrics import metrics as _metrics
 from repo_wiki import WikiEntry
 
 _SYNTHESIS_ID_RE = re.compile(r"^(\d+)-")
@@ -606,6 +607,7 @@ class WikiCompiler:
         tribal: TribalWikiStore,
     ) -> ADRDraftDecision:
         """Evaluate the 4 gates for an ADR_DRAFT_SUGGESTION."""
+        _metrics.increment("adr_drafts_judged")
         decision = ADRDraftDecision()
 
         # Gate 1 — evidence list has ≥2 distinct issues

--- a/tests/test_event_reducer_coverage.py
+++ b/tests/test_event_reducer_coverage.py
@@ -62,8 +62,6 @@ SKIP_LIST: set[str] = {
     # Tribal promotion events are consumed server-side for audit; no
     # dashboard reducer case.
     "tribal_promotion",
-    # ADR-draft issue-creation events are consumed server-side.
-    "adr_draft_opened",
 }
 
 

--- a/tests/test_extract_hindsight_to_wiki.py
+++ b/tests/test_extract_hindsight_to_wiki.py
@@ -1,0 +1,93 @@
+"""Tests for the pre-cutover Hindsight → wiki extraction script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+# The script lives under scripts/, not src/ — add it to sys.path so tests can import it.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from extract_hindsight_to_wiki import (
+    extract_corroborated_memories,
+    write_entries_to_wiki,
+)
+
+
+def test_extract_corroborated_requires_two_citations():
+    raw = [
+        {"text": "A", "citations": []},
+        {"text": "B", "citations": ["issue#1"]},
+        {"text": "C", "citations": ["issue#1", "issue#2"]},
+    ]
+    survivors = extract_corroborated_memories(raw)
+    assert len(survivors) == 1
+    assert survivors[0]["text"] == "C"
+
+
+def test_extract_keeps_memories_tied_to_closed_issues():
+    raw = [
+        {
+            "text": "Only one cite but tied to closed",
+            "citations": ["issue#99"],
+            "closed_issue": True,
+        },
+        {
+            "text": "Only one cite, open",
+            "citations": ["issue#99"],
+            "closed_issue": False,
+        },
+    ]
+    survivors = extract_corroborated_memories(raw)
+    assert len(survivors) == 1
+    assert "closed" in survivors[0]["text"]
+
+
+def test_extract_handles_missing_citations_field():
+    raw = [{"text": "no citations key at all"}]
+    survivors = extract_corroborated_memories(raw)
+    assert survivors == []
+
+
+async def test_write_entries_runs_synthesize_per_memory(tmp_path):
+    from repo_wiki import RepoWikiStore, WikiEntry
+
+    store = RepoWikiStore(tmp_path / "wiki")
+    compiler = MagicMock()
+    compiler.synthesize_ingest = AsyncMock(
+        return_value=[
+            WikiEntry(
+                title="extracted",
+                content="body",
+                source_type="librarian",
+                topic="patterns",
+            ),
+        ]
+    )
+    written = await write_entries_to_wiki(
+        store=store,
+        compiler=compiler,
+        repo="acme/widget",
+        memories=[{"text": "raw memory", "citations": ["issue#1", "issue#2"]}],
+    )
+    assert written == 1
+    out = store.query("acme/widget")
+    assert "extracted" in out
+
+
+async def test_write_entries_empty_survivor_list_writes_nothing(tmp_path):
+    from repo_wiki import RepoWikiStore
+
+    store = RepoWikiStore(tmp_path / "wiki")
+    compiler = MagicMock()
+    compiler.synthesize_ingest = AsyncMock(return_value=[])  # librarian drops
+    written = await write_entries_to_wiki(
+        store=store,
+        compiler=compiler,
+        repo="acme/widget",
+        memories=[{"text": "raw", "citations": ["issue#1", "issue#2"]}],
+    )
+    assert written == 0

--- a/tests/test_knowledge_metrics.py
+++ b/tests/test_knowledge_metrics.py
@@ -1,0 +1,57 @@
+"""Tests for knowledge-system in-memory metric counters."""
+
+from __future__ import annotations
+
+import pytest
+
+from knowledge_metrics import KnowledgeMetrics
+
+
+def test_metrics_starts_at_zero():
+    m = KnowledgeMetrics()
+    snap = m.snapshot()
+    assert snap["wiki_entries_ingested"] == 0
+    assert snap["wiki_supersedes"] == 0
+    assert snap["tribal_promotions"] == 0
+    assert snap["adr_drafts_judged"] == 0
+    assert snap["adr_drafts_opened"] == 0
+    assert snap["reflections_bridged"] == 0
+
+
+def test_increment_is_independent_across_counters():
+    m = KnowledgeMetrics()
+    m.increment("wiki_supersedes", 3)
+    m.increment("tribal_promotions", 1)
+    snap = m.snapshot()
+    assert snap["wiki_supersedes"] == 3
+    assert snap["tribal_promotions"] == 1
+    assert snap["wiki_entries_ingested"] == 0
+
+
+def test_default_increment_is_one():
+    m = KnowledgeMetrics()
+    m.increment("wiki_supersedes")
+    m.increment("wiki_supersedes")
+    assert m.snapshot()["wiki_supersedes"] == 2
+
+
+def test_unknown_counter_raises():
+    m = KnowledgeMetrics()
+    with pytest.raises(KeyError):
+        m.increment("nonexistent_counter")
+
+
+def test_module_level_metrics_singleton_is_shared():
+    """Callers should import ``metrics`` and share state."""
+    from knowledge_metrics import metrics as m1
+    from knowledge_metrics import metrics as m2
+
+    assert m1 is m2
+
+
+def test_reset_zeroes_all_counters():
+    m = KnowledgeMetrics()
+    m.increment("wiki_supersedes", 5)
+    m.reset()
+    snap = m.snapshot()
+    assert all(v == 0 for v in snap.values())

--- a/tests/test_knowledge_metrics_integration.py
+++ b/tests/test_knowledge_metrics_integration.py
@@ -1,0 +1,214 @@
+"""Integration tests: each counter fires from its real call site."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from knowledge_metrics import metrics
+from repo_wiki import RepoWikiStore, WikiEntry
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics():
+    metrics.reset()
+    yield
+    metrics.reset()
+
+
+async def test_wiki_entries_ingested_increments_on_ingest(tmp_path):
+    from repo_wiki_ingest import ingest_phase_output
+    from wiki_compiler import ContradictionCheck
+
+    store = RepoWikiStore(tmp_path / "wiki")
+    compiler = AsyncMock()
+    compiler.detect_contradictions = AsyncMock(return_value=ContradictionCheck())
+
+    entries = [
+        WikiEntry(title="x", content="y", source_type="plan", topic="patterns"),
+        WikiEntry(title="z", content="w", source_type="plan", topic="patterns"),
+    ]
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=entries,
+        compiler=compiler,
+    )
+    assert metrics.snapshot()["wiki_entries_ingested"] == 2
+
+
+async def test_wiki_supersedes_increments(tmp_path):
+    from repo_wiki_ingest import ingest_phase_output
+    from wiki_compiler import ContradictedEntry, ContradictionCheck
+
+    store = RepoWikiStore(tmp_path / "wiki")
+
+    a = WikiEntry(
+        id="01HQ0000000000000000000000",
+        title="A",
+        content="a",
+        source_type="plan",
+        topic="patterns",
+    )
+    compiler = AsyncMock()
+    compiler.detect_contradictions = AsyncMock(return_value=ContradictionCheck())
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[a],
+        compiler=compiler,
+    )
+
+    # EventBus stub is required because _emit_wiki_supersedes expects one.
+    event_bus = MagicMock()
+    event_bus.publish = AsyncMock()
+
+    b = WikiEntry(
+        id="01HQ1111111111111111111111",
+        title="B",
+        content="b",
+        source_type="plan",
+        topic="patterns",
+    )
+    compiler.detect_contradictions = AsyncMock(
+        return_value=ContradictionCheck(
+            contradicts=[ContradictedEntry(id=a.id, reason="replaces")]
+        )
+    )
+    await ingest_phase_output(
+        store=store,
+        repo="acme/widget",
+        entries=[b],
+        compiler=compiler,
+        event_bus=event_bus,
+    )
+    assert metrics.snapshot()["wiki_supersedes"] == 1
+
+
+async def test_tribal_promotions_increments(tmp_path):
+    from repo_wiki_loop import run_generalization_pass
+    from tribal_wiki import TribalWikiStore
+    from wiki_compiler import GeneralizationCheck
+
+    per_repo = RepoWikiStore(tmp_path / "per")
+    tribal = TribalWikiStore(tmp_path / "tribal")
+    per_repo.ingest(
+        "acme/a",
+        [
+            WikiEntry(
+                id="01HQA00000000000000000000A",
+                title="P",
+                content="Testing: same idea.",
+                source_type="plan",
+                topic="testing",
+                source_repo="acme/a",
+            )
+        ],
+    )
+    per_repo.ingest(
+        "other/b",
+        [
+            WikiEntry(
+                id="01HQB00000000000000000000B",
+                title="Q",
+                content="Testing: also the same idea.",
+                source_type="plan",
+                topic="testing",
+                source_repo="other/b",
+            )
+        ],
+    )
+    compiler = MagicMock()
+    compiler.generalize_pair = AsyncMock(
+        return_value=GeneralizationCheck(
+            same_principle=True,
+            generalized_title="T",
+            generalized_body="TB.",
+            confidence="high",
+        )
+    )
+    await run_generalization_pass(
+        per_repo=per_repo,
+        tribal=tribal,
+        compiler=compiler,
+    )
+    assert metrics.snapshot()["tribal_promotions"] >= 1
+
+
+async def test_adr_drafts_judged_increments(tmp_path):
+    from tribal_wiki import TribalWikiStore
+    from wiki_compiler import WikiCompiler
+
+    tribal = TribalWikiStore(tmp_path / "tribal")
+    tribal.ingest(
+        [
+            WikiEntry(
+                id="01HQ0000000000000000000000",
+                title="p",
+                content="p",
+                source_type="librarian",
+                topic="patterns",
+            )
+        ]
+    )
+    compiler = WikiCompiler.__new__(WikiCompiler)
+    compiler._call_model = AsyncMock(
+        return_value=('{"architectural": false, "load_bearing": false, "reason": "x"}')
+    )
+    await compiler.judge_adr_draft(
+        suggestion={
+            "title": "x",
+            "context": "y",
+            "decision": "z",
+            "consequences": "w",
+            "evidence_issues": [1, 2],
+            "evidence_wiki_entries": ["01HQ0000000000000000000000"],
+        },
+        tribal=tribal,
+    )
+    assert metrics.snapshot()["adr_drafts_judged"] == 1
+
+
+async def test_adr_drafts_opened_increments():
+    from adr_draft_opener import open_adr_draft_issue
+    from wiki_compiler import ADRDraftDecision
+
+    gh = AsyncMock()
+    gh.create_issue = AsyncMock(return_value={"number": 99})
+    decision = ADRDraftDecision(
+        two_plus_issues=True,
+        in_tribal=True,
+        architectural=True,
+        load_bearing=True,
+        draft_ok=True,
+    )
+    await open_adr_draft_issue(
+        suggestion={"title": "x"},
+        decision=decision,
+        gh_client=gh,
+    )
+    assert metrics.snapshot()["adr_drafts_opened"] == 1
+
+
+async def test_reflections_bridged_increments(tmp_path):
+    from post_merge_handler import _bridge_reflections_to_wiki
+    from reflections import append_reflection
+    from wiki_compiler import ContradictionCheck
+
+    cfg = MagicMock()
+    cfg.data_root = tmp_path
+
+    store = RepoWikiStore(tmp_path / "wiki")
+    compiler = AsyncMock()
+    compiler.detect_contradictions = AsyncMock(return_value=ContradictionCheck())
+    append_reflection(cfg, 42, phase="plan", content="architecture: insight.")
+
+    await _bridge_reflections_to_wiki(
+        config=cfg,
+        issue_number=42,
+        repo="acme/widget",
+        store=store,
+        compiler=compiler,
+    )
+    assert metrics.snapshot()["reflections_bridged"] == 1

--- a/tests/test_wiki_routes.py
+++ b/tests/test_wiki_routes.py
@@ -333,3 +333,120 @@ class TestAdminEndpoints:
         )
         handler = find_endpoint(r, "/api/wiki/admin/run-now", "POST")
         assert handler()["status"] == "acknowledged"
+
+
+def test_get_wiki_metrics_returns_snapshot_including_counters():
+    """The metrics endpoint returns a JSON snapshot of all counters."""
+    from unittest.mock import MagicMock
+
+    from fastapi import APIRouter
+    from fastapi.testclient import TestClient
+
+    from dashboard_routes._wiki_routes import register
+    from knowledge_metrics import metrics
+
+    metrics.reset()
+    metrics.increment("wiki_supersedes", 3)
+    metrics.increment("tribal_promotions", 1)
+
+    router = APIRouter()
+    ctx = MagicMock()
+    ctx.get_orchestrator = lambda: None  # no running loop — not needed for /metrics
+    register(router, ctx)
+
+    # Build a test app
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+
+    client = TestClient(app)
+    resp = client.get("/api/wiki/metrics")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["wiki_supersedes"] == 3
+    assert body["tribal_promotions"] == 1
+    assert body["adr_drafts_opened"] == 0
+
+    metrics.reset()
+
+
+def test_get_wiki_health_reports_unconfigured_when_no_loop():
+    """When the orchestrator isn't running, health reports 'unconfigured'."""
+    from unittest.mock import MagicMock
+
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    from dashboard_routes._wiki_routes import register
+
+    router = APIRouter()
+    ctx = MagicMock()
+    ctx.get_orchestrator = lambda: None
+    register(router, ctx)
+
+    app = FastAPI()
+    app.include_router(router)
+    resp = TestClient(app).get("/api/wiki/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["store"] == "unconfigured"
+    assert body["tribal"] == "unconfigured"
+
+
+def test_get_wiki_health_reports_populated_when_loop_has_stores(tmp_path):
+    """When the loop exposes wiki + tribal stores, health reports their status."""
+    from unittest.mock import MagicMock
+
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    from dashboard_routes._wiki_routes import register
+    from repo_wiki import RepoWikiStore, WikiEntry
+    from tribal_wiki import TribalWikiStore
+
+    store = RepoWikiStore(tmp_path / "per")
+    store.ingest(
+        "acme/widget",
+        [
+            WikiEntry(
+                title="x",
+                content="y",
+                source_type="plan",
+                topic="patterns",
+            )
+        ],
+    )
+    tribal = TribalWikiStore(tmp_path / "tribal")
+    tribal.ingest(
+        [
+            WikiEntry(
+                title="z",
+                content="w",
+                source_type="librarian",
+                topic="patterns",
+            )
+        ]
+    )
+
+    loop = MagicMock()
+    loop._wiki_store = store
+    loop._tribal_store = tribal
+
+    orch = MagicMock()
+    orch._svc = MagicMock()
+    orch._svc.repo_wiki_loop = loop
+
+    router = APIRouter()
+    ctx = MagicMock()
+    ctx.get_orchestrator = lambda: orch
+    register(router, ctx)
+
+    app = FastAPI()
+    app.include_router(router)
+    resp = TestClient(app).get("/api/wiki/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["store"] == "populated"
+    assert body["repos"] == 1
+    assert body["tribal"] == "populated"


### PR DESCRIPTION
## Summary

Phase 3 of the HydraFlow knowledge-system redesign — the **observability and rollout-prep** half. Builds on Phase 1 (#8379) and Phase 2 (#8382). Hindsight is **not** deleted in this PR — only made flag-controllable. Cutover (PR 10 in the plan) is a follow-up after a 2-week observation window.

## What changes

### PR 7 — Observability groundwork (additive)
- New `src/knowledge_metrics.py` — thread-safe counter module with module-level `metrics` singleton: `wiki_entries_ingested`, `wiki_supersedes`, `tribal_promotions`, `adr_drafts_judged`, `adr_drafts_opened`, `reflections_bridged`.
- Counters wired at every emission site: ingest path, contradiction detector, generalization pass, ADR judge, issue opener, reflection bridge.
- New `/api/wiki/metrics` and `/api/wiki/health` dashboard endpoints (in `src/dashboard_routes/_wiki_routes.py`).
- Dashboard reducer now surfaces `ADR_DRAFT_OPENED` events in an `adrDrafts` activity feed.
- Debug log when `_save_transcript` skips the ADR pipeline outside an event loop (Phase 2 follow-up).

### PR 8 — Production wiring + extraction script
- `PostMergeHandler.__init__` accepts `wiki_store` + `wiki_compiler` as keyword-only kwargs. Reflection-bridge hook now fires in production (closes Phase 2 deferred follow-up).
- `service_registry.build_services` constructs `TribalWikiStore` at `data_path("tribal")` and threads it into `RepoWikiLoop` (generalization pass active), all 6 BaseRunner subclasses (plan/implement/review inject tribal), and `PostMergeHandler`.
- `AgentRunner.__init__` extended with `tribal_wiki_store` kwarg (other runners inherit `BaseRunner.__init__` directly which accepts it from Phase 2).
- New `scripts/extract_hindsight_to_wiki.py` with tested filter logic (`extract_corroborated_memories` keeps memories with ≥2 citations or 1 cite + closed issue) and write logic (`write_entries_to_wiki` calls `WikiCompiler.synthesize_ingest`). Live `_run` driver is a documented stub — operators wire it against the actual Hindsight + config shape when running the cutover.

### PR 9 — Stop Hindsight recall (reversible)
- `hindsight_recall_enabled: bool` config flag (default `True`). Env var: `HYDRAFLOW_HINDSIGHT_RECALL_ENABLED`.
- `BaseRunner._inject_memory` consults the flag — when False, skips Hindsight recall block entirely. Retains (writes) unaffected.
- `docs/agents/commands.md` documents the rollback procedure + dashboard metrics to watch.

## Deferred

- **Shadow-mode divergence counters (Task 8.4)** — comparing Hindsight vs wiki content per phase needed deep `_inject_memory` surgery; integration risk disproportionate to value during the observation window. Operators can compare counters over time via `/api/wiki/metrics` instead.
- **PR 10 — Hindsight deletion + UI repurpose** — separate PR after the 2-week observation window. Plan section is fully written; just held for the observation window.

## Test plan

- [x] Unit tests for `KnowledgeMetrics` counter primitive
- [x] Integration tests: each counter fires from its real call site (6 tests)
- [x] Dashboard endpoint tests: `/api/wiki/metrics`, `/api/wiki/health` (3 tests)
- [x] `test_event_reducer_coverage` — `adr_draft_opened` removed from SKIP_LIST (real reducer case now)
- [x] Filter + write functions for the extraction script (5 tests)
- [x] Existing `test_post_merge_handler` + `test_reflection_bridge` still pass after `wiki_store`/`wiki_compiler` constructor kwargs added
- [x] All 6 BaseRunner subclasses construct cleanly via `service_registry`
- [x] `make quality` green (11,218 passed)

## Spec + plans

- Design spec: `docs/superpowers/specs/2026-04-22-knowledge-system-redesign-design.md`
- Plans: `docs/superpowers/plans/2026-04-22-knowledge-system-phase{1,2,3}*.md` (local/gitignored)
- Phase 1: #8379 (merged)
- Phase 2: #8382 (merged)
- This PR: Phase 3 part 1 (observability + wiring + reversible flag)
- Phase 3 part 2 (PR 10 — Hindsight deletion + UI repurpose): TODO after observation window

## Operator notes

After merge, set `HYDRAFLOW_HINDSIGHT_RECALL_ENABLED=false` to start the observation window. Watch `/api/wiki/metrics`:

- `wiki_entries_ingested` should climb at the rate of phase completions
- `reflections_bridged` should bump per target-repo issue merge
- `wiki_supersedes` should appear within a few days
- Issue auto-merge rate should stay within ±10% of baseline

If divergence appears, `unset HYDRAFLOW_HINDSIGHT_RECALL_ENABLED` reverts in one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)