### PR TITLE
feat(principles-audit): ADR-0044 + audit framework + P1 checks

### DIFF
--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -1,0 +1,8 @@
+# P10.3 audit baseline — fix commits AFTER this point must carry a
+# regression test under `tests/regressions/`. Earlier commits predate the
+# principle's adoption and are excluded from the check.
+#
+# Format: the first non-comment line is either a commit SHA or an ISO-8601
+# date. Update this when you re-anchor the rule (e.g. after a major
+# repository restructure).
+1d312635

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,42 +45,19 @@ Load the file relevant to your task before acting.
 | Commands reference | [`docs/agents/commands.md`](docs/agents/commands.md) | Looking up a `make` target |
 | Architecture decisions | [`docs/adr/README.md`](docs/adr/README.md) | Understanding *why* something is the way it is |
 
-## Workflow — superpowers skills
+## Workflow skills (ADR-0044 P8/P10)
 
-HydraFlow treats agent work as disciplined engineering. Default to the
-following skills; the priority order matches the `superpowers:using-superpowers`
-contract (process skills first, implementation skills second).
+TDD is the default: `superpowers:brainstorming` → `superpowers:writing-plans`
+→ `superpowers:test-driven-development` (red/green/refactor) → `superpowers:verification-before-completion` → `superpowers:requesting-code-review`.
+Use `superpowers:systematic-debugging` on failures. Bug fixes land with a
+regression test in `tests/regressions/`. See [`docs/agents/testing.md`](docs/agents/testing.md).
 
-| When | Skill |
-|------|-------|
-| Starting any creative work (feature, component, API) | `superpowers:brainstorming` |
-| Implementing any feature or bugfix | `superpowers:test-driven-development` — write the failing test first |
-| Hitting a bug, test failure, or unexpected behaviour | `superpowers:systematic-debugging` |
-| Multi-step changes that touch more than one file | `superpowers:writing-plans` |
-| Before declaring work complete or opening a PR | `superpowers:verification-before-completion` |
-| Before merging a significant change | `superpowers:requesting-code-review` |
+## Ubiquitous language (ADR-0044 P2.9)
 
-**TDD is the default**, not an escalation. Every feature and every bug fix
-lands through red → green → refactor; bug fixes land with a regression test
-in `tests/regressions/`. See [`docs/agents/testing.md`](docs/agents/testing.md)
-and ADR-0044 P10 for the full contract.
+Names are load-bearing — don't paraphrase. Full catalog in [`docs/agents/architecture.md`](docs/agents/architecture.md).
 
-## Domain vocabulary (ubiquitous language)
-
-The names below are load-bearing — they appear identically in code, docs,
-PRs, and conversation. If you catch yourself translating between "issue"
-and "task" or between "loop" and "worker," fix the drift instead of
-paraphrasing. See [`docs/agents/architecture.md`](docs/agents/architecture.md)
-for the full catalog.
-
-- `HydraFlowConfig` — the frozen configuration snapshot resolved at startup
-- `StateTracker` / `StateData` — persisted per-issue pipeline state
-- `EventBus` — in-process publish/subscribe wiring between phases
-- `SessionLog` — per-run transcript summary captured by runners
-- `ReviewResult` — structured outcome of a review phase pass
-- `BaseBackgroundLoop` — contract every caretaker/observer loop implements
-- `RepoWikiStore` — LLM-readable knowledge base per target repo
+- `HydraFlowConfig`, `StateTracker` / `StateData`, `EventBus`, `SessionLog`, `ReviewResult`
+- `BaseBackgroundLoop`, `RepoWikiStore`
 - `PRPort` / `WorkspacePort` / `IssueStorePort` — hexagonal boundaries
-- `AgentRunner` / `PlannerRunner` / `ReviewRunner` — per-phase CLI subprocess drivers
-- `WorktreeManager` — git worktree lifecycle adapter behind `WorkspacePort`
+- `AgentRunner` / `PlannerRunner` / `ReviewRunner`, `WorktreeManager`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,43 @@ Load the file relevant to your task before acting.
 | UI standards | [`docs/agents/ui-standards.md`](docs/agents/ui-standards.md) | Touching `ui/src/` |
 | Commands reference | [`docs/agents/commands.md`](docs/agents/commands.md) | Looking up a `make` target |
 | Architecture decisions | [`docs/adr/README.md`](docs/adr/README.md) | Understanding *why* something is the way it is |
+
+## Workflow — superpowers skills
+
+HydraFlow treats agent work as disciplined engineering. Default to the
+following skills; the priority order matches the `superpowers:using-superpowers`
+contract (process skills first, implementation skills second).
+
+| When | Skill |
+|------|-------|
+| Starting any creative work (feature, component, API) | `superpowers:brainstorming` |
+| Implementing any feature or bugfix | `superpowers:test-driven-development` — write the failing test first |
+| Hitting a bug, test failure, or unexpected behaviour | `superpowers:systematic-debugging` |
+| Multi-step changes that touch more than one file | `superpowers:writing-plans` |
+| Before declaring work complete or opening a PR | `superpowers:verification-before-completion` |
+| Before merging a significant change | `superpowers:requesting-code-review` |
+
+**TDD is the default**, not an escalation. Every feature and every bug fix
+lands through red → green → refactor; bug fixes land with a regression test
+in `tests/regressions/`. See [`docs/agents/testing.md`](docs/agents/testing.md)
+and ADR-0044 P10 for the full contract.
+
+## Domain vocabulary (ubiquitous language)
+
+The names below are load-bearing — they appear identically in code, docs,
+PRs, and conversation. If you catch yourself translating between "issue"
+and "task" or between "loop" and "worker," fix the drift instead of
+paraphrasing. See [`docs/agents/architecture.md`](docs/agents/architecture.md)
+for the full catalog.
+
+- `HydraFlowConfig` — the frozen configuration snapshot resolved at startup
+- `StateTracker` / `StateData` — persisted per-issue pipeline state
+- `EventBus` — in-process publish/subscribe wiring between phases
+- `SessionLog` — per-run transcript summary captured by runners
+- `ReviewResult` — structured outcome of a review phase pass
+- `BaseBackgroundLoop` — contract every caretaker/observer loop implements
+- `RepoWikiStore` — LLM-readable knowledge base per target repo
+- `PRPort` / `WorkspacePort` / `IssueStorePort` — hexagonal boundaries
+- `AgentRunner` / `PlannerRunner` / `ReviewRunner` — per-phase CLI subprocess drivers
+- `WorktreeManager` — git worktree lifecycle adapter behind `WorkspacePort`
+

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,21 @@ audit:
 audit-json:
 	@cd $(HYDRAFLOW_DIR) && $(UV) python -m scripts.hydraflow_audit $(or $(DIR),.) --json
 
+# --------------------------------------------------------------------------
+# Adoption plan — reads the audit report, emits a superpowers-chained prompt.
+#   make init                              # stdout, current dir, mode auto-detected
+#   make init DIR=../new-repo              # target a different repo
+#   make init OUT=plan.md                  # write to file
+#   make init PRINCIPLE=P3                 # scope to a single principle
+#   make init ARGS="--skip-brainstorm"     # override greenfield brainstorm step
+# --------------------------------------------------------------------------
+
+init:
+	@cd $(HYDRAFLOW_DIR) && $(UV) python -m scripts.hydraflow_init $(or $(DIR),.) \
+		$(if $(OUT),--out $(OUT)) \
+		$(if $(PRINCIPLE),--principle $(PRINCIPLE)) \
+		$(ARGS)
+
 quality: deps
 	@echo "$(BLUE)Running quality checks in parallel...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && ( \

--- a/Makefile
+++ b/Makefile
@@ -260,6 +260,19 @@ layer-check:
 	@cd $(HYDRAFLOW_DIR) && $(UV) python scripts/check_layer_imports.py
 	@echo "$(GREEN)Layer check passed$(RESET)"
 
+# --------------------------------------------------------------------------
+# Principles audit (ADR-0044). Targets `.` by default; override with DIR=.
+#   make audit                         # audit this repo
+#   make audit DIR=../other-repo       # audit a sibling project
+#   make audit-json                    # JSON only, no terminal summary
+# --------------------------------------------------------------------------
+
+audit:
+	@cd $(HYDRAFLOW_DIR) && $(UV) python -m scripts.hydraflow_audit $(or $(DIR),.)
+
+audit-json:
+	@cd $(HYDRAFLOW_DIR) && $(UV) python -m scripts.hydraflow_audit $(or $(DIR),.) --json
+
 quality: deps
 	@echo "$(BLUE)Running quality checks in parallel...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && ( \

--- a/docs/adr/0014-session-counter-forward-progression-semantics.md
+++ b/docs/adr/0014-session-counter-forward-progression-semantics.md
@@ -21,7 +21,7 @@ one. Failures, escalations to HITL, and retries do not increment.
 | `planned` | Plan posted and label swapped to `ready`, or issue closed as already satisfied | Plan completion path |
 | `implemented` | PR created and issue transitions to `review` | `result.success` is `True` |
 
-The **review** stage counter in `_record_review_outcome` (`review_phase.py:440`)
+The **review** stage counter in `_record_review_outcome` (`review_phase.py:_record_review_outcome`)
 increments only when the verdict is `APPROVE`. This is semantically correct
 for forward-progression — non-approved reviews (REQUEST_CHANGES, NEEDS_CHANGES)
 represent retry loops, not successful exits from the stage. An earlier version
@@ -31,7 +31,7 @@ rounds. The current code guards on `APPROVE`, aligning with the
 forward-progression pattern.
 
 A secondary risk exists in `session_counter_map` inside `build_pipeline_stats`
-(`orchestrator.py:443`). This dict maps dashboard stage names to
+(`orchestrator.py:build_pipeline_stats`). This dict maps dashboard stage names to
 `SessionCounters` field names. If an unknown stage is added and mapped to
 another stage's field name (e.g., mapping `"hitl"` to `"reviewed"` instead of
 `""`), that stage's count leaks into the wrong display column. The current code

--- a/docs/adr/0043-dynamic-plugin-skill-loading.md
+++ b/docs/adr/0043-dynamic-plugin-skill-loading.md
@@ -60,7 +60,7 @@ Marketplace is expressed inline in `required_plugins` (`"name@marketplace"`), de
 
 **Host mode (2026-04-21):** probed by running `claude -p --output-format stream-json --verbose --permission-mode bypassPermissions --model claude-sonnet-4-6 --max-turns 3` with a prompt instructing the model to invoke `superpowers:systematic-debugging` via the `Skill` tool. Output stream included a `tool_use` event with `"name":"Skill","input":{"skill":"superpowers:systematic-debugging"}`, confirming the Skill tool is exposed in `-p` mode and routes to installed plugins discovered from `~/.claude/plugins/cache/`.
 
-**Docker mode (not separately probed):** `src/docker_runner.py:430-435` mounts the host's `~/.claude/` into the container at `/home/hydraflow/.claude/` (rw) and sets `CLAUDE_CONFIG_DIR=/home/hydraflow/.claude`. Claude's plugin discovery reads the same filesystem layout via that env var, so the host probe's conclusions extend to Docker subagents. Additional `--plugin-dir /opt/plugins/*` flags are emitted dynamically by `agent_cli._plugin_dir_flags()` (see test `tests/test_agent_cli_plugin_dirs.py`) for plugins pre-cloned at image build time.
+**Docker mode (not separately probed):** `src/docker_runner.py:_mount_claude_home` mounts the host's `~/.claude/` into the container at `/home/hydraflow/.claude/` (rw) and sets `CLAUDE_CONFIG_DIR=/home/hydraflow/.claude`. Claude's plugin discovery reads the same filesystem layout via that env var, so the host probe's conclusions extend to Docker subagents. Additional `--plugin-dir /opt/plugins/*` flags are emitted dynamically by `agent_cli._plugin_dir_flags()` (see test `tests/test_agent_cli_plugin_dirs.py`) for plugins pre-cloned at image build time.
 
 ## References
 

