### PR TITLE
feat(post-merge): compile tracked wiki inline on merge (P5)

### DIFF
--- a/src/post_merge_handler.py
+++ b/src/post_merge_handler.py
@@ -6,6 +6,7 @@ import logging
 import re
 from collections.abc import Coroutine
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from acceptance_criteria import AcceptanceCriteriaGenerator
@@ -50,6 +51,68 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hydraflow.post_merge_handler")
 
 _T = TypeVar("_T")
+
+
+async def _compile_tracked_topics_for_merge(
+    *,
+    tracked_root: Path,
+    repo_slug: str,
+    compiler: WikiCompiler | None,
+) -> None:
+    """Run WikiCompiler.compile_topic_tracked for every tracked topic
+    that has ≥2 active entries.
+
+    Runs inline on the post-merge hook chain so the next issue sees a
+    deduplicated wiki instead of waiting for the RepoWikiLoop interval
+    tick. Side effects are file mutations in ``{tracked_root}/{repo}/
+    {topic}/``; those become uncommitted diffs that the existing
+    ``RepoWikiLoop._maybe_open_maintenance_pr`` tick rolls up into a
+    ``chore(wiki): maintenance`` PR.
+
+    No-op when compiler is None, tracked_root is missing, or no topic
+    has enough entries to merit a compile pass.
+    """
+    if compiler is None:
+        return
+    repo_dir = tracked_root / repo_slug
+    if not repo_dir.is_dir():
+        return
+    for topic_dir in sorted(p for p in repo_dir.iterdir() if p.is_dir()):
+        if _count_active_entries(topic_dir) < 2:
+            continue
+        await compiler.compile_topic_tracked(
+            tracked_root=tracked_root,
+            repo=repo_slug,
+            topic=topic_dir.name,
+        )
+
+
+def _count_active_entries(topic_dir: Path) -> int:
+    """Count per-entry markdown files whose frontmatter has status: active."""
+    count = 0
+    for path in topic_dir.glob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # Minimal frontmatter scan — matches the same pattern
+        # _split_tracked_entry uses in repo_wiki.py.
+        if not text.startswith("---\n"):
+            continue
+        try:
+            end = text.index("\n---\n", 4)
+        except ValueError:
+            continue
+        block = text[4:end]
+        # Default status is "active" when absent.
+        status = "active"
+        for line in block.splitlines():
+            if line.startswith("status:"):
+                status = line.split(":", 1)[1].strip()
+                break
+        if status == "active":
+            count += 1
+    return count
 
 
 async def _bridge_reflections_to_wiki(
@@ -563,6 +626,19 @@ class PostMergeHandler:
                     store=self._wiki_store,
                     compiler=self._wiki_compiler,
                     event_bus=self._event_bus,
+                ),
+                pr.issue_number,
+            )
+            # P5: compile the tracked wiki inline so the next issue
+            # sees a deduplicated view instead of waiting for the
+            # RepoWikiLoop interval. File mutations roll into the
+            # existing chore(wiki) maintenance PR flow.
+            await self._safe_hook(
+                "wiki compile on merge",
+                _compile_tracked_topics_for_merge(
+                    tracked_root=(self._config.repo_root / self._config.repo_wiki_path),
+                    repo_slug=self._config.repo or "",
+                    compiler=self._wiki_compiler,
                 ),
                 pr.issue_number,
             )

