### PR TITLE
fix(staging-bisect): close G3+G7 dark-factory gaps

### DIFF
--- a/docs/adr/0048-auto-revert-on-rc-red.md
+++ b/docs/adr/0048-auto-revert-on-rc-red.md
@@ -30,7 +30,7 @@ Before bisecting, re-run the RC's gate command (`make bisect-probe`) against the
 Run `git bisect` between `last_green_rc_sha` and `last_rc_red_sha` using `make bisect-probe` as the is-broken predicate. The result is a single culprit SHA.
 
 ### 3. Guardrail: one auto-revert per RC cycle
-`state.get_auto_reverts_in_cycle()` tracks reverts within the current RC cycle (a cycle starts when a new `last_rc_red_sha` is observed). If `>= 1`, `_check_guardrail_and_maybe_escalate` fires — file a `hitl-escalation` + `rc-red-attribution-unsafe` issue and do NOT revert. This prevents the loop from thrashing: two failed reverts mean a human needs to look.
+`state.get_auto_reverts_in_cycle()` tracks reverts within the current RC cycle (a cycle starts when a new `last_rc_red_sha` is observed). If `>= 1`, `_check_guardrail_and_maybe_escalate` fires — file a `hitl-escalation` + `rc-red-bisect-exhausted` issue and do NOT revert. This prevents the loop from thrashing: two failed reverts mean a human needs to look. (The spec §6 fail-mode table is the source of truth for this label; the original ADR draft cited `rc-red-attribution-unsafe`, which diverged from the spec — corrected here.)
 
 ### 4. Open a revert PR that auto-merges
 The revert PR has labels `[hydraflow-find, auto-revert, rc-red-attribution]`. It flows through the same reviewer + quality-gate + auto-merge path as any other PR — no special privileges. On successful merge, a watchdog (`_check_pending_watchdog`) waits 8 hours for the next green RC. If the next RC is green, the cycle completes. If not, `hitl-escalation` + `rc-red-verify-timeout` fires.

--- a/src/staging_bisect_loop.py
+++ b/src/staging_bisect_loop.py
@@ -536,7 +536,7 @@ class StagingBisectLoop(BaseBackgroundLoop):
             "### Bisect log\n\n"
             f"```\n{bisect_log[:5000]}\n```"
         )
-        labels = ["hitl-escalation", "rc-red-attribution-unsafe"]
+        labels = ["hitl-escalation", "rc-red-bisect-exhausted"]
         issue = await self._prs.create_issue(title, body, labels)
         logger.error("StagingBisectLoop: guardrail tripped — escalated #%d", issue)
         return {"status": "guardrail_escalated", "escalation_issue": issue}
@@ -561,8 +561,17 @@ class StagingBisectLoop(BaseBackgroundLoop):
         body: str,
         branch: str,
         labels: list[str],
+        auto_merge: bool = False,
     ) -> int:
-        """Open a PR via ``gh pr create``; return the PR number (0 on failure)."""
+        """Open a PR via ``gh pr create``; return the PR number (0 on failure).
+
+        When ``auto_merge=True``, follow the create with
+        ``gh pr merge --auto --squash`` so the PR self-merges once
+        required CI checks pass — matches ADR-0048's "revert PR
+        auto-merges through the standard reviewer + auto-merge path".
+        Without this flag the revert PR sits open until a human
+        merges, breaking the lights-off cadence on RC red.
+        """
         import re  # noqa: PLC0415
         import tempfile  # noqa: PLC0415
         from pathlib import Path  # noqa: PLC0415
@@ -590,7 +599,29 @@ class StagingBisectLoop(BaseBackgroundLoop):
                 cmd.extend(["--label", label])
             out = await self._run_gh(cmd)
             match = re.search(r"/pull/(\d+)", out)
-            return int(match.group(1)) if match else 0
+            pr_number = int(match.group(1)) if match else 0
+            if auto_merge and pr_number:
+                try:
+                    await self._run_gh(
+                        [
+                            "gh",
+                            "pr",
+                            "merge",
+                            str(pr_number),
+                            "--repo",
+                            self._config.repo,
+                            "--auto",
+                            "--squash",
+                        ]
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "auto-merge enable failed for PR #%d — PR will need "
+                        "manual merge",
+                        pr_number,
+                        exc_info=True,
+                    )
+            return pr_number
         finally:
             body_path.unlink(missing_ok=True)
 
@@ -684,6 +715,7 @@ class StagingBisectLoop(BaseBackgroundLoop):
             body=body,
             branch=branch,
             labels=["hydraflow-find", "auto-revert", "rc-red-attribution"],
+            auto_merge=True,
         )
         return pr_number, branch
 