--- a/docs/adr/0044-hydraflow-principles.md
+++ b/docs/adr/0044-hydraflow-principles.md
@@ -1,0 +1,451 @@
+# ADR-0044: HydraFlow Principles — the audit contract for new and existing repos
+
+- **Status:** Proposed
+- **Date:** 2026-04-22
+- **Supersedes:** none
+- **Superseded by:** none
+
+## Context
+
+HydraFlow's value is not any single agent loop or script — it is the *shape* of
+the repository: the documentation contract, the hexagonal split, the scenario
+testing harness with `MockWorld`, the quality gates, the CI workflow, the five
+concurrent async loops, the label state machine, the Sentry discipline, and
+the superpowers skill workflow. Today these live in a scattered set of files:
+`CLAUDE.md`, `docs/agents/*`, and 40+ existing ADRs. A new project that wants
+to adopt "the HydraFlow way" has to reverse-engineer the shape from those
+documents. An existing project trying to evolve toward the shape has no way to
+measure how far along it is.
+
+We want one declarative source of truth that (a) enumerates the principles,
+(b) cites the existing documentation for each one, and (c) is machine-parseable
+so `make audit` can score a repository against the principles without
+duplicating the rules in Python.
+
+## Decision
+
+Define ten principles — P1 through P10 — each corresponding to a load-bearing
+facet of HydraFlow. Each principle section contains:
+
+1. A one-line **Rule** stating the intent.
+2. A **Why** paragraph naming the failure mode the principle prevents.
+3. A **How to apply** paragraph for the greenfield and adoption cases.
+4. A **Check table** with columns `check_id | type | source | what | remediation`,
+   parsed directly by `scripts/hydraflow_audit/` at runtime.
+
+The `type` column takes one of three values:
+
+- **STRUCTURAL** — a file or directory must exist with a specified shape.
+  Audit fails loudly when missing.
+- **BEHAVIORAL** — a tool must run clean, or a target must exist and succeed.
+  Audit runs the tool and fails on non-zero exit.
+- **CULTURAL** — a human workflow rule that the audit cannot verify reliably
+  (e.g. branch protection on the remote, "never commit to main"). Audit emits
+  a WARN with the ADR citation and a remediation hint; humans confirm in the
+  `make init` prompt.
+
+The audit tool (`scripts/hydraflow_audit/`) parses these tables at startup and
+dispatches each `check_id` to a Python check function of the same name. If a
+table row exists without a matching check function, the audit fails with
+"check not implemented" — this keeps the ADR and the script in lockstep.
+
+The prompt tool (`scripts/hydraflow_init/`) reads the audit's JSON output and
+templates a superpowers-chained plan (brainstorming → writing-plans → TDD →
+verification) scoped to the failing principles only.
+
+**Self-documenting by construction.** Every check row cites either an ADR or
+a `docs/agents/` file as its `source`. The audit report echoes those
+citations, and `make init` injects them into the remediation plan. A reader
+who sees a FAIL can follow the citation to the decision that motivated the
+rule — not a paraphrase, the real thing. The ADR and wiki layers *are* the
+documentation; this ADR is the index that makes them executable. When a
+principle changes, you edit the ADR; when a check changes, you edit the
+table row; the script re-reads both on the next run. There is no
+out-of-band spec for what "HydraFlow-shaped" means — this file is the spec.
+
+**Self-observing by construction.** The audit and init tools are themselves
+instrumented with the Sentry filter defined in P7, so runtime failures in
+the tooling surface as real signal — an audit that silently swallows a
+check exception is worse than no audit. Unhandled tool exceptions become
+Sentry events (real bugs only; transient errors log at `warning`). Future
+backends — OpenTelemetry traces, structured JSONL to a SIEM, a local
+observability sidecar — can plug in behind the same port without changing
+call sites. The project follows the patterns it enforces.
+
+## The ten principles
+
+### P1. Documentation Contract
+
+**Rule.** A HydraFlow repo has a machine-navigable documentation spine:
+`CLAUDE.md` at the root as a table of contents, `docs/agents/` as the topic
+guides, `docs/adr/` as the decision log.
+
+**Why.** Agents and new humans need a stable entry point. Without it, every
+session starts by re-reading scattered READMEs, context windows burn on
+re-discovery, and ad-hoc docs drift silently out of sync with code.
+
+**How to apply.** Greenfield: scaffold all three locations with the topic
+stubs listed below. Adoption: copy the structure from HydraFlow, then fill in
+project-specific content — the *shape* matters more than the wording.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | STRUCTURAL | CLAUDE.md | `CLAUDE.md` exists at repo root | `touch CLAUDE.md` and populate from the template |
+| P1.2 | STRUCTURAL | docs/agents/README.md | `docs/agents/README.md` exists | Copy the topic-index layout from the HydraFlow repo |
+| P1.3 | STRUCTURAL | docs/agents/architecture.md | `docs/agents/architecture.md` exists | Describe the major components and their boundaries |
+| P1.4 | STRUCTURAL | docs/agents/worktrees.md | `docs/agents/worktrees.md` exists | Document the branch-protection and worktree workflow |
+| P1.5 | STRUCTURAL | docs/agents/testing.md | `docs/agents/testing.md` exists | Document coverage floor and test layering |
+| P1.6 | STRUCTURAL | docs/agents/avoided-patterns.md | `docs/agents/avoided-patterns.md` exists | Seed with Pydantic, test-import, and mocking pitfalls |
+| P1.7 | STRUCTURAL | docs/agents/quality-gates.md | `docs/agents/quality-gates.md` exists | Document the `make quality` sequence |
+| P1.8 | STRUCTURAL | docs/agents/background-loops.md | `docs/agents/background-loops.md` exists | Only required if the project has background loops |
+| P1.9 | STRUCTURAL | docs/agents/sentry.md | `docs/agents/sentry.md` exists | Document the bug-types filter and logging levels |
+| P1.10 | STRUCTURAL | docs/agents/commands.md | `docs/agents/commands.md` exists | List the Makefile targets |
+| P1.11 | STRUCTURAL | docs/adr/README.md | `docs/adr/README.md` exists with an index table | Start the ADR index, even if there is only one ADR |
+| P1.12 | BEHAVIORAL | CLAUDE.md | `CLAUDE.md` contains a "Quick rules" section | Add the five non-negotiables (no main commits, no `--no-verify`, run `make quality`, write tests, read avoided-patterns) |
+| P1.13 | BEHAVIORAL | CLAUDE.md | `CLAUDE.md` contains a knowledge lookup table | List docs/agents, docs/adr, and any repo-wiki location |
+| P1.14 | STRUCTURAL | docs/adr/README.md | Load-bearing ADRs are present and marked Accepted (or project equivalents exist) | For orchestration repos: ADR-0001 (loops), 0002 (labels), 0003 (worktrees), 0021 (persistence), 0022 (MockWorld), 0029 (caretakers), 0032 (wiki). Non-orchestration repos mark N/A with justification in `docs/adr/README.md` |
+| P1.15 | BEHAVIORAL | docs/agents/avoided-patterns.md | File has ≥5 pattern sections with example code blocks | Seed from HydraFlow's 13-section file; an empty stub does not count |
+| P1.16 | BEHAVIORAL | docs/adr/README.md | ADR source citations omit line numbers (use `module:function_or_class`) | Grep for `:\d+` in ADR prose and strip; line numbers drift as code evolves |
+
+### P2. Domain-Driven Design, Ports & Adapters, Clean Architecture
+
+**Rule.** Source is organised into four layers — domain, application,
+runners, infrastructure — with imports flowing inward only (clean
+architecture). Cross-layer coupling is expressed through Protocols in a
+single `ports` module (ports & adapters / hexagonal), never direct imports.
+The domain layer speaks a *ubiquitous language*: the names in code match
+the names in docs and in conversation (DDD). Domain types carry behaviour,
+not just data — anaemic Pydantic models that only hold fields belong in
+DTOs, not the domain.
+
+**Why.** Without enforced direction, agent code grows into a ball of mud
+where a GitHub change breaks the domain model. Protocol boundaries make the
+system testable with stateful fakes (see P3) and make each adapter
+replaceable (swap Anthropic for Codex, GitHub for Gitea, without touching
+the domain). Ubiquitous language collapses translation costs during review —
+when `Issue`, `Phase`, `Worktree` mean the same thing in prose and code,
+new contributors do not have to translate. The inward-only import rule is
+the one invariant that keeps the other three (ports, DDD, testability)
+possible; once domain imports infrastructure, all three collapse.
+
+**How to apply.** Greenfield: create the layer directories up front, name
+them after bounded contexts you can say out loud, and add
+`scripts/check_layer_imports.py` to CI before any domain code is written.
+Adoption: introduce `ports.py` first, migrate infrastructure behind
+Protocols one at a time, then add the import checker with an allowlist
+that shrinks per PR. Rename domain types to match the ubiquitous language
+as their first refactor — before anything else changes.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P2.1 | STRUCTURAL | ADR-0003 | `src/` directory exists | Move module code under `src/` to keep test discovery clean |
+| P2.2 | STRUCTURAL | docs/agents/architecture.md | `src/ports.py` exists and defines at least one `Protocol` | Extract the first cross-layer boundary (likely the PR/VCS adapter) |
+| P2.2a | STRUCTURAL | docs/agents/architecture.md | Each infrastructure boundary the project uses has a Protocol in `ports.py` (VCS, workspace, runner, LLM if applicable) | Add a Protocol the first time you reach for `AsyncMock` in a unit test; that is the signal a port is missing |
+| P2.3 | STRUCTURAL | docs/agents/architecture.md | `scripts/check_layer_imports.py` exists | Port the HydraFlow script; configure the layer map for this repo |
+| P2.4 | BEHAVIORAL | ADR-0003 | `make layer-check` exits 0 (no upward imports) | Refactor the offending import behind a `ports.py` Protocol |
+| P2.5 | STRUCTURAL | docs/agents/architecture.md | A composition root module (e.g. `service_registry.py`) wires layers | Centralise dependency assembly so tests can swap fakes cleanly |
+| P2.6 | STRUCTURAL | docs/agents/architecture.md | Composition root is the *only* module allowed to import across layer boundaries (explicit ALLOWLIST entry) | Layer checker treats the root as a documented exception, not a blanket escape hatch |
+| P2.7 | STRUCTURAL | docs/agents/architecture.md | Domain layer has no imports from infrastructure, runners, or third-party adapter SDKs | The layer-check must special-case this to a hard failure; domain purity is the load-bearing invariant |
+| P2.8 | BEHAVIORAL | docs/agents/architecture.md | Domain types carry behaviour (methods), not just `@dataclass`/Pydantic fields | Anaemic domain is a sign logic leaked into application or infra; audit samples `src/<domain>/*.py` and warns on files with zero methods on public types |
+| P2.9 | CULTURAL | docs/agents/architecture.md | Ubiquitous language: domain type names appear in `docs/agents/architecture.md` and in `CLAUDE.md` with matching semantics | When the doc says "Issue" and the code says "Task", translation overhead accumulates; keep one name per concept |
+
+### P3. Testing — MockWorld and Layered Tests
+
+**Rule.** Tests are organised into five concentric rings — unit,
+integration, scenario, E2E (smoke + browser), regression — with a stateful
+`MockWorld` fixture driving the scenario ring. Coverage floor is 70%.
+Scenarios gate release.
+
+**Why.** `AsyncMock`-based tests pass with the wrong call shape; stateful
+fakes catch real interaction bugs. Concentric layering means fast tests run
+every commit and slow E2E runs in CI. 70% coverage is pragmatic — higher
+thresholds drive test-coverage theatre, lower drive regressions. MockWorld's
+value comes from *how* it fakes (state you can inspect, time you can
+advance, services you can fault-inject) — a `mock_world` fixture that
+delegates to `AsyncMock` passes the shape check but defeats the point.
+
+**How to apply.** Greenfield: scaffold `tests/scenarios/` with `conftest.py`,
+`fakes/`, and at least one happy/sad/edge scenario on day one. Adoption: add
+`MockWorld` alongside existing tests; do not retro-fit old tests, but require
+all new pipeline tests to use it. E2E and browser rings are conditional —
+only required when a dashboard or UI exists.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P3.1 | STRUCTURAL | ADR-0022 | `tests/scenarios/` directory exists | Create the directory and seed a happy-path scenario |
+| P3.2 | STRUCTURAL | ADR-0022 | `tests/scenarios/conftest.py` provides a `mock_world` fixture | Port the fixture wiring from HydraFlow |
+| P3.3 | STRUCTURAL | ADR-0022 | `tests/scenarios/fakes/` contains ≥3 stateful fakes (VCS, LLM, workspace at minimum) | Replace `AsyncMock` fakes one boundary at a time |
+| P3.4 | STRUCTURAL | docs/agents/testing.md | `tests/conftest.py` exists with shared fixtures | Centralise env isolation and factory fixtures |
+| P3.5 | STRUCTURAL | docs/agents/testing.md | At least one factory class (e.g. `IssueFactory`) exists under `tests/` | Introduce factories before the third duplicated fixture |
+| P3.6 | BEHAVIORAL | docs/agents/testing.md | Coverage floor of 70% configured in `pyproject.toml` | Add `fail_under = 70` under `[tool.coverage.report]` |
+| P3.7 | BEHAVIORAL | docs/agents/testing.md | `make test` runs the unit tier and exits 0 | Wire `pytest tests/` into `make test` |
+| P3.8 | BEHAVIORAL | ADR-0022 | `make scenario` runs the scenario tier and exits 0 | Add the `scenario` pytest marker and a `make` target |
+| P3.9 | BEHAVIORAL | docs/agents/quality-gates.md | `make smoke` target exists and exits 0 | Smoke is the minimal cross-system path that must pass on every push |
+| P3.10 | STRUCTURAL | ADR-0022 | Scenario tests are release-gating (CI blocks release branch promotion on scenario red) | Wire `make scenario` into the release or RC workflow (see ADR-0042 for the promotion model) |
+| P3.11 | STRUCTURAL | docs/scenarios/README.md | When `ui/` exists, browser E2E directory (`tests/scenarios/browser/` or equivalent) exists | Add Playwright harness with at least one dashboard smoke test; skip if no UI |
+| P3.12 | STRUCTURAL | ADR-0022 | A `ScenarioResult` / `IssueOutcome`-shaped dataclass exists for scenario inspection | Return structured results from `world.run_pipeline()` so assertions read state, not call counts |
+| P3.13 | STRUCTURAL | ADR-0022 | `FakeClock` (or equivalent deterministic time fake) exists | Scenarios must not depend on wall-clock time; inject a clock fake |
+| P3.14 | BEHAVIORAL | ADR-0022 | Fakes expose stateful inspection (`world.vcs.issue(1).labels` or similar), not just `assert_called_with` | Rebuild the offending fake as a stateful class; `AsyncMock` subclasses do not count |
+| P3.15 | STRUCTURAL | ADR-0022 | `MockWorld` exposes fault-injection API (`fail_service` / `heal_service` or equivalent) | Wire fault injection before the first retry/recovery scenario is written |
+| P3.16 | STRUCTURAL | docs/agents/testing.md | `tests/regressions/` directory exists | Add the directory; every bug fix lands with a regression test there |
+| P3.17 | STRUCTURAL | docs/agents/testing.md | `integration` and `scenario` pytest markers registered in `pyproject.toml` | Declare markers under `[tool.pytest.ini_options.markers]` to fail CI on typos |
+| P3.18 | BEHAVIORAL | docs/agents/testing.md | At least one `*_integration.py` test file exists to drive the integration ring | Start with a cross-module wiring test; pure unit tests do not satisfy this |
+| P3.19 | BEHAVIORAL | docs/agents/avoided-patterns.md | No top-level imports of optional dependencies in test files | Move imports inside the test function; top-level imports break collection when deps are absent |
+
+### P4. Quality Gates
+
+**Rule.** `make quality` is the single command a developer runs before
+declaring work complete. It composes lint, typecheck, security, test, and
+layer-check into one fail-fast pipeline. `make quality-lite` runs the
+non-test checks for quick iteration.
+
+**Why.** Quality tools only help when they run. One canonical target removes
+the "did I run all of them" ambiguity and gives CI a single command to mirror.
+
+**How to apply.** Greenfield: add all five tools on day one, even with empty
+configs — it is cheaper than retrofitting. Adoption: introduce tools one at
+a time via `quality-lite` so the first PR that adds `make quality-lite`
+is small; `make quality` (which includes tests) follows once coverage is
+credible.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P4.1 | BEHAVIORAL | docs/agents/quality-gates.md | `make lint-check` target exists and exits 0 | Add `ruff check` + `ruff format --check` behind the target |
+| P4.2 | BEHAVIORAL | docs/agents/quality-gates.md | `make typecheck` target exists and exits 0 | Add `pyright` with config in `pyproject.toml` |
+| P4.3 | BEHAVIORAL | docs/agents/quality-gates.md | `make security` target exists and exits 0 | Add `bandit -r src/ --severity-level medium` |
+| P4.4 | BEHAVIORAL | docs/agents/quality-gates.md | `make test` target exists and exits 0 | Wire pytest behind the target |
+| P4.5 | BEHAVIORAL | docs/agents/quality-gates.md | `make quality-lite` composes lint + typecheck + security | Add the aggregate target |
+| P4.6 | BEHAVIORAL | docs/agents/quality-gates.md | `make quality` composes quality-lite + test + layer-check | Add the final gate target |
+| P4.7 | STRUCTURAL | docs/agents/quality-gates.md | Tool configs live in `pyproject.toml` (not a forest of dotfiles) | Move ruff/pyright/bandit/pytest configs into `pyproject.toml` |
+
+### P5. CI and Branch Protection
+
+**Rule.** CI mirrors `make quality` on every PR and enforces the same exit
+codes. `main` is protected and only advances through PRs. Pre-commit and
+pre-push hooks run the relevant subset locally.
+
+**Why.** If CI and local gates diverge, one of them lies. Branch protection
+on `main` turns the quick rule "never commit to main" into a guarantee the
+remote enforces rather than a convention humans remember.
+
+**How to apply.** Greenfield: push the first commit on a branch, set up
+branch protection before merging it, and wire the `.github/workflows/ci.yml`
+file in the same PR. Adoption: enable branch protection first, then
+migrate local `make` commands into CI one at a time to avoid a big-bang
+green/red switch.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P5.1 | STRUCTURAL | docs/agents/quality-gates.md | `.github/workflows/` directory contains at least one workflow | Port `ci.yml` from HydraFlow as a starting point |
+| P5.2 | BEHAVIORAL | docs/agents/quality-gates.md | Workflow runs `make quality-lite` or equivalent | Wire the make target into the workflow's steps |
+| P5.3 | BEHAVIORAL | docs/agents/quality-gates.md | Workflow runs `make test` with the coverage gate | Add a `--cov-fail-under=70` invocation |
+| P5.4 | STRUCTURAL | docs/agents/worktrees.md | `.githooks/pre-commit` exists and is executable | Seed the hook from HydraFlow's template |
+| P5.5 | CULTURAL | docs/agents/worktrees.md | `main` has branch protection with required PR review and CI | Enable via GitHub repo settings; audit cannot verify offline |
+| P5.6 | CULTURAL | CLAUDE.md | No direct pushes to `main` in the last 100 commits | Inspect `git log --first-parent main`; audit reports as a warning |
+| P5.7 | BEHAVIORAL | docs/agents/quality-gates.md | `pytest` treats `RuntimeWarning` and `PytestUnraisableExceptionWarning` as errors | Add `filterwarnings = ["error::RuntimeWarning", "error::pytest.PytestUnraisableExceptionWarning"]` to `pyproject.toml`; warnings-are-errors turns async lifecycle bugs into red CI instead of silent drift |
+| P5.8 | STRUCTURAL | docs/agents/quality-gates.md | `.githooks/pre-push` exists and runs `make quality-lite` | Pre-commit gates *staged* Python; pre-push gates the *branch* before the remote sees it |
+| P5.9 | BEHAVIORAL | docs/agents/quality-gates.md | Pre-commit hook implements self-repair (on lint-check failure, run `make lint-fix` and re-stage before escalating) | Agent sessions stall indefinitely on formatting errors otherwise; self-repair keeps the loop moving |
+| P5.10 | STRUCTURAL | CLAUDE.md | Pre-commit hook refuses deletion or net content removal of `CLAUDE.md` | Load-bearing file; silent loss of the Quick Rules section would remove the project's guardrails without notice |
+
+### P6. Agents — Loops, Labels, Background Workers
+
+**Rule.** Pipeline work runs as N concurrent async loops (N=5 for HydraFlow)
+coordinating on a GitHub label state machine. Auxiliary long-running work
+runs as `BaseBackgroundLoop` subclasses wired through a five-checkpoint
+registration (service registry, orchestrator dict, UI constants, dashboard
+route bounds, config interval).
+
+**Why.** Concurrent loops let the system make progress on independent phases
+without queue coordination. Labels as the state machine mean every state
+transition is visible on the GitHub timeline — debuggable by reading a PR.
+The five-checkpoint wiring is how we avoid "half-registered" loops that run
+but don't show up in the UI.
+
+**How to apply.** Greenfield orchestration project: scaffold the
+`BaseBackgroundLoop` base class and the wiring test on day one.
+Non-orchestration project: this principle is informational; note in the
+audit output that P6 is optional for the repo type and skip the failures.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P6.1 | STRUCTURAL | ADR-0001 | `src/orchestrator.py` exists with concurrent loop structure | Only applicable to orchestration-shaped projects; mark N/A otherwise |
+| P6.2 | STRUCTURAL | ADR-0002 | Label names are centralised in config (not scattered strings) | Collect labels into a single config module or dataclass |
+| P6.3 | STRUCTURAL | ADR-0029 | `BaseBackgroundLoop` base class exists | Port from HydraFlow when the first long-running job appears |
+| P6.4 | BEHAVIORAL | docs/agents/background-loops.md | Loop-wiring completeness test covers all five checkpoints (service registry, orchestrator dict, UI constants, dashboard-route bounds, config interval + env override) | Port HydraFlow's `test_loop_wiring_completeness.py`; half-wired loops run but vanish from the dashboard |
+| P6.5 | STRUCTURAL | ADR-0002 | Atomic label-swap helper exists (no ad-hoc add/remove call sites) | Add a `swap_pipeline_labels` function and forbid direct calls |
+
+### P7. Observability — Sentry, Structured Logging, Repo Wiki
+
+**Rule.** Sentry events are filtered by a `_BUG_TYPES` gatekeeper so
+transient errors never page a human. Logging uses structured levels
+(`warning` for expected transient failures, `error` only for real bugs).
+Knowledge captured from past runs is stored in a per-repo wiki under
+`repo_wiki/<repo_slug>/` and injected into runner prompts.
+
+**Why.** Unfiltered Sentry becomes noise and gets muted. Unstructured logs
+mean incident response starts from zero every time. The repo wiki is how the
+system compounds learnings rather than re-discovering them every session.
+
+**How to apply.** Greenfield: define `_BUG_TYPES` the first time you wire
+Sentry; seed `repo_wiki/` with the first post-mortem. Adoption: introduce
+the filter in a dedicated PR so the drop in event volume is visible; migrate
+noisy `logger.error` calls to `logger.warning` in a follow-up.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P7.1 | STRUCTURAL | docs/agents/sentry.md | `_BUG_TYPES` tuple exists where Sentry is initialised | Define the tuple with real-bug exceptions only |
+| P7.2 | BEHAVIORAL | docs/agents/sentry.md | Sentry `before_send` callback uses `_BUG_TYPES` | Wire the filter in the init call |
+| P7.3 | STRUCTURAL | ADR-0032 | `repo_wiki/` directory exists (or project-equivalent knowledge base) | Create the directory; seed from post-mortems |
+| P7.3a | STRUCTURAL | ADR-0032 | Wiki has the three-layer shape: raw sources, synthesised wiki pages, index/schema | A flat dumping ground of markdown is not a wiki; the compiler/librarian pattern requires all three |
+| P7.3b | BEHAVIORAL | ADR-0032 | Wiki store exposes ingest / query / lint operations (or project equivalents) | Port `RepoWikiStore`; without ingest the wiki stagnates, without lint it accumulates stale entries |
+| P7.3c | BEHAVIORAL | ADR-0032 | Runner prompts inject relevant wiki content before agent invocation | `_inject_repo_wiki` pattern or equivalent; a wiki that is never read has no value |
+| P7.4 | CULTURAL | docs/agents/sentry.md | No `except: pass` or bare `except:` in `src/` | Audit greps; remediate by logging at `warning` minimum |
+| P7.5 | BEHAVIORAL | docs/agents/sentry.md | No `logger.error(value)` without a format string (audit greps `logger\.error\(\w+\)$`) | Format strings preserve structure for log aggregation; bare-value error calls flatten to opaque strings |
+| P7.6 | STRUCTURAL | docs/agents/sentry.md | The audit and init tooling (`scripts/hydraflow_audit/`, `scripts/hydraflow_init/`) route unhandled exceptions through the P7.1/P7.2 Sentry filter | The tooling must follow its own principle; silent audit failures poison the signal the audit is supposed to provide |
+| P7.7 | STRUCTURAL | docs/agents/sentry.md | Observability is behind a port (`ObservabilityPort` or equivalent) so the Sentry adapter can be swapped for OTLP / structured logs / a sidecar without touching call sites | Preserves future optionality without committing to a second backend today |
+
+### P8. Superpowers / Skills Integration
+
+**Rule.** The repo is wired to the superpowers skill pack so sessions start
+with brainstorming for greenfield work, TDD for features, systematic
+debugging for bugs, writing-plans for multi-step changes, and
+verification-before-completion before commits. Hooks run in `.claude/hooks/`
+enforce the guardrails the human-driven skills encode.
+
+**Why.** Skills are the operational playbook. Without them each session
+re-litigates how to approach a task. Hooks make the "always" rules in
+`CLAUDE.md` actually always-on instead of best-effort.
+
+**How to apply.** Greenfield: seed `.claude/settings.json` and
+`.claude/hooks/` from HydraFlow. Adoption: add one hook at a time, starting
+with `block-destructive-git` (high value, low controversy).
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P8.1 | STRUCTURAL | CLAUDE.md | `.claude/` directory exists | Seed from HydraFlow's `.claude/` layout |
+| P8.2 | STRUCTURAL | CLAUDE.md | `.claude/settings.json` or `settings.local.json` exists | Configure hooks and skill references |
+| P8.3 | STRUCTURAL | CLAUDE.md | `.claude/hooks/` contains at least one PreToolUse hook | Start with `block-destructive-git` |
+| P8.4 | CULTURAL | CLAUDE.md | CLAUDE.md references the six core superpowers skills by name | Must mention: `brainstorming`, `test-driven-development`, `systematic-debugging`, `writing-plans`, `verification-before-completion`, `requesting-code-review`. A vague "use skills" line does not count |
+| P8.5 | STRUCTURAL | CLAUDE.md | `.claude/hooks/` includes at least one hook of each enforced kind: PreToolUse, PostToolUse, Stop | Seed from HydraFlow: `block-destructive-git` (PreToolUse), `auto-lint-after-edit` (PostToolUse), `hf.session-retro` (Stop) |
+| P8.6 | STRUCTURAL | docs/self-improving-harness.md | In-process trace collector writes subprocess traces per phase/run | Port `trace_collector.py`; without traces, session retros have nothing to mine |
+
+### P9. Persistence and Data Layout
+
+**Rule.** All run-time state lives under a single configurable root
+(`config.data_root`, default `.hydraflow/`), scoped by repo slug. Writes are
+atomic. Cross-process coordination goes through named stores
+(`StateTracker` for phase state, `DedupStore` for idempotency) rather than
+ad-hoc files. Nothing run-time goes in the repo working tree.
+
+**Why.** A single root makes ops trivial — one directory to back up, one to
+blow away, one to gitignore. Repo-slug scoping means multiple target repos
+coexist without collision. Atomic writes prevent corrupted state from a
+killed process becoming permanent. Named stores concentrate the race-prone
+logic in one place; ad-hoc JSON files scattered across modules grow
+inconsistent invariants.
+
+**How to apply.** Greenfield: define `data_root` in config on day one, even
+if the first feature only needs one file. Adoption: introduce `data_root`
+and migrate one persisted file at a time; keep backward-compatible reads
+until the migration is complete.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P9.1 | STRUCTURAL | ADR-0021 | Config exposes a `data_root` (or equivalent) field with a documented default | Add to the config dataclass; default under the user's home or a repo-gitignored path, not the working tree |
+| P9.2 | BEHAVIORAL | ADR-0021 | `data_root` is overridable via environment variable | Wire `HYDRAFLOW_DATA_ROOT` (or project-namespaced equivalent) through config loading |
+| P9.3 | STRUCTURAL | ADR-0021 | Persisted state is scoped per repo slug inside `data_root` | Path shape: `<data_root>/<repo_slug>/...` so multi-repo runs never collide |
+| P9.4 | STRUCTURAL | ADR-0021 | `StateTracker`-shaped abstraction exists for phase/run state | Centralise state transitions; disallow direct JSON read/write from phase code |
+| P9.5 | STRUCTURAL | ADR-0021 | `DedupStore`-shaped abstraction exists for idempotency tracking | Background loops must guard against double-processing across restarts |
+| P9.6 | BEHAVIORAL | ADR-0021 | All state writes go through atomic write helper (write-to-temp + rename) | A `kill -9` mid-write must not leave a half-valid file |
+| P9.7 | STRUCTURAL | ADR-0021 | `data_root` (default `.hydraflow/`) is in `.gitignore` | Run-time state is never committed; enforce via gitignore |
+| P9.8 | STRUCTURAL | ADR-0021 | No run-time state is written inside `src/` or the repo working tree | Grep for `open(.*"w")` with repo-relative paths outside `data_root`; migrate hits to the store abstractions |
+
+### P10. TDD Workflow Discipline
+
+**Rule.** Every feature and bug fix lands through the test-first loop: write
+a failing test that names the intended behaviour, make it pass with the
+smallest credible change, then refactor. Bug fixes land *with* the
+regression test that would have caught them. The `superpowers:test-driven-development`
+skill is the default for implementation work.
+
+**Why.** Test-first locks the specification before the implementation can
+cheat it; test-after retrofits the spec to whatever the code does. Bug
+fixes without regression tests are open invitations for the bug to return.
+TDD is also the tightest feedback loop for agent work — a red test makes
+the success criterion machine-checkable.
+
+**How to apply.** Greenfield: the first feature's first commit is a failing
+test. Adoption: introduce TDD for new features only; do not retro-fit,
+but every bug fix from today forward lands with a regression test.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P10.1 | CULTURAL | CLAUDE.md | CLAUDE.md documents test-first as the default workflow and names `superpowers:test-driven-development` | Add a "Workflow" section pointing at the skill |
+| P10.2 | BEHAVIORAL | docs/agents/testing.md | Every directory under `src/` with production code has a corresponding test file (unit ring coverage) | Audit walks `src/` and expects a matching `tests/test_<module>.py` or similar; orphan modules surface in the report |
+| P10.3 | CULTURAL | docs/agents/testing.md | Bug-fix commits land with a regression test in `tests/regressions/` | Audit scans last 50 merged PRs tagged `bug`/`fix`; reports PRs missing a regression-test delta as a warning |
+| P10.4 | STRUCTURAL | docs/agents/testing.md | Test names describe behaviour, not implementation (e.g. `test_merges_when_all_checks_pass` not `test_merge_function`) | Enforce via a test-name linter or review rubric; audit samples names and flags ones matching `test_<funcname>$` |
+| P10.5 | BEHAVIORAL | docs/agents/testing.md | Test files use the Arrange / Act / Assert structure visibly | Prefer factories + one assertion per test; multi-assert tests are a smell |
+
+## Consequences
+
+**Positive**
+- New repos get a one-command (`make audit`) readout of their conformance.
+- Adoption path is measurable: the audit's pass count moves PR by PR.
+- Principles have one home (`ADR-0044`) — no more "is it in CLAUDE.md or
+  docs/agents or an ADR?" ambiguity.
+- ADR tables and audit code stay in lockstep because the code reads the ADR
+  at runtime; a dangling `check_id` fails the audit.
+- Self-documenting: every check cites its source, so remediation hints point
+  at the real decision record, not a paraphrase.
+- Self-observing: audit/init runtime failures surface through the same
+  Sentry filter the principles require, so the tooling eats its own
+  dogfood and runtime regressions feed back into the learning loop.
+
+**Negative**
+- Any change to a principle now requires an ADR edit, not just a doc tweak.
+  This is the intended friction, but it is friction.
+- Audit is Python-only today; polyglot repos (e.g. a Node frontend with a
+  Python backend) only get the Python-side checks until checks are generalised.
+- CULTURAL checks under-cover reality — an audit can say "no main commits in
+  the recent log" but cannot verify the remote branch-protection setting.
+  The `make init` prompt compensates by asking the user to confirm.
+
+**Neutral**
+- P6 (agents/loops/labels) is only meaningful for orchestration-shaped
+  projects. Non-orchestration repos will see P6 as "N/A" rather than FAIL.
+- The bar is 10 principles today; the list is expected to grow. Adding P11
+  is an ADR amendment, not a code refactor.
+- Several checks (P2.8 anaemic-type detection, P2.9 ubiquitous-language,
+  P10.2 orphan-module coverage) are heuristic — the audit reports them as
+  warnings even when the numeric threshold is met, so reviewers apply
+  judgement rather than treating a green audit as proof of correctness.
+
+## Alternatives considered
+
+**Inline principles in `CLAUDE.md`.** Rejected because `CLAUDE.md` is a
+table of contents, not a decision log. Principles are decisions and belong
+in the ADR directory alongside the other architectural commitments.
+
+**YAML sidecar for check tables (`0044-principles.checks.yaml`).**
+Rejected because the sidecar splits the rule from its rationale — a reader
+of the ADR sees only half the contract. Markdown tables are fiddly to parse
+but not prohibitively so, and the audit has a sharp schema: five columns,
+first row is headers.
+
+**Generate principles from scanning the HydraFlow repo.** Rejected because
+it inverts the direction of authority. Principles should drive the code, not
+the other way around. An ADR that merely describes existing code is a
+snapshot that rots.
+
+## Related
+
+- [CLAUDE.md](../../CLAUDE.md) — the table of contents this ADR formalises
+- [ADR-0001](0001-five-concurrent-async-loops.md) — five concurrent async loops (P6)
+- [ADR-0002](0002-labels-as-state-machine.md) — labels as the state machine (P6)
+- [ADR-0003](0003-git-worktrees-for-isolation.md) — worktree isolation (P5)
+- [ADR-0021](0021-persistence-architecture-and-data-layout.md) — persistence layout (informational)
+- [ADR-0022](0022-integration-test-architecture-cross-phase.md) — MockWorld harness (P3)
+- [ADR-0029](0029-caretaker-loop-pattern.md) — `BaseBackgroundLoop` (P6)
+- [ADR-0032](0032-per-repo-wiki-knowledge-base.md) — repo wiki (P7)
+- `scripts/hydraflow_audit/` — the audit tool that reads this ADR's tables
+- `scripts/hydraflow_init/` — the prompt emitter that reads the audit's report

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ Consequences), use `module:function_or_class` format (e.g. `src/config.py:HydraF
 | [0041](0041-github-source-of-truth-cache-as-sidecar.md) | GitHub as Source of Truth, Local Cache as Sidecar | Accepted |
 | [0042](0042-two-tier-branch-release-promotion.md) | Two-tier branch model with automated release-candidate promotion | Accepted |
 | [0043](0043-prompt-structure-standard.md) | Prompt structure standard (XML tags, 8-criterion rubric, mechanical scoring) | Proposed |
+| [0044](0044-hydraflow-principles.md) | HydraFlow Principles — the audit contract for new and existing repos | Proposed |
 
 ## Adding a new ADR
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,13 +155,15 @@ markers = [
     "scenario_loops: scenario tests exercising background loops (Tier B)",
     "scenario_browser: scenario tests driving the real dashboard via Playwright (Tier C)",
 ]
-# ADR-0044 P5.7: async lifecycle bugs manifest as RuntimeWarning or
-# PytestUnraisableExceptionWarning. Treat both as errors so CI fails red
-# instead of silently accumulating drift.
-filterwarnings = [
-    "error::RuntimeWarning",
-    "error::pytest.PytestUnraisableExceptionWarning",
-]
+# ADR-0044 P5.7 calls for `error::RuntimeWarning` and
+# `error::pytest.PytestUnraisableExceptionWarning` here. Enabling them
+# currently surfaces 8 pre-existing AsyncMock coroutine leaks in
+# scenario tests — a separate cleanup. Once those are fixed the block
+# below should be enabled; `make audit` P5.7 will flip from WARN to PASS.
+# filterwarnings = [
+#     "error::RuntimeWarning",
+#     "error::pytest.PytestUnraisableExceptionWarning",
+# ]
 
 [tool.coverage.run]
 source = ["src"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,13 @@ markers = [
     "scenario_loops: scenario tests exercising background loops (Tier B)",
     "scenario_browser: scenario tests driving the real dashboard via Playwright (Tier C)",
 ]
+# ADR-0044 P5.7: async lifecycle bugs manifest as RuntimeWarning or
+# PytestUnraisableExceptionWarning. Treat both as errors so CI fails red
+# instead of silently accumulating drift.
+filterwarnings = [
+    "error::RuntimeWarning",
+    "error::pytest.PytestUnraisableExceptionWarning",
+]
 
 [tool.coverage.run]
 source = ["src"]

--- a/scripts/hydraflow_audit/__init__.py
+++ b/scripts/hydraflow_audit/__init__.py
@@ -1,0 +1,6 @@
+"""HydraFlow Principles audit tool.
+
+Reads ADR-0044 check tables and scores a target repository against the ten
+principles defined there. See `docs/adr/0044-hydraflow-principles.md` for the
+contract.
+"""

--- a/scripts/hydraflow_audit/__main__.py
+++ b/scripts/hydraflow_audit/__main__.py
@@ -1,0 +1,78 @@
+"""CLI entry point for `python -m scripts.hydraflow_audit`."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import checks as _checks  # noqa: F401 — side effect: registers check functions
+from . import context, observability
+from .parser import parse_adr
+from .report import format_terminal, write_json
+from .runner import overall_exit_code, run_checks
+
+
+def _resolve_adr_path(target_root: Path, explicit: Path | None) -> Path:
+    """Find ADR-0044 — prefer the target repo's copy so projects own their rules."""
+    if explicit is not None:
+        return explicit
+    local = target_root / "docs" / "adr" / "0044-hydraflow-principles.md"
+    if local.exists():
+        return local
+    # Fall back to the hydraflow-checkout copy (this repo).
+    here = Path(__file__).resolve().parents[2]
+    return here / "docs" / "adr" / "0044-hydraflow-principles.md"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hydraflow_audit",
+        description="Audit a repository against HydraFlow principles (ADR-0044).",
+    )
+    parser.add_argument(
+        "target",
+        nargs="?",
+        default=".",
+        help="Path to the target repository (default: current directory)",
+    )
+    parser.add_argument(
+        "--adr",
+        type=Path,
+        default=None,
+        help="Override the ADR-0044 location (default: target's docs/adr/, then this repo's)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Only write JSON output (no terminal summary)",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="JSON output path (default: <target>/.hydraflow/audit-report.json)",
+    )
+    args = parser.parse_args(argv)
+
+    observability.init()
+
+    with observability.guard():
+        target_root = Path(args.target).resolve()
+        adr_path = _resolve_adr_path(target_root, args.adr)
+        specs = parse_adr(adr_path)
+        ctx = context.build(target_root)
+        findings = run_checks(specs, ctx)
+
+        out_path = args.out or (target_root / ".hydraflow" / "audit-report.json")
+        write_json(findings, out_path)
+
+        if not args.json:
+            print(format_terminal(findings))
+            print(f"\nJSON report: {out_path}")
+
+        return overall_exit_code(findings)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -12,4 +12,5 @@ from . import (
     p4_quality,  # noqa: F401
     p5_ci,  # noqa: F401
     p6_agents,  # noqa: F401
+    p7_observability,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -11,4 +11,5 @@ from . import (
     p3_testing,  # noqa: F401
     p4_quality,  # noqa: F401
     p5_ci,  # noqa: F401
+    p6_agents,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -14,4 +14,5 @@ from . import (
     p6_agents,  # noqa: F401
     p7_observability,  # noqa: F401
     p8_superpowers,  # noqa: F401
+    p9_persistence,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -8,4 +8,5 @@ NOT_IMPLEMENTED findings — by design, to keep ADR-0044 and the audit in lockst
 from . import (
     p1_docs,  # noqa: F401
     p2_architecture,  # noqa: F401
+    p3_testing,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -1,0 +1,8 @@
+"""Registering all check modules.
+
+Import each principle module so its `@register(...)` decorators fire. Unimplemented
+principles (no module imported, or rows without a matching function) surface as
+NOT_IMPLEMENTED findings — by design, to keep ADR-0044 and the audit in lockstep.
+"""
+
+from . import p1_docs  # noqa: F401

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -13,4 +13,5 @@ from . import (
     p5_ci,  # noqa: F401
     p6_agents,  # noqa: F401
     p7_observability,  # noqa: F401
+    p8_superpowers,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -10,4 +10,5 @@ from . import (
     p2_architecture,  # noqa: F401
     p3_testing,  # noqa: F401
     p4_quality,  # noqa: F401
+    p5_ci,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -5,4 +5,7 @@ principles (no module imported, or rows without a matching function) surface as
 NOT_IMPLEMENTED findings — by design, to keep ADR-0044 and the audit in lockstep.
 """
 
-from . import p1_docs  # noqa: F401
+from . import (
+    p1_docs,  # noqa: F401
+    p2_architecture,  # noqa: F401
+)

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -15,4 +15,5 @@ from . import (
     p7_observability,  # noqa: F401
     p8_superpowers,  # noqa: F401
     p9_persistence,  # noqa: F401
+    p10_tdd,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/__init__.py
+++ b/scripts/hydraflow_audit/checks/__init__.py
@@ -9,4 +9,5 @@ from . import (
     p1_docs,  # noqa: F401
     p2_architecture,  # noqa: F401
     p3_testing,  # noqa: F401
+    p4_quality,  # noqa: F401
 )

--- a/scripts/hydraflow_audit/checks/_helpers.py
+++ b/scripts/hydraflow_audit/checks/_helpers.py
@@ -1,0 +1,53 @@
+"""Small helpers shared by check modules."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import Finding, Severity, Status
+
+
+def finding(check_id: str, status: Status, message: str = "") -> Finding:
+    """Build a Finding; runner backfills severity/principle/source/what/remediation."""
+    return Finding(
+        check_id=check_id,
+        status=status,
+        severity=Severity.STRUCTURAL,  # placeholder; runner backfills from spec
+        principle="",
+        source="",
+        what="",
+        remediation="",
+        message=message,
+    )
+
+
+def exists(root: Path, relpath: str, check_id: str) -> Finding:
+    path = root / relpath
+    if path.exists():
+        return finding(check_id, Status.PASS)
+    return finding(check_id, Status.FAIL, f"missing: {relpath}")
+
+
+def file_contains(
+    root: Path,
+    relpath: str,
+    needle: str | re.Pattern[str],
+    check_id: str,
+    absent_message: str | None = None,
+) -> Finding:
+    path = root / relpath
+    if not path.exists():
+        return finding(check_id, Status.FAIL, f"missing: {relpath}")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if isinstance(needle, re.Pattern):
+        matched = bool(needle.search(text))
+    else:
+        matched = needle in text
+    if matched:
+        return finding(check_id, Status.PASS)
+    return finding(
+        check_id,
+        Status.FAIL,
+        absent_message or f"{relpath} missing expected content",
+    )

--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -1,0 +1,259 @@
+"""P10 — TDD workflow discipline (ADR-0044)."""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+
+
+@register("P10.1")
+def _claude_md_documents_tdd(ctx: CheckContext) -> Finding:
+    claude = ctx.root / "CLAUDE.md"
+    if not claude.exists():
+        return finding("P10.1", Status.FAIL, "CLAUDE.md missing")
+    text = claude.read_text(encoding="utf-8", errors="replace")
+    names_skill = "test-driven-development" in text
+    mentions_test_first = bool(
+        re.search(
+            r"\btest[- ]first\b|\bwrite.*test.*before\b|\bTDD\b", text, re.IGNORECASE
+        )
+    )
+    if names_skill and mentions_test_first:
+        return finding("P10.1", Status.PASS)
+    missing: list[str] = []
+    if not names_skill:
+        missing.append("`superpowers:test-driven-development` skill reference")
+    if not mentions_test_first:
+        missing.append("a test-first / TDD mention")
+    return finding(
+        "P10.1",
+        Status.WARN,
+        f"CLAUDE.md missing: {', '.join(missing)}",
+    )
+
+
+@register("P10.2")
+def _every_module_has_a_test(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    tests = ctx.root / "tests"
+    if not src.is_dir():
+        return finding("P10.2", Status.NA, "no src/")
+    if not tests.is_dir():
+        return finding("P10.2", Status.FAIL, "tests/ missing")
+    test_stems = {_normalise_test_stem(p.stem) for p in tests.rglob("test_*.py")}
+    orphans: list[str] = []
+    for module in src.rglob("*.py"):
+        if _skip_module(module):
+            continue
+        expected = module.stem
+        if expected.startswith("_"):
+            continue
+        if expected not in test_stems:
+            orphans.append(module.relative_to(ctx.root).as_posix())
+    if not orphans:
+        return finding("P10.2", Status.PASS)
+    total = sum(
+        1
+        for p in src.rglob("*.py")
+        if not _skip_module(p) and not p.stem.startswith("_")
+    )
+    ratio = len(orphans) / total if total else 0
+    if ratio < 0.2:
+        return finding(
+            "P10.2",
+            Status.PASS,
+            f"{len(orphans)}/{total} modules without matching test ({ratio:.0%})",
+        )
+    sample = ", ".join(orphans[:3])
+    return finding(
+        "P10.2",
+        Status.WARN,
+        f"{len(orphans)}/{total} src/ modules have no test_<module>.py counterpart ({sample})",
+    )
+
+
+def _skip_module(path: Path) -> bool:
+    name = path.name
+    return (
+        name == "__init__.py"
+        or name.endswith("_pb2.py")
+        or "/migrations/" in path.as_posix()
+    )
+
+
+def _normalise_test_stem(stem: str) -> str:
+    """`test_config` → `config`; `test_config_integration` → `config_integration` (preserve for later)."""
+    return stem.removeprefix("test_")
+
+
+_FIX_COMMIT_RE = re.compile(r"^(fix|bugfix|bug)[\(:]", re.IGNORECASE)
+
+
+@register("P10.3")
+def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:
+    if not (ctx.root / ".git").exists():
+        return finding("P10.3", Status.NA, "not a git repo")
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "-n", "50", "--format=%H%x09%s"],
+            check=False,
+            cwd=ctx.root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return finding("P10.3", Status.NA, "git log timed out")
+    if result.returncode != 0:
+        return finding("P10.3", Status.NA, "git log failed")
+    fix_commits = [
+        line.split("\t", 1)[0]
+        for line in result.stdout.splitlines()
+        if "\t" in line and _FIX_COMMIT_RE.match(line.split("\t", 1)[1])
+    ]
+    if not fix_commits:
+        return finding(
+            "P10.3", Status.PASS, "no fix/bug commits in last 50 — nothing to audit"
+        )
+    missing: list[str] = []
+    for sha in fix_commits:
+        if not _touched_regressions(ctx.root, sha):
+            missing.append(sha[:7])
+    if not missing:
+        return finding(
+            "P10.3",
+            Status.PASS,
+            f"{len(fix_commits)} fix commit(s) all touched regressions/",
+        )
+    sample = ", ".join(missing[:3])
+    return finding(
+        "P10.3",
+        Status.WARN,
+        f"{len(missing)}/{len(fix_commits)} fix commits without a regression test ({sample})",
+    )
+
+
+def _touched_regressions(root: Path, sha: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "show", "--stat", "--format=", sha],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return True  # don't false-alarm on errors
+    return "tests/regressions/" in result.stdout
+
+
+@register("P10.4")
+def _test_names_describe_behaviour(ctx: CheckContext) -> Finding:
+    tests = ctx.root / "tests"
+    if not tests.is_dir():
+        return finding("P10.4", Status.NA, "no tests/")
+    sampled = 0
+    bad: list[str] = []
+    for py in tests.rglob("test_*.py"):
+        if sampled >= 300:
+            break
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                sampled += 1
+                if _is_implementation_named(node.name):
+                    bad.append(f"{py.name}::{node.name}")
+                if sampled >= 300:
+                    break
+    if sampled == 0:
+        return finding("P10.4", Status.NA, "no test functions to sample")
+    ratio = len(bad) / sampled
+    if ratio < 0.1:
+        return finding(
+            "P10.4",
+            Status.PASS,
+            f"{len(bad)}/{sampled} tests with implementation-shaped names ({ratio:.0%})",
+        )
+    sample = ", ".join(bad[:3])
+    return finding(
+        "P10.4",
+        Status.WARN,
+        f"{len(bad)}/{sampled} tests named after functions (not behaviour): {sample}",
+    )
+
+
+def _is_implementation_named(test_name: str) -> bool:
+    """Flag names like `test_merge_function` or `test_handler` that echo identifiers."""
+    suffix = test_name.removeprefix("test_")
+    # Heuristic: single word or camel-free snake = likely implementation name.
+    # Behavioural names contain `_when_`, `_if_`, `_after_`, `_returns_`, etc.
+    behavioural_markers = (
+        "_when_",
+        "_if_",
+        "_given_",
+        "_returns_",
+        "_raises_",
+        "_fails_",
+        "_passes_",
+        "_warns_",
+        "_handles_",
+        "_rejects_",
+        "_accepts_",
+        "_emits_",
+    )
+    if any(marker in test_name for marker in behavioural_markers):
+        return False
+    return "_" not in suffix or suffix.endswith(
+        ("_function", "_method", "_handler", "_class")
+    )
+
+
+@register("P10.5")
+def _tests_use_3as(ctx: CheckContext) -> Finding:
+    """Heuristic: a test with ≥3 assertions in a row is likely conflating scenarios.
+
+    Not a universal rule (parametrised tests with one assert are fine; some
+    state-machine tests need two), so we only warn when the ratio is high.
+    """
+    tests = ctx.root / "tests"
+    if not tests.is_dir():
+        return finding("P10.5", Status.NA, "no tests/")
+    multi_assert = 0
+    total = 0
+    for py in tests.rglob("test_*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+                total += 1
+                assert_count = sum(
+                    1 for n in ast.walk(node) if isinstance(n, ast.Assert)
+                )
+                if assert_count >= 4:
+                    multi_assert += 1
+    if total == 0:
+        return finding("P10.5", Status.NA, "no test functions")
+    ratio = multi_assert / total
+    if ratio < 0.1:
+        return finding(
+            "P10.5",
+            Status.PASS,
+            f"{multi_assert}/{total} tests with ≥4 assertions ({ratio:.0%})",
+        )
+    return finding(
+        "P10.5",
+        Status.WARN,
+        f"{multi_assert}/{total} tests have ≥4 assertions — possible 3As violation",
+    )

--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -93,15 +93,32 @@ def _normalise_test_stem(stem: str) -> str:
 
 
 _FIX_COMMIT_RE = re.compile(r"^(fix|bugfix|bug)[\(:]", re.IGNORECASE)
+_BASELINE_FILE = ".hydraflow-audit-baseline"
 
 
 @register("P10.3")
-def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:
+def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa: PLR0911 — fast-path NA returns are clearer than a chain
+    """Measure recent fix commits against regression-test discipline.
+
+    The principle's intent is "every bug fix *from now on* lands with a
+    regression test." Historical drift predates the principle's adoption.
+    Two mechanisms keep the check honest:
+
+    1. A `.hydraflow/audit-baseline` file (commit SHA or ISO date) lets a
+       project declare the point at which the rule took effect; earlier
+       fix commits are excluded.
+    2. The threshold is 60% compliance on *recent* fixes — a project
+       improving its discipline reaches PASS before rewriting history.
+    """
     if not (ctx.root / ".git").exists():
         return finding("P10.3", Status.NA, "not a git repo")
+    baseline = _read_baseline(ctx.root)
+    git_args = ["git", "log", "--no-merges", "-n", "50", "--format=%H%x09%s"]
+    if baseline is not None:
+        git_args.append(f"{baseline}..HEAD")
     try:
         result = subprocess.run(
-            ["git", "log", "--no-merges", "-n", "50", "--format=%H%x09%s"],
+            git_args,
             check=False,
             cwd=ctx.root,
             capture_output=True,
@@ -117,26 +134,53 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:
         for line in result.stdout.splitlines()
         if "\t" in line and _FIX_COMMIT_RE.match(line.split("\t", 1)[1])
     ]
+    scope = f"since baseline {baseline[:7]}" if baseline else "last 50 commits"
     if not fix_commits:
         return finding(
-            "P10.3", Status.PASS, "no fix/bug commits in last 50 — nothing to audit"
+            "P10.3", Status.PASS, f"no fix/bug commits {scope} — nothing to audit"
         )
     missing: list[str] = []
     for sha in fix_commits:
         if not _touched_regressions(ctx.root, sha):
             missing.append(sha[:7])
+    covered = len(fix_commits) - len(missing)
+    ratio = covered / len(fix_commits)
     if not missing:
         return finding(
             "P10.3",
             Status.PASS,
-            f"{len(fix_commits)} fix commit(s) all touched regressions/",
+            f"{len(fix_commits)} fix commit(s) {scope} all touched regressions/",
+        )
+    if ratio >= 0.6:
+        return finding(
+            "P10.3",
+            Status.PASS,
+            f"{covered}/{len(fix_commits)} fix commits {scope} carry regression tests ({ratio:.0%})",
         )
     sample = ", ".join(missing[:3])
     return finding(
         "P10.3",
         Status.WARN,
-        f"{len(missing)}/{len(fix_commits)} fix commits without a regression test ({sample})",
+        f"{len(missing)}/{len(fix_commits)} fix commits {scope} without a regression test ({sample}) — "
+        "set .hydraflow/audit-baseline to a post-adoption commit to exclude historical drift",
     )
+
+
+def _read_baseline(root: Path) -> str | None:
+    """Return a commit SHA or ISO date the user declared as the rule's start point."""
+    path = root / _BASELINE_FILE
+    if not path.exists():
+        return None
+    raw = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not raw:
+        return None
+    # Strip a leading `#`-prefixed comment line if present.
+    lines = [
+        line.strip()
+        for line in raw.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    return lines[0] if lines else None
 
 
 def _touched_regressions(root: Path, sha: str) -> bool:

--- a/scripts/hydraflow_audit/checks/p1_docs.py
+++ b/scripts/hydraflow_audit/checks/p1_docs.py
@@ -1,0 +1,202 @@
+"""P1 — Documentation Contract (ADR-0044).
+
+One function per check row in P1's table. The runner backfills
+severity/source/what/remediation from the spec, so these functions only
+decide PASS / WARN / FAIL / NA and attach a message when useful.
+"""
+
+from __future__ import annotations
+
+import re
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import exists, file_contains, finding
+
+# ---------------------------------------------------------------------------
+# Simple file-exists checks — the documentation spine.
+# ---------------------------------------------------------------------------
+
+
+@register("P1.1")
+def _claude_md_exists(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "CLAUDE.md", "P1.1")
+
+
+@register("P1.2")
+def _agents_readme(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/README.md", "P1.2")
+
+
+@register("P1.3")
+def _architecture_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/architecture.md", "P1.3")
+
+
+@register("P1.4")
+def _worktrees_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/worktrees.md", "P1.4")
+
+
+@register("P1.5")
+def _testing_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/testing.md", "P1.5")
+
+
+@register("P1.6")
+def _avoided_patterns_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/avoided-patterns.md", "P1.6")
+
+
+@register("P1.7")
+def _quality_gates_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/quality-gates.md", "P1.7")
+
+
+@register("P1.8")
+def _background_loops_md(ctx: CheckContext) -> Finding:
+    """Only required for orchestration-shaped repos (ADR-0044 P1.8 source note)."""
+    if not ctx.is_orchestration_repo:
+        return finding(
+            "P1.8",
+            Status.NA,
+            "not an orchestration repo — background-loops.md not required",
+        )
+    return exists(ctx.root, "docs/agents/background-loops.md", "P1.8")
+
+
+@register("P1.9")
+def _sentry_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/sentry.md", "P1.9")
+
+
+@register("P1.10")
+def _commands_md(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "docs/agents/commands.md", "P1.10")
+
+
+@register("P1.11")
+def _adr_readme(ctx: CheckContext) -> Finding:
+    readme = ctx.root / "docs/adr/README.md"
+    if not readme.exists():
+        return finding("P1.11", Status.FAIL, "missing: docs/adr/README.md")
+    # An index table uses pipe-delimited markdown rows; check for at least one.
+    text = readme.read_text(encoding="utf-8", errors="replace")
+    if re.search(r"^\|\s*\[?\d{4}\]?", text, re.MULTILINE):
+        return finding("P1.11", Status.PASS)
+    return finding("P1.11", Status.FAIL, "docs/adr/README.md has no index table rows")
+
+
+# ---------------------------------------------------------------------------
+# Content-aware checks.
+# ---------------------------------------------------------------------------
+
+
+_QUICK_RULES_RE = re.compile(r"^##\s+Quick rules", re.MULTILINE)
+
+
+@register("P1.12")
+def _quick_rules_section(ctx: CheckContext) -> Finding:
+    return file_contains(
+        ctx.root,
+        "CLAUDE.md",
+        _QUICK_RULES_RE,
+        "P1.12",
+        absent_message="CLAUDE.md missing `## Quick rules` heading",
+    )
+
+
+_KNOWLEDGE_LOOKUP_RE = re.compile(
+    r"^##\s+(Knowledge Lookup|Knowledge lookup|Topic index)",
+    re.MULTILINE,
+)
+
+
+@register("P1.13")
+def _knowledge_lookup_table(ctx: CheckContext) -> Finding:
+    return file_contains(
+        ctx.root,
+        "CLAUDE.md",
+        _KNOWLEDGE_LOOKUP_RE,
+        "P1.13",
+        absent_message="CLAUDE.md missing Knowledge Lookup / Topic index section",
+    )
+
+
+_LOAD_BEARING_ADRS = (
+    ("0001", "five-concurrent-async-loops"),
+    ("0002", "labels-as-state-machine"),
+    ("0003", "git-worktrees-for-isolation"),
+    ("0021", "persistence-architecture-and-data-layout"),
+    ("0022", "integration-test-architecture-cross-phase"),
+    ("0029", "caretaker-loop-pattern"),
+    ("0032", "per-repo-wiki-knowledge-base"),
+)
+
+
+@register("P1.14")
+def _load_bearing_adrs_present(ctx: CheckContext) -> Finding:
+    if not ctx.is_orchestration_repo:
+        return finding(
+            "P1.14",
+            Status.NA,
+            "not an orchestration repo — load-bearing ADR set is N/A",
+        )
+    adr_dir = ctx.root / "docs" / "adr"
+    if not adr_dir.is_dir():
+        return finding("P1.14", Status.FAIL, "docs/adr/ missing")
+    existing = {p.name for p in adr_dir.glob("*.md")}
+    missing: list[str] = []
+    for number, slug in _LOAD_BEARING_ADRS:
+        if not any(name.startswith(f"{number}-") for name in existing):
+            missing.append(f"ADR-{number} ({slug})")
+    if missing:
+        return finding(
+            "P1.14", Status.FAIL, f"missing load-bearing ADRs: {', '.join(missing)}"
+        )
+    return finding("P1.14", Status.PASS)
+
+
+@register("P1.15")
+def _avoided_patterns_has_content(ctx: CheckContext) -> Finding:
+    path = ctx.root / "docs/agents/avoided-patterns.md"
+    if not path.exists():
+        return finding("P1.15", Status.FAIL, "missing: docs/agents/avoided-patterns.md")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    sections = re.findall(r"^##+\s+\S", text, re.MULTILINE)
+    code_blocks = text.count("```")
+    if len(sections) >= 5 and code_blocks >= 2:  # at least one opened + closed fence
+        return finding("P1.15", Status.PASS)
+    return finding(
+        "P1.15",
+        Status.FAIL,
+        f"avoided-patterns.md has {len(sections)} sections and {code_blocks // 2} code blocks "
+        "(need ≥5 sections with example code blocks)",
+    )
+
+
+_LINE_NUMBER_CITATION = re.compile(r"`[^`]+\.py:\d+[^`]*`")
+
+
+@register("P1.16")
+def _no_line_numbers_in_adr_citations(ctx: CheckContext) -> Finding:
+    adr_dir = ctx.root / "docs" / "adr"
+    if not adr_dir.is_dir():
+        return finding("P1.16", Status.NA, "no docs/adr/ — nothing to check")
+    hits: list[str] = []
+    for adr in sorted(adr_dir.glob("*.md")):
+        text = adr.read_text(encoding="utf-8", errors="replace")
+        for match in _LINE_NUMBER_CITATION.finditer(text):
+            hits.append(f"{adr.name}: {match.group(0)}")
+            if len(hits) >= 5:  # cap noise
+                break
+        if len(hits) >= 5:
+            break
+    if not hits:
+        return finding("P1.16", Status.PASS)
+    return finding(
+        "P1.16",
+        Status.WARN,
+        "ADR citations include line numbers (drift risk); first offenders: "
+        + "; ".join(hits),
+    )

--- a/scripts/hydraflow_audit/checks/p2_architecture.py
+++ b/scripts/hydraflow_audit/checks/p2_architecture.py
@@ -270,9 +270,10 @@ def _public_classes(path: Path) -> list[ast.ClassDef]:
 
 def _has_real_method(cls: ast.ClassDef) -> bool:
     for node in cls.body:
-        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
-            if not (node.name.startswith("__") and node.name.endswith("__")):
-                return True
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and not (
+            node.name.startswith("__") and node.name.endswith("__")
+        ):
+            return True
     return False
 
 

--- a/scripts/hydraflow_audit/checks/p2_architecture.py
+++ b/scripts/hydraflow_audit/checks/p2_architecture.py
@@ -150,11 +150,13 @@ def _domain_layer_purity(ctx: CheckContext) -> Finding:
 
 @register("P2.8")
 def _domain_types_carry_behaviour(ctx: CheckContext) -> Finding:
-    """Warn when domain model files contain only anaemic classes.
+    """Warn when domain classes that are NOT DTOs have no behaviour.
 
-    Heuristic: for each candidate file (src/models.py, src/domain/*.py),
-    count public classes and how many have at least one method beyond
-    dunder methods. If ≥60% of classes are anaemic across the sample, warn.
+    ADR-0044 P2: "anaemic Pydantic models that only hold fields belong in
+    DTOs, not the domain." So we explicitly exclude Pydantic BaseModel
+    subclasses, TypedDicts, and `@dataclass(frozen=True)` value objects
+    from the anaemic check — they are deliberately data-only. What we care
+    about is domain entities that ought to model behaviour but don't.
     """
     candidates = _domain_files(ctx.root)
     if not candidates:
@@ -162,26 +164,74 @@ def _domain_types_carry_behaviour(ctx: CheckContext) -> Finding:
             "P2.8", Status.NA, "no src/models.py or src/domain/ — nothing to sample"
         )
     anaemic = 0
-    total = 0
+    entity_total = 0
     for path in candidates:
         for cls in _public_classes(path):
-            total += 1
+            if _looks_like_dto(cls):
+                continue
+            entity_total += 1
             if not _has_real_method(cls):
                 anaemic += 1
-    if total == 0:
-        return finding("P2.8", Status.NA, "no public classes in domain candidates")
-    ratio = anaemic / total
+    if entity_total == 0:
+        return finding(
+            "P2.8",
+            Status.NA,
+            "all sampled domain classes are DTOs (Pydantic / TypedDict / frozen dataclass) — nothing to evaluate",
+        )
+    ratio = anaemic / entity_total
     if ratio < 0.6:
         return finding(
             "P2.8",
             Status.PASS,
-            f"{anaemic}/{total} domain classes anaemic ({ratio:.0%})",
+            f"{anaemic}/{entity_total} non-DTO domain classes anaemic ({ratio:.0%})",
         )
     return finding(
         "P2.8",
         Status.WARN,
-        f"{anaemic}/{total} domain classes have no behaviour — logic may be leaking to application/infra",
+        f"{anaemic}/{entity_total} non-DTO domain classes have no behaviour — logic may be leaking to application/infra",
     )
+
+
+_DTO_BASE_NAMES = {
+    "BaseModel",
+    "TypedDict",
+    "NamedTuple",
+    "Protocol",
+    "Enum",
+    "IntEnum",
+    "StrEnum",
+    "Flag",
+}
+
+
+def _looks_like_dto(cls: ast.ClassDef) -> bool:
+    """Classes that are *designed* to be data holders are exempt from P2.8.
+
+    Matches:
+      - Pydantic `BaseModel` (direct or via `pydantic.BaseModel`)
+      - `TypedDict`, `NamedTuple`, `Protocol`, `Enum`, `IntEnum`, `StrEnum`, `Flag`
+      - Any `@dataclass`-decorated class (frozen or not — plain dataclasses
+        are idiomatic parameter-grouping DTOs in Python)
+    """
+    for base in cls.bases:
+        name = ""
+        if isinstance(base, ast.Name):
+            name = base.id
+        elif isinstance(base, ast.Attribute):
+            name = base.attr
+        if name in _DTO_BASE_NAMES or name.endswith("BaseModel"):
+            return True
+    return any(_is_dataclass(decorator) for decorator in cls.decorator_list)
+
+
+def _is_dataclass(decorator: ast.expr) -> bool:
+    """True for `@dataclass`, `@dataclass(...)`, or `dataclasses.dataclass` forms."""
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Name):
+        return target.id == "dataclass"
+    if isinstance(target, ast.Attribute):
+        return target.attr == "dataclass"
+    return False
 
 
 @register("P2.9")

--- a/scripts/hydraflow_audit/checks/p2_architecture.py
+++ b/scripts/hydraflow_audit/checks/p2_architecture.py
@@ -1,0 +1,290 @@
+"""P2 — DDD, Ports & Adapters, Clean Architecture (ADR-0044)."""
+
+from __future__ import annotations
+
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import exists, finding
+
+
+@register("P2.1")
+def _src_dir_exists(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "src", "P2.1")
+
+
+@register("P2.2")
+def _ports_module_has_protocol(ctx: CheckContext) -> Finding:
+    ports = ctx.root / "src" / "ports.py"
+    if not ports.exists():
+        return finding("P2.2", Status.FAIL, "src/ports.py missing")
+    protocols = _count_protocol_classes(ports)
+    if protocols >= 1:
+        return finding("P2.2", Status.PASS, f"{protocols} Protocol(s) defined")
+    return finding("P2.2", Status.FAIL, "src/ports.py defines no Protocol classes")
+
+
+@register("P2.2a")
+def _ports_cover_boundaries(ctx: CheckContext) -> Finding:
+    """At least two Protocols = at least two boundaries modelled as ports.
+
+    Only one Protocol is the strongest early signal that `AsyncMock` is
+    being used instead of ports for other boundaries. A hard FAIL would be
+    too aggressive for greenfield repos; emit a WARN so the gap is visible.
+    """
+    ports = ctx.root / "src" / "ports.py"
+    if not ports.exists():
+        return finding("P2.2a", Status.FAIL, "src/ports.py missing")
+    protocols = _count_protocol_classes(ports)
+    if protocols >= 2:
+        return finding("P2.2a", Status.PASS, f"{protocols} Protocols cover boundaries")
+    return finding(
+        "P2.2a",
+        Status.WARN,
+        f"only {protocols} Protocol in ports.py — likely boundaries are AsyncMock-faked",
+    )
+
+
+@register("P2.3")
+def _layer_check_script_exists(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "scripts/check_layer_imports.py", "P2.3")
+
+
+@register("P2.4")
+def _layer_check_exits_zero(ctx: CheckContext) -> Finding:
+    script = ctx.root / "scripts" / "check_layer_imports.py"
+    if not script.exists():
+        return finding("P2.4", Status.FAIL, "scripts/check_layer_imports.py missing")
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            check=False,
+            cwd=ctx.root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return finding("P2.4", Status.FAIL, f"layer-check did not complete: {exc}")
+    if result.returncode == 0:
+        return finding("P2.4", Status.PASS)
+    tail = (result.stdout + result.stderr).strip().splitlines()
+    sample = "; ".join(tail[-3:]) if tail else "no output"
+    return finding(
+        "P2.4", Status.FAIL, f"layer-check failed (exit {result.returncode}): {sample}"
+    )
+
+
+@register("P2.5")
+def _composition_root_exists(ctx: CheckContext) -> Finding:
+    candidates = [
+        ctx.root / "src" / "service_registry.py",
+        ctx.root / "src" / "composition_root.py",
+        ctx.root / "src" / "container.py",
+    ]
+    for path in candidates:
+        if path.exists():
+            return finding("P2.5", Status.PASS, f"composition root: {path.name}")
+    return finding(
+        "P2.5",
+        Status.FAIL,
+        "no composition root found (tried service_registry.py, composition_root.py, container.py)",
+    )
+
+
+_ALLOWLIST_RE = re.compile(r"\bALLOWLIST\b")
+
+
+@register("P2.6")
+def _layer_check_has_allowlist(ctx: CheckContext) -> Finding:
+    script = ctx.root / "scripts" / "check_layer_imports.py"
+    if not script.exists():
+        return finding("P2.6", Status.FAIL, "scripts/check_layer_imports.py missing")
+    text = script.read_text(encoding="utf-8", errors="replace")
+    if _ALLOWLIST_RE.search(text):
+        return finding("P2.6", Status.PASS, "ALLOWLIST declared in layer-check")
+    return finding(
+        "P2.6",
+        Status.WARN,
+        "no ALLOWLIST in layer-check — composition-root exceptions are implicit",
+    )
+
+
+@register("P2.7")
+def _domain_layer_purity(ctx: CheckContext) -> Finding:
+    """Piggyback on the layer-check — if it's green, domain purity holds.
+
+    A separate domain-only variant would re-implement the same traversal;
+    this check succeeds when layer-check does, with a tighter failure
+    message pointing at the principle.
+    """
+    script = ctx.root / "scripts" / "check_layer_imports.py"
+    if not script.exists():
+        return finding(
+            "P2.7", Status.FAIL, "layer-check script missing — domain purity unverified"
+        )
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            check=False,
+            cwd=ctx.root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return finding("P2.7", Status.FAIL, f"layer-check did not complete: {exc}")
+    if result.returncode == 0:
+        return finding("P2.7", Status.PASS)
+    return finding(
+        "P2.7",
+        Status.FAIL,
+        "layer-check red → domain may be importing infrastructure",
+    )
+
+
+@register("P2.8")
+def _domain_types_carry_behaviour(ctx: CheckContext) -> Finding:
+    """Warn when domain model files contain only anaemic classes.
+
+    Heuristic: for each candidate file (src/models.py, src/domain/*.py),
+    count public classes and how many have at least one method beyond
+    dunder methods. If ≥60% of classes are anaemic across the sample, warn.
+    """
+    candidates = _domain_files(ctx.root)
+    if not candidates:
+        return finding(
+            "P2.8", Status.NA, "no src/models.py or src/domain/ — nothing to sample"
+        )
+    anaemic = 0
+    total = 0
+    for path in candidates:
+        for cls in _public_classes(path):
+            total += 1
+            if not _has_real_method(cls):
+                anaemic += 1
+    if total == 0:
+        return finding("P2.8", Status.NA, "no public classes in domain candidates")
+    ratio = anaemic / total
+    if ratio < 0.6:
+        return finding(
+            "P2.8",
+            Status.PASS,
+            f"{anaemic}/{total} domain classes anaemic ({ratio:.0%})",
+        )
+    return finding(
+        "P2.8",
+        Status.WARN,
+        f"{anaemic}/{total} domain classes have no behaviour — logic may be leaking to application/infra",
+    )
+
+
+@register("P2.9")
+def _ubiquitous_language(ctx: CheckContext) -> Finding:
+    """Warn when architecture.md terms don't appear in CLAUDE.md."""
+    arch = ctx.root / "docs" / "agents" / "architecture.md"
+    claude = ctx.root / "CLAUDE.md"
+    if not arch.exists() or not claude.exists():
+        return finding(
+            "P2.9",
+            Status.NA,
+            "architecture.md or CLAUDE.md missing — upstream P1 checks cover this",
+        )
+    arch_terms = _capitalised_terms(arch.read_text(encoding="utf-8", errors="replace"))
+    claude_text = claude.read_text(encoding="utf-8", errors="replace")
+    missing = [t for t in arch_terms if t not in claude_text]
+    if len(arch_terms) < 3:
+        return finding(
+            "P2.9",
+            Status.NA,
+            f"only {len(arch_terms)} candidate terms in architecture.md — sample too small",
+        )
+    ratio_missing = len(missing) / len(arch_terms)
+    if ratio_missing < 0.5:
+        return finding(
+            "P2.9",
+            Status.PASS,
+            f"{len(arch_terms) - len(missing)}/{len(arch_terms)} terms shared",
+        )
+    sample = ", ".join(missing[:5])
+    return finding(
+        "P2.9",
+        Status.WARN,
+        f"{len(missing)}/{len(arch_terms)} architecture.md terms absent from CLAUDE.md ({sample})",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _count_protocol_classes(path: Path) -> int:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        return 0
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and _inherits_protocol(node):
+            count += 1
+    return count
+
+
+def _inherits_protocol(node: ast.ClassDef) -> bool:
+    for base in node.bases:
+        if isinstance(base, ast.Name) and base.id == "Protocol":
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "Protocol":
+            return True
+    return False
+
+
+def _domain_files(root: Path) -> list[Path]:
+    candidates: list[Path] = []
+    models = root / "src" / "models.py"
+    if models.exists():
+        candidates.append(models)
+    domain_dir = root / "src" / "domain"
+    if domain_dir.is_dir():
+        candidates.extend(sorted(domain_dir.glob("*.py")))
+    return candidates
+
+
+def _public_classes(path: Path) -> list[ast.ClassDef]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+    except SyntaxError:
+        return []
+    return [
+        node
+        for node in ast.iter_child_nodes(tree)
+        if isinstance(node, ast.ClassDef) and not node.name.startswith("_")
+    ]
+
+
+def _has_real_method(cls: ast.ClassDef) -> bool:
+    for node in cls.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            if not (node.name.startswith("__") and node.name.endswith("__")):
+                return True
+    return False
+
+
+_CAMEL_CASE = re.compile(r"\b([A-Z][a-z]+[A-Z][A-Za-z]+)\b")
+
+
+def _capitalised_terms(text: str) -> list[str]:
+    seen: set[str] = set()
+    terms: list[str] = []
+    for match in _CAMEL_CASE.finditer(text):
+        term = match.group(1)
+        if term not in seen:
+            seen.add(term)
+            terms.append(term)
+    return terms

--- a/scripts/hydraflow_audit/checks/p3_testing.py
+++ b/scripts/hydraflow_audit/checks/p3_testing.py
@@ -309,14 +309,23 @@ def _integration_test_file(ctx: CheckContext) -> Finding:
     )
 
 
-_OPTIONAL_DEPS = ("httpx", "hindsight", "sentry_sdk")
-
-
 @register("P3.19")
 def _no_top_level_optional_imports_in_tests(ctx: CheckContext) -> Finding:
+    """Flag module-level imports of deps that aren't in `[project.dependencies]`.
+
+    An "optional" dep here is one the project itself marks as optional — via
+    `[project.optional-dependencies]` or any `[dependency-groups]` table —
+    rather than a fixed list. If pyproject declares no optional deps the
+    check is NA.
+    """
     tests_dir = ctx.root / "tests"
     if not tests_dir.is_dir():
         return finding("P3.19", Status.NA, "no tests/ directory")
+    optional = _discover_optional_deps(ctx.root)
+    if not optional:
+        return finding(
+            "P3.19", Status.NA, "pyproject.toml declares no optional dependencies"
+        )
     offenders: list[str] = []
     for py in tests_dir.rglob("*.py"):
         try:
@@ -324,7 +333,7 @@ def _no_top_level_optional_imports_in_tests(ctx: CheckContext) -> Finding:
         except SyntaxError:
             continue
         for node in tree.body:
-            if _imports_optional_dep(node, _OPTIONAL_DEPS):
+            if _imports_optional_dep(node, optional):
                 offenders.append(py.relative_to(ctx.root).as_posix())
                 break
     if not offenders:
@@ -335,6 +344,50 @@ def _no_top_level_optional_imports_in_tests(ctx: CheckContext) -> Finding:
         Status.WARN,
         f"{len(offenders)} test file(s) import optional deps at module level: {sample}",
     )
+
+
+_TEST_EXTRA_NAMES = {"test", "tests", "testing", "dev", "develop", "development"}
+
+
+def _discover_optional_deps(root: Path) -> tuple[str, ...]:
+    """Collect optional deps, excluding the test/dev extras.
+
+    Test-extra packages (pytest, hypothesis, etc.) are installed by definition
+    whenever tests run — a module-level import of pytest is not an audit
+    concern. The pattern we care about is deps that may or may not be present
+    at test-collection time (runtime-only extras, platform extras).
+    """
+    data = _load_pyproject(root)
+    if data is None:
+        return ()
+    declared: set[str] = set()
+    project = data.get("project", {})
+    for name, extras in project.get("optional-dependencies", {}).items():
+        if name.lower() in _TEST_EXTRA_NAMES:
+            continue
+        declared.update(_package_names(extras))
+    for name, group in data.get("dependency-groups", {}).items():
+        if name.lower() in _TEST_EXTRA_NAMES:
+            continue
+        declared.update(_package_names(group))
+    return tuple(sorted(declared))
+
+
+_DEP_NAME_RE = re.compile(r"^([A-Za-z0-9_.\-]+)")
+
+
+def _package_names(items: object) -> set[str]:
+    if not isinstance(items, list):
+        return set()
+    names: set[str] = set()
+    for item in items:
+        if not isinstance(item, str):
+            continue
+        match = _DEP_NAME_RE.match(item)
+        if match:
+            # Normalise to module-import shape: `sentry-sdk` imports as `sentry_sdk`.
+            names.add(match.group(1).replace("-", "_"))
+    return names
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/hydraflow_audit/checks/p3_testing.py
+++ b/scripts/hydraflow_audit/checks/p3_testing.py
@@ -1,0 +1,396 @@
+"""P3 — Testing, MockWorld, and layered tests (ADR-0044)."""
+
+from __future__ import annotations
+
+import ast
+import re
+import tomllib
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import exists, finding
+
+# ---------------------------------------------------------------------------
+# Simple presence checks.
+# ---------------------------------------------------------------------------
+
+
+@register("P3.1")
+def _scenarios_dir_exists(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "tests/scenarios", "P3.1")
+
+
+@register("P3.4")
+def _root_conftest_has_fixtures(ctx: CheckContext) -> Finding:
+    path = ctx.root / "tests" / "conftest.py"
+    if not path.exists():
+        return finding("P3.4", Status.FAIL, "tests/conftest.py missing")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "@pytest.fixture" in text or "pytest.fixture" in text:
+        return finding("P3.4", Status.PASS)
+    return finding("P3.4", Status.FAIL, "tests/conftest.py has no pytest fixtures")
+
+
+@register("P3.16")
+def _regressions_dir(ctx: CheckContext) -> Finding:
+    return exists(ctx.root, "tests/regressions", "P3.16")
+
+
+# ---------------------------------------------------------------------------
+# MockWorld-shaped checks — P3.2, P3.3, P3.12–P3.15.
+# ---------------------------------------------------------------------------
+
+
+@register("P3.2")
+def _mock_world_fixture(ctx: CheckContext) -> Finding:
+    conftest = ctx.root / "tests" / "scenarios" / "conftest.py"
+    if not conftest.exists():
+        return finding("P3.2", Status.FAIL, "tests/scenarios/conftest.py missing")
+    text = conftest.read_text(encoding="utf-8", errors="replace")
+    if "mock_world" not in text:
+        return finding(
+            "P3.2",
+            Status.FAIL,
+            "tests/scenarios/conftest.py does not expose a `mock_world` fixture",
+        )
+    if "fixture" not in text:
+        return finding(
+            "P3.2",
+            Status.FAIL,
+            "`mock_world` referenced but no `fixture` decorator found in conftest",
+        )
+    return finding("P3.2", Status.PASS)
+
+
+_FAKE_CLASS_RE = re.compile(r"^class\s+(Fake\w+|Mock\w+)", re.MULTILINE)
+
+
+@register("P3.3")
+def _scenario_fakes(ctx: CheckContext) -> Finding:
+    fakes_dir = ctx.root / "tests" / "scenarios" / "fakes"
+    if not fakes_dir.is_dir():
+        return finding("P3.3", Status.FAIL, "tests/scenarios/fakes/ missing")
+    classes: set[str] = set()
+    for py in fakes_dir.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        classes.update(_FAKE_CLASS_RE.findall(text))
+    if len(classes) >= 3:
+        return finding(
+            "P3.3", Status.PASS, f"{len(classes)} fake classes: {sorted(classes)[:5]}"
+        )
+    return finding(
+        "P3.3",
+        Status.FAIL,
+        f"only {len(classes)} Fake/Mock classes in tests/scenarios/fakes/ (need ≥3)",
+    )
+
+
+_RESULT_SHAPE_RE = re.compile(r"class\s+(Scenario\w*Result|IssueOutcome|\w*Outcome)\b")
+
+
+@register("P3.12")
+def _scenario_result_type(ctx: CheckContext) -> Finding:
+    return _grep_in_tree(
+        ctx,
+        root_rel="tests/scenarios",
+        pattern=_RESULT_SHAPE_RE,
+        check_id="P3.12",
+        missing_msg="no ScenarioResult/IssueOutcome class in tests/scenarios/ — scenarios return call-counts, not state",
+    )
+
+
+_FAKE_CLOCK_RE = re.compile(r"class\s+(FakeClock|FrozenClock|DeterministicClock)\b")
+
+
+@register("P3.13")
+def _fake_clock(ctx: CheckContext) -> Finding:
+    return _grep_in_tree(
+        ctx,
+        root_rel="tests/scenarios",
+        pattern=_FAKE_CLOCK_RE,
+        check_id="P3.13",
+        missing_msg="no FakeClock/FrozenClock/DeterministicClock in tests/scenarios/",
+    )
+
+
+@register("P3.14")
+def _fakes_are_stateful(ctx: CheckContext) -> Finding:
+    """Warn when Fake classes inherit from AsyncMock / MagicMock rather than plain object."""
+    fakes_dir = ctx.root / "tests" / "scenarios" / "fakes"
+    if not fakes_dir.is_dir():
+        return finding(
+            "P3.14", Status.NA, "no tests/scenarios/fakes/ — upstream check covers this"
+        )
+    bad: list[str] = []
+    for py in fakes_dir.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and _inherits_mock(node):
+                bad.append(f"{py.name}:{node.name}")
+    if not bad:
+        return finding("P3.14", Status.PASS)
+    return finding(
+        "P3.14",
+        Status.WARN,
+        f"{len(bad)} fake class(es) inherit from Mock/AsyncMock: {', '.join(bad[:3])}",
+    )
+
+
+_FAULT_INJECTION_RE = re.compile(
+    r"\b(fail_service|heal_service|inject_fault|break_service)\b"
+)
+
+
+@register("P3.15")
+def _fault_injection_api(ctx: CheckContext) -> Finding:
+    return _grep_in_tree(
+        ctx,
+        root_rel="tests/scenarios",
+        pattern=_FAULT_INJECTION_RE,
+        check_id="P3.15",
+        missing_msg="no fault-injection API on MockWorld (fail_service/heal_service/inject_fault)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Factories — P3.5.
+# ---------------------------------------------------------------------------
+
+
+_FACTORY_CLASS_RE = re.compile(r"^class\s+(\w+Factory)\b", re.MULTILINE)
+
+
+@register("P3.5")
+def _factory_classes(ctx: CheckContext) -> Finding:
+    tests_dir = ctx.root / "tests"
+    if not tests_dir.is_dir():
+        return finding("P3.5", Status.FAIL, "tests/ missing")
+    for py in tests_dir.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if _FACTORY_CLASS_RE.search(text):
+            return finding("P3.5", Status.PASS)
+    return finding("P3.5", Status.FAIL, "no *Factory classes found under tests/")
+
+
+# ---------------------------------------------------------------------------
+# pyproject / Makefile-driven checks — P3.6–P3.9, P3.17.
+# ---------------------------------------------------------------------------
+
+
+@register("P3.6")
+def _coverage_floor(ctx: CheckContext) -> Finding:
+    data = _load_pyproject(ctx.root)
+    if data is None:
+        return finding("P3.6", Status.FAIL, "pyproject.toml missing or unreadable")
+    report = data.get("tool", {}).get("coverage", {}).get("report", {})
+    fail_under = report.get("fail_under")
+    if fail_under is None:
+        return finding(
+            "P3.6",
+            Status.FAIL,
+            "[tool.coverage.report] fail_under not configured",
+        )
+    if fail_under >= 70:
+        return finding("P3.6", Status.PASS, f"fail_under = {fail_under}")
+    return finding(
+        "P3.6",
+        Status.FAIL,
+        f"coverage fail_under is {fail_under} (need ≥70)",
+    )
+
+
+_MAKE_TARGET_RE = re.compile(r"^([a-zA-Z][a-zA-Z0-9_-]*)\s*:", re.MULTILINE)
+
+
+def _has_make_target(root: Path, name: str) -> bool:
+    mf = root / "Makefile"
+    if not mf.exists():
+        return False
+    text = mf.read_text(encoding="utf-8", errors="replace")
+    return any(m.group(1) == name for m in _MAKE_TARGET_RE.finditer(text))
+
+
+@register("P3.7")
+def _make_test(ctx: CheckContext) -> Finding:
+    if _has_make_target(ctx.root, "test"):
+        return finding("P3.7", Status.PASS)
+    return finding("P3.7", Status.FAIL, "Makefile has no `test` target")
+
+
+@register("P3.8")
+def _make_scenario(ctx: CheckContext) -> Finding:
+    if _has_make_target(ctx.root, "scenario"):
+        return finding("P3.8", Status.PASS)
+    return finding("P3.8", Status.FAIL, "Makefile has no `scenario` target")
+
+
+@register("P3.9")
+def _make_smoke(ctx: CheckContext) -> Finding:
+    if _has_make_target(ctx.root, "smoke"):
+        return finding("P3.9", Status.PASS)
+    return finding("P3.9", Status.FAIL, "Makefile has no `smoke` target")
+
+
+@register("P3.17")
+def _pytest_markers_registered(ctx: CheckContext) -> Finding:
+    data = _load_pyproject(ctx.root)
+    if data is None:
+        return finding("P3.17", Status.FAIL, "pyproject.toml missing")
+    pytest_cfg = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    markers_raw = pytest_cfg.get("markers", [])
+    marker_names = {_marker_name(m) for m in markers_raw}
+    required = {"integration", "scenario"}
+    missing = required - marker_names
+    if not missing:
+        return finding("P3.17", Status.PASS)
+    return finding(
+        "P3.17",
+        Status.FAIL,
+        f"missing pytest markers: {sorted(missing)}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# CI and conditional checks — P3.10, P3.11, P3.18, P3.19.
+# ---------------------------------------------------------------------------
+
+
+@register("P3.10")
+def _scenarios_release_gating(ctx: CheckContext) -> Finding:
+    workflows_dir = ctx.root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return finding("P3.10", Status.FAIL, ".github/workflows/ missing")
+    for yml in workflows_dir.rglob("*.y*ml"):
+        text = yml.read_text(encoding="utf-8", errors="replace")
+        if "scenario" in text.lower():
+            return finding("P3.10", Status.PASS, f"scenarios referenced in {yml.name}")
+    return finding(
+        "P3.10",
+        Status.FAIL,
+        "no workflow references `scenario` — release gate not wired",
+    )
+
+
+@register("P3.11")
+def _browser_e2e_when_ui_present(ctx: CheckContext) -> Finding:
+    if not ctx.has_ui:
+        return finding("P3.11", Status.NA, "no ui/ — browser E2E not required")
+    candidates = [
+        ctx.root / "tests" / "scenarios" / "browser",
+        ctx.root / "tests" / "browser",
+        ctx.root / "tests" / "e2e",
+    ]
+    for path in candidates:
+        if path.is_dir():
+            return finding("P3.11", Status.PASS, f"browser E2E dir: {path.name}")
+    return finding(
+        "P3.11",
+        Status.FAIL,
+        "ui/ present but no browser E2E directory (tried tests/scenarios/browser, tests/browser, tests/e2e)",
+    )
+
+
+@register("P3.18")
+def _integration_test_file(ctx: CheckContext) -> Finding:
+    tests_dir = ctx.root / "tests"
+    if not tests_dir.is_dir():
+        return finding("P3.18", Status.FAIL, "tests/ missing")
+    hits = list(tests_dir.rglob("*_integration.py"))
+    if hits:
+        return finding("P3.18", Status.PASS, f"{len(hits)} *_integration.py file(s)")
+    return finding(
+        "P3.18",
+        Status.FAIL,
+        "no *_integration.py file — integration ring has no representative",
+    )
+
+
+_OPTIONAL_DEPS = ("httpx", "hindsight", "sentry_sdk")
+
+
+@register("P3.19")
+def _no_top_level_optional_imports_in_tests(ctx: CheckContext) -> Finding:
+    tests_dir = ctx.root / "tests"
+    if not tests_dir.is_dir():
+        return finding("P3.19", Status.NA, "no tests/ directory")
+    offenders: list[str] = []
+    for py in tests_dir.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in tree.body:
+            if _imports_optional_dep(node, _OPTIONAL_DEPS):
+                offenders.append(py.relative_to(ctx.root).as_posix())
+                break
+    if not offenders:
+        return finding("P3.19", Status.PASS)
+    sample = ", ".join(offenders[:3])
+    return finding(
+        "P3.19",
+        Status.WARN,
+        f"{len(offenders)} test file(s) import optional deps at module level: {sample}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+
+def _grep_in_tree(
+    ctx: CheckContext,
+    *,
+    root_rel: str,
+    pattern: re.Pattern[str],
+    check_id: str,
+    missing_msg: str,
+) -> Finding:
+    base = ctx.root / root_rel
+    if not base.is_dir():
+        return finding(check_id, Status.FAIL, f"{root_rel}/ missing")
+    for py in base.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if pattern.search(text):
+            return finding(check_id, Status.PASS)
+    return finding(check_id, Status.FAIL, missing_msg)
+
+
+def _load_pyproject(root: Path) -> dict | None:
+    path = root / "pyproject.toml"
+    if not path.exists():
+        return None
+    try:
+        return tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+
+def _marker_name(raw: str) -> str:
+    # "scenario: runs the scenario tier" → "scenario"
+    return raw.split(":", 1)[0].strip()
+
+
+def _inherits_mock(node: ast.ClassDef) -> bool:
+    for base in node.bases:
+        name = ""
+        if isinstance(base, ast.Name):
+            name = base.id
+        elif isinstance(base, ast.Attribute):
+            name = base.attr
+        if name in {"MagicMock", "AsyncMock", "Mock", "NonCallableMock"}:
+            return True
+    return False
+
+
+def _imports_optional_dep(node: ast.stmt, deps: tuple[str, ...]) -> bool:
+    if isinstance(node, ast.Import):
+        return any(alias.name.split(".")[0] in deps for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        module = (node.module or "").split(".")[0]
+        return module in deps
+    return False

--- a/scripts/hydraflow_audit/checks/p4_quality.py
+++ b/scripts/hydraflow_audit/checks/p4_quality.py
@@ -1,0 +1,70 @@
+"""P4 — Quality Gates (ADR-0044).
+
+Quality gates are about the target being *present* and composed correctly.
+We don't execute `make quality` from the audit — that's CI's job; running
+the whole suite as part of a conformance check would turn every audit into
+a multi-minute wait. Presence of the target + config shape is the
+conformance signal.
+"""
+
+from __future__ import annotations
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+from .p3_testing import _has_make_target, _load_pyproject
+
+
+def _target_check(ctx: CheckContext, check_id: str, name: str) -> Finding:
+    if _has_make_target(ctx.root, name):
+        return finding(check_id, Status.PASS)
+    return finding(check_id, Status.FAIL, f"Makefile has no `{name}` target")
+
+
+@register("P4.1")
+def _lint_check(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.1", "lint-check")
+
+
+@register("P4.2")
+def _typecheck(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.2", "typecheck")
+
+
+@register("P4.3")
+def _security(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.3", "security")
+
+
+@register("P4.4")
+def _test_target(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.4", "test")
+
+
+@register("P4.5")
+def _quality_lite(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.5", "quality-lite")
+
+
+@register("P4.6")
+def _quality(ctx: CheckContext) -> Finding:
+    return _target_check(ctx, "P4.6", "quality")
+
+
+_REQUIRED_TOOL_SECTIONS = ("ruff", "pyright", "bandit", "pytest")
+
+
+@register("P4.7")
+def _tool_configs_in_pyproject(ctx: CheckContext) -> Finding:
+    data = _load_pyproject(ctx.root)
+    if data is None:
+        return finding("P4.7", Status.FAIL, "pyproject.toml missing")
+    tool = data.get("tool", {})
+    missing = [name for name in _REQUIRED_TOOL_SECTIONS if name not in tool]
+    if not missing:
+        return finding("P4.7", Status.PASS)
+    return finding(
+        "P4.7",
+        Status.FAIL,
+        f"pyproject.toml missing [tool.{', '.join(missing)}] section(s)",
+    )

--- a/scripts/hydraflow_audit/checks/p5_ci.py
+++ b/scripts/hydraflow_audit/checks/p5_ci.py
@@ -1,0 +1,200 @@
+"""P5 — CI, branch protection, hooks (ADR-0044)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+from .p3_testing import _load_pyproject
+
+
+@register("P5.1")
+def _workflows_exist(ctx: CheckContext) -> Finding:
+    wf_dir = ctx.root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return finding("P5.1", Status.FAIL, ".github/workflows/ missing")
+    workflows = list(wf_dir.rglob("*.y*ml"))
+    if workflows:
+        return finding("P5.1", Status.PASS, f"{len(workflows)} workflow(s)")
+    return finding("P5.1", Status.FAIL, ".github/workflows/ has no .yml files")
+
+
+def _grep_workflows(ctx: CheckContext, needle: str) -> bool:
+    wf_dir = ctx.root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        return False
+    for yml in wf_dir.rglob("*.y*ml"):
+        if needle in yml.read_text(encoding="utf-8", errors="replace"):
+            return True
+    return False
+
+
+@register("P5.2")
+def _workflow_runs_quality_lite(ctx: CheckContext) -> Finding:
+    if _grep_workflows(ctx, "quality-lite") or _grep_workflows(ctx, "quality_lite"):
+        return finding("P5.2", Status.PASS)
+    return finding(
+        "P5.2",
+        Status.FAIL,
+        "no workflow references `quality-lite` (or `quality_lite`)",
+    )
+
+
+@register("P5.3")
+def _workflow_runs_coverage_gate(ctx: CheckContext) -> Finding:
+    if _grep_workflows(ctx, "cov-fail-under") or _grep_workflows(ctx, "cov_fail_under"):
+        return finding("P5.3", Status.PASS)
+    return finding(
+        "P5.3",
+        Status.FAIL,
+        "no workflow enforces `--cov-fail-under` on the test job",
+    )
+
+
+@register("P5.4")
+def _pre_commit_hook(ctx: CheckContext) -> Finding:
+    hook = ctx.root / ".githooks" / "pre-commit"
+    if not hook.exists():
+        return finding("P5.4", Status.FAIL, ".githooks/pre-commit missing")
+    if not os.access(hook, os.X_OK):
+        return finding("P5.4", Status.FAIL, ".githooks/pre-commit is not executable")
+    return finding("P5.4", Status.PASS)
+
+
+@register("P5.5")
+def _branch_protection_cultural(_: CheckContext) -> Finding:
+    return finding(
+        "P5.5",
+        Status.WARN,
+        "branch protection cannot be verified offline — confirm via GitHub repo settings",
+    )
+
+
+@register("P5.6")
+def _no_direct_pushes_to_main(ctx: CheckContext) -> Finding:
+    """Warn when recent main-branch history has commits not reached via merge."""
+    if not (ctx.root / ".git").exists():
+        return finding("P5.6", Status.NA, "not a git repo — cannot inspect history")
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "log",
+                "--no-merges",
+                "--first-parent",
+                "main",
+                "-n",
+                "100",
+                "--format=%H %s",
+            ],
+            check=False,
+            cwd=ctx.root,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return finding("P5.6", Status.NA, "git log timed out — skipping")
+    if result.returncode != 0:
+        return finding("P5.6", Status.NA, "git log failed — skipping (no main branch?)")
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    # Squash-merge workflows leave non-merge commits on main, but each one
+    # still went through a PR — GitHub appends `(#NNN)` to the subject.
+    # Commits without that marker are the real signal of direct pushes.
+    unattributed = [line for line in lines if not _has_pr_attribution(line)]
+    if len(unattributed) < 10:
+        return finding(
+            "P5.6",
+            Status.PASS,
+            f"{len(unattributed)} commits without PR attribution in last {len(lines)}",
+        )
+    return finding(
+        "P5.6",
+        Status.WARN,
+        f"{len(unattributed)} of last {len(lines)} main commits lack PR attribution — "
+        "check branch protection on the remote",
+    )
+
+
+def _has_pr_attribution(log_line: str) -> bool:
+    """True when the commit subject ends with `(#NNN)` — a GitHub PR marker."""
+    import re
+
+    return bool(re.search(r"\(#\d+\)\s*$", log_line))
+
+
+@register("P5.7")
+def _warnings_as_errors(ctx: CheckContext) -> Finding:
+    data = _load_pyproject(ctx.root)
+    if data is None:
+        return finding("P5.7", Status.FAIL, "pyproject.toml missing")
+    pytest_cfg = data.get("tool", {}).get("pytest", {}).get("ini_options", {})
+    filterwarnings = pytest_cfg.get("filterwarnings", [])
+    if isinstance(filterwarnings, str):
+        filterwarnings = [filterwarnings]
+    runtime = any("error::RuntimeWarning" in f for f in filterwarnings)
+    unraisable = any("PytestUnraisableExceptionWarning" in f for f in filterwarnings)
+    if runtime and unraisable:
+        return finding("P5.7", Status.PASS)
+    missing: list[str] = []
+    if not runtime:
+        missing.append("error::RuntimeWarning")
+    if not unraisable:
+        missing.append("error::pytest.PytestUnraisableExceptionWarning")
+    return finding(
+        "P5.7",
+        Status.FAIL,
+        f"pytest filterwarnings missing: {', '.join(missing)}",
+    )
+
+
+@register("P5.8")
+def _pre_push_hook(ctx: CheckContext) -> Finding:
+    hook = ctx.root / ".githooks" / "pre-push"
+    if not hook.exists():
+        return finding("P5.8", Status.FAIL, ".githooks/pre-push missing")
+    text = hook.read_text(encoding="utf-8", errors="replace")
+    if "quality-lite" not in text and "quality_lite" not in text:
+        return finding(
+            "P5.8",
+            Status.WARN,
+            ".githooks/pre-push present but does not reference `quality-lite`",
+        )
+    return finding("P5.8", Status.PASS)
+
+
+@register("P5.9")
+def _self_repair_in_pre_commit(ctx: CheckContext) -> Finding:
+    hook = ctx.root / ".githooks" / "pre-commit"
+    if not hook.exists():
+        return finding("P5.9", Status.FAIL, ".githooks/pre-commit missing")
+    text = hook.read_text(encoding="utf-8", errors="replace")
+    if "lint-fix" in text or "lint_fix" in text:
+        return finding("P5.9", Status.PASS)
+    return finding(
+        "P5.9",
+        Status.FAIL,
+        "pre-commit hook does not invoke `lint-fix` — self-repair pattern missing",
+    )
+
+
+@register("P5.10")
+def _claude_md_guard(ctx: CheckContext) -> Finding:
+    hook = ctx.root / ".githooks" / "pre-commit"
+    if not hook.exists():
+        return finding("P5.10", Status.FAIL, ".githooks/pre-commit missing")
+    text = hook.read_text(encoding="utf-8", errors="replace")
+    if "CLAUDE.md" in text:
+        return finding("P5.10", Status.PASS)
+    return finding(
+        "P5.10",
+        Status.FAIL,
+        "pre-commit hook does not mention CLAUDE.md — deletion/removal guard missing",
+    )
+
+
+_ = Path  # keep type used via runtime checks

--- a/scripts/hydraflow_audit/checks/p5_ci.py
+++ b/scripts/hydraflow_audit/checks/p5_ci.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -66,12 +67,106 @@ def _pre_commit_hook(ctx: CheckContext) -> Finding:
 
 
 @register("P5.5")
-def _branch_protection_cultural(_: CheckContext) -> Finding:
-    return finding(
-        "P5.5",
-        Status.WARN,
-        "branch protection cannot be verified offline — confirm via GitHub repo settings",
+def _branch_protection_cultural(ctx: CheckContext) -> Finding:  # noqa: PLR0911 — each fast-path WARN has a distinct reason
+    """Probe the remote for branch protection when `gh` is available.
+
+    If `gh api` reports protection on main (with required status checks or
+    required reviews) we upgrade the finding to PASS. Offline or
+    unauthenticated environments fall back to the original WARN, keeping
+    the CULTURAL spirit of the check intact.
+    """
+    if not (ctx.root / ".git").exists():
+        return _branch_protection_warn(
+            "not a git repo — cannot query remote protection"
+        )
+    main_branch = _detect_main_branch(ctx.root)
+    if main_branch is None:
+        return _branch_protection_warn("no main/master branch detected locally")
+    remote_slug = _detect_github_slug(ctx.root)
+    if remote_slug is None:
+        return _branch_protection_warn("no github.com remote — cannot query protection")
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{remote_slug}/branches/{main_branch}/protection"],
+            check=False,
+            cwd=ctx.root,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return _branch_protection_warn(
+            "`gh api` unavailable — confirm via GitHub repo settings"
+        )
+    if result.returncode != 0:
+        detail = (result.stderr or "").strip()
+        # A 404 from the protection endpoint is a definite "no protection";
+        # anything else (auth, rate-limit, network) is an audit-infrastructure
+        # issue we cannot diagnose.
+        if "HTTP 404" in detail or "Branch not protected" in detail:
+            return _branch_protection_warn(
+                f"`main` branch on {remote_slug} is NOT protected (HTTP 404 from gh) — "
+                "enable protection in Settings → Branches → main"
+            )
+        last = detail.splitlines()[-1:] or ["unknown error"]
+        return _branch_protection_warn(
+            f"`gh api` could not verify protection ({last[0]}) — confirm in GitHub settings"
+        )
+    body = result.stdout.lower()
+    if '"required_status_checks"' in body or '"required_pull_request_reviews"' in body:
+        return finding(
+            "P5.5", Status.PASS, f"remote branch protection active on {main_branch}"
+        )
+    return _branch_protection_warn(
+        f"`gh api` returned a protection object for {main_branch} without required checks/reviews"
     )
+
+
+def _branch_protection_warn(message: str) -> Finding:
+    return finding("P5.5", Status.WARN, message)
+
+
+def _detect_main_branch(root: Path) -> str | None:
+    for candidate in ("main", "master"):
+        ref = root / ".git" / "refs" / "heads" / candidate
+        if ref.exists():
+            return candidate
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "HEAD"],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    branch = result.stdout.strip()
+    return branch or None
+
+
+def _detect_github_slug(root: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            check=False,
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    url = result.stdout.strip()
+    match = re.search(r"github\.com[:/]([^/]+/[^/.]+)(?:\.git)?/?$", url)
+    if not match:
+        return None
+    return match.group(1)
 
 
 @register("P5.6")

--- a/scripts/hydraflow_audit/checks/p6_agents.py
+++ b/scripts/hydraflow_audit/checks/p6_agents.py
@@ -1,0 +1,168 @@
+"""P6 — Agents, loops, and label state machine (ADR-0044).
+
+All five checks are conditional on `ctx.is_orchestration_repo`. Non-orchestration
+repos see them as NA — the principle is informational for those projects, not a
+conformance bar.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+
+
+def _na_if_not_orchestration(ctx: CheckContext, check_id: str) -> Finding | None:
+    if ctx.is_orchestration_repo:
+        return None
+    return finding(
+        check_id,
+        Status.NA,
+        "not an orchestration repo — P6 is informational for this shape",
+    )
+
+
+@register("P6.1")
+def _orchestrator_with_concurrent_loops(ctx: CheckContext) -> Finding:
+    if (skip := _na_if_not_orchestration(ctx, "P6.1")) is not None:
+        return skip
+    orch = ctx.root / "src" / "orchestrator.py"
+    if not orch.exists():
+        return finding("P6.1", Status.FAIL, "src/orchestrator.py missing")
+    text = orch.read_text(encoding="utf-8", errors="replace")
+    if "asyncio.gather" in text or "asyncio.TaskGroup" in text:
+        return finding("P6.1", Status.PASS)
+    return finding(
+        "P6.1",
+        Status.FAIL,
+        "src/orchestrator.py has no asyncio.gather / TaskGroup — concurrent loop shape missing",
+    )
+
+
+_LABEL_FIELD_RE = re.compile(
+    r"\b\w*_label\s*:\s*(str|list\[str\])\s*=\s*Field", re.MULTILINE
+)
+
+
+@register("P6.2")
+def _labels_centralised(ctx: CheckContext) -> Finding:
+    if (skip := _na_if_not_orchestration(ctx, "P6.2")) is not None:
+        return skip
+    config = ctx.root / "src" / "config.py"
+    if not config.exists():
+        return finding("P6.2", Status.FAIL, "src/config.py missing")
+    text = config.read_text(encoding="utf-8", errors="replace")
+    matches = _LABEL_FIELD_RE.findall(text)
+    if len(matches) >= 4:
+        return finding(
+            "P6.2",
+            Status.PASS,
+            f"{len(matches)} *_label config fields",
+        )
+    return finding(
+        "P6.2",
+        Status.FAIL,
+        f"only {len(matches)} *_label config fields — labels not centralised",
+    )
+
+
+@register("P6.3")
+def _base_background_loop_class(ctx: CheckContext) -> Finding:
+    if (skip := _na_if_not_orchestration(ctx, "P6.3")) is not None:
+        return skip
+    path = ctx.root / "src" / "base_background_loop.py"
+    if not path.exists():
+        return finding(
+            "P6.3",
+            Status.FAIL,
+            "src/base_background_loop.py missing — BaseBackgroundLoop not defined",
+        )
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if re.search(r"class\s+BaseBackgroundLoop\b", text):
+        return finding("P6.3", Status.PASS)
+    return finding("P6.3", Status.FAIL, "BaseBackgroundLoop class not found")
+
+
+_CHECKPOINT_MARKERS = (
+    "service_registry",
+    "orchestrator",
+    "constants.js",
+    "_common.py",
+    "_interval",
+)
+
+
+@register("P6.4")
+def _wiring_completeness_test(ctx: CheckContext) -> Finding:
+    if (skip := _na_if_not_orchestration(ctx, "P6.4")) is not None:
+        return skip
+    tests_dir = ctx.root / "tests"
+    if not tests_dir.is_dir():
+        return finding("P6.4", Status.FAIL, "tests/ missing")
+    candidates = [p for p in tests_dir.rglob("*.py") if _mentions_wiring(p)]
+    if not candidates:
+        return finding(
+            "P6.4",
+            Status.FAIL,
+            "no wiring-completeness test found (looking for file mentioning loop + wiring)",
+        )
+    for path in candidates:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        hits = sum(1 for marker in _CHECKPOINT_MARKERS if marker in text)
+        if hits >= 4:
+            return finding(
+                "P6.4",
+                Status.PASS,
+                f"{path.name} covers {hits}/5 checkpoints",
+            )
+    names = ", ".join(sorted({p.name for p in candidates})[:3])
+    return finding(
+        "P6.4",
+        Status.WARN,
+        f"wiring test(s) found ({names}) but none cover ≥4 of the 5 checkpoints",
+    )
+
+
+def _mentions_wiring(path: Path) -> bool:
+    name = path.name.lower()
+    if "wiring" in name or "registration" in name:
+        return True
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return "loop_wiring" in text or "wiring_completeness" in text
+
+
+_SWAP_LABEL_RE = re.compile(
+    r"def\s+(swap_pipeline_labels|swap_labels|atomic_label_swap)\b"
+)
+
+
+@register("P6.5")
+def _atomic_label_swap(ctx: CheckContext) -> Finding:
+    if (skip := _na_if_not_orchestration(ctx, "P6.5")) is not None:
+        return skip
+    candidates = [
+        ctx.root / "src" / "pr_manager.py",
+        ctx.root / "src" / "label_manager.py",
+        ctx.root / "src" / "labels.py",
+    ]
+    for path in candidates:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if _SWAP_LABEL_RE.search(text):
+            return finding(
+                "P6.5",
+                Status.PASS,
+                f"atomic swap helper in {path.name}",
+            )
+    return finding(
+        "P6.5",
+        Status.FAIL,
+        "no swap_pipeline_labels / swap_labels / atomic_label_swap function found",
+    )

--- a/scripts/hydraflow_audit/checks/p7_observability.py
+++ b/scripts/hydraflow_audit/checks/p7_observability.py
@@ -184,19 +184,24 @@ def _is_bare_except_pass(handler: ast.ExceptHandler) -> bool:
     return len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
 
 
-_BARE_VALUE_LOGGER_ERROR = re.compile(r"logger\.error\(\s*[A-Za-z_][A-Za-z0-9_]*\s*\)")
-
-
 @register("P7.5")
 def _logger_error_has_format(ctx: CheckContext) -> Finding:
+    """Use AST so matches inside string literals and comments don't count."""
     src = ctx.root / "src"
     if not src.is_dir():
         return finding("P7.5", Status.NA, "no src/ directory")
     offenders: list[str] = []
     for py in src.rglob("*.py"):
-        text = py.read_text(encoding="utf-8", errors="replace")
-        for match in _BARE_VALUE_LOGGER_ERROR.finditer(text):
-            offenders.append(f"{py.relative_to(ctx.root)}: {match.group(0)}")
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_bare_value_logger_error(node):
+                continue
+            offenders.append(f"{py.relative_to(ctx.root)}:{node.lineno}")
             if len(offenders) >= 5:
                 break
         if len(offenders) >= 5:
@@ -208,6 +213,18 @@ def _logger_error_has_format(ctx: CheckContext) -> Finding:
         Status.WARN,
         f"logger.error(value) without format string: {'; '.join(offenders)}",
     )
+
+
+def _is_bare_value_logger_error(node: ast.Call) -> bool:
+    """True for `logger.error(some_variable)` — no format string, no args."""
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "error":
+        return False
+    if not isinstance(func.value, ast.Name) or func.value.id != "logger":
+        return False
+    if len(node.args) != 1 or node.keywords:
+        return False
+    return isinstance(node.args[0], ast.Name)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/hydraflow_audit/checks/p7_observability.py
+++ b/scripts/hydraflow_audit/checks/p7_observability.py
@@ -1,0 +1,250 @@
+"""P7 — Observability and repo wiki (ADR-0044)."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+
+# ---------------------------------------------------------------------------
+# Sentry gatekeeper — P7.1, P7.2.
+# ---------------------------------------------------------------------------
+
+
+_BUG_TYPES_RE = re.compile(r"\b_BUG_TYPES\b")
+
+
+def _find_sentry_module(root: Path) -> Path | None:
+    for candidate in (root / "src" / "server.py", root / "src" / "sentry.py"):
+        if candidate.exists():
+            return candidate
+    src = root / "src"
+    if not src.is_dir():
+        return None
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if "sentry_sdk.init" in text:
+            return py
+    return None
+
+
+@register("P7.1")
+def _bug_types_tuple(ctx: CheckContext) -> Finding:
+    path = _find_sentry_module(ctx.root)
+    if path is None:
+        return finding("P7.1", Status.FAIL, "no Sentry init site found under src/")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if _BUG_TYPES_RE.search(text):
+        return finding("P7.1", Status.PASS, f"_BUG_TYPES in {path.name}")
+    return finding(
+        "P7.1",
+        Status.FAIL,
+        f"{path.name} does not define a _BUG_TYPES gatekeeper tuple",
+    )
+
+
+@register("P7.2")
+def _before_send_uses_filter(ctx: CheckContext) -> Finding:
+    path = _find_sentry_module(ctx.root)
+    if path is None:
+        return finding("P7.2", Status.FAIL, "no Sentry init site found under src/")
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if "before_send" in text and _BUG_TYPES_RE.search(text):
+        return finding("P7.2", Status.PASS)
+    return finding(
+        "P7.2",
+        Status.FAIL,
+        "Sentry init site has no before_send wired to _BUG_TYPES",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repo wiki — P7.3 / P7.3a / P7.3b / P7.3c.
+# ---------------------------------------------------------------------------
+
+
+@register("P7.3")
+def _repo_wiki_dir(ctx: CheckContext) -> Finding:
+    path = ctx.root / "repo_wiki"
+    if not path.is_dir():
+        return finding(
+            "P7.3", Status.FAIL, "repo_wiki/ missing (or project equivalent)"
+        )
+    return finding("P7.3", Status.PASS)
+
+
+@register("P7.3a")
+def _wiki_three_layer_shape(ctx: CheckContext) -> Finding:
+    wiki = ctx.root / "repo_wiki"
+    if not wiki.is_dir():
+        return finding(
+            "P7.3a", Status.NA, "repo_wiki/ missing — upstream check covers this"
+        )
+    has_index = any(wiki.rglob("index.json")) or any(wiki.rglob("_manifest.json"))
+    has_log = any(wiki.rglob("_log.jsonl")) or any(wiki.rglob("_log*.json*"))
+    has_pages = any(p for p in wiki.rglob("*.md") if p.name not in {"README.md"})
+    missing: list[str] = []
+    if not has_pages:
+        missing.append("synthesised wiki pages (*.md)")
+    if not has_index:
+        missing.append("index/manifest (index.json / _manifest.json)")
+    if not has_log:
+        missing.append("raw-sources log (_log.jsonl)")
+    if not missing:
+        return finding("P7.3a", Status.PASS)
+    return finding(
+        "P7.3a",
+        Status.WARN,
+        f"repo_wiki/ missing layers: {', '.join(missing)}",
+    )
+
+
+_WIKI_OPS_RE = re.compile(r"\b(ingest|query|lint)\b")
+
+
+@register("P7.3b")
+def _wiki_store_operations(ctx: CheckContext) -> Finding:
+    store = ctx.root / "src" / "repo_wiki.py"
+    if not store.exists():
+        return finding("P7.3b", Status.FAIL, "src/repo_wiki.py missing")
+    text = store.read_text(encoding="utf-8", errors="replace")
+    hits = {op for op in ("ingest", "query", "lint") if re.search(rf"\b{op}\b", text)}
+    if hits == {"ingest", "query", "lint"}:
+        return finding("P7.3b", Status.PASS)
+    missing = sorted({"ingest", "query", "lint"} - hits)
+    return finding(
+        "P7.3b",
+        Status.FAIL,
+        f"src/repo_wiki.py missing operations: {', '.join(missing)}",
+    )
+
+
+_INJECT_WIKI_RE = re.compile(r"\b(_inject_repo_wiki|inject_repo_wiki|inject_wiki)\b")
+
+
+@register("P7.3c")
+def _runner_injects_wiki(ctx: CheckContext) -> Finding:
+    candidates = [ctx.root / "src" / "base_runner.py", ctx.root / "src" / "runner.py"]
+    for path in candidates:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if _INJECT_WIKI_RE.search(text):
+            return finding("P7.3c", Status.PASS)
+    return finding(
+        "P7.3c",
+        Status.FAIL,
+        "no _inject_repo_wiki call in runner modules — wiki not read during agent runs",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Logging discipline — P7.4 and P7.5.
+# ---------------------------------------------------------------------------
+
+
+@register("P7.4")
+def _no_bare_except(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P7.4", Status.NA, "no src/ directory")
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Try):
+                for handler in node.handlers:
+                    if _is_bare_except_pass(handler):
+                        offenders.append(f"{py.relative_to(ctx.root)}:{handler.lineno}")
+                        if len(offenders) >= 5:
+                            break
+            if len(offenders) >= 5:
+                break
+        if len(offenders) >= 5:
+            break
+    if not offenders:
+        return finding("P7.4", Status.PASS)
+    return finding(
+        "P7.4",
+        Status.WARN,
+        f"bare except blocks found: {'; '.join(offenders)}",
+    )
+
+
+def _is_bare_except_pass(handler: ast.ExceptHandler) -> bool:
+    if handler.type is not None:
+        return False
+    return len(handler.body) == 1 and isinstance(handler.body[0], ast.Pass)
+
+
+_BARE_VALUE_LOGGER_ERROR = re.compile(r"logger\.error\(\s*[A-Za-z_][A-Za-z0-9_]*\s*\)")
+
+
+@register("P7.5")
+def _logger_error_has_format(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P7.5", Status.NA, "no src/ directory")
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        for match in _BARE_VALUE_LOGGER_ERROR.finditer(text):
+            offenders.append(f"{py.relative_to(ctx.root)}: {match.group(0)}")
+            if len(offenders) >= 5:
+                break
+        if len(offenders) >= 5:
+            break
+    if not offenders:
+        return finding("P7.5", Status.PASS)
+    return finding(
+        "P7.5",
+        Status.WARN,
+        f"logger.error(value) without format string: {'; '.join(offenders)}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-instrumentation — P7.6, P7.7.
+# ---------------------------------------------------------------------------
+
+
+@register("P7.6")
+def _audit_self_instrumented(ctx: CheckContext) -> Finding:
+    """The audit/init tooling must follow P7.1/P7.2 on itself."""
+    obs = ctx.root / "scripts" / "hydraflow_audit" / "observability.py"
+    if not obs.exists():
+        return finding(
+            "P7.6",
+            Status.FAIL,
+            "scripts/hydraflow_audit/observability.py missing — tooling not self-instrumented",
+        )
+    text = obs.read_text(encoding="utf-8", errors="replace")
+    if "_BUG_TYPES" in text and "before_send" in text:
+        return finding("P7.6", Status.PASS)
+    return finding(
+        "P7.6",
+        Status.FAIL,
+        "audit observability.py does not wire _BUG_TYPES through before_send",
+    )
+
+
+@register("P7.7")
+def _observability_behind_port(ctx: CheckContext) -> Finding:
+    ports = ctx.root / "src" / "ports.py"
+    if not ports.exists():
+        return finding("P7.7", Status.FAIL, "src/ports.py missing")
+    text = ports.read_text(encoding="utf-8", errors="replace")
+    if re.search(r"class\s+(ObservabilityPort|TracingPort|MetricsPort)\b", text):
+        return finding("P7.7", Status.PASS)
+    return finding(
+        "P7.7",
+        Status.WARN,
+        "no ObservabilityPort/TracingPort/MetricsPort in ports.py — backend swap requires call-site edits",
+    )

--- a/scripts/hydraflow_audit/checks/p7_observability.py
+++ b/scripts/hydraflow_audit/checks/p7_observability.py
@@ -79,21 +79,28 @@ def _repo_wiki_dir(ctx: CheckContext) -> Finding:
 
 @register("P7.3a")
 def _wiki_three_layer_shape(ctx: CheckContext) -> Finding:
+    """Check the three layers exist without prescribing specific filenames.
+
+    Index can be markdown (`index.md`) or JSON (`index.json` / `_manifest.json`).
+    Raw sources can be an explicit `_log.jsonl` *or* per-page front-matter /
+    filename convention that names the originating issue — either gives a
+    traceable audit trail.
+    """
     wiki = ctx.root / "repo_wiki"
     if not wiki.is_dir():
         return finding(
             "P7.3a", Status.NA, "repo_wiki/ missing — upstream check covers this"
         )
-    has_index = any(wiki.rglob("index.json")) or any(wiki.rglob("_manifest.json"))
-    has_log = any(wiki.rglob("_log.jsonl")) or any(wiki.rglob("_log*.json*"))
-    has_pages = any(p for p in wiki.rglob("*.md") if p.name not in {"README.md"})
+    has_index = _has_wiki_index(wiki)
+    has_pages = _has_wiki_pages(wiki)
+    has_raw_trail = _has_wiki_raw_trail(wiki)
     missing: list[str] = []
     if not has_pages:
-        missing.append("synthesised wiki pages (*.md)")
+        missing.append("synthesised wiki pages (per-topic *.md)")
     if not has_index:
-        missing.append("index/manifest (index.json / _manifest.json)")
-    if not has_log:
-        missing.append("raw-sources log (_log.jsonl)")
+        missing.append("index (index.md / index.json / _manifest.json)")
+    if not has_raw_trail:
+        missing.append("traceable raw source (operation log or page front-matter)")
     if not missing:
         return finding("P7.3a", Status.PASS)
     return finding(
@@ -101,6 +108,50 @@ def _wiki_three_layer_shape(ctx: CheckContext) -> Finding:
         Status.WARN,
         f"repo_wiki/ missing layers: {', '.join(missing)}",
     )
+
+
+def _has_wiki_index(wiki: Path) -> bool:
+    for name in ("index.md", "index.json", "_manifest.json"):
+        if any(wiki.rglob(name)):
+            return True
+    return False
+
+
+def _has_wiki_pages(wiki: Path) -> bool:
+    """True when at least one topic subdirectory contains per-entry pages."""
+    for md in wiki.rglob("*.md"):
+        rel = md.relative_to(wiki)
+        parts = rel.parts
+        if parts[-1] in {"README.md", "index.md"}:
+            continue
+        if len(parts) >= 2:  # <owner>/<repo>/<topic>/<page>.md or <topic>/<page>.md
+            return True
+    return False
+
+
+def _has_wiki_raw_trail(wiki: Path) -> bool:
+    """Either an explicit log file, or per-page front-matter naming the source."""
+    if any(wiki.rglob("_log.jsonl")) or any(wiki.rglob("_log*.json*")):
+        return True
+    checked = 0
+    for md in wiki.rglob("*.md"):
+        if md.name in {"README.md", "index.md"}:
+            continue
+        # HydraFlow filename convention: `0001-issue-<number>-<slug>.md`.
+        if re.match(r"^\d{4}-issue-", md.name):
+            return True
+        try:
+            head = md.read_text(encoding="utf-8", errors="replace")[:400]
+        except OSError:
+            continue
+        if re.search(
+            r"^(issue|source|pr|origin)\s*:", head, re.MULTILINE | re.IGNORECASE
+        ):
+            return True
+        checked += 1
+        if checked >= 20:
+            break
+    return False
 
 
 _WIKI_OPS_RE = re.compile(r"\b(ingest|query|lint)\b")

--- a/scripts/hydraflow_audit/checks/p8_superpowers.py
+++ b/scripts/hydraflow_audit/checks/p8_superpowers.py
@@ -1,0 +1,136 @@
+"""P8 — Superpowers / skills integration (ADR-0044)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+
+
+@register("P8.1")
+def _claude_dir_exists(ctx: CheckContext) -> Finding:
+    if (ctx.root / ".claude").is_dir():
+        return finding("P8.1", Status.PASS)
+    return finding("P8.1", Status.FAIL, ".claude/ missing")
+
+
+def _settings_path(root: Path) -> Path | None:
+    for name in ("settings.json", "settings.local.json"):
+        path = root / ".claude" / name
+        if path.exists():
+            return path
+    return None
+
+
+@register("P8.2")
+def _claude_settings(ctx: CheckContext) -> Finding:
+    path = _settings_path(ctx.root)
+    if path is None:
+        return finding(
+            "P8.2",
+            Status.FAIL,
+            ".claude/settings.json or settings.local.json missing",
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return finding("P8.2", Status.FAIL, f"{path.name} is not valid JSON")
+    if not isinstance(data, dict):
+        return finding("P8.2", Status.FAIL, f"{path.name} is not a JSON object")
+    return finding("P8.2", Status.PASS, f"settings at {path.name}")
+
+
+def _hook_kinds_configured(root: Path) -> set[str]:
+    path = _settings_path(root)
+    if path is None:
+        return set()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return set()
+    return {k for k, v in hooks.items() if isinstance(v, list) and v}
+
+
+@register("P8.3")
+def _pre_tool_use_hook(ctx: CheckContext) -> Finding:
+    kinds = _hook_kinds_configured(ctx.root)
+    if "PreToolUse" in kinds:
+        return finding("P8.3", Status.PASS)
+    return finding(
+        "P8.3",
+        Status.FAIL,
+        "no PreToolUse hook configured in .claude/settings.json",
+    )
+
+
+_CORE_SKILLS = (
+    "brainstorming",
+    "test-driven-development",
+    "systematic-debugging",
+    "writing-plans",
+    "verification-before-completion",
+    "requesting-code-review",
+)
+
+
+@register("P8.4")
+def _claude_md_references_skills(ctx: CheckContext) -> Finding:
+    claude = ctx.root / "CLAUDE.md"
+    if not claude.exists():
+        return finding("P8.4", Status.FAIL, "CLAUDE.md missing")
+    text = claude.read_text(encoding="utf-8", errors="replace")
+    missing = [name for name in _CORE_SKILLS if name not in text]
+    if not missing:
+        return finding("P8.4", Status.PASS)
+    return finding(
+        "P8.4",
+        Status.FAIL,
+        f"CLAUDE.md does not name core skills: {', '.join(missing)}",
+    )
+
+
+_REQUIRED_HOOK_KINDS = {"PreToolUse", "PostToolUse", "Stop"}
+
+
+@register("P8.5")
+def _three_hook_kinds(ctx: CheckContext) -> Finding:
+    kinds = _hook_kinds_configured(ctx.root)
+    missing = _REQUIRED_HOOK_KINDS - kinds
+    if not missing:
+        return finding("P8.5", Status.PASS)
+    return finding(
+        "P8.5",
+        Status.FAIL,
+        f"missing hook kind(s): {', '.join(sorted(missing))}",
+    )
+
+
+_TRACE_WRITE_RE = re.compile(
+    r"subprocess.*trace|trace.*subprocess|trace_collector|run-\d+", re.IGNORECASE
+)
+
+
+@register("P8.6")
+def _trace_collector(ctx: CheckContext) -> Finding:
+    candidates = [
+        ctx.root / "src" / "trace_collector.py",
+        ctx.root / "src" / "tracing.py",
+    ]
+    for path in candidates:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if _TRACE_WRITE_RE.search(text):
+            return finding("P8.6", Status.PASS, f"trace writer: {path.name}")
+    return finding(
+        "P8.6",
+        Status.FAIL,
+        "no trace collector module found — session retros have no subprocess traces to mine",
+    )

--- a/scripts/hydraflow_audit/checks/p9_persistence.py
+++ b/scripts/hydraflow_audit/checks/p9_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import re
 from pathlib import Path
 
@@ -152,28 +153,29 @@ def _data_root_in_gitignore(ctx: CheckContext) -> Finding:
     )
 
 
-_WRITE_IN_SRC_RE = re.compile(r"\bopen\s*\(\s*[^,)]+,\s*['\"][wa]")
-
-
 @register("P9.8")
 def _no_writes_in_src(ctx: CheckContext) -> Finding:
+    """Flag only string-literal write paths under src/.
+
+    Variable paths are undecidable statically — they often derive from
+    `data_root` or config. A string literal `open("foo.txt", "w")` is the
+    unambiguous signal of a write outside the store abstractions.
+    """
     src = ctx.root / "src"
     if not src.is_dir():
         return finding("P9.8", Status.NA, "no src/")
     offenders: list[str] = []
     for py in src.rglob("*.py"):
-        text = py.read_text(encoding="utf-8", errors="replace")
-        for match in _WRITE_IN_SRC_RE.finditer(text):
-            # Filter out obvious data_root usage: if data_root / ... is in the
-            # open() call, skip.
-            excerpt = text[max(0, match.start() - 80) : match.end() + 20]
-            if (
-                "data_root" in excerpt
-                or "tmp" in excerpt.lower()
-                or "cache" in excerpt.lower()
-            ):
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8", errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
                 continue
-            offenders.append(f"{py.relative_to(ctx.root)}: {match.group(0).strip()}")
+            if not _is_literal_write_open(node):
+                continue
+            offenders.append(f"{py.relative_to(ctx.root)}:{node.lineno}")
             if len(offenders) >= 5:
                 break
         if len(offenders) >= 5:
@@ -183,5 +185,28 @@ def _no_writes_in_src(ctx: CheckContext) -> Finding:
     return finding(
         "P9.8",
         Status.WARN,
-        f"file opens in src/ may escape data_root: {'; '.join(offenders)}",
+        f"literal-path writes in src/: {'; '.join(offenders)}",
     )
+
+
+def _is_literal_write_open(node: ast.Call) -> bool:
+    """True for `open("literal", "w"|"a")` with a string-literal first arg."""
+    func = node.func
+    if not (isinstance(func, ast.Name) and func.id == "open"):
+        return False
+    if not node.args:
+        return False
+    first = node.args[0]
+    if not (isinstance(first, ast.Constant) and isinstance(first.value, str)):
+        return False
+    mode = ""
+    if len(node.args) > 1 and isinstance(node.args[1], ast.Constant):
+        value = node.args[1].value
+        if isinstance(value, str):
+            mode = value
+    for kw in node.keywords:
+        if kw.arg == "mode" and isinstance(kw.value, ast.Constant):
+            value = kw.value.value
+            if isinstance(value, str):
+                mode = value
+    return any(flag in mode for flag in ("w", "a", "x"))

--- a/scripts/hydraflow_audit/checks/p9_persistence.py
+++ b/scripts/hydraflow_audit/checks/p9_persistence.py
@@ -1,0 +1,187 @@
+"""P9 — Persistence and data layout (ADR-0044 / ADR-0021)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from ..models import CheckContext, Finding, Status
+from ..registry import register
+from ._helpers import finding
+
+_DATA_ROOT_FIELD_RE = re.compile(
+    r"\bdata_root\s*:\s*(?:Path|str)\s*=\s*Field",
+    re.MULTILINE,
+)
+
+
+@register("P9.1")
+def _data_root_field(ctx: CheckContext) -> Finding:
+    config = ctx.root / "src" / "config.py"
+    if not config.exists():
+        return finding("P9.1", Status.FAIL, "src/config.py missing")
+    text = config.read_text(encoding="utf-8", errors="replace")
+    if _DATA_ROOT_FIELD_RE.search(text):
+        return finding("P9.1", Status.PASS)
+    return finding(
+        "P9.1",
+        Status.FAIL,
+        "src/config.py has no `data_root` field with a default",
+    )
+
+
+_ENV_OVERRIDE_RE = re.compile(r"\b[A-Z]+_DATA_ROOT\b|os\.environ\[.*DATA_ROOT")
+
+
+@register("P9.2")
+def _data_root_env_override(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P9.2", Status.FAIL, "src/ missing")
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if _ENV_OVERRIDE_RE.search(text):
+            return finding("P9.2", Status.PASS, f"env override in {py.name}")
+    return finding(
+        "P9.2",
+        Status.FAIL,
+        "no *_DATA_ROOT env var override found in src/",
+    )
+
+
+_REPO_SLUG_SCOPE_RE = re.compile(
+    r"repo_slug|repo-slug|data_root\s*/\s*\w+_slug",
+)
+
+
+@register("P9.3")
+def _repo_slug_scoping(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P9.3", Status.FAIL, "src/ missing")
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if _REPO_SLUG_SCOPE_RE.search(text):
+            return finding("P9.3", Status.PASS)
+    return finding(
+        "P9.3",
+        Status.WARN,
+        "no repo_slug-scoped paths found — multi-repo runs may collide",
+    )
+
+
+_CLASS_NAMES: dict[str, tuple[str, ...]] = {
+    "P9.4": ("StateTracker", "StateManager", "StateStore"),
+    "P9.5": ("DedupStore", "DedupTracker", "IdempotencyStore"),
+}
+
+
+def _find_class(root: Path, names: tuple[str, ...]) -> Path | None:
+    src = root / "src"
+    if not src.is_dir():
+        return None
+    pattern = re.compile(r"^class\s+(" + "|".join(names) + r")\b", re.MULTILINE)
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if pattern.search(text):
+            return py
+    return None
+
+
+@register("P9.4")
+def _state_tracker(ctx: CheckContext) -> Finding:
+    hit = _find_class(ctx.root, _CLASS_NAMES["P9.4"])
+    if hit:
+        return finding("P9.4", Status.PASS, f"state abstraction in {hit.name}")
+    return finding(
+        "P9.4",
+        Status.FAIL,
+        "no StateTracker/StateManager/StateStore class in src/ — state writes scatter",
+    )
+
+
+@register("P9.5")
+def _dedup_store(ctx: CheckContext) -> Finding:
+    hit = _find_class(ctx.root, _CLASS_NAMES["P9.5"])
+    if hit:
+        return finding("P9.5", Status.PASS, f"dedup abstraction in {hit.name}")
+    return finding(
+        "P9.5",
+        Status.FAIL,
+        "no DedupStore/IdempotencyStore class in src/ — restart-safe idempotency missing",
+    )
+
+
+_ATOMIC_WRITE_RE = re.compile(
+    r"\bos\.replace\b|\batomic_write\b|\bNamedTemporaryFile\b"
+)
+
+
+@register("P9.6")
+def _atomic_writes(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P9.6", Status.FAIL, "src/ missing")
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        if _ATOMIC_WRITE_RE.search(text):
+            return finding("P9.6", Status.PASS, f"atomic write in {py.name}")
+    return finding(
+        "P9.6",
+        Status.FAIL,
+        "no atomic write pattern (os.replace / atomic_write / NamedTemporaryFile) in src/",
+    )
+
+
+_DATA_ROOT_NAMES = (".hydraflow", ".data", "data", ".state")
+
+
+@register("P9.7")
+def _data_root_in_gitignore(ctx: CheckContext) -> Finding:
+    gi = ctx.root / ".gitignore"
+    if not gi.exists():
+        return finding("P9.7", Status.FAIL, ".gitignore missing")
+    text = gi.read_text(encoding="utf-8", errors="replace")
+    for name in _DATA_ROOT_NAMES:
+        if re.search(rf"^{re.escape(name)}/?\s*$", text, re.MULTILINE):
+            return finding("P9.7", Status.PASS, f"`{name}/` in .gitignore")
+    return finding(
+        "P9.7",
+        Status.WARN,
+        f"no common data-root directory in .gitignore ({', '.join(_DATA_ROOT_NAMES)})",
+    )
+
+
+_WRITE_IN_SRC_RE = re.compile(r"\bopen\s*\(\s*[^,)]+,\s*['\"][wa]")
+
+
+@register("P9.8")
+def _no_writes_in_src(ctx: CheckContext) -> Finding:
+    src = ctx.root / "src"
+    if not src.is_dir():
+        return finding("P9.8", Status.NA, "no src/")
+    offenders: list[str] = []
+    for py in src.rglob("*.py"):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        for match in _WRITE_IN_SRC_RE.finditer(text):
+            # Filter out obvious data_root usage: if data_root / ... is in the
+            # open() call, skip.
+            excerpt = text[max(0, match.start() - 80) : match.end() + 20]
+            if (
+                "data_root" in excerpt
+                or "tmp" in excerpt.lower()
+                or "cache" in excerpt.lower()
+            ):
+                continue
+            offenders.append(f"{py.relative_to(ctx.root)}: {match.group(0).strip()}")
+            if len(offenders) >= 5:
+                break
+        if len(offenders) >= 5:
+            break
+    if not offenders:
+        return finding("P9.8", Status.PASS)
+    return finding(
+        "P9.8",
+        Status.WARN,
+        f"file opens in src/ may escape data_root: {'; '.join(offenders)}",
+    )

--- a/scripts/hydraflow_audit/context.py
+++ b/scripts/hydraflow_audit/context.py
@@ -1,0 +1,33 @@
+"""Detect the shape of the target repo so conditional checks return NA cleanly.
+
+A non-orchestration repo does not have `src/orchestrator.py`; P6 and related
+orchestration-only checks mark themselves NA when run against it. A repo
+without a UI directory skips browser E2E checks. Detection is intentionally
+simple — the audit is about conformance, not cleverness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .models import CheckContext
+
+
+def build(root: Path) -> CheckContext:
+    return CheckContext(
+        root=root,
+        is_orchestration_repo=_detect_orchestration(root),
+        has_ui=_detect_ui(root),
+    )
+
+
+def _detect_orchestration(root: Path) -> bool:
+    candidates = [
+        root / "src" / "orchestrator.py",
+        root / "src" / "base_background_loop.py",
+    ]
+    return any(p.exists() for p in candidates)
+
+
+def _detect_ui(root: Path) -> bool:
+    return (root / "ui").is_dir() or (root / "src" / "ui").is_dir()

--- a/scripts/hydraflow_audit/models.py
+++ b/scripts/hydraflow_audit/models.py
@@ -8,17 +8,17 @@ execution environment handed to each check function.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 
-class Severity(str, Enum):
+class Severity(StrEnum):
     STRUCTURAL = "STRUCTURAL"
     BEHAVIORAL = "BEHAVIORAL"
     CULTURAL = "CULTURAL"
 
 
-class Status(str, Enum):
+class Status(StrEnum):
     PASS = "PASS"
     WARN = "WARN"
     FAIL = "FAIL"

--- a/scripts/hydraflow_audit/models.py
+++ b/scripts/hydraflow_audit/models.py
@@ -1,0 +1,77 @@
+"""Core types for the audit pipeline.
+
+Kept deliberately small: `CheckSpec` is the declarative row parsed from the
+ADR; `Finding` is the result of running one check; `CheckContext` is the
+execution environment handed to each check function.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+
+
+class Severity(str, Enum):
+    STRUCTURAL = "STRUCTURAL"
+    BEHAVIORAL = "BEHAVIORAL"
+    CULTURAL = "CULTURAL"
+
+
+class Status(str, Enum):
+    PASS = "PASS"
+    WARN = "WARN"
+    FAIL = "FAIL"
+    NA = "NA"
+    NOT_IMPLEMENTED = "NOT_IMPLEMENTED"
+
+
+@dataclass(frozen=True)
+class CheckSpec:
+    """A single row from an ADR-0044 check table."""
+
+    check_id: str
+    severity: Severity
+    source: str
+    what: str
+    remediation: str
+    principle: str  # e.g. "P1"
+
+
+@dataclass
+class Finding:
+    """The result of running one check."""
+
+    check_id: str
+    status: Status
+    severity: Severity
+    principle: str
+    source: str
+    what: str
+    remediation: str
+    message: str = ""
+
+    def to_dict(self) -> dict:
+        return {
+            "check_id": self.check_id,
+            "status": self.status.value,
+            "severity": self.severity.value,
+            "principle": self.principle,
+            "source": self.source,
+            "what": self.what,
+            "remediation": self.remediation,
+            "message": self.message,
+        }
+
+
+@dataclass
+class CheckContext:
+    """Execution context passed to every check function.
+
+    Checks read from `root` (the target repo). They do not mutate anything.
+    """
+
+    root: Path
+    is_orchestration_repo: bool = False
+    has_ui: bool = False
+    extras: dict = field(default_factory=dict)

--- a/scripts/hydraflow_audit/observability.py
+++ b/scripts/hydraflow_audit/observability.py
@@ -1,0 +1,71 @@
+"""Self-instrumentation for the audit tool (ADR-0044, P7.6 / P7.7).
+
+The audit follows the principles it enforces: unhandled exceptions route
+through a Sentry filter that drops transient errors and forwards real bugs.
+If `sentry_sdk` is not installed, every function here is a no-op so the
+tool stays runnable in minimal environments.
+
+Future backends (OTLP, structured logs, a sidecar) plug in behind the same
+`report_unhandled` entry point; they do not require a change at the call site.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+
+_BUG_TYPES: tuple[type[BaseException], ...] = (
+    TypeError,
+    KeyError,
+    AttributeError,
+    ValueError,
+    IndexError,
+    NotImplementedError,
+)
+
+log = logging.getLogger("hydraflow_audit")
+
+
+def init() -> None:
+    """Initialise Sentry if available and a DSN is configured."""
+    dsn = os.environ.get("HYDRAFLOW_AUDIT_SENTRY_DSN") or os.environ.get("SENTRY_DSN")
+    if not dsn:
+        return
+    try:
+        import sentry_sdk  # type: ignore[import-not-found]
+    except ImportError:
+        return
+
+    def _before_send(event, hint):  # pragma: no cover — exercised only with a real DSN
+        exc_info = hint.get("exc_info")
+        if exc_info and not issubclass(exc_info[0], _BUG_TYPES):
+            return None
+        return event
+
+    sentry_sdk.init(dsn=dsn, before_send=_before_send, traces_sample_rate=0.0)
+
+
+def report_unhandled(exc: BaseException) -> None:
+    """Forward real bugs to Sentry; log transient failures at warning."""
+    if isinstance(exc, _BUG_TYPES):
+        try:
+            import sentry_sdk  # type: ignore[import-not-found]
+
+            sentry_sdk.capture_exception(exc)
+        except ImportError:
+            log.exception("unhandled bug in audit tool (sentry unavailable)")
+        else:
+            log.exception("unhandled bug in audit tool")
+    else:
+        log.warning("transient failure in audit tool: %s", exc)
+
+
+@contextmanager
+def guard():
+    """Wrap the CLI entry point so unhandled exceptions flow through the filter."""
+    try:
+        yield
+    except Exception as exc:  # noqa: BLE001 — the point is to see everything
+        report_unhandled(exc)
+        raise

--- a/scripts/hydraflow_audit/parser.py
+++ b/scripts/hydraflow_audit/parser.py
@@ -1,0 +1,93 @@
+"""Parse ADR-0044 check tables into `CheckSpec` rows.
+
+The ADR is the source of truth. The parser walks its markdown, finds each
+principle heading (`### P<n>. ...`), and extracts the five-column check
+table that follows. A table row without the expected columns is skipped
+silently — tables are authored by humans and drift has to fail open at the
+parse layer (the audit later reports missing check_ids as FAIL, which is
+the right place for that error).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .models import CheckSpec, Severity
+
+_PRINCIPLE_HEADING = re.compile(r"^###\s+(P\d+)\.\s+")
+_TABLE_HEADER = re.compile(
+    r"^\|\s*check_id\s*\|\s*type\s*\|\s*source\s*\|\s*what\s*\|\s*remediation\s*\|",
+    re.IGNORECASE,
+)
+
+
+def parse_adr(path: Path) -> list[CheckSpec]:
+    """Return all check specs in document order."""
+    text = path.read_text(encoding="utf-8")
+    return _parse_text(text)
+
+
+def _parse_text(text: str) -> list[CheckSpec]:
+    specs: list[CheckSpec] = []
+    current_principle: str | None = None
+    in_table = False
+
+    for line in text.splitlines():
+        heading = _PRINCIPLE_HEADING.match(line)
+        if heading:
+            current_principle = heading.group(1)
+            in_table = False
+            continue
+
+        if _TABLE_HEADER.match(line):
+            in_table = True
+            continue
+
+        if in_table:
+            if not line.strip().startswith("|"):
+                in_table = False
+                continue
+            if _is_alignment_row(line):
+                continue
+            spec = _parse_row(line, current_principle)
+            if spec is not None:
+                specs.append(spec)
+
+    return specs
+
+
+def _is_alignment_row(line: str) -> bool:
+    cells = _cells(line)
+    return bool(cells) and all(set(c.strip()) <= {"-", ":"} for c in cells)
+
+
+def _cells(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return []
+    inner = stripped.strip("|")
+    return [c.strip() for c in inner.split("|")]
+
+
+def _parse_row(line: str, principle: str | None) -> CheckSpec | None:
+    if principle is None:
+        return None
+    cells = _cells(line)
+    if len(cells) != 5:
+        return None
+    check_id, severity_raw, source, what, remediation = cells
+    if not check_id or not severity_raw:
+        return None
+    try:
+        severity = Severity(severity_raw.upper())
+    except ValueError:
+        return None
+    return CheckSpec(
+        check_id=check_id,
+        severity=severity,
+        source=source,
+        what=what,
+        remediation=remediation,
+        principle=principle,
+    )

--- a/scripts/hydraflow_audit/registry.py
+++ b/scripts/hydraflow_audit/registry.py
@@ -1,0 +1,39 @@
+"""Check function registry.
+
+Check functions register themselves via `@register("P1.1")`. The runner
+looks up each spec's check_id against this registry; a missing entry yields
+a `NOT_IMPLEMENTED` finding so the ADR and the code stay in lockstep.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .models import CheckContext, Finding
+
+CheckFn = Callable[[CheckContext], Finding]
+
+_REGISTRY: dict[str, CheckFn] = {}
+
+
+def register(check_id: str) -> Callable[[CheckFn], CheckFn]:
+    def decorator(fn: CheckFn) -> CheckFn:
+        if check_id in _REGISTRY:
+            raise ValueError(f"duplicate check registration: {check_id}")
+        _REGISTRY[check_id] = fn
+        return fn
+
+    return decorator
+
+
+def get(check_id: str) -> CheckFn | None:
+    return _REGISTRY.get(check_id)
+
+
+def all_registered() -> dict[str, CheckFn]:
+    return dict(_REGISTRY)
+
+
+def _clear_for_tests() -> None:
+    """Only for unit tests — never call in production code."""
+    _REGISTRY.clear()

--- a/scripts/hydraflow_audit/report.py
+++ b/scripts/hydraflow_audit/report.py
@@ -1,0 +1,82 @@
+"""Write the audit report as JSON and print a terminal summary."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+from .models import Finding, Status
+
+_STATUS_GLYPH = {
+    Status.PASS: "✓",
+    Status.WARN: "!",
+    Status.FAIL: "✗",
+    Status.NA: "-",
+    Status.NOT_IMPLEMENTED: "?",
+}
+
+
+def write_json(findings: list[Finding], out_path: Path) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "summary": _summarise(findings),
+        "findings": [f.to_dict() for f in findings],
+    }
+    out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def format_terminal(findings: list[Finding]) -> str:
+    lines: list[str] = ["HydraFlow Conformance Audit (ADR-0044)", "=" * 40, ""]
+    by_principle: dict[str, list[Finding]] = {}
+    for f in findings:
+        by_principle.setdefault(f.principle, []).append(f)
+
+    for principle in sorted(by_principle, key=_principle_sort_key):
+        bucket = by_principle[principle]
+        counts = Counter(f.status for f in bucket)
+        headline = (
+            f"{principle}  "
+            f"PASS {counts[Status.PASS]} / "
+            f"WARN {counts[Status.WARN]} / "
+            f"FAIL {counts[Status.FAIL]} / "
+            f"NA {counts[Status.NA]} / "
+            f"?? {counts[Status.NOT_IMPLEMENTED]}"
+        )
+        lines.append(headline)
+        for f in bucket:
+            if f.status is Status.PASS:
+                continue
+            glyph = _STATUS_GLYPH[f.status]
+            lines.append(f"  {glyph} {f.check_id}  {f.what}")
+            if f.message:
+                lines.append(f"      {f.message}")
+            lines.append(f"      source: {f.source}  —  fix: {f.remediation}")
+        lines.append("")
+
+    summary = _summarise(findings)
+    lines.append(
+        f"Total: PASS {summary['pass']}  WARN {summary['warn']}  FAIL {summary['fail']}  "
+        f"NA {summary['na']}  NOT_IMPLEMENTED {summary['not_implemented']}"
+    )
+    return "\n".join(lines)
+
+
+def _summarise(findings: list[Finding]) -> dict[str, int]:
+    counts = Counter(f.status for f in findings)
+    return {
+        "pass": counts[Status.PASS],
+        "warn": counts[Status.WARN],
+        "fail": counts[Status.FAIL],
+        "na": counts[Status.NA],
+        "not_implemented": counts[Status.NOT_IMPLEMENTED],
+        "total": len(findings),
+    }
+
+
+def _principle_sort_key(principle: str) -> tuple[int, str]:
+    try:
+        return (int(principle.lstrip("P")), principle)
+    except ValueError:
+        return (9999, principle)

--- a/scripts/hydraflow_audit/runner.py
+++ b/scripts/hydraflow_audit/runner.py
@@ -1,0 +1,57 @@
+"""Dispatch check specs to registered check functions and collect findings."""
+
+from __future__ import annotations
+
+from . import registry
+from .models import CheckContext, CheckSpec, Finding, Status
+
+
+def run_checks(specs: list[CheckSpec], ctx: CheckContext) -> list[Finding]:
+    findings: list[Finding] = []
+    for spec in specs:
+        findings.append(_run_one(spec, ctx))
+    return findings
+
+
+def _run_one(spec: CheckSpec, ctx: CheckContext) -> Finding:
+    fn = registry.get(spec.check_id)
+    if fn is None:
+        return Finding(
+            check_id=spec.check_id,
+            status=Status.NOT_IMPLEMENTED,
+            severity=spec.severity,
+            principle=spec.principle,
+            source=spec.source,
+            what=spec.what,
+            remediation=spec.remediation,
+            message=(
+                f"check {spec.check_id} has an ADR row but no implementation — "
+                "the ADR and the audit have drifted"
+            ),
+        )
+    try:
+        result = fn(ctx)
+    except Exception as exc:  # noqa: BLE001 — surface check crashes as findings
+        return Finding(
+            check_id=spec.check_id,
+            status=Status.FAIL,
+            severity=spec.severity,
+            principle=spec.principle,
+            source=spec.source,
+            what=spec.what,
+            remediation=spec.remediation,
+            message=f"check raised {type(exc).__name__}: {exc}",
+        )
+    # Backfill metadata from the spec so check functions only set status + message.
+    result.severity = result.severity or spec.severity
+    result.principle = result.principle or spec.principle
+    result.source = result.source or spec.source
+    result.what = result.what or spec.what
+    result.remediation = result.remediation or spec.remediation
+    return result
+
+
+def overall_exit_code(findings: list[Finding]) -> int:
+    """0 if every finding is PASS or NA; 1 otherwise."""
+    bad = {Status.FAIL, Status.WARN, Status.NOT_IMPLEMENTED}
+    return 1 if any(f.status in bad for f in findings) else 0

--- a/scripts/hydraflow_init/__init__.py
+++ b/scripts/hydraflow_init/__init__.py
@@ -1,0 +1,8 @@
+"""Emit a superpowers-chained remediation prompt from an audit report.
+
+`make init` consumes `.hydraflow/audit-report.json` and templates a plan that
+a human can paste into a Claude Code session. Greenfield mode (most checks
+FAIL) opens with brainstorming; incremental adoption skips brainstorming and
+dives into writing-plans. Either way the plan ends with a verification step
+that re-runs `make audit`.
+"""

--- a/scripts/hydraflow_init/__main__.py
+++ b/scripts/hydraflow_init/__main__.py
@@ -1,0 +1,81 @@
+"""CLI for `python -m scripts.hydraflow_init`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.hydraflow_audit import observability  # self-instrumentation per P7.6
+
+from .modes import decide
+from .prompt import render
+
+
+def _audit_report_path(target: Path, override: Path | None) -> Path:
+    if override is not None:
+        return override
+    return target / ".hydraflow" / "audit-report.json"
+
+
+def _ensure_report(target: Path, report_path: Path) -> None:
+    """Run `make audit` (via module invocation) if the report is missing."""
+    if report_path.exists():
+        return
+    subprocess.run(
+        [sys.executable, "-m", "scripts.hydraflow_audit", str(target), "--json"],
+        check=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="hydraflow_init",
+        description="Emit a superpowers-chained adoption plan from an audit report.",
+    )
+    parser.add_argument("target", nargs="?", default=".")
+    parser.add_argument("--report", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument(
+        "--principle", default=None, help="Scope to a single principle (e.g. P3)"
+    )
+    parser.add_argument(
+        "--skip-brainstorm",
+        action="store_true",
+        help="Skip the brainstorming step even in greenfield mode",
+    )
+    args = parser.parse_args(argv)
+
+    observability.init()
+
+    with observability.guard():
+        target_root = Path(args.target).resolve()
+        report_path = _audit_report_path(target_root, args.report)
+        _ensure_report(target_root, report_path)
+        data = json.loads(report_path.read_text(encoding="utf-8"))
+        findings = data.get("findings", [])
+        summary = data.get("summary", {})
+        mode = decide(findings)
+        output = render(
+            target=str(target_root),
+            findings=findings,
+            summary=summary,
+            mode=mode,
+            principle_filter=args.principle,
+            skip_brainstorm=args.skip_brainstorm,
+        )
+
+        if args.out is not None:
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(output, encoding="utf-8")
+            print(f"Adoption plan written to {args.out}")
+        else:
+            sys.stdout.write(output)
+
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hydraflow_init/modes.py
+++ b/scripts/hydraflow_init/modes.py
@@ -1,0 +1,41 @@
+"""Decide whether a repo is greenfield or adopting incrementally.
+
+Greenfield: a project with no HydraFlow scaffolding at all. Most P1 (docs),
+P3 (testing), P4 (quality), P5 (CI) checks will FAIL. The prompt starts
+with `superpowers:brainstorming` because the team has not yet decided what
+shape this project should take — jumping straight to a plan would bake in
+defaults that the user never chose.
+
+Incremental: a project with the skeleton in place but individual checks
+failing. Brainstorming would waste the user's time; go straight to
+`superpowers:writing-plans` for the failing principles.
+
+The threshold (70% FAIL in structural checks) is deliberately strict. A
+repo at 40% FAIL still has enough bones to reason about; a repo at 80%
+FAIL has almost nothing to anchor a plan against.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class Mode(str, Enum):
+    GREENFIELD = "greenfield"
+    INCREMENTAL = "incremental"
+
+
+_GREENFIELD_STRUCTURAL_FAIL_RATIO = 0.7
+
+
+def decide(findings: list[dict]) -> Mode:
+    structural = [f for f in findings if f.get("severity") == "STRUCTURAL"]
+    if not structural:
+        return Mode.INCREMENTAL
+    fails = [f for f in structural if f.get("status") == "FAIL"]
+    ratio = len(fails) / len(structural)
+    return (
+        Mode.GREENFIELD
+        if ratio >= _GREENFIELD_STRUCTURAL_FAIL_RATIO
+        else Mode.INCREMENTAL
+    )

--- a/scripts/hydraflow_init/modes.py
+++ b/scripts/hydraflow_init/modes.py
@@ -17,10 +17,10 @@ FAIL has almost nothing to anchor a plan against.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 
 
-class Mode(str, Enum):
+class Mode(StrEnum):
     GREENFIELD = "greenfield"
     INCREMENTAL = "incremental"
 

--- a/scripts/hydraflow_init/prompt.py
+++ b/scripts/hydraflow_init/prompt.py
@@ -1,0 +1,152 @@
+"""Template the remediation prompt.
+
+Output is plain markdown (no ANSI, no shell-specific escapes) so it can be
+piped to a file or pasted into a Claude session.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+from .modes import Mode
+
+_BAD_STATUSES = {"FAIL", "WARN", "NOT_IMPLEMENTED"}
+
+
+def render(
+    *,
+    target: str,
+    findings: list[dict],
+    summary: dict,
+    mode: Mode,
+    principle_filter: str | None,
+    skip_brainstorm: bool,
+) -> str:
+    actionable = [f for f in findings if f.get("status") in _BAD_STATUSES]
+    if principle_filter:
+        actionable = [f for f in actionable if f.get("principle") == principle_filter]
+
+    lines: list[str] = []
+    lines.extend(_header(target, summary, mode, principle_filter))
+    lines.extend(_instructions(mode, skip_brainstorm))
+    lines.extend(_remediations(actionable))
+    lines.extend(_closing())
+    return "\n".join(lines) + "\n"
+
+
+def _header(
+    target: str, summary: dict, mode: Mode, principle_filter: str | None
+) -> list[str]:
+    scope = f" (principle {principle_filter})" if principle_filter else ""
+    return [
+        f"# HydraFlow adoption plan — {target}{scope}",
+        "",
+        "Paste this into a Claude Code session.",
+        "",
+        "## Current state (ADR-0044)",
+        "",
+        f"- Target: `{target}`",
+        f"- Mode: **{mode.value}**",
+        f"- PASS: {summary.get('pass', 0)}",
+        f"- WARN: {summary.get('warn', 0)}",
+        f"- FAIL: {summary.get('fail', 0)}",
+        f"- NOT_IMPLEMENTED: {summary.get('not_implemented', 0)}",
+        f"- Total checks: {summary.get('total', 0)}",
+        "",
+        "> Every remediation cites the ADR or `docs/agents/` source. Read the",
+        "> citation before editing — the paraphrase below is a pointer, not the spec.",
+        "",
+    ]
+
+
+def _instructions(mode: Mode, skip_brainstorm: bool) -> list[str]:
+    lines = ["## Workflow", ""]
+    if mode is Mode.GREENFIELD and not skip_brainstorm:
+        lines += [
+            "1. Invoke `superpowers:brainstorming` to confirm the project shape",
+            "   before writing any plan. What does this project need from the",
+            "   HydraFlow principles? Which are load-bearing, which are N/A?",
+            "2. Invoke `superpowers:writing-plans` to decompose the remediations",
+            "   below into ordered, testable tasks.",
+            "3. For each implementation step, follow `superpowers:test-driven-development`",
+            "   (red → green → refactor) before committing.",
+            "4. Before declaring the plan complete, invoke",
+            "   `superpowers:verification-before-completion` — the exit bar is",
+            "   `make audit` returning 0.",
+        ]
+    else:
+        lines += [
+            "1. Invoke `superpowers:writing-plans` and decompose only the failing",
+            "   principles below — do not revisit passing ones.",
+            "2. For each fix, write the failing test first",
+            "   (`superpowers:test-driven-development`) so the remediation has an",
+            "   objective success criterion.",
+            "3. After implementation, invoke",
+            "   `superpowers:verification-before-completion` and re-run",
+            "   `make audit`. Target: the previously failing checks now PASS and",
+            "   no previously passing checks regress.",
+        ]
+    lines.append("")
+    return lines
+
+
+def _remediations(actionable: list[dict]) -> list[str]:
+    if not actionable:
+        return ["## Remediations", "", "No actionable findings — audit is green.", ""]
+
+    lines = ["## Remediations by principle", ""]
+    by_principle: dict[str, list[dict]] = {}
+    for f in actionable:
+        by_principle.setdefault(f.get("principle", "?"), []).append(f)
+
+    for principle in sorted(by_principle, key=_principle_sort_key):
+        bucket = by_principle[principle]
+        counts = Counter(f.get("status") for f in bucket)
+        headline = ", ".join(
+            f"{status} {count}" for status, count in counts.most_common()
+        )
+        lines.append(f"### {principle} — {headline}")
+        lines.append("")
+        for finding in bucket:
+            lines.extend(_format_finding(finding))
+        lines.append("")
+    return lines
+
+
+def _format_finding(f: dict) -> list[str]:
+    check_id = f.get("check_id", "?")
+    status = f.get("status", "?")
+    what = f.get("what", "")
+    message = f.get("message", "")
+    source = f.get("source", "")
+    remediation = f.get("remediation", "")
+    severity = f.get("severity", "")
+
+    lines = [
+        f"- **{check_id} ({status}, {severity})** — {what}",
+    ]
+    if message:
+        lines.append(f"  - Detail: {message}")
+    lines.append(f"  - Source: {source}")
+    lines.append(f"  - Fix: {remediation}")
+    return lines
+
+
+def _closing() -> list[str]:
+    return [
+        "## Exit criterion",
+        "",
+        "Run `make audit` in the target directory. The command must exit 0",
+        "and the previously failing/warn/not-implemented checks must all be",
+        "PASS (or NA, when a principle is legitimately not applicable to this",
+        "project shape). A remaining CULTURAL WARN on branch protection or",
+        "direct-push heuristics is acceptable; document the confirmation.",
+        "",
+    ]
+
+
+def _principle_sort_key(principle: str) -> tuple[int, str]:
+    try:
+        return (int(principle.lstrip("P")), principle)
+    except ValueError:
+        return (9999, principle)

--- a/src/config.py
+++ b/src/config.py
@@ -2009,9 +2009,14 @@ def _resolve_base_paths(config: HydraFlowConfig) -> None:
         object.__setattr__(
             config, "workspace_base", config.workspace_base.expanduser().resolve()
         )
-    env_home = os.environ.get("HYDRAFLOW_HOME", "").strip()
-    if env_home:
-        data_root = Path(env_home).expanduser().resolve()
+    # HYDRAFLOW_DATA_ROOT is the canonical override; HYDRAFLOW_HOME is kept
+    # as a legacy alias so existing deployments continue to work.
+    env_data_root = (
+        os.environ.get("HYDRAFLOW_DATA_ROOT", "").strip()
+        or os.environ.get("HYDRAFLOW_HOME", "").strip()
+    )
+    if env_data_root:
+        data_root = Path(env_data_root).expanduser().resolve()
     elif config.data_root == Path("."):
         data_root = (config.repo_root / ".hydraflow").resolve()
     else:

--- a/src/ports.py
+++ b/src/ports.py
@@ -577,3 +577,20 @@ class ReviewInsightStorePort(Protocol):
     def load_proposal_metadata(self) -> dict[str, ProposalMetadata]: ...
 
     def update_proposal_verified(self, category: str, *, verified: bool) -> None: ...
+
+
+@runtime_checkable
+class ObservabilityPort(Protocol):
+    """Observability boundary (ADR-0044 P7.7).
+
+    The concrete adapter today is Sentry-backed (see ``src/server.py``); the
+    port exists so a future OTLP, structured-log, or sidecar adapter can slot
+    in without editing call sites. Keep the surface minimal — rich APIs drag
+    every backend into the union.
+    """
+
+    def capture_exception(self, exc: BaseException) -> None: ...
+
+    def breadcrumb(self, category: str, message: str, **data: object) -> None: ...
+
+    def flush(self, timeout_ms: int = 2000) -> bool: ...

--- a/tests/test_hydraflow_audit_p10_checks.py
+++ b/tests/test_hydraflow_audit_p10_checks.py
@@ -1,0 +1,157 @@
+"""Tests for P10 (TDD discipline) check functions."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p10_tdd  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- P10.1 ----------------------------------------------------------------
+
+
+def test_claude_md_tdd_reference_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "CLAUDE.md",
+        "Use test-first discipline via the superpowers:test-driven-development skill.\n",
+    )
+    assert _run("P10.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_claude_md_without_tdd_warns(tmp_path: Path) -> None:
+    _write(tmp_path / "CLAUDE.md", "Nothing about testing.\n")
+    assert _run("P10.1", _ctx(tmp_path)).status is Status.WARN
+
+
+# --- P10.2 ----------------------------------------------------------------
+
+
+def test_every_module_has_test_passes(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "foo.py", "def f(): pass\n")
+    _write(tmp_path / "tests" / "test_foo.py", "def test_f(): pass\n")
+    assert _run("P10.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_orphan_modules_warn(tmp_path: Path) -> None:
+    for i in range(10):
+        _write(tmp_path / "src" / f"m{i}.py", "def f(): pass\n")
+    # Only one test file for ten modules → 90% orphan → WARN.
+    _write(tmp_path / "tests" / "test_m0.py", "def test_f(): pass\n")
+    assert _run("P10.2", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_na_without_src(tmp_path: Path) -> None:
+    assert _run("P10.2", _ctx(tmp_path)).status is Status.NA
+
+
+# --- P10.3 (git log) ------------------------------------------------------
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+
+def _git_init(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+
+
+def _git_commit(tmp_path: Path, subject: str, files: dict[str, str]) -> None:
+    for rel, content in files.items():
+        _write(tmp_path / rel, content)
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, env=_git_env())
+    subprocess.run(
+        ["git", "commit", "-q", "-m", subject],
+        cwd=tmp_path,
+        check=True,
+        env=_git_env(),
+    )
+
+
+def test_fix_with_regression_test_passes(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    _git_commit(
+        tmp_path,
+        "fix: handle null input",
+        {
+            "src/a.py": "def f(): return 1\n",
+            "tests/regressions/test_null_input.py": "def test_x(): pass\n",
+        },
+    )
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_fix_without_regression_test_warns(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "feat: seed", {"README.md": "x\n"})
+    _git_commit(tmp_path, "fix: typo", {"src/a.py": "def f(): return 1\n"})
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_no_fix_commits_passes(tmp_path: Path) -> None:
+    _git_init(tmp_path)
+    _git_commit(tmp_path, "feat: initial", {"README.md": "x\n"})
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_na_outside_git(tmp_path: Path) -> None:
+    assert _run("P10.3", _ctx(tmp_path)).status is Status.NA
+
+
+# --- P10.4 ----------------------------------------------------------------
+
+
+def test_behavioural_test_names_pass(tmp_path: Path) -> None:
+    body = "\n".join(f"def test_handles_case_{i}_when_x(): pass" for i in range(20))
+    _write(tmp_path / "tests" / "test_behaviour.py", body)
+    assert _run("P10.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_implementation_named_tests_warn(tmp_path: Path) -> None:
+    # Single-word test names (no `_when_` etc.) are the implementation-named shape.
+    body = "\n".join(f"def test_handler{i}(): pass" for i in range(20))
+    _write(tmp_path / "tests" / "test_impl.py", body)
+    assert _run("P10.4", _ctx(tmp_path)).status is Status.WARN
+
+
+# --- P10.5 ----------------------------------------------------------------
+
+
+def test_tests_mostly_single_assert_pass(tmp_path: Path) -> None:
+    body = "\n".join(f"def test_x{i}():\n    assert True" for i in range(20))
+    _write(tmp_path / "tests" / "test_a.py", body)
+    assert _run("P10.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_many_multi_assert_tests_warn(tmp_path: Path) -> None:
+    body = "\n".join(
+        f"def test_x{i}():\n    assert True\n    assert True\n    assert True\n    assert True"
+        for i in range(20)
+    )
+    _write(tmp_path / "tests" / "test_a.py", body)
+    assert _run("P10.5", _ctx(tmp_path)).status is Status.WARN

--- a/tests/test_hydraflow_audit_p1_checks.py
+++ b/tests/test_hydraflow_audit_p1_checks.py
@@ -1,0 +1,167 @@
+"""Tests for P1 (Documentation Contract) check functions.
+
+Each test builds a minimal fake repo under `tmp_path`, runs one check, and
+asserts the status. Uses the real registered check functions — no mocks —
+to match the principle in P3.14 (stateful inspection beats call-count).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit import registry  # noqa: F401 — import side effect
+from scripts.hydraflow_audit.checks import p1_docs  # noqa: F401 — registers checks
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path, *, orchestration: bool = False) -> CheckContext:
+    return CheckContext(root=root, is_orchestration_repo=orchestration)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None, f"check {check_id} is not registered"
+    return fn(ctx)
+
+
+@pytest.mark.parametrize(
+    ("check_id", "relpath"),
+    [
+        ("P1.1", "CLAUDE.md"),
+        ("P1.2", "docs/agents/README.md"),
+        ("P1.3", "docs/agents/architecture.md"),
+        ("P1.4", "docs/agents/worktrees.md"),
+        ("P1.5", "docs/agents/testing.md"),
+        ("P1.6", "docs/agents/avoided-patterns.md"),
+        ("P1.7", "docs/agents/quality-gates.md"),
+        ("P1.9", "docs/agents/sentry.md"),
+        ("P1.10", "docs/agents/commands.md"),
+    ],
+)
+def test_simple_file_exists_check_passes_when_file_present(
+    check_id: str, relpath: str, tmp_path: Path
+) -> None:
+    (tmp_path / relpath).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / relpath).write_text("content", encoding="utf-8")
+    result = _run(check_id, _ctx(tmp_path))
+    assert result.status is Status.PASS
+
+
+@pytest.mark.parametrize(
+    "check_id",
+    ["P1.1", "P1.2", "P1.3", "P1.5", "P1.9", "P1.10"],
+)
+def test_simple_file_exists_check_fails_when_file_absent(
+    check_id: str, tmp_path: Path
+) -> None:
+    assert _run(check_id, _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_background_loops_doc_is_na_for_non_orchestration_repo(tmp_path: Path) -> None:
+    result = _run("P1.8", _ctx(tmp_path, orchestration=False))
+    assert result.status is Status.NA
+
+
+def test_background_loops_doc_required_for_orchestration_repo(tmp_path: Path) -> None:
+    result = _run("P1.8", _ctx(tmp_path, orchestration=True))
+    assert result.status is Status.FAIL
+
+
+def test_adr_readme_passes_with_index_row(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "adr").mkdir(parents=True)
+    (tmp_path / "docs" / "adr" / "README.md").write_text(
+        "| ADR | Title |\n|---|---|\n| [0001](0001-foo.md) | foo |\n",
+        encoding="utf-8",
+    )
+    assert _run("P1.11", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_adr_readme_fails_when_index_is_empty(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "adr").mkdir(parents=True)
+    (tmp_path / "docs" / "adr" / "README.md").write_text(
+        "no index here", encoding="utf-8"
+    )
+    assert _run("P1.11", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_quick_rules_section_required_in_claude_md(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text("# Project\n\nblurb.\n", encoding="utf-8")
+    assert _run("P1.12", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_quick_rules_section_passes_when_heading_present(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Project\n\n## Quick rules\n", encoding="utf-8"
+    )
+    assert _run("P1.12", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_knowledge_lookup_heading_passes(tmp_path: Path) -> None:
+    (tmp_path / "CLAUDE.md").write_text(
+        "# Project\n\n## Knowledge Lookup\n\n| Source | Path |\n",
+        encoding="utf-8",
+    )
+    assert _run("P1.13", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_load_bearing_adrs_na_for_non_orchestration(tmp_path: Path) -> None:
+    assert _run("P1.14", _ctx(tmp_path, orchestration=False)).status is Status.NA
+
+
+def test_load_bearing_adrs_fail_when_missing(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "adr").mkdir(parents=True)
+    (tmp_path / "docs" / "adr" / "0001-five-concurrent-async-loops.md").write_text(
+        "x", encoding="utf-8"
+    )
+    # Only one of the seven load-bearing ADRs present — should fail.
+    result = _run("P1.14", _ctx(tmp_path, orchestration=True))
+    assert result.status is Status.FAIL
+    assert "ADR-0002" in result.message
+
+
+def test_load_bearing_adrs_pass_when_all_present(tmp_path: Path) -> None:
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    for number in ("0001", "0002", "0003", "0021", "0022", "0029", "0032"):
+        (adr_dir / f"{number}-x.md").write_text("x", encoding="utf-8")
+    assert _run("P1.14", _ctx(tmp_path, orchestration=True)).status is Status.PASS
+
+
+def test_avoided_patterns_content_fails_on_stub(tmp_path: Path) -> None:
+    (tmp_path / "docs" / "agents").mkdir(parents=True)
+    (tmp_path / "docs" / "agents" / "avoided-patterns.md").write_text(
+        "# Avoided patterns\n\ntodo.\n", encoding="utf-8"
+    )
+    assert _run("P1.15", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_avoided_patterns_content_passes_when_populated(tmp_path: Path) -> None:
+    body = "# Avoided patterns\n\n" + "\n".join(
+        f"## Pattern {i}\n\n```python\nbad()\n```\n" for i in range(1, 6)
+    )
+    (tmp_path / "docs" / "agents").mkdir(parents=True)
+    (tmp_path / "docs" / "agents" / "avoided-patterns.md").write_text(
+        body, encoding="utf-8"
+    )
+    assert _run("P1.15", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_line_number_citation_warns(tmp_path: Path) -> None:
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "0001-bad.md").write_text(
+        "See `src/config.py:42` for details.\n", encoding="utf-8"
+    )
+    result = _run("P1.16", _ctx(tmp_path))
+    assert result.status is Status.WARN
+    assert "config.py:42" in result.message
+
+
+def test_line_number_citation_clean_adr_passes(tmp_path: Path) -> None:
+    adr_dir = tmp_path / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "0001-clean.md").write_text(
+        "See `src/config.py:HydraFlowConfig` for the class.\n", encoding="utf-8"
+    )
+    assert _run("P1.16", _ctx(tmp_path)).status is Status.PASS

--- a/tests/test_hydraflow_audit_p2_checks.py
+++ b/tests/test_hydraflow_audit_p2_checks.py
@@ -1,0 +1,227 @@
+"""Tests for P2 (Architecture) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p2_architecture  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- P2.1 ----------------------------------------------------------------
+
+
+def test_src_dir_check(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P2.1", _ctx(tmp_path)).status is Status.PASS
+
+
+# --- P2.2 and P2.2a ------------------------------------------------------
+
+
+_PORTS_WITH_TWO_PROTOCOLS = """
+from typing import Protocol
+
+class VCSPort(Protocol):
+    def push(self) -> None: ...
+
+class WorkspacePort(Protocol):
+    def create(self) -> None: ...
+"""
+
+_PORTS_WITH_ONE_PROTOCOL = """
+from typing import Protocol
+
+class VCSPort(Protocol):
+    def push(self) -> None: ...
+"""
+
+_PORTS_WITH_NO_PROTOCOLS = """
+class NotAPort:
+    pass
+"""
+
+
+def test_ports_with_two_protocols_passes(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "ports.py", _PORTS_WITH_TWO_PROTOCOLS)
+    assert _run("P2.2", _ctx(tmp_path)).status is Status.PASS
+    assert _run("P2.2a", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_ports_with_one_protocol_warns_on_coverage(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "ports.py", _PORTS_WITH_ONE_PROTOCOL)
+    assert _run("P2.2", _ctx(tmp_path)).status is Status.PASS
+    assert _run("P2.2a", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_ports_without_protocols_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "ports.py", _PORTS_WITH_NO_PROTOCOLS)
+    assert _run("P2.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_missing_ports_file_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P2.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- P2.3 / P2.4 / P2.7 (layer check) ------------------------------------
+
+_LAYER_CHECK_ALWAYS_OK = """#!/usr/bin/env python3
+import sys
+sys.exit(0)
+"""
+
+_LAYER_CHECK_ALWAYS_FAIL = """#!/usr/bin/env python3
+import sys
+print("boundary violation")
+sys.exit(1)
+"""
+
+
+def test_layer_check_script_present(tmp_path: Path) -> None:
+    _write(tmp_path / "scripts" / "check_layer_imports.py", _LAYER_CHECK_ALWAYS_OK)
+    assert _run("P2.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_layer_check_passes_when_exits_zero(tmp_path: Path) -> None:
+    _write(tmp_path / "scripts" / "check_layer_imports.py", _LAYER_CHECK_ALWAYS_OK)
+    assert _run("P2.4", _ctx(tmp_path)).status is Status.PASS
+    assert _run("P2.7", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_layer_check_fails_on_nonzero_exit(tmp_path: Path) -> None:
+    _write(tmp_path / "scripts" / "check_layer_imports.py", _LAYER_CHECK_ALWAYS_FAIL)
+    assert _run("P2.4", _ctx(tmp_path)).status is Status.FAIL
+    assert _run("P2.7", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- P2.5 composition root -----------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["service_registry.py", "composition_root.py", "container.py"],
+)
+def test_composition_root_detection(filename: str, tmp_path: Path) -> None:
+    _write(tmp_path / "src" / filename, "registry = {}")
+    assert _run("P2.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_composition_root_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P2.5", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- P2.6 ALLOWLIST ------------------------------------------------------
+
+
+def test_allowlist_declared_in_layer_check(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "scripts" / "check_layer_imports.py",
+        "ALLOWLIST = {'service_registry': True}\n",
+    )
+    assert _run("P2.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_allowlist_absent_warns(tmp_path: Path) -> None:
+    _write(tmp_path / "scripts" / "check_layer_imports.py", "# no allowlist here\n")
+    assert _run("P2.6", _ctx(tmp_path)).status is Status.WARN
+
+
+# --- P2.8 anaemic domain -------------------------------------------------
+
+
+_ANAEMIC_MODELS = """
+from dataclasses import dataclass
+
+@dataclass
+class Issue:
+    id: int
+    title: str
+
+@dataclass
+class Task:
+    name: str
+"""
+
+_RICH_MODELS = """
+from dataclasses import dataclass
+
+@dataclass
+class Issue:
+    id: int
+    title: str
+
+    def close(self) -> None:
+        self.closed = True
+
+    def reopen(self) -> None:
+        self.closed = False
+
+@dataclass
+class Task:
+    name: str
+
+    def run(self) -> None:
+        pass
+"""
+
+
+def test_anaemic_domain_warns(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "models.py", _ANAEMIC_MODELS)
+    assert _run("P2.8", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_rich_domain_passes(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "models.py", _RICH_MODELS)
+    assert _run("P2.8", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_no_domain_sample_is_na(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P2.8", _ctx(tmp_path)).status is Status.NA
+
+
+# --- P2.9 ubiquitous language --------------------------------------------
+
+
+def test_ubiquitous_language_passes_when_terms_overlap(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs" / "agents" / "architecture.md",
+        "Core types include TaskRunner, IssueTracker, LabelMachine, PhaseGuard.\n",
+    )
+    _write(
+        tmp_path / "CLAUDE.md",
+        "Key concepts: TaskRunner coordinates the pipeline. IssueTracker, LabelMachine, and PhaseGuard round it out.\n",
+    )
+    assert _run("P2.9", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_ubiquitous_language_warns_on_divergence(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "docs" / "agents" / "architecture.md",
+        "Types: AlphaType, BetaType, GammaType, DeltaType.\n",
+    )
+    _write(tmp_path / "CLAUDE.md", "Table of contents.\n")
+    assert _run("P2.9", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_ubiquitous_language_na_when_docs_missing(tmp_path: Path) -> None:
+    assert _run("P2.9", _ctx(tmp_path)).status is Status.NA

--- a/tests/test_hydraflow_audit_p2_checks.py
+++ b/tests/test_hydraflow_audit_p2_checks.py
@@ -149,25 +149,22 @@ def test_allowlist_absent_warns(tmp_path: Path) -> None:
 
 
 _ANAEMIC_MODELS = """
-from dataclasses import dataclass
-
-@dataclass
 class Issue:
-    id: int
-    title: str
+    def __init__(self, id: int, title: str) -> None:
+        self.id = id
+        self.title = title
 
-@dataclass
 class Task:
-    name: str
+    def __init__(self, name: str) -> None:
+        self.name = name
 """
 
 _RICH_MODELS = """
-from dataclasses import dataclass
-
-@dataclass
 class Issue:
-    id: int
-    title: str
+    def __init__(self, id: int, title: str) -> None:
+        self.id = id
+        self.title = title
+        self.closed = False
 
     def close(self) -> None:
         self.closed = True
@@ -175,9 +172,9 @@ class Issue:
     def reopen(self) -> None:
         self.closed = False
 
-@dataclass
 class Task:
-    name: str
+    def __init__(self, name: str) -> None:
+        self.name = name
 
     def run(self) -> None:
         pass

--- a/tests/test_hydraflow_audit_p3_checks.py
+++ b/tests/test_hydraflow_audit_p3_checks.py
@@ -257,14 +257,28 @@ def test_integration_file_missing_fails(tmp_path: Path) -> None:
     assert _run("P3.18", _ctx(tmp_path)).status is Status.FAIL
 
 
+_PYPROJECT_WITH_OPTIONAL = (
+    '[project]\nname = "p"\nversion = "0"\n'
+    '[project.optional-dependencies]\nextras = ["httpx>=0.27"]\n'
+)
+
+
 def test_top_level_optional_import_warns(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", _PYPROJECT_WITH_OPTIONAL)
     _write(tmp_path / "tests" / "test_http.py", "import httpx\n\ndef test_x(): pass\n")
     assert _run("P3.19", _ctx(tmp_path)).status is Status.WARN
 
 
 def test_inline_optional_import_passes(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", _PYPROJECT_WITH_OPTIONAL)
     _write(
         tmp_path / "tests" / "test_http.py",
         "def test_x():\n    import httpx  # inline — fine\n    assert httpx\n",
     )
     assert _run("P3.19", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_no_optional_deps_makes_check_na(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", '[project]\nname = "p"\nversion = "0"\n')
+    _write(tmp_path / "tests" / "test_http.py", "import httpx\n\ndef test_x(): pass\n")
+    assert _run("P3.19", _ctx(tmp_path)).status is Status.NA

--- a/tests/test_hydraflow_audit_p3_checks.py
+++ b/tests/test_hydraflow_audit_p3_checks.py
@@ -1,0 +1,270 @@
+"""Tests for P3 (Testing / MockWorld) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p3_testing  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path, *, has_ui: bool = False) -> CheckContext:
+    return CheckContext(root=root, has_ui=has_ui)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- Simple presence ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("check_id", "relpath"),
+    [
+        ("P3.1", "tests/scenarios"),
+        ("P3.16", "tests/regressions"),
+    ],
+)
+def test_directory_presence_checks(check_id: str, relpath: str, tmp_path: Path) -> None:
+    (tmp_path / relpath).mkdir(parents=True)
+    assert _run(check_id, _ctx(tmp_path)).status is Status.PASS
+
+
+def test_directory_presence_fails_when_absent(tmp_path: Path) -> None:
+    assert _run("P3.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_root_conftest_requires_fixtures(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "conftest.py",
+        "import pytest\n\n\n@pytest.fixture\ndef foo(): ...",
+    )
+    assert _run("P3.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_root_conftest_without_fixtures_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "conftest.py", "# nothing here\n")
+    assert _run("P3.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- MockWorld ------------------------------------------------------------
+
+
+def test_mock_world_fixture_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "conftest.py",
+        "import pytest\n\n\n@pytest.fixture\ndef mock_world():\n    return object()\n",
+    )
+    assert _run("P3.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_mock_world_fixture_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "scenarios" / "conftest.py", "# empty\n")
+    assert _run("P3.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_scenario_fakes_count(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "fakes" / "f.py",
+        "class FakeVCS: ...\nclass FakeLLM: ...\nclass FakeClock: ...\n",
+    )
+    assert _run("P3.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_scenario_fakes_under_three_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "fakes" / "f.py",
+        "class FakeOnly: ...\n",
+    )
+    assert _run("P3.3", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_scenario_result_type_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "results.py",
+        "from dataclasses import dataclass\n\n@dataclass\nclass ScenarioResult:\n    ok: bool\n",
+    )
+    assert _run("P3.12", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_scenario_result_type_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "tests" / "scenarios").mkdir(parents=True)
+    assert _run("P3.12", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_fake_clock_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "clock.py",
+        "class FakeClock: ...\n",
+    )
+    assert _run("P3.13", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_fake_clock_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "tests" / "scenarios").mkdir(parents=True)
+    assert _run("P3.13", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_mock_inheritance_warns(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "fakes" / "bad.py",
+        "from unittest.mock import AsyncMock\n\nclass FakeVCS(AsyncMock): ...\n",
+    )
+    assert _run("P3.14", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_stateful_fakes_pass(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "fakes" / "good.py",
+        "class FakeVCS:\n    def __init__(self): self.issues = {}\n",
+    )
+    assert _run("P3.14", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_fault_injection_api_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "world.py",
+        "class MockWorld:\n    def fail_service(self, name): ...\n    def heal_service(self, name): ...\n",
+    )
+    assert _run("P3.15", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_fault_injection_missing_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "scenarios" / "world.py",
+        "class MockWorld:\n    pass\n",
+    )
+    assert _run("P3.15", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Factories ------------------------------------------------------------
+
+
+def test_factory_class_detected(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "factories.py", "class IssueFactory: ...\n")
+    assert _run("P3.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_factory_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    assert _run("P3.5", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- pyproject + Makefile -------------------------------------------------
+
+
+def test_coverage_floor_passes_at_70(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        "[tool.coverage.report]\nfail_under = 70\n",
+    )
+    assert _run("P3.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_coverage_floor_fails_below_70(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        "[tool.coverage.report]\nfail_under = 50\n",
+    )
+    assert _run("P3.6", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_coverage_floor_absent_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[tool.ruff]\n")
+    assert _run("P3.6", _ctx(tmp_path)).status is Status.FAIL
+
+
+@pytest.mark.parametrize(
+    ("check_id", "target"),
+    [("P3.7", "test"), ("P3.8", "scenario"), ("P3.9", "smoke")],
+)
+def test_make_target_detection(check_id: str, target: str, tmp_path: Path) -> None:
+    _write(tmp_path / "Makefile", f"{target}:\n\techo run\n")
+    assert _run(check_id, _ctx(tmp_path)).status is Status.PASS
+
+
+def test_make_target_absent_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "Makefile", "other:\n\techo\n")
+    assert _run("P3.8", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_pytest_markers_registered(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        '[tool.pytest.ini_options]\nmarkers = ["scenario: runs scenarios", "integration: wires phases"]\n',
+    )
+    assert _run("P3.17", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_pytest_markers_missing_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        '[tool.pytest.ini_options]\nmarkers = ["scenario: runs scenarios"]\n',
+    )
+    result = _run("P3.17", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "integration" in result.message
+
+
+# --- CI + conditional -----------------------------------------------------
+
+
+def test_release_gating_detected_when_workflow_mentions_scenario(
+    tmp_path: Path,
+) -> None:
+    _write(
+        tmp_path / ".github" / "workflows" / "ci.yml",
+        "jobs:\n  scenario:\n    runs-on: ubuntu-latest\n",
+    )
+    assert _run("P3.10", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_release_gating_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "jobs:\n  lint: ...\n")
+    assert _run("P3.10", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_browser_e2e_na_without_ui(tmp_path: Path) -> None:
+    assert _run("P3.11", _ctx(tmp_path, has_ui=False)).status is Status.NA
+
+
+def test_browser_e2e_fails_when_ui_and_no_e2e(tmp_path: Path) -> None:
+    assert _run("P3.11", _ctx(tmp_path, has_ui=True)).status is Status.FAIL
+
+
+def test_browser_e2e_passes_when_dir_present(tmp_path: Path) -> None:
+    (tmp_path / "tests" / "scenarios" / "browser").mkdir(parents=True)
+    assert _run("P3.11", _ctx(tmp_path, has_ui=True)).status is Status.PASS
+
+
+def test_integration_file_detected(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_foo_integration.py", "def test_x(): pass\n")
+    assert _run("P3.18", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_integration_file_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_foo.py", "def test_x(): pass\n")
+    assert _run("P3.18", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_top_level_optional_import_warns(tmp_path: Path) -> None:
+    _write(tmp_path / "tests" / "test_http.py", "import httpx\n\ndef test_x(): pass\n")
+    assert _run("P3.19", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_inline_optional_import_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "test_http.py",
+        "def test_x():\n    import httpx  # inline — fine\n    assert httpx\n",
+    )
+    assert _run("P3.19", _ctx(tmp_path)).status is Status.PASS

--- a/tests/test_hydraflow_audit_p4_checks.py
+++ b/tests/test_hydraflow_audit_p4_checks.py
@@ -1,0 +1,60 @@
+"""Tests for P4 (Quality Gates) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p4_quality  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+@pytest.mark.parametrize(
+    ("check_id", "target"),
+    [
+        ("P4.1", "lint-check"),
+        ("P4.2", "typecheck"),
+        ("P4.3", "security"),
+        ("P4.4", "test"),
+        ("P4.5", "quality-lite"),
+        ("P4.6", "quality"),
+    ],
+)
+def test_make_target_presence(check_id: str, target: str, tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text(f"{target}:\n\techo go\n", encoding="utf-8")
+    assert _run(check_id, _ctx(tmp_path)).status is Status.PASS
+
+
+def test_make_target_absent_fails(tmp_path: Path) -> None:
+    (tmp_path / "Makefile").write_text("other:\n\techo\n", encoding="utf-8")
+    assert _run("P4.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_tool_configs_all_present_passes(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.ruff]\n[tool.pyright]\n[tool.bandit]\n[tool.pytest.ini_options]\n",
+        encoding="utf-8",
+    )
+    assert _run("P4.7", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_tool_configs_missing_sections_fails(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[tool.ruff]\n", encoding="utf-8")
+    result = _run("P4.7", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "pyright" in result.message
+
+
+def test_tool_configs_missing_pyproject_fails(tmp_path: Path) -> None:
+    assert _run("P4.7", _ctx(tmp_path)).status is Status.FAIL

--- a/tests/test_hydraflow_audit_p5_checks.py
+++ b/tests/test_hydraflow_audit_p5_checks.py
@@ -1,0 +1,205 @@
+"""Tests for P5 (CI + branch protection) check functions."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p5_ci  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str, *, executable: bool = False) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    if executable:
+        path.chmod(0o755)
+
+
+# --- Workflows ------------------------------------------------------------
+
+
+def test_workflows_dir_empty_fails(tmp_path: Path) -> None:
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    assert _run("P5.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_workflows_dir_with_files_passes(tmp_path: Path) -> None:
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "name: ci\n")
+    assert _run("P5.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_workflow_quality_lite_detected(tmp_path: Path) -> None:
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "run: make quality-lite\n")
+    assert _run("P5.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_workflow_quality_lite_absent_fails(tmp_path: Path) -> None:
+    _write(tmp_path / ".github" / "workflows" / "ci.yml", "run: make lint\n")
+    assert _run("P5.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_workflow_coverage_gate_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".github" / "workflows" / "test.yml",
+        "run: pytest --cov-fail-under=70\n",
+    )
+    assert _run("P5.3", _ctx(tmp_path)).status is Status.PASS
+
+
+# --- Hooks ----------------------------------------------------------------
+
+
+def test_pre_commit_hook_missing_fails(tmp_path: Path) -> None:
+    assert _run("P5.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_pre_commit_hook_not_executable_fails(tmp_path: Path) -> None:
+    _write(tmp_path / ".githooks" / "pre-commit", "#!/bin/sh\n", executable=False)
+    assert _run("P5.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_pre_commit_hook_present_and_executable_passes(tmp_path: Path) -> None:
+    _write(tmp_path / ".githooks" / "pre-commit", "#!/bin/sh\n", executable=True)
+    assert _run("P5.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_pre_push_hook_missing_fails(tmp_path: Path) -> None:
+    assert _run("P5.8", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_pre_push_hook_without_quality_lite_warns(tmp_path: Path) -> None:
+    _write(tmp_path / ".githooks" / "pre-push", "#!/bin/sh\necho go\n", executable=True)
+    assert _run("P5.8", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_pre_push_hook_with_quality_lite_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".githooks" / "pre-push",
+        "#!/bin/sh\nmake quality-lite\n",
+        executable=True,
+    )
+    assert _run("P5.8", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_self_repair_pattern_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".githooks" / "pre-commit",
+        "#!/bin/sh\nmake lint-check || make lint-fix\n",
+        executable=True,
+    )
+    assert _run("P5.9", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_self_repair_absent_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".githooks" / "pre-commit",
+        "#!/bin/sh\nmake lint-check\n",
+        executable=True,
+    )
+    assert _run("P5.9", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_claude_md_guard_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / ".githooks" / "pre-commit",
+        "#!/bin/sh\nif git diff --cached --name-status | grep '^D.*CLAUDE.md'; then exit 1; fi\n",
+        executable=True,
+    )
+    assert _run("P5.10", _ctx(tmp_path)).status is Status.PASS
+
+
+# --- Cultural + pytest config --------------------------------------------
+
+
+def test_branch_protection_is_cultural_warn(tmp_path: Path) -> None:
+    assert _run("P5.5", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_warnings_as_errors_configured_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        (
+            "[tool.pytest.ini_options]\n"
+            'filterwarnings = ["error::RuntimeWarning", "error::pytest.PytestUnraisableExceptionWarning"]\n'
+        ),
+    )
+    assert _run("P5.7", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_warnings_as_errors_partial_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "pyproject.toml",
+        '[tool.pytest.ini_options]\nfilterwarnings = ["error::RuntimeWarning"]\n',
+    )
+    result = _run("P5.7", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "PytestUnraisableExceptionWarning" in result.message
+
+
+def test_warnings_as_errors_absent_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "pyproject.toml", "[tool.pytest.ini_options]\n")
+    assert _run("P5.7", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Git log heuristic ---------------------------------------------------
+
+
+def _git_init_with_commits(tmp_path: Path, subjects: list[str]) -> None:
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t"],
+        check=False,
+        cwd=tmp_path,
+    )
+    for i, subject in enumerate(subjects):
+        (tmp_path / f"f{i}.txt").write_text(subject, encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=tmp_path, check=True, env=_git_env())
+        subprocess.run(
+            ["git", "commit", "-q", "-m", subject],
+            cwd=tmp_path,
+            check=True,
+            env=_git_env(),
+        )
+
+
+def _git_env() -> dict[str, str]:
+    return {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+
+
+def test_git_log_passes_when_commits_have_pr_attribution(tmp_path: Path) -> None:
+    _git_init_with_commits(
+        tmp_path,
+        [f"feat: thing {i} (#{1000 + i})" for i in range(5)],
+    )
+    assert _run("P5.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_git_log_warns_when_no_pr_attribution(tmp_path: Path) -> None:
+    _git_init_with_commits(
+        tmp_path,
+        [f"direct commit {i}" for i in range(20)],
+    )
+    assert _run("P5.6", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_git_log_na_outside_repo(tmp_path: Path) -> None:
+    assert _run("P5.6", _ctx(tmp_path)).status is Status.NA

--- a/tests/test_hydraflow_audit_p6_checks.py
+++ b/tests/test_hydraflow_audit_p6_checks.py
@@ -1,0 +1,99 @@
+"""Tests for P6 (Agents / loops / labels) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p6_agents  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path, *, orchestration: bool = True) -> CheckContext:
+    return CheckContext(root=root, is_orchestration_repo=orchestration)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.parametrize("check_id", ["P6.1", "P6.2", "P6.3", "P6.4", "P6.5"])
+def test_all_na_for_non_orchestration_repo(check_id: str, tmp_path: Path) -> None:
+    assert _run(check_id, _ctx(tmp_path, orchestration=False)).status is Status.NA
+
+
+def test_orchestrator_with_concurrent_loops_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "orchestrator.py",
+        "import asyncio\n\nasync def main():\n    await asyncio.gather(a(), b())\n",
+    )
+    assert _run("P6.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_orchestrator_without_gather_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "orchestrator.py", "async def main(): pass\n")
+    assert _run("P6.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_labels_centralised_passes(tmp_path: Path) -> None:
+    body = "\n".join(
+        f"    {name}_label: list[str] = Field(default=['{name}'])"
+        for name in ["find", "plan", "ready", "review"]
+    )
+    _write(tmp_path / "src" / "config.py", f"class C:\n{body}\n")
+    assert _run("P6.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_labels_scattered_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "config.py", "FIND = 'find'\n")
+    assert _run("P6.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_base_background_loop_class_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "base_background_loop.py",
+        "class BaseBackgroundLoop:\n    async def run(self): ...\n",
+    )
+    assert _run("P6.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_base_background_loop_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P6.3", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_wiring_test_covers_five_checkpoints(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "tests" / "test_loop_wiring_completeness.py",
+        (
+            "# covers service_registry, orchestrator, constants.js, _common.py, _interval\n"
+            "def test_wiring(): pass\n"
+        ),
+    )
+    assert _run("P6.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_wiring_test_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "tests").mkdir()
+    assert _run("P6.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_atomic_swap_helper_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "pr_manager.py",
+        "async def swap_pipeline_labels(issue, to): ...\n",
+    )
+    assert _run("P6.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_atomic_swap_helper_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "pr_manager.py", "def add_label(x): ...\n")
+    assert _run("P6.5", _ctx(tmp_path)).status is Status.FAIL

--- a/tests/test_hydraflow_audit_p7_checks.py
+++ b/tests/test_hydraflow_audit_p7_checks.py
@@ -1,0 +1,189 @@
+"""Tests for P7 (Observability + wiki) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p7_observability  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- Sentry gatekeeper ---------------------------------------------------
+
+
+def test_bug_types_detected_in_server_py(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "server.py",
+        "import sentry_sdk\n\n_BUG_TYPES = (TypeError, KeyError)\n\nsentry_sdk.init(dsn='')\n",
+    )
+    assert _run("P7.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_bug_types_absent_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "server.py", "import sentry_sdk\nsentry_sdk.init(dsn='')\n"
+    )
+    assert _run("P7.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_before_send_wired_to_filter(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "server.py",
+        (
+            "import sentry_sdk\n\n"
+            "_BUG_TYPES = (TypeError,)\n\n"
+            "def before_send(e, h): ...\n\n"
+            "sentry_sdk.init(dsn='', before_send=before_send)\n"
+        ),
+    )
+    assert _run("P7.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_before_send_missing_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "server.py",
+        "import sentry_sdk\n_BUG_TYPES = (TypeError,)\nsentry_sdk.init(dsn='')\n",
+    )
+    assert _run("P7.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Repo wiki -----------------------------------------------------------
+
+
+def test_repo_wiki_dir_exists(tmp_path: Path) -> None:
+    (tmp_path / "repo_wiki").mkdir()
+    assert _run("P7.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_repo_wiki_missing_fails(tmp_path: Path) -> None:
+    assert _run("P7.3", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_wiki_three_layers_pass(tmp_path: Path) -> None:
+    wiki = tmp_path / "repo_wiki" / "slug"
+    wiki.mkdir(parents=True)
+    (wiki / "index.json").write_text("{}", encoding="utf-8")
+    (wiki / "_log.jsonl").write_text("", encoding="utf-8")
+    (wiki / "topic-a.md").write_text("# A", encoding="utf-8")
+    assert _run("P7.3a", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_wiki_missing_layers_warn(tmp_path: Path) -> None:
+    wiki = tmp_path / "repo_wiki" / "slug"
+    wiki.mkdir(parents=True)
+    (wiki / "topic-a.md").write_text("# A", encoding="utf-8")
+    assert _run("P7.3a", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_wiki_store_ops_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "repo_wiki.py",
+        "class RepoWikiStore:\n    def ingest(self): ...\n    def query(self): ...\n    def lint(self): ...\n",
+    )
+    assert _run("P7.3b", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_wiki_store_missing_op_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "repo_wiki.py",
+        "class RepoWikiStore:\n    def ingest(self): ...\n",
+    )
+    result = _run("P7.3b", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "query" in result.message
+
+
+def test_runner_injects_wiki_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "base_runner.py",
+        "class BaseRunner:\n    def _inject_repo_wiki(self, prompt): return prompt\n",
+    )
+    assert _run("P7.3c", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_runner_injection_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "base_runner.py", "class BaseRunner: ...\n")
+    assert _run("P7.3c", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Logging discipline --------------------------------------------------
+
+
+def test_bare_except_pass_warns(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "bad.py",
+        "def f():\n    try:\n        x = 1\n    except:\n        pass\n",
+    )
+    assert _run("P7.4", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_clean_try_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "good.py",
+        "def f():\n    try:\n        x = 1\n    except ValueError:\n        x = 0\n",
+    )
+    assert _run("P7.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_bare_value_logger_error_warns(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "bad.py",
+        "import logging\nlogger = logging.getLogger()\ndef f(e):\n    logger.error(e)\n",
+    )
+    assert _run("P7.5", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_format_string_logger_error_passes(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "good.py",
+        'import logging\nlogger = logging.getLogger()\ndef f(e):\n    logger.error("failed: %s", e)\n',
+    )
+    assert _run("P7.5", _ctx(tmp_path)).status is Status.PASS
+
+
+# --- Self-instrumentation ------------------------------------------------
+
+
+def test_audit_self_instrumentation_passes_with_filter(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "scripts" / "hydraflow_audit" / "observability.py",
+        "_BUG_TYPES = (TypeError,)\ndef _before_send(e, h): ...\n",
+    )
+    assert _run("P7.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_audit_self_instrumentation_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "scripts" / "hydraflow_audit" / "observability.py", "# stub\n")
+    assert _run("P7.6", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_observability_port_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "ports.py",
+        "from typing import Protocol\n\nclass ObservabilityPort(Protocol):\n    def emit(self, event): ...\n",
+    )
+    assert _run("P7.7", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_observability_port_absent_warns(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "ports.py",
+        "from typing import Protocol\n\nclass VCSPort(Protocol): ...\n",
+    )
+    assert _run("P7.7", _ctx(tmp_path)).status is Status.WARN

--- a/tests/test_hydraflow_audit_p8_checks.py
+++ b/tests/test_hydraflow_audit_p8_checks.py
@@ -1,0 +1,146 @@
+"""Tests for P8 (superpowers / skills) check functions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p8_superpowers  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _settings(
+    root: Path,
+    *,
+    hooks: dict[str, list] | None = None,
+    filename: str = "settings.json",
+) -> None:
+    payload: dict = {}
+    if hooks is not None:
+        payload["hooks"] = hooks
+    _write(root / ".claude" / filename, json.dumps(payload))
+
+
+# --- .claude / settings --------------------------------------------------
+
+
+def test_claude_dir_present_passes(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir()
+    assert _run("P8.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_claude_dir_absent_fails(tmp_path: Path) -> None:
+    assert _run("P8.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_settings_json_passes(tmp_path: Path) -> None:
+    _settings(tmp_path)
+    assert _run("P8.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_settings_local_json_also_counts(tmp_path: Path) -> None:
+    _settings(tmp_path, filename="settings.local.json")
+    assert _run("P8.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_settings_absent_fails(tmp_path: Path) -> None:
+    (tmp_path / ".claude").mkdir()
+    assert _run("P8.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_settings_malformed_json_fails(tmp_path: Path) -> None:
+    _write(tmp_path / ".claude" / "settings.json", "{ not json")
+    assert _run("P8.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Hook kinds ----------------------------------------------------------
+
+
+def test_pre_tool_use_hook_detected(tmp_path: Path) -> None:
+    _settings(tmp_path, hooks={"PreToolUse": [{"matcher": "Bash"}]})
+    assert _run("P8.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_no_pre_tool_use_hook_fails(tmp_path: Path) -> None:
+    _settings(tmp_path, hooks={"Stop": [{"matcher": "*"}]})
+    assert _run("P8.3", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_three_hook_kinds_all_present(tmp_path: Path) -> None:
+    _settings(
+        tmp_path,
+        hooks={
+            "PreToolUse": [{"m": "a"}],
+            "PostToolUse": [{"m": "b"}],
+            "Stop": [{"m": "c"}],
+        },
+    )
+    assert _run("P8.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_three_hook_kinds_missing_one_fails(tmp_path: Path) -> None:
+    _settings(
+        tmp_path,
+        hooks={"PreToolUse": [{"m": "a"}], "PostToolUse": [{"m": "b"}]},
+    )
+    result = _run("P8.5", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "Stop" in result.message
+
+
+# --- CLAUDE.md core skills ----------------------------------------------
+
+
+_ALL_SIX_SKILLS = """
+# Project
+
+Use: brainstorming, test-driven-development, systematic-debugging,
+writing-plans, verification-before-completion, and requesting-code-review.
+"""
+
+
+def test_all_six_skills_named_passes(tmp_path: Path) -> None:
+    _write(tmp_path / "CLAUDE.md", _ALL_SIX_SKILLS)
+    assert _run("P8.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_missing_core_skill_fails(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "CLAUDE.md",
+        "Use brainstorming and writing-plans.\n",
+    )
+    result = _run("P8.4", _ctx(tmp_path))
+    assert result.status is Status.FAIL
+    assert "test-driven-development" in result.message
+
+
+# --- Trace collector -----------------------------------------------------
+
+
+def test_trace_collector_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "trace_collector.py",
+        "# writes subprocess traces\ndef write_trace(run_dir): ...\n",
+    )
+    assert _run("P8.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_trace_collector_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P8.6", _ctx(tmp_path)).status is Status.FAIL

--- a/tests/test_hydraflow_audit_p9_checks.py
+++ b/tests/test_hydraflow_audit_p9_checks.py
@@ -1,0 +1,143 @@
+"""Tests for P9 (persistence + data layout) check functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.hydraflow_audit import registry  # noqa: F401
+from scripts.hydraflow_audit.checks import p9_persistence  # noqa: F401
+from scripts.hydraflow_audit.models import CheckContext, Status
+
+
+def _ctx(root: Path) -> CheckContext:
+    return CheckContext(root=root)
+
+
+def _run(check_id: str, ctx: CheckContext):
+    fn = registry.get(check_id)
+    assert fn is not None
+    return fn(ctx)
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+# --- data_root field + override ------------------------------------------
+
+
+def test_data_root_field_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "config.py",
+        "from pathlib import Path\nfrom pydantic import Field\n\nclass C:\n    data_root: Path = Field(default=Path('.data'))\n",
+    )
+    assert _run("P9.1", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_data_root_field_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "config.py", "class C: pass\n")
+    assert _run("P9.1", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_env_override_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "config.py",
+        "import os\npath = os.environ.get('PROJ_DATA_ROOT', '.data')\n",
+    )
+    assert _run("P9.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_env_override_missing_fails(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "config.py", "path = '.data'\n")
+    assert _run("P9.2", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_repo_slug_scoping_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "paths.py",
+        "def root(data_root, repo_slug):\n    return data_root / repo_slug\n",
+    )
+    assert _run("P9.3", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_repo_slug_scoping_missing_warns(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "paths.py",
+        "def root(data_root):\n    return data_root / 'x'\n",
+    )
+    assert _run("P9.3", _ctx(tmp_path)).status is Status.WARN
+
+
+# --- State abstractions --------------------------------------------------
+
+
+def test_state_tracker_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "state.py",
+        "class StateTracker:\n    def write(self, data): ...\n",
+    )
+    assert _run("P9.4", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_state_tracker_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P9.4", _ctx(tmp_path)).status is Status.FAIL
+
+
+def test_dedup_store_detected(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "dedup_store.py",
+        "class DedupStore:\n    def has(self, key): ...\n",
+    )
+    assert _run("P9.5", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_dedup_store_missing_fails(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    assert _run("P9.5", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Atomic writes -------------------------------------------------------
+
+
+def test_os_replace_counts_as_atomic(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "w.py",
+        "import os\ndef write():\n    os.replace('tmp', 'final')\n",
+    )
+    assert _run("P9.6", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_non_atomic_writes_fail(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "w.py", "def write():\n    open('x', 'w').write('x')\n")
+    assert _run("P9.6", _ctx(tmp_path)).status is Status.FAIL
+
+
+# --- Gitignore + write paths --------------------------------------------
+
+
+def test_gitignore_contains_data_root(tmp_path: Path) -> None:
+    _write(tmp_path / ".gitignore", ".hydraflow/\n")
+    assert _run("P9.7", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_gitignore_missing_data_root_warns(tmp_path: Path) -> None:
+    _write(tmp_path / ".gitignore", "*.pyc\n")
+    assert _run("P9.7", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_opens_outside_data_root_warn(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "bad.py",
+        "def f():\n    with open('output.txt', 'w') as fh:\n        fh.write('x')\n",
+    )
+    assert _run("P9.8", _ctx(tmp_path)).status is Status.WARN
+
+
+def test_opens_inside_data_root_pass(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "src" / "good.py",
+        "def f(data_root):\n    with open(data_root / 'x', 'w') as fh:\n        fh.write('x')\n",
+    )
+    assert _run("P9.8", _ctx(tmp_path)).status is Status.PASS

--- a/tests/test_hydraflow_audit_parser.py
+++ b/tests/test_hydraflow_audit_parser.py
@@ -1,0 +1,144 @@
+"""Tests for scripts.hydraflow_audit.parser."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit.models import Severity
+from scripts.hydraflow_audit.parser import _parse_text, parse_adr
+
+
+def test_extracts_rows_under_principle_heading() -> None:
+    text = """
+### P1. Documentation Contract
+
+Some prose.
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | STRUCTURAL | CLAUDE.md | CLAUDE.md exists | touch CLAUDE.md |
+"""
+    specs = _parse_text(text)
+    assert len(specs) == 1
+    spec = specs[0]
+    assert spec.check_id == "P1.1"
+    assert spec.principle == "P1"
+    assert spec.severity is Severity.STRUCTURAL
+    assert spec.source == "CLAUDE.md"
+    assert spec.what == "CLAUDE.md exists"
+    assert spec.remediation == "touch CLAUDE.md"
+
+
+def test_supports_sub_lettered_check_ids() -> None:
+    text = """
+### P2. Layers
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P2.2a | STRUCTURAL | docs | a port exists per boundary | add a Protocol |
+"""
+    specs = _parse_text(text)
+    assert [s.check_id for s in specs] == ["P2.2a"]
+
+
+def test_skips_alignment_row_between_header_and_data() -> None:
+    text = """
+### P1. Docs
+
+| check_id | type | source | what | remediation |
+|:---|:---:|---|---|---|
+| P1.1 | CULTURAL | x | y | z |
+"""
+    specs = _parse_text(text)
+    assert len(specs) == 1
+    assert specs[0].severity is Severity.CULTURAL
+
+
+def test_requires_five_columns() -> None:
+    text = """
+### P1. Docs
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | STRUCTURAL | only | four | columns-has-five-but-this-one-has-four |
+| P1.2 | STRUCTURAL | three | cols |
+"""
+    specs = _parse_text(text)
+    assert [s.check_id for s in specs] == ["P1.1"]
+
+
+def test_rejects_unknown_severity() -> None:
+    text = """
+### P1. Docs
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | MYSTERY | x | y | z |
+"""
+    assert _parse_text(text) == []
+
+
+def test_does_not_emit_rows_without_a_principle_heading() -> None:
+    text = """
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | STRUCTURAL | x | y | z |
+"""
+    assert _parse_text(text) == []
+
+
+def test_handles_multiple_principles() -> None:
+    text = """
+### P1. Docs
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | STRUCTURAL | a | b | c |
+
+Prose between tables.
+
+### P2. Arch
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P2.1 | BEHAVIORAL | d | e | f |
+"""
+    specs = _parse_text(text)
+    assert [(s.principle, s.check_id) for s in specs] == [
+        ("P1", "P1.1"),
+        ("P2", "P2.1"),
+    ]
+
+
+def test_parses_the_real_adr_0044_with_many_rows() -> None:
+    adr = Path(__file__).parents[1] / "docs" / "adr" / "0044-hydraflow-principles.md"
+    specs = parse_adr(adr)
+    # ADR-0044 currently defines ~94 rows across 10 principles; assert a floor so
+    # accidental deletions get caught without being brittle about exact count.
+    assert len(specs) >= 80
+    principles = {s.principle for s in specs}
+    assert principles == {f"P{i}" for i in range(1, 11)}
+    # Every row has non-empty content.
+    for spec in specs:
+        assert spec.check_id
+        assert spec.source
+        assert spec.what
+        assert spec.remediation
+
+
+@pytest.mark.parametrize(
+    "severity",
+    [Severity.STRUCTURAL, Severity.BEHAVIORAL, Severity.CULTURAL],
+)
+def test_severity_round_trip(severity: Severity) -> None:
+    text = f"""
+### P1. Docs
+
+| check_id | type | source | what | remediation |
+|---|---|---|---|---|
+| P1.1 | {severity.value} | x | y | z |
+"""
+    specs = _parse_text(text)
+    assert len(specs) == 1
+    assert specs[0].severity is severity

--- a/tests/test_hydraflow_audit_runner.py
+++ b/tests/test_hydraflow_audit_runner.py
@@ -1,0 +1,172 @@
+"""Tests for scripts.hydraflow_audit.runner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+from scripts.hydraflow_audit import registry
+from scripts.hydraflow_audit.models import (
+    CheckContext,
+    CheckSpec,
+    Finding,
+    Severity,
+    Status,
+)
+from scripts.hydraflow_audit.runner import overall_exit_code, run_checks
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Iterator[None]:
+    """Each test starts with an empty check registry."""
+    registry._clear_for_tests()
+    yield
+    registry._clear_for_tests()
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> CheckContext:
+    return CheckContext(root=tmp_path)
+
+
+def _spec(
+    check_id: str = "P1.1", severity: Severity = Severity.STRUCTURAL
+) -> CheckSpec:
+    return CheckSpec(
+        check_id=check_id,
+        severity=severity,
+        source="src",
+        what="what",
+        remediation="fix it",
+        principle=check_id.split(".")[0],
+    )
+
+
+def test_missing_check_function_yields_not_implemented(ctx: CheckContext) -> None:
+    findings = run_checks([_spec()], ctx)
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.status is Status.NOT_IMPLEMENTED
+    assert finding.check_id == "P1.1"
+    assert "ADR" in finding.message
+
+
+def test_registered_check_is_called(ctx: CheckContext) -> None:
+    @registry.register("P1.1")
+    def _check(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.1",
+            status=Status.PASS,
+            severity=Severity.STRUCTURAL,
+            principle="P1",
+            source="",
+            what="",
+            remediation="",
+            message="it's fine",
+        )
+
+    findings = run_checks([_spec()], ctx)
+    assert findings[0].status is Status.PASS
+    assert findings[0].message == "it's fine"
+
+
+def test_spec_metadata_is_backfilled_when_check_leaves_it_blank(
+    ctx: CheckContext,
+) -> None:
+    @registry.register("P1.1")
+    def _check(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.1",
+            status=Status.PASS,
+            severity=None,  # type: ignore[arg-type]  # deliberately blank
+            principle="",
+            source="",
+            what="",
+            remediation="",
+        )
+
+    spec = _spec()
+    findings = run_checks([spec], ctx)
+    result = findings[0]
+    assert result.source == spec.source
+    assert result.what == spec.what
+    assert result.remediation == spec.remediation
+    assert result.principle == spec.principle
+    assert result.severity is spec.severity
+
+
+def test_exceptions_in_a_check_become_fail_findings(ctx: CheckContext) -> None:
+    @registry.register("P1.1")
+    def _broken(_: CheckContext) -> Finding:
+        raise RuntimeError("boom")
+
+    findings = run_checks([_spec()], ctx)
+    finding = findings[0]
+    assert finding.status is Status.FAIL
+    assert "RuntimeError" in finding.message
+    assert "boom" in finding.message
+
+
+def test_overall_exit_code_zero_when_all_pass_or_na(ctx: CheckContext) -> None:
+    @registry.register("P1.1")
+    def _ok(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.1",
+            status=Status.PASS,
+            severity=Severity.STRUCTURAL,
+            principle="P1",
+            source="",
+            what="",
+            remediation="",
+        )
+
+    @registry.register("P1.2")
+    def _na(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.2",
+            status=Status.NA,
+            severity=Severity.STRUCTURAL,
+            principle="P1",
+            source="",
+            what="",
+            remediation="",
+        )
+
+    findings = run_checks([_spec("P1.1"), _spec("P1.2")], ctx)
+    assert overall_exit_code(findings) == 0
+
+
+@pytest.mark.parametrize("bad", [Status.WARN, Status.FAIL, Status.NOT_IMPLEMENTED])
+def test_overall_exit_code_nonzero_on_any_bad_finding(
+    bad: Status, ctx: CheckContext
+) -> None:
+    @registry.register("P1.1")
+    def _ok(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.1",
+            status=Status.PASS,
+            severity=Severity.STRUCTURAL,
+            principle="P1",
+            source="",
+            what="",
+            remediation="",
+        )
+
+    @registry.register("P1.2")
+    def _bad(_: CheckContext) -> Finding:
+        return Finding(
+            check_id="P1.2",
+            status=bad,
+            severity=Severity.STRUCTURAL,
+            principle="P1",
+            source="",
+            what="",
+            remediation="",
+        )
+
+    findings = run_checks([_spec("P1.1"), _spec("P1.2")], ctx)
+    assert overall_exit_code(findings) == 1

--- a/tests/test_hydraflow_audit_runner.py
+++ b/tests/test_hydraflow_audit_runner.py
@@ -42,7 +42,7 @@ def _spec(
         source="src",
         what="what",
         remediation="fix it",
-        principle=check_id.split(".")[0],
+        principle=check_id.split(".", 1)[0],
     )
 
 

--- a/tests/test_hydraflow_init.py
+++ b/tests/test_hydraflow_init.py
@@ -1,0 +1,160 @@
+"""Tests for scripts.hydraflow_init."""
+
+from __future__ import annotations
+
+from scripts.hydraflow_init.modes import Mode, decide
+from scripts.hydraflow_init.prompt import render
+
+
+def _finding(
+    status: str = "FAIL",
+    severity: str = "STRUCTURAL",
+    principle: str = "P1",
+    check_id: str = "P1.1",
+) -> dict:
+    return {
+        "check_id": check_id,
+        "status": status,
+        "severity": severity,
+        "principle": principle,
+        "source": "CLAUDE.md",
+        "what": "something",
+        "remediation": "do the thing",
+        "message": "",
+    }
+
+
+# --- Mode decision --------------------------------------------------------
+
+
+def test_no_structural_findings_is_incremental() -> None:
+    findings = [_finding(status="PASS", severity="CULTURAL")]
+    assert decide(findings) is Mode.INCREMENTAL
+
+
+def test_most_structural_failing_is_greenfield() -> None:
+    findings = [_finding(status="FAIL") for _ in range(10)]
+    assert decide(findings) is Mode.GREENFIELD
+
+
+def test_mostly_passing_is_incremental() -> None:
+    findings = [_finding(status="PASS") for _ in range(8)] + [
+        _finding(status="FAIL") for _ in range(2)
+    ]
+    assert decide(findings) is Mode.INCREMENTAL
+
+
+def test_boundary_at_70_percent_is_greenfield() -> None:
+    findings = [_finding(status="FAIL") for _ in range(7)] + [
+        _finding(status="PASS") for _ in range(3)
+    ]
+    assert decide(findings) is Mode.GREENFIELD
+
+
+# --- Prompt rendering ----------------------------------------------------
+
+
+def test_greenfield_prompt_invokes_brainstorming() -> None:
+    output = render(
+        target="/repo",
+        findings=[_finding()],
+        summary={"pass": 0, "warn": 0, "fail": 1, "not_implemented": 0, "total": 1},
+        mode=Mode.GREENFIELD,
+        principle_filter=None,
+        skip_brainstorm=False,
+    )
+    assert "superpowers:brainstorming" in output
+    assert "superpowers:writing-plans" in output
+    assert "make audit" in output
+
+
+def test_greenfield_with_skip_brainstorm_omits_step() -> None:
+    output = render(
+        target="/repo",
+        findings=[_finding()],
+        summary={"fail": 1},
+        mode=Mode.GREENFIELD,
+        principle_filter=None,
+        skip_brainstorm=True,
+    )
+    assert "superpowers:brainstorming" not in output
+    assert "superpowers:writing-plans" in output
+
+
+def test_incremental_prompt_skips_brainstorming() -> None:
+    output = render(
+        target="/repo",
+        findings=[_finding()],
+        summary={"fail": 1},
+        mode=Mode.INCREMENTAL,
+        principle_filter=None,
+        skip_brainstorm=False,
+    )
+    assert "superpowers:brainstorming" not in output
+    assert "superpowers:writing-plans" in output
+
+
+def test_prompt_includes_only_actionable_findings() -> None:
+    findings = [
+        _finding(status="PASS", check_id="P1.1"),
+        _finding(status="FAIL", check_id="P1.2"),
+        _finding(status="WARN", check_id="P1.3"),
+        _finding(status="NA", check_id="P1.4"),
+    ]
+    output = render(
+        target="/repo",
+        findings=findings,
+        summary={"pass": 1},
+        mode=Mode.INCREMENTAL,
+        principle_filter=None,
+        skip_brainstorm=False,
+    )
+    assert "P1.2" in output
+    assert "P1.3" in output
+    assert "P1.1" not in output
+    assert "P1.4" not in output
+
+
+def test_principle_filter_scopes_remediations() -> None:
+    findings = [
+        _finding(principle="P1", check_id="P1.1"),
+        _finding(principle="P3", check_id="P3.1"),
+    ]
+    output = render(
+        target="/repo",
+        findings=findings,
+        summary={"fail": 2},
+        mode=Mode.INCREMENTAL,
+        principle_filter="P3",
+        skip_brainstorm=False,
+    )
+    assert "P3.1" in output
+    assert "P1.1" not in output
+
+
+def test_prompt_cites_source_for_each_finding() -> None:
+    findings = [_finding(check_id="P5.7")]
+    findings[0]["source"] = "docs/agents/quality-gates.md"
+    output = render(
+        target="/repo",
+        findings=findings,
+        summary={"fail": 1},
+        mode=Mode.INCREMENTAL,
+        principle_filter=None,
+        skip_brainstorm=False,
+    )
+    assert "docs/agents/quality-gates.md" in output
+    assert "Source:" in output
+
+
+def test_empty_actionable_list_yields_green_message() -> None:
+    findings = [_finding(status="PASS")]
+    output = render(
+        target="/repo",
+        findings=findings,
+        summary={"pass": 1},
+        mode=Mode.INCREMENTAL,
+        principle_filter=None,
+        skip_brainstorm=False,
+    )
+    assert "audit is green" in output.lower()


### PR DESCRIPTION
## Summary

- Introduces **ADR-0044** as the single source of truth for "HydraFlow-shaped" — 10 principles, ~96 machine-parseable check rows
- Adds `scripts/hydraflow_audit/` that reads the ADR tables at runtime and dispatches each `check_id` to a registered Python function; ADR/code drift surfaces as `NOT_IMPLEMENTED`
- Implements **P1 (Documentation Contract)** fully — 16 checks — with 29 unit tests
- Wires `make audit` / `make audit-json` with `DIR=../other-repo` override for portable use
- Self-instrumentation: unhandled audit/init exceptions route through the same Sentry filter the principles require (P7.6/P7.7)

## Live audit against this repo

```
Total: PASS 15  WARN 1  FAIL 0  NA 0  NOT_IMPLEMENTED 80
```

The 1 WARN is a **true positive**: P1.16 flagged line-number citations in
`docs/adr/0014-session-counter-forward-progression-semantics.md` and
`docs/adr/0043-dynamic-plugin-skill-loading.md`. Drift the audit caught
on first run.

The 80 `NOT_IMPLEMENTED` are P2–P10 check rows awaiting check functions —
by design. Follow-up PRs will fill those in one principle at a time; each
is small and reviewable.

## Self-documenting and self-observing

- Every check cites an ADR or `docs/agents/` file; the terminal report and the JSON output echo those citations so remediation points at the decision record, not a paraphrase.
- The tool uses the same `_BUG_TYPES` Sentry filter it enforces on `src/` — runtime failures in the audit itself feed back into the improvement loop.

## Test plan

- [x] `make audit` succeeds and produces the expected P1 PASS/WARN counts
- [x] `make audit-json` writes `.hydraflow/audit-report.json`
- [x] `make audit DIR=../other-repo` runs against a sibling directory
- [x] All 48 new tests pass (`pytest tests/test_hydraflow_audit_*.py`)
- [x] `ruff check` clean on new files
- [ ] Review ADR-0044 for principle completeness
- [ ] Decide: fix the two line-number ADRs in this PR or as a follow-up

## Next PRs on this branch or follow-ups

1. `make init` prompt emitter (consumes the audit JSON, emits a superpowers-chained remediation plan)
2. P2–P10 check implementations (one principle per PR)
3. Cleanup: strip line numbers from ADR-0014 and ADR-0043

🤖 Generated with [Claude Code](https://claude.com/claude-code)