### PR TITLE
feat(gemini)!: add gemini backend, restructure .env to tool:model combos, default triage to gemini-3-pro

### DIFF
--- a/.claude/commands/hf.adr.md
+++ b/.claude/commands/hf.adr.md
@@ -19,7 +19,7 @@ Before creating anything, resolve:
 
 1. `REPO`: `echo "$HYDRAFLOW_GITHUB_REPO"`; if empty, use `git remote get-url origin` and parse `owner/repo`.
 2. `ASSIGNEE`: `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"`; if empty, use repo owner.
-3. `LABEL`: `echo "$HYDRAFLOW_LABEL_FIND"`; if empty, use `hydraflow-find`.
+3. `LABEL`: Use `hydraflow-find`.
 
 Never pass empty values to `gh issue create`.
 
@@ -84,5 +84,5 @@ Return:
 ## Notes
 
 - ADR formatting is validated by HydraFlow ADR routing logic.
-- Use `hydraflow-find` (or `HYDRAFLOW_LABEL_FIND`) so the issue is queued into the pipeline.
+- Use `hydraflow-find` so the issue is queued into the pipeline.
 - Keep decision text concrete and implementation-actionable.

--- a/.claude/commands/hf.audit-code.md
+++ b/.claude/commands/hf.audit-code.md
@@ -7,7 +7,7 @@ Run a comprehensive code quality audit across the entire repo. Dynamically analy
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_FIND"` — if set, use it as the label for created issues. If empty, default to `hydraflow-find`.
+   - Use `hydraflow-find` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.claude/commands/hf.audit-integration-tests.md
+++ b/.claude/commands/hf.audit-integration-tests.md
@@ -7,7 +7,7 @@ Run a comprehensive integration test audit across the entire repo. Dynamically d
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_FIND"` — if set, use it as the label for created issues. If empty, default to `hydraflow-find`.
+   - Use `hydraflow-find` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.claude/commands/hf.audit-tests.md
+++ b/.claude/commands/hf.audit-tests.md
@@ -7,7 +7,7 @@ Run a comprehensive test quality audit across the entire repo. Analyzes test nam
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_FIND"` — if set, use it as the label for created issues. If empty, default to `hydraflow-find`.
+   - Use `hydraflow-find` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.claude/commands/hf.issue.md
+++ b/.claude/commands/hf.issue.md
@@ -21,7 +21,7 @@ Before doing anything else, resolve these three values. Use the EXACT fallback l
 
 1. **REPO**: Run `echo "$HYDRAFLOW_GITHUB_REPO"`. If the output is empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
 2. **ASSIGNEE**: Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"`. If the output is empty, extract the owner from the repo slug (the part before `/`).
-3. **LABEL**: Run `echo "$HYDRAFLOW_LABEL_FIND"`. If the output is empty, **hardcode `hydraflow-find`**. NEVER pass an empty `--label` flag.
+3. **LABEL**: Use `hydraflow-find` (the canonical label for discovery-stage issues).
 
 ### Phase 0.5: Check for Screenshot
 

--- a/.codex/skills/hf.adr/SKILL.md
+++ b/.codex/skills/hf.adr/SKILL.md
@@ -22,7 +22,7 @@ Create an ADR draft issue that HydraFlow queues into the normal pipeline for tri
 
 - `REPO`: `HYDRAFLOW_GITHUB_REPO` fallback to git origin slug
 - `ASSIGNEE`: `HYDRAFLOW_GITHUB_ASSIGNEE` fallback to repo owner
-- `LABEL`: `HYDRAFLOW_LABEL_FIND` fallback to `hydraflow-find`
+- `LABEL`: `hydraflow-find`
 
 ### 2) Build ADR content
 
@@ -67,7 +67,7 @@ gh issue create --repo "$REPO" \
 rm -f "$BODY_FILE"
 ```
 
-Use `hydraflow-find` (or `HYDRAFLOW_LABEL_FIND`) so the ADR is queued into the pipeline.
+Use `hydraflow-find` so the ADR is queued into the pipeline.
 
 ### 4) Report result
 

--- a/.codex/skills/hf.audit-code/SKILL.md
+++ b/.codex/skills/hf.audit-code/SKILL.md
@@ -12,7 +12,7 @@ Run a comprehensive code quality audit across the entire repo. Dynamically analy
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_PLAN"` — if set, use it as the label for created issues. If empty, default to `hydraflow-plan`.
+   - Use `hydraflow-plan` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.codex/skills/hf.audit-integration-tests/SKILL.md
+++ b/.codex/skills/hf.audit-integration-tests/SKILL.md
@@ -12,7 +12,7 @@ Run a comprehensive integration test audit across the entire repo. Dynamically d
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_PLAN"` — if set, use it as the label for created issues. If empty, default to `hydraflow-plan`.
+   - Use `hydraflow-plan` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.codex/skills/hf.audit-tests/SKILL.md
+++ b/.codex/skills/hf.audit-tests/SKILL.md
@@ -12,7 +12,7 @@ Run a comprehensive test quality audit across the entire repo. Analyzes test nam
 1. **Resolve configuration** before doing anything else:
    - Run `echo "$HYDRAFLOW_GITHUB_REPO"` — if set, use it as the target repo (e.g., `owner/repo`). If empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
    - Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"` — if set, use it as the issue assignee. If empty, extract the owner from the repo slug (the part before `/`).
-   - Run `echo "$HYDRAFLOW_LABEL_PLAN"` — if set, use it as the label for created issues. If empty, default to `hydraflow-plan`.
+   - Use `hydraflow-plan` as the label for created issues.
    - Store resolved values as `$REPO`, `$ASSIGNEE`, `$LABEL`.
 
 2. **Discover project structure:**

--- a/.codex/skills/hf.issue/SKILL.md
+++ b/.codex/skills/hf.issue/SKILL.md
@@ -26,7 +26,7 @@ Before doing anything else, resolve these three values. Use the EXACT fallback l
 
 1. **REPO**: Run `echo "$HYDRAFLOW_GITHUB_REPO"`. If the output is empty, run `git remote get-url origin` and extract the `owner/repo` slug (strip `https://github.com/` prefix and `.git` suffix).
 2. **ASSIGNEE**: Run `echo "$HYDRAFLOW_GITHUB_ASSIGNEE"`. If the output is empty, extract the owner from the repo slug (the part before `/`).
-3. **LABEL**: Run `echo "$HYDRAFLOW_LABEL_FIND"`. If the output is empty, **hardcode `hydraflow-find`**. NEVER pass an empty `--label` flag.
+3. **LABEL**: Use `hydraflow-find` (the canonical label for discovery-stage issues).
 
 ### Phase 1: Understand the Request
 

--- a/.env.sample
+++ b/.env.sample
@@ -23,7 +23,8 @@
 # HYDRAFLOW_REVIEW=claude:sonnet
 # HYDRAFLOW_TRIAGE=gemini:gemini-3-pro
 # HYDRAFLOW_AC=claude:sonnet
-# HYDRAFLOW_VERIFICATION_JUDGE=claude:sonnet
+# verification_judge has no env var — it auto-syncs to review_tool
+# (they share review_model).
 
 # --- Background workers ---
 # HYDRAFLOW_TRANSCRIPT_SUMMARY=claude:haiku

--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@
 # HYDRAFLOW_IMPLEMENT=claude:opus
 # HYDRAFLOW_PLANNER=claude:opus
 # HYDRAFLOW_REVIEW=claude:sonnet
-# HYDRAFLOW_TRIAGE=gemini:gemini-3-pro
+# HYDRAFLOW_TRIAGE=gemini:gemini-2.5-pro
 # HYDRAFLOW_AC=claude:sonnet
 # verification_judge has no env var — it auto-syncs to review_tool
 # (they share review_model).
@@ -39,7 +39,7 @@
 # HYDRAFLOW_IMPLEMENT=codex:gpt-5-codex
 # HYDRAFLOW_PLANNER=claude:opus
 # HYDRAFLOW_REVIEW=claude:sonnet
-# HYDRAFLOW_TRIAGE=gemini:gemini-3-pro
+# HYDRAFLOW_TRIAGE=gemini:gemini-2.5-pro
 
 # --- Runtime / host ---
 # HYDRAFLOW_EXECUTION_MODE=host              # host | docker

--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@
 # HYDRAFLOW_IMPLEMENT=claude:opus
 # HYDRAFLOW_PLANNER=claude:opus
 # HYDRAFLOW_REVIEW=claude:sonnet
-# HYDRAFLOW_TRIAGE=gemini:gemini-2.5-pro
+# HYDRAFLOW_TRIAGE=gemini:gemini-3.1-pro-preview
 # HYDRAFLOW_AC=claude:sonnet
 # verification_judge has no env var — it auto-syncs to review_tool
 # (they share review_model).
@@ -39,7 +39,7 @@
 # HYDRAFLOW_IMPLEMENT=codex:gpt-5-codex
 # HYDRAFLOW_PLANNER=claude:opus
 # HYDRAFLOW_REVIEW=claude:sonnet
-# HYDRAFLOW_TRIAGE=gemini:gemini-2.5-pro
+# HYDRAFLOW_TRIAGE=gemini:gemini-3.1-pro-preview
 
 # --- Runtime / host ---
 # HYDRAFLOW_EXECUTION_MODE=host              # host | docker

--- a/.env.sample
+++ b/.env.sample
@@ -1,153 +1,60 @@
 # HydraFlow Environment Variables
 # Copy to .env and customize as needed:  cp .env.sample .env
+#
+# Every stage is configured as a single combo var: tool:model
+#   tool  ∈ {claude, codex, gemini, pi}
+#   model ∈ tool-specific model slug
+#
+# Labels, tiered-policy knobs, and *_TOOL/*_MODEL legacy vars have been
+# removed — those live in code defaults now. Edit src/config.py if you
+# need to change them.
 
-# GitHub repo (auto-detected from git remote if unset)
+# --- GitHub target + identity ---
 # HYDRAFLOW_GITHUB_REPO=owner/repo
-
-# Issue assignee (repo owner if unset)
 # HYDRAFLOW_GITHUB_ASSIGNEE=username
-
-# --- Ops user identity (optional) ---
-# Configure a dedicated GitHub account for HydraFlow's automated operations.
-# If unset, HydraFlow uses your local git identity and gh CLI auth.
-#
-# HYDRAFLOW_GH_TOKEN — GitHub PAT for the ops account (repo scope required).
-#   Controls who creates PRs, posts comments, submits reviews, and merges.
-#   Falls back to your shell's GH_TOKEN / gh auth if unset.
 # HYDRAFLOW_GH_TOKEN=ghp_...
-#
-# HYDRAFLOW_GIT_USER_NAME / HYDRAFLOW_GIT_USER_EMAIL — Git commit authorship.
-#   Set per-worktree via `git config user.name/email`.
-#   Falls back to your global git config if unset.
 # HYDRAFLOW_GIT_USER_NAME=T-rav-HydraFlow-Ops
 # HYDRAFLOW_GIT_USER_EMAIL=t@koderex.dev
 
-# Label lifecycle (defaults shown — uncomment to override)
-HYDRAFLOW_LABEL_FIND=hydraflow-find
-HYDRAFLOW_LABEL_PLAN=hydraflow-plan
-HYDRAFLOW_LABEL_READY=hydraflow-ready
-HYDRAFLOW_LABEL_REVIEW=hydraflow-review
-HYDRAFLOW_LABEL_HITL=hydraflow-hitl
-HYDRAFLOW_LABEL_FIXED=hydraflow-fixed
+# --- Pipeline stages (tool:model per stage) ---
+# Defaults shown — uncomment to override.
+# HYDRAFLOW_IMPLEMENT=claude:opus
+# HYDRAFLOW_PLANNER=claude:opus
+# HYDRAFLOW_REVIEW=claude:sonnet
+# HYDRAFLOW_TRIAGE=gemini:gemini-3-pro
+# HYDRAFLOW_AC=claude:sonnet
+# HYDRAFLOW_VERIFICATION_JUDGE=claude:sonnet
 
-# Pipeline stage tools (defaults shown)
-# HYDRAFLOW_IMPLEMENTATION_TOOL=claude
-# HYDRAFLOW_REVIEW_TOOL=claude
-# HYDRAFLOW_SUBSKILL_TOOL=claude
-# HYDRAFLOW_PLANNER_TOOL=claude
-# HYDRAFLOW_TRIAGE_TOOL=claude
-# HYDRAFLOW_DEBUG_TOOL=claude
-# HYDRAFLOW_AC_TOOL=claude
-# HYDRAFLOW_VERIFICATION_JUDGE_TOOL=claude
+# --- Background workers ---
+# HYDRAFLOW_TRANSCRIPT_SUMMARY=claude:haiku
+# HYDRAFLOW_WIKI_COMPILATION=claude:haiku
+# HYDRAFLOW_REPORT_ISSUE=claude:opus
 
-# Pi-first profile (optional)
-# HYDRAFLOW_SYSTEM_TOOL=pi
-# HYDRAFLOW_BACKGROUND_TOOL=pi
-# HYDRAFLOW_IMPLEMENTATION_TOOL=pi
-# HYDRAFLOW_REVIEW_TOOL=pi
-# HYDRAFLOW_PLANNER_TOOL=pi
-# HYDRAFLOW_TRIAGE_TOOL=pi
-# HYDRAFLOW_AC_TOOL=pi
-# HYDRAFLOW_VERIFICATION_JUDGE_TOOL=pi
-# HYDRAFLOW_MEMORY_COMPACTION_TOOL=pi
-# HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL=pi
-# HYDRAFLOW_MODEL=gpt-5.3-codex
-# HYDRAFLOW_REVIEW_MODEL=gpt-5.3-codex
-# HYDRAFLOW_PLANNER_MODEL=gpt-5.3-codex
-# HYDRAFLOW_TRIAGE_MODEL=gpt-5.3-codex
+# --- Meta (inherit cascades to every per-stage default) ---
+# HYDRAFLOW_SYSTEM=inherit
+# HYDRAFLOW_BACKGROUND=inherit
 
-# Simple grouped defaults (recommended for most setups)
-# HYDRAFLOW_SYSTEM_TOOL=inherit
-# HYDRAFLOW_SYSTEM_MODEL=
-# HYDRAFLOW_BACKGROUND_TOOL=inherit
-# HYDRAFLOW_BACKGROUND_MODEL=
+# --- Alternative profile: codex-heavy (uncomment block to activate) ---
+# HYDRAFLOW_IMPLEMENT=codex:gpt-5-codex
+# HYDRAFLOW_PLANNER=claude:opus
+# HYDRAFLOW_REVIEW=claude:sonnet
+# HYDRAFLOW_TRIAGE=gemini:gemini-3-pro
 
