### PR TITLE
feat(ci): ADR touchpoint gate on PRs (P2)

### DIFF
--- a/.github/workflows/adr-touchpoints.yml
+++ b/.github/workflows/adr-touchpoints.yml
@@ -1,0 +1,40 @@
+name: ADR Touchpoints
+
+on:
+  pull_request:
+    branches: [main, staging]
+    types: [opened, synchronize, edited]
+
+jobs:
+  adr-gate:
+    name: ADR gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # full history so `git diff --name-only base...head` works
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check for Skip-ADR marker
+        id: skip
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -n "$PR_BODY" ] && echo "$PR_BODY" | grep -qE '^[[:space:]]*Skip-ADR:[[:space:]]*\S+'; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            echo "PR carries Skip-ADR marker; gate skipped."
+          else
+            echo "skipped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run ADR touchpoint check
+        if: steps.skip.outputs.skipped != 'true'
+        run: |
+          python scripts/check_adr_touchpoints.py \
+            --base origin/${{ github.event.pull_request.base.ref }} \
+            --head HEAD

--- a/scripts/check_adr_touchpoints.py
+++ b/scripts/check_adr_touchpoints.py
@@ -1,0 +1,103 @@
+"""ADR touchpoint gate — P2 of the wiki-evolution audit.
+
+Given a git diff (``--base`` vs ``--head``), reports Accepted ADRs
+whose ``src/...`` citations intersect the changed files. The PR is
+expected to either:
+
+1. Include ADR updates in the diff (``docs/adr/*.md`` files touched).
+2. Carry a ``Skip-ADR: <reason>`` marker in the PR body (checked by
+   CI, not this script).
+
+Without one of the escape hatches, the script exits non-zero so the
+CI gate can fail the PR and surface which ADRs need attention.
+
+Usage (CI):
+
+    python scripts/check_adr_touchpoints.py \\
+        --base origin/main --head HEAD
+
+Usage (local):
+
+    python scripts/check_adr_touchpoints.py --base main --head HEAD
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from adr_index import ADR, ADRIndex  # noqa: E402
+
+
+def _changed_files(base: str, head: str) -> list[str]:
+    """Return the list of files changed between *base* and *head*."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head}"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=REPO_ROOT,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _pr_touches_any_adr(changed: list[str]) -> bool:
+    """Return True if any ADR markdown file is included in the diff."""
+    return any(p.startswith("docs/adr/") and p.endswith(".md") for p in changed)
+
+
+def _format_report(hits: dict[str, list[ADR]]) -> str:
+    lines = ["Accepted ADRs cite files touched in this PR:", ""]
+    for path in sorted(hits):
+        adrs = sorted(hits[path], key=lambda a: a.number)
+        summaries = ", ".join(f"ADR-{a.number:04d} ({a.title})" for a in adrs)
+        lines.append(f"  {path}")
+        lines.append(f"    → {summaries}")
+    lines.extend(
+        [
+            "",
+            "Next steps:",
+            "  - Update the relevant ADR(s) in the same PR, OR",
+            "  - Add `Skip-ADR: <reason>` to the PR body (enforced by the",
+            "    CI workflow — this script only reports touchpoints).",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="Git base ref (e.g. origin/main)")
+    parser.add_argument("--head", default="HEAD", help="Git head ref (default HEAD)")
+    parser.add_argument(
+        "--adr-dir",
+        default=str(REPO_ROOT / "docs" / "adr"),
+        help="ADR directory (default docs/adr)",
+    )
+    args = parser.parse_args()
+
+    changed = _changed_files(args.base, args.head)
+    if not changed:
+        return 0
+
+    idx = ADRIndex(Path(args.adr_dir))
+    hits = idx.adrs_touching(changed)
+    if not hits:
+        return 0
+
+    if _pr_touches_any_adr(changed):
+        # PR already updates at least one ADR; assume the author is aware.
+        print("ADR file(s) modified in this PR — touchpoint gate passes.")
+        return 0
+
+    print(_format_report(hits), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -29,6 +29,10 @@ _TITLE_RE = re.compile(r"^#\s*ADR-(\d{4}):\s*(.+?)\s*$", re.MULTILINE)
 _STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(.+?)\s*$", re.MULTILINE)
 _CONTEXT_RE = re.compile(r"##\s+Context\s*\n\s*\n(.+?)(?=\n\s*\n|\n##\s|\Z)", re.DOTALL)
 _SUPERSEDED_RE = re.compile(r"Superseded\s+by\s+(ADR-\d{4})", re.IGNORECASE)
+# Matches `src/some/path.py:Symbol` citations — shared with
+# adr_pre_validator._SOURCE_SYMBOL_RE. Used for ADR↔source-file inverse
+# indexing so the CI gate can flag PRs touching files cited in Accepted ADRs.
+_SOURCE_FILE_CITATION_RE = re.compile(r"`(src/[^`:\s]+\.py):[A-Za-z_]\w*`")
 
 
 @dataclass(frozen=True)
@@ -38,6 +42,9 @@ class ADR:
     status: str  # normalized: Accepted | Proposed | Superseded | Deprecated | Unknown
     summary: str  # first paragraph of ## Context, flattened
     superseded_by: str | None = None
+    source_files: frozenset[str] = frozenset()
+    """Set of `src/...` paths cited anywhere in the ADR body — used by
+    the P2 CI gate to flag PRs touching files under Accepted ADRs."""
 
 
 def parse_adr_file(path: Path) -> ADR:
@@ -71,12 +78,15 @@ def parse_adr_file(path: Path) -> ADR:
     if ctx_match:
         summary = " ".join(ctx_match.group(1).split())[:300]
 
+    source_files = frozenset(_SOURCE_FILE_CITATION_RE.findall(text))
+
     return ADR(
         number=number,
         title=title,
         status=status_norm,
         summary=summary,
         superseded_by=superseded_by,
+        source_files=source_files,
     )
 
 
@@ -174,6 +184,23 @@ class ADRIndex:
             self._cached = scan_adr_directory(self._adr_dir)
             self._fingerprint = fingerprint
         return self._cached
+
+    def adrs_touching(self, paths: list[str] | tuple[str, ...]) -> dict[str, list[ADR]]:
+        """Return a mapping of input paths → Accepted ADRs that cite each.
+
+        Only Accepted ADRs are considered — Superseded / Deprecated /
+        Proposed don't trigger the P2 gate. Paths with no hits are
+        omitted from the result.
+        """
+        if not paths:
+            return {}
+        accepted = [a for a in self.adrs() if a.status == "Accepted"]
+        result: dict[str, list[ADR]] = {}
+        for path in paths:
+            hits = [a for a in accepted if path in a.source_files]
+            if hits:
+                result[path] = hits
+        return result
 
     def _compute_fingerprint(self) -> tuple[float, ...]:
         if not self._adr_dir.exists():

--- a/tests/test_adr_touchpoints.py
+++ b/tests/test_adr_touchpoints.py
@@ -1,0 +1,106 @@
+"""Tests for ADR → source file inverse indexing (P2 wiki-evolution audit).
+
+The validator/CI gate uses this to answer: "if a PR touches file X,
+which Accepted ADRs cite X and might need updating?".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adr_index import ADR, ADRIndex
+
+
+def _write_adr(
+    adr_dir: Path,
+    number: int,
+    title: str,
+    citations: list[str],
+    *,
+    status: str = "Accepted",
+) -> Path:
+    """Write a minimal ADR file with `src/path:Symbol`-style citations."""
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    path = adr_dir / f"{number:04d}-{title.lower().replace(' ', '-')}.md"
+    citation_lines = "\n".join(f"- `{c}`" for c in citations)
+    path.write_text(
+        f"# ADR-{number:04d}: {title}\n\n"
+        f"**Status:** {status}\n"
+        f"**Date:** 2026-04-24\n\n"
+        f"## Context\n\nTest fixture.\n\n"
+        f"## Decision\n\nDo the thing.\n\n"
+        f"### Related\n\n{citation_lines}\n"
+    )
+    return path
+
+
+def test_parse_adr_extracts_source_files(tmp_path: Path) -> None:
+    """An ADR parsed from disk carries the set of `src/...` files it cites."""
+    _write_adr(
+        tmp_path,
+        32,
+        "Per-Repo Wiki",
+        citations=[
+            "src/repo_wiki.py:RepoWikiStore",
+            "src/wiki_compiler.py:WikiCompiler",
+        ],
+    )
+    idx = ADRIndex(tmp_path)
+
+    adrs = idx.adrs()
+    adr = next(a for a in adrs if a.number == 32)
+
+    assert "src/repo_wiki.py" in adr.source_files
+    assert "src/wiki_compiler.py" in adr.source_files
+
+
+def test_adrs_touching_returns_file_to_adrs_map(tmp_path: Path) -> None:
+    """adrs_touching() returns {file: [ADRs citing it]} for the given paths."""
+    _write_adr(tmp_path, 1, "A", ["src/foo.py:Foo"])
+    _write_adr(tmp_path, 2, "B", ["src/foo.py:Bar", "src/bar.py:Baz"])
+    _write_adr(tmp_path, 3, "C", ["src/bar.py:Qux"])
+    idx = ADRIndex(tmp_path)
+
+    touched = idx.adrs_touching(["src/foo.py", "src/unrelated.py"])
+
+    assert set(touched.keys()) == {"src/foo.py"}
+    numbers = {a.number for a in touched["src/foo.py"]}
+    assert numbers == {1, 2}
+
+
+def test_adrs_touching_skips_non_accepted(tmp_path: Path) -> None:
+    """Superseded / Deprecated / Proposed ADRs don't trigger the gate."""
+    _write_adr(tmp_path, 10, "Old", ["src/foo.py:X"], status="Superseded")
+    _write_adr(tmp_path, 11, "Live", ["src/foo.py:Y"], status="Accepted")
+    idx = ADRIndex(tmp_path)
+
+    touched = idx.adrs_touching(["src/foo.py"])
+
+    numbers = {a.number for a in touched["src/foo.py"]}
+    assert numbers == {11}
+
+
+def test_adrs_touching_empty_input_returns_empty(tmp_path: Path) -> None:
+    _write_adr(tmp_path, 1, "A", ["src/foo.py:X"])
+    idx = ADRIndex(tmp_path)
+
+    assert idx.adrs_touching([]) == {}
+    assert idx.adrs_touching(["src/unrelated.py"]) == {}
+
+
+def test_source_files_ignores_non_src_citations(tmp_path: Path) -> None:
+    """Only `src/...` citations count — tests/, docs/, scripts/ don't."""
+    _write_adr(
+        tmp_path,
+        1,
+        "Mixed",
+        citations=[
+            "src/foo.py:Foo",
+            "tests/test_foo.py",  # not matched by _SOURCE_SYMBOL_RE
+            "docs/adr/0001.md",
+        ],
+    )
+    idx = ADRIndex(tmp_path)
+
+    adr: ADR = next(a for a in idx.adrs() if a.number == 1)
+    assert adr.source_files == frozenset({"src/foo.py"})


### PR DESCRIPTION
## Summary

**P2 of the wiki-evolution audit.** PRs could touch files cited by Accepted ADRs without updating those ADRs — architectural drift happened silently. This adds a CI gate that flags it.

## How it works

1. Each Accepted ADR's body is scanned for \`src/...:Symbol\` citations. ADRIndex exposes \`adrs_touching(paths)\` mapping changed-files to the ADRs that cite them.
2. \`scripts/check_adr_touchpoints.py\` diffs \`--base…--head\`, reports touchpoints, exits non-zero if any ADR'd file was touched without an ADR update in the same PR.
3. \`.github/workflows/adr-touchpoints.yml\` runs it on every PR. PRs with \`Skip-ADR: <reason>\` in the body bypass the gate (for incidental touches, renames, unrelated bug fixes).

## Author experience

- **You update a file cited in an Accepted ADR** → either update the ADR in the same PR or add \`Skip-ADR: <reason>\` to the PR body.
- **PR already modifies an ADR file** → gate passes automatically (assumed the author is aware).

## Changes

| File | Change |
|---|---|
| \`src/adr_index.py\` | \`ADR.source_files\` field + \`ADRIndex.adrs_touching()\` method |
| \`scripts/check_adr_touchpoints.py\` | New — the gate logic |
| \`.github/workflows/adr-touchpoints.yml\` | New — CI workflow |
| \`tests/test_adr_touchpoints.py\` | 5 new unit tests |

## Test plan

- [x] 5 new unit tests pass.
- [x] Smoke-run on current branch: clean exit.
- [ ] First PR touching an ADR'd file after merge should see the gate fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)