### PR TITLE
feat(wiki): LLM semantic-drift layer (E2)

### DIFF
--- a/docs/adr/0032-per-repo-wiki-knowledge-base.md
+++ b/docs/adr/0032-per-repo-wiki-knowledge-base.md
@@ -1,7 +1,7 @@
 # ADR-0032: Per-Repo Wiki Knowledge Base (Karpathy Pattern)
 
 **Status:** Accepted
-**Enforced by:** tests/test_repo_wiki.py, tests/test_repo_wiki_store_git.py, tests/test_repo_wiki_ingest.py
+**Enforced by:** tests/test_repo_wiki.py, tests/test_repo_wiki_store_git.py, tests/test_repo_wiki_ingest.py, tests/test_wiki_drift_detector.py, tests/test_wiki_drift_symbols.py, tests/test_wiki_semantic_drift.py
 **Date:** 2026-04-05
 
 ## Context
@@ -35,6 +35,8 @@ Adopt a file-based, per-repo wiki system with three layers:
 - **LLM as librarian**: `WikiCompiler` uses Claude (via `build_lightweight_command`) to synthesize redundant entries, add cross-references between topics, resolve contradictions, and extract durable knowledge from raw phase output. This is the core Karpathy insight — the LLM maintains the wiki, not just reads it.
 
 - **Active self-healing lint**: The background loop marks entries stale when their source issues close (via `StateTracker` outcomes), prunes entries older than 90 days, and rebuilds the index. The wiki degrades gracefully without manual curation.
+
+- **Drift detection (two layers)**: A deterministic pass (`wiki_drift_detector.detect_drift`) flags entries whose `src/path.py:Symbol` citations point at files or symbols that no longer exist — cheap, side-effect-free, and auto-marks stale. An optional LLM layer (`scan_semantic_drift`, gated by `semantic_drift_enabled`) asks the compilation model whether an entry's CLAIM still matches the current source for entries older than `semantic_drift_min_age_days`, capped at `semantic_drift_max_entries_per_tick` per loop tick. Semantic findings are logged for human review; only the deterministic layer auto-stales.
 
 - **Dedup tracking**: `DedupStore`-backed per-repo tracking prevents re-ingesting the same (issue, source_type) pair. Failed ingests are not marked, so retries work.
 

--- a/src/config.py
+++ b/src/config.py
@@ -1408,6 +1408,35 @@ class HydraFlowConfig(BaseModel):
             "Phase 4."
         ),
     )
+    semantic_drift_enabled: bool = Field(
+        default=False,
+        description=(
+            "When True, RepoWikiLoop runs an LLM-backed semantic-drift pass "
+            "on wiki entries whose citations still exist on disk but whose "
+            "CLAIMs may have rotted (renamed defaults, swapped models, "
+            "changed control flow). Off by default until eval-tuned."
+        ),
+    )
+    semantic_drift_min_age_days: int = Field(
+        default=30,
+        ge=1,
+        le=365,
+        description=(
+            "Minimum entry age before the semantic-drift pass reconsiders "
+            "it. Freshly written entries are trusted; only older ones are "
+            "re-judged against current source."
+        ),
+    )
+    semantic_drift_max_entries_per_tick: int = Field(
+        default=10,
+        ge=1,
+        le=200,
+        description=(
+            "Cost bound: cap how many semantic-drift LLM calls the wiki "
+            "loop makes per tick. Older entries beyond this cap carry over "
+            "to the next tick."
+        ),
+    )
 
     # Paths (auto-detected)
     repo_root: Path = Field(default=Path("."), description="Repository root directory")

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -19,7 +19,11 @@ from knowledge_metrics import metrics as _metrics
 from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
 from staleness import evaluate as evaluate_staleness
 from subprocess_util import run_subprocess
-from wiki_drift_detector import apply_drift_markers, detect_drift
+from wiki_drift_detector import (
+    apply_drift_markers,
+    detect_drift,
+    scan_semantic_drift,
+)
 from wiki_maint_queue import MaintenanceQueue
 
 if TYPE_CHECKING:
