### PR TITLE
chore: gitignore hook cache + audit baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,14 +220,13 @@ src/ui/e2e/results/
 
 # HydraFlow runtime state
 .hydraflow/
-.hydraflow-hook-cache/
 .hydra/
-.hydraflow-hook-cache/
 jolly-sea-65a9/
 .DS_Store
 
 # HydraFlow hook cache (generated artifacts, machine-specific)
 .hydraflow-hook-cache/
+.hydraflow-audit-baseline
 
 # Claude Code
 .claude/plans/

--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -1,8 +1,0 @@
-# P10.3 audit baseline — fix commits AFTER this point must carry a
-# regression test under `tests/regressions/`. Earlier commits predate the
-# principle's adoption and are excluded from the check.
-#
-# Format: the first non-comment line is either a commit SHA or an ISO-8601
-# date. Update this when you re-anchor the rule (e.g. after a major
-# repository restructure).
-1d312635

--- a/.hydraflow-hook-cache/pre-commit-02a89010b640059b82955bb55ec8c09d8e1302ff6906e6d351e84bb0ca0d7b97
+++ b/.hydraflow-hook-cache/pre-commit-02a89010b640059b82955bb55ec8c09d8e1302ff6906e6d351e84bb0ca0d7b97
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-06f8e2c710a022bfbe0556f2f17ab05b645c8b45fa191cc76084fd202f8f46ce
+++ b/.hydraflow-hook-cache/pre-commit-06f8e2c710a022bfbe0556f2f17ab05b645c8b45fa191cc76084fd202f8f46ce
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-0a2009cf538b575a65dee62fc9018f551030759cd0074ad08c4a5d0ff4cf032f
+++ b/.hydraflow-hook-cache/pre-commit-0a2009cf538b575a65dee62fc9018f551030759cd0074ad08c4a5d0ff4cf032f
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Add your lint command here
-exit 0

--- a/.hydraflow-hook-cache/pre-commit-23f9617537072c2804626bf555ac4dce74a55b5926d69be97f75c08728b1e223
+++ b/.hydraflow-hook-cache/pre-commit-23f9617537072c2804626bf555ac4dce74a55b5926d69be97f75c08728b1e223
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-30cd9ab0633ba84df0709d9c7c36e1b1677da68eebd4510f802c71970269c12e
+++ b/.hydraflow-hook-cache/pre-commit-30cd9ab0633ba84df0709d9c7c36e1b1677da68eebd4510f802c71970269c12e
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-4030192d4c23b5304b8fd9147aac596a003e4affc4faae1363ec80cffe22f6a8
+++ b/.hydraflow-hook-cache/pre-commit-4030192d4c23b5304b8fd9147aac596a003e4affc4faae1363ec80cffe22f6a8
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-479a684f8ad75185d37e2d9154d33aa83374cf34b953ccf5da1bd8b48c642dd9
+++ b/.hydraflow-hook-cache/pre-commit-479a684f8ad75185d37e2d9154d33aa83374cf34b953ccf5da1bd8b48c642dd9
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-4c3a7b3d2245db0bf5256c630256e656ccd092313dbea9a4047f6c1665bea6ee
+++ b/.hydraflow-hook-cache/pre-commit-4c3a7b3d2245db0bf5256c630256e656ccd092313dbea9a4047f6c1665bea6ee
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-5eeb501d992f7aaa754f2e718c480a7fe6817ae496d3b6470e6cf70c8a1459e0
+++ b/.hydraflow-hook-cache/pre-commit-5eeb501d992f7aaa754f2e718c480a7fe6817ae496d3b6470e6cf70c8a1459e0
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-6501fadc146502587eb1221cdf73441e5ac27d773832d714a3231a69103c2936
+++ b/.hydraflow-hook-cache/pre-commit-6501fadc146502587eb1221cdf73441e5ac27d773832d714a3231a69103c2936
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-659578715b4188ea3ada6bd0998a74eac18d80db7681b973b060495aff10f488
+++ b/.hydraflow-hook-cache/pre-commit-659578715b4188ea3ada6bd0998a74eac18d80db7681b973b060495aff10f488
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-6d6521e65cef7aaac6459bdb03d6eba3a481aab212c549e60e9d301d25173f5c
+++ b/.hydraflow-hook-cache/pre-commit-6d6521e65cef7aaac6459bdb03d6eba3a481aab212c549e60e9d301d25173f5c
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-755477c5a3ff6601a3b83ed9af0302877998ecad8d79b6f95037545f633813ff
+++ b/.hydraflow-hook-cache/pre-commit-755477c5a3ff6601a3b83ed9af0302877998ecad8d79b6f95037545f633813ff
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-77eff6c0594c39b26599488eed312b8649da189623b01d46e0e63071033f871e
+++ b/.hydraflow-hook-cache/pre-commit-77eff6c0594c39b26599488eed312b8649da189623b01d46e0e63071033f871e
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-795ab259791b1e0ba232d0d11a37f161188a160d3ac9a570daf7903bd7bb8584
+++ b/.hydraflow-hook-cache/pre-commit-795ab259791b1e0ba232d0d11a37f161188a160d3ac9a570daf7903bd7bb8584
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-87b18cd07f00150b0410d8c437a951450590bd2c38d4f9ecb40589f4da23dbed
+++ b/.hydraflow-hook-cache/pre-commit-87b18cd07f00150b0410d8c437a951450590bd2c38d4f9ecb40589f4da23dbed
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-8fc592e355cd5754a975a200ef3d610d27335d9dd93c958fb4927e538f91c3e8
+++ b/.hydraflow-hook-cache/pre-commit-8fc592e355cd5754a975a200ef3d610d27335d9dd93c958fb4927e538f91c3e8
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-93bf09e91e5fe5858bab2a10bd173863e9020ba939952c69522eee32ba6aefd5
+++ b/.hydraflow-hook-cache/pre-commit-93bf09e91e5fe5858bab2a10bd173863e9020ba939952c69522eee32ba6aefd5
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-96c9168a4588c57533591ad85eeec957d23f4ff84b665b9e115c091c94558c62
+++ b/.hydraflow-hook-cache/pre-commit-96c9168a4588c57533591ad85eeec957d23f4ff84b665b9e115c091c94558c62
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-a3a30e588590be371b5753bd365e4bd099a702aba40189e46e9f284c1f6f3729
+++ b/.hydraflow-hook-cache/pre-commit-a3a30e588590be371b5753bd365e4bd099a702aba40189e46e9f284c1f6f3729
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Add your lint command here
-exit 0

