### PR TITLE
feat(wiki): first-cut deterministic drift detector (P4)

### DIFF
--- a/src/wiki_drift_detector.py
+++ b/src/wiki_drift_detector.py
@@ -1,0 +1,129 @@
+"""Wiki-vs-code drift detection — P4 of the wiki-evolution audit.
+
+First-cut detector is deterministic and cheap: for every *active*
+tracked-layout entry under ``{tracked_root}/{repo_slug}/{topic}/``,
+extract ``src/...`` citations from its body and verify each cited
+file still exists under ``repo_root``.  Missing files = drift.
+
+Symbol-level drift (cited class/function removed while file remains)
+is intentionally out of scope for this pass — adding an LLM
+validator on top of this skeleton is the Phase 2 extension.
+
+The RepoWikiLoop calls ``detect_drift`` on a weekly cadence and can
+use the returned findings to mark entries stale with a
+``stale_reason: drift_detected <files>`` note.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Same shape as src/adr_index.py:_SOURCE_FILE_CITATION_RE — matches
+# `src/some/path.py:Symbol` citations inside backticks.
+_SOURCE_FILE_CITATION_RE = re.compile(r"`(src/[^`:\s]+\.py):[A-Za-z_]\w*`")
+
+
+@dataclass(frozen=True)
+class DriftFinding:
+    """One drifted wiki entry with the cited files that no longer exist."""
+
+    entry_path: Path
+    entry_id: str
+    topic: str
+    missing_files: frozenset[str]
+
+
+@dataclass
+class DriftResult:
+    findings: list[DriftFinding] = field(default_factory=list)
+
+
+def _parse_frontmatter(text: str) -> dict[str, str]:
+    """Minimal parser of the leading ``---`` YAML-ish block.
+
+    Mirrors ``src/repo_wiki.py:_split_tracked_entry`` — kept separate
+    to avoid importing a heavy module.
+    """
+    if not text.startswith("---\n"):
+        return {}
+    try:
+        end = text.index("\n---\n", 4)
+    except ValueError:
+        return {}
+    block = text[4:end]
+    out: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip()
+    return out
+
+
+def _entry_body(text: str) -> str:
+    """Return the body after the leading frontmatter (or the whole
+    text when no frontmatter is present)."""
+    if not text.startswith("---\n"):
+        return text
+    try:
+        end = text.index("\n---\n", 4)
+    except ValueError:
+        return text
+    return text[end + len("\n---\n") :]
+
+
+def detect_drift(
+    *,
+    tracked_root: Path,
+    repo_root: Path,
+    repo_slug: str,
+) -> DriftResult:
+    """Scan tracked-layout active entries and flag those citing missing files.
+
+    Parameters
+    ----------
+    tracked_root:
+        Root where the per-entry layout lives (typically
+        ``{repo_root}/repo_wiki``).
+    repo_root:
+        Working tree root used to resolve ``src/...`` citations.
+    repo_slug:
+        ``owner/repo`` slug scoping the lookup.
+    """
+    result = DriftResult()
+    repo_dir = tracked_root / repo_slug
+    if not repo_dir.is_dir():
+        return result
+
+    for topic_dir in sorted(p for p in repo_dir.iterdir() if p.is_dir()):
+        for entry_path in sorted(topic_dir.glob("*.md")):
+            try:
+                text = entry_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            fields = _parse_frontmatter(text)
+            if fields.get("status", "active") != "active":
+                continue
+
+            body = _entry_body(text)
+            cited = set(_SOURCE_FILE_CITATION_RE.findall(body))
+            if not cited:
+                continue
+
+            missing = {c for c in cited if not (repo_root / c).is_file()}
+            if not missing:
+                continue
+
+            result.findings.append(
+                DriftFinding(
+                    entry_path=entry_path,
+                    entry_id=fields.get("id", ""),
+                    topic=topic_dir.name,
+                    missing_files=frozenset(missing),
+                )
+            )
+
+    return result

--- a/tests/test_wiki_drift_detector.py
+++ b/tests/test_wiki_drift_detector.py
@@ -1,0 +1,175 @@
+"""Tests for the wiki-vs-code drift detector (P4 wiki-evolution audit).
+
+First-cut detector is heuristic / deterministic: for each active
+entry, extract ``src/...`` citations from its body, then verify each
+cited file still exists under ``repo_root``.  Missing files = drift.
+Symbol-level checks (grep for ``class Foo`` etc.) are a follow-up.
+
+Output is a ``DriftResult`` the RepoWikiLoop can use to mark flagged
+entries stale with a ``stale_reason: drift_detected <files>`` note.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from wiki_drift_detector import DriftFinding, detect_drift
+
+
+def _write_entry(
+    tracked_root: Path,
+    repo_slug: str,
+    topic: str,
+    *,
+    body: str,
+    entry_id: str = "01JF000000000000000001",
+    source_issue: int = 1,
+    status: str = "active",
+) -> Path:
+    topic_dir = tracked_root / repo_slug / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    path = topic_dir / f"0001-issue-{source_issue}.md"
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: implement\n"
+        f"created_at: {now}\n"
+        f"status: {status}\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_detects_entry_citing_missing_file(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="# title\n\nThe relevant code lives in `src/ghost.py:Ghost`.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root,
+        repo_root=repo_root,
+        repo_slug="o/r",
+    )
+
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert isinstance(finding, DriftFinding)
+    assert "src/ghost.py" in finding.missing_files
+
+
+def test_passes_when_cited_file_exists(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "exists.py").write_text("class Exists: pass\n")
+
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="# title\n\nImplemented in `src/exists.py:Exists`.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root,
+        repo_root=repo_root,
+        repo_slug="o/r",
+    )
+
+    assert result.findings == []
+
+
+def test_ignores_stale_and_superseded_entries(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="Old body citing `src/ghost.py:Ghost`.",
+        entry_id="01JF000000000000000002",
+        source_issue=2,
+        status="stale",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root,
+        repo_root=repo_root,
+        repo_slug="o/r",
+    )
+
+    assert result.findings == []
+
+
+def test_entry_without_src_citations_is_skipped(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="# title\n\nGeneral architectural note. No source pointers.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root,
+        repo_root=repo_root,
+        repo_slug="o/r",
+    )
+
+    assert result.findings == []
+
+
+def test_returns_empty_when_no_tracked_entries(tmp_path: Path) -> None:
+    result = detect_drift(
+        tracked_root=tmp_path / "missing",
+        repo_root=tmp_path / "repo",
+        repo_slug="o/r",
+    )
+    assert result.findings == []
+
+
+def test_aggregates_findings_across_topics(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="cites `src/one.py:A`",
+        entry_id="01JF000000000000000001",
+        source_issue=1,
+    )
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "testing",
+        body="cites `src/two.py:B`",
+        entry_id="01JF000000000000000002",
+        source_issue=2,
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root,
+        repo_root=repo_root,
+        repo_slug="o/r",
+    )
+
+    assert len(result.findings) == 2
+    topics = {f.topic for f in result.findings}
+    assert topics == {"patterns", "testing"}


