### PR TITLE
feat(adr-gate): symbol-level precision so unrelated edits stop tripping it

### DIFF
--- a/docs/adr/0012-epic-merge-coordination-architecture.md
+++ b/docs/adr/0012-epic-merge-coordination-architecture.md
@@ -183,5 +183,5 @@ an epic body directive parsed during registration.
 - `src/post_merge_handler.py` (`handle_approved`, `_should_defer_merge` — merge interception)
 - `src/epic.py` (`EpicManager.on_child_approved`, `_handle_bundled_ready`, `_handle_ordered_ready`, `_get_merge_order`)
 - `src/models.py` (`EpicState` — model to extend)
-- `src/review_phase.py` (`_handle_approved_merge` — review-to-merge flow)
+- `src/review_phase.py:_handle_approved_merge` — review-to-merge flow
 - `src/epic_monitor_loop.py` (stale epic detection — relevant for held bundles)

--- a/docs/adr/0015-protocol-callback-gate-pattern.md
+++ b/docs/adr/0015-protocol-callback-gate-pattern.md
@@ -140,6 +140,6 @@ exception in spirit: pragmatic co-location where the type has a narrow scope.
 - Issue: #1746
 - `src/models.py` — `CiGateFn`, `VisualGateFn`, `MergeConflictFixFn`, `EscalateFn`, `PublishFn`, `VisualValidationDecision`
 - `src/post_merge_handler.py` — `handle_approved()` callback injection
-- `src/review_phase.py` — `check_visual_gate()`, `_fetch_code_scanning_alerts()`
+- `src/review_phase.py:check_visual_gate`, `src/review_phase.py:_fetch_code_scanning_alerts`
 - `src/visual_validation.py` — `compute_visual_validation()`
 - `src/escalation_gate.py` — `should_escalate_debug()`

--- a/docs/adr/0024-implementation-retry-recovery-architecture.md
+++ b/docs/adr/0024-implementation-retry-recovery-architecture.md
@@ -70,8 +70,8 @@ by whether review feedback is present.
 ### Scope boundaries
 
 - The retry recovery changes are scoped to the implement phase
-  (`src/implement_phase.py`) and its interaction with `StateTracker`
-  (`src/state.py`) and `AgentRunner` (`src/agent.py`).
+  (`src/implement_phase.py`) and its interaction with
+  `src/state.py:StateTracker` and `src/agent.py:AgentRunner`.
 - The review phase's own retry/escalation logic remains unchanged.
 - The `max_issue_attempts` cap continues to serve as the upper bound for all
   retry paths, preventing infinite retry loops.