--- a/.hydraflow-hook-cache/pre-commit-b53e0f08effa2303714b87c9fcbc7bb7d62d96447ab4ea1ce60f1593ed580b12
+++ b/.hydraflow-hook-cache/pre-commit-b53e0f08effa2303714b87c9fcbc7bb7d62d96447ab4ea1ce60f1593ed580b12
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-b687f37ba062b0e0286b4e2cce05145bda73a6a457a2ac4f3a33abe5db9d57f4
+++ b/.hydraflow-hook-cache/pre-commit-b687f37ba062b0e0286b4e2cce05145bda73a6a457a2ac4f3a33abe5db9d57f4
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-bbfa8bb3cac4a374b41ecb515196bd2e09f4f3fa95f65219608568d0fe3cdb8d
+++ b/.hydraflow-hook-cache/pre-commit-bbfa8bb3cac4a374b41ecb515196bd2e09f4f3fa95f65219608568d0fe3cdb8d
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-bd2da7657ec3f5539cc2dcc63fdf7d8c4211932f4ac16e0ff016bf5e2b58fc0e
+++ b/.hydraflow-hook-cache/pre-commit-bd2da7657ec3f5539cc2dcc63fdf7d8c4211932f4ac16e0ff016bf5e2b58fc0e
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Add your lint command here
-exit 0

--- a/.hydraflow-hook-cache/pre-commit-c3fe5efcd733e9418580d2d7c31d0852388d9a6764b565f3204bfbf3cc2c0be1
+++ b/.hydraflow-hook-cache/pre-commit-c3fe5efcd733e9418580d2d7c31d0852388d9a6764b565f3204bfbf3cc2c0be1
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-c85923fed65ee3902becf50bb5ce9619f7ebf4ed6538277a09e577f5382fe777
+++ b/.hydraflow-hook-cache/pre-commit-c85923fed65ee3902becf50bb5ce9619f7ebf4ed6538277a09e577f5382fe777
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-cb28af69aef59f9340a2e867e2ec2f45e78a3a11d410d5ae3477998faa5fa663
+++ b/.hydraflow-hook-cache/pre-commit-cb28af69aef59f9340a2e867e2ec2f45e78a3a11d410d5ae3477998faa5fa663
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-d13296a71df5dd3b9e402127646fd4a1f2306a59bd50c026a086818b973b47b8
+++ b/.hydraflow-hook-cache/pre-commit-d13296a71df5dd3b9e402127646fd4a1f2306a59bd50c026a086818b973b47b8
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Add your lint command here
-exit 0

--- a/.hydraflow-hook-cache/pre-commit-daa9e530a19b5934058a95bde85c746188a25db0258752196e283fdb25d35f3e
+++ b/.hydraflow-hook-cache/pre-commit-daa9e530a19b5934058a95bde85c746188a25db0258752196e283fdb25d35f3e
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-e6f784ea9398d467d2a2f9520370710f25fe50164f736d8647f21dc1c9a00188
+++ b/.hydraflow-hook-cache/pre-commit-e6f784ea9398d467d2a2f9520370710f25fe50164f736d8647f21dc1c9a00188
@@ -1,2 +1,0 @@
-#!/bin/sh
-npx eslint .

--- a/.hydraflow-hook-cache/pre-commit-e810cbc75b2c47725f1ae44d128c3caa2968bece4a0317857c8dd15f6ff21a75
+++ b/.hydraflow-hook-cache/pre-commit-e810cbc75b2c47725f1ae44d128c3caa2968bece4a0317857c8dd15f6ff21a75
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check

--- a/.hydraflow-hook-cache/pre-commit-f4b3fd8317fd66d9cacd8632bf54642ea400ee975cd0e4807102c16f02f3eead
+++ b/.hydraflow-hook-cache/pre-commit-f4b3fd8317fd66d9cacd8632bf54642ea400ee975cd0e4807102c16f02f3eead
@@ -1,2 +1,0 @@
-#!/bin/sh
-ruff check . && ruff format . --check


### PR DESCRIPTION
## Summary
- Untrack `.hydraflow-hook-cache/` (pre-commit cache, 33 machine-specific files)
- Untrack `.hydraflow-audit-baseline` and add it to `.gitignore`
- Dedupe stale `.hydraflow-hook-cache/` entries in `.gitignore` (was listed 3×)

## Test plan
- [ ] `git status` is clean after re-running pre-commit (cache regenerates locally, ignored)
- [ ] `make quality` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)