### PR TITLE
feat(wiki): symbol-level drift detection (B3)

### DIFF
--- a/src/wiki_drift_detector.py
+++ b/src/wiki_drift_detector.py
@@ -23,19 +23,28 @@ from pathlib import Path
 
 logger = logging.getLogger("hydraflow.wiki_drift_detector")
 
-# Same shape as src/adr_index.py:_SOURCE_FILE_CITATION_RE — matches
-# `src/some/path.py:Symbol` citations inside backticks.
-_SOURCE_FILE_CITATION_RE = re.compile(r"`(src/[^`:\s]+\.py):[A-Za-z_]\w*`")
+# Matches `src/some/path.py:Symbol` citations inside backticks and
+# captures (file, symbol). Shares shape with
+# src/adr_index.py:_SOURCE_FILE_CITATION_RE.
+_SOURCE_PAIR_CITATION_RE = re.compile(r"`(src/[^`:\s]+\.py):([A-Za-z_]\w*)`")
 
 
 @dataclass(frozen=True)
 class DriftFinding:
-    """One drifted wiki entry with the cited files that no longer exist."""
+    """One drifted wiki entry.
+
+    ``missing_files`` lists cited ``src/...py`` files that no longer
+    exist under ``repo_root``.  ``missing_symbols`` lists
+    ``src/path.py:Symbol`` citations where the file exists but the
+    symbol (``class Symbol`` / ``def Symbol`` / ``async def Symbol``)
+    is not defined in it.
+    """
 
     entry_path: Path
     entry_id: str
     topic: str
     missing_files: frozenset[str]
+    missing_symbols: frozenset[str] = frozenset()
 
 
 @dataclass
@@ -77,6 +86,37 @@ def _entry_body(text: str) -> str:
     return text[end + len("\n---\n") :]
 
 
