### PR TITLE
feat(wiki): auto-mark drift findings stale (B2)

### DIFF
--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -19,7 +19,7 @@ from knowledge_metrics import metrics as _metrics
 from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
 from staleness import evaluate as evaluate_staleness
 from subprocess_util import run_subprocess
-from wiki_drift_detector import detect_drift
+from wiki_drift_detector import apply_drift_markers, detect_drift
 from wiki_maint_queue import MaintenanceQueue
 
 if TYPE_CHECKING:
@@ -343,11 +343,13 @@ class RepoWikiLoop(BaseBackgroundLoop):
         # until Phase 5 ports them.
         # Phase 9: wiki-vs-code drift detection (deterministic, cheap).
         # Scans every active tracked entry for `src/...:Symbol` citations
-        # and flags ones pointing at files that no longer exist. Findings
-        # are logged now and, on a follow-up pass, will be auto-marked
-        # stale. Keeping the action side read-only for the first landing
-        # so operators can see the signal before we start mutating files.
+        # and flags ones pointing at files that no longer exist. B2
+        # auto-marks flagged entries stale — safe because the detector
+        # is deterministic (file missing or not, no LLM guesswork). The
+        # stale flips land as uncommitted diffs the maintenance PR
+        # rolls up.
         drift_findings = 0
+        drift_marked = 0
         if tracked_root is not None:
             for slug in repos:
                 try:
@@ -370,7 +372,12 @@ class RepoWikiLoop(BaseBackgroundLoop):
                         f.entry_id,
                         sorted(f.missing_files),
                     )
+                if result.findings:
+                    drift_marked += await asyncio.to_thread(
+                        apply_drift_markers, result.findings
+                    )
         stats["drift_findings"] = drift_findings
+        stats["drift_marked_stale"] = drift_marked
 
         stats["queue_drained"] = len(drained)
         await self._poll_and_merge_open_pr(stats)

--- a/src/wiki_drift_detector.py
+++ b/src/wiki_drift_detector.py
@@ -16,9 +16,12 @@ use the returned findings to mark entries stale with a
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger("hydraflow.wiki_drift_detector")
 
 # Same shape as src/adr_index.py:_SOURCE_FILE_CITATION_RE — matches
 # `src/some/path.py:Symbol` citations inside backticks.
@@ -127,3 +130,47 @@ def detect_drift(
             )
 
     return result
+
+
+def apply_drift_markers(findings: list[DriftFinding]) -> int:
+    """Flip each flagged entry's ``status: active`` → ``stale`` with a
+    ``stale_reason: drift_detected: <files>`` annotation.
+
+    Only mutates files whose frontmatter still says ``status: active`` —
+    idempotent on second call, safe against entries that a prior lint
+    pass already marked stale.
+
+    Returns the count of entries actually updated. Never raises on
+    per-file read / write failures; logs and continues.
+    """
+    updated = 0
+    for finding in findings:
+        try:
+            text = finding.entry_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            logger.warning(
+                "drift automark: cannot read %s; skipping", finding.entry_path
+            )
+            continue
+        fields = _parse_frontmatter(text)
+        if not fields or fields.get("status", "active") != "active":
+            continue
+        body = _entry_body(text)
+        reason = "drift_detected: " + ",".join(sorted(finding.missing_files))
+        fields["status"] = "stale"
+        fields["stale_reason"] = reason
+        rebuilt = (
+            "---\n"
+            + "\n".join(f"{k}: {v}" for k, v in fields.items())
+            + "\n---\n"
+            + body
+        )
+        try:
+            finding.entry_path.write_text(rebuilt, encoding="utf-8")
+        except OSError:
+            logger.warning(
+                "drift automark: cannot write %s; skipping", finding.entry_path
+            )
+            continue
+        updated += 1
+    return updated

--- a/tests/test_wiki_drift_automark.py
+++ b/tests/test_wiki_drift_automark.py
@@ -1,0 +1,105 @@
+"""B2 — auto-stale-mark drift findings (extension of P4).
+
+``detect_drift`` flags entries citing missing files. A companion
+helper flips those entries' ``status: active`` → ``stale`` with a
+``stale_reason: drift_detected: <files>`` annotation so they drop
+out of ``query()``'s prompt-injection results immediately.
+
+Safe by construction: P4's detector is deterministic — a missing
+file is binary, no LLM guesswork.  Auto-marking is therefore low
+risk for false positives.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from wiki_drift_detector import DriftFinding, apply_drift_markers, detect_drift
+
+
+def _write_entry(
+    tracked_root: Path,
+    repo_slug: str,
+    topic: str,
+    *,
+    body: str,
+    entry_id: str = "01JF000000000000000001",
+    source_issue: int = 1,
+    status: str = "active",
+) -> Path:
+    topic_dir = tracked_root / repo_slug / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    path = topic_dir / f"0001-issue-{source_issue}.md"
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: implement\n"
+        f"created_at: {now}\n"
+        f"status: {status}\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_apply_markers_flips_active_to_stale(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    entry_path = _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="# title\n\nCited in `src/ghost.py:Ghost`.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+    marked = apply_drift_markers(result.findings)
+
+    assert marked == 1
+    updated_text = entry_path.read_text()
+    assert "status: stale" in updated_text
+    assert "stale_reason: drift_detected" in updated_text
+    assert "src/ghost.py" in updated_text
+
+
+def test_apply_markers_preserves_body(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    body_text = "# title\n\nThe important insight here.\n\nCited `src/ghost.py:Ghost`."
+    entry_path = _write_entry(tracked_root, "o/r", "patterns", body=body_text)
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+    apply_drift_markers(result.findings)
+
+    text = entry_path.read_text()
+    # Body survives
+    assert "The important insight here." in text
+    # Still one frontmatter block
+    assert text.count("---\n") == 2
+
+
+def test_apply_markers_returns_zero_for_empty_findings() -> None:
+    assert apply_drift_markers([]) == 0
+
+
+def test_apply_markers_skips_unreadable_files(tmp_path: Path) -> None:
+    # Finding pointing at a path that doesn't exist: apply_drift_markers
+    # must not raise; it should skip and report 0.
+    finding = DriftFinding(
+        entry_path=tmp_path / "missing.md",
+        entry_id="x",
+        topic="patterns",
+        missing_files=frozenset({"src/ghost.py"}),
+    )
+    assert apply_drift_markers([finding]) == 0


### PR DESCRIPTION
## Summary

Before: \`RepoWikiLoop\` ran \`detect_drift\` per tick but only logged findings (read-only — per the cleanup-PR landing). Wiki entries citing deleted files stayed flagged as \`active\` indefinitely.

After: findings get flipped to \`status: stale\` with \`stale_reason: drift_detected: <files>\` via a new \`apply_drift_markers\` helper. Entries drop out of \`query()\` prompt injection immediately; the mutation rolls into the existing \`chore(wiki)\` maintenance PR.

## Safety

P4's detector is deterministic — file-missing is binary, no LLM guesswork. False-positive risk rounds to zero, so gating behind manual review would only add latency.

## Changes

- \`src/wiki_drift_detector.py\` — new \`apply_drift_markers(findings)\`. Idempotent, never raises, preserves entry body verbatim.
- \`src/repo_wiki_loop.py\` — calls it on every drift finding; adds \`drift_marked_stale\` to stats.
- \`tests/test_wiki_drift_automark.py\` — 4 new unit tests.

## Test plan

- [x] 18 wiki-drift + RepoWikiLoop tests pass.
- [ ] First production run: observe \`drift_marked_stale > 0\` for any entries that cite now-deleted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)