### PR TITLE
feat(principles): inject ADR-0044 checklist into plan + review prompts

### DIFF
--- a/docs/adr/0044-hydraflow-principles.md
+++ b/docs/adr/0044-hydraflow-principles.md
@@ -4,6 +4,7 @@
 - **Date:** 2026-04-22
 - **Supersedes:** none
 - **Superseded by:** none
+- **Enforced by:** scripts/hydraflow_audit/* (structural/behavioural checks), tests/test_planner.py::test_build_prompt_includes_principles_checklist, tests/test_reviewer.py::test_build_review_prompt_includes_hydraflow_principles_checks (prompt-level enforcement in plan + review phases)
 
 ## Context
 

--- a/src/planner.py
+++ b/src/planner.py
@@ -482,7 +482,13 @@ Use semantic tools first (before grep):
 5. Build a Task Graph with dependency-ordered phases (full plans only).
 6. Write behavioral test specs for each phase — describe observable outcomes, not test code.
 7. For UI work, call out reusable components/shared modules (`constants.js`, `types.js`, `theme.js`).
-8. **Audit the plan against `docs/agents/avoided-patterns.md`.** Every code snippet,
+8. **Principles (ADR-0044).** Before declaring the plan done, check each item. Missing any of these in the plan is cheaper to fix now than at review:
+   - **MockWorld scenario coverage:** if the change crosses phases or touches orchestrator/runner behaviour, add a release-gating scenario under `tests/scenarios/` that uses `MockWorld` fakes (no real subprocess / GitHub / git). Name the scenario after the behaviour, not the code.
+   - **TDD + behavioral test names:** every phase's **Tests:** entries must describe observable behaviour (given/when/then-style), not function names. "POST /widgets with missing name returns 400" — good. "Test create_widget" — bad.
+   - **Hexagonal Ports:** new GitHub / git / worktree / subprocess calls must go through `PRPort`, `IssueStorePort`, or `WorkspacePort`. If your plan introduces a direct `subprocess.run`, `gh`, or `git` call in a non-adapter file, route it through the existing Port (or extend the Port) instead.
+   - **One responsibility per file:** if you're adding ≥~200 lines to an already-big file, split by responsibility in the plan. Don't bolt unrelated concerns onto a mega-file just because the imports are handy.
+   - **3As tests:** every test in the plan's test specs should map cleanly to Arrange / Act / Assert with one logical assertion per test. List tests in the plan at the behaviour level — the implementer will write each one red-first.
+9. **Audit the plan against `docs/agents/avoided-patterns.md`.** Every code snippet,
    test fixture, and cross-module import in your plan must avoid the anti-patterns
    listed there. Specifically check: symbols imported across modules do not start
    with `_`; test helpers do not duplicate ones in `tests/conftest.py` (grep first);

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -829,6 +829,12 @@ Quality: No issues — <justification>
      - **Misplaced I/O:** flag new direct use of I/O primitives (`subprocess`, `socket`, `httpx`, `requests`, `urllib`, `boto3`, `sqlalchemy`, `pymongo`, `redis`, `kafka`, raw `open()`, file reads/writes) inside files whose path or name suggests "pure" logic — anything under `domain/`, `core/`, `models/`, `entities/`, or files named `*_model.py`, `*_entity.py`, `*_value*.py`, `*_rules.py`. The I/O should live in an adapter, not in a domain or model file.
      - **God-file creep:** note files in the diff that grew significantly (many new imports, or >~50% line-count increase) and ask whether the file is still doing one thing. A previously-focused file that now orchestrates unrelated concerns is a drift signal.
      - **Escape hatch:** if the repo has no recognisable layering convention (no `domain/`, `core/`, `adapters/`, or similar signal directories, and no naming pattern in filenames) then **skip this bullet entirely — do not invent violations**. Architectural drift is a finding only when there is a recognisable architecture to drift from.
+   - **HydraFlow principles (ADR-0044)** — check the diff for HydraFlow-specific drift beyond generic layering. Flag any of these as findings:
+     - **MockWorld scenario coverage:** new cross-phase / orchestrator / runner behaviour without a matching release-gating scenario under `tests/scenarios/` using `MockWorld` fakes. Unit tests alone don't cover the loop; a missing scenario is a finding.
+     - **BDD-flavour test naming:** new tests named after the function under test (`test_create_widget`, `test_helper_util`) instead of the behaviour (`test_create_widget_with_duplicate_name_raises_integrity_error`). Flag test names that would rot the minute the function is renamed.
+     - **Port compliance:** new direct use of `subprocess`, `gh`, or `git` CLI, or direct GitHub API calls, in files outside the known adapter layer. HydraFlow routes these through `PRPort`, `IssueStorePort`, and `WorkspacePort`. Suggest routing through the existing Port or extending it.
+     - **One responsibility per file:** large additions to an already-large file that introduce a second concern. Prefer a new file over continuing to grow an existing mega-file.
+     - **Escape hatch:** skip this bullet if the repo isn't HydraFlow and has no `tests/scenarios/`, `ports.py`, or similar HydraFlow-style seams.
 {ui_criteria}
 ## If Issues Found
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -204,6 +204,37 @@ async def test_build_prompt_includes_plan_markers(config, event_bus, issue):
 
 
 @pytest.mark.asyncio
+async def test_build_prompt_includes_principles_checklist(config, event_bus, issue):
+    """Planner must produce plans that honour HydraFlow's engineering
+    principles (ADR-0044). The prompt gates this up front so plans don't
+    reach review with missing scenario coverage, wrong layering, or
+    implementation-named tests — cheaper to catch in the plan than in
+    the PR diff."""
+    runner = _make_runner(config, event_bus)
+    task = issue.to_task()
+    prompt, _ = await runner._build_prompt_with_stats(task)
+
+    assert "Principles" in prompt, (
+        "planner prompt no longer contains the Principles checklist"
+    )
+    # MockWorld / scenario coverage for new cross-phase behaviour.
+    assert "MockWorld" in prompt
+    assert "tests/scenarios/" in prompt
+    # TDD + BDD-flavour test names.
+    assert "TDD" in prompt
+    assert "behavioral" in prompt.lower() or "behaviour" in prompt.lower()
+    # Hexagonal port compliance.
+    assert "Port" in prompt
+    # One-responsibility files.
+    assert (
+        "one responsibility" in prompt.lower()
+        or "single responsibility" in prompt.lower()
+    )
+    # 3As test layout.
+    assert "3As" in prompt or "Arrange" in prompt
+
+
+@pytest.mark.asyncio
 async def test_build_prompt_includes_comments_when_present(config, event_bus):
     task = TaskFactory.create(
         body="It is broken.",
@@ -234,8 +265,9 @@ async def test_build_prompt_truncates_long_body(config, event_bus):
 
     assert "…(truncated)" in prompt
     # Well under original 20k body. Upper bound accommodates the ADR titles
-    # index (~2k chars for ~40 ADRs) which is now injected into plan prompts.
-    assert len(prompt) < 14_000
+    # index (~2k chars for ~40 ADRs) and the ADR-0044 principles checklist
+    # (~900 chars) that the plan prompt now injects.
+    assert len(prompt) < 15_000
 
 
 @pytest.mark.asyncio

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -129,6 +129,39 @@ async def test_build_review_prompt_includes_arch_drift_checks(
 
 
 @pytest.mark.asyncio
+async def test_build_review_prompt_includes_hydraflow_principles_checks(
+    config, event_bus, pr_info, task
+):
+    """Reviewer prompt must ask for HydraFlow-specific principle drift
+    (ADR-0044). The architectural-drift bullet handles generic layer
+    concerns; this bullet adds MockWorld scenario coverage, TDD + BDD
+    test naming, Port compliance, and one-responsibility-per-file. These
+    are the principles plans and PRs tend to skip first."""
+    runner = _make_runner(config, event_bus)
+    prompt, _ = await runner._build_review_prompt_with_stats(pr_info, task, "some diff")
+
+    assert "HydraFlow principles" in prompt, (
+        "reviewer prompt no longer contains the HydraFlow principles bullet"
+    )
+    # MockWorld / scenario coverage for new cross-phase behaviour.
+    assert "MockWorld" in prompt
+    assert "tests/scenarios/" in prompt
+    # TDD + BDD-flavour test naming.
+    assert (
+        "BDD" in prompt
+        or "behavioural" in prompt.lower()
+        or "behavioral" in prompt.lower()
+    )
+    # Hexagonal port compliance.
+    assert "PRPort" in prompt or "IssueStorePort" in prompt or "WorkspacePort" in prompt
+    # One-responsibility files.
+    assert (
+        "one responsibility" in prompt.lower()
+        or "single responsibility" in prompt.lower()
+    )
+
+
+@pytest.mark.asyncio
 async def test_build_review_prompt_includes_diff(config, event_bus, pr_info, task):
     runner = _make_runner(config, event_bus)
     diff = "diff --git a/foo.py b/foo.py\n+added line"


### PR DESCRIPTION
## Summary

Catches HydraFlow-principle drift at the cheapest point — **in the plan** and **in the review** — rather than at CI or post-merge. ``scripts/hydraflow_audit`` already covers structural/behavioural checks; this wires the same principles into the two LLM phases that actually shape the code.

## What's injected

**Plan phase** — new step 8 "Principles (ADR-0044)" covering:
- **MockWorld scenario coverage** for cross-phase behaviour (release-gating scenarios under ``tests/scenarios/`` with ``MockWorld`` fakes)
- **TDD + behavioural test names** (given/when/then-style, not ``test_function_name``)
- **Hexagonal Port compliance** (``PRPort`` / ``IssueStorePort`` / ``WorkspacePort``)
- **One responsibility per file** — don't bolt unrelated concerns onto mega-files
- **3As test layout** (Arrange / Act / Assert, one logical assertion)

**Review phase** — new "HydraFlow principles (ADR-0044)" bullet in the architectural-drift block, flagging:
- missing scenario tests for new cross-phase behaviour
- tests named after functions instead of behaviours
- direct ``subprocess``/``gh``/``git`` calls outside the adapter layer
- unrelated concerns added to an already-large file

Both bullets include an **escape hatch** so they no-op on non-HydraFlow repos (no ``tests/scenarios/``, no ``ports.py``, etc.).

## Design decisions

- Prompt-only — no new runtime validator, no CI gate. Reviewer and planner are already LLM-driven; adding a bulleted checklist is the cheapest, highest-signal intervention and rides with every issue/PR automatically.
- Mirrors the existing architectural-drift bullet pattern (commit ``0d50ca58``) — same structure, same escape-hatch pattern, same test shape.
- ADR-0044 gets an ``Enforced by:`` line pointing at the two new prompt-coverage tests.

## Test plan

- [x] ``tests/test_planner.py::test_build_prompt_includes_principles_checklist`` — asserts all 5 principles appear in the plan prompt
- [x] ``tests/test_reviewer.py::test_build_review_prompt_includes_hydraflow_principles_checks`` — asserts all 4 bullets appear in the review prompt
- [x] Existing ``test_build_review_prompt_includes_arch_drift_checks`` still green (no regression)
- [x] Full planner + reviewer suites: **367/367 pass**
- [x] ``ruff check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Skip-ADR: reviewer.py change is a prompt-level enforcement hook for ADR-0044 (Proposed, so not counted by the gate). ADR-0044 itself is updated in this PR with an Enforced-by line pointing at the new prompt tests. No Accepted ADR on this touchpoint is affected.
