### PR TITLE
feat(wiki): depth upgrades — corroborations counter + temporal tags

### DIFF
--- a/docs/adr/0032-per-repo-wiki-knowledge-base.md
+++ b/docs/adr/0032-per-repo-wiki-knowledge-base.md
@@ -1,7 +1,7 @@
 # ADR-0032: Per-Repo Wiki Knowledge Base (Karpathy Pattern)
 
 **Status:** Accepted
-**Enforced by:** tests/test_repo_wiki.py, tests/test_repo_wiki_store_git.py, tests/test_repo_wiki_ingest.py, tests/test_wiki_drift_detector.py, tests/test_wiki_drift_symbols.py, tests/test_wiki_semantic_drift.py
+**Enforced by:** tests/test_repo_wiki.py, tests/test_repo_wiki_store_git.py, tests/test_repo_wiki_ingest.py, tests/test_wiki_drift_detector.py, tests/test_wiki_drift_symbols.py, tests/test_wiki_semantic_drift.py, tests/test_repo_wiki_temporal.py, tests/test_wiki_corroboration.py
 **Date:** 2026-04-05
 
 ## Context
@@ -37,6 +37,8 @@ Adopt a file-based, per-repo wiki system with three layers:
 - **Active self-healing lint**: The background loop marks entries stale when their source issues close (via `StateTracker` outcomes), prunes entries older than 90 days, and rebuilds the index. The wiki degrades gracefully without manual curation.
 
 - **Drift detection (two layers)**: A deterministic pass (`wiki_drift_detector.detect_drift`) flags entries whose `src/path.py:Symbol` citations point at files or symbols that no longer exist — cheap, side-effect-free, and auto-marks stale. An optional LLM layer (`scan_semantic_drift`, gated by `semantic_drift_enabled`) asks the compilation model whether an entry's CLAIM still matches the current source for entries older than `semantic_drift_min_age_days`, capped at `semantic_drift_max_entries_per_tick` per loop tick. Semantic findings are logged for human review; only the deterministic layer auto-stales.
+
+- **Depth signals (corroborations + temporal tags)**: every active entry carries a `corroborations` counter in its frontmatter (default 1). `WikiCompiler.dedup_or_corroborate` uses `generalize_pair` to decide whether a newly-ingested entry is a re-discovery of an existing active entry and returns a `CorroborationDecision` carrying the canonical's file path; callers then use `increment_corroboration(path)` to atomically bump the counter instead of writing a sibling duplicate. On the read path, `RepoWikiStore.query_with_tags` returns a `{title: temporal_tag}` map alongside the markdown, and `BaseRunner._inject_repo_wiki` weaves the tags inline as italic lines under each entry — so the planner/reviewer sees `### Always use factories\n*(stable for 6 months (+4))*`. Tag vocabulary: `recently added` (<30d), `stable for N months`, `stable for N year(s)`, `age unknown`; `(+N)` suffix when corroborations > 1. Addresses two depth gaps vs. agentic-memory systems: evidence-weighting and temporal reasoning about when claims settled.
 
 - **Dedup tracking**: `DedupStore`-backed per-repo tracking prevents re-ingesting the same (issue, source_type) pair. Failed ingests are not marked, so retries work.
 

--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -36,6 +36,23 @@ if TYPE_CHECKING:
     from tribal_wiki import TribalWikiStore
 
 
+def _weave_temporal_tags(markdown: str, tags: dict[str, str]) -> str:
+    """Insert temporal tags as italic lines after matching ``### <title>``
+    headings in the rendered wiki markdown. No-op on empty tags or empty
+    markdown so callers can pass through unconditionally.
+    """
+    if not tags or not markdown:
+        return markdown
+    out: list[str] = []
+    for line in markdown.splitlines():
+        out.append(line)
+        if line.startswith("### "):
+            title = line[4:].strip()
+            if title in tags:
+                out.append(f"*({tags[title]})*")
+    return "\n".join(out)
+
+
 class BaseRunner:
     """Shared base for ``AgentRunner``, ``PlannerRunner``, ``ReviewRunner``, and ``HITLRunner``.
 
@@ -372,11 +389,20 @@ class BaseRunner:
             if query_context
             else None
         )
-        per_repo_section = self._wiki_store.query(
-            repo,
-            keywords=keywords,
-            max_chars=self._config.max_repo_wiki_chars,
-        )
+        tags: dict[str, str] = {}
+        if hasattr(self._wiki_store, "query_with_tags"):
+            per_repo_section, tags = self._wiki_store.query_with_tags(
+                repo,
+                keywords=keywords,
+                max_chars=self._config.max_repo_wiki_chars,
+            )
+        else:
+            per_repo_section = self._wiki_store.query(
+                repo,
+                keywords=keywords,
+                max_chars=self._config.max_repo_wiki_chars,
+            )
+        per_repo_section = _weave_temporal_tags(per_repo_section, tags)
 
         tribal = getattr(self, "_tribal_wiki_store", None)
         tribal_section = ""

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -23,7 +23,12 @@ from phase_utils import (
     store_lifecycle,
 )
 from planner import PlannerRunner
-from repo_wiki import RepoWikiStore, WikiEntry, classify_topic
+from repo_wiki import (
+    RepoWikiStore,
+    WikiEntry,
+    classify_topic,
+    increment_corroboration,
+)
 from research_runner import ResearchRunner
 from state import StateTracker
 from task_source import TaskTransitioner
@@ -35,7 +40,7 @@ if TYPE_CHECKING:
     from issue_cache import IssueCache
     from plan_reviewer import PlanReviewer
     from ports import IssueStorePort, PRPort
-    from wiki_compiler import WikiCompiler  # noqa: TCH004
+    from wiki_compiler import CorroborationDecision, WikiCompiler  # noqa: TCH004
 
 logger = logging.getLogger("hydraflow.plan_phase")
 
@@ -418,9 +423,17 @@ class PlanPhase:
                 )
                 if entries:
                     if tracked_store is not None and worktree_path is not None:
-                        # Offload the sync file + git-subprocess work off the
-                        # event loop so the other four concurrent phase loops
-                        # (ADR-0001) don't stall on `git commit`.
+                        # Precompute corroboration decisions on the event
+                        # loop (async LLM calls) so the sync commit step
+                        # can just read them.
+                        decisions = await self._precompute_corroboration(
+                            tracked_store=tracked_store,
+                            repo=repo,
+                            entries=entries,
+                        )
+                        # Offload the sync file + git-subprocess work off
+                        # the event loop so the other four concurrent
+                        # phase loops (ADR-0001) don't stall on git commit.
                         await asyncio.to_thread(
                             self._wiki_commit_compiler_entries,
                             tracked_store=tracked_store,
@@ -429,6 +442,7 @@ class PlanPhase:
                             issue_number=issue_number,
                             phase="plan",
                             entries=entries,
+                            decisions=decisions,
                         )
                     else:
                         self._wiki_store.ingest(repo, entries)
@@ -480,6 +494,50 @@ class PlanPhase:
             worktree_path,
         )
 
+    async def _precompute_corroboration(
+        self,
+        *,
+        tracked_store: RepoWikiStore,
+        repo: str,
+        entries: list[WikiEntry],
+    ) -> list[CorroborationDecision]:
+        from wiki_compiler import CorroborationDecision  # noqa: PLC0415
+
+        """Run ``dedup_or_corroborate`` per entry against existing active
+        entries in the same topic. Returns one decision per entry in the
+        same order. Bounded per-entry by ``max_candidates_per_entry`` so
+        a large topic doesn't fire one LLM call per existing entry.
+        """
+        decisions: list[CorroborationDecision] = []
+        if self._wiki_compiler is None:
+            return [CorroborationDecision() for _ in entries]
+        max_candidates = 5
+        for entry in entries:
+            topic = classify_topic(entry)
+            topic_dir = tracked_store._tracked_topic_dir(repo, topic)
+            existing_pairs: list[tuple[WikiEntry, Path]] = []
+            if topic_dir is not None:
+                existing_pairs = (
+                    tracked_store._load_tracked_topic_entries_with_paths(topic_dir)
+                )[:max_candidates]
+            try:
+                decision = await self._wiki_compiler.dedup_or_corroborate(
+                    repo_slug=repo,
+                    entry=entry,
+                    existing_entries=existing_pairs,
+                    topic=topic,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "corroboration precompute failed for %s/%s",
+                    repo,
+                    entry.title,
+                    exc_info=True,
+                )
+                decision = CorroborationDecision()
+            decisions.append(decision)
+        return decisions
+
     def _wiki_commit_compiler_entries(
         self,
         *,
@@ -489,24 +547,44 @@ class PlanPhase:
         issue_number: int,
         phase: str,
         entries: list[WikiEntry],
+        decisions: list[CorroborationDecision] | None = None,
     ) -> None:
+        from wiki_compiler import CorroborationDecision  # noqa: PLC0415
+
         """Route compiler-synthesized entries through ``write_entry`` then
         commit. Topic classification mirrors ``RepoWikiStore.ingest``.
         Rolls back any files written before a mid-batch failure.
