### PR TITLE
feat(config): individual combo vars for sentry / code_grooming / adr_review

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -33,6 +33,10 @@
 # HYDRAFLOW_SENTRY=claude:opus            # Sentry event triage + issue filing
 # HYDRAFLOW_CODE_GROOMING=claude:sonnet   # Daily code-quality audit
 # HYDRAFLOW_ADR_REVIEW=claude:sonnet      # ADR council orchestrator
+#
+# Migration note: sentry_loop used to inherit tool from HYDRAFLOW_REPORT_ISSUE.
+# If you had a non-claude value there and want sentry to match, set
+# HYDRAFLOW_SENTRY explicitly (or set HYDRAFLOW_BACKGROUND for a group pin).
 
 # --- Meta (inherit cascades to every per-stage default) ---
 # HYDRAFLOW_SYSTEM=inherit

--- a/.env.sample
+++ b/.env.sample
@@ -30,10 +30,13 @@
 # HYDRAFLOW_TRANSCRIPT_SUMMARY=claude:haiku
 # HYDRAFLOW_WIKI_COMPILATION=claude:haiku
 # HYDRAFLOW_REPORT_ISSUE=claude:opus
+# HYDRAFLOW_SENTRY=claude:opus            # Sentry event triage + issue filing
+# HYDRAFLOW_CODE_GROOMING=claude:sonnet   # Daily code-quality audit
+# HYDRAFLOW_ADR_REVIEW=claude:sonnet      # ADR council orchestrator
 
 # --- Meta (inherit cascades to every per-stage default) ---
 # HYDRAFLOW_SYSTEM=inherit
-# HYDRAFLOW_BACKGROUND=inherit
+# HYDRAFLOW_BACKGROUND=inherit            # Also cascades to sentry/code_grooming/adr_review
 
 # --- Alternative profile: codex-heavy (uncomment block to activate) ---
 # HYDRAFLOW_IMPLEMENT=codex:gpt-5-codex

--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -443,13 +443,10 @@ minority_note: <dissenting opinion if not unanimous, or "none">"""
 
     async def _execute_orchestrator(self, prompt: str) -> str | None:
         """Call the configured CLI backend to run the council session."""
-        tool = self._config.background_tool
-        if tool == "inherit":
-            tool = "claude"
-        model = self._config.adr_review_model
-
         cmd, cmd_input = build_lightweight_command(
-            tool=tool, model=model, prompt=prompt
+            tool=self._config.adr_review_tool,
+            model=self._config.adr_review_model,
+            prompt=prompt,
         )
 
         env = make_clean_env(self._credentials.gh_token)

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -63,9 +63,7 @@ class CodeGroomingLoop(BaseBackgroundLoop):
         ``id``, ``severity``, ``title``, and ``description`` keys.
         """
         cmd = build_agent_command(
-            tool=self._config.background_tool
-            if self._config.background_tool != "inherit"
-            else "claude",
+            tool=self._config.code_grooming_tool,
             model=self._config.code_grooming_model,
             max_turns=10,
         )

--- a/src/config.py
+++ b/src/config.py
@@ -319,6 +319,9 @@ _ENV_COMBO_OVERRIDES: list[tuple[str, str, str]] = [
         "transcript_summary_model",
     ),
     ("HYDRAFLOW_WIKI_COMPILATION", "wiki_compilation_tool", "wiki_compilation_model"),
+    ("HYDRAFLOW_SENTRY", "sentry_tool", "sentry_model"),
+    ("HYDRAFLOW_CODE_GROOMING", "code_grooming_tool", "code_grooming_model"),
+    ("HYDRAFLOW_ADR_REVIEW", "adr_review_tool", "adr_review_model"),
     ("HYDRAFLOW_REPORT_ISSUE", "report_issue_tool", "report_issue_model"),
 ]
 
@@ -1302,9 +1305,17 @@ class HydraFlowConfig(BaseModel):
         default="opus",
         description="Model for report-issue worker (codebase research + structured issue creation)",
     )
