### PR TITLE
feat(docker): bundle hindsight-skills plugin in agent image

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -79,6 +79,7 @@ RUN npm install -g @beads/bd --no-fund --no-audit
 RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /opt/plugins/claude-plugins-official \
     && git clone --depth 1 https://github.com/obra/superpowers.git /opt/plugins/superpowers \
     && git clone --depth 1 https://github.com/8thlight/lightfactory.git /opt/plugins/lightfactory \
+    && git clone --depth 1 https://github.com/vectorize-io/hindsight-skills.git /opt/plugins/hindsight-skills \
     && rm -rf /opt/plugins/*/.git
 
 # Pre-install Python quality tools into a venv

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -71,6 +71,7 @@ RUN npm install -g @beads/bd --no-fund --no-audit
 RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /opt/plugins/claude-plugins-official \
     && git clone --depth 1 https://github.com/obra/superpowers.git /opt/plugins/superpowers \
     && git clone --depth 1 https://github.com/8thlight/lightfactory.git /opt/plugins/lightfactory \
+    && git clone --depth 1 https://github.com/vectorize-io/hindsight-skills.git /opt/plugins/hindsight-skills \
     && rm -rf /opt/plugins/*/.git
 
 # Pre-install Python quality tools into a venv


### PR DESCRIPTION
## Summary

Pre-clones [vectorize-io/hindsight-skills](https://github.com/vectorize-io/hindsight-skills) into \`/opt/plugins/\` at image-build time, alongside the existing \`claude-plugins-official\`, \`superpowers\`, and \`lightfactory\` plugins. Claude agents running inside the HydraFlow agent image now auto-discover the \`hindsight-docs\` and \`hindsight-architect\` skills via the standard plugin path.

## Why

After retiring Hindsight's factory-embed in #8389 and removing the zombie container in #8395, the question was: how do we still let Claude help users who want to wire up Hindsight-based memory in their projects?

Answer: ship the Hindsight skills as a bundled plugin. No runtime cost when unused (skills load on-demand based on Claude's discretion). No factory coupling. Complementary to — not a substitute for — running a Hindsight MCP server for actual persistent memory, which is a separate operator-side decision.

## What changed

Two one-line additions to the existing \`git clone\` chain in:
- \`Dockerfile.agent:79-82\`
- \`Dockerfile.agent-base:71-74\`

Net: +2 lines.

## Test plan

- [ ] Docker image builds cleanly: \`docker build -f Dockerfile.agent-base -t hf-base:test .\`
- [ ] \`/opt/plugins/hindsight-skills/\` exists in the built image
- [ ] Claude agents spawned inside the image see the skill in their discovery listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)