+
+        When ``decisions`` is provided (same length as ``entries``), any
+        entry whose decision says ``should_corroborate`` skips the write
+        and instead bumps the canonical's counter via
+        ``increment_corroboration``. This is the ingest-side of the
+        depth-signal system (ADR-0032).
         """
         # Classification uses the module-level helper — same keyword
         # scheme the legacy layout used, so synthesized entries land in
         # the expected topic directory.
         written: list[Path] = []
+        if decisions is None or len(decisions) != len(entries):
+            decisions = [CorroborationDecision() for _ in entries]
         try:
-            for entry in entries:
+            any_wrote = False
+            for entry, decision in zip(entries, decisions, strict=True):
+                if decision.should_corroborate and decision.canonical_path is not None:
+                    increment_corroboration(decision.canonical_path)
+                    continue
                 topic = classify_topic(entry)
                 written.append(tracked_store.write_entry(repo, entry, topic=topic))
+                any_wrote = True
             tracked_store.append_log(
                 repo,
                 issue_number,
-                {"phase": phase, "action": "ingest", "entries": len(entries)},
+                {"phase": phase, "action": "ingest", "entries": len(written)},
             )
+            # Always commit — a pure corroboration pass (0 writes) still
+            # flipped counters, which are tracked in files that need to
+            # ride along on the PR.
+            _ = any_wrote
             tracked_store.commit_pending_entries(
                 worktree_path=worktree_path,
                 phase=phase,

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -811,6 +811,37 @@ class RepoWikiStore:
         result = "\n".join(parts)
         return result[:max_chars]
 
+    def query_with_tags(
+        self,
+        repo_slug: str,
+        keywords: list[str] | None = None,
+        topics: list[str] | None = None,
+        max_chars: int = 15_000,
+    ) -> tuple[str, dict[str, str]]:
+        """Like ``query`` but also returns a ``{title: temporal_tag}``
+        map for the tracked-layout entries.
+
+        Callers that want tagged output inline can weave the tags in at
+        render time (see ``BaseRunner._inject_repo_wiki``). Returns an
+        empty tag map when the store has no tracked_root or the repo
+        has no tracked entries.
+        """
+        markdown = self.query(
+            repo_slug, keywords=keywords, topics=topics, max_chars=max_chars
+        )
+        tags: dict[str, str] = {}
+        if self._tracked_root is None:
+            return markdown, tags
+        now = datetime.now(UTC)
+        for topic in self._list_tracked_topics(repo_slug):
+            topic_dir = self._tracked_topic_dir(repo_slug, topic)
+            if topic_dir is None or not topic_dir.is_dir():
+                continue
+            entries = self._load_tracked_topic_entries(topic_dir)
+            for entry, tag in annotate_entries_with_temporal_tags(entries, now=now):
+                tags[entry.title] = tag
+        return markdown, tags
+
     def lint(self, repo_slug: str) -> LintResult:
         """Run a health check on the wiki for the given repo.
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -277,6 +277,7 @@ def _load_tracked_active_entries(topic_dir: Path) -> list[dict[str, Any]]:
                 "source_issue": fields.get("source_issue", ""),
                 "source_phase": fields.get("source_phase", ""),
                 "created_at": fields.get("created_at", ""),
+                "corroborations": fields.get("corroborations", "1"),
                 "path": str(path),
             }
         )
@@ -315,6 +316,7 @@ def _write_tracked_synthesis_entry(
         "source_phase: synthesis",
         f"created_at: {now}",
         "status: active",
+        f"corroborations: {entry.corroborations}",
     ]
     if supersedes:
         lines.append("supersedes: " + ",".join(supersedes))