+    sentry_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
+        default="claude",
+        description="CLI backend for sentry_loop ingestion worker",
+    )
     sentry_model: str = Field(
         default="opus",
         description="Model for sentry_loop ingestion worker (issue triage + filing from Sentry events)",
+    )
+    code_grooming_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
+        default="claude",
+        description="CLI backend for code_grooming_loop audit worker",
     )
     code_grooming_model: str = Field(
         default="sonnet",
@@ -1543,6 +1554,10 @@ class HydraFlowConfig(BaseModel):
         ge=1,
         le=5,
         description="Maximum deliberation rounds before forcing a decision",
+    )
+    adr_review_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
+        default="claude",
+        description="CLI backend for the ADR council review orchestrator",
     )
     adr_review_model: str = Field(
         default="sonnet",
@@ -1945,6 +1960,9 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
             "triage_tool",
             "transcript_summary_tool",
             "report_issue_tool",
+            "sentry_tool",
+            "code_grooming_tool",
+            "adr_review_tool",
         ):
             _apply_if_default(field, config.background_tool)
 
@@ -1955,6 +1973,7 @@ def _apply_profile_overrides(config: HydraFlowConfig) -> None:
             "report_issue_model",
             "sentry_model",
             "code_grooming_model",
+            "adr_review_model",
         ):
             _apply_if_default(field, config.background_model)
 
@@ -2027,6 +2046,9 @@ def _harmonize_tool_model_defaults(config: HydraFlowConfig) -> None:
             config.wiki_compilation_model,
         ),
         ("report_issue", config.report_issue_tool, config.report_issue_model),
+        ("sentry", config.sentry_tool, config.sentry_model),
+        ("code_grooming", config.code_grooming_tool, config.code_grooming_model),
+        ("adr_review", config.adr_review_tool, config.adr_review_model),
     ]
 
     for stage, tool, model in stage_pairs:

--- a/src/sentry_loop.py
+++ b/src/sentry_loop.py
@@ -366,7 +366,7 @@ class SentryLoop(BaseBackgroundLoop):
         from runner_utils import StreamConfig, stream_claude_process  # noqa: PLC0415
 
         cmd = build_agent_command(
-            tool=self._config.report_issue_tool,
+            tool=self._config.sentry_tool,
             model=self._config.sentry_model,
             max_turns=10,
         )

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -1449,6 +1449,10 @@ class TestExecuteOrchestrator:
             repo_root=tmp_path / "repo",
             background_tool="codex",
             background_model="gpt-5-codex",
+            # ConfigFactory passes adr_review_model explicitly (default "sonnet"),
+            # which blocks the background_model cascade. Override to keep the
+            # (tool, model) pair coherent under the strict harmonize guard.
+            adr_review_model="gpt-5-codex",
         )
         from events import EventBus
 

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -218,3 +218,15 @@ def test_background_cascade_reaches_sentry_code_grooming_adr_review() -> None:
         assert cfg.code_grooming_model == "sonnet"
         assert cfg.adr_review_tool == "claude"
         assert cfg.adr_review_model == "sonnet"
+
+
+def test_background_cascade_cross_provider_codex() -> None:
+    """HYDRAFLOW_BACKGROUND=codex:gpt-5-codex must cascade tool+model coherently
+    to every bg-only worker and pass harmonize's cross-provider check."""
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_BACKGROUND": "codex:gpt-5-codex"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        for stage in ("sentry", "code_grooming", "adr_review"):
+            assert getattr(cfg, f"{stage}_tool") == "codex"
+            assert getattr(cfg, f"{stage}_model") == "gpt-5-codex"

--- a/tests/test_config_combo_env.py
+++ b/tests/test_config_combo_env.py
@@ -183,3 +183,38 @@ def test_triage_defaults_to_gemini_pro() -> None:
     cfg = HydraFlowConfig()
     assert cfg.triage_tool == "gemini"
     assert cfg.triage_model == "gemini-3.1-pro-preview"
