### PR TITLE
feat(loops): ADR-0049 in-body kill-switch gate for all 18 caretaker loops

### DIFF
--- a/src/adr_reviewer_loop.py
+++ b/src/adr_reviewer_loop.py
@@ -29,4 +29,6 @@ class ADRReviewerLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Review proposed ADRs via the council process."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         return await self._adr_reviewer.review_proposed_adrs()

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -116,6 +116,9 @@ class CodeGroomingLoop(BaseBackgroundLoop):
         return findings
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if self._config.dry_run:
             return None
 

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -38,6 +38,8 @@ class DependabotMergeLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Check bot PRs and auto-merge if CI passes."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         settings = self._state.get_dependabot_merge_settings()
         processed = self._state.get_dependabot_merge_processed()
         bot_authors = {a.lower() for a in settings.authors}

--- a/src/diagnostic_loop.py
+++ b/src/diagnostic_loop.py
@@ -89,6 +89,8 @@ class DiagnosticLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Poll for diagnosed issues and run the diagnostic pipeline."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         try:
             issues = await self._prs.list_issues_by_label(
                 self._config.diagnose_label[0]

--- a/src/epic_monitor_loop.py
+++ b/src/epic_monitor_loop.py
@@ -30,6 +30,8 @@ class EpicMonitorLoop(BaseBackgroundLoop):
         return self._config.epic_monitor_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         stale = await self._epic_manager.check_stale_epics()
         await self._epic_manager.refresh_cache()
         all_progress = self._epic_manager.get_all_progress()

--- a/src/epic_sweeper_loop.py
+++ b/src/epic_sweeper_loop.py
@@ -41,6 +41,8 @@ class EpicSweeperLoop(BaseBackgroundLoop):
         return self._config.epic_sweep_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         epics = await self._fetcher.fetch_issues_by_labels(
             self._config.epic_label, limit=50
         )

--- a/src/github_cache_loop.py
+++ b/src/github_cache_loop.py
@@ -268,6 +268,8 @@ class GitHubCacheLoop(BaseBackgroundLoop):
         self._cache = cache
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         stats = await self._cache.poll()
         logger.info(
             "GitHub cache refreshed: %s",

--- a/src/pr_unsticker_loop.py
+++ b/src/pr_unsticker_loop.py
@@ -34,6 +34,8 @@ class PRUnstickerLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Resolve all HITL causes (conflicts, CI failures, generic)."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         hitl_items = await self._prs.list_hitl_items(self._config.hitl_label)
         # Only process HITL issues that currently have an open PR.
         active_pr_items = [item for item in hitl_items if int(item.pr or 0) > 0]

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -182,6 +182,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
         return {int(k) for k, v in outcomes.items() if v.outcome in _TERMINAL_OUTCOMES}
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         # Drain console-triggered admin tasks up front — admin actions
         # may target repos the store does not yet see (e.g. rebuild-index
         # of a freshly migrated repo), so draining before the list_repos

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -225,7 +225,10 @@ class ReportIssueLoop(BaseBackgroundLoop):
         m = cls._ISSUE_URL_RE.search(url)
         return int(m.group(1)) if m else 0
 
-    async def _do_work(self) -> dict[str, Any] | None:
+    async def _do_work(self) -> dict[str, Any] | None:  # noqa: PLR0911
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if self._config.dry_run:
             return None
 

--- a/src/retrospective_loop.py
+++ b/src/retrospective_loop.py
@@ -52,6 +52,8 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         return self._config.retrospective_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         items = self._queue.load()
         if not items:
             return {"processed": 0, "patterns_filed": 0, "stale_proposals": 0}

--- a/src/runs_gc_loop.py
+++ b/src/runs_gc_loop.py
@@ -34,6 +34,8 @@ class RunsGCLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Run one GC cycle: purge expired runs, then enforce size cap."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         expired = self._recorder.purge_expired(self._config.artifact_retention_days)
         oversized = self._recorder.purge_oversized(self._config.artifact_max_size_mb)
         stats = self._recorder.get_storage_stats()

--- a/src/security_patch_loop.py
+++ b/src/security_patch_loop.py
@@ -76,6 +76,9 @@ class SecurityPatchLoop(BaseBackgroundLoop):
         return pkg, severity, summary
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if self._config.dry_run:
             return None
 

--- a/src/sentry_loop.py
+++ b/src/sentry_loop.py
@@ -83,6 +83,9 @@ class SentryLoop(BaseBackgroundLoop):
             self._dedup.add(sentry_id)
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if not self._credentials.sentry_auth_token or not self._config.sentry_org:
             return {"skipped": True, "reason": "no credentials"}
 

--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -45,6 +45,9 @@ class StagingPromotionLoop(BaseBackgroundLoop):
         return self._config.staging_promotion_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if not self._config.staging_enabled:
             return {"status": "staging_disabled"}
 

--- a/src/stale_issue_gc_loop.py
+++ b/src/stale_issue_gc_loop.py
@@ -45,6 +45,9 @@ class StaleIssueGCLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Run one GC cycle: find and close stale HITL issues."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
         if self._config.dry_run:
             return None
 

--- a/src/stale_issue_loop.py
+++ b/src/stale_issue_loop.py
@@ -37,6 +37,8 @@ class StaleIssueLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Scan for stale issues and close them."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         settings = self._state.get_stale_issue_settings()
         already_closed = self._state.get_stale_issue_closed()
 

--- a/src/workspace_gc_loop.py
+++ b/src/workspace_gc_loop.py
@@ -51,6 +51,8 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Run one GC cycle: state workspaces, orphan dirs, orphan branches."""
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         collected = 0
         skipped = 0
         errors = 0

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -84,6 +84,8 @@ def _stub_loop(
     loop._queue = queue or MaintenanceQueue(path=config.repo_root / ".wmq.json")
     loop._open_pr_branch = None
     loop._open_pr_url = None
+    loop._worker_name = "repo_wiki"
+    loop._enabled_cb = lambda _name: True
     return loop
 
 


### PR DESCRIPTION
## Summary

Wires the universal in-body \`enabled_cb\` gate at the top of \`_do_work\` in all 18 non-trust loops, completing the ADR-0049 universal mandate. Closes the last process-level dark-factory gap.

**Why this matters for dark-factory operation:**
- \`github_cache_loop\` and \`sentry_loop\` use \`run_on_startup=True\` — the run-loop's gate fires before scheduling the *next* tick, but the *first* tick runs unconditionally. Without an in-body gate, flipping a worker off in the UI didn't stop its initial cycle on orchestrator restart.
- The other 16 loops gain defense-in-depth against mid-tick toggle flips and any future entry path that calls \`_do_work\` directly.

## Files modified

18 caretaker loops + 1 test stub:

\`\`\`
src/adr_reviewer_loop.py        src/repo_wiki_loop.py
src/code_grooming_loop.py       src/report_issue_loop.py
src/dependabot_merge_loop.py    src/retrospective_loop.py
src/diagnostic_loop.py          src/runs_gc_loop.py
src/epic_monitor_loop.py        src/security_patch_loop.py
src/epic_sweeper_loop.py        src/sentry_loop.py
src/github_cache_loop.py        src/staging_promotion_loop.py
src/pr_unsticker_loop.py        src/stale_issue_gc_loop.py
src/stale_issue_loop.py         src/workspace_gc_loop.py

tests/test_repo_wiki_loop_pr.py
\`\`\`

\`code_grooming_loop\` keeps its existing \`code_grooming_enabled\` config gate as a second layer; \`staging_promotion_loop\` keeps \`staging_enabled\`. Both now also honor \`enabled_cb\` per the spec ("no per-loop \\\`*_enabled\\\` config field as sole gate").

The standard insertion pattern:

\`\`\`python
async def _do_work(self) -> dict[str, Any] | None:
    if not self._enabled_cb(self._worker_name):
        return {\"status\": \"disabled\"}
    # ...rest
\`\`\`

## Test plan

- [x] \`uv run pytest tests/test_*loop*.py\` — 383 passed, 1 skipped
- [x] \`uv run pytest tests/scenarios/test_caretaker_loops*.py\` — 33 passed
- [x] \`uv run pytest tests/test_base_background_loop.py tests/test_bg_worker_*.py tests/test_orchestrator_loops.py\` — 184 passed
- [x] Broader sweep \`-k \"loop or worker\"\` — 1130 passed
- [x] \`uv run ruff check src/ tests/\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Skip-ADR: This PR uniformly applies the ADR-0049 kill-switch gate across loops. The other ADRs cited by the ADR Touchpoints checker (0012, 0018, 0032, 0045) describe per-loop responsibilities (epic merge coordination, screenshot pipeline, repo wiki, trust fleet) that are unchanged by adding a defensive enabled_cb check at the top of _do_work. ADR-0049 is the governing decision and is already updated/honoured by this change.