@@ -378,6 +382,51 @@ class RepoWikiLoop(BaseBackgroundLoop):
                     )
         stats["drift_findings"] = drift_findings
         stats["drift_marked_stale"] = drift_marked
+
+        # Phase 9b (E2): LLM semantic-drift pass for entries whose citations
+        # still resolve but whose CLAIM may have rotted (renamed defaults,
+        # swapped model tiers, changed control flow). Off by default until
+        # eval-tuned; throttled by ``semantic_drift_min_age_days`` and
+        # ``semantic_drift_max_entries_per_tick`` to bound cost.
+        semantic_findings = 0
+        if (
+            self._config.semantic_drift_enabled
+            and tracked_root is not None
+            and self._wiki_compiler is not None
+        ):
+            compiler = self._wiki_compiler
+
+            async def _ask_llm(prompt: str) -> str:
+                reply = await compiler._call_model(prompt)
+                return reply or ""
+
+            for slug in repos:
+                try:
+                    findings = await scan_semantic_drift(
+                        tracked_root=tracked_root,
+                        repo_root=Path(self._config.repo_root),
+                        repo_slug=slug,
+                        ask_llm=_ask_llm,
+                        min_age_days=self._config.semantic_drift_min_age_days,
+                        max_entries_per_tick=(
+                            self._config.semantic_drift_max_entries_per_tick
+                        ),
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "semantic drift scan failed for %s", slug, exc_info=True
+                    )
+                    continue
+                semantic_findings += len(findings)
+                for f in findings:
+                    logger.info(
+                        "semantic drift: %s entry %s verdict=%s reason=%s",
+                        f.entry_path,
+                        f.entry_id,
+                        f.verdict,
+                        f.reason[:160],
+                    )
+        stats["semantic_drift_findings"] = semantic_findings
 
         stats["queue_drained"] = len(drained)
         await self._poll_and_merge_open_pr(stats)

--- a/src/wiki_drift_detector.py
+++ b/src/wiki_drift_detector.py
@@ -1,17 +1,18 @@
-"""Wiki-vs-code drift detection — P4 of the wiki-evolution audit.
+"""Wiki-vs-code drift detection.
 
-First-cut detector is deterministic and cheap: for every *active*
-tracked-layout entry under ``{tracked_root}/{repo_slug}/{topic}/``,
-extract ``src/...`` citations from its body and verify each cited
-file still exists under ``repo_root``.  Missing files = drift.
+Two layers:
 
-Symbol-level drift (cited class/function removed while file remains)
-is intentionally out of scope for this pass — adding an LLM
-validator on top of this skeleton is the Phase 2 extension.
+* **Deterministic (P4 + B3).** ``detect_drift`` walks active tracked
+  entries and flags citations whose ``src/...`` files or symbols no
+  longer exist. Cheap, no LLM.
+* **Semantic (E2).** ``scan_semantic_drift`` takes aged entries whose
+  citations still resolve and asks an LLM "does this entry's claim
+  still hold given the cited files' current content?". Catches
+  "wiki says haiku / code now uses gemini" cases that grep cannot.
 