--- a/tests/test_staging_bisect_loop.py
+++ b/tests/test_staging_bisect_loop.py
@@ -278,7 +278,7 @@ class TestGuardrail:
         prs.create_issue.assert_awaited_once()
         title = prs.create_issue.await_args.args[0]
         labels = prs.create_issue.await_args.args[2]
-        assert "rc-red-attribution-unsafe" in labels
+        assert "rc-red-bisect-exhausted" in labels
         assert "hitl-escalation" in labels
         assert "current_red" in title
 
@@ -554,3 +554,62 @@ class TestInvalidRange:
 
         assert result == {"status": "invalid_bisect_range", "sha": "red_sha"}
         assert any("invalid bisect range" in rec.message for rec in caplog.records)
+
+
+class TestAutoMergeOnRevertPR:
+    """Spec §4.3 + ADR-0048 — revert PRs must auto-merge on green."""
+
+    @pytest.mark.asyncio
+    async def test_create_pr_via_gh_with_auto_merge_calls_gh_pr_merge(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+        gh_calls: list[list[str]] = []
+
+        async def fake_run_gh(cmd: list[str]) -> str:
+            gh_calls.append(list(cmd))
+            if cmd[1] == "pr" and cmd[2] == "create":
+                return "https://github.com/o/r/pull/4242\n"
+            return ""
+
+        loop._run_gh = fake_run_gh  # type: ignore[method-assign]
+
+        pr_number = await loop._create_pr_via_gh(
+            title="t",
+            body="b",
+            branch="auto-revert/x",
+            labels=["auto-revert"],
+            auto_merge=True,
+        )
+
+        assert pr_number == 4242
+        # Two gh invocations: create then merge --auto.
+        assert len(gh_calls) == 2
+        assert gh_calls[0][:3] == ["gh", "pr", "create"]
+        assert gh_calls[1][:3] == ["gh", "pr", "merge"]
+        assert "--auto" in gh_calls[1]
+        assert "--squash" in gh_calls[1]
+
+    @pytest.mark.asyncio
+    async def test_create_pr_via_gh_without_auto_merge_skips_merge_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, _prs, _state = _make_loop(tmp_path, monkeypatch)
+        gh_calls: list[list[str]] = []
+
+        async def fake_run_gh(cmd: list[str]) -> str:
+            gh_calls.append(list(cmd))
+            return "https://github.com/o/r/pull/55\n"
+
+        loop._run_gh = fake_run_gh  # type: ignore[method-assign]
+
+        await loop._create_pr_via_gh(
+            title="t",
+            body="b",
+            branch="b",
+            labels=[],
+        )
+
+        # Only `gh pr create` — no follow-up merge.
+        assert len(gh_calls) == 1
+        assert gh_calls[0][:3] == ["gh", "pr", "create"]


### PR DESCRIPTION
## Summary

First wave of dark-factory hardening following the post-#8390 audit. Closes two staging-bisect bugs tracked under bd epic [hydraflow-tt0c](https://github.com/T-rav/hydraflow/issues): **G7** (escalation label drifted from spec) and **G3** (revert PR doesn't auto-merge).

### G7 — escalation label
- Spec §6 line 1553: \`hitl-escalation\` + \`rc-red-bisect-exhausted\`
- ADR-0048 §3 (drafted in #8390): \`rc-red-attribution-unsafe\`
- Code in main: \`rc-red-attribution-unsafe\` (followed the ADR's divergence)

Operator queries and downstream automation keyed on the spec label miss these escalations. Spec wins. Code + test + ADR all updated.

### G3 — revert PR auto-merge
\`_create_pr_via_gh\` was running plain \`gh pr create\` with no auto-merge wiring. \`dependabot_merge_loop\` only merges *bot-authored* PRs, so revert PRs would sit open until a human merged — breaking the lights-off cadence ADR-0048 §4 promises.

Added an \`auto_merge\` kwarg that follows \`gh pr create\` with \`gh pr merge <pr> --auto --squash\`. Caller for revert PRs passes \`auto_merge=True\`. Auto-merge enable failure is logged but doesn't fail the create.

## Test plan

- [x] \`tests/test_staging_bisect_loop.py::TestAutoMergeOnRevertPR\` — two new tests verifying \`gh pr merge --auto --squash\` is invoked when (and only when) \`auto_merge=True\`
- [x] \`TestAttributionEscalation\` — updated label assertion to spec-mandated value
- [x] All 27 \`tests/test_staging_bisect_loop.py\` tests pass
- [x] \`make lint-check\` passed

Skip-ADR: ADR-0048 updated in this PR; no new architectural decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)