### PR TITLE
fix(trust-fleet): G11 + G12 + G13 spec-drift cleanup

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -223,7 +223,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("wiki_rot_detector_interval", "HYDRAFLOW_WIKI_ROT_DETECTOR_INTERVAL", 604800),
     ("trust_fleet_sanity_interval", "HYDRAFLOW_TRUST_FLEET_SANITY_INTERVAL", 600),
     ("loop_anomaly_issues_per_hour", "HYDRAFLOW_LOOP_ANOMALY_ISSUES_PER_HOUR", 10),
-    ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 604800),
+    ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 3600),
     ("contract_refresh_interval", "HYDRAFLOW_CONTRACT_REFRESH_INTERVAL", 604800),
     ("max_fake_repair_attempts", "HYDRAFLOW_MAX_FAKE_REPAIR_ATTEMPTS", 3),
 ]
@@ -1503,17 +1503,17 @@ class HydraFlowConfig(BaseModel):
         ),
     )
     max_retry_lineage_attempts: int = Field(
-        default=3,
+        default=2,
         ge=1,
         le=20,
         description=(
-            "Per-lineage cap (spec §4.3 lines 645–659). The bisect loop "
-            "tracks retry attempts per `lineage_id` (hash of culprit-PR "
-            "title + impacted-test set). When the count exceeds this cap, "
-            "the loop stops retrying that lineage and files an "
-            "`rc-red-lineage-exhausted` escalation. Bounds infinite churn "
-            "when the same root-cause keeps re-appearing on different "
-            "commits."
+            "Per-lineage cap (spec §4.3 lines 645–659; default 2). The "
+            "bisect loop tracks retry attempts per `lineage_id` (hash of "
+            "culprit-PR title + impacted-test set). When the count exceeds "
+            "this cap, the loop stops retrying that lineage and files a "
+            "`retry-lineage-exhausted` escalation. The default bounds the "
+            "spec's worst-case sequence: original → revert → retry → red "
+            "→ human."
         ),
     )
     staging_bisect_watchdog_rc_cycles: int = Field(
@@ -1869,10 +1869,14 @@ class HydraFlowConfig(BaseModel):
 
     # Trust fleet — CorpusLearningLoop (spec §4.1 v2)
     corpus_learning_interval: int = Field(
-        default=604800,
+        default=3600,
         ge=3600,
         le=2_592_000,
-        description="Seconds between CorpusLearningLoop ticks (default 7d)",
+        description=(
+            "Seconds between CorpusLearningLoop ticks (default 1h, "
+            "spec §4.1: the loop is reactive on new escape issues, so "
+            "frequent ticks pick them up quickly)"
+        ),
     )
     corpus_learning_signal_labels: tuple[str, ...] = Field(
         default=("skill-escape", "discover-escape", "shape-escape"),

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -280,7 +280,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   wiki_rot_detector: 604800,
   trust_fleet_sanity: 600,
   contract_refresh: 604800,
-  corpus_learning: 604800,
+  corpus_learning: 3600,
 }
 
 /**

--- a/tests/test_corpus_learning_loop.py
+++ b/tests/test_corpus_learning_loop.py
@@ -111,9 +111,10 @@ def test_loop_constructs_with_expected_worker_name(tmp_path: Path) -> None:
 
 
 def test_default_interval_reads_from_config(tmp_path: Path) -> None:
-    # Default from the ``corpus_learning_interval`` Field (weekly cadence).
+    # Default from the ``corpus_learning_interval`` Field (hourly per
+    # spec §4.1 — the loop is reactive on escape-signal issues).
     loop = _loop(tmp_path)
-    assert loop._get_default_interval() == 604800
+    assert loop._get_default_interval() == 3600
 
 
 def test_default_interval_reflects_config_override(tmp_path: Path) -> None:

--- a/tests/test_diagnostics_loop_cost.py
+++ b/tests/test_diagnostics_loop_cost.py
@@ -1,0 +1,60 @@
+"""Spec §7 line 1621 — `/api/diagnostics/loops/cost` endpoint.
+
+Full-coverage integration test for the cost rollup family lives in
+``tests/test_diagnostics_cost_rollup_routes.py``. This file is the
+spec-named entry-point: smoke tests asserting the loops/cost endpoint
+is mounted and returns a stable shape, so a §7 audit greps for
+``test_diagnostics_loop_cost.py`` and lands on real coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dashboard_routes._diagnostics_routes import build_diagnostics_router
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    cfg = MagicMock()
+    cfg.data_root = tmp_path
+    cfg.data_path = tmp_path.joinpath
+    cfg.repo = "o/r"
+    app = FastAPI()
+    app.include_router(build_diagnostics_router(config=cfg))
+    return TestClient(app)
+
+
+def test_loops_cost_route_registered(client: TestClient) -> None:
+    """Endpoint must be mounted; missing it means the trust-fleet UI's
+    machinery-level cost panel has no data source."""
+    response = client.get("/api/diagnostics/loops/cost")
+    assert response.status_code != 404, (
+        "/api/diagnostics/loops/cost not mounted on the diagnostics router"
+    )
+
+
+def test_loops_cost_returns_json_envelope(client: TestClient) -> None:
+    """The endpoint always returns a JSON object even when no loops have
+    cost data yet — the UI relies on a stable shape."""
+    response = client.get("/api/diagnostics/loops/cost")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, dict | list), (
+        "/api/diagnostics/loops/cost must return a JSON object or list, not a scalar"
+    )
+
+
+def test_loops_cost_accepts_range_param(client: TestClient) -> None:
+    """The endpoint should accept a `range` query param (7d / 30d / 90d
+    per spec §4.11). At minimum it must not 500 on a recognized value."""
+    for window in ("7d", "30d", "90d"):
+        response = client.get(f"/api/diagnostics/loops/cost?range={window}")
+        assert response.status_code in (200, 422), (
+            f"unexpected status {response.status_code} for range={window!r}"
+        )

--- a/tests/test_diagnostics_waterfall.py
+++ b/tests/test_diagnostics_waterfall.py
@@ -1,0 +1,51 @@
+"""Spec §7 line 1618 — `/api/diagnostics/issue/{issue}/waterfall` endpoint.
+
+Full-coverage integration test lives in
+``tests/test_diagnostics_waterfall_route.py``. This file is the
+spec-named entry-point: smoke tests asserting the endpoint is present
+in the diagnostics router and rejects bad inputs, so a §7 audit greps
+for ``test_diagnostics_waterfall.py`` and lands on real coverage.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dashboard_routes._diagnostics_routes import build_diagnostics_router
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    cfg = MagicMock()
+    cfg.data_root = tmp_path
+    cfg.data_path = tmp_path.joinpath
+    cfg.repo = "o/r"
+    app = FastAPI()
+    app.include_router(build_diagnostics_router(config=cfg))
+    return TestClient(app)
+
+
+def test_waterfall_route_registered(client: TestClient) -> None:
+    """Endpoint must be mounted; a 404 here means the route isn't
+    declared and operators can't see per-issue cost waterfalls."""
+    response = client.get("/api/diagnostics/issue/123/waterfall")
+    assert response.status_code != 404, (
+        "/api/diagnostics/issue/{issue}/waterfall not mounted on the diagnostics router"
+    )
+
+
+def test_waterfall_returns_json_envelope(client: TestClient, tmp_path: Path) -> None:
+    """The endpoint always returns a JSON object, even when there's no
+    data for the issue — the UI relies on a stable shape."""
+    response = client.get("/api/diagnostics/issue/9999/waterfall")
+    assert response.status_code == 200
+    body = response.json()
+    assert isinstance(body, dict), (
+        "/api/diagnostics/issue/{issue}/waterfall must return a JSON object "
+        "(dict), not a raw list or scalar"
+    )

--- a/tests/test_discover_runner_evaluator_dispatch.py
+++ b/tests/test_discover_runner_evaluator_dispatch.py
@@ -1,0 +1,42 @@
+"""Spec §7 line 1615 — DiscoverRunner evaluator dispatch wiring.
+
+The full-coverage dispatch tests live in
+``tests/test_discover_runner_evaluator.py``. This file is the spec-named
+shim verifying the loop is wired through the runner: the runner can
+construct, holds the right config knobs, and exposes the dispatch hook
+the evaluator skill relies on.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_discover_runner_module_imports() -> None:
+    """A regression on the module path itself catches broken imports
+    before the runner is ever instantiated."""
+    from discover_runner import DiscoverRunner  # noqa: F401
+
+
+def test_discover_runner_exposes_evaluator_attempt_cap_config() -> None:
+    """Spec §4.10: the runner reads `max_discover_attempts` from config
+    to bound the evaluator-retry loop. Without the field the loop runs
+    unbounded."""
+    from config import HydraFlowConfig
+
+    field = HydraFlowConfig.model_fields.get("max_discover_attempts")
+    assert field is not None, (
+        "max_discover_attempts missing from HydraFlowConfig — "
+        "DiscoverRunner cannot bound its evaluator retries"
+    )
+
+
+def test_discover_runner_class_constructs_callable() -> None:
+    """The runner module must expose DiscoverRunner as a callable class —
+    the dispatch wiring imports and instantiates it."""
+    from discover_runner import DiscoverRunner
+
+    assert inspect.isclass(DiscoverRunner), (
+        "DiscoverRunner missing or not a class — evaluator dispatch has "
+        "nowhere to plug into the runner"
+    )

--- a/tests/test_product_phase_evaluators.py
+++ b/tests/test_product_phase_evaluators.py
@@ -1,0 +1,71 @@
+"""Spec §7 line 1612 — unit tests for the two product-phase evaluator skills.
+
+The deeper unit tests live in:
+- ``tests/test_discover_completeness_skill.py``
+- ``tests/test_shape_coherence_skill.py``
+
+This file provides the spec-named entry-point: high-level wiring + smoke
+tests that prove both skills are registered, callable, and surface a
+verdict the runners can act on. Adding a third evaluator? Add a row
+here too — that gives the §7 audit a single place to verify the set is
+complete without grepping the registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_discover_completeness_skill_registered() -> None:
+    """The Discover phase's evaluator skill must be in the registry so
+    the runner can dispatch it."""
+    from skill_registry import BUILTIN_SKILLS
+
+    names = {s.name for s in BUILTIN_SKILLS}
+    assert "discover-completeness" in names, (
+        "discover-completeness skill missing from BUILTIN_SKILLS — "
+        "DiscoverRunner.run_turn cannot dispatch the evaluator"
+    )
+
+
+def test_shape_coherence_skill_registered() -> None:
+    """The Shape phase's evaluator skill must be in the registry."""
+    from skill_registry import BUILTIN_SKILLS
+
+    names = {s.name for s in BUILTIN_SKILLS}
+    assert "shape-coherence" in names, (
+        "shape-coherence skill missing from BUILTIN_SKILLS — "
+        "ShapeRunner.run_turn cannot dispatch the evaluator"
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_name",
+    ["discover-completeness", "shape-coherence"],
+)
+def test_evaluator_skill_has_prompt_builder(skill_name: str) -> None:
+    """Both evaluator skills must have a callable prompt_builder; missing
+    it would mean the LLM gets no rubric and returns garbage."""
+    from skill_registry import BUILTIN_SKILLS
+
+    skill = next((s for s in BUILTIN_SKILLS if s.name == skill_name), None)
+    assert skill is not None, f"skill {skill_name!r} not found"
+    assert callable(skill.prompt_builder), (
+        f"skill {skill_name!r} has no callable prompt_builder"
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_name",
+    ["discover-completeness", "shape-coherence"],
+)
+def test_evaluator_skill_has_result_parser(skill_name: str) -> None:
+    """Result parser must be callable; without it the runner can't read
+    the verdict back from the LLM response."""
+    from skill_registry import BUILTIN_SKILLS
+
+    skill = next((s for s in BUILTIN_SKILLS if s.name == skill_name), None)
+    assert skill is not None, f"skill {skill_name!r} not found"
+    assert callable(skill.result_parser), (
+        f"skill {skill_name!r} has no callable result_parser"
+    )

--- a/tests/test_shape_runner_evaluator_dispatch.py
+++ b/tests/test_shape_runner_evaluator_dispatch.py
@@ -1,0 +1,35 @@
+"""Spec §7 line 1616 — ShapeRunner evaluator dispatch wiring.
+
+Mirror of ``tests/test_discover_runner_evaluator_dispatch.py`` for the
+Shape phase. Full-coverage tests live in
+``tests/test_shape_runner_evaluator.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_shape_runner_module_imports() -> None:
+    from shape_runner import ShapeRunner  # noqa: F401
+
+
+def test_shape_runner_exposes_evaluator_attempt_cap_config() -> None:
+    """Spec §4.10: ShapeRunner reads `max_shape_attempts` from config
+    to bound the evaluator-retry loop."""
+    from config import HydraFlowConfig
+
+    field = HydraFlowConfig.model_fields.get("max_shape_attempts")
+    assert field is not None, (
+        "max_shape_attempts missing from HydraFlowConfig — "
+        "ShapeRunner cannot bound its evaluator retries"
+    )
+
+
+def test_shape_runner_class_constructs_callable() -> None:
+    from shape_runner import ShapeRunner
+
+    assert inspect.isclass(ShapeRunner), (
+        "ShapeRunner missing or not a class — evaluator dispatch has "
+        "nowhere to plug into the runner"
+    )

--- a/tests/test_staging_bisect_loop.py
+++ b/tests/test_staging_bisect_loop.py
@@ -695,4 +695,4 @@ class TestG10RetryLineageState:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         cfg = _make_cfg(tmp_path, monkeypatch)
-        assert cfg.max_retry_lineage_attempts == 3
+        assert cfg.max_retry_lineage_attempts == 2


### PR DESCRIPTION
## Summary

Follow-up to PRs #8390, #8416, #8420–#8425. A full section-by-section read of the spec (every §1–§12.5 paragraph against current code) surfaced three remaining gaps. All three closed here.

| ID | Gap | Spec ref | Impact |
|---|---|---|---|
| G11 | \`corpus_learning_interval\` default \`3600\` (spec) vs \`604800\` (code) | §4.1 line 374 | Reactive loop became weekly — escape signals delayed up to 7d |
| G12 | \`max_retry_lineage_attempts\` default \`2\` (spec) vs \`3\` (code, from #8425) | §4.3 line 654 | One extra revert+retry churn cycle before lineage cap fires |
| G13 | Five §7-mandated test filenames absent on disk | §7 lines 1441, 1612–1621 | Spec-name audit grep finds nothing despite behaviors being tested under different filenames |

The audit also flagged that when G10's wiring follow-up lands, the escalation label must be \`retry-lineage-exhausted\` (spec) not \`rc-red-lineage-exhausted\` — recorded in the updated config field description so the wiring change matches.

## Test plan

- [x] G11: \`test_default_interval_reads_from_config\` updated + passes
- [x] G12: \`test_max_retry_lineage_attempts_config_default\` updated + passes
- [x] G13: 5 new test files (17 new tests total), all pass
- [x] \`test_state_tracking\`, \`test_staging_bisect_loop\`, \`test_corpus_learning_loop\` all pass with new defaults

Skip-ADR: spec-drift fixes; ADR-0048 §3 already names the escalation label invariant. No new architectural decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)