@@ -505,6 +507,15 @@ class WikiEntry(BaseModel):
     stale: bool = Field(
         default=False,
         description="Legacy marker; see superseded_by for canonical staleness",
+    )
+    corroborations: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "How many independent sources have re-asserted this principle. "
+            "Entries loaded without this field default to 1. Incremented by "
+            "the ingest-path dedup/corroboration logic in wiki_compiler."
+        ),
     )
 
     @model_validator(mode="after")
@@ -1012,6 +1023,7 @@ class RepoWikiStore:
                 f"source_phase: {source_phase}",
                 f"created_at: {entry.created_at}",
                 f"status: {status}",
+                f"corroborations: {entry.corroborations}",
                 "---",
                 "",
                 f"# {entry.title}",
@@ -1200,6 +1212,11 @@ class RepoWikiStore:
         entries: list[WikiEntry] = []
         for raw in _load_tracked_active_entries(topic_dir):
             try:
+                corroborations_raw = raw.get("corroborations", "1")
+                try:
+                    corroborations = max(1, int(str(corroborations_raw).strip()))
+                except (TypeError, ValueError):
+                    corroborations = 1
                 entries.append(
                     WikiEntry(
                         id=raw.get("id") or "",
@@ -1214,6 +1231,7 @@ class RepoWikiStore:
                         ),
                         created_at=raw.get("created_at")
                         or datetime.now(UTC).isoformat(),
+                        corroborations=corroborations,
                     )
                 )
             except (ValueError, TypeError):

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -361,6 +361,38 @@ def _mark_tracked_entry_superseded(entry_path: Path, *, superseded_by: str) -> N
         )
 
 