+def _file_defines_symbol(file_path: Path, symbol: str) -> bool:
+    """Grep *file_path* for a top-level or indented definition of *symbol*.
+
+    Matches ``class Symbol`` / ``def Symbol`` / ``async def Symbol``
+    with optional leading whitespace (so methods inside classes count)
+    followed by ``(``, ``:``, ``[``, or whitespace — whatever Python
+    syntax permits. Module-level assignments (constants / aliases) are
+    caught by the trailing ``=`` / ``:`` alternative.
+
+    False positives on comments/strings would be rare and one-directional
+    (under-flagging drift rather than over-flagging), so we keep it
+    regex-simple rather than AST-parsing.
+    """
+    try:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    pattern = re.compile(
+        rf"^\s*(?:class|def|async\s+def)\s+{re.escape(symbol)}\b",
+        re.MULTILINE,
+    )
+    if pattern.search(text):
+        return True
+    # Module-level constants/aliases: `FOO = ...` or `FOO: Type = ...`.
+    assign_pattern = re.compile(
+        rf"^{re.escape(symbol)}\s*(?::\s*[^=\n]+)?\s*=",
+        re.MULTILINE,
+    )
+    return bool(assign_pattern.search(text))
+
+
 def detect_drift(
     *,
     tracked_root: Path,
@@ -112,12 +152,21 @@ def detect_drift(
                 continue
 
             body = _entry_body(text)
-            cited = set(_SOURCE_FILE_CITATION_RE.findall(body))
-            if not cited:
+            pairs = set(_SOURCE_PAIR_CITATION_RE.findall(body))
+            if not pairs:
                 continue
 
-            missing = {c for c in cited if not (repo_root / c).is_file()}
-            if not missing:
+            missing_files: set[str] = set()
+            missing_symbols: set[str] = set()
+            for file_ref, symbol in pairs:
+                file_path = repo_root / file_ref
+                if not file_path.is_file():
+                    missing_files.add(file_ref)
+                    continue
+                if not _file_defines_symbol(file_path, symbol):
+                    missing_symbols.add(f"{file_ref}:{symbol}")
+
+            if not missing_files and not missing_symbols:
                 continue
 
             result.findings.append(
@@ -125,7 +174,8 @@ def detect_drift(
                     entry_path=entry_path,
                     entry_id=fields.get("id", ""),
                     topic=topic_dir.name,
-                    missing_files=frozenset(missing),
+                    missing_files=frozenset(missing_files),
+                    missing_symbols=frozenset(missing_symbols),
                 )
             )
 
@@ -156,7 +206,8 @@ def apply_drift_markers(findings: list[DriftFinding]) -> int:
         if not fields or fields.get("status", "active") != "active":
             continue
         body = _entry_body(text)
-        reason = "drift_detected: " + ",".join(sorted(finding.missing_files))
+        parts = sorted(finding.missing_files) + sorted(finding.missing_symbols)
+        reason = "drift_detected: " + ",".join(parts)
         fields["status"] = "stale"
         fields["stale_reason"] = reason
         rebuilt = (

--- a/tests/test_wiki_drift_symbols.py
+++ b/tests/test_wiki_drift_symbols.py
@@ -1,0 +1,158 @@
+"""B3 — symbol-level drift detection.
+
+P4 flagged entries citing files that no longer exist. B3 extends
+the detector to also flag entries where the file still exists but
+the cited symbol (class / function name after the colon) is no
+longer defined in that file. Pure deterministic check — grep the
+file for ``class <Symbol>`` or ``def <Symbol>`` (covering
+``async def`` and leading whitespace).
+
+LLM-driven semantic drift ("the claim about this symbol is stale
+even though the symbol exists") is a follow-up; this pass is the
+cheap deterministic foundation.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from wiki_drift_detector import detect_drift
+
+
+def _write_entry(
+    tracked_root: Path,
+    repo_slug: str,
+    topic: str,
+    *,
+    body: str,
+    entry_id: str = "01JF000000000000000001",
+    source_issue: int = 1,
+) -> Path:
+    topic_dir = tracked_root / repo_slug / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC).isoformat()
+    path = topic_dir / f"0001-issue-{source_issue}.md"
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: implement\n"
+        f"created_at: {now}\n"
+        "status: active\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_flags_missing_class_symbol(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    # File exists but NO Ghost class/function defined.
+    (repo_root / "src" / "foo.py").write_text("class OtherThing:\n    pass\n")
+
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="Cited in `src/foo.py:Ghost`.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.missing_files == frozenset()
+    assert "src/foo.py:Ghost" in finding.missing_symbols
+
+
+def test_passes_when_class_symbol_exists(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "foo.py").write_text("class Ghost:\n    pass\n")
+
+    _write_entry(tracked_root, "o/r", "patterns", body="Cited `src/foo.py:Ghost`.")
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert result.findings == []
+
+
+def test_passes_when_function_symbol_exists(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "foo.py").write_text("def ghost():\n    return None\n")
+
+    _write_entry(tracked_root, "o/r", "patterns", body="Cited `src/foo.py:ghost`.")
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert result.findings == []
+
+
+def test_passes_for_async_function(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "foo.py").write_text("async def go():\n    pass\n")
+
+    _write_entry(tracked_root, "o/r", "patterns", body="Cited `src/foo.py:go`.")
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert result.findings == []
+
+
+def test_passes_for_indented_method(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "foo.py").write_text(
+        "class Container:\n    def the_method(self):\n        pass\n"
+    )
+
+    _write_entry(tracked_root, "o/r", "patterns", body="Cited `src/foo.py:the_method`.")
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert result.findings == []
+
+
+def test_mixed_missing_file_and_missing_symbol(tmp_path: Path) -> None:
+    tracked_root = tmp_path / "repo_wiki"
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "present.py").write_text("class NotTheOne:\n    pass\n")
+    # src/ghost.py deliberately missing
+
+    _write_entry(
+        tracked_root,
+        "o/r",
+        "patterns",
+        body="Cites `src/ghost.py:Ghost` and `src/present.py:TheMissing`.",
+    )
+
+    result = detect_drift(
+        tracked_root=tracked_root, repo_root=repo_root, repo_slug="o/r"
+    )
+
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert "src/ghost.py" in finding.missing_files
+    assert "src/present.py:TheMissing" in finding.missing_symbols


### PR DESCRIPTION
## Summary

**B3 of the wiki-evolution backlog.** P4 flagged entries citing missing FILES. B3 extends the detector to also flag entries where the file exists but the cited SYMBOL is no longer defined — renames, class/function deletions while the file stays.

## How it works

Still deterministic — regex-matches the file's text for \`class <Symbol>\`, \`def <Symbol>\`, \`async def <Symbol>\`, or a module-level assignment (\`SYMBOL = ...\`). LLM-driven *semantic* drift is the next layer; this is the cheap grep foundation.

## Changes

- \`DriftFinding\` gains \`missing_symbols: frozenset[str]\` alongside \`missing_files\`.
- \`_SOURCE_PAIR_CITATION_RE\` replaces the file-only regex — captures \`(file, symbol)\` pairs.
- \`_file_defines_symbol\` helper — regex grep. Regex simplicity is intentional: false positives underflag rather than overflag.
- \`apply_drift_markers\` now includes \`missing_symbols\` in \`stale_reason\` so the maintenance PR diff shows the full picture.

## Test plan

- [x] 6 new unit tests: missing class, existing class, existing def, async def, indented method, mixed file-missing + symbol-missing.
- [x] All 16 drift tests pass.

## Dependency

Builds on \`feature/drift-automark\` (#8403 B2). Merge order: B2 first, then this PR rebases clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)