-# Background worker-specific overrides (defaults shown)
-# HYDRAFLOW_MEMORY_COMPACTION_TOOL=claude
-# HYDRAFLOW_MEMORY_COMPACTION_MODEL=haiku
-# HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL=claude
-# HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL=haiku
-
-# Execution mode: "host" (default) runs agents on the host; "docker" runs them
-# in Docker containers (requires Docker on PATH and a configured image).
-# HYDRAFLOW_EXECUTION_MODE=host
-
-# Dashboard binding (set HOST=0.0.0.0 to expose UI beyond localhost)
+# --- Runtime / host ---
+# HYDRAFLOW_EXECUTION_MODE=host              # host | docker
 # HYDRAFLOW_DASHBOARD_HOST=127.0.0.1
 # HYDRAFLOW_DASHBOARD_PORT=5555
-
-# Polling intervals (seconds)
-# HYDRAFLOW_DATA_POLL_INTERVAL=300
-
-# Pipeline stage models (defaults shown)
-# HYDRAFLOW_MODEL=opus
-# HYDRAFLOW_REVIEW_MODEL=sonnet
-# HYDRAFLOW_PLANNER_MODEL=opus
-# HYDRAFLOW_TRIAGE_MODEL=haiku
-# HYDRAFLOW_SUBSKILL_MODEL=haiku
-# HYDRAFLOW_DEBUG_MODEL=opus
-# HYDRAFLOW_AC_MODEL=sonnet
-# HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL=haiku
-
-# Background worker models (defaults shown — each worker is independently tunable)
-# HYDRAFLOW_REPORT_ISSUE_MODEL=opus       # report_issue_loop (codebase research)
-# HYDRAFLOW_SENTRY_MODEL=opus             # sentry_loop (Sentry event triage/filing)
-# HYDRAFLOW_CODE_GROOMING_ENABLED=false   # opt in to the code grooming loop (default off — noisy)
-# HYDRAFLOW_CODE_GROOMING_MODEL=sonnet    # code_grooming_loop (daily code audit)
-# HYDRAFLOW_ADR_REVIEW_MODEL=sonnet       # adr_reviewer council
-# HYDRAFLOW_MEMORY_JUDGE_MODEL=haiku      # tribal-memory candidate judge
-# HYDRAFLOW_WIKI_COMPILATION_MODEL=haiku  # per-repo wiki compactor
-# HYDRAFLOW_MEMORY_COMPACTION_MODEL=haiku # memory_sync compaction
-# HYDRAFLOW_BACKGROUND_MODEL=             # empty = keep per-worker defaults;
-                                          # set to cascade to triage/transcript/
-                                          # report_issue/sentry/code_grooming
-
-# Token-saver profile (~50% less prompt context payload)
-# HYDRAFLOW_PLANNER_TOOL=claude
-# HYDRAFLOW_PLANNER_MODEL=opus
-# HYDRAFLOW_IMPLEMENTATION_TOOL=codex
-# HYDRAFLOW_MODEL=gpt-5-codex
-# HYDRAFLOW_REVIEW_TOOL=claude
-# HYDRAFLOW_REVIEW_MODEL=sonnet
-# HYDRAFLOW_TRIAGE_TOOL=claude
-# HYDRAFLOW_TRIAGE_MODEL=sonnet
-# HYDRAFLOW_MAX_ISSUE_BODY_CHARS=4000
-# HYDRAFLOW_MAX_REVIEW_DIFF_CHARS=7000
-# HYDRAFLOW_MAX_MEMORY_PROMPT_CHARS=1500
-# HYDRAFLOW_MAX_MANIFEST_PROMPT_CHARS=1000
-# HYDRAFLOW_MAX_TRANSCRIPT_SUMMARY_CHARS=20000
-# HYDRAFLOW_MAX_RUNTIME_LOG_CHARS=3000
-# HYDRAFLOW_MAX_CI_LOG_CHARS=6000
-
-# --- Hindsight semantic memory (optional) ---
-# Hindsight provides semantic retain/recall/reflect for agent memory.
-# Started automatically via `make run` (requires Docker Compose).
-#
-# HYDRAFLOW_HINDSIGHT_URL=http://localhost:8888
-# HYDRAFLOW_HINDSIGHT_API_KEY=
-# HYDRAFLOW_HINDSIGHT_TIMEOUT=30
+# HYDRAFLOW_ENV=development
 
 # --- Sentry error tracking ---
 # SENTRY_DSN=https://<key>@o<org>.ingest.us.sentry.io/<project>
 # SENTRY_AUTH_TOKEN=sntryu_...
 # SENTRY_ORG=your-org-slug
-# HYDRAFLOW_ENV=development
 
-# --- WhatsApp Notifications (Shape conversation mode) ---
-# Get these from the Meta Developer Console → WhatsApp Business API
+# --- WhatsApp notifications (Shape conversation mode) ---
 # HYDRAFLOW_WHATSAPP_ENABLED=true
 # HYDRAFLOW_WHATSAPP_PHONE_ID=your_phone_number_id
 # HYDRAFLOW_WHATSAPP_TOKEN=your_whatsapp_api_token
 # HYDRAFLOW_WHATSAPP_VERIFY_TOKEN=your_custom_verify_token
 # HYDRAFLOW_WHATSAPP_RECIPIENT=recipient_phone_with_country_code
 # HYDRAFLOW_DASHBOARD_URL=https://your-public-dashboard-url.com
-
-# --- Dolt embedded state ---
-# Dolt is always enabled for versioned state persistence.
-# Requires the `dolt` CLI to be installed (https://doltdb.com).
-
-# --- In-process tracing ---
-# Tracing is enabled by default and writes to <data_root>/traces/<issue>/<phase>/run-N/
-# via src/trace_collector.py during each agent subprocess. No environment
-# variables are required. The Factory Diagnostics dashboard tab (Plan B)
-# visualizes the resulting data.

--- a/.pi/skills/hf-adr.md
+++ b/.pi/skills/hf-adr.md
@@ -14,7 +14,7 @@ Create a draft ADR issue and queue it into HydraFlow's normal pipeline.
 1. Resolve repo/assignee/label defaults:
    - repo: `HYDRAFLOW_GITHUB_REPO` or git origin slug
    - assignee: `HYDRAFLOW_GITHUB_ASSIGNEE` or repo owner
-   - label: `HYDRAFLOW_LABEL_FIND` or `hydraflow-find`
+   - label: `hydraflow-find`
 2. Create issue with title format: `[ADR] <title>`.
 3. Ensure body includes:
    - `## Context`
@@ -27,5 +27,5 @@ Create a draft ADR issue and queue it into HydraFlow's normal pipeline.
 ## Notes
 
 - ADR shape is validated in HydraFlow triage/review phases.
-- Use `hydraflow-find` to queue ADR work into the pipeline.
+- Use `hydraflow-find` to queue ADR work into the pipeline (the canonical label for this purpose).
 - Keep decisions explicit, bounded, and actionable.

--- a/.pi/skills/hf-issue.md
+++ b/.pi/skills/hf-issue.md
@@ -11,7 +11,7 @@ Create a well-structured GitHub issue and queue it into HydraFlow's normal pipel
 1. Resolve repo/assignee/label defaults:
    - repo: `HYDRAFLOW_GITHUB_REPO` or git origin slug
    - assignee: `HYDRAFLOW_GITHUB_ASSIGNEE` or repo owner
-   - label: `HYDRAFLOW_LABEL_FIND` or `hydraflow-find`
+   - label: `hydraflow-find`
 2. Parse user input to identify area, problem/feature, and relevant services.
 3. Research codebase (Grep/Glob/Read) for concrete context: file paths, functions, patterns.
 4. Check for duplicates: `gh issue list --label hydraflow-find --state open --search "<terms>"`.

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -68,8 +68,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # ---------------------------------------------------------------------------
 FROM base AS tools
 
-# Install agent CLIs globally via npm (Claude, Codex, Pi)
-RUN npm install -g @anthropic-ai/claude-code @openai/codex @mariozechner/pi-coding-agent --no-fund --no-audit
+# Install agent CLIs globally via npm (Claude, Codex, Gemini, Pi)
+RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli @mariozechner/pi-coding-agent --no-fund --no-audit
 
 # Install bd (beads) separately — its postinstall downloads a native binary
 # that needs the ICU compat symlinks from the base stage.
@@ -91,10 +91,11 @@ RUN uv venv /opt/hydraflow-venv \
 # ---------------------------------------------------------------------------
 FROM base AS default-base
 
-# Copy Node.js global packages (Claude, Codex, Pi CLIs)
+# Copy Node.js global packages (Claude, Codex, Gemini, Pi CLIs)
 COPY --from=tools /usr/lib/node_modules /usr/lib/node_modules
 COPY --from=tools /usr/bin/claude /usr/bin/claude
 RUN ln -s ../lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex \
+    && ln -s ../lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini \
     && ln -s ../lib/node_modules/@mariozechner/pi-coding-agent/dist/cli.js /usr/bin/pi \
     && ln -s ../lib/node_modules/@beads/bd/bin/bd /usr/bin/bd
 

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -60,8 +60,8 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
 # ---------------------------------------------------------------------------
 FROM base AS tools
 
-# Install agent CLIs globally via npm (Claude, Codex, Pi)
-RUN npm install -g @anthropic-ai/claude-code @openai/codex @mariozechner/pi-coding-agent --no-fund --no-audit
+# Install agent CLIs globally via npm (Claude, Codex, Gemini, Pi)
+RUN npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli @mariozechner/pi-coding-agent --no-fund --no-audit
 
 # Install bd (beads) separately — its postinstall downloads a native binary
 # that needs the ICU compat symlinks from the base stage.
@@ -83,10 +83,11 @@ RUN uv venv /opt/hydraflow-venv \
 # ---------------------------------------------------------------------------
 FROM base AS runtime
 
-# Copy Node.js global packages (Claude, Codex, Pi CLIs)
+# Copy Node.js global packages (Claude, Codex, Gemini, Pi CLIs)
 COPY --from=tools /usr/lib/node_modules /usr/lib/node_modules
 COPY --from=tools /usr/bin/claude /usr/bin/claude
 RUN ln -s ../lib/node_modules/@openai/codex/bin/codex.js /usr/bin/codex \
+    && ln -s ../lib/node_modules/@google/gemini-cli/bundle/gemini.js /usr/bin/gemini \
     && ln -s ../lib/node_modules/@mariozechner/pi-coding-agent/dist/cli.js /usr/bin/pi \
     && ln -s ../lib/node_modules/@beads/bd/bin/bd /usr/bin/bd
 

--- a/src/activity_parser.py
+++ b/src/activity_parser.py
@@ -253,7 +253,7 @@ class GeminiActivityParser:
     def _parse_tool_result(self, event: dict[str, Any]) -> AgentActivityPayload | None:
         output = event.get("output", "")
         status = str(event.get("status", ""))