+def increment_corroboration(entry_path: Path, *, by: int = 1) -> None:
+    """Atomically bump the ``corroborations`` counter in a tracked-layout
+    entry file. No-op when the file is missing or has no frontmatter
+    block. A missing ``corroborations`` field is treated as 1 and then
+    incremented.
+    """
+    from file_util import atomic_write  # noqa: PLC0415
+
+    if by < 1:
+        return
+    try:
+        text = entry_path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    fields, _block, body = _split_tracked_entry(text)
+    if not fields:
+        return
+    current_raw = fields.get("corroborations", "1")
+    try:
+        current = max(1, int(str(current_raw).strip()))
+    except (TypeError, ValueError):
+        current = 1
+    fields["corroborations"] = str(current + by)
+    rebuilt = (
+        "---\n" + "\n".join(f"{k}: {v}" for k, v in fields.items()) + "\n---\n" + body
+    )
+    try:
+        atomic_write(entry_path, rebuilt)
+    except OSError:
+        logger.warning("increment_corroboration: failed to rewrite %s", entry_path)
+
+
 def active_lint_tracked(
     tracked_root: Path,
     repo_slug: str,

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -557,6 +557,49 @@ class WikiEntry(BaseModel):
         return self
 
 
+def annotate_entries_with_temporal_tags(
+    entries: list[WikiEntry],
+    *,
+    now: datetime,
+) -> list[tuple[WikiEntry, str]]:
+    """Tag each entry with a short human-readable stability string.
+
+    Tags:
+    - ``"recently added"`` — age < 30 days
+    - ``"stable for N months"`` — 30 days ≤ age < 365 days
+    - ``"stable for N year(s)"`` — age ≥ 365 days
+    - ``"age unknown"`` — ``created_at`` unparseable
+
+    When ``corroborations`` > 1, a ``(+N)`` suffix is appended so the
+    planner/reviewer can see how independently-re-discovered the claim
+    is at a glance. Pure function — no I/O, no LLM calls, safe to run
+    on every wiki read.
+    """
+    annotated: list[tuple[WikiEntry, str]] = []
+    for entry in entries:
+        try:
+            created = datetime.fromisoformat(entry.created_at)
+        except (TypeError, ValueError):
+            annotated.append((entry, "age unknown"))
+            continue
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        age_days = (now - created).days
+        if age_days < 30:
+            base = "recently added"
+        elif age_days < 365:
+            months = max(1, age_days // 30)
+            base = f"stable for {months} months"
+        else:
+            years = age_days // 365
+            suffix = "year" if years == 1 else "years"
+            base = f"stable for {years} {suffix}"
+        if entry.corroborations > 1:
+            base = f"{base} (+{entry.corroborations})"
+        annotated.append((entry, base))
+    return annotated
+
+
 class WikiIndex(BaseModel):
     """Master index for a repo wiki — stored as index.json for programmatic access."""
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -1315,7 +1315,20 @@ class RepoWikiStore:
         are returned; ``stale`` / ``superseded`` entries are filtered out since
         callers use this for prompt injection.
         """
-        entries: list[WikiEntry] = []
+        return [
+            entry for entry, _ in self._load_tracked_topic_entries_with_paths(topic_dir)
+        ]
+
+    def _load_tracked_topic_entries_with_paths(
+        self, topic_dir: Path
+    ) -> list[tuple[WikiEntry, Path]]:
+        """Like ``_load_tracked_topic_entries`` but preserves each entry's
+        source file path. Used by the ingest-time corroboration hook:
+        ``CorroborationDecision.canonical_path`` is populated from these
+        tuples so the caller can atomically bump the counter without a
+        second directory walk.
+        """
+        pairs: list[tuple[WikiEntry, Path]] = []
         for raw in _load_tracked_active_entries(topic_dir):
             try:
                 corroborations_raw = raw.get("corroborations", "1")
@@ -1323,26 +1336,24 @@ class RepoWikiStore:
                     corroborations = max(1, int(str(corroborations_raw).strip()))
                 except (TypeError, ValueError):
                     corroborations = 1
-                entries.append(
-                    WikiEntry(
-                        id=raw.get("id") or "",
-                        title=raw.get("title") or "(untitled)",
-                        content=raw.get("body") or "",
-                        topic=topic_dir.name,
-                        source_type=raw.get("source_phase") or "unknown",
-                        source_issue=(
-                            int(raw["source_issue"])
-                            if raw.get("source_issue")
-                            else None
-                        ),
-                        created_at=raw.get("created_at")
-                        or datetime.now(UTC).isoformat(),
-                        corroborations=corroborations,
-                    )
+                entry = WikiEntry(
+                    id=raw.get("id") or "",
+                    title=raw.get("title") or "(untitled)",
+                    content=raw.get("body") or "",
+                    topic=topic_dir.name,
+                    source_type=raw.get("source_phase") or "unknown",
+                    source_issue=(
+                        int(raw["source_issue"]) if raw.get("source_issue") else None
+                    ),
+                    created_at=raw.get("created_at") or datetime.now(UTC).isoformat(),
+                    corroborations=corroborations,
                 )
+                path_raw = raw.get("path")
+                path = Path(path_raw) if path_raw else topic_dir / "unknown.md"
+                pairs.append((entry, path))
             except (ValueError, TypeError):
                 logger.warning("Skipping malformed tracked entry under %s", topic_dir)
-        return entries
+        return pairs
 
     def _load_topic_entries(self, topic_path: Path) -> list[WikiEntry]:
         """Parse a topic markdown file back into entries.

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -19,7 +19,10 @@ if TYPE_CHECKING:
     from precondition_gate import PreconditionGate
     from retrospective_queue import RetrospectiveQueue
     from visual_validator import VisualValidator
-    from wiki_compiler import WikiCompiler  # noqa: TCH004 — used in __init__ signature
+    from wiki_compiler import (  # noqa: TCH004 — used in __init__ signature
+        CorroborationDecision,
+        WikiCompiler,
+    )
 
 from adr_utils import (
     adr_validation_reasons,
@@ -64,7 +67,12 @@ from phase_utils import (
     store_lifecycle,
 )
 from post_merge_handler import PostMergeHandler
-from repo_wiki import RepoWikiStore, WikiEntry, classify_topic
+from repo_wiki import (
+    RepoWikiStore,
+    WikiEntry,
+    classify_topic,
+    increment_corroboration,
+)
 from review_insights import (
     _PROPOSAL_STALE_DAYS,
     CATEGORY_DESCRIPTIONS,
@@ -264,6 +272,11 @@ class ReviewPhase:
                 )
                 if entries:
                     if tracked_store is not None and worktree_path is not None:
+                        decisions = await self._precompute_corroboration(
+                            tracked_store=tracked_store,
+                            repo=repo,
+                            entries=entries,
+                        )
                         # Offload sync file + git-subprocess work off the
                         # event loop — ADR-0001 — so other concurrent
                         # phase loops don't stall on ``git commit``.
@@ -275,6 +288,7 @@ class ReviewPhase:
                             issue_number=issue_number,
                             phase="review",
                             entries=entries,
+                            decisions=decisions,
                         )
                     else:
                         self._wiki_store.ingest(repo, entries)
@@ -325,6 +339,50 @@ class ReviewPhase:
             worktree_path,
         )
 
+    async def _precompute_corroboration(
+        self,
+        *,
+        tracked_store: RepoWikiStore,
+        repo: str,
+        entries: list[WikiEntry],
+    ) -> list[CorroborationDecision]:
+        """Run ``dedup_or_corroborate`` per entry against existing active
+        entries in the same topic. Returns one decision per entry in the
+        same order. Bounded per-entry by a candidate cap so a large
+        topic doesn't fire one LLM call per existing entry.
+        """
+        from wiki_compiler import CorroborationDecision  # noqa: PLC0415
+
+        if self._wiki_compiler is None:
+            return [CorroborationDecision() for _ in entries]
+        max_candidates = 5
+        decisions: list[CorroborationDecision] = []
+        for entry in entries:
+            topic = classify_topic(entry)
+            topic_dir = tracked_store._tracked_topic_dir(repo, topic)
+            existing_pairs: list[tuple[WikiEntry, Path]] = []
+            if topic_dir is not None:
+                existing_pairs = (
+                    tracked_store._load_tracked_topic_entries_with_paths(topic_dir)
+                )[:max_candidates]
+            try:
+                decision = await self._wiki_compiler.dedup_or_corroborate(
+                    repo_slug=repo,
+                    entry=entry,
+                    existing_entries=existing_pairs,
+                    topic=topic,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "corroboration precompute failed for %s/%s",
+                    repo,
+                    entry.title,
+                    exc_info=True,
+                )
+                decision = CorroborationDecision()
+            decisions.append(decision)
+        return decisions
+
     def _wiki_commit_compiler_entries(
         self,
         *,
@@ -334,19 +392,33 @@ class ReviewPhase:
         issue_number: int,
         phase: str,
         entries: list[WikiEntry],
+        decisions: list[CorroborationDecision] | None = None,
     ) -> None:
         """Route compiler-synthesized entries through ``write_entry`` then
         commit.  Rolls back any files written before a mid-batch failure.
+
+        When ``decisions`` is provided (same length as ``entries``),
+        entries whose decision says ``should_corroborate`` skip the
+        write and instead bump the canonical's counter via
+        ``increment_corroboration`` — the ingest side of the
+        depth-signal system (ADR-0032).
         """
+        from wiki_compiler import CorroborationDecision  # noqa: PLC0415
+
         written: list[Path] = []
+        if decisions is None or len(decisions) != len(entries):
+            decisions = [CorroborationDecision() for _ in entries]
         try:
-            for entry in entries:
+            for entry, decision in zip(entries, decisions, strict=True):
+                if decision.should_corroborate and decision.canonical_path is not None:
+                    increment_corroboration(decision.canonical_path)
+                    continue
                 topic = classify_topic(entry)
                 written.append(tracked_store.write_entry(repo, entry, topic=topic))
             tracked_store.append_log(
                 repo,
                 issue_number,
-                {"phase": phase, "action": "ingest", "entries": len(entries)},
+                {"phase": phase, "action": "ingest", "entries": len(written)},
             )
             tracked_store.commit_pending_entries(
                 worktree_path=worktree_path,

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -48,6 +48,24 @@ class GeneralizationCheck(BaseModel):
     confidence: Literal["high", "medium", "low"] = "low"
 
 
+class CorroborationDecision(BaseModel):
+    """Outcome of ``WikiCompiler.dedup_or_corroborate``.
+
+    When ``should_corroborate`` is True, the caller should bump
+    ``canonical_path``'s ``corroborations`` counter instead of writing
+    the new entry as a sibling. ``canonical_path`` is carried directly
+    because ``WikiEntry.id`` is a ULID while filenames use a separate
+    per-topic sequential prefix — there's no reliable id → path map.
+    """
+
+    should_corroborate: bool = False
+    canonical_title: str = ""
+    canonical_id: str = ""
+    canonical_path: Path | None = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
 class ADRDraftDecision(BaseModel):
     two_plus_issues: bool = False
     in_tribal: bool = False
@@ -599,6 +617,45 @@ class WikiCompiler:
         if raw is None:
             return GeneralizationCheck()
         return self._parse_generalization_output(raw)
+
+    async def dedup_or_corroborate(
+        self,
+        *,
+        repo_slug: str,
+        entry: WikiEntry,
+        existing_entries: list[tuple[WikiEntry, Path]],
+        topic: str,
+        min_confidence: Literal["medium", "high"] = "medium",
+    ) -> CorroborationDecision:
+        """Use ``generalize_pair`` to decide whether ``entry`` is a
+        re-discovery of an existing active entry.
+
+        ``existing_entries`` carries ``(WikiEntry, Path)`` tuples so the
+        path travels with the entry — the caller then bumps the
+        canonical's ``corroborations`` counter without re-walking the
+        topic directory. Stops at the first confident match: we don't
+        need to rank matches, just detect one.
+
+        Returns an empty decision (``should_corroborate=False``) when
+        there are no existing entries, or no match hits the confidence
+        floor.
+        """
+        del repo_slug  # carried for symmetry with other compiler methods
+        if not existing_entries:
+            return CorroborationDecision()
+        acceptable = {"high"} if min_confidence == "high" else {"high", "medium"}
+        for existing, existing_path in existing_entries:
+            check = await self.generalize_pair(
+                entry_a=entry, entry_b=existing, topic=topic
+            )
+            if check.same_principle and check.confidence in acceptable:
+                return CorroborationDecision(
+                    should_corroborate=True,
+                    canonical_title=existing.title,
+                    canonical_id=existing.id,
+                    canonical_path=existing_path,
+                )
+        return CorroborationDecision()
 
     async def judge_adr_draft(
         self,

--- a/tests/scenarios/fakes/fake_wiki_compiler.py
+++ b/tests/scenarios/fakes/fake_wiki_compiler.py
@@ -59,3 +59,15 @@ class FakeWikiCompiler:
             contradicts: list = []
 
         return _Empty()
+
+    async def dedup_or_corroborate(self, **kwargs):
+        """Corroboration decision stub.
+
+        Default is 'no match' so scenarios exercise the normal write
+        path. Tests that need corroboration to fire should assign
+        ``fake.dedup_decision = CorroborationDecision(...)`` before
+        running the tick.
+        """
+        from wiki_compiler import CorroborationDecision  # noqa: PLC0415
+
+        return getattr(self, "dedup_decision", CorroborationDecision())

--- a/tests/test_repo_wiki_store_git.py
+++ b/tests/test_repo_wiki_store_git.py
@@ -136,6 +136,67 @@ class TestWriteEntry:
         assert len(loaded) == 1
         assert loaded[0].corroborations == 7
 
+    def test_increment_corroboration_bumps_counter_atomically(
+        self, tmp_path: Path
+    ) -> None:
+        """increment_corroboration must bump the counter in frontmatter
+        and leave the body untouched."""
+        from repo_wiki import increment_corroboration
+
+        entry_path = tmp_path / "0001-issue-1-x.md"
+        entry_path.write_text(
+            "---\n"
+            "id: 0001\n"
+            "topic: patterns\n"
+            "source_issue: 1\n"
+            "source_phase: review\n"
+            "created_at: 2026-01-01T00:00:00+00:00\n"
+            "status: active\n"
+            "corroborations: 3\n"
+            "---\n"
+            "# Title\n\nBody with important details.\n",
+            encoding="utf-8",
+        )
+
+        increment_corroboration(entry_path, by=2)
+
+        text = entry_path.read_text(encoding="utf-8")
+        assert "corroborations: 5" in text
+        assert "Body with important details." in text
+
+    def test_increment_corroboration_defaults_to_one_when_field_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing field → treated as 1, bumped to 1+by."""
+        from repo_wiki import increment_corroboration
+
+        entry_path = tmp_path / "0001-issue-1-x.md"
+        entry_path.write_text(
+            "---\n"
+            "id: 0001\n"
+            "topic: patterns\n"
+            "source_issue: 1\n"
+            "source_phase: review\n"
+            "created_at: 2026-01-01T00:00:00+00:00\n"
+            "status: active\n"
+            "---\n"
+            "# Title\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        increment_corroboration(entry_path, by=1)
+
+        text = entry_path.read_text(encoding="utf-8")
+        assert "corroborations: 2" in text
+
+    def test_increment_corroboration_noop_on_nonexistent_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing file → silent no-op, never raises."""
+        from repo_wiki import increment_corroboration
+
+        increment_corroboration(tmp_path / "does-not-exist.md", by=1)
+
     def test_corroborations_defaults_to_one_when_field_missing_from_frontmatter(
         self, store: RepoWikiStore, tmp_path: Path
     ) -> None:

--- a/tests/test_repo_wiki_store_git.py
+++ b/tests/test_repo_wiki_store_git.py
@@ -117,6 +117,49 @@ class TestWriteEntry:
         )
         assert "source_phase: synthesis" in path.read_text()
 
+    def test_corroborations_field_round_trips_through_write_and_load(
+        self, store: RepoWikiStore
+    ) -> None:
+        """corroborations must survive write → read unchanged."""
+        entry = WikiEntry(
+            title="Use factories not direct instantiation",
+            content="Details about factories.",
+            source_type="review",
+            source_issue=42,
+            corroborations=7,
+        )
+        path = store.write_entry(REPO, entry, topic="patterns")
+
+        assert "corroborations: 7" in path.read_text()
+
+        loaded = store._load_tracked_topic_entries(path.parent)
+        assert len(loaded) == 1
+        assert loaded[0].corroborations == 7
+
+    def test_corroborations_defaults_to_one_when_field_missing_from_frontmatter(
+        self, store: RepoWikiStore, tmp_path: Path
+    ) -> None:
+        """Entries written before this field existed must load as 1."""
+        tmp_path / "widget-root" / REPO / "patterns"
+        # Reuse the store's actual topic dir instead of a fresh tmp path.
+        real_topic_dir = store._repo_dir(REPO) / "patterns"
+        real_topic_dir.mkdir(parents=True, exist_ok=True)
+        (real_topic_dir / "0001-issue-1-old.md").write_text(
+            "---\n"
+            "id: 0001\n"
+            "topic: patterns\n"
+            "source_issue: 1\n"
+            "source_phase: review\n"
+            "created_at: 2026-01-01T00:00:00+00:00\n"
+            "status: active\n"
+            "---\n"
+            "# Old entry\n\nBody.\n",
+            encoding="utf-8",
+        )
+        loaded = store._load_tracked_topic_entries(real_topic_dir)
+        assert len(loaded) == 1
+        assert loaded[0].corroborations == 1
+
 
 class TestAppendLog:
     def test_appends_per_issue_jsonl(self, store: RepoWikiStore) -> None:

--- a/tests/test_repo_wiki_temporal.py
+++ b/tests/test_repo_wiki_temporal.py
@@ -163,3 +163,39 @@ def test_query_with_tags_returns_title_to_tag_map_for_corroborated_entry(
     assert tag is not None
     assert "stable for" in tag
     assert "+4" in tag
+
+
+# ----------------------------------------------------------------------
+# Direct unit tests for _weave_temporal_tags.
+# ----------------------------------------------------------------------
+
+from base_runner import _weave_temporal_tags  # noqa: E402
+
+
+def test_weave_temporal_tags_appends_italic_line_after_matching_h3() -> None:
+    markdown = "## Patterns\n\n### Always use factories\nBody text.\n"
+    tags = {"Always use factories": "stable for 6 months (+4)"}
+
+    woven = _weave_temporal_tags(markdown, tags)
+
+    assert "### Always use factories\n*(stable for 6 months (+4))*" in woven
+
+
+def test_weave_temporal_tags_noop_on_empty_tags() -> None:
+    markdown = "### x\nbody\n"
+    assert _weave_temporal_tags(markdown, {}) == markdown
+
+
+def test_weave_temporal_tags_noop_on_empty_markdown() -> None:
+    assert _weave_temporal_tags("", {"x": "y"}) == ""
+
+
+def test_weave_temporal_tags_ignores_h2_headings() -> None:
+    """Only ### (entry) headings get tagged — ## are topic sections."""
+    markdown = "## Patterns\n### foo\nbody\n"
+    tags = {"Patterns": "stale", "foo": "recent"}
+
+    woven = _weave_temporal_tags(markdown, tags)
+
+    assert "## Patterns\n*(stale)*" not in woven
+    assert "### foo\n*(recent)*" in woven

--- a/tests/test_repo_wiki_temporal.py
+++ b/tests/test_repo_wiki_temporal.py
@@ -1,0 +1,103 @@
+"""Temporal annotator — turns created_at + corroboration counts into
+short stability tags the planner/reviewer can read alongside the entry
+body. Pure function, no I/O, no LLM calls."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from repo_wiki import WikiEntry, annotate_entries_with_temporal_tags
+
+
+def _entry(
+    *,
+    title: str,
+    created_at: datetime,
+    corroborations: int = 1,
+) -> WikiEntry:
+    return WikiEntry(
+        title=title,
+        content="body",
+        source_type="review",
+        created_at=created_at.isoformat(),
+        corroborations=corroborations,
+    )
+
+
+def test_recently_created_entry_is_tagged_recent() -> None:
+    now = datetime.now(UTC)
+    young = _entry(title="x", created_at=now - timedelta(days=3))
+
+    [(entry, tag)] = annotate_entries_with_temporal_tags([young], now=now)
+
+    assert entry.title == "x"
+    assert tag == "recently added"
+
+
+def test_months_old_entry_is_tagged_stable_for_n_months() -> None:
+    now = datetime.now(UTC)
+    old = _entry(title="y", created_at=now - timedelta(days=200))
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([old], now=now)
+
+    assert tag == "stable for 6 months"
+
+
+def test_year_old_entry_is_tagged_stable_for_one_year() -> None:
+    now = datetime.now(UTC)
+    ancient = _entry(title="z", created_at=now - timedelta(days=400))
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([ancient], now=now)
+
+    assert tag == "stable for 1 year"
+
+
+def test_multi_year_old_entry_uses_years_plural() -> None:
+    now = datetime.now(UTC)
+    ancient = _entry(title="z", created_at=now - timedelta(days=800))
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([ancient], now=now)
+
+    assert tag == "stable for 2 years"
+
+
+def test_high_corroboration_is_reflected_in_tag() -> None:
+    """Entries with many corroborations get a (+N) suffix so the reader
+    can see how independently-re-discovered the claim is at a glance."""
+    now = datetime.now(UTC)
+    e = _entry(title="q", created_at=now - timedelta(days=200), corroborations=12)
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([e], now=now)
+
+    assert tag == "stable for 6 months (+12)"
+
+
+def test_single_corroboration_does_not_add_suffix() -> None:
+    """(+1) would be noise on every entry — skip the suffix until >=2."""
+    now = datetime.now(UTC)
+    e = _entry(title="q", created_at=now - timedelta(days=200), corroborations=1)
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([e], now=now)
+
+    assert tag == "stable for 6 months"
+
+
+def test_empty_input_returns_empty_list() -> None:
+    now = datetime.now(UTC)
+
+    assert annotate_entries_with_temporal_tags([], now=now) == []
+
+
+def test_malformed_created_at_tags_as_age_unknown() -> None:
+    """Never crash on bad timestamps — entry passes through with a
+    placeholder tag."""
+    e = WikiEntry(
+        title="w",
+        content="body",
+        source_type="review",
+        created_at="not a date",
+    )
+
+    [(_e, tag)] = annotate_entries_with_temporal_tags([e], now=datetime.now(UTC))
+
+    assert tag == "age unknown"

--- a/tests/test_repo_wiki_temporal.py
+++ b/tests/test_repo_wiki_temporal.py
@@ -101,3 +101,65 @@ def test_malformed_created_at_tags_as_age_unknown() -> None:
     [(_e, tag)] = annotate_entries_with_temporal_tags([e], now=datetime.now(UTC))
 
     assert tag == "age unknown"
+
+
+# ----------------------------------------------------------------------
+# Integration — query_with_tags returns a title → tag map alongside
+# the markdown so callers can weave tags into the injected prompt.
+# ----------------------------------------------------------------------
+
+import subprocess  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+import pytest  # noqa: E402
+
+from repo_wiki import RepoWikiStore  # noqa: E402
+
+
+@pytest.fixture
+def tracked_store(tmp_path: Path) -> RepoWikiStore:
+    root = tmp_path / "tracked"
+    root.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / "seed").write_text("x")
+    subprocess.run(
+        ["git", "add", "seed"], cwd=tmp_path, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True
+    )
+    return RepoWikiStore(wiki_root=root, tracked_root=root)
+
+
+def test_query_with_tags_returns_title_to_tag_map_for_corroborated_entry(
+    tracked_store: RepoWikiStore,
+) -> None:
+    """query_with_tags must emit the markdown body and a
+    ``title → stability-tag`` dict so ``_inject_repo_wiki`` can weave
+    tags inline."""
+    old_date = (datetime.now(UTC) - timedelta(days=200)).isoformat()
+    entry = WikiEntry(
+        title="Always use factories",
+        content="Details about factories.",
+        source_type="review",
+        source_issue=1,
+        created_at=old_date,
+        corroborations=4,
+    )
+    tracked_store.write_entry("o/r", entry, topic="patterns")
+
+    markdown, tags = tracked_store.query_with_tags("o/r")
+
+    assert "Always use factories" in markdown
+    tag = tags.get("Always use factories")
+    assert tag is not None
+    assert "stable for" in tag
+    assert "+4" in tag

--- a/tests/test_wiki_corroboration.py
+++ b/tests/test_wiki_corroboration.py
@@ -137,3 +137,109 @@ async def test_stops_at_first_confident_match(compiler: WikiCompiler) -> None:
     assert decision.should_corroborate is True
     assert decision.canonical_path == Path("/tmp/e0.md")
     assert len(calls) == 1
+
+
+# ----------------------------------------------------------------------
+# Ingest wiring — PlanPhase._wiki_commit_compiler_entries reads the
+# decisions list and bumps the canonical instead of writing a sibling.
+# ----------------------------------------------------------------------
+
+import subprocess  # noqa: E402
+
+from repo_wiki import RepoWikiStore  # noqa: E402
+
+
+def test_commit_entries_with_corroborate_decision_bumps_canonical_and_skips_write(
+    tmp_path: Path,
+) -> None:
+    """Ingest commit: when the decision says corroborate, the canonical's
+    counter bumps and no new file is written for that entry."""
+    from wiki_compiler import CorroborationDecision  # runtime-import
+
+    # Set up a real git worktree so commit_pending_entries doesn't fail.
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    subprocess.run(
+        ["git", "init", "-b", "main"], cwd=worktree, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=worktree,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=worktree, check=True)
+    (worktree / "seed").write_text("x")
+    subprocess.run(
+        ["git", "add", "seed"], cwd=worktree, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "init"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+
+    tracked_root = worktree / "repo_wiki"
+    store = RepoWikiStore(wiki_root=tracked_root, tracked_root=tracked_root)
+
+    # Seed an existing canonical entry that a new ingest will match.
+    canonical = WikiEntry(
+        title="Factories over direct instantiation",
+        content="Use a factory.",
+        source_type="review",
+        source_issue=1,
+    )
+    canonical_path = store.write_entry("o/r", canonical, topic="patterns")
+    subprocess.run(
+        ["git", "add", "repo_wiki"], cwd=worktree, check=True, capture_output=True
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "seed"],
+        cwd=worktree,
+        check=True,
+        capture_output=True,
+    )
+
+    # Now call _wiki_commit_compiler_entries directly with a pre-populated
+    # "should_corroborate" decision. We don't need PlanPhase — just the
+    # bound method's logic.
+    from plan_phase import PlanPhase
+
+    new_entry = _entry("Another factories insight")
+    decisions = [
+        CorroborationDecision(
+            should_corroborate=True,
+            canonical_title=canonical.title,
+            canonical_id=canonical.id,
+            canonical_path=canonical_path,
+        )
+    ]
+
+    topic_dir = canonical_path.parent
+    before_count = sum(1 for _ in topic_dir.glob("*.md"))
+
+    # Build a PlanPhase-like object with the minimum surface to call the
+    # method. The method only reads self._config.repo_wiki_path and
+    # doesn't touch other state in this path.
+    phase_config = MagicMock()
+    phase_config.repo_wiki_path = "repo_wiki"
+    phase = PlanPhase.__new__(PlanPhase)
+    phase._config = phase_config
+
+    phase._wiki_commit_compiler_entries(
+        tracked_store=store,
+        worktree_path=worktree,
+        repo="o/r",
+        issue_number=99,
+        phase="plan",
+        entries=[new_entry],
+        decisions=decisions,
+    )
+
+    # Canonical's corroborations bumped from 1 to 2.
+    canonical_text = canonical_path.read_text(encoding="utf-8")
+    assert "corroborations: 2" in canonical_text
+
+    # No new file written for the corroborated entry.
+    after_count = sum(1 for _ in topic_dir.glob("*.md"))
+    assert after_count == before_count

--- a/tests/test_wiki_corroboration.py
+++ b/tests/test_wiki_corroboration.py
@@ -1,0 +1,139 @@
+"""Ingest-path dedup: re-discoveries of the same principle should
+bump the canonical entry's corroboration counter instead of landing
+as a sibling. Uses generalize_pair as the semantic-match primitive."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from repo_wiki import WikiEntry
+from wiki_compiler import (
+    GeneralizationCheck,
+    WikiCompiler,
+)
+
+
+def _entry(title: str, content: str = "body") -> WikiEntry:
+    return WikiEntry(
+        title=title,
+        content=content,
+        source_type="review",
+        source_issue=1,
+        topic="patterns",
+    )
+
+
+@pytest.fixture
+def compiler() -> WikiCompiler:
+    config = MagicMock()
+    runner = MagicMock()
+    creds = MagicMock()
+    return WikiCompiler(config=config, runner=runner, credentials=creds)
+
+
+@pytest.mark.asyncio
+async def test_match_with_high_confidence_returns_corroboration_decision(
+    compiler: WikiCompiler,
+) -> None:
+    new = _entry("Always use factories")
+    canonical = _entry("Use factories not direct instantiation")
+    canonical_path = Path("/tmp/canonical.md")
+    existing = [(canonical, canonical_path)]
+    compiler.generalize_pair = AsyncMock(
+        return_value=GeneralizationCheck(same_principle=True, confidence="high")
+    )
+
+    decision = await compiler.dedup_or_corroborate(
+        repo_slug="o/r",
+        entry=new,
+        existing_entries=existing,
+        topic="patterns",
+    )
+
+    assert decision.should_corroborate is True
+    assert decision.canonical_title == "Use factories not direct instantiation"
+    assert decision.canonical_path == canonical_path
+
+
+@pytest.mark.asyncio
+async def test_low_confidence_does_not_corroborate(compiler: WikiCompiler) -> None:
+    new = _entry("Always use factories")
+    existing = [(_entry("Unrelated"), Path("/tmp/u.md"))]
+    compiler.generalize_pair = AsyncMock(
+        return_value=GeneralizationCheck(same_principle=True, confidence="low")
+    )
+
+    decision = await compiler.dedup_or_corroborate(
+        repo_slug="o/r",
+        entry=new,
+        existing_entries=existing,
+        topic="patterns",
+    )
+
+    assert decision.should_corroborate is False
+
+
+@pytest.mark.asyncio
+async def test_no_same_principle_returns_no_corroboration(
+    compiler: WikiCompiler,
+) -> None:
+    new = _entry("Always use factories")
+    existing = [(_entry("Unrelated"), Path("/tmp/u.md"))]
+    compiler.generalize_pair = AsyncMock(
+        return_value=GeneralizationCheck(same_principle=False, confidence="high")
+    )
+
+    decision = await compiler.dedup_or_corroborate(
+        repo_slug="o/r",
+        entry=new,
+        existing_entries=existing,
+        topic="patterns",
+    )
+
+    assert decision.should_corroborate is False
+
+
+@pytest.mark.asyncio
+async def test_empty_existing_entries_skips_llm(compiler: WikiCompiler) -> None:
+    new = _entry("First")
+    compiler.generalize_pair = AsyncMock()
+
+    decision = await compiler.dedup_or_corroborate(
+        repo_slug="o/r",
+        entry=new,
+        existing_entries=[],
+        topic="patterns",
+    )
+
+    assert decision.should_corroborate is False
+    compiler.generalize_pair.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stops_at_first_confident_match(compiler: WikiCompiler) -> None:
+    """Cost bound — don't query every existing entry once we have a match."""
+    new = _entry("q")
+    existing = [(_entry(f"e{i}"), Path(f"/tmp/e{i}.md")) for i in range(5)]
+    calls: list[tuple[str, str]] = []
+
+    async def fake_generalize(*, entry_a, entry_b, topic):
+        calls.append((entry_a.title, entry_b.title))
+        if entry_b.title == "e0":
+            return GeneralizationCheck(same_principle=True, confidence="high")
+        return GeneralizationCheck()
+
+    compiler.generalize_pair = fake_generalize  # type: ignore[method-assign]
+
+    decision = await compiler.dedup_or_corroborate(
+        repo_slug="o/r",
+        entry=new,
+        existing_entries=existing,
+        topic="patterns",
+    )
+
+    assert decision.should_corroborate is True
+    assert decision.canonical_path == Path("/tmp/e0.md")
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary

Addresses two depth gaps in HydraFlow's wiki vs. richer agentic-memory systems (Hindsight et al.):

1. **Evidence weighting.** Every active entry now carries a ``corroborations`` counter in frontmatter (default 1 — entries without the field load as "seen once"). On every plan/review ingest, ``WikiCompiler.dedup_or_corroborate`` judges via ``generalize_pair`` whether each new entry is a re-discovery of an existing active one in the same topic. On match, ``increment_corroboration`` bumps the canonical's counter atomically and the write is skipped — no more sibling duplicates.
2. **Temporal reasoning.** ``annotate_entries_with_temporal_tags`` turns ``created_at`` + corroboration count → short stability tags. ``RepoWikiStore.query_with_tags`` returns a ``{title: tag}`` map alongside the markdown, and ``BaseRunner._inject_repo_wiki`` weaves them inline, so planner/reviewer prompts see:

   ```
   ### Always use factories
   *(stable for 6 months (+4))*
   ```

## What's in this PR (end-to-end)

**Data model**
- ``WikiEntry.corroborations: int = 1`` — round-trips through frontmatter
- ``increment_corroboration(path, *, by)`` — atomic counter bump

**Read path (temporal)**
- ``annotate_entries_with_temporal_tags(entries, *, now)`` — pure function, vocabulary: ``recently added`` / ``stable for N months`` / ``stable for N year(s)`` / ``age unknown``, ``(+N)`` suffix when >1
- ``RepoWikiStore.query_with_tags()`` — returns ``(markdown, {title: tag})``
- ``BaseRunner._weave_temporal_tags()`` — inserts italic tag lines under each ``### <title>`` entry heading

**Ingest path (corroboration)**
- ``WikiCompiler.dedup_or_corroborate(repo_slug, entry, existing_entries, topic)`` — async LLM judgment; stops at first confident match for cost bound
- ``CorroborationDecision`` dataclass — carries ``canonical_path: Path | None`` directly (entry ULIDs don't map to filenames)
- ``RepoWikiStore._load_tracked_topic_entries_with_paths()`` — returns ``(entry, path)`` tuples
- ``PlanPhase._precompute_corroboration()`` / ``ReviewPhase._precompute_corroboration()`` — runs the async LLM pass on the event loop
- ``_wiki_commit_compiler_entries`` accepts a ``decisions`` list; entries with ``should_corroborate`` bump the canonical instead of writing

**Bounds + graceful degradation**
- ``max_candidates_per_entry = 5`` — a large topic won't fire one LLM call per existing entry
- ``WikiCompiler is None`` → every decision empty, write path runs as before
- Per-entry exception handling — one failed judgment doesn't sink the batch

**Stubs + docs**
- ``FakeWikiCompiler.dedup_or_corroborate`` — scenario tests get a "no match" default; tests that need corroboration to fire can override via ``fake.dedup_decision``
- ADR-0032 "Depth signals" bullet + Enforced-by additions

## Test plan

- [x] 9 temporal annotator tests — tag vocabulary, corroboration suffix, malformed date fallback, weave helper, end-to-end ``query_with_tags`` round-trip
- [x] 6 corroboration tests — decision primitive (high/low/no-match, empty, first-match stop) + end-to-end ingest-commit wiring (bump + skip-write path via real git worktree)
- [x] 4 new tests on ``test_repo_wiki_store_git.py`` — round-trip, default-when-missing, ``increment_corroboration`` (by=N + missing field + nonexistent file)
- [x] ``567/567 passed`` on the touched areas (plan_phase + review_phase_{core,ci,complexity} + repo_wiki_{temporal,store_git} + wiki_corroboration + scenarios excluding browser)
- [x] ``ruff check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Skip-ADR: plan_phase.py and review_phase.py touches are the ingest-hook wiring for ADR-0032 depth signals (which is updated in this PR). ADR-0014 (Session Counter Forward-Progression Semantics) is unrelated — these edits do not change session-counter semantics.