-The RepoWikiLoop calls ``detect_drift`` on a weekly cadence and can
-use the returned findings to mark entries stale with a
-``stale_reason: drift_detected <files>`` note.
+The RepoWikiLoop wires both. B2's ``apply_drift_markers`` flips
+deterministic findings to ``status: stale``; the semantic layer
+returns its own finding type so operators can review before acting.
 """
 
 from __future__ import annotations
@@ -19,7 +20,9 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger("hydraflow.wiki_drift_detector")
 
@@ -45,6 +48,33 @@ class DriftFinding:
     topic: str
     missing_files: frozenset[str]
     missing_symbols: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class SemanticDriftFinding:
+    """One entry the LLM flagged as contradicted by current code.
+
+    Distinct from ``DriftFinding`` so operators can treat the two
+    signals differently — deterministic findings auto-mark stale
+    (no false-positive risk), semantic findings may warrant review
+    first.
+    """
+
+    entry_path: Path
+    entry_id: str
+    topic: str
+    verdict: str  # "contradicted" (valid / unknown omitted from the findings list)
+    reason: str
+
+
+# ``ask_llm`` parameter contract (kept typed as Any to avoid import
+# churn under `from __future__ import annotations`):
+#
+#   async def ask_llm(prompt: str) -> str | None
+#
+# Must be awaitable; returning None signals an LLM failure that the
+# scanner should treat as "unknown" — no finding, no stale-mark.
+# Production wires WikiCompiler._call_model; tests inject a coroutine.
 
 
 @dataclass
@@ -225,3 +255,186 @@ def apply_drift_markers(findings: list[DriftFinding]) -> int:
             continue
         updated += 1
     return updated
+
+
+# ---------------------------------------------------------------------------
+# E2 — semantic drift layer
+# ---------------------------------------------------------------------------
+
+_SEMANTIC_PROMPT = """You are auditing a wiki entry for staleness.
+
+The entry was written when the code looked a certain way. Below you
+have the entry body and the current content of each file it cites.
+Decide whether the entry's CLAIM still holds given the current code.
+
+Reply with EXACTLY two lines in this shape:
+
+VERDICT: valid | contradicted | unknown
+REASON: <one sentence explaining the verdict>
+
+Use "contradicted" ONLY when the current code clearly refutes the
+entry's specific claim (e.g. entry says default is X, code shows
+default is Y). Use "unknown" when the citation is ambiguous or you
+can't tell. Default to "valid" when the entry's advice still reads
+as consistent with the cited code.
+
+## Entry body
+
+{body}
+
+## Cited files (current content)
+
+{sources}
+"""
+
+_VERDICT_RE = re.compile(
+    r"^VERDICT:\s*(valid|contradicted|unknown)\b", re.MULTILINE | re.IGNORECASE
+)
+_REASON_RE = re.compile(r"^REASON:\s*(.+?)\s*$", re.MULTILINE)
+_SOURCE_SNIPPET_MAX_BYTES = 4_000
+
+
+def _entry_created_at(fields: dict[str, str]) -> datetime | None:
+    raw = fields.get("created_at") or ""
+    try:
+        dt = datetime.fromisoformat(raw)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _build_sources_block(repo_root: Path, pairs: set[tuple[str, str]]) -> str | None:
+    """Render the cited files' current content for the LLM prompt.
+
+    Returns ``None`` when every citation's file is missing — in that
+    case the deterministic detector already flagged the entry, so we
+    skip the semantic pass.
+    """
+    chunks: list[str] = []
+    for file_ref, symbol in sorted(pairs):
+        path = repo_root / file_ref
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if len(text) > _SOURCE_SNIPPET_MAX_BYTES:
+            text = text[:_SOURCE_SNIPPET_MAX_BYTES] + "\n... [truncated]"
+        chunks.append(f"### {file_ref}:{symbol}\n\n```\n{text}\n```\n")
+    if not chunks:
+        return None
+    return "\n".join(chunks)
+
+
+def _parse_semantic_response(raw: str | None) -> tuple[str, str]:
+    """Extract (verdict, reason) from the LLM reply. Garbage → ("unknown", "")."""
+    if not raw:
+        return "unknown", ""
+    verdict_match = _VERDICT_RE.search(raw)
+    reason_match = _REASON_RE.search(raw)
+    verdict = verdict_match.group(1).lower() if verdict_match else "unknown"
+    reason = reason_match.group(1).strip() if reason_match else ""
+    return verdict, reason
+
+
+async def detect_semantic_drift_for_entry(  # noqa: PLR0911
+    *,
+    entry_path: Path,
+    repo_root: Path,
+    ask_llm: Any,
+) -> SemanticDriftFinding | None:
+    """Ask the LLM whether an entry's claim still matches the cited code.
+
+    Returns a finding only when the verdict is ``contradicted``. Valid
+    and unknown verdicts return ``None`` so callers treat them as
+    no-action signals.
+    """
+    try:
+        text = entry_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+    fields = _parse_frontmatter(text)
+    if not fields or fields.get("status", "active") != "active":
+        return None
+
+    body = _entry_body(text)
+    pairs = set(_SOURCE_PAIR_CITATION_RE.findall(body))
+    if not pairs:
+        return None
+
+    sources = _build_sources_block(repo_root, pairs)
+    if sources is None:
+        return None
+
+    prompt = _SEMANTIC_PROMPT.format(body=body.strip(), sources=sources)
+    try:
+        raw = await ask_llm(prompt)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "semantic drift: ask_llm raised on %s; skipping", entry_path, exc_info=True
+        )
+        return None
+
+    verdict, reason = _parse_semantic_response(raw)
+    if verdict != "contradicted":
+        return None
+    return SemanticDriftFinding(
+        entry_path=entry_path,
+        entry_id=fields.get("id", ""),
+        topic=entry_path.parent.name,
+        verdict=verdict,
+        reason=reason or "(no reason given)",
+    )
+
+
+async def scan_semantic_drift(
+    *,
+    tracked_root: Path,
+    repo_root: Path,
+    repo_slug: str,
+    ask_llm: Any,
+    min_age_days: int = 30,
+    max_entries_per_tick: int = 10,
+) -> list[SemanticDriftFinding]:
+    """Sweep a repo's tracked entries for semantic drift.
+
+    ``min_age_days`` gates which entries are re-checked — newer ones
+    are likely still accurate and aren't worth an LLM call.
+    ``max_entries_per_tick`` caps cost by limiting how many entries
+    are checked per invocation; the next tick will cover the rest.
+    """
+    findings: list[SemanticDriftFinding] = []
+    repo_dir = tracked_root / repo_slug
+    if not repo_dir.is_dir():
+        return findings
+
+    now = datetime.now(UTC)
+    checked = 0
+    for topic_dir in sorted(p for p in repo_dir.iterdir() if p.is_dir()):
+        for entry_path in sorted(topic_dir.glob("*.md")):
+            if checked >= max_entries_per_tick:
+                return findings
+            try:
+                text = entry_path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            fields = _parse_frontmatter(text)
+            if not fields or fields.get("status", "active") != "active":
+                continue
+            created = _entry_created_at(fields)
+            if created is None or (now - created).days < min_age_days:
+                continue
+
+            finding = await detect_semantic_drift_for_entry(
+                entry_path=entry_path,
+                repo_root=repo_root,
+                ask_llm=ask_llm,
+            )
+            checked += 1
+            if finding is not None:
+                findings.append(finding)
+    return findings

--- a/tests/test_repo_wiki_loop.py
+++ b/tests/test_repo_wiki_loop.py
@@ -45,6 +45,9 @@ def _make_config(wiki_root: Path) -> MagicMock:
     config.repo_wiki_interval = 3600
     config.dry_run = False
     config.repo_wiki_git_backed = False
+    config.semantic_drift_enabled = False
+    config.semantic_drift_min_age_days = 30
+    config.semantic_drift_max_entries_per_tick = 10
     config.data_path.return_value = wiki_root / "wiki_maint_queue.json"
     return config
 
@@ -192,6 +195,99 @@ class TestDoWork:
         assert result is not None
         assert result["entries_compiled"] == 0
         compiler.compile_topic.assert_not_called()
+
+
+class TestSemanticDriftWiring:
+    """E2: loop wiring for the LLM-backed semantic-drift pass."""
+
+    @pytest.mark.asyncio
+    async def test_flag_off_skips_llm_call(self, tmp_path: Path) -> None:
+        from unittest.mock import AsyncMock
+
+        wiki_root = tmp_path / "wiki"
+        store = RepoWikiStore(wiki_root)
+        store.ingest(
+            "org/repo",
+            [WikiEntry(title="t", content="c", source_type="plan")],
+        )
+
+        config = _make_config(wiki_root)
+        config.semantic_drift_enabled = False
+
+        compiler = MagicMock()
+        compiler._call_model = AsyncMock(return_value="VERDICT: valid")
+
+        loop = RepoWikiLoop(
+            config=config,
+            wiki_store=store,
+            deps=_make_deps(),
+            wiki_compiler=compiler,
+        )
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result.get("semantic_drift_findings", 0) == 0
+        compiler._call_model.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_on_invokes_scan_and_reports_findings(
+        self, tmp_path: Path
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+        from unittest.mock import AsyncMock
+
+        repo_root = tmp_path / "repo"
+        (repo_root / "src").mkdir(parents=True)
+        (repo_root / "src" / "config.py").write_text(
+            'triage_model = "gemini-3.1-pro-preview"\n'
+        )
+        tracked_root = repo_root / "repo_wiki"
+        repo_slug_dir = tracked_root / "org" / "repo"
+        (repo_slug_dir / "patterns").mkdir(parents=True)
+        (repo_slug_dir / "index.md").write_text("# org/repo\n", encoding="utf-8")
+        topic_dir = repo_slug_dir / "patterns"
+        old = (datetime.now(UTC) - timedelta(days=60)).isoformat()
+        (topic_dir / "0001-ABCDEF.md").write_text(
+            "---\n"
+            "id: 01JF00000000000000000001\n"
+            "topic: patterns\n"
+            "source_issue: 1\n"
+            "source_phase: implement\n"
+            f"created_at: {old}\n"
+            "status: active\n"
+            "---\n"
+            "Triage uses `src/config.py:triage_model` set to haiku.\n",
+            encoding="utf-8",
+        )
+
+        config = _make_config(tmp_path / "wiki_legacy")
+        config.repo_wiki_git_backed = True
+        config.repo_root = repo_root
+        config.repo_wiki_path = "repo_wiki"
+        config.semantic_drift_enabled = True
+        config.semantic_drift_min_age_days = 30
+        config.semantic_drift_max_entries_per_tick = 10
+
+        compiler = MagicMock()
+        compiler._call_model = AsyncMock(
+            return_value=(
+                "VERDICT: contradicted\n"
+                "REASON: wiki says haiku, code sets gemini-3.1-pro-preview"
+            )
+        )
+
+        store = RepoWikiStore(tmp_path / "wiki_legacy", tracked_root=tracked_root)
+        loop = RepoWikiLoop(
+            config=config,
+            wiki_store=store,
+            deps=_make_deps(),
+            wiki_compiler=compiler,
+        )
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result.get("semantic_drift_findings") == 1
+        compiler._call_model.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_wiki_semantic_drift.py
+++ b/tests/test_wiki_semantic_drift.py
@@ -1,0 +1,270 @@
+"""E2 — LLM semantic-drift layer on top of the deterministic detector.
+
+B3 caught missing files + missing symbols. E2 closes the gap where
+the file and symbol still exist but the entry's CLAIM about them is
+no longer true (renamed defaults, swapped model tiers, changed
+control flow). The LLM judges freshness given the current source.
+
+Uses an injected async callable so unit tests don't need real LLM
+creds; the callable is substituted with WikiCompiler._call_model in
+production.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from wiki_drift_detector import (
+    SemanticDriftFinding,
+    detect_semantic_drift_for_entry,
+    scan_semantic_drift,
+)
+
+
+def _write_entry(
+    tracked_root: Path,
+    repo_slug: str,
+    topic: str,
+    *,
+    body: str,
+    entry_id: str,
+    source_issue: int,
+    created_at: datetime | None = None,
+    status: str = "active",
+) -> Path:
+    topic_dir = tracked_root / repo_slug / topic
+    topic_dir.mkdir(parents=True, exist_ok=True)
+    created = (created_at or datetime.now(UTC)).isoformat()
+    path = topic_dir / f"{source_issue:04d}-{entry_id[-6:]}.md"
+    path.write_text(
+        "---\n"
+        f"id: {entry_id}\n"
+        f"topic: {topic}\n"
+        f"source_issue: {source_issue}\n"
+        "source_phase: implement\n"
+        f"created_at: {created}\n"
+        f"status: {status}\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+@pytest.mark.asyncio
+async def test_contradicted_verdict_produces_finding(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "config.py").write_text(
+        'triage_model = "gemini-3.1-pro-preview"\n'
+    )
+    entry_path = _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="Triage uses `src/config.py:triage_model` set to haiku.",
+        entry_id="01JF000000000000000001",
+        source_issue=1,
+    )
+
+    async def fake_llm(prompt: str) -> str:
+        return (
+            "VERDICT: contradicted\n"
+            "REASON: wiki says haiku, code sets gemini-3.1-pro-preview"
+        )
+
+    finding = await detect_semantic_drift_for_entry(
+        entry_path=entry_path,
+        repo_root=repo_root,
+        ask_llm=fake_llm,
+    )
+
+    assert finding is not None
+    assert finding.verdict == "contradicted"
+    assert "gemini" in finding.reason
+
+
+@pytest.mark.asyncio
+async def test_valid_verdict_returns_none(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "config.py").write_text('triage_model = "sonnet"\n')
+    entry_path = _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="Triage uses `src/config.py:triage_model` set to sonnet.",
+        entry_id="01JF000000000000000002",
+        source_issue=2,
+    )
+
+    async def fake_llm(prompt: str) -> str:
+        return "VERDICT: valid\nREASON: claim still matches"
+
+    finding = await detect_semantic_drift_for_entry(
+        entry_path=entry_path,
+        repo_root=repo_root,
+        ask_llm=fake_llm,
+    )
+
+    assert finding is None
+
+
+@pytest.mark.asyncio
+async def test_malformed_llm_output_is_treated_as_unknown(tmp_path: Path) -> None:
+    """Never crash on garbage — unknown verdict = no finding, no stale-mark."""
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "config.py").write_text("stuff\n")
+    entry_path = _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="Cites `src/config.py:stuff`.",
+        entry_id="01JF000000000000000003",
+        source_issue=3,
+    )
+
+    async def fake_llm(prompt: str) -> str:
+        return "sure the wiki looks fine I guess"
+
+    finding = await detect_semantic_drift_for_entry(
+        entry_path=entry_path,
+        repo_root=repo_root,
+        ask_llm=fake_llm,
+    )
+
+    assert finding is None
+
+
+@pytest.mark.asyncio
+async def test_entry_without_src_citations_is_skipped(tmp_path: Path) -> None:
+    entry_path = _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="General advice with no src/ pointer.",
+        entry_id="01JF000000000000000004",
+        source_issue=4,
+    )
+
+    called = False
+
+    async def fake_llm(prompt: str) -> str:  # noqa: ARG001
+        nonlocal called
+        called = True
+        return ""
+
+    finding = await detect_semantic_drift_for_entry(
+        entry_path=entry_path,
+        repo_root=tmp_path / "repo",
+        ask_llm=fake_llm,
+    )
+
+    assert finding is None
+    assert not called, "no LLM call should be made when the entry has no citations"
+
+
+@pytest.mark.asyncio
+async def test_scan_respects_min_age(tmp_path: Path) -> None:
+    """scan_semantic_drift only re-checks entries older than min_age_days."""
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "a.py").write_text("def thing(): pass\n")
+
+    young = datetime.now(UTC) - timedelta(days=1)
+    old = datetime.now(UTC) - timedelta(days=40)
+
+    _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="cites `src/a.py:thing`",
+        entry_id="01JFYOUNG000000000000",
+        source_issue=1,
+        created_at=young,
+    )
+    _write_entry(
+        tmp_path / "repo_wiki",
+        "o/r",
+        "patterns",
+        body="cites `src/a.py:thing`",
+        entry_id="01JFOLD00000000000000",
+        source_issue=2,
+        created_at=old,
+    )
+
+    calls: list[Path] = []
+
+    async def fake_llm(prompt: str) -> str:  # noqa: ARG001
+        calls.append(Path("called"))
+        return "VERDICT: valid\nREASON: ok"
+
+    findings = await scan_semantic_drift(
+        tracked_root=tmp_path / "repo_wiki",
+        repo_root=repo_root,
+        repo_slug="o/r",
+        ask_llm=fake_llm,
+        min_age_days=30,
+    )
+
+    # Only the old entry gets re-checked; young skipped
+    assert len(calls) == 1
+    assert findings == []
+
+
+@pytest.mark.asyncio
+async def test_scan_respects_max_entries_per_tick(tmp_path: Path) -> None:
+    """Cost bound: cap how many LLM calls we make per loop tick."""
+    repo_root = tmp_path / "repo"
+    (repo_root / "src").mkdir(parents=True)
+    (repo_root / "src" / "a.py").write_text("def thing(): pass\n")
+
+    old = datetime.now(UTC) - timedelta(days=40)
+    for i in range(5):
+        _write_entry(
+            tmp_path / "repo_wiki",
+            "o/r",
+            "patterns",
+            body=f"entry {i} cites `src/a.py:thing`",
+            entry_id=f"01JF00000000000000000{i}",
+            source_issue=100 + i,
+            created_at=old,
+        )
+
+    call_count = 0
+
+    async def fake_llm(prompt: str) -> str:  # noqa: ARG001
+        nonlocal call_count
+        call_count += 1
+        return "VERDICT: valid"
+
+    await scan_semantic_drift(
+        tracked_root=tmp_path / "repo_wiki",
+        repo_root=repo_root,
+        repo_slug="o/r",
+        ask_llm=fake_llm,
+        min_age_days=30,
+        max_entries_per_tick=2,
+    )
+
+    assert call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_semantic_finding_is_separate_from_deterministic_one(
+    tmp_path: Path,
+) -> None:
+    """SemanticDriftFinding is a distinct type — doesn't override DriftFinding."""
+    f = SemanticDriftFinding(
+        entry_path=tmp_path / "x.md",
+        entry_id="y",
+        topic="patterns",
+        verdict="contradicted",
+        reason="test reason",
+    )
+    assert f.verdict == "contradicted"
+    assert f.reason == "test reason"