-        preview_source = str(output) if isinstance(output, str) else status
+        preview_source = str(output) if output else status
         preview = preview_source[:80].replace("\n", " ") if preview_source else "(done)"
         return {
             "activity_type": "tool_result",

--- a/src/activity_parser.py
+++ b/src/activity_parser.py
@@ -44,7 +44,7 @@ def _summarize_tool(name: str, tool_input: dict[str, Any]) -> str:
     verb = _FILE_PATH_VERBS.get(normalized)
     if verb:
         return f"{verb} {tool_input.get('file_path', '?')}"
-    if normalized == "bash":
+    if normalized in ("bash", "run_shell_command"):
         cmd = tool_input.get("command", "")
         return f"Running: {cmd[:60]}" if cmd else "Running command"
     if normalized == "glob":
@@ -209,6 +209,82 @@ class CodexActivityParser:
         return None
 
 
+class GeminiActivityParser:
+    """Parses Gemini ``--output-format stream-json`` lines into activity events."""
+
+    def __init__(self) -> None:
+        self._seen_tool_ids: set[str] = set()
+
+    def parse(self, raw_line: str) -> AgentActivityPayload | None:
+        try:
+            event = json.loads(raw_line)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+        event_type = event.get("type", "")
+
+        if event_type == "tool_use":
+            return self._parse_tool_use(event)
+        if event_type == "tool_result":
+            return self._parse_tool_result(event)
+        if event_type == "message":
+            return self._parse_message(event)
+        if event_type == "error":
+            return self._parse_error(event)
+        return None
+
+    def _parse_tool_use(self, event: dict[str, Any]) -> AgentActivityPayload | None:
+        tool_id = event.get("tool_id", "")
+        if tool_id and tool_id in self._seen_tool_ids:
+            return None
+        if tool_id:
+            self._seen_tool_ids.add(tool_id)
+        name = str(event.get("tool_name", "?"))
+        params = event.get("parameters", {})
+        if not isinstance(params, dict):
+            params = {}
+        return {
+            "activity_type": "tool_call",
+            "tool_name": name,
+            "summary": _summarize_tool(name, params),
+            "detail": _truncate(str(params), _MAX_DETAIL_LEN),
+        }
+
+    def _parse_tool_result(self, event: dict[str, Any]) -> AgentActivityPayload | None:
+        output = event.get("output", "")
+        status = str(event.get("status", ""))
+        preview_source = str(output) if isinstance(output, str) else status
+        preview = preview_source[:80].replace("\n", " ") if preview_source else "(done)"
+        return {
+            "activity_type": "tool_result",
+            "tool_name": None,
+            "summary": f"Result: {preview}",
+            "detail": _truncate(str(output or status), _MAX_DETAIL_LEN),
+        }
+
+    def _parse_message(self, event: dict[str, Any]) -> AgentActivityPayload | None:
+        if event.get("role") != "assistant":
+            return None
+        text = str(event.get("content", "")).strip()
+        if len(text) >= _MIN_TEXT_LEN:
+            return {
+                "activity_type": "text",
+                "tool_name": None,
+                "summary": _truncate(text, 80),
+                "detail": _truncate(text, _MAX_DETAIL_LEN),
+            }
+        return None
+
+    def _parse_error(self, event: dict[str, Any]) -> AgentActivityPayload | None:
+        msg = event.get("message", "Unknown error")
+        return {
+            "activity_type": "error",
+            "tool_name": None,
+            "summary": _truncate(str(msg), 80),
+            "detail": _truncate(str(msg), _MAX_DETAIL_LEN),
+        }
+
+
 class PiActivityParser:
     """No-op stub for Pi CLI — returns None for all lines."""
 
@@ -222,6 +298,7 @@ def get_activity_parser(backend: str) -> ActivityParser:
     parsers: dict[str, ActivityParser] = {
         "claude": ClaudeActivityParser(),
         "codex": CodexActivityParser(),
+        "gemini": GeminiActivityParser(),
         "pi": PiActivityParser(),
     }
     return parsers.get(backend, PiActivityParser())

--- a/src/agent_cli.py
+++ b/src/agent_cli.py
@@ -136,6 +136,8 @@ def build_lightweight_command(
         return cmd, None
 
     # Gemini: `-p <prompt>` for small prompts, `-p -` + stdin for large ones.
+    # Mirrors claude/pi inline pattern (not the codex delegation pattern) —
+    # lightweight callers deliberately omit --output-format stream-json.
     if tool == "gemini":
         prompt_bytes = prompt.encode()
         if len(prompt_bytes) > 100_000:

--- a/src/agent_cli.py
+++ b/src/agent_cli.py
@@ -135,14 +135,19 @@ def build_lightweight_command(
         cmd.append(prompt)
         return cmd, None
 
-    # Gemini: `-p <prompt>` for small prompts, `-p -` + stdin for large ones.
-    # Mirrors claude/pi inline pattern (not the codex delegation pattern) —
-    # lightweight callers deliberately omit --output-format stream-json.
+    # Gemini: `-p <prompt>` for small prompts; for large ones, pass an
+    # empty -p flag and let the prompt flow in via stdin (gemini's docs:
+    # "Appended to input on stdin (if any)"). `-p -` would pass the
+    # literal string "-" as a prompt prefix, not "read from stdin" —
+    # that's a claude convention, not gemini's.
+    #
+    # Mirrors claude/pi inline pattern (not the codex delegation pattern)
+    # — lightweight callers deliberately omit --output-format stream-json.
     if tool == "gemini":
         prompt_bytes = prompt.encode()
         if len(prompt_bytes) > 100_000:
             return (
-                ["gemini", "-p", "-", "--model", model, "--approval-mode", "yolo"],
+                ["gemini", "-p", "", "--model", model, "--approval-mode", "yolo"],
                 prompt_bytes,
             )
         return (

--- a/src/agent_cli.py
+++ b/src/agent_cli.py
@@ -1,11 +1,11 @@
-"""Agent CLI command builders for Claude, Codex, and Pi backends."""
+"""Agent CLI command builders for Claude, Codex, Gemini, and Pi backends."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Literal
 
-AgentTool = Literal["claude", "codex", "pi"]
+AgentTool = Literal["claude", "codex", "gemini", "pi"]
 
 # Base directory for plugins pre-cloned into the Docker image at build time
 # (see Dockerfile.agent-base). Each subdirectory is passed as ``--plugin-dir``
@@ -46,6 +46,8 @@ def build_agent_command(
     """
     if tool == "codex":
         return _build_codex_command(model=model)
+    if tool == "gemini":
+        return _build_gemini_command(model=model)
     if tool == "pi":
         return _build_pi_command(
             model=model,
@@ -89,6 +91,25 @@ def _build_codex_command(*, model: str) -> list[str]:
     ]
 
 
+def _build_gemini_command(*, model: str) -> list[str]:
+    """Build a Gemini headless command with streaming JSONL output.
+
+    The prompt is spliced in by ``_route_prompt_to_cmd`` (runner_utils) —
+    leaving ``-p`` dangling here lets the splicer insert the prompt at the
+    exact position gemini requires (immediately after ``-p``).
+    """
+    return [
+        "gemini",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--model",
+        model,
+        "--approval-mode",
+        "yolo",
+    ]
+
+
 def build_lightweight_command(
     *,
     tool: AgentTool,
@@ -113,6 +134,19 @@ def build_lightweight_command(
         cmd = _build_codex_command(model=model)
         cmd.append(prompt)
         return cmd, None
+
+    # Gemini: `-p <prompt>` for small prompts, `-p -` + stdin for large ones.
+    if tool == "gemini":
+        prompt_bytes = prompt.encode()
+        if len(prompt_bytes) > 100_000:
+            return (
+                ["gemini", "-p", "-", "--model", model, "--approval-mode", "yolo"],
+                prompt_bytes,
+            )
+        return (
+            ["gemini", "-p", prompt, "--model", model, "--approval-mode", "yolo"],
+            None,
+        )
 
     # For large prompts, pass via stdin to avoid OS ARG_MAX limit.
     prompt_bytes = prompt.encode()

--- a/src/config.py
+++ b/src/config.py
@@ -114,8 +114,6 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("adr_review_approval_threshold", "HYDRAFLOW_ADR_REVIEW_APPROVAL_THRESHOLD", 2),
     ("adr_review_max_rounds", "HYDRAFLOW_ADR_REVIEW_MAX_ROUNDS", 3),
     ("pr_unstick_batch_size", "HYDRAFLOW_PR_UNSTICK_BATCH_SIZE", 10),
-    ("max_subskill_attempts", "HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS", 0),
-    ("max_debug_attempts", "HYDRAFLOW_MAX_DEBUG_ATTEMPTS", 1),
     ("harness_insight_window", "HYDRAFLOW_HARNESS_INSIGHT_WINDOW", 20),
     ("harness_pattern_threshold", "HYDRAFLOW_HARNESS_PATTERN_THRESHOLD", 3),
     ("max_runtime_log_chars", "HYDRAFLOW_MAX_RUNTIME_LOG_CHARS", 8_000),
@@ -174,17 +172,6 @@ _ENV_STR_OVERRIDES: list[tuple[str, str, str]] = [
     ("test_command", "HYDRAFLOW_TEST_COMMAND", "make test"),
     ("docker_image", "HYDRAFLOW_DOCKER_IMAGE", "ghcr.io/t-rav/hydraflow-agent:latest"),
     ("docker_network", "HYDRAFLOW_DOCKER_NETWORK", ""),
-    ("system_model", "HYDRAFLOW_SYSTEM_MODEL", ""),
-    ("background_model", "HYDRAFLOW_BACKGROUND_MODEL", ""),
-    ("transcript_summary_model", "HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL", "haiku"),
-    ("wiki_compilation_model", "HYDRAFLOW_WIKI_COMPILATION_MODEL", "haiku"),
-    ("triage_model", "HYDRAFLOW_TRIAGE_MODEL", "haiku"),
-    ("subskill_model", "HYDRAFLOW_SUBSKILL_MODEL", "haiku"),
-    ("debug_model", "HYDRAFLOW_DEBUG_MODEL", "opus"),
-    ("report_issue_model", "HYDRAFLOW_REPORT_ISSUE_MODEL", "opus"),
-    ("sentry_model", "HYDRAFLOW_SENTRY_MODEL", "opus"),
-    ("code_grooming_model", "HYDRAFLOW_CODE_GROOMING_MODEL", "sonnet"),
-    ("adr_review_model", "HYDRAFLOW_ADR_REVIEW_MODEL", "sonnet"),
     ("changelog_file", "HYDRAFLOW_CHANGELOG_FILE", ""),
     ("release_tag_prefix", "HYDRAFLOW_RELEASE_TAG_PREFIX", "v"),
     ("main_branch", "HYDRAFLOW_MAIN_BRANCH", "main"),
@@ -232,7 +219,6 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         "HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED",
         True,
     ),
-    ("debug_escalation_enabled", "HYDRAFLOW_DEBUG_ESCALATION_ENABLED", True),
     ("unstick_auto_merge", "HYDRAFLOW_UNSTICK_AUTO_MERGE", True),
     ("unstick_all_causes", "HYDRAFLOW_UNSTICK_ALL_CAUSES", True),
     (
@@ -262,19 +248,6 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
 _ENV_LITERAL_OVERRIDES: list[tuple[str, str]] = [
     ("execution_mode", "HYDRAFLOW_EXECUTION_MODE"),
     ("docker_network_mode", "HYDRAFLOW_DOCKER_NETWORK_MODE"),
-    ("system_tool", "HYDRAFLOW_SYSTEM_TOOL"),
-    ("background_tool", "HYDRAFLOW_BACKGROUND_TOOL"),
-    ("implementation_tool", "HYDRAFLOW_IMPLEMENTATION_TOOL"),
-    ("review_tool", "HYDRAFLOW_REVIEW_TOOL"),
-    ("planner_tool", "HYDRAFLOW_PLANNER_TOOL"),
-    ("triage_tool", "HYDRAFLOW_TRIAGE_TOOL"),
-    ("transcript_summary_tool", "HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL"),
-    ("wiki_compilation_tool", "HYDRAFLOW_WIKI_COMPILATION_TOOL"),
-    ("ac_tool", "HYDRAFLOW_AC_TOOL"),
-    ("verification_judge_tool", "HYDRAFLOW_VERIFICATION_JUDGE_TOOL"),
-    ("subskill_tool", "HYDRAFLOW_SUBSKILL_TOOL"),
-    ("debug_tool", "HYDRAFLOW_DEBUG_TOOL"),
-    ("report_issue_tool", "HYDRAFLOW_REPORT_ISSUE_TOOL"),
     ("epic_merge_strategy", "HYDRAFLOW_EPIC_MERGE_STRATEGY"),
     ("release_version_source", "HYDRAFLOW_RELEASE_VERSION_SOURCE"),
 ]
@@ -290,26 +263,6 @@ _DEPRECATED_ENV_ALIASES: dict[str, str] = {
 # Reverse lookup: canonical key → deprecated key (built once at import time).
 _DEPRECATED_ENV_REVERSE: dict[str, str] = {
     v: k for k, v in _DEPRECATED_ENV_ALIASES.items()
-}
-
-# Label env var overrides — maps env key → (field_name, default_value)
-_ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
-    "HYDRAFLOW_LABEL_FIND": ("find_label", ["hydraflow-find"]),
-    "HYDRAFLOW_LABEL_DISCOVER": ("discover_label", ["hydraflow-discover"]),
-    "HYDRAFLOW_LABEL_SHAPE": ("shape_label", ["hydraflow-shape"]),
-    "HYDRAFLOW_LABEL_PLAN": ("planner_label", ["hydraflow-plan"]),
-    "HYDRAFLOW_LABEL_READY": ("ready_label", ["hydraflow-ready"]),
-    "HYDRAFLOW_LABEL_REVIEW": ("review_label", ["hydraflow-review"]),
-    "HYDRAFLOW_LABEL_HITL": ("hitl_label", ["hydraflow-hitl"]),
-    "HYDRAFLOW_LABEL_HITL_ACTIVE": ("hitl_active_label", ["hydraflow-hitl-active"]),
-    "HYDRAFLOW_LABEL_HITL_AUTOFIX": ("hitl_autofix_label", ["hydraflow-hitl-autofix"]),
-    "HYDRAFLOW_LABEL_FIXED": ("fixed_label", ["hydraflow-fixed"]),
-    "HYDRAFLOW_LABEL_DUP": ("dup_label", ["hydraflow-dup"]),
-    "HYDRAFLOW_LABEL_EPIC": ("epic_label", ["hydraflow-epic"]),
-    "HYDRAFLOW_LABEL_EPIC_CHILD": ("epic_child_label", ["hydraflow-epic-child"]),
-    "HYDRAFLOW_LABEL_VERIFY": ("verify_label", ["hydraflow-verify"]),
-    "HYDRAFLOW_LABEL_PARKED": ("parked_label", ["hydraflow-parked"]),
-    "HYDRAFLOW_LABEL_DIAGNOSE": ("diagnose_label", ["hydraflow-diagnose"]),
 }
 
 _ALLOWED_TOOLS_COMBO: set[str] = {"claude", "codex", "gemini", "pi"}
@@ -1904,18 +1857,13 @@ class HydraFlowConfig(BaseModel):
             HYDRAFLOW_GIT_USER_NAME     → git_user_name
             HYDRAFLOW_GIT_USER_EMAIL    → git_user_email
             HYDRAFLOW_MIN_PLAN_WORDS    → min_plan_words
-            HYDRAFLOW_LABEL_FIND        → find_label   (discovery stage)
-            HYDRAFLOW_LABEL_PLAN        → planner_label
-            HYDRAFLOW_LABEL_READY       → ready_label  (implement stage)
-            HYDRAFLOW_LABEL_REVIEW      → review_label
-            HYDRAFLOW_LABEL_HITL        → hitl_label
-            HYDRAFLOW_LABEL_HITL_ACTIVE  → hitl_active_label
-            HYDRAFLOW_LABEL_HITL_AUTOFIX → hitl_autofix_label
-            HYDRAFLOW_LABEL_FIXED       → fixed_label
-            HYDRAFLOW_LABEL_VERIFY      → verify_label
-            HYDRAFLOW_LABEL_DUP         → dup_label
-            HYDRAFLOW_LABEL_EPIC        → epic_label
-            HYDRAFLOW_LABEL_EPIC_CHILD  → epic_child_label
+
+        Tool/model overrides use the combo syntax (BREAKING: legacy *_TOOL/*_MODEL
+        single-field env vars are no longer supported):
+            HYDRAFLOW_TRIAGE=tool:model, HYDRAFLOW_IMPLEMENT=tool:model, etc.
+
+        Label fields (ready_label, find_label, etc.) are config-file-only;
+        HYDRAFLOW_LABEL_* env vars were removed in the Task 7 breaking change.
         """
         _resolve_base_paths(self)
         _resolve_repo_and_identity(self)
@@ -2485,20 +2433,6 @@ def _apply_env_overrides(config: HydraFlowConfig) -> None:
                     msg = f"HYDRAFLOW_DOCKER_PIDS_LIMIT must be between 16 and 4096, got {pids_val}"
                     raise ValueError(msg)
                 object.__setattr__(config, "docker_pids_limit", pids_val)
-
-    # Label env var overrides (only apply when still at the default)
-    for env_key, (field_name, default_val) in _ENV_LABEL_MAP.items():
-        current = getattr(config, field_name)
-        env_val = os.environ.get(env_key)
-        if env_val is not None and current == default_val:
-            # Split on comma, ignoring empty parts; skip override if result is empty
-            labels = (
-                [part.strip() for part in env_val.split(",") if part.strip()]
-                if env_val
-                else []
-            )
-            if labels:
-                object.__setattr__(config, field_name, labels)
 
 
 def _validate_docker(config: HydraFlowConfig) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -413,7 +413,7 @@ class HydraFlowConfig(BaseModel):
             )
         return v
 
-    system_tool: Literal["inherit", "claude", "codex", "pi"] = Field(
+    system_tool: Literal["inherit", "claude", "codex", "gemini", "pi"] = Field(
         default="inherit",
         description="Optional global default tool for system agents; 'inherit' keeps per-agent defaults",
     )
@@ -421,7 +421,7 @@ class HydraFlowConfig(BaseModel):
         default="",
         description="Optional global default model for system agents; empty keeps per-agent defaults",
     )
-    background_tool: Literal["inherit", "claude", "codex", "pi"] = Field(
+    background_tool: Literal["inherit", "claude", "codex", "gemini", "pi"] = Field(
         default="inherit",
         description="Optional global default tool for background workers; 'inherit' keeps per-worker defaults",
     )
@@ -429,14 +429,14 @@ class HydraFlowConfig(BaseModel):
         default="",
         description="Optional global default model for background workers; empty keeps per-worker defaults",
     )
-    implementation_tool: Literal["claude", "codex", "pi"] = Field(
+    implementation_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for implementation agents",
     )
     model: str = Field(default="opus", description="Model for implementation agents")
 
     # Review configuration
-    review_tool: Literal["claude", "codex", "pi"] = Field(
+    review_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for review agents",
     )
@@ -751,7 +751,7 @@ class HydraFlowConfig(BaseModel):
         default=["hydraflow-plan"],
         description="Labels for issues needing plans (OR logic)",
     )
-    planner_tool: Literal["claude", "codex", "pi"] = Field(
+    planner_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for planning agents",
     )
@@ -761,7 +761,7 @@ class HydraFlowConfig(BaseModel):
         ge=0,
         description="Max fix attempts per TDD REFACTOR sub-agent before reporting failure",
     )
-    triage_tool: Literal["claude", "codex", "pi"] = Field(
+    triage_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for triage agents",
     )
@@ -833,7 +833,7 @@ class HydraFlowConfig(BaseModel):
     )
 
     # Agent prompt configuration
-    subskill_tool: Literal["claude", "codex", "pi"] = Field(
+    subskill_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for low-tier subskill/tool-chain passes",
     )
@@ -851,7 +851,7 @@ class HydraFlowConfig(BaseModel):
         default=True,
         description="Enable automatic escalation to debug model when low-tier prechecks signal risk/ambiguity",
     )
-    debug_tool: Literal["claude", "codex", "pi"] = Field(
+    debug_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for debug escalation passes",
     )
@@ -1068,7 +1068,7 @@ class HydraFlowConfig(BaseModel):
         default="haiku",
         description="Model for wiki compilation and synthesis",
     )
-    wiki_compilation_tool: Literal["claude", "codex", "pi"] = Field(
+    wiki_compilation_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for wiki compilation",
     )
@@ -1272,7 +1272,7 @@ class HydraFlowConfig(BaseModel):
         default="haiku",
         description="Cheap model for summarising agent transcripts into structured learnings",
     )
-    transcript_summary_tool: Literal["claude", "codex", "pi"] = Field(
+    transcript_summary_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for transcript summarization",
     )
@@ -1283,7 +1283,7 @@ class HydraFlowConfig(BaseModel):
         description="Max transcript characters to send for summarization (truncated from end)",
     )
     # Report issue worker
-    report_issue_tool: Literal["claude", "codex", "pi"] = Field(
+    report_issue_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for report-issue worker",
     )
@@ -1551,11 +1551,11 @@ class HydraFlowConfig(BaseModel):
         default="sonnet",
         description="Model for acceptance criteria generation (post-merge)",
     )
-    ac_tool: Literal["claude", "codex", "pi"] = Field(
+    ac_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for acceptance criteria generation",
     )
-    verification_judge_tool: Literal["claude", "codex", "pi"] = Field(
+    verification_judge_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",
         description="CLI backend for verification judge agents",
     )

--- a/src/config.py
+++ b/src/config.py
@@ -1958,14 +1958,73 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
             _apply_if_default(field, config.background_model)
 
 
-def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
-    """Align tool/model defaults when model remains implicit.
+# Model prefix → required tool. Any model starting with a listed prefix
+# MUST pair with the given tool; any other pairing is rejected.
+_MODEL_TOOL_REQUIRED: list[tuple[str, str]] = [
+    ("gemini", "gemini"),
+    ("gpt-", "codex"),
+    ("opus", "claude"),
+    ("sonnet", "claude"),
+    ("haiku", "claude"),
+    ("claude-", "claude"),
+]
 
-    Prevent Codex runs from inheriting the Claude-oriented implementation model
-    default (`opus`) when no explicit implementation model was provided.
+
+def _required_tool_for_model(model: str) -> str | None:
+    m = model.lower()
+    for prefix, tool in _MODEL_TOOL_REQUIRED:
+        if m.startswith(prefix):
+            return tool
+    return None
+
+
+def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
+    """Validate that every (tool, model) pair is internally consistent.
+
+    Rejects:
+      - Any ``*-flash*`` model in any role (quality guard for the factory).
+      - Cross-provider mismatches (e.g. ``codex`` + ``opus``,
+        ``gemini`` + ``gpt-5-codex``).
     """
-    if config.implementation_tool == "codex" and config.model == "opus":
-        object.__setattr__(config, "model", "gpt-5-codex")
+    stage_pairs: list[tuple[str, str, str]] = [
+        ("implementation", config.implementation_tool, config.model),
+        ("review", config.review_tool, config.review_model),
+        ("planner", config.planner_tool, config.planner_model),
+        ("triage", config.triage_tool, config.triage_model),
+        ("ac", config.ac_tool, config.ac_model),
+        ("verification_judge", config.verification_judge_tool, config.ac_model),
+        ("subskill", config.subskill_tool, config.subskill_model),
+        ("debug", config.debug_tool, config.debug_model),
+        (
+            "transcript_summary",
+            config.transcript_summary_tool,
+            config.transcript_summary_model,
+        ),
+        (
+            "wiki_compilation",
+            config.wiki_compilation_tool,
+            config.wiki_compilation_model,
+        ),
+        ("report_issue", config.report_issue_tool, config.report_issue_model),
+    ]
+
+    for stage, tool, model in stage_pairs:
+        if not model:
+            continue  # empty — inherited/unset
+        if "flash" in model.lower():
+            msg = (
+                f"{stage}: model {model!r} is a *flash* variant; "
+                "flash models are rejected for the factory (insufficient "
+                "reasoning quality). Use a pro-tier model instead."
+            )
+            raise ValueError(msg)
+        required = _required_tool_for_model(model)
+        if required is not None and required != tool:
+            msg = (
+                f"{stage}: mismatched pair {tool!r}+{model!r}; "
+                f"model {model!r} requires tool {required!r}"
+            )
+            raise ValueError(msg)
 
 
 def _resolve_base_paths(config: HydraFlowConfig) -> None:

--- a/src/config.py
+++ b/src/config.py
@@ -284,7 +284,7 @@ def _parse_combo(env_key: str, value: str) -> tuple[str, str]:
     if ":" not in stripped:
         msg = (
             f"{env_key}={value!r} must be 'tool:model' "
-            f"(e.g. claude:opus, gemini:gemini-3-pro) or 'inherit'"
+            f"(e.g. claude:opus, gemini:gemini-2.5-pro) or 'inherit'"
         )
         raise ValueError(msg)
     tool, _, model = stripped.partition(":")
@@ -776,7 +776,7 @@ class HydraFlowConfig(BaseModel):
         description="CLI backend for triage agents",
     )
     triage_model: str = Field(
-        default="gemini-3-pro", description="Model for triage evaluation (fast/cheap)"
+        default="gemini-2.5-pro", description="Model for triage evaluation (fast/cheap)"
     )
     min_plan_words: int = Field(
         default=200,
@@ -1963,6 +1963,9 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
 _MODEL_TOOL_REQUIRED: list[tuple[str, str]] = [
     ("gemini", "gemini"),
     ("gpt-", "codex"),
+    ("o1", "codex"),
+    ("o3", "codex"),
+    ("o4", "codex"),
     ("opus", "claude"),
     ("sonnet", "claude"),
     ("haiku", "claude"),
@@ -1989,8 +1992,19 @@ def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
     Also auto-syncs ``verification_judge_tool`` to ``review_tool`` because
     the two share ``review_model`` — the tools MUST agree, so we pick the
     review side as the source of truth and let the ``review`` pair check
-    catch the underlying model mismatch if one exists.
+    catch the underlying model mismatch if one exists. Emits a warning
+    when an explicit ``verification_judge_tool`` is being overridden so
+    the user isn't surprised.
     """
+    if config.verification_judge_tool != config.review_tool:
+        logger.warning(
+            "verification_judge_tool=%r does not match review_tool=%r; "
+            "the two share review_model so they must agree. "
+            "Overriding verification_judge_tool to %r.",
+            config.verification_judge_tool,
+            config.review_tool,
+            config.review_tool,
+        )
     object.__setattr__(config, "verification_judge_tool", config.review_tool)
 
     stage_pairs: list[tuple[str, str, str]] = [

--- a/src/config.py
+++ b/src/config.py
@@ -284,7 +284,7 @@ def _parse_combo(env_key: str, value: str) -> tuple[str, str]:
     if ":" not in stripped:
         msg = (
             f"{env_key}={value!r} must be 'tool:model' "
-            f"(e.g. claude:opus, gemini:gemini-2.5-pro) or 'inherit'"
+            f"(e.g. claude:opus, gemini:gemini-3.1-pro-preview) or 'inherit'"
         )
         raise ValueError(msg)
     tool, _, model = stripped.partition(":")
@@ -776,7 +776,8 @@ class HydraFlowConfig(BaseModel):
         description="CLI backend for triage agents",
     )
     triage_model: str = Field(
-        default="gemini-2.5-pro", description="Model for triage evaluation (fast/cheap)"
+        default="gemini-3.1-pro-preview",
+        description="Model for triage evaluation (fast/cheap)",
     )
     min_plan_words: int = Field(
         default=200,

--- a/src/config.py
+++ b/src/config.py
@@ -773,11 +773,11 @@ class HydraFlowConfig(BaseModel):
         description="Max fix attempts per TDD REFACTOR sub-agent before reporting failure",
     )
     triage_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
-        default="claude",
+        default="gemini",
         description="CLI backend for triage agents",
     )
     triage_model: str = Field(
-        default="haiku", description="Model for triage evaluation (fast/cheap)"
+        default="gemini-3-pro", description="Model for triage evaluation (fast/cheap)"
     )
     min_plan_words: int = Field(
         default=200,

--- a/src/config.py
+++ b/src/config.py
@@ -313,7 +313,6 @@ _ENV_COMBO_OVERRIDES: list[tuple[str, str, str]] = [
     ("HYDRAFLOW_PLANNER", "planner_tool", "planner_model"),
     ("HYDRAFLOW_TRIAGE", "triage_tool", "triage_model"),
     ("HYDRAFLOW_AC", "ac_tool", "ac_model"),
-    ("HYDRAFLOW_VERIFICATION_JUDGE", "verification_judge_tool", "ac_model"),
     (
         "HYDRAFLOW_TRANSCRIPT_SUMMARY",
         "transcript_summary_tool",
@@ -1985,14 +1984,20 @@ def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
       - Any ``*-flash*`` model in any role (quality guard for the factory).
       - Cross-provider mismatches (e.g. ``codex`` + ``opus``,
         ``gemini`` + ``gpt-5-codex``).
+
+    Also auto-syncs ``verification_judge_tool`` to ``review_tool`` because
+    the two share ``review_model`` — the tools MUST agree, so we pick the
+    review side as the source of truth and let the ``review`` pair check
+    catch the underlying model mismatch if one exists.
     """
+    object.__setattr__(config, "verification_judge_tool", config.review_tool)
+
     stage_pairs: list[tuple[str, str, str]] = [
         ("implementation", config.implementation_tool, config.model),
         ("review", config.review_tool, config.review_model),
         ("planner", config.planner_tool, config.planner_model),
         ("triage", config.triage_tool, config.triage_model),
         ("ac", config.ac_tool, config.ac_model),
-        ("verification_judge", config.verification_judge_tool, config.ac_model),
         ("subskill", config.subskill_tool, config.subskill_model),
         ("debug", config.debug_tool, config.debug_model),
         (

--- a/src/config.py
+++ b/src/config.py
@@ -312,6 +312,64 @@ _ENV_LABEL_MAP: dict[str, tuple[str, list[str]]] = {
     "HYDRAFLOW_LABEL_DIAGNOSE": ("diagnose_label", ["hydraflow-diagnose"]),
 }
 
+_ALLOWED_TOOLS_COMBO: set[str] = {"claude", "codex", "gemini", "pi"}
+
+
+def _parse_combo(env_key: str, value: str) -> tuple[str, str]:
+    """Parse a ``tool:model`` combo env var.
+
+    Accepts the sentinel ``"inherit"`` for the SYSTEM / BACKGROUND variables,
+    returning ``("inherit", "")``.  Any other value must contain exactly one
+    colon: the left side a known tool, the right side a non-empty model
+    string.
+
+    Raises :class:`ValueError` with a clear message on malformed input.
+    """
+    stripped = value.strip()
+    if stripped == "inherit":
+        return "inherit", ""
+    if ":" not in stripped:
+        msg = (
+            f"{env_key}={value!r} must be 'tool:model' "
+            f"(e.g. claude:opus, gemini:gemini-3-pro) or 'inherit'"
+        )
+        raise ValueError(msg)
+    tool, _, model = stripped.partition(":")
+    tool = tool.strip()
+    model = model.strip()
+    if tool not in _ALLOWED_TOOLS_COMBO:
+        msg = (
+            f"{env_key}={value!r} unknown tool {tool!r}; "
+            f"allowed: {sorted(_ALLOWED_TOOLS_COMBO)}"
+        )
+        raise ValueError(msg)
+    if not model:
+        msg = f"{env_key}={value!r} model part is empty"
+        raise ValueError(msg)
+    return tool, model
+
+
+# Each tuple: (env_key, tool_field, model_field)
+# "inherit" is accepted for fields whose tool type includes it
+# (system, background); otherwise it's rejected by Pydantic's Literal.
+_ENV_COMBO_OVERRIDES: list[tuple[str, str, str]] = [
+    ("HYDRAFLOW_SYSTEM", "system_tool", "system_model"),
+    ("HYDRAFLOW_BACKGROUND", "background_tool", "background_model"),
+    ("HYDRAFLOW_IMPLEMENT", "implementation_tool", "model"),
+    ("HYDRAFLOW_REVIEW", "review_tool", "review_model"),
+    ("HYDRAFLOW_PLANNER", "planner_tool", "planner_model"),
+    ("HYDRAFLOW_TRIAGE", "triage_tool", "triage_model"),
+    ("HYDRAFLOW_AC", "ac_tool", "ac_model"),
+    ("HYDRAFLOW_VERIFICATION_JUDGE", "verification_judge_tool", "ac_model"),
+    (
+        "HYDRAFLOW_TRANSCRIPT_SUMMARY",
+        "transcript_summary_tool",
+        "transcript_summary_model",
+    ),
+    ("HYDRAFLOW_WIKI_COMPILATION", "wiki_compilation_tool", "wiki_compilation_model"),
+    ("HYDRAFLOW_REPORT_ISSUE", "report_issue_tool", "report_issue_model"),
+]
+
 
 class HydraFlowConfig(BaseModel):
     """Configuration for the HydraFlow orchestrator."""
@@ -2324,6 +2382,23 @@ def _apply_env_overrides(config: HydraFlowConfig) -> None:
                     field,
                     env_val.lower() not in ("0", "false", "no"),
                 )
+
+    # Combo env vars: HYDRAFLOW_<STAGE>=tool:model
+    for env_key, tool_field, model_field in _ENV_COMBO_OVERRIDES:
+        env_val = _get_env(env_key)
+        if env_val is None:
+            continue
+        tool, model = _parse_combo(env_key, env_val)  # raises on malformed
+        # "inherit" is only valid for fields whose Literal includes it;
+        # Pydantic would reject otherwise — pre-empt with a clearer message.
+        if tool == "inherit" and tool_field not in {"system_tool", "background_tool"}:
+            msg = (
+                f"{env_key}=inherit not allowed; {tool_field} requires an explicit tool"
+            )
+            raise ValueError(msg)
+        object.__setattr__(config, tool_field, tool)
+        if model:  # empty model only for "inherit"
+            object.__setattr__(config, model_field, model)
 
     # Data-driven env var overrides (Literal-typed fields)
     for field, env_key in _ENV_LITERAL_OVERRIDES:

--- a/src/config.py
+++ b/src/config.py
@@ -1921,11 +1921,12 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
             "review_tool",
             "planner_tool",
             "ac_tool",
-            "verification_judge_tool",
             "subskill_tool",
             "debug_tool",
         ):
             _apply_if_default(field, config.system_tool)
+        # verification_judge_tool intentionally omitted — it is auto-synced
+        # to review_tool inside _harmonize_tool_model_defaults.
 
     if config.system_model.strip():
         for field in (

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -59,6 +59,7 @@ def _route_prompt_to_cmd(cmd: list[str], prompt: str) -> tuple[list[str], int]:
     use_codex_exec = len(cmd) >= 2 and cmd[0] == "codex" and cmd[1] == "exec"
     use_pi_print = cmd and cmd[0] == "pi" and ("-p" in cmd or "--print" in cmd)
     use_claude_print = cmd and cmd[0] == "claude" and "-p" in cmd
+    # Gemini CLI only supports -p (no --print alias).
     use_gemini_print = cmd and cmd[0] == "gemini" and "-p" in cmd
     use_prompt_arg = (
         use_codex_exec or use_pi_print or use_claude_print or use_gemini_print

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -59,11 +59,14 @@ def _route_prompt_to_cmd(cmd: list[str], prompt: str) -> tuple[list[str], int]:
     use_codex_exec = len(cmd) >= 2 and cmd[0] == "codex" and cmd[1] == "exec"
     use_pi_print = cmd and cmd[0] == "pi" and ("-p" in cmd or "--print" in cmd)
     use_claude_print = cmd and cmd[0] == "claude" and "-p" in cmd
-    use_prompt_arg = use_codex_exec or use_pi_print or use_claude_print
+    use_gemini_print = cmd and cmd[0] == "gemini" and "-p" in cmd
+    use_prompt_arg = (
+        use_codex_exec or use_pi_print or use_claude_print or use_gemini_print
+    )
     if use_prompt_arg:
-        if use_claude_print or use_pi_print:
-            # Claude/Pi CLI require the prompt immediately after -p/--print;
-            # placing it at the end causes "Input must be provided" errors.
+        if use_claude_print or use_pi_print or use_gemini_print:
+            # Claude / Pi / Gemini all require the prompt immediately after
+            # -p/--print; placing it at the end causes CLI errors.
             flag = "-p" if "-p" in cmd else "--print"
             idx = cmd.index(flag)
             cmd_to_run = [*cmd[: idx + 1], prompt, *cmd[idx + 1 :]]
@@ -277,6 +280,8 @@ async def stream_claude_process(
         _backend = "claude"
         if cmd and cmd[0] == "codex":
             _backend = "codex"
+        elif cmd and cmd[0] == "gemini":
+            _backend = "gemini"
         elif cmd and cmd[0] == "pi":
             _backend = "pi"
         activity_parser = get_activity_parser(_backend)

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -37,6 +37,20 @@ class AuthenticationRetryError(RuntimeError):
     """
 
 
+# Backend-specific auth-failure signatures. Keep these conservative —
+# false positives turn real agent output into spurious retries.
+_AUTH_FAILURE_PATTERNS = (
+    "authentication_failed",  # claude-code stream-json
+    "Please set an Auth method",  # gemini-cli startup
+    "AuthenticationError",  # generic SDK exceptions
+)
+
+
+def _is_auth_failure(text: str) -> bool:
+    """Check if *text* indicates a retryable authentication failure."""
+    return any(pattern in text for pattern in _AUTH_FAILURE_PATTERNS)
+
+
 @dataclass(frozen=True, slots=True)
 class StreamConfig:
     """Rarely-varying options for :func:`stream_claude_process`."""
@@ -106,10 +120,12 @@ def _post_stream_result(
     # Skip auth/credit checks when early_killed — killing the process can cause
     # in-flight API requests to fail with spurious errors.
     raw_output = "\n".join(raw_lines)
-    if not early_killed and "authentication_failed" in raw_output:
+    combined_for_auth = f"{stderr_text}\n{raw_output}"
+    if not early_killed and _is_auth_failure(combined_for_auth):
         raise AuthenticationRetryError(
-            "Agent CLI authentication failed — check "
-            "ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN"
+            "Agent CLI authentication failed — check the provider's auth "
+            "(ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / GEMINI_API_KEY / "
+            "~/.gemini/settings.json / CODEX_HOME)"
         )
 
     combined = f"{stderr_text}\n{accumulated_text}"

--- a/src/stream_parser.py
+++ b/src/stream_parser.py
@@ -127,6 +127,40 @@ class _CodexUsageExtractor(_UsageExtractor):
         return str(event.get("type", "")) in {"turn.completed", "result"}
 
 
+class _GeminiUsageExtractor(_UsageExtractor):
+    backend = "gemini"
+    _EVENT_TYPES = {"init", "message", "tool_use", "tool_result", "result"}
+
+    def extract(
+        self, event: dict[str, Any]
+    ) -> tuple[dict[str, int], list[dict[str, Any]]]:
+        if str(event.get("type", "")) not in self._EVENT_TYPES:
+            return {}, []
+        totals: dict[str, int] = {}
+        raw: list[dict[str, Any]] = []
+
+        # The result event carries final stats: {total, input, output, cached, ...}
+        stats_obj = event.get("stats")
+        if isinstance(stats_obj, dict):
+            mapped = _map_usage_payload(stats_obj)
+            if mapped:
+                totals.update(mapped)
+            raw.append(
+                {
+                    "backend": self.backend,
+                    "event_type": str(event.get("type", "")),
+                    "path": "stats",
+                    "payload": stats_obj,
+                }
+            )
+        return totals, raw
+
+    def is_final_event(self, event: dict[str, Any]) -> bool:
+        return str(event.get("type", "")) == "result" and isinstance(
+            event.get("stats"), dict
+        )
+
+
 class _PiUsageExtractor(_UsageExtractor):
     backend = "pi"
     _EVENT_TYPES = {
@@ -237,13 +271,28 @@ class StreamParser:
         if event_type == "assistant":
             display = self._parse_assistant(event)
         elif event_type == "result":
-            result = event.get("result", "")
+            # Disambiguate claude vs gemini result events by payload shape.
+            if isinstance(event.get("stats"), dict) and not isinstance(
+                event.get("result"), str
+            ):
+                result = self._last_result_text
+            else:
+                result = event.get("result", "")
         elif event_type == "user":
             display = self._parse_user(event)
         elif event_type == "item.completed":
             display = self._parse_codex_item(event)
         elif event_type == "turn.completed":
             result = self._last_result_text
+        elif event_type == "init":
+            # Gemini session meta — no transcript line, just lock backend.
+            display = ""
+        elif event_type == "message":
+            display = self._parse_gemini_message(event)
+        elif event_type == "tool_use":
+            display = self._parse_gemini_tool_use(event)
+        elif event_type == "tool_result":
+            display = self._parse_gemini_tool_result(event)
         elif event_type == "message_update":
             display = self._parse_pi_message_update(event)
         elif event_type == "message_end":
@@ -369,6 +418,39 @@ class StreamParser:
             return f"  → {item_type}"
         return ""
 
+    def _parse_gemini_message(self, event: dict[str, Any]) -> str:
+        """Parse a Gemini message event (role=user|assistant, delta?)."""
+        role = event.get("role", "")
+        content = str(event.get("content", ""))
+        if role != "assistant" or not content:
+            return ""
+        # Assistant deltas accumulate into _last_result_text so the final
+        # `result` event can emit the full message as transcript output.
+        self._last_result_text += content
+        return content
+
+    def _parse_gemini_tool_use(self, event: dict[str, Any]) -> str:
+        """Parse a Gemini tool_use event into a transcript line."""
+        tool_id = event.get("tool_id", "")
+        if tool_id and tool_id in self._seen_tool_ids:
+            return ""
+        if tool_id:
+            self._seen_tool_ids.add(tool_id)
+        name = str(event.get("tool_name", "?"))
+        params = event.get("parameters", {})
+        if not isinstance(params, dict):
+            params = {}
+        return f"  → {name}: {_summarize_input(name, params)}"
+
+    def _parse_gemini_tool_result(self, event: dict[str, Any]) -> str:
+        """Parse a Gemini tool_result event into a brief transcript line."""
+        output = event.get("output", "")
+        status = str(event.get("status", ""))
+        if isinstance(output, str) and output.strip():
+            preview = output.strip().replace("\n", " ")[:80]
+            return f"    ← {preview}{'…' if len(output.strip()) > 80 else ''}"
+        return f"    ← ({status or 'done'})"
+
     def _parse_pi_message_update(self, event: dict[str, Any]) -> str:
         """Extract text deltas from Pi JSON `message_update` events."""
         update = event.get("assistantMessageEvent", {})
@@ -446,6 +528,13 @@ def _pick_usage_extractor(
     current: _UsageExtractor, event: dict[str, Any]
 ) -> _UsageExtractor:
     event_type = str(event.get("type", ""))
+    # Gemini's `init` is unique — lock the backend as soon as we see it.
+    if event_type == "init":
+        return _GeminiUsageExtractor()
+    # Once gemini is locked, keep it — gemini's other event types overlap with
+    # claude's ("result", "message").
+    if isinstance(current, _GeminiUsageExtractor):
+        return current
     if event_type in {
         "message_update",
         "message_end",
@@ -523,6 +612,7 @@ def _canonical_usage_key(raw_key: str) -> str:
         "cache_read_tokens",
         "cached_tokens",
         "cached_input_tokens",
+        "cached",
         "cachereadinputtokens",
         "cacheread",
     }:
@@ -546,7 +636,7 @@ def _summarize_input(name: str, tool_input: dict[str, Any]) -> str:  # noqa: PLR
         pattern = tool_input.get("pattern", "")
         path = tool_input.get("path", ".")
         return f"/{pattern}/ in {path}"[:120]
-    if name in ("Bash", "bash"):
+    if name in ("Bash", "bash", "run_shell_command"):
         return tool_input.get("command", str(tool_input))[:120]
     if name in ("Task", "task"):
         desc = tool_input.get("description", "")

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -190,6 +190,10 @@ _DOCKER_ENV_PASSTHROUGH_KEYS = (
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
     "GOOGLE_GENERATIVE_AI_API_KEY",
+    # Gemini auth-method selection / Vertex project for non-API-key flows
+    "GOOGLE_GENAI_USE_VERTEXAI",
+    "GOOGLE_GENAI_USE_GCA",
+    "GOOGLE_CLOUD_PROJECT",
     "XAI_API_KEY",
     "DEEPSEEK_API_KEY",
     "MISTRAL_API_KEY",

--- a/tests/test_activity_parser_gemini.py
+++ b/tests/test_activity_parser_gemini.py
@@ -73,7 +73,7 @@ def test_gemini_short_delta_returns_none() -> None:
 
 def test_gemini_init_event_returns_none() -> None:
     parser = GeminiActivityParser()
-    raw = json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+    raw = json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
     assert parser.parse(raw) is None
 
 

--- a/tests/test_activity_parser_gemini.py
+++ b/tests/test_activity_parser_gemini.py
@@ -89,3 +89,20 @@ def test_gemini_dedups_tool_use_by_id() -> None:
     )
     assert parser.parse(raw) is not None
     assert parser.parse(raw) is None  # dedup
+
+
+def test_gemini_tool_result_handles_missing_output() -> None:
+    """Live Gemini runs sometimes emit tool_result without an `output` field."""
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "tool_result",
+            "tool_id": "t1",
+            "status": "success",
+        }
+    )
+    activity = parser.parse(raw)
+    assert activity is not None
+    assert activity["activity_type"] == "tool_result"
+    # Falls back to status for the preview
+    assert "success" in activity["summary"]

--- a/tests/test_activity_parser_gemini.py
+++ b/tests/test_activity_parser_gemini.py
@@ -1,0 +1,91 @@
+"""Tests for the Gemini activity parser."""
+
+from __future__ import annotations
+
+import json
+
+from activity_parser import GeminiActivityParser, get_activity_parser
+
+
+def test_gemini_parser_registered_in_dispatch() -> None:
+    parser = get_activity_parser("gemini")
+    assert isinstance(parser, GeminiActivityParser)
+
+
+def test_gemini_tool_use_emits_tool_call_activity() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "tool_use",
+            "tool_name": "run_shell_command",
+            "tool_id": "t1",
+            "parameters": {"command": "ls"},
+        }
+    )
+    activity = parser.parse(raw)
+    assert activity is not None
+    assert activity["activity_type"] == "tool_call"
+    assert activity["tool_name"] == "run_shell_command"
+
+
+def test_gemini_tool_result_emits_tool_result_activity() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "tool_result",
+            "tool_id": "t1",
+            "status": "success",
+            "output": "file1.txt\nfile2.txt",
+        }
+    )
+    activity = parser.parse(raw)
+    assert activity is not None
+    assert activity["activity_type"] == "tool_result"
+
+
+def test_gemini_assistant_delta_emits_text_when_long_enough() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "This is a long enough delta to pass the threshold.",
+            "delta": True,
+        }
+    )
+    activity = parser.parse(raw)
+    assert activity is not None
+    assert activity["activity_type"] == "text"
+
+
+def test_gemini_short_delta_returns_none() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": "hi",
+            "delta": True,
+        }
+    )
+    assert parser.parse(raw) is None
+
+
+def test_gemini_init_event_returns_none() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+    assert parser.parse(raw) is None
+
+
+def test_gemini_dedups_tool_use_by_id() -> None:
+    parser = GeminiActivityParser()
+    raw = json.dumps(
+        {
+            "type": "tool_use",
+            "tool_name": "Read",
+            "tool_id": "t1",
+            "parameters": {"file_path": "/x"},
+        }
+    )
+    assert parser.parse(raw) is not None
+    assert parser.parse(raw) is None  # dedup

--- a/tests/test_activity_parser_gemini.py
+++ b/tests/test_activity_parser_gemini.py
@@ -73,7 +73,9 @@ def test_gemini_short_delta_returns_none() -> None:
 
 def test_gemini_init_event_returns_none() -> None:
     parser = GeminiActivityParser()
-    raw = json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
+    raw = json.dumps(
+        {"type": "init", "session_id": "x", "model": "gemini-3.1-pro-preview"}
+    )
     assert parser.parse(raw) is None
 
 

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -1448,6 +1448,7 @@ class TestExecuteOrchestrator:
         config = ConfigFactory.create(
             repo_root=tmp_path / "repo",
             background_tool="codex",
+            background_model="gpt-5-codex",
         )
         from events import EventBus
 

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,4 +1,4 @@
-"""Tests for agent_cli.py — CLI command builders for Claude, Codex, and Pi."""
+"""Tests for agent_cli.py — CLI command builders for Claude, Codex, Gemini, and Pi."""
 
 from __future__ import annotations
 

--- a/tests/test_agent_cli_gemini.py
+++ b/tests/test_agent_cli_gemini.py
@@ -51,3 +51,5 @@ def test_build_lightweight_command_gemini_uses_stdin_for_large_prompt() -> None:
     assert "-p" in cmd
     p_idx = cmd.index("-p")
     assert cmd[p_idx + 1] == "-"
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"

--- a/tests/test_agent_cli_gemini.py
+++ b/tests/test_agent_cli_gemini.py
@@ -6,20 +6,20 @@ from agent_cli import build_agent_command, build_lightweight_command
 
 
 def test_build_agent_command_gemini_base_flags() -> None:
-    cmd = build_agent_command(tool="gemini", model="gemini-3-pro")
+    cmd = build_agent_command(tool="gemini", model="gemini-2.5-pro")
     assert cmd[0] == "gemini"
     assert "-p" in cmd
     assert "--output-format" in cmd
     assert cmd[cmd.index("--output-format") + 1] == "stream-json"
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"
     assert "--approval-mode" in cmd
     assert cmd[cmd.index("--approval-mode") + 1] == "yolo"
 
 
 def test_build_agent_command_gemini_has_no_prompt_value() -> None:
     """`-p` must be present without an inline value; runner splices the prompt."""
-    cmd = build_agent_command(tool="gemini", model="gemini-3-pro")
+    cmd = build_agent_command(tool="gemini", model="gemini-2.5-pro")
     p_idx = cmd.index("-p")
     assert cmd[p_idx + 1].startswith("--"), (
         "prompt must not be baked in; runner splices it after -p"
@@ -29,14 +29,14 @@ def test_build_agent_command_gemini_has_no_prompt_value() -> None:
 def test_build_lightweight_command_gemini_passes_prompt_after_p() -> None:
     cmd, stdin_bytes = build_lightweight_command(
         tool="gemini",
-        model="gemini-3-pro",
+        model="gemini-2.5-pro",
         prompt="hello world",
     )
     assert cmd[0] == "gemini"
     p_idx = cmd.index("-p")
     assert cmd[p_idx + 1] == "hello world"
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"
     assert stdin_bytes is None
 
 
@@ -44,12 +44,14 @@ def test_build_lightweight_command_gemini_uses_stdin_for_large_prompt() -> None:
     huge = "x" * 150_000  # > 100 KB threshold
     cmd, stdin_bytes = build_lightweight_command(
         tool="gemini",
-        model="gemini-3-pro",
+        model="gemini-2.5-pro",
         prompt=huge,
     )
     assert stdin_bytes == huge.encode()
     assert "-p" in cmd
     p_idx = cmd.index("-p")
-    assert cmd[p_idx + 1] == "-"
+    # Gemini appends stdin to the -p value, so we pass an empty string
+    # rather than the claude-style "-" which would leak into the prompt.
+    assert cmd[p_idx + 1] == ""
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"

--- a/tests/test_agent_cli_gemini.py
+++ b/tests/test_agent_cli_gemini.py
@@ -1,0 +1,53 @@
+"""Tests for the Gemini CLI command builder."""
+
+from __future__ import annotations
+
+from agent_cli import build_agent_command, build_lightweight_command
+
+
+def test_build_agent_command_gemini_base_flags() -> None:
+    cmd = build_agent_command(tool="gemini", model="gemini-3-pro")
+    assert cmd[0] == "gemini"
+    assert "-p" in cmd
+    assert "--output-format" in cmd
+    assert cmd[cmd.index("--output-format") + 1] == "stream-json"
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"
+    assert "--approval-mode" in cmd
+    assert cmd[cmd.index("--approval-mode") + 1] == "yolo"
+
+
+def test_build_agent_command_gemini_has_no_prompt_value() -> None:
+    """`-p` must be present without an inline value; runner splices the prompt."""
+    cmd = build_agent_command(tool="gemini", model="gemini-3-pro")
+    p_idx = cmd.index("-p")
+    assert cmd[p_idx + 1].startswith("--"), (
+        "prompt must not be baked in; runner splices it after -p"
+    )
+
+
+def test_build_lightweight_command_gemini_passes_prompt_after_p() -> None:
+    cmd, stdin_bytes = build_lightweight_command(
+        tool="gemini",
+        model="gemini-3-pro",
+        prompt="hello world",
+    )
+    assert cmd[0] == "gemini"
+    p_idx = cmd.index("-p")
+    assert cmd[p_idx + 1] == "hello world"
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "gemini-3-pro"
+    assert stdin_bytes is None
+
+
+def test_build_lightweight_command_gemini_uses_stdin_for_large_prompt() -> None:
+    huge = "x" * 150_000  # > 100 KB threshold
+    cmd, stdin_bytes = build_lightweight_command(
+        tool="gemini",
+        model="gemini-3-pro",
+        prompt=huge,
+    )
+    assert stdin_bytes == huge.encode()
+    assert "-p" in cmd
+    p_idx = cmd.index("-p")
+    assert cmd[p_idx + 1] == "-"

--- a/tests/test_agent_cli_gemini.py
+++ b/tests/test_agent_cli_gemini.py
@@ -6,20 +6,20 @@ from agent_cli import build_agent_command, build_lightweight_command
 
 
 def test_build_agent_command_gemini_base_flags() -> None:
-    cmd = build_agent_command(tool="gemini", model="gemini-2.5-pro")
+    cmd = build_agent_command(tool="gemini", model="gemini-3.1-pro-preview")
     assert cmd[0] == "gemini"
     assert "-p" in cmd
     assert "--output-format" in cmd
     assert cmd[cmd.index("--output-format") + 1] == "stream-json"
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-3.1-pro-preview"
     assert "--approval-mode" in cmd
     assert cmd[cmd.index("--approval-mode") + 1] == "yolo"
 
 
 def test_build_agent_command_gemini_has_no_prompt_value() -> None:
     """`-p` must be present without an inline value; runner splices the prompt."""
-    cmd = build_agent_command(tool="gemini", model="gemini-2.5-pro")
+    cmd = build_agent_command(tool="gemini", model="gemini-3.1-pro-preview")
     p_idx = cmd.index("-p")
     assert cmd[p_idx + 1].startswith("--"), (
         "prompt must not be baked in; runner splices it after -p"
@@ -29,14 +29,14 @@ def test_build_agent_command_gemini_has_no_prompt_value() -> None:
 def test_build_lightweight_command_gemini_passes_prompt_after_p() -> None:
     cmd, stdin_bytes = build_lightweight_command(
         tool="gemini",
-        model="gemini-2.5-pro",
+        model="gemini-3.1-pro-preview",
         prompt="hello world",
     )
     assert cmd[0] == "gemini"
     p_idx = cmd.index("-p")
     assert cmd[p_idx + 1] == "hello world"
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-3.1-pro-preview"
     assert stdin_bytes is None
 
 
@@ -44,7 +44,7 @@ def test_build_lightweight_command_gemini_uses_stdin_for_large_prompt() -> None:
     huge = "x" * 150_000  # > 100 KB threshold
     cmd, stdin_bytes = build_lightweight_command(
         tool="gemini",
-        model="gemini-2.5-pro",
+        model="gemini-3.1-pro-preview",
         prompt=huge,
     )
     assert stdin_bytes == huge.encode()
@@ -54,4 +54,4 @@ def test_build_lightweight_command_gemini_uses_stdin_for_large_prompt() -> None:
     # rather than the claude-style "-" which would leak into the prompt.
     assert cmd[p_idx + 1] == ""
     assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "gemini-2.5-pro"
+    assert cmd[cmd.index("--model") + 1] == "gemini-3.1-pro-preview"

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import os
+from unittest.mock import patch
+
 import pytest
 from pydantic import ValidationError
 
-from config import HydraFlowConfig
+from config import HydraFlowConfig, _parse_combo
 
 
 def test_triage_tool_accepts_gemini() -> None:
@@ -27,3 +30,74 @@ def test_system_tool_accepts_gemini() -> None:
 def test_invalid_tool_rejected() -> None:
     with pytest.raises(ValidationError):
         HydraFlowConfig(triage_tool="bogus")
+
+
+def test_parse_combo_basic() -> None:
+    assert _parse_combo("HYDRAFLOW_IMPLEMENT", "claude:opus") == ("claude", "opus")
+
+
+def test_parse_combo_gemini() -> None:
+    assert _parse_combo("HYDRAFLOW_TRIAGE", "gemini:gemini-3-pro") == (
+        "gemini",
+        "gemini-3-pro",
+    )
+
+
+def test_parse_combo_inherit() -> None:
+    assert _parse_combo("HYDRAFLOW_SYSTEM", "inherit") == ("inherit", "")
+
+
+def test_parse_combo_missing_colon_raises() -> None:
+    with pytest.raises(ValueError, match="must be 'tool:model'"):
+        _parse_combo("HYDRAFLOW_IMPLEMENT", "claude-opus")
+
+
+def test_parse_combo_unknown_tool_raises() -> None:
+    with pytest.raises(ValueError, match="unknown tool"):
+        _parse_combo("HYDRAFLOW_IMPLEMENT", "bogus:opus")
+
+
+def test_parse_combo_empty_model_raises() -> None:
+    with pytest.raises(ValueError, match="model part is empty"):
+        _parse_combo("HYDRAFLOW_IMPLEMENT", "claude:")
+
+
+def test_combo_env_sets_triage_tool_and_model() -> None:
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_TRIAGE": "gemini:gemini-3-pro"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.triage_tool == "gemini"
+        assert cfg.triage_model == "gemini-3-pro"
+
+
+def test_combo_env_sets_implementation_tool_and_model() -> None:
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_IMPLEMENT": "codex:gpt-5-codex"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.implementation_tool == "codex"
+        assert cfg.model == "gpt-5-codex"
+
+
+def test_combo_env_review_and_planner() -> None:
+    with patch.dict(
+        os.environ,
+        {
+            "HYDRAFLOW_REVIEW": "claude:sonnet",
+            "HYDRAFLOW_PLANNER": "claude:opus",
+        },
+        clear=False,
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.review_tool == "claude"
+        assert cfg.review_model == "sonnet"
+        assert cfg.planner_tool == "claude"
+        assert cfg.planner_model == "opus"
+
+
+def test_combo_env_system_inherit() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_SYSTEM": "inherit"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.system_tool == "inherit"
+        assert cfg.system_model == ""

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -1,0 +1,29 @@
+"""Tests for the HydraFlowConfig combo env var restructure."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from config import HydraFlowConfig
+
+
+def test_triage_tool_accepts_gemini() -> None:
+    cfg = HydraFlowConfig(triage_tool="gemini", triage_model="gemini-3-pro")
+    assert cfg.triage_tool == "gemini"
+    assert cfg.triage_model == "gemini-3-pro"
+
+
+def test_implementation_tool_accepts_gemini() -> None:
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3-pro")
+    assert cfg.implementation_tool == "gemini"
+
+
+def test_system_tool_accepts_gemini() -> None:
+    cfg = HydraFlowConfig(system_tool="gemini")
+    assert cfg.system_tool == "gemini"
+
+
+def test_invalid_tool_rejected() -> None:
+    with pytest.raises(ValidationError):
+        HydraFlowConfig(triage_tool="bogus")

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -177,3 +177,9 @@ def test_harmonize_allows_gemini_pro() -> None:
 def test_harmonize_allows_codex_gpt() -> None:
     cfg = HydraFlowConfig(implementation_tool="codex", model="gpt-5-codex")
     assert cfg.model == "gpt-5-codex"
+
+
+def test_triage_defaults_to_gemini_pro() -> None:
+    cfg = HydraFlowConfig()
+    assert cfg.triage_tool == "gemini"
+    assert cfg.triage_model == "gemini-3-pro"

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -12,18 +12,18 @@ from config import HydraFlowConfig, _parse_combo
 
 
 def test_triage_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(triage_tool="gemini", triage_model="gemini-2.5-pro")
+    cfg = HydraFlowConfig(triage_tool="gemini", triage_model="gemini-3.1-pro-preview")
     assert cfg.triage_tool == "gemini"
-    assert cfg.triage_model == "gemini-2.5-pro"
+    assert cfg.triage_model == "gemini-3.1-pro-preview"
 
 
 def test_implementation_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-2.5-pro")
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3.1-pro-preview")
     assert cfg.implementation_tool == "gemini"
 
 
 def test_system_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(system_tool="gemini", system_model="gemini-2.5-pro")
+    cfg = HydraFlowConfig(system_tool="gemini", system_model="gemini-3.1-pro-preview")
     assert cfg.system_tool == "gemini"
 
 
@@ -37,9 +37,9 @@ def test_parse_combo_basic() -> None:
 
 
 def test_parse_combo_gemini() -> None:
-    assert _parse_combo("HYDRAFLOW_TRIAGE", "gemini:gemini-2.5-pro") == (
+    assert _parse_combo("HYDRAFLOW_TRIAGE", "gemini:gemini-3.1-pro-preview") == (
         "gemini",
-        "gemini-2.5-pro",
+        "gemini-3.1-pro-preview",
     )
 
 
@@ -64,11 +64,11 @@ def test_parse_combo_empty_model_raises() -> None:
 
 def test_combo_env_sets_triage_tool_and_model() -> None:
     with patch.dict(
-        os.environ, {"HYDRAFLOW_TRIAGE": "gemini:gemini-2.5-pro"}, clear=False
+        os.environ, {"HYDRAFLOW_TRIAGE": "gemini:gemini-3.1-pro-preview"}, clear=False
     ):
         cfg = HydraFlowConfig()
         assert cfg.triage_tool == "gemini"
-        assert cfg.triage_model == "gemini-2.5-pro"
+        assert cfg.triage_model == "gemini-3.1-pro-preview"
 
 
 def test_combo_env_sets_implementation_tool_and_model() -> None:
@@ -170,8 +170,8 @@ def test_harmonize_allows_claude_opus() -> None:
 
 
 def test_harmonize_allows_gemini_pro() -> None:
-    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-2.5-pro")
-    assert cfg.model == "gemini-2.5-pro"
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3.1-pro-preview")
+    assert cfg.model == "gemini-3.1-pro-preview"
 
 
 def test_harmonize_allows_codex_gpt() -> None:
@@ -182,4 +182,4 @@ def test_harmonize_allows_codex_gpt() -> None:
 def test_triage_defaults_to_gemini_pro() -> None:
     cfg = HydraFlowConfig()
     assert cfg.triage_tool == "gemini"
-    assert cfg.triage_model == "gemini-2.5-pro"
+    assert cfg.triage_model == "gemini-3.1-pro-preview"

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -12,18 +12,18 @@ from config import HydraFlowConfig, _parse_combo
 
 
 def test_triage_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(triage_tool="gemini", triage_model="gemini-3-pro")
+    cfg = HydraFlowConfig(triage_tool="gemini", triage_model="gemini-2.5-pro")
     assert cfg.triage_tool == "gemini"
-    assert cfg.triage_model == "gemini-3-pro"
+    assert cfg.triage_model == "gemini-2.5-pro"
 
 
 def test_implementation_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3-pro")
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-2.5-pro")
     assert cfg.implementation_tool == "gemini"
 
 
 def test_system_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(system_tool="gemini", system_model="gemini-3-pro")
+    cfg = HydraFlowConfig(system_tool="gemini", system_model="gemini-2.5-pro")
     assert cfg.system_tool == "gemini"
 
 
@@ -37,9 +37,9 @@ def test_parse_combo_basic() -> None:
 
 
 def test_parse_combo_gemini() -> None:
-    assert _parse_combo("HYDRAFLOW_TRIAGE", "gemini:gemini-3-pro") == (
+    assert _parse_combo("HYDRAFLOW_TRIAGE", "gemini:gemini-2.5-pro") == (
         "gemini",
-        "gemini-3-pro",
+        "gemini-2.5-pro",
     )
 
 
@@ -64,11 +64,11 @@ def test_parse_combo_empty_model_raises() -> None:
 
 def test_combo_env_sets_triage_tool_and_model() -> None:
     with patch.dict(
-        os.environ, {"HYDRAFLOW_TRIAGE": "gemini:gemini-3-pro"}, clear=False
+        os.environ, {"HYDRAFLOW_TRIAGE": "gemini:gemini-2.5-pro"}, clear=False
     ):
         cfg = HydraFlowConfig()
         assert cfg.triage_tool == "gemini"
-        assert cfg.triage_model == "gemini-3-pro"
+        assert cfg.triage_model == "gemini-2.5-pro"
 
 
 def test_combo_env_sets_implementation_tool_and_model() -> None:
@@ -170,8 +170,8 @@ def test_harmonize_allows_claude_opus() -> None:
 
 
 def test_harmonize_allows_gemini_pro() -> None:
-    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3-pro")
-    assert cfg.model == "gemini-3-pro"
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-2.5-pro")
+    assert cfg.model == "gemini-2.5-pro"
 
 
 def test_harmonize_allows_codex_gpt() -> None:
@@ -182,4 +182,4 @@ def test_harmonize_allows_codex_gpt() -> None:
 def test_triage_defaults_to_gemini_pro() -> None:
     cfg = HydraFlowConfig()
     assert cfg.triage_tool == "gemini"
-    assert cfg.triage_model == "gemini-3-pro"
+    assert cfg.triage_model == "gemini-2.5-pro"

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -101,3 +101,41 @@ def test_combo_env_system_inherit() -> None:
         cfg = HydraFlowConfig()
         assert cfg.system_tool == "inherit"
         assert cfg.system_model == ""
+
+
+def test_legacy_triage_tool_env_var_is_ignored() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_TRIAGE_TOOL": "codex"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.triage_tool == HydraFlowConfig.model_fields["triage_tool"].default
+
+
+def test_legacy_model_env_var_is_ignored() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_MODEL": "gpt-5-codex"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.model == HydraFlowConfig.model_fields["model"].default
+
+
+def test_legacy_label_env_var_is_ignored() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_LABEL_READY": "custom-ready"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.ready_label == HydraFlowConfig.model_fields["ready_label"].default
+
+
+def test_legacy_max_subskill_attempts_env_var_is_ignored() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS": "5"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert (
+            cfg.max_subskill_attempts
+            == HydraFlowConfig.model_fields["max_subskill_attempts"].default
+        )
+
+
+def test_legacy_debug_escalation_env_var_is_ignored() -> None:
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_DEBUG_ESCALATION_ENABLED": "false"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        assert (
+            cfg.debug_escalation_enabled
+            == HydraFlowConfig.model_fields["debug_escalation_enabled"].default
+        )

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -23,7 +23,7 @@ def test_implementation_tool_accepts_gemini() -> None:
 
 
 def test_system_tool_accepts_gemini() -> None:
-    cfg = HydraFlowConfig(system_tool="gemini")
+    cfg = HydraFlowConfig(system_tool="gemini", system_model="gemini-3-pro")
     assert cfg.system_tool == "gemini"
 
 
@@ -139,3 +139,41 @@ def test_legacy_debug_escalation_env_var_is_ignored() -> None:
             cfg.debug_escalation_enabled
             == HydraFlowConfig.model_fields["debug_escalation_enabled"].default
         )
+
+
+def test_harmonize_rejects_gemini_flash_model() -> None:
+    with pytest.raises(ValueError, match="flash"):
+        HydraFlowConfig(
+            implementation_tool="gemini",
+            model="gemini-3-flash-preview",
+        )
+
+
+def test_harmonize_rejects_flash_in_triage() -> None:
+    with pytest.raises(ValueError, match="flash"):
+        HydraFlowConfig(triage_tool="gemini", triage_model="gemini-3-flash-preview")
+
+
+def test_harmonize_rejects_claude_model_on_gemini_tool() -> None:
+    with pytest.raises(ValueError, match="mismatched"):
+        HydraFlowConfig(implementation_tool="gemini", model="opus")
+
+
+def test_harmonize_rejects_codex_model_on_claude_tool() -> None:
+    with pytest.raises(ValueError, match="mismatched"):
+        HydraFlowConfig(implementation_tool="claude", model="gpt-5-codex")
+
+
+def test_harmonize_allows_claude_opus() -> None:
+    cfg = HydraFlowConfig(implementation_tool="claude", model="opus")
+    assert cfg.model == "opus"
+
+
+def test_harmonize_allows_gemini_pro() -> None:
+    cfg = HydraFlowConfig(implementation_tool="gemini", model="gemini-3-pro")
+    assert cfg.model == "gemini-3-pro"
+
+
+def test_harmonize_allows_codex_gpt() -> None:
+    cfg = HydraFlowConfig(implementation_tool="codex", model="gpt-5-codex")
+    assert cfg.model == "gpt-5-codex"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -365,17 +365,6 @@ class TestHydraFlowConfigGitIdentity(GitIdentityEnvMixin):
 class TestHydraFlowConfigHitlActiveLabel:
     """Tests for hitl_active_label env var override."""
 
-    def test_hitl_active_label_env_var_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_LABEL_HITL_ACTIVE", "custom-active")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            workspace_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.hitl_active_label == ["custom-active"]
-
     def test_hitl_active_label_env_var_not_applied_when_explicit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -414,17 +403,6 @@ class TestHydraFlowConfigDupLabel:
         )
         assert cfg.dup_label == ["my-dup"]
 
-    def test_dup_label_env_var_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_LABEL_DUP", "custom-dup")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            workspace_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.dup_label == ["custom-dup"]
-
     def test_dup_label_env_var_not_applied_when_explicit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -457,17 +435,6 @@ class TestHydraFlowConfigEpicChildLabel:
             state_file=tmp_path / "s.json",
         )
         assert cfg.epic_child_label == ["my-epic-child"]
-
-    def test_epic_child_label_env_var_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_LABEL_EPIC_CHILD", "custom-epic-child")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            workspace_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.epic_child_label == ["custom-epic-child"]
 
     def test_epic_child_label_env_var_not_applied_when_explicit(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -1102,17 +1069,6 @@ class TestTranscriptSummarizationConfig:
         )
         assert cfg.transcript_summarization_enabled is False
 
-    def test_env_var_model_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL", "sonnet")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            workspace_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.transcript_summary_model == "sonnet"
-
     def test_env_var_max_chars_override(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -1221,18 +1177,6 @@ class TestLabelValidation:
             state_file=tmp_path / "s.json",
         )
         assert cfg.verify_label == ["hydraflow-verify"]
-
-    def test_verify_label_env_override(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """HYDRAFLOW_LABEL_VERIFY should override verify_label."""
-        monkeypatch.setenv("HYDRAFLOW_LABEL_VERIFY", "custom-verify")
-        cfg = HydraFlowConfig(
-            repo_root=tmp_path,
-            workspace_base=tmp_path / "wt",
-            state_file=tmp_path / "s.json",
-        )
-        assert cfg.verify_label == ["custom-verify"]
 
     def test_verify_label_in_all_pipeline_labels(self, tmp_path: Path) -> None:
         """verify_label should appear in all_pipeline_labels."""
@@ -1676,13 +1620,14 @@ class TestAgentToolFields:
     def test_tool_env_overrides(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_IMPLEMENTATION_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_REVIEW_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_PLANNER_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_TRIAGE_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_AC_TOOL", "codex")
-        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE_TOOL", "codex")
+        # Legacy HYDRAFLOW_*_TOOL vars are gone; use combo syntax instead.
+        monkeypatch.setenv("HYDRAFLOW_IMPLEMENT", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_REVIEW", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_PLANNER", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_TRIAGE", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_AC", "codex:gpt-5-codex")
+        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE", "codex:gpt-5-codex")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",
@@ -1700,17 +1645,18 @@ class TestAgentToolFields:
     def test_tool_env_overrides_accept_pi(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("HYDRAFLOW_IMPLEMENTATION_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_REVIEW_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_PLANNER_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_TRIAGE_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_AC_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_SUBSKILL_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_DEBUG_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_SYSTEM_TOOL", "pi")
-        monkeypatch.setenv("HYDRAFLOW_BACKGROUND_TOOL", "pi")
+        # Legacy HYDRAFLOW_*_TOOL vars are gone; use combo syntax instead.
+        # Note: subskill_tool and debug_tool have no dedicated combo var;
+        # they are set via system_tool profile propagation.
+        monkeypatch.setenv("HYDRAFLOW_IMPLEMENT", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_REVIEW", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_PLANNER", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_TRIAGE", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_AC", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_SYSTEM", "pi:pi-model")
+        monkeypatch.setenv("HYDRAFLOW_BACKGROUND", "pi:pi-model")
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",
@@ -1723,8 +1669,6 @@ class TestAgentToolFields:
         assert cfg.transcript_summary_tool == "pi"
         assert cfg.ac_tool == "pi"
         assert cfg.verification_judge_tool == "pi"
-        assert cfg.subskill_tool == "pi"
-        assert cfg.debug_tool == "pi"
         assert cfg.system_tool == "pi"
         assert cfg.background_tool == "pi"
 

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1627,7 +1627,7 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_TRIAGE", "codex:gpt-5-codex")
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY", "codex:gpt-5-codex")
         monkeypatch.setenv("HYDRAFLOW_AC", "codex:gpt-5-codex")
-        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE", "codex:gpt-5-codex")
+        # verification_judge has no env var — it auto-syncs to review_tool.
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",
@@ -1654,7 +1654,7 @@ class TestAgentToolFields:
         monkeypatch.setenv("HYDRAFLOW_TRIAGE", "pi:pi-model")
         monkeypatch.setenv("HYDRAFLOW_TRANSCRIPT_SUMMARY", "pi:pi-model")
         monkeypatch.setenv("HYDRAFLOW_AC", "pi:pi-model")
-        monkeypatch.setenv("HYDRAFLOW_VERIFICATION_JUDGE", "pi:pi-model")
+        # verification_judge has no env var — it auto-syncs to review_tool.
         monkeypatch.setenv("HYDRAFLOW_SYSTEM", "pi:pi-model")
         monkeypatch.setenv("HYDRAFLOW_BACKGROUND", "pi:pi-model")
         cfg = HydraFlowConfig(

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1610,7 +1610,7 @@ class TestAgentToolFields:
         assert cfg.implementation_tool == "claude"
         assert cfg.review_tool == "claude"
         assert cfg.planner_tool == "claude"
-        assert cfg.triage_tool == "claude"
+        assert cfg.triage_tool == "gemini"
         assert cfg.transcript_summary_tool == "claude"
         assert cfg.ac_tool == "claude"
         assert cfg.verification_judge_tool == "claude"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1678,7 +1678,9 @@ class TestAgentToolFields:
             workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
             system_tool="codex",
+            system_model="gpt-5-codex",
             background_tool="codex",
+            background_model="gpt-5-codex",
         )
         assert cfg.implementation_tool == "codex"
         assert cfg.model == "gpt-5-codex"
@@ -1696,7 +1698,9 @@ class TestAgentToolFields:
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",
             state_file=tmp_path / "s.json",
+            system_tool="codex",
             system_model="gpt-5-codex",
+            background_tool="codex",
             background_model="gpt-5-codex",
         )
         assert cfg.model == "gpt-5-codex"

--- a/tests/test_runner_utils_gemini.py
+++ b/tests/test_runner_utils_gemini.py
@@ -53,7 +53,7 @@ def test_route_prompt_splices_after_p_for_gemini() -> None:
         "--output-format",
         "stream-json",
         "--model",
-        "gemini-3-pro",
+        "gemini-2.5-pro",
     ]
     cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, "do the thing")
 
@@ -83,7 +83,7 @@ class TestGeminiIntegration:
             "--output-format",
             "stream-json",
             "--model",
-            "gemini-3-pro",
+            "gemini-2.5-pro",
         ]
         prompt = "do the thing"
 

--- a/tests/test_runner_utils_gemini.py
+++ b/tests/test_runner_utils_gemini.py
@@ -3,12 +3,47 @@
 from __future__ import annotations
 
 import asyncio
-import sys
+import logging
 from pathlib import Path
+from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).parent.parent))
+import pytest
 
-from runner_utils import _route_prompt_to_cmd
+from runner_utils import StreamConfig, _route_prompt_to_cmd, stream_claude_process
+from tests.helpers import make_streaming_proc
+
+
+def _default_kwargs(event_bus, **overrides):
+    """Build default kwargs for stream_claude_process.
+
+    Keys that belong on :class:`StreamConfig` (``on_output``, ``timeout``,
+    ``runner``, ``usage_stats``, ``gh_token``, ``trace_collector``) are
+    extracted and bundled into a ``config`` kwarg automatically.
+    """
+    _CONFIG_KEYS = {
+        "on_output",
+        "timeout",
+        "runner",
+        "usage_stats",
+        "gh_token",
+        "trace_collector",
+    }
+    config_overrides = {
+        k: overrides.pop(k) for k in list(overrides) if k in _CONFIG_KEYS
+    }
+    defaults = {
+        "cmd": ["claude", "-p"],
+        "prompt": "test prompt",
+        "cwd": Path("/tmp/test"),
+        "active_procs": set(),
+        "event_bus": event_bus,
+        "event_data": {"issue": 1},
+        "logger": logging.getLogger("test"),
+    }
+    defaults.update(overrides)
+    if config_overrides:
+        defaults["config"] = StreamConfig(**config_overrides)
+    return defaults
 
 
 def test_route_prompt_splices_after_p_for_gemini() -> None:
@@ -33,3 +68,33 @@ def test_route_prompt_leaves_non_gemini_cmds_alone() -> None:
     cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, "hello")
     assert cmd_to_run == cmd
     assert stdin_mode == asyncio.subprocess.PIPE
+
+
+class TestGeminiIntegration:
+    """Integration tests for gemini prompt passing through stream_claude_process."""
+
+    @pytest.mark.asyncio
+    async def test_gemini_passes_prompt_as_argument(self, event_bus) -> None:
+        """Gemini print mode should insert prompt right after -p."""
+        mock_create = make_streaming_proc(returncode=0, stdout="ok")
+        cmd = [
+            "gemini",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--model",
+            "gemini-3-pro",
+        ]
+        prompt = "do the thing"
+
+        with patch("asyncio.create_subprocess_exec", mock_create) as mock_exec:
+            await stream_claude_process(
+                **_default_kwargs(event_bus, cmd=cmd, prompt=prompt)
+            )
+
+        args = list(mock_exec.call_args[0])
+        kwargs = mock_exec.call_args[1]
+        # Prompt must be immediately after -p for the CLI to recognise it.
+        p_idx = args.index("-p")
+        assert args[p_idx + 1] == prompt
+        assert kwargs["stdin"] == asyncio.subprocess.DEVNULL

--- a/tests/test_runner_utils_gemini.py
+++ b/tests/test_runner_utils_gemini.py
@@ -53,7 +53,7 @@ def test_route_prompt_splices_after_p_for_gemini() -> None:
         "--output-format",
         "stream-json",
         "--model",
-        "gemini-2.5-pro",
+        "gemini-3.1-pro-preview",
     ]
     cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, "do the thing")
 
@@ -83,7 +83,7 @@ class TestGeminiIntegration:
             "--output-format",
             "stream-json",
             "--model",
-            "gemini-2.5-pro",
+            "gemini-3.1-pro-preview",
         ]
         prompt = "do the thing"
 

--- a/tests/test_runner_utils_gemini.py
+++ b/tests/test_runner_utils_gemini.py
@@ -1,0 +1,35 @@
+"""Tests for gemini prompt routing and backend detection in runner_utils."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from runner_utils import _route_prompt_to_cmd
+
+
+def test_route_prompt_splices_after_p_for_gemini() -> None:
+    cmd = [
+        "gemini",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--model",
+        "gemini-3-pro",
+    ]
+    cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, "do the thing")
+
+    p_idx = cmd_to_run.index("-p")
+    assert cmd_to_run[p_idx + 1] == "do the thing"
+    assert cmd_to_run[p_idx + 2] == "--output-format"
+    assert stdin_mode == asyncio.subprocess.DEVNULL
+
+
+def test_route_prompt_leaves_non_gemini_cmds_alone() -> None:
+    cmd = ["pytest", "-v"]
+    cmd_to_run, stdin_mode = _route_prompt_to_cmd(cmd, "hello")
+    assert cmd_to_run == cmd
+    assert stdin_mode == asyncio.subprocess.PIPE

--- a/tests/test_stream_parser_gemini.py
+++ b/tests/test_stream_parser_gemini.py
@@ -1,0 +1,147 @@
+"""Tests for gemini event parsing and usage extraction in stream_parser."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from stream_parser import StreamParser
+
+
+def _parse_lines(parser: StreamParser, events: list[dict]) -> tuple[list[str], str]:
+    displays: list[str] = []
+    final = ""
+    for event in events:
+        display, result = parser.parse(json.dumps(event))
+        if display:
+            displays.append(display)
+        if result is not None:
+            final = result
+    return displays, final
+
+
+def test_gemini_init_event_locks_backend() -> None:
+    parser = StreamParser()
+    parser.parse(
+        json.dumps(
+            {
+                "type": "init",
+                "session_id": "abc",
+                "model": "gemini-3-pro",
+            }
+        )
+    )
+    snapshot = parser.usage_snapshot
+    assert snapshot["usage_backend"] == "gemini"
+
+
+def test_gemini_result_event_captures_stats() -> None:
+    parser = StreamParser()
+    parser.parse(
+        json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+    )
+    parser.parse(
+        json.dumps(
+            {
+                "type": "result",
+                "status": "success",
+                "stats": {
+                    "total_tokens": 1000,
+                    "input_tokens": 800,
+                    "output_tokens": 200,
+                    "cached": 400,
+                    "duration_ms": 1200,
+                    "tool_calls": 2,
+                },
+            }
+        )
+    )
+    totals = parser.usage_totals
+    assert totals["input_tokens"] == 800
+    assert totals["output_tokens"] == 200
+    assert totals["total_tokens"] == 1000
+    assert totals["cache_read_input_tokens"] == 400  # "cached" maps to cache_read
+
+
+def test_gemini_tool_use_emits_display_line() -> None:
+    parser = StreamParser()
+    displays, _ = _parse_lines(
+        parser,
+        [
+            {"type": "init", "session_id": "x", "model": "gemini-3-pro"},
+            {
+                "type": "tool_use",
+                "tool_name": "run_shell_command",
+                "tool_id": "t1",
+                "parameters": {"command": "ls -la"},
+            },
+        ],
+    )
+    assert any("run_shell_command" in d for d in displays)
+    assert any("ls -la" in d for d in displays)
+
+
+def test_gemini_assistant_message_deltas_accumulate() -> None:
+    displays, final = _parse_lines(
+        StreamParser(),
+        [
+            {"type": "init", "session_id": "y", "model": "gemini-3-pro"},
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "Hello ",
+                "delta": True,
+            },
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": "world.",
+                "delta": True,
+            },
+            {
+                "type": "result",
+                "status": "success",
+                "stats": {"total_tokens": 5, "input_tokens": 3, "output_tokens": 2},
+            },
+        ],
+    )
+    assert final == "Hello world."
+
+
+def test_gemini_result_does_not_collide_with_claude_result() -> None:
+    """Claude's 'result' event carries `result` string; gemini's carries `stats`.
+    Dispatcher must pick the correct extractor based on payload shape."""
+    # Claude-style result (no prior init event)
+    parser_claude = StreamParser()
+    parser_claude.parse(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                    "content": [],
+                },
+            }
+        )
+    )
+    parser_claude.parse(json.dumps({"type": "result", "result": "done", "usage": {}}))
+    assert parser_claude.usage_snapshot["usage_backend"] == "claude"
+
+    # Gemini-style result (after init)
+    parser_gemini = StreamParser()
+    parser_gemini.parse(
+        json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+    )
+    parser_gemini.parse(
+        json.dumps(
+            {
+                "type": "result",
+                "status": "success",
+                "stats": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            }
+        )
+    )
+    assert parser_gemini.usage_snapshot["usage_backend"] == "gemini"

--- a/tests/test_stream_parser_gemini.py
+++ b/tests/test_stream_parser_gemini.py
@@ -30,7 +30,7 @@ def test_gemini_init_event_locks_backend() -> None:
             {
                 "type": "init",
                 "session_id": "abc",
-                "model": "gemini-2.5-pro",
+                "model": "gemini-3.1-pro-preview",
             }
         )
     )
@@ -41,7 +41,9 @@ def test_gemini_init_event_locks_backend() -> None:
 def test_gemini_result_event_captures_stats() -> None:
     parser = StreamParser()
     parser.parse(
-        json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
+        json.dumps(
+            {"type": "init", "session_id": "x", "model": "gemini-3.1-pro-preview"}
+        )
     )
     parser.parse(
         json.dumps(
@@ -71,7 +73,7 @@ def test_gemini_tool_use_emits_display_line() -> None:
     displays, _ = _parse_lines(
         parser,
         [
-            {"type": "init", "session_id": "x", "model": "gemini-2.5-pro"},
+            {"type": "init", "session_id": "x", "model": "gemini-3.1-pro-preview"},
             {
                 "type": "tool_use",
                 "tool_name": "run_shell_command",
@@ -88,7 +90,7 @@ def test_gemini_assistant_message_deltas_accumulate() -> None:
     displays, final = _parse_lines(
         StreamParser(),
         [
-            {"type": "init", "session_id": "y", "model": "gemini-2.5-pro"},
+            {"type": "init", "session_id": "y", "model": "gemini-3.1-pro-preview"},
             {
                 "type": "message",
                 "role": "assistant",
@@ -133,7 +135,9 @@ def test_gemini_result_does_not_collide_with_claude_result() -> None:
     # Gemini-style result (after init)
     parser_gemini = StreamParser()
     parser_gemini.parse(
-        json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
+        json.dumps(
+            {"type": "init", "session_id": "x", "model": "gemini-3.1-pro-preview"}
+        )
     )
     parser_gemini.parse(
         json.dumps(

--- a/tests/test_stream_parser_gemini.py
+++ b/tests/test_stream_parser_gemini.py
@@ -30,7 +30,7 @@ def test_gemini_init_event_locks_backend() -> None:
             {
                 "type": "init",
                 "session_id": "abc",
-                "model": "gemini-3-pro",
+                "model": "gemini-2.5-pro",
             }
         )
     )
@@ -41,7 +41,7 @@ def test_gemini_init_event_locks_backend() -> None:
 def test_gemini_result_event_captures_stats() -> None:
     parser = StreamParser()
     parser.parse(
-        json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+        json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
     )
     parser.parse(
         json.dumps(
@@ -71,7 +71,7 @@ def test_gemini_tool_use_emits_display_line() -> None:
     displays, _ = _parse_lines(
         parser,
         [
-            {"type": "init", "session_id": "x", "model": "gemini-3-pro"},
+            {"type": "init", "session_id": "x", "model": "gemini-2.5-pro"},
             {
                 "type": "tool_use",
                 "tool_name": "run_shell_command",
@@ -88,7 +88,7 @@ def test_gemini_assistant_message_deltas_accumulate() -> None:
     displays, final = _parse_lines(
         StreamParser(),
         [
-            {"type": "init", "session_id": "y", "model": "gemini-3-pro"},
+            {"type": "init", "session_id": "y", "model": "gemini-2.5-pro"},
             {
                 "type": "message",
                 "role": "assistant",
@@ -133,7 +133,7 @@ def test_gemini_result_does_not_collide_with_claude_result() -> None:
     # Gemini-style result (after init)
     parser_gemini = StreamParser()
     parser_gemini.parse(
-        json.dumps({"type": "init", "session_id": "x", "model": "gemini-3-pro"})
+        json.dumps({"type": "init", "session_id": "x", "model": "gemini-2.5-pro"})
     )
     parser_gemini.parse(
         json.dumps(

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -154,6 +154,7 @@ class TestBuildCommand:
     def test_supports_codex_backend(self, tmp_path):
         cfg = ConfigFactory.create(
             verification_judge_tool="codex",
+            review_tool="codex",
             review_model="gpt-5-codex",
             repo_root=tmp_path / "repo",
             workspace_base=tmp_path / "wt",


### PR DESCRIPTION
## Summary

- **Adds Gemini CLI as a first-class `AgentTool` backend** alongside Claude/Codex/Pi — new command builder, prompt routing, stream-JSON event parser, and activity parser.
- **Restructures env config** from 31 scattered `HYDRAFLOW_*_TOOL` / `HYDRAFLOW_*_MODEL` variables to one `HYDRAFLOW_<STAGE>=tool:model` combo per stage. **Breaking change — no deprecation**; also removes `HYDRAFLOW_LABEL_*`, `HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS`, `HYDRAFLOW_DEBUG_ESCALATION_ENABLED`, and related tiered-policy env overrides (now code defaults only).
- **Flips triage default to `gemini:gemini-3-pro`** and hard-rejects `*flash*` models + cross-provider mismatches in `_harmonize_tool_model_defaults`.

## What shipped (13 commits)

| # | Commit | Change |
|---|--------|--------|
| 1 | `effc465c` | `feat(agent-cli)`: gemini backend with streaming JSONL output |
| 2 | `2ddc7026` + `cd401d24` | `feat(runner-utils)`: route gemini prompts and detect backend (+ review fixes) |
| 3 | `e35762e1` | `feat(stream-parser)`: gemini event parsing and usage extraction |
| 4 | `6cb50007` | `feat(activity-parser)`: gemini activity parser |
| 5 | `bae6a23a` | `feat(config)`: add gemini to every `AgentTool` Literal |
| 6 | `b04652db` | `feat(config)`: add tool:model combo env var overrides |
| 7 | `1f217577` | `feat(config)!`: drop legacy *_TOOL/*_MODEL/LABEL env overrides |
| 8 | `7f7238c0` | `feat(config)`: reject *flash* models + cross-provider mismatches |
| 9 | `66b10c3c` | `feat(config)`: default triage to gemini:gemini-3-pro |
| 10 | `a858876c` | `docs(env)`: rewrite .env.sample for tool:model combo syntax (154 → 60 lines) |
| 11 | `80f9254d` | `chore(gemini)`: address review follow-ups |
| 12 | `4a1b8d61` | `fix(config)`: correct verification_judge model mapping + auto-sync tool |

## Plan

`docs/superpowers/plans/2026-04-23-gemini-triage-env-restructure.md` — 11 tasks, TDD throughout, fresh subagent + spec/quality review per task.

## Quality gate

- ✅ `ruff check` + `ruff format --check`
- ✅ `pyright`
- ✅ `bandit --severity-level medium`
- ✅ `scripts/check_layer_imports.py`
- ⏳ `pytest tests/` — full suite running in background; the targeted 501-test regression on all files touched in this branch passed, plus the 3 codex tests caught by the harmonize guard have been fixed.

## Breaking changes

Operators must update their `.env` to the new combo syntax. Legacy vars silently stop working (no warnings — hard cut). See `.env.sample` for the canonical shape.

Removed env vars: `HYDRAFLOW_{IMPLEMENTATION,REVIEW,PLANNER,TRIAGE,AC,VERIFICATION_JUDGE,SUBSKILL,DEBUG,TRANSCRIPT_SUMMARY,WIKI_COMPILATION,REPORT_ISSUE,SYSTEM,BACKGROUND}_{TOOL,MODEL}`, `HYDRAFLOW_MODEL`, `HYDRAFLOW_MEMORY_COMPACTION_{TOOL,MODEL}`, `HYDRAFLOW_MEMORY_JUDGE_MODEL`, `HYDRAFLOW_SENTRY_MODEL`, `HYDRAFLOW_CODE_GROOMING_MODEL`, `HYDRAFLOW_ADR_REVIEW_MODEL`, `HYDRAFLOW_LABEL_*` (all 15), `HYDRAFLOW_MAX_SUBSKILL_ATTEMPTS`, `HYDRAFLOW_MAX_DEBUG_ATTEMPTS`, `HYDRAFLOW_SUBSKILL_CONFIDENCE_THRESHOLD`, `HYDRAFLOW_DEBUG_ESCALATION_ENABLED`.

## Test plan

- [ ] Full `pytest tests/` run clean (in flight)
- [ ] Live smoke test: trigger a triage run with `HYDRAFLOW_TRIAGE=gemini:gemini-3-pro` and verify the stream-JSON transcript parses correctly with `usage_backend == "gemini"`
- [ ] Spot-check that a non-updated `.env` produces clear failures (legacy vars silently ignored, combos required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)