--- a/tests/test_post_merge_wiki_compile.py
+++ b/tests/test_post_merge_wiki_compile.py
@@ -1,0 +1,124 @@
+"""Tests for on-PR-merge wiki compilation (P5 wiki-evolution audit).
+
+Before this change, wiki compilation only ran on the RepoWikiLoop
+interval (cron-ish). After a PR merged with new entries, agents on
+the next issue still saw un-deduped siblings until the loop fired.
+
+P5 adds an explicit compile trigger to PostMergeHandler's post-merge
+hook chain. compile_topic_tracked is invoked for every topic that has
+≥2 active entries under the tracked layout, running under _safe_hook
+so failures don't block the merge path.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from post_merge_handler import _compile_tracked_topics_for_merge
+
+
+def _write_tracked_entry(
+    tracked_root: Path,
+    repo_slug: str,
+    topic: str,
+    entry_id: str,
+    source_issue: int,
+) -> None:
+    topic_dir = tracked_root / repo_slug / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    (topic_dir / f"{source_issue:04d}-{entry_id[-6:]}.md").write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: implement\n"
+        f"created_at: {now}\n"
+        "status: active\n"
+        "---\n"
+        f"# Insight {entry_id[-4:]}\n\nBody for entry {entry_id}.\n",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_runs_for_topics_with_multiple_active_entries(
+    tmp_path: Path,
+) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    _write_tracked_entry(tracked_root, "o/r", "patterns", "01JF000000000000000001", 1)
+    _write_tracked_entry(tracked_root, "o/r", "patterns", "01JF000000000000000002", 2)
+
+    compiler = MagicMock()
+    compiler.compile_topic_tracked = AsyncMock(return_value=1)
+
+    await _compile_tracked_topics_for_merge(
+        tracked_root=tracked_root,
+        repo_slug="o/r",
+        compiler=compiler,
+    )
+
+    compiler.compile_topic_tracked.assert_awaited_once()
+    call = compiler.compile_topic_tracked.await_args
+    assert call.kwargs["repo"] == "o/r"
+    assert call.kwargs["topic"] == "patterns"
+    assert call.kwargs["tracked_root"] == tracked_root
+
+
+@pytest.mark.asyncio
+async def test_compile_skips_topics_with_single_entry(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    _write_tracked_entry(tracked_root, "o/r", "patterns", "01JF000000000000000001", 1)
+
+    compiler = MagicMock()
+    compiler.compile_topic_tracked = AsyncMock(return_value=0)
+
+    await _compile_tracked_topics_for_merge(
+        tracked_root=tracked_root,
+        repo_slug="o/r",
+        compiler=compiler,
+    )
+
+    compiler.compile_topic_tracked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_compile_is_noop_when_tracked_root_missing(tmp_path: Path) -> None:
+    compiler = MagicMock()
+    compiler.compile_topic_tracked = AsyncMock()
+
+    await _compile_tracked_topics_for_merge(
+        tracked_root=tmp_path / "does-not-exist",
+        repo_slug="o/r",
+        compiler=compiler,
+    )
+
+    compiler.compile_topic_tracked.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_compile_aggregates_multiple_topics(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    _write_tracked_entry(tracked_root, "o/r", "patterns", "01JF000000000000000001", 1)
+    _write_tracked_entry(tracked_root, "o/r", "patterns", "01JF000000000000000002", 2)
+    _write_tracked_entry(tracked_root, "o/r", "testing", "01JF000000000000000003", 3)
+    _write_tracked_entry(tracked_root, "o/r", "testing", "01JF000000000000000004", 4)
+
+    compiler = MagicMock()
+    compiler.compile_topic_tracked = AsyncMock(return_value=1)
+
+    await _compile_tracked_topics_for_merge(
+        tracked_root=tracked_root,
+        repo_slug="o/r",
+        compiler=compiler,
+    )
+
+    assert compiler.compile_topic_tracked.await_count == 2
+    topics_called = {
+        c.kwargs["topic"] for c in compiler.compile_topic_tracked.await_args_list
+    }
+    assert topics_called == {"patterns", "testing"}


### PR DESCRIPTION
## Summary

**P5 of the wiki-evolution audit.** Wiki compilation only ran on the \`RepoWikiLoop\` interval tick. After a PR merged with fresh entries, the next issue's plan/review saw un-deduped siblings until the loop fired — could be hours or days.

## Change

\`PostMergeHandler._run_post_merge_hooks\` now invokes \`_compile_tracked_topics_for_merge\` right after the reflection-bridge hook. It walks \`{repo_root}/{repo_wiki_path}/{owner}/{repo}/\` and calls \`WikiCompiler.compile_topic_tracked\` for every topic that has ≥2 active entries. Runs under \`_safe_hook\` so compile failures don't block the merge.

File mutations from synthesis land as uncommitted diffs which the existing \`RepoWikiLoop._maybe_open_maintenance_pr\` rolls up into a \`chore(wiki)\` PR — no separate commit path.

## Test plan

- [x] 4 new unit tests: multi-entry compiled once, single-entry skipped, missing tracked_root no-op, multi-topic aggregation.
- [x] 67 post_merge tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)