+
+
+def test_combo_env_sets_sentry_tool_and_model() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_SENTRY": "claude:sonnet"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.sentry_tool == "claude"
+        assert cfg.sentry_model == "sonnet"
+
+
+def test_combo_env_sets_code_grooming_tool_and_model() -> None:
+    with patch.dict(
+        os.environ, {"HYDRAFLOW_CODE_GROOMING": "codex:gpt-5-codex"}, clear=False
+    ):
+        cfg = HydraFlowConfig()
+        assert cfg.code_grooming_tool == "codex"
+        assert cfg.code_grooming_model == "gpt-5-codex"
+
+
+def test_combo_env_sets_adr_review_tool_and_model() -> None:
+    with patch.dict(os.environ, {"HYDRAFLOW_ADR_REVIEW": "claude:opus"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.adr_review_tool == "claude"
+        assert cfg.adr_review_model == "opus"
+
+
+def test_background_cascade_reaches_sentry_code_grooming_adr_review() -> None:
+    """HYDRAFLOW_BACKGROUND=claude:sonnet must pin the bg-only workers."""
+    with patch.dict(os.environ, {"HYDRAFLOW_BACKGROUND": "claude:sonnet"}, clear=False):
+        cfg = HydraFlowConfig()
+        assert cfg.sentry_tool == "claude"
+        assert cfg.sentry_model == "sonnet"
+        assert cfg.code_grooming_tool == "claude"
+        assert cfg.code_grooming_model == "sonnet"
+        assert cfg.adr_review_tool == "claude"
+        assert cfg.adr_review_model == "sonnet"


### PR DESCRIPTION
## Summary

Follow-up to #8393. Adds **`HYDRAFLOW_SENTRY=tool:model`**, **`HYDRAFLOW_CODE_GROOMING=tool:model`**, and **`HYDRAFLOW_ADR_REVIEW=tool:model`** so those three background workers are individually configurable (they were previously only reachable as a group via the \`HYDRAFLOW_BACKGROUND\` cascade).

## Why

When #8393 restructured env to \`tool:model\` combos, three bg workers had only \`*_model\` fields — no dedicated \`*_tool\`. That produced oddities:

- \`sentry_loop.py\` piggybacked on \`report_issue_tool\`
- \`code_grooming_loop.py\` and \`adr_reviewer.py\` duplicated an inherit-fallback shim at the call site
- No way for operators to, e.g., run sentry on codex while keeping code_grooming on claude

## What changed

- **New fields** (\`src/config.py\`): \`sentry_tool\`, \`code_grooming_tool\`, \`adr_review_tool\` — Literal[\"claude\", \"codex\", \"gemini\", \"pi\"], all default to \`\"claude\"\`.
- **Combo env vars**: \`HYDRAFLOW_SENTRY\`, \`HYDRAFLOW_CODE_GROOMING\`, \`HYDRAFLOW_ADR_REVIEW\` added to \`_ENV_COMBO_OVERRIDES\`.
- **Harmonize validation**: all three pairs added to \`stage_pairs\` (flash-rejection + cross-provider mismatch guard applies).
- **Background cascade**: \`background_tool\` now cascades to the new tool fields; \`background_model\` cascade gains \`adr_review_model\` (it was missing before — a bug).
- **Call sites** simplified: \`sentry_loop.py:370\`, \`code_grooming_loop.py:65\`, \`adr_reviewer.py:447\` now use the dedicated fields; inherit-shims removed.
- **\`.env.sample\`** documents the three new knobs.
- **4 new unit tests** + **1 cascade test**. 413 focused tests pass.

## Test plan

- [ ] \`uv run pytest tests/test_config_combo_env.py tests/test_config_validation.py tests/test_sentry_loop.py tests/test_code_grooming_loop.py tests/test_adr_reviewer.py\` — 413 passed locally
- [ ] \`make quality\` — lint / type / security / layer-check green
- [ ] Smoke: set \`HYDRAFLOW_SENTRY=claude:sonnet\` and verify sentry_loop runs sonnet instead of the default opus

🤖 Generated with [Claude Code](https://claude.com/claude-code)