@@ -126,4 +126,4 @@ by whether review feedback is present.
 
 - Source memory: [#2258 — Implementation retry recovery architecture](https://github.com/T-rav/hydra/issues/2258)
 - Implementing issue: [#2264](https://github.com/T-rav/hydra/issues/2264)
-- Key files: `src/implement_phase.py`, `src/state.py`, `src/agent.py`
+- Key files: `src/implement_phase.py`, `src/state.py:StateTracker`, `src/agent.py:AgentRunner`

--- a/docs/adr/0045-trust-architecture-hardening.md
+++ b/docs/adr/0045-trust-architecture-hardening.md
@@ -89,7 +89,7 @@ The following files carry this ADR's decisions and must be kept in sync with any
 - `src/config.py` — loop interval fields, anomaly thresholds, budget-alert configs.
 - `src/models.py` — `StateData` fields for every new loop (attempts counters, last-green markers, dedup surfaces).
 - `src/orchestrator.py` — `bg_loop_registry` entries for all 10 loops + `set_bg_workers` post-ctor injection calls.
-- `src/service_registry.py` — dataclass fields + `build_services` instantiation for each loop.
+- `src/service_registry.py:build_services`, `src/service_registry.py:ServiceRegistry` — dataclass fields + `build_services` instantiation for each loop.
 - `src/pr_manager.py` — per-issue cost-alert hook (§4.11).
 - `src/trust_fleet_sanity_loop.py` — meta-observability implementation (§12.1).
 - `src/health_monitor_loop.py` — dead-man-switch for the meta-observer.

--- a/scripts/check_adr_touchpoints.py
+++ b/scripts/check_adr_touchpoints.py
@@ -24,6 +24,7 @@ Usage (local):
 from __future__ import annotations
 
 import argparse
+import ast
 import re
 import subprocess
 import sys
@@ -47,6 +48,75 @@ def _changed_files(base: str, head: str) -> list[str]:
     return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
+def _file_at_rev(rev: str, path: str) -> str:
+    """Return the contents of *path* at *rev*, or empty string if absent."""
+    result = subprocess.run(
+        ["git", "show", f"{rev}:{path}"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    return result.stdout if result.returncode == 0 else ""
+
+
+def _file_symbols(source: str) -> dict[str, str] | None:
+    """Return ``{qualified_name: source_text}`` for top-level + method
+    symbols.  Returns ``None`` if *source* is not parseable Python — the
+    caller should treat that as 'unknown, fire conservatively'."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    out: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            out[node.name] = ast.unparse(node)
+        elif isinstance(node, ast.ClassDef):
+            out[node.name] = ast.unparse(node)
+            for child in node.body:
+                if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
+                    out[f"{node.name}.{child.name}"] = ast.unparse(child)
+    return out
+
+
+def _changed_symbols_in_file(before: str, after: str) -> set[str] | None:
+    """Return the set of qualified symbols that differ between *before*
+    and *after*.
+
+    Returns ``None`` if either side fails to parse — callers must treat
+    ``None`` as 'unknown' and fire the gate conservatively.  An empty
+    set means 'no symbol-level changes' (e.g. only imports / module
+    docstring / module-level constants changed)."""
+    before_syms = _file_symbols(before)
+    after_syms = _file_symbols(after)
+    if before_syms is None or after_syms is None:
+        return None
+    changed: set[str] = set()
+    for name, src in after_syms.items():
+        if before_syms.get(name) != src:
+            changed.add(name)
+    for name in before_syms:
+        if name not in after_syms:
+            changed.add(name)
+    return changed
+
+
+def _changed_symbols_per_file(
+    base: str, head: str, files: list[str]
+) -> dict[str, set[str] | None]:
+    """For each ``src/*.py`` file, return the set of changed symbols
+    (or ``None`` if either revision can't be parsed)."""
+    result: dict[str, set[str] | None] = {}
+    for path in files:
+        if not path.startswith("src/") or not path.endswith(".py"):
+            continue
+        before = _file_at_rev(base, path)
+        after = _file_at_rev(head, path)
+        result[path] = _changed_symbols_in_file(before, after)
+    return result
+
+
 _ADR_FILENAME_RE = re.compile(r"docs/adr/(\d{4})-[^/]+\.md$")
 
 
@@ -60,24 +130,63 @@ def _touched_adr_numbers(changed: list[str]) -> set[int]:
     return numbers
 
 
+def _adr_fires_for_file(
+    adr: ADR, file_path: str, changed_symbols: set[str] | None
+) -> bool:
+    """Decide whether *adr* should still fire for *file_path*.
+
+    - Bare citation (empty symbol set) → fires on any change.
+    - Symbol citation + ``changed_symbols is None`` → fires (unparseable diff).
+    - Symbol citation + intersection with changed symbols → fires.
+    - Symbol citation + no intersection → skipped.
+    """
+    cited_symbols = adr.source_symbols.get(file_path, frozenset())
+    if not cited_symbols:
+        # Bare citation — backwards-compatible "any change fires"
+        return True
+    if changed_symbols is None:
+        # Unknown — be conservative
+        return True
+    for cited in cited_symbols:
+        if cited in changed_symbols:
+            return True
+        # Class-level citation also fires on any of its method changes
+        method_prefix = cited + "."
+        if any(c.startswith(method_prefix) for c in changed_symbols):
+            return True
+    return False
+
+
 def evaluate_gate(
     changed: list[str],
     hits: dict[str, list[ADR]],
+    changed_symbols: dict[str, set[str] | None] | None = None,
 ) -> tuple[bool, dict[str, list[ADR]]]:
     """Pure decision function: does the diff clear the ADR gate?
 
-    Returns ``(passed, unresolved_hits)``. A hit is **resolved** when at
-    least one of the ADRs citing that file is also updated in the diff.
-    The gate passes only when *every* hit is resolved — touching an
-    unrelated ADR no longer clears a gate fired by a different ADR.
+    Returns ``(passed, unresolved_hits)``. A hit is **resolved** either
+    by (1) updating one of the citing ADRs in the same diff, or (2) the
+    diff not actually changing any of the symbols the ADR cites
+    (symbol-level precision).  When *changed_symbols* is omitted, the
+    gate falls back to the original file-level behavior — touching the
+    file at all counts as a change.
     """
     if not hits:
         return True, {}
     touched_adrs = _touched_adr_numbers(changed)
     unresolved: dict[str, list[ADR]] = {}
     for path, adrs in hits.items():
-        if not any(a.number in touched_adrs for a in adrs):
-            unresolved[path] = adrs
+        if any(a.number in touched_adrs for a in adrs):
+            continue  # ADR updated in same PR — resolved
+        symbols = changed_symbols.get(path) if changed_symbols is not None else None
+        # When changed_symbols was supplied for this file, filter ADRs
+        # whose cited symbols are unchanged.
+        if changed_symbols is not None:
+            still_firing = [a for a in adrs if _adr_fires_for_file(a, path, symbols)]
+        else:
+            still_firing = list(adrs)
+        if still_firing:
+            unresolved[path] = still_firing
     return (not unresolved), unresolved
 
 
@@ -120,7 +229,8 @@ def main() -> int:
     if not hits:
         return 0
 
-    passed, unresolved = evaluate_gate(changed, hits)
+    changed_symbols = _changed_symbols_per_file(args.base, args.head, changed)
+    passed, unresolved = evaluate_gate(changed, hits, changed_symbols)
     if passed:
         print("Every touchpoint has a corresponding ADR update in this PR.")
         return 0

--- a/src/adr_index.py
+++ b/src/adr_index.py
@@ -22,20 +22,24 @@ Status is normalized to one of: "Accepted", "Proposed", "Superseded",
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _TITLE_RE = re.compile(r"^#\s*ADR-(\d{4}):\s*(.+?)\s*$", re.MULTILINE)
 _STATUS_RE = re.compile(r"\*\*Status:\*\*\s*(.+?)\s*$", re.MULTILINE)
 _CONTEXT_RE = re.compile(r"##\s+Context\s*\n\s*\n(.+?)(?=\n\s*\n|\n##\s|\Z)", re.DOTALL)
 _SUPERSEDED_RE = re.compile(r"Superseded\s+by\s+(ADR-\d{4})", re.IGNORECASE)
-# Matches `src/some/path.py` or `src/some/path.py:Symbol` citations.
+# Matches `src/some/path.py` or `src/some/path.py:Symbol[.attr...]` citations.
 # Shared with adr_pre_validator._SOURCE_SYMBOL_RE. Used for
 # ADR↔source-file inverse indexing so the CI gate can flag PRs
 # touching files cited in Accepted ADRs. The ``:Symbol`` tail is
 # optional so umbrella ADRs that cite files in prose (without a
-# specific symbol) also satisfy the gate.
-_SOURCE_FILE_CITATION_RE = re.compile(r"`(src/[^`:\s]+\.py)(?::[A-Za-z_]\w*)?`")
+# specific symbol) also satisfy the gate. Dotted symbols like
+# ``Class.method`` round-trip intact so the gate can match method-level
+# citations against AST-extracted method names.
+_SOURCE_FILE_CITATION_RE = re.compile(
+    r"`(src/[^`:\s]+\.py)(?::([A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*))?`"
+)
 
 
 @dataclass(frozen=True)
@@ -48,6 +52,13 @@ class ADR:
     source_files: frozenset[str] = frozenset()
     """Set of `src/...` paths cited anywhere in the ADR body — used by
     the P2 CI gate to flag PRs touching files under Accepted ADRs."""
+    source_symbols: dict[str, frozenset[str]] = field(default_factory=dict)
+    """Per-cited-file set of qualified symbols (``Class``, ``func``, or
+    ``Class.method``).  An *empty* frozenset for a file means at least
+    one bare ``src/foo.py`` citation exists — the gate then fires on any
+    change to that file (backwards-compatible with pre-symbol citations).
+    A non-empty frozenset means *only* changes to those symbols fire the
+    gate."""
 
 
 def parse_adr_file(path: Path) -> ADR:
@@ -81,7 +92,20 @@ def parse_adr_file(path: Path) -> ADR:
     if ctx_match:
         summary = " ".join(ctx_match.group(1).split())[:300]
 
-    source_files = frozenset(_SOURCE_FILE_CITATION_RE.findall(text))
+    source_symbols: dict[str, set[str]] = {}
+    bare_files: set[str] = set()
+    for file_path, symbol in _SOURCE_FILE_CITATION_RE.findall(text):
+        if symbol:
+            source_symbols.setdefault(file_path, set()).add(symbol)
+        else:
+            bare_files.add(file_path)
+            source_symbols.setdefault(file_path, set())
+    # A bare citation collapses any symbol-qualified citations for the
+    # same file: the gate fires on any change.
+    for f in bare_files:
+        source_symbols[f] = set()
+    source_files = frozenset(source_symbols.keys())
+    source_symbols_frozen = {f: frozenset(s) for f, s in source_symbols.items()}
 
     return ADR(
         number=number,
@@ -90,6 +114,7 @@ def parse_adr_file(path: Path) -> ADR:
         summary=summary,
         superseded_by=superseded_by,
         source_files=source_files,
+        source_symbols=source_symbols_frozen,
     )
 
 

--- a/tests/test_adr_gate_symbol_relevance.py
+++ b/tests/test_adr_gate_symbol_relevance.py
@@ -1,0 +1,308 @@
+"""Symbol-level precision for the ADR touchpoint gate.
+
+Today the gate fires whenever any cited file is touched, even if the
+edit is unrelated to what the ADR covers (e.g. removing an unused
+parameter from ``src/agent.py`` drags in ADR-0024 + ADR-0027).
+
+Per-ADR file citations already accept a ``:Symbol`` suffix
+(``src/foo.py:Bar``).  When a citation is symbol-qualified, the gate
+should only fire when the diff actually changes that symbol.  Bare
+file citations (``src/foo.py``) keep firing unconditionally —
+backwards-compatible.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from check_adr_touchpoints import (  # noqa: E402
+    _changed_symbols_in_file,
+    evaluate_gate,
+)
+
+from adr_index import ADR, ADRIndex  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Citation parsing — symbol_citations is populated from `src/...:Symbol`
+# ---------------------------------------------------------------------------
+
+
+def _write_adr(
+    adr_dir: Path,
+    number: int,
+    title: str,
+    citations: list[str],
+    *,
+    status: str = "Accepted",
+) -> Path:
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    path = adr_dir / f"{number:04d}-{title.lower().replace(' ', '-')}.md"
+    cite_lines = "\n".join(f"- `{c}`" for c in citations)
+    path.write_text(
+        f"# ADR-{number:04d}: {title}\n\n"
+        f"**Status:** {status}\n"
+        f"**Date:** 2026-04-25\n\n"
+        f"## Context\n\nFixture.\n\n"
+        f"## Related\n\n{cite_lines}\n"
+    )
+    return path
+
+
+class TestSymbolCitationParsing:
+    def test_symbol_qualified_citation_populates_symbol_set(
+        self, tmp_path: Path
+    ) -> None:
+        _write_adr(tmp_path, 1, "A", ["src/foo.py:Bar"])
+        adr = next(a for a in ADRIndex(tmp_path).adrs() if a.number == 1)
+
+        assert adr.source_symbols == {"src/foo.py": frozenset({"Bar"})}
+        assert "src/foo.py" in adr.source_files
+
+    def test_dotted_symbol_citation_is_captured_intact(self, tmp_path: Path) -> None:
+        """``Bar.method`` must round-trip — many ADRs cite class.method."""
+        _write_adr(tmp_path, 1, "A", ["src/foo.py:Bar.method"])
+        adr = next(a for a in ADRIndex(tmp_path).adrs() if a.number == 1)
+
+        assert adr.source_symbols == {"src/foo.py": frozenset({"Bar.method"})}
+
+    def test_multiple_symbols_for_same_file_accumulate(self, tmp_path: Path) -> None:
+        _write_adr(
+            tmp_path, 1, "A", ["src/foo.py:Bar", "src/foo.py:Baz", "src/foo.py:Qux"]
+        )
+        adr = next(a for a in ADRIndex(tmp_path).adrs() if a.number == 1)
+
+        assert adr.source_symbols == {
+            "src/foo.py": frozenset({"Bar", "Baz", "Qux"}),
+        }
+
+    def test_bare_citation_marks_file_with_empty_symbol_set(
+        self, tmp_path: Path
+    ) -> None:
+        """A bare file citation signals 'fire on any change'."""
+        _write_adr(tmp_path, 1, "A", ["src/foo.py"])
+        adr = next(a for a in ADRIndex(tmp_path).adrs() if a.number == 1)
+
+        # File present in source_files; symbol set is empty (= bare).
+        assert "src/foo.py" in adr.source_files
+        assert adr.source_symbols.get("src/foo.py") == frozenset()
+
+    def test_mixed_bare_and_symbol_for_same_file_collapses_to_bare(
+        self, tmp_path: Path
+    ) -> None:
+        """If even one citation is bare, the file is treated as bare."""
+        _write_adr(tmp_path, 1, "A", ["src/foo.py:Bar", "src/foo.py"])
+        adr = next(a for a in ADRIndex(tmp_path).adrs() if a.number == 1)
+
+        # bare wins → empty set means 'any change fires'
+        assert adr.source_symbols.get("src/foo.py") == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Symbol-diff extraction — what the gate uses to know what changed
+# ---------------------------------------------------------------------------
+
+
+class TestChangedSymbolExtraction:
+    """``_changed_symbols_in_file`` returns the set of changed top-level
+    and method symbols between two AST snapshots."""
+
+    def test_modified_function_body_is_flagged(self) -> None:
+        before = "def foo():\n    return 1\n"
+        after = "def foo():\n    return 2\n"
+        assert _changed_symbols_in_file(before, after) == {"foo"}
+
+    def test_added_function_is_flagged(self) -> None:
+        before = "def foo():\n    return 1\n"
+        after = "def foo():\n    return 1\n\ndef bar():\n    return 2\n"
+        assert _changed_symbols_in_file(before, after) == {"bar"}
+
+    def test_removed_function_is_flagged(self) -> None:
+        before = "def foo():\n    return 1\n\ndef bar():\n    return 2\n"
+        after = "def foo():\n    return 1\n"
+        assert _changed_symbols_in_file(before, after) == {"bar"}
+
+    def test_modified_method_is_flagged_with_dotted_name(self) -> None:
+        before = "class Bar:\n    def m(self):\n        return 1\n"
+        after = "class Bar:\n    def m(self):\n        return 2\n"
+        # Both Bar.m (the method) AND Bar (the class as a whole) change
+        # because the class's full source text differs.
+        assert "Bar.m" in _changed_symbols_in_file(before, after)
+        assert "Bar" in _changed_symbols_in_file(before, after)
+
+    def test_pure_import_change_does_not_flag_any_symbol(self) -> None:
+        """Adding/removing an import is not a symbol change."""
+        before = "import os\n\ndef foo():\n    return 1\n"
+        after = "import os\nimport sys\n\ndef foo():\n    return 1\n"
+        assert _changed_symbols_in_file(before, after) == set()
+
+    def test_pure_module_docstring_change_does_not_flag_any_symbol(self) -> None:
+        before = '"""Old."""\n\ndef foo():\n    return 1\n'
+        after = '"""New."""\n\ndef foo():\n    return 1\n'
+        assert _changed_symbols_in_file(before, after) == set()
+
+    def test_unparseable_python_falls_back_to_sentinel(self) -> None:
+        """Conservative: if we can't parse, treat as 'everything changed'."""
+        before = "def foo():\n    return 1\n"
+        after = "def foo(\n    return 2\n"  # syntax error
+        assert _changed_symbols_in_file(before, after) is None
+
+    def test_added_async_function_is_flagged(self) -> None:
+        before = ""
+        after = "async def foo():\n    return 1\n"
+        assert _changed_symbols_in_file(before, after) == {"foo"}
+
+
+# ---------------------------------------------------------------------------
+# Gate-level: combine ADR symbol citations + changed symbols
+# ---------------------------------------------------------------------------
+
+
+def _adr(
+    number: int,
+    *,
+    source_symbols: dict[str, frozenset[str]],
+) -> ADR:
+    return ADR(
+        number=number,
+        title=f"Fixture {number}",
+        status="Accepted",
+        summary="",
+        source_files=frozenset(source_symbols.keys()),
+        source_symbols=source_symbols,
+    )
+
+
+class TestEvaluateGateWithSymbols:
+    """``evaluate_gate`` skips a hit when the cited symbol is unchanged."""
+
+    def test_symbol_qualified_citation_skipped_when_symbol_unchanged(self) -> None:
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})})
+        hits = {"src/agent.py": [adr]}
+        # Author touched src/agent.py but the changed symbol is `__init__`,
+        # not `run` — gate should pass.
+        changed_symbols = {"src/agent.py": {"AgentRunner.__init__"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert passed
+        assert unresolved == {}
+
+    def test_symbol_qualified_citation_fires_when_symbol_changed(self) -> None:
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})})
+        hits = {"src/agent.py": [adr]}
+        changed_symbols = {"src/agent.py": {"AgentRunner.run"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert not passed
+        assert "src/agent.py" in unresolved
+
+    def test_class_citation_fires_on_method_change(self) -> None:
+        """Citing ``ClassName`` fires if any ``ClassName.method`` changed."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner"})})
+        hits = {"src/agent.py": [adr]}
+        changed_symbols = {"src/agent.py": {"AgentRunner.run"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert not passed
+
+    def test_bare_citation_fires_on_any_change(self) -> None:
+        """Backwards compat: bare citation = any-change-fires."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset()})
+        hits = {"src/agent.py": [adr]}
+        # Even an unrelated symbol change fires
+        changed_symbols = {"src/agent.py": {"_helper"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert not passed
+
+    def test_bare_citation_fires_even_with_no_symbol_changes(self) -> None:
+        """A pure import/docstring touch on a bare-cited file still fires."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset()})
+        hits = {"src/agent.py": [adr]}
+        changed_symbols = {"src/agent.py": set()}  # no symbols changed
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert not passed
+
+    def test_symbol_citation_skipped_when_only_imports_changed(self) -> None:
+        """The headline benefit: pure import cleanup on a symbol-cited
+        file no longer trips the gate."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})})
+        hits = {"src/agent.py": [adr]}
+        changed_symbols = {"src/agent.py": set()}  # only imports changed
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert passed
+
+    def test_unparseable_diff_falls_back_to_firing(self) -> None:
+        """Sentinel ``None`` from the extractor means 'unknown' → conservative."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})})
+        hits = {"src/agent.py": [adr]}
+        changed_symbols = {"src/agent.py": None}  # extractor failed
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert not passed
+
+    def test_no_changed_symbols_arg_falls_back_to_file_level_behavior(self) -> None:
+        """When the caller doesn't supply changed_symbols, behave like today."""
+        adr = _adr(24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})})
+        hits = {"src/agent.py": [adr]}
+
+        passed, unresolved = evaluate_gate(changed=["src/agent.py"], hits=hits)
+
+        assert not passed
+
+    def test_per_adr_resolution_when_one_cites_symbol_and_other_bare(self) -> None:
+        """Two ADRs cite the same file — one with symbol, one bare.
+        The bare citation alone is enough to fire the gate."""
+        adr_symbol = _adr(
+            24, source_symbols={"src/agent.py": frozenset({"AgentRunner.run"})}
+        )
+        adr_bare = _adr(27, source_symbols={"src/agent.py": frozenset()})
+        hits = {"src/agent.py": [adr_symbol, adr_bare]}
+        changed_symbols = {"src/agent.py": {"AgentRunner.__init__"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        # adr_bare keeps firing → gate fails, both ADRs reported as still
+        # needing attention (or at least the bare-citing one).
+        assert not passed
+        assert "src/agent.py" in unresolved
+
+    def test_all_symbol_adrs_skipped_clears_the_gate(self) -> None:
+        adr1 = _adr(24, source_symbols={"src/agent.py": frozenset({"X"})})
+        adr2 = _adr(27, source_symbols={"src/agent.py": frozenset({"Y"})})
+        hits = {"src/agent.py": [adr1, adr2]}
+        changed_symbols = {"src/agent.py": {"Z"}}
+
+        passed, unresolved = evaluate_gate(
+            changed=["src/agent.py"], hits=hits, changed_symbols=changed_symbols
+        )
+
+        assert passed


### PR DESCRIPTION
## Summary
The ADR touchpoint gate currently fires on **any** edit to a cited file. Removing an optional parameter from `src/agent.py` drags in ADR-0024 + ADR-0027; deleting one Protocol from `src/ports.py` drags in ADR-0003 + ADR-0044. The Skip-ADR escape hatch is the only way out, and it provides zero audit value.

The citation regex already accepts `src/foo.py:Symbol` (e.g. `src/repo_wiki.py:RepoWikiStore`). The gate just ignored the symbol suffix. **This PR makes the gate use it.**

## Behavior

| Citation form | When the gate fires |
|---|---|
| `src/foo.py:Bar` | Only when `Bar` (function or class) actually changes |
| `src/foo.py:Bar.method` | Only when that specific method changes |
| `src/foo.py:Bar` (class) | When `Bar` itself or any of its methods change |
| `src/foo.py` (bare) | On any edit (backwards-compatible) |
| Mixed bare + symbol for same file | Treated as bare (author's "any change matters" signal wins) |
| Unparseable Python on either side | Fires (conservative fallback) |
| Pure import / module-docstring / top-level constant change | Doesn't fire (AST-based diff sees no symbol change) |

## Implementation
- `src/adr_index.py` — regex now captures `(:Symbol[.attr...]?)`. New `ADR.source_symbols: dict[str, frozenset[str]]` field maps cited file → set of symbols (empty set = bare). `source_files` is preserved for backwards compat.
- `scripts/check_adr_touchpoints.py`:
  - `_file_symbols(source)` — AST-extracts `{Class, Class.method, function}` → source-text map.
  - `_changed_symbols_in_file(before, after)` — set-difference between two AST snapshots; `None` on parse error.
  - `_changed_symbols_per_file(base, head, files)` — `git show` both revs, compute per-file changed-symbol sets.
  - `evaluate_gate(...)` gains an optional `changed_symbols` parameter; `main()` populates it.

## Citation sweep
Qualified four ADRs that fired in recent PRs (illustrating the pattern; rest can be done incrementally):
- ADR-0012 → `src/review_phase.py:_handle_approved_merge`
- ADR-0015 → `src/review_phase.py:check_visual_gate`, `src/review_phase.py:_fetch_code_scanning_alerts`
- ADR-0024 → `src/state.py:StateTracker`, `src/agent.py:AgentRunner` (both at scope-boundaries citation + related-files listing)
- ADR-0045 → `src/service_registry.py:build_services`, `src/service_registry.py:ServiceRegistry`

Other ADRs with bare citations can be qualified PR-by-PR. Bare remains the safe fallback so nothing regresses.

## Test plan
- [x] `tests/test_adr_gate_symbol_relevance.py` — 23 cases covering parsing (5), AST extraction (8), gate decisions (10)
- [x] All existing ADR-gate tests still pass: `test_adr_index.py` (13), `test_adr_touchpoints.py` (5), `test_adr_gate_relevance.py` (5) — 46/46 green together
- [ ] CI passes (skipped local `make quality` to ship; targeted tests pass)

Skip-ADR: This PR modifies `src/adr_index.py` and `scripts/check_adr_touchpoints.py` — the gate machinery itself, not files cited by any ADR. The four ADR doc updates are part of the citation-precision sweep this PR introduces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)