### PR TITLE
feat(caretakers): act on LLM-usage audit findings

### DIFF
--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -83,15 +83,36 @@ class CodeGroomingLoop(BaseBackgroundLoop):
 
     @classmethod
     def _parse_findings(cls, transcript: str) -> list[dict]:
-        """Extract structured finding dicts from audit transcript."""
+        """Extract structured finding dicts from audit transcript.
+
+        Logs a warning when a non-trivial transcript parses to zero
+        findings — that's the smoke signal that the LLM wrote prose
+        instead of JSON (prompt drift or model deviation). Without
+        this, a broken audit run would silently file nothing forever.
+        """
         findings: list[dict] = []
+        match_count = 0
         for match in cls._FINDING_RE.finditer(transcript):
+            match_count += 1
             try:
                 obj = json.loads(match.group(0))
                 if isinstance(obj, dict) and "id" in obj and "severity" in obj:
                     findings.append(obj)
             except (json.JSONDecodeError, TypeError):
                 continue
+
+        # Heuristic: substantial output + zero parsed findings = shape
+        # drift worth surfacing. Threshold avoids noisy warnings on
+        # expected "nothing to groom" runs.
+        if not findings and len(transcript.strip()) > 500:
+            logger.warning(
+                "Code grooming audit produced a %d-char transcript but "
+                "zero parseable findings (regex saw %d candidate JSON "
+                "blocks; none matched required keys). Check the skill "
+                "prompt and model output shape.",
+                len(transcript),
+                match_count,
+            )
         return findings
 
     async def _do_work(self) -> dict[str, Any] | None:

--- a/src/config.py
+++ b/src/config.py
@@ -1310,8 +1310,8 @@ class HydraFlowConfig(BaseModel):
         description="CLI backend for sentry_loop ingestion worker",
     )
     sentry_model: str = Field(
-        default="opus",
-        description="Model for sentry_loop ingestion worker (issue triage + filing from Sentry events)",
+        default="sonnet",
+        description="Model for sentry_loop ingestion worker (issue triage + filing from Sentry events) — sonnet is sufficient; the task is stack-trace parsing + issue filing, not deep reasoning. Opus was 4-5× the cost for no measurable quality win.",
     )
     code_grooming_tool: Literal["claude", "codex", "gemini", "pi"] = Field(
         default="claude",

--- a/tests/test_code_grooming_parse_warning.py
+++ b/tests/test_code_grooming_parse_warning.py
@@ -1,0 +1,62 @@
+"""Tests for the parse-warning smoke signal in CodeGroomingLoop.
+
+Closes the LLM-audit gap where a grooming run that produced prose
+output (wrong shape) silently filed zero findings with no operator
+alert. Parsing remains best-effort — we just log when the signal
+looks suspicious.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from code_grooming_loop import CodeGroomingLoop
+
+
+def test_parse_empty_transcript_is_silent(caplog) -> None:
+    with caplog.at_level(logging.WARNING):
+        findings = CodeGroomingLoop._parse_findings("")
+    assert findings == []
+    assert "zero parseable findings" not in caplog.text
+
+
+def test_parse_short_transcript_is_silent(caplog) -> None:
+    """Under 500 chars = "nothing to audit" signal, not prompt drift."""
+    with caplog.at_level(logging.WARNING):
+        findings = CodeGroomingLoop._parse_findings("Nothing to groom today.")
+    assert findings == []
+    assert "zero parseable findings" not in caplog.text
+
+
+def test_parse_long_prose_transcript_emits_warning(caplog) -> None:
+    """Large transcript with zero JSON findings = probable prompt drift."""
+    prose = (
+        "The code base appears to be in good shape. I examined " * 40
+        + "the core modules and found no critical issues."
+    )
+    with caplog.at_level(logging.WARNING):
+        findings = CodeGroomingLoop._parse_findings(prose)
+    assert findings == []
+    assert "zero parseable findings" in caplog.text
+
+
+def test_parse_valid_json_findings_no_warning(caplog) -> None:
+    transcript = (
+        "Here are the findings from the audit run.\n\n"
+        '{"id": "X-1", "severity": "high", "title": "t", "description": "d"}\n'
+        '{"id": "X-2", "severity": "critical", "title": "u", "description": "e"}\n'
+        "End of report.\n"
+    )
+    with caplog.at_level(logging.WARNING):
+        findings = CodeGroomingLoop._parse_findings(transcript)
+    assert len(findings) == 2
+    assert "zero parseable findings" not in caplog.text
+
+
+def test_parse_malformed_json_in_long_output_emits_warning(caplog) -> None:
+    """Matches regex but fails json.loads — still flagged."""
+    transcript = 'Here is a finding: {"id": "broken, "severity": "high"} ' * 30
+    with caplog.at_level(logging.WARNING):
+        findings = CodeGroomingLoop._parse_findings(transcript)
+    assert findings == []
+    assert "zero parseable findings" in caplog.text


### PR DESCRIPTION
## Summary

End-of-session audit of caretaker background loops flagged two actionable items.

### 1. Sentry triage default: \`opus → sonnet\`

Stack-trace parsing + issue filing is plumbing, not deep reasoning. Opus was 4-5× the cost with no measurable quality win. sonnet is the default tier for the other similar workers (code_grooming, adr_review). Operators who hit a case where the upgrade pays off can still set \`HYDRAFLOW_SENTRY=claude:opus\`.

### 2. \`CodeGroomingLoop\` silent-drop warning

Prior behavior: when the audit skill wrote prose instead of JSON (prompt drift / model deviation / skill file change), \`_parse_findings\` returned zero, nothing filed, no operator signal — loop marched on forever.

Now: when the transcript is non-trivial (>500 chars) but zero findings parse, \`_parse_findings\` emits a WARNING. The 500-char threshold avoids noise on legit \"nothing to groom\" runs while catching shape drift.

## Changes

| File | Change |
|---|---|
| \`src/config.py:1312\` | \`sentry_model\` default \`opus\` → \`sonnet\` + rationale in docstring |
| \`src/code_grooming_loop.py\` | \`_parse_findings\` tracks match count + emits WARNING on shape drift |
| \`tests/test_code_grooming_parse_warning.py\` | 5 new unit tests (silent paths + warning paths) |

## Test plan

- [x] 48 config + code_grooming tests pass.
- [ ] Post-merge smoke: next sentry ingestion run uses sonnet (check metrics).
- [ ] Watch for the new \"zero parseable findings\" warning in logs — that's the signal to tune the audit skill prompt.

## Deferred from the audit

WikiCompiler generalization pass may miss cross-repo semantic matches on haiku. Decision needs an eval set (benchmark haiku vs sonnet on ~10 known same / known different pairs). Filed as follow-up; not a code change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)