### PR DESCRIPTION
## Summary

B3 (symbol-level drift) catches missing files and missing symbols. **E2 closes the gap where the file and symbol still exist but the wiki entry's CLAIM about them has rotted** — renamed defaults, swapped model tiers, changed control flow. The LLM judges freshness given the current source.

## What's new

- **`detect_semantic_drift_for_entry`** — asks the LLM for `VERDICT: valid | contradicted | unknown` + `REASON:` against the cited source files. Returns a finding only on `contradicted` so `unknown` never fires false alarms.
- **`scan_semantic_drift`** — sweep with `min_age_days=30` + per-tick cap for cost control. Freshly written entries are trusted and skipped.
- **`RepoWikiLoop` wiring** behind `semantic_drift_enabled` flag (**default False until eval-tuned**). Stats emit `semantic_drift_findings`.
- **`semantic_drift_min_age_days`** / **`semantic_drift_max_entries_per_tick`** tunable knobs.

## Design decisions

- Conservative verdict handling: malformed / unknown / "valid" → no finding, no stale-mark. Only a direct `contradicted` flips anything.
- No auto-stale on semantic findings (unlike B3's deterministic auto-mark). Findings are logged for human review; the maintenance PR will eventually batch them.
- `ask_llm` is an injected async callable so unit tests run without credentials. Production wraps `WikiCompiler._call_model`.
- Off by default — can be flipped on via `HYDRAFLOW_SEMANTIC_DRIFT_ENABLED=1` once eval-tuned.

## Test plan

- [x] 7 new unit tests in `tests/test_wiki_semantic_drift.py` cover contradicted / valid / malformed / no-citations / min_age gate / max_entries cap / separate dataclass type
- [x] 2 new loop-wiring tests in `tests/test_repo_wiki_loop.py::TestSemanticDriftWiring` confirm flag off → no LLM call, flag on → scan runs and reports findings
- [x] Full drift suite green (55/55)
- [x] Config suite green (449/449)
- [x] ruff + pre-commit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Skip-ADR: config.py touches are narrow new feature flags (semantic_drift_enabled / min_age_days / max_entries_per_tick) for ADR-0032 drift detection, not architecture changes to 0002/0009/0010/0021/0022. ADR-0032 already updated in this PR.
