### PR TITLE
docs(adr): backfill real Enforced-by refs for 14 ADRs (B1)

### DIFF
--- a/docs/adr/0004-agent-cli-as-runtime.md
+++ b/docs/adr/0004-agent-cli-as-runtime.md
@@ -1,7 +1,7 @@
 # ADR-0004: CLI-based Agent Runtime (Claude / Codex / Pi.dev)
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_agent_cli.py, tests/test_base_runner.py
 **Date:** 2026-02-26
 
 ## Context

--- a/docs/adr/0005-pr-recovery-and-zero-diff-branch-handling.md
+++ b/docs/adr/0005-pr-recovery-and-zero-diff-branch-handling.md
@@ -1,7 +1,7 @@
 # ADR-0005: PR Recovery and Zero-Diff Branch Handling in Implement Phase
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_implement_phase.py
 **Date:** 2026-02-27
 
 ## Context

--- a/docs/adr/0007-dashboard-api-multi-repo-scoping.md
+++ b/docs/adr/0007-dashboard-api-multi-repo-scoping.md
@@ -1,7 +1,7 @@
 # ADR-0007: Dashboard API Architecture for Multi-Repo Scoping
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_dashboard_routes_repo.py
 **Date:** 2026-02-28
 
 ## Context

--- a/docs/adr/0008-multi-repo-dashboard-architecture.md
+++ b/docs/adr/0008-multi-repo-dashboard-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0008: Multi-Repo Dashboard Architecture
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_dashboard_routes_repo.py
 **Date:** 2026-02-28
 
 ## Context

--- a/docs/adr/0009-multi-repo-process-per-repo-model.md
+++ b/docs/adr/0009-multi-repo-process-per-repo-model.md
@@ -1,7 +1,7 @@
 # ADR-0009: Multi-Repo Process-Per-Repo Model
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** (process)
 **Date:** 2026-02-28
 
 ## Context

--- a/docs/adr/0011-epic-release-creation-architecture.md
+++ b/docs/adr/0011-epic-release-creation-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0011: Epic Release Creation Architecture
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_epic.py, tests/test_release.py
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0012-epic-merge-coordination-architecture.md
+++ b/docs/adr/0012-epic-merge-coordination-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0012: Epic Merge Coordination Architecture
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_epic_merge_coordination.py
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0015-protocol-callback-gate-pattern.md
+++ b/docs/adr/0015-protocol-callback-gate-pattern.md
@@ -1,7 +1,7 @@
 # ADR-0015: Protocol-Based Callback Injection for Merge-Phase Gates
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_review_phase_hooks.py
 **Date:** 2026-03-18
 
 ## Context

--- a/docs/adr/0016-visual-validation-skipped-override-semantics.md
+++ b/docs/adr/0016-visual-validation-skipped-override-semantics.md
@@ -1,7 +1,7 @@
 # ADR-0016: VisualValidation SKIPPED Override Semantics — Partial Suppression by Design
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_visual_validation.py
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0018-screenshot-capture-pipeline.md
+++ b/docs/adr/0018-screenshot-capture-pipeline.md
@@ -1,7 +1,7 @@
 # ADR-0018: Screenshot Capture Pipeline Architecture
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_screenshot_scanner.py, tests/test_report_issue_loop.py
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0019-background-task-delegation-abstraction-layer.md
+++ b/docs/adr/0019-background-task-delegation-abstraction-layer.md
@@ -1,7 +1,7 @@
 # ADR-0019: Background Task Delegation — Call the Right Abstraction Layer
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_epic_manager.py, tests/test_post_merge_handler.py
 **Date:** 2026-03-01
 
 ## Context

--- a/docs/adr/0024-implementation-retry-recovery-architecture.md
+++ b/docs/adr/0024-implementation-retry-recovery-architecture.md
@@ -1,7 +1,7 @@
 # ADR-0024: Implementation Retry Recovery Architecture
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_implement_phase.py, tests/scenarios/fakes/test_prior_failure_propagation.py
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0037-supersession-regex-all-verb-forms.md
+++ b/docs/adr/0037-supersession-regex-all-verb-forms.md
@@ -1,7 +1,7 @@
 # ADR-0037: Supersession Regex Must Include All Verb Forms
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_adr_pre_validator.py
 **Date:** 2026-03-08
 
 ## Context

--- a/docs/adr/0041-github-source-of-truth-cache-as-sidecar.md
+++ b/docs/adr/0041-github-source-of-truth-cache-as-sidecar.md
@@ -1,7 +1,7 @@
 # ADR-0041: GitHub as Source of Truth, Local Cache as Sidecar
 
 **Status:** Accepted
-**Enforced by:** (none)
+**Enforced by:** tests/test_issue_cache.py, tests/test_precondition_gate.py
 **Date:** 2026-04-08
 
 ## Context


### PR DESCRIPTION
## Summary

**B1 of the wiki-evolution backlog.** P3 (#8398) seeded 14 Accepted ADRs with \`**Enforced by:** (none)\` — \"structure now, real refs later.\" This PR closes that gap. Every remaining placeholder replaced with real test paths or a justified \`(process)\` marker.

## Mappings

| ADR | Enforced by |
|---|---|
| 0004 agent-cli-as-runtime | \`tests/test_agent_cli.py\`, \`tests/test_base_runner.py\` |
| 0005 pr-recovery-and-zero-diff | \`tests/test_implement_phase.py\` |
| 0007 dashboard-api-multi-repo-scoping | \`tests/test_dashboard_routes_repo.py\` |
| 0008 multi-repo-dashboard-architecture | \`tests/test_dashboard_routes_repo.py\` |
| **0009** multi-repo-process-per-repo-model | \`(process)\` — runtime architectural property |
| 0011 epic-release-creation-architecture | \`tests/test_epic.py\`, \`tests/test_release.py\` |
| 0012 epic-merge-coordination-architecture | \`tests/test_epic_merge_coordination.py\` |
| 0015 protocol-callback-gate-pattern | \`tests/test_review_phase_hooks.py\` |
| 0016 visual-validation-skipped-override | \`tests/test_visual_validation.py\` |
| 0018 screenshot-capture-pipeline | \`tests/test_screenshot_scanner.py\`, \`tests/test_report_issue_loop.py\` |
| 0019 background-task-delegation | \`tests/test_epic_manager.py\`, \`tests/test_post_merge_handler.py\` |
| 0024 implementation-retry-recovery | \`tests/test_implement_phase.py\`, \`tests/scenarios/fakes/test_prior_failure_propagation.py\` |
| 0037 supersession-regex-all-verb-forms | \`tests/test_adr_pre_validator.py\` |
| 0041 github-source-of-truth-cache | \`tests/test_issue_cache.py\`, \`tests/test_precondition_gate.py\` |

Only ADR-0009 kept \`(process)\`: multi-repo isolation is a runtime property (supervisor subprocess lifecycle + env separation), not a unit-testable invariant.

## Test plan

- [x] All 42 Accepted ADRs now have an Enforced-by line.
- [x] Zero \`(none)\` placeholders remain.
- [x] 56/56 \`tests/test_adr_enforcement.py\` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)