### PR TITLE
trust-arch-followup: close 4 spec gaps from §3/§5/§11/§12 audit

### DIFF
--- a/src/ci_monitor_loop.py
+++ b/src/ci_monitor_loop.py
@@ -56,8 +56,11 @@ class CIMonitorLoop(BaseBackgroundLoop):
         except Exception:
             logger.debug("CI monitor: could not rehydrate open issue", exc_info=True)
 
-    async def _do_work(self) -> dict[str, Any] | None:
+    async def _do_work(self) -> dict[str, Any] | None:  # noqa: PLR0911
         """Check CI status and create/close issues as needed."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if self._config.dry_run:
             return None
 

--- a/src/config.py
+++ b/src/config.py
@@ -1848,6 +1848,14 @@ class HydraFlowConfig(BaseModel):
         le=2_592_000,
         description="Seconds between CorpusLearningLoop ticks (default 7d)",
     )
+    corpus_learning_signal_labels: tuple[str, ...] = Field(
+        default=("skill-escape", "discover-escape", "shape-escape"),
+        description=(
+            "Escape-signal labels CorpusLearningLoop reads. Spec §4.1: covers "
+            "skill-escape (post-impl), discover-escape (Discover §4.10), and "
+            "shape-escape (Shape §4.10). Override for a stripped-down deployment."
+        ),
+    )
 
     # Trust fleet — ContractRefreshLoop (spec §4.2)
     contract_refresh_interval: int = Field(

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -72,10 +72,20 @@ logger = logging.getLogger("hydraflow.corpus_learning_loop")
 
 #: Default GitHub label that marks an issue as a production escape
 #: signal. Task 15 will surface this as a
-#: ``corpus_learning_signal_label`` config field; until then callers and
-#: tests can override via the ``label`` parameter on
-#: :meth:`CorpusLearningLoop._list_escape_signals`.
+#: Default label for backwards-compatible single-label callers (tests).
+#: Production reads :data:`DEFAULT_ESCAPE_SIGNAL_LABELS` via the
+#: ``corpus_learning_signal_labels`` config field (spec §4.1).
 DEFAULT_ESCAPE_LABEL = "skill-escape"
+
+#: Spec §4.1: the loop reads three escape-label families. ``skill-escape``
+#: covers post-impl skills; ``discover-escape`` and ``shape-escape``
+#: cover product-phase evaluator escapes (§4.10). Configurable via
+#: ``HydraFlowConfig.corpus_learning_signal_labels``.
+DEFAULT_ESCAPE_SIGNAL_LABELS: tuple[str, ...] = (
+    "skill-escape",
+    "discover-escape",
+    "shape-escape",
+)
 
 #: Default recency window (days) for escape signals. Issues whose
 #: ``updated_at`` is older than this are dropped from the reader so the
@@ -589,8 +599,23 @@ class CorpusLearningLoop(BaseBackgroundLoop):
         # Tolerate PR-query failures — a broken ``gh`` in the env must
         # not propagate as an AuthenticationError that pauses the whole
         # orchestrator. Next tick retries.
+        # Spec §4.1: the loop reads ALL escape-signal label families
+        # (skill-escape, discover-escape, shape-escape by default) so
+        # product-phase escapes from §4.10 feed the same synthesis
+        # pipeline as post-impl skill escapes.
+        labels = (
+            getattr(self._config, "corpus_learning_signal_labels", None)
+            or DEFAULT_ESCAPE_SIGNAL_LABELS
+        )
+        signals: list[EscapeSignal] = []
         try:
-            signals = await self._list_escape_signals()
+            seen_issues: set[int] = set()
+            for label in labels:
+                for sig in await self._list_escape_signals(label=label):
+                    if sig.issue_number in seen_issues:
+                        continue
+                    seen_issues.add(sig.issue_number)
+                    signals.append(sig)
         except Exception:  # noqa: BLE001
             logger.warning(
                 "corpus-learning: escape-signal query failed — skipping tick",

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -108,6 +108,57 @@ _bg_worker_defs = [
         "ADR Reviewer",
         "Reviews proposed ADRs via a 3-judge council and routes to accept, reject, or escalate.",
     ),
+    # --- Trust fleet (ADR-0045) ---
+    (
+        "corpus_learning",
+        "Corpus Learning",
+        "Synthesizes adversarial cases from skill/discover/shape escape signals and opens corpus-update PRs.",
+    ),
+    (
+        "contract_refresh",
+        "Contract Refresh",
+        "Re-records fake-adapter cassettes and opens refresh PRs when committed cassettes drift from live behavior.",
+    ),
+    (
+        "staging_bisect",
+        "Staging Bisect",
+        "Bisects RC red between last-green and current-red; opens auto-revert PRs and watches the next RC.",
+    ),
+    (
+        "principles_audit",
+        "Principles Audit",
+        "Weekly ADR-0044 audit of HydraFlow-self plus managed repos; blocks onboarding on P1–P5 fails.",
+    ),
+    (
+        "flake_tracker",
+        "Flake Tracker",
+        "Detects persistently flaky tests across recent RC runs and files flake-tracker issues.",
+    ),
+    (
+        "skill_prompt_eval",
+        "Skill Prompt Eval",
+        "Weekly adversarial-corpus gate against built-in skills; flags PASS→FAIL regressions.",
+    ),
+    (
+        "fake_coverage_auditor",
+        "Fake Coverage Auditor",
+        "Flags fake-adapter methods without cassettes and scenario helpers nobody calls.",
+    ),
+    (
+        "rc_budget",
+        "RC Budget",
+        "Detects RC wall-clock bloat via rolling-median + spike signals across recent runs.",
+    ),
+    (
+        "wiki_rot_detector",
+        "Wiki Rot Detector",
+        "Scans per-repo wikis for citations whose source code has moved or vanished.",
+    ),
+    (
+        "trust_fleet_sanity",
+        "Trust Fleet Sanity",
+        "Meta-observer — watches the 9 trust loops for stalls, escalation spam, dedup growth, errors, cost spikes.",
+    ),
 ]
 
 # Workers that have independent configurable intervals
@@ -116,6 +167,17 @@ _INTERVAL_WORKERS = {
     "pr_unsticker",
     "pipeline_poller",
     "report_issue",
+    # Trust fleet (ADR-0045): every loop's interval is operator-tunable.
+    "corpus_learning",
+    "contract_refresh",
+    "staging_bisect",
+    "principles_audit",
+    "flake_tracker",
+    "skill_prompt_eval",
+    "fake_coverage_auditor",
+    "rc_budget",
+    "wiki_rot_detector",
+    "trust_fleet_sanity",
 }
 # Pipeline loops share poll_interval (read-only display)
 _PIPELINE_WORKERS = {"triage", "plan", "implement", "review"}

--- a/src/dashboard_routes/_trust_routes.py
+++ b/src/dashboard_routes/_trust_routes.py
@@ -310,13 +310,107 @@ async def _read_fleet(
         )
 
     anomalies = _cached_anomalies(config, anomaly_reader)
+    escape_closure = _compute_escape_closure(config, since=since, until=now)
     range_label = "30d" if range_td.days >= 30 else "7d"
     return {
         "range": range_label,
         "generated_at": now.isoformat(),
         "loops": loops,
         "anomalies_recent": anomalies,
+        "escape_closure": escape_closure,
     }
+
+
+_ESCAPE_LABELS: tuple[str, ...] = (
+    "skill-escape",
+    "discover-escape",
+    "shape-escape",
+)
+_ESCAPE_CLOSURE_TARGET_DAYS = 7
+_ESCAPE_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_ESCAPE_CACHE_TTL = 60
+
+
+def _compute_escape_closure(
+    config: HydraFlowConfig, *, since: datetime, until: datetime
+) -> dict[str, Any]:
+    """Compute spec §12.4 success metric: 7-day escape closure ratio.
+
+    Returns ``{"opened": n, "closed_within_7d": k, "ratio": k/n, "target": 0.95}``
+    aggregated across the three escape labels in [since, until]. Values are
+    cached for 60s to amortize the gh-issue-list calls. Failures are soft
+    — return zeros rather than blow up the fleet endpoint.
+    """
+    cache_key = f"{config.repo or '_local_'}:{since.isoformat()}:{until.isoformat()}"
+    cached = _ESCAPE_CACHE.get(cache_key)
+    if cached is not None and time.time() - cached[0] < _ESCAPE_CACHE_TTL:
+        return cached[1]
+
+    target_window = timedelta(days=_ESCAPE_CLOSURE_TARGET_DAYS)
+    opened = 0
+    closed_within_target = 0
+    for label in _ESCAPE_LABELS:
+        argv = [
+            "gh",
+            "issue",
+            "list",
+            "--state",
+            "all",
+            "--label",
+            label,
+            "--limit",
+            "200",
+            "--json",
+            "createdAt,closedAt",
+        ]
+        if config.repo:
+            argv.extend(["--repo", config.repo])
+        try:
+            out = subprocess.run(  # noqa: S603 — trusted ``gh`` invocation
+                argv,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+            rows = json.loads(out.stdout or "[]")
+        except (
+            subprocess.CalledProcessError,
+            subprocess.TimeoutExpired,
+            json.JSONDecodeError,
+            FileNotFoundError,
+        ):
+            logger.debug("escape-closure: gh issue list failed for %s", label)
+            continue
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            created = _parse_iso(row.get("createdAt"))
+            if created is None or created < since or created > until:
+                continue
+            opened += 1
+            closed = _parse_iso(row.get("closedAt"))
+            if closed is not None and (closed - created) <= target_window:
+                closed_within_target += 1
+
+    ratio = (closed_within_target / opened) if opened else 0.0
+    payload = {
+        "opened": opened,
+        "closed_within_7d": closed_within_target,
+        "ratio": round(ratio, 4),
+        "target": 0.95,
+    }
+    _ESCAPE_CACHE[cache_key] = (time.time(), payload)
+    return payload
+
+
+def _parse_iso(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def build_trust_router(

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -357,6 +357,9 @@ class HealthMonitorLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Execute one health-monitor cycle."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         # Dead-man-switch: detect a stalled TrustFleetSanityLoop (spec §12.1).
         try:
             await self._check_sanity_loop_staleness()

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -93,7 +93,13 @@ Response JSON:
       "issue_number": <int>,
       "details": {<detector-specific>}
     }
-  ]
+  ],
+  "escape_closure": {                       # spec §12.4 success metric
+    "opened": <int>,                          # escape issues opened in window
+    "closed_within_7d": <int>,                # closed within 7 days of open
+    "ratio": <float>,                         # closed_within_7d / opened
+    "target": 0.95                            # spec §12.4 target ratio
+  }
 }
 
 Implementation notes for Plan 6b:

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -287,7 +287,7 @@ class TestSystemWorkersEndpoint:
 
         response = await endpoint()
         data = json.loads(response.body)
-        assert len(data["workers"]) == 11
+        assert len(data["workers"]) == 21
         names = [w["name"] for w in data["workers"]]
         assert names == [
             "triage",
@@ -301,6 +301,17 @@ class TestSystemWorkersEndpoint:
             "pr_unsticker",
             "report_issue",
             "adr_reviewer",
+            # Trust fleet (ADR-0045)
+            "corpus_learning",
+            "contract_refresh",
+            "staging_bisect",
+            "principles_audit",
+            "flake_tracker",
+            "skill_prompt_eval",
+            "fake_coverage_auditor",
+            "rc_budget",
+            "wiki_rot_detector",
+            "trust_fleet_sanity",
         ]
         assert all(
             isinstance(w["description"], str) and w["description"]

--- a/tests/test_corpus_learning_integration.py
+++ b/tests/test_corpus_learning_integration.py
@@ -42,7 +42,6 @@ import pytest
 from base_background_loop import LoopDeps
 from config import HydraFlowConfig
 from corpus_learning_loop import (
-    DEFAULT_ESCAPE_LABEL,
     CorpusLearningLoop,
     SynthesizedCase,
 )
@@ -212,8 +211,11 @@ def test_end_to_end_happy_path_files_one_pr(
     assert result["cases_validated"] == 1
     assert result["cases_filed"] == 1
 
-    # Reader seam was called exactly once with the configured label.
-    _prs.list_issues_by_label.assert_awaited_once_with(DEFAULT_ESCAPE_LABEL)
+    # Spec §4.1: reader is invoked once per escape-label family (default 3).
+    awaited_labels = [
+        call.args[0] for call in _prs.list_issues_by_label.await_args_list
+    ]
+    assert awaited_labels == ["skill-escape", "discover-escape", "shape-escape"]
 
     # PR-open seam was called exactly once, with the derived title/body
     # and the expected label set.

--- a/tests/test_corpus_learning_loop.py
+++ b/tests/test_corpus_learning_loop.py
@@ -296,7 +296,11 @@ def test_do_work_invokes_escape_signal_reader_when_enabled(tmp_path: Path) -> No
 
     result = asyncio.run(loop._do_work())
 
-    prs.list_issues_by_label.assert_awaited_once_with(DEFAULT_ESCAPE_LABEL)
+    # Spec §4.1: the loop now reads three escape-label families per tick.
+    # Each call returns the same mocked issue; dedup-by-issue-number means
+    # the post-dedup count is still 1.
+    awaited_labels = [call.args[0] for call in prs.list_issues_by_label.await_args_list]
+    assert awaited_labels == ["skill-escape", "discover-escape", "shape-escape"]
     assert isinstance(result, dict)
     assert result.get("escape_issues_seen") == 1
     # Task 14 replaces the proposed/escalated stubs with cases_synthesized


### PR DESCRIPTION
## Summary

Follow-up to #8390. After that PR merged, a spec-by-section audit (sections §3 / §5 / §11 / §12) turned up four real gaps that the plan-by-plan review didn't catch. This PR closes them.

| ID | Gap | Spec ref |
|---|---|---|
| G1 | `corpus_learning` reads only `skill-escape`; spec mandates all three escape-label families | §4.1 |
| G3 | All 10 trust loops absent from `_bg_worker_defs` → no System-tab kill-switch UI | §12.1, §12.2 |
| G4 | `HealthMonitorLoop`/`CIMonitorLoop` missing in-body `enabled_cb` gate | §12.2, ADR-0049 |
| G5 | Escape-closure success metric (7-day) not computed or surfaced | §12.4 |

G2 (orchestrator onboarding gate) was investigated and confirmed a false positive — the orchestrator already gates dispatch via `state.blocked_slugs()` in `_pipeline_work_wrapper` at all 7 pipeline call sites; `tests/test_orchestrator_blocked_repos.py` covers it.

## What changed

- `corpus_learning_loop.py` — reads `corpus_learning_signal_labels` config (default 3 labels), dedupes by issue number across labels
- `config.py` — adds `corpus_learning_signal_labels: tuple[str, ...]` field
- `_control_routes.py` — 10 trust loops added to `_bg_worker_defs` + `_INTERVAL_WORKERS`
- `health_monitor_loop.py` / `ci_monitor_loop.py` — `if not self._enabled_cb(...): return {"status": "disabled"}` at the top of `_do_work`
- `_trust_routes.py` — `_compute_escape_closure` (60s cache) joined into `/api/trust/fleet` payload as `escape_closure: {opened, closed_within_7d, ratio, target}`
- `trust_fleet_sanity_loop.py` — `FLEET_ENDPOINT_SCHEMA` docstring updated to document `escape_closure`
- `tests/test_corpus_learning_loop.py` — assertion updated for new 3-label query

## Test plan

- [x] `pytest tests/test_corpus_learning_loop.py` — 40 passing
- [x] `pytest tests/test_health_monitor_sanity_stall.py tests/test_ci_monitor_loop.py` — kill-switch additions don't break existing tests
- [x] `pytest tests/test_trust_fleet_route.py tests/test_trust_fleet_sanity_loop.py` — endpoint payload still valid
- [x] `pytest tests/test_orchestrator_blocked_repos.py` — confirms G2 was a false positive
- [x] `make lint-check` — all checks passed
- [ ] CI green
- [ ] Operator-visual verification: open System tab and confirm 10 trust-loop kill-switches render

Skip-ADR: implements gaps that ADR-0045 + ADR-0049 already mandate (audit follow-up); no new architectural decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)