### PR DESCRIPTION
## Summary

**P4 of the wiki-evolution audit.** Wiki entries that claim \"X lives in \`src/foo.py:SomeClass\`\" could drift silently when the file was renamed or deleted. This ships a fast, deterministic detector as the foundation — an LLM validator can plug on top later.

## How it works

1. Walk \`{tracked_root}/{owner}/{repo}/{topic}/*.md\` active entries.
2. Extract \`src/...:Symbol\` citations (same regex used by the P2 ADR-gate).
3. Flag every entry whose cited files are missing under \`repo_root\`.
4. Return a \`DriftResult\` the caller uses to mark entries stale.

## Changes

- New \`src/wiki_drift_detector.py\` — \`detect_drift(tracked_root, repo_root, repo_slug) -> DriftResult\`, \`DriftFinding\` dataclass.
- 6 unit tests: file-missing flag, file-exists pass, stale/superseded skipped, entries without \`src:\` citations skipped, missing \`tracked_root\` no-op, multi-topic aggregation.

## Out of scope

- **Symbol-level drift** (file present but class/function removed) — LLM layer, next iteration.
- **RepoWikiLoop wiring** — weekly cadence + stale-marking — follow-up after we've watched the detector produce signal in practice.

## Test plan

- [x] 6 unit tests pass.
- [ ] Follow-up: wire into RepoWikiLoop; mark findings stale with \`drift_detected\` reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)