### PR TITLE
fix(corpus-learning): per-tick PR cap (G1)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1856,6 +1856,16 @@ class HydraFlowConfig(BaseModel):
             "shape-escape (Shape §4.10). Override for a stripped-down deployment."
         ),
     )
+    corpus_learning_max_prs_per_tick: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description=(
+            "Max PRs CorpusLearningLoop opens per tick. Bounds blast radius "
+            "when escape-signal dedup misses (e.g. issue retitled mid-tick). "
+            "Surplus validated cases defer to the next tick."
+        ),
+    )
 
     # Trust fleet — ContractRefreshLoop (spec §4.2)
     contract_refresh_interval: int = Field(

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -657,7 +657,19 @@ class CorpusLearningLoop(BaseBackgroundLoop):
                 )
 
         repo_root = Path(self._config.repo_root)
+        # Per-tick cap. Spec §3.2: a misbehaving loop must not flood
+        # the issue queue. The dedup is keyed on (issue_number, slug),
+        # so a burst of escape issues with churning slugs (e.g. retitled
+        # between ticks) bypasses dedup. The trust-fleet-sanity loop's
+        # `issues_per_hour` detector is post-hoc — by the time it fires,
+        # the burst has already happened. This cap bounds blast radius
+        # to a known multiple before any anomaly detector runs.
+        max_per_tick = self._config.corpus_learning_max_prs_per_tick
+        truncated = False
         for case in validated_cases:
+            if cases_filed >= max_per_tick:
+                truncated = True
+                break
             paths = self._materialize_case_on_disk(case, repo_root)
             title = f"test(trust): corpus-learning case for escape #{case.issue_number}"
             body = _build_pr_body(case)
@@ -666,6 +678,13 @@ class CorpusLearningLoop(BaseBackgroundLoop):
             )
             if pr_number is not None:
                 cases_filed += 1
+        if truncated:
+            logger.warning(
+                "corpus-learning: per-tick cap %d hit — %d validated cases "
+                "deferred until next tick",
+                max_per_tick,
+                len(validated_cases) - cases_filed,
+            )
 
         return {
             "status": "noop",

--- a/tests/test_corpus_learning_loop.py
+++ b/tests/test_corpus_learning_loop.py
@@ -1051,3 +1051,50 @@ class _AutoPrResultStub:
         self.pr_url = pr_url
         self.branch = "test-branch"
         self.error = error
+
+
+def test_do_work_caps_prs_per_tick(tmp_path: Path) -> None:
+    """G1: a burst of validated cases must not exceed the per-tick cap."""
+    # 25 escape signals all parseable, all synthesizable, all validated.
+    issues = [
+        {
+            "number": 1000 + i,
+            "title": f"escape #{1000 + i}",
+            "body": (
+                "## What slipped through\n"
+                "test_x asserted 1 != 2\n"
+                "## Catcher\n"
+                "test-completeness\n"
+                "## Slug\n"
+                f"escape-{i}\n"
+            ),
+            "updated_at": _iso_now_offset(-1),
+        }
+        for i in range(25)
+    ]
+    prs = AsyncMock()
+    prs.list_issues_by_label = AsyncMock(return_value=issues)
+    prs.create_pr = AsyncMock(return_value=42)
+
+    # Cap at 5 — anything above is deferred.
+    loop = _loop(tmp_path, prs=prs, corpus_learning_max_prs_per_tick=5)
+
+    # Force every signal to validate cleanly.
+    loop._synthesize_case = lambda sig: SynthesizedCase(  # type: ignore[method-assign]
+        issue_number=sig.issue_number,
+        slug=f"case-{sig.issue_number}",
+        expected_catcher="test-completeness",
+        keyword="x",
+        before_files={"src/x.py": "before"},
+        after_files={"src/x.py": "after"},
+        readme="r",
+    )
+    loop._validate_case = lambda c: ValidationResult(ok=True)  # type: ignore[method-assign]
+    loop._materialize_case_on_disk = lambda c, r: []  # type: ignore[method-assign]
+    loop._open_pr_for_case = AsyncMock(return_value=42)  # type: ignore[method-assign]
+
+    result = asyncio.run(loop._do_work())
+
+    assert result["cases_filed"] == 5
+    assert result["cases_validated"] == 25  # all validated, just deferred
+    assert loop._open_pr_for_case.await_count == 5


### PR DESCRIPTION
## Summary

Closes G1 from the dark-factory audit. Caps CorpusLearningLoop at \`corpus_learning_max_prs_per_tick\` (default 10) per tick to bound blast radius when escape-issue dedup misses.

### Why

The dedup is keyed on \`(issue_number, slug)\` where slug derives from the escape-issue title. A retitle between ticks bypasses dedup. The trust-fleet-sanity loop's \`issues_per_hour\` detector observes the burst *after* the PRs land; this PR prevents the burst.

### What

- \`config.corpus_learning_max_prs_per_tick: int\` (default 10, range 1–100)
- \`CorpusLearningLoop._do_work\` breaks out of the materialize-and-open loop when the count hits the cap; logs a warning naming how many cases got deferred
- All deferred cases re-evaluate on the next tick (no data loss)

## Test

- \`tests/test_corpus_learning_loop.py::test_do_work_caps_prs_per_tick\` — 25 validated cases through cap=5, assert exactly 5 PRs opened, 20 deferred
- All 41 existing corpus tests pass

bd: hydraflow-mq3x → in_progress; PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Skip-ADR: pure config + behavior tweak; no architectural change. ADR-0045 §3.2 already mandates per-loop self-cap.