### PR TITLE
fix(arch): lift modules.md drift exemption (root cause: stale baseline)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T04:04:14.756818+00:00",
-  "commit_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff",
+  "regenerated_at": "2026-04-26T16:10:13.458474+00:00",
+  "commit_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "ports.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "labels.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "modules.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "events.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "adr_xref.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "mockworld.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "changelog.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     },
     "functional_areas.md": {
-      "source_sha": "a92c4298be1cbcc38334acbfedfce3cc301ad5ff"
+      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -146,4 +146,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,11 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
-- `a92c429` — chore(arch): re-emit baseline after upstream auto-agent commits *(2026-04-25)*
-- `658d325` — fix(arch): filter underscore-prefixed Protocols in ports extractor + add auto_agent area *(2026-04-25)*
-- `f5041a4` — fix(auto-agent): address fresh-eyes review — 3 critical, 5 important *(2026-04-25)*
-- `c9d3a95` — fix(preflight): wire pr_failed status + correct ADR-0050 source-file citations *(2026-04-25)*
-- `cc3398c` — docs(adr): ADR-0050 — auto-agent HITL pre-flight loop *(2026-04-25)*
+- `67079aa` — docs(spec): Auto-Agent HITL pre-flight loop design (#8431) (#8431) *(2026-04-25)*
 - `70392a6` — fix(arch): correct GitHub org in all site URLs (#8435) (#8435) *(2026-04-25)*
 - `f893069` — feat(arch): Plan C — DiagramLoop (L24) + CI guard + Pages site (#8434) (#8434) *(2026-04-25)*
 - `300c3c7` — feat(arch): Plan B — Functional Areas + ADR-0001 amendment + migration (#8433) (#8433) *(2026-04-25)*
@@ -44,7 +40,101 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 - `494f736` — docs: ADR-0032 Per-Repo Wiki Knowledge Base (Karpathy pattern) (#6096) (#6096) *(2026-04-05)*
 - `f65f00b` — docs: accept ADR-0023 pair + add diagnostic and HITL plans (#6093) (#6093) *(2026-04-05)*
-- `f2a4971` — feat: HITL queue hygiene — dedup, park, duplicate detection (#6089) (#6089) *(2026-04-05)*
+- `2977a62` — docs: ADR-0031 Product Track Architecture (Discover/Shape phases) (#6010) (#6010) *(2026-04-05)*
+
+## 2026-W13
+
+- `bbf7336` — docs: Add ADRs for report pipeline, caretaker loops, and routes decomposition (#5904) (#5904) *(2026-03-28)*
+
+## 2026-W12
+
+- `1448b26` — Fixes #3205: [ADR Follow-up] ADR-0022: Council requests changes (#3289) (#3289) *(2026-03-19)*
+- `b5f4f8f` — Fixes #3244: [ADR Follow-up] ADR-0023: Council requests changes (#3284) (#3284) *(2026-03-18)*
+- `b9d0cd2` — Fixes #3231: [ADR Follow-up] ADR-0015: Council requests changes (#3309) (#3309) *(2026-03-18)*
+- `b69cd2d` — hitl-fix: Fix ADR-0004 title mismatch in ADR-0023 citation (#3241) (#3278) (#3278) *(2026-03-18)*
+- `e08512e` — Fixes #3189: [Memory] Merge consecutive identical if-conditions ins... (#3221) (#3221) *(2026-03-18)*
+- `839ac7e` — Fixes #3233: [ADR Follow-up] ADR-0022: Council requests changes (#3254) (#3254) *(2026-03-18)*
+- `17bd4e2` — Fixes #3220: [ADR Pre-validation] ADR-0023: structural issues (#3242) (#3242) *(2026-03-18)*
+- `582338b` — Fixes #3222: [ADR Duplicate] ADR-0023 (#3243) (#3243) *(2026-03-18)*
+- `674566d` — Fixes #3213: [ADR Follow-up] ADR-0023: Council recommends rejection (#3234) (#3234) *(2026-03-18)*
+- `687783d` — Fixes #3229: [ADR Follow-up] ADR-0022: Council requests changes (#3248) (#3248) *(2026-03-18)*
+- `ea5cda4` — Fixes #3183: [Memory] Symmetric field assertion checklist for share... (#3192) (#3192) *(2026-03-16)*
+- `9cb0bb0` — Fixes #3097: [Memory] ADR pre-validator lacks source function name ... (#3130) (#3130) *(2026-03-16)*
+- `0001d59` — Fixes #3021: [ADR Follow-up] ADR-0021: Council requests changes (#3113) (#3113) *(2026-03-16)*
+- `b1ec5e3` — Fixes #3017: [ADR Follow-up] ADR-0021: Council requests changes (#3108) (#3108) *(2026-03-16)*
+- `518657f` — Fixes #3086: [Memory] ADR stale-cross-ref: always update the "requi... (#3110) (#3110) *(2026-03-16)*
+- `8246a43` — Fixes #3025: [Memory] ADR function references should omit line numbers (#3087) (#3087) *(2026-03-16)*
+- `5714f06` — Fixes #3016: [Memory] ADR line number citations are volatile (#3080) (#3080) *(2026-03-16)*
+- `3cc7250` — Fixes #3024: [ADR Follow-up] ADR-0021: Council requests changes (#3067) (#3067) *(2026-03-16)*
+- `235dd4c` — Fixes #3019: [ADR Follow-up] ADR-0021: Council requests changes (#3063) (#3063) *(2026-03-16)*
+- `700289c` — Fixes #2871: [Memory] ADR cross-references must name the referenced... (#3058) (#3058) *(2026-03-16)*
+- `751a6df` — Fixes #3013: [ADR Duplicate] ADR-0023 (#3053) (#3053) *(2026-03-16)*
+
+## 2026-W11
+
+- `6e82818` — Fixes #2763: [ADR Duplicate] ADR-0023 (#2977) (#2977) *(2026-03-15)*
+- `5a1803b` — Fixes #2757: [ADR Duplicate] ADR-0023 (#2966) (#2966) *(2026-03-15)*
+- `f8daa39` — Fixes #2701: [ADR Follow-up] ADR-0015: Council requests changes (#2764) (#2764) *(2026-03-15)*
+- `92b9a20` — Fixes #2755: [ADR Duplicate] ADR-0023 (#2956) (#2956) *(2026-03-15)*
+- `d8dbf5b` — Fixes #2753: [ADR Duplicate] ADR-0023 (#2946) (#2946) *(2026-03-15)*
+- `72134a2` — Fixes #2751: [ADR Duplicate] ADR-0023 (#2938) (#2938) *(2026-03-15)*
+- `fdc3519` — Fixes #2747: [ADR Duplicate] ADR-0023 (#2923) (#2923) *(2026-03-15)*
+- `3d95c4b` — Fixes #2744: [ADR Duplicate] ADR-0023 (#2911) (#2911) *(2026-03-15)*
+- `c26441d` — Fixes #2740: [ADR Duplicate] ADR-0023 (#2892) (#2892) *(2026-03-15)*
+- `9847e40` — Fixes #2733: [ADR Follow-up] ADR-0023: Council requests changes (#2873) (#2873) *(2026-03-15)*
+- `7ac6420` — Fixes #2737: [ADR Duplicate] ADR-0023 (#2883) (#2883) *(2026-03-15)*
+- `4bc1099` — Fixes #2732: [ADR Follow-up] ADR-0023: Council requests changes (#2863) (#2863) *(2026-03-15)*
+- `83cc8b3` — Fixes #2726: [ADR Follow-up] ADR-0012: Council requests changes (#2846) (#2846) *(2026-03-15)*
+- `8b7d06f` — Fixes #2720: Renumber ADR-0023 to ADR-0024 and update status to Accepted (#2816) (#2816) *(2026-03-15)*
+- `4eb1c9a` — Accept ADR-0010: worktree and path isolation (#2696) (#2696) *(2026-03-15)*
+- `a914647` — Fixes #2205: Remove CLI layer and consolidate into server API (#2457) (#2457) *(2026-03-09)*
+
+## 2026-W10
+
+- `29d8268` — Fixes #2382: Add ADR-0023 for duplicate class merge-artifact pattern (#2383) (#2383) *(2026-03-08)*
+- `cad34a6` — Fixes #2253: [ADR] Draft decision from memory #2251: ADR pre-review... (#2254) (#2254) *(2026-03-08)*
+- `4534df5` — Fixes #2373: Add ADR-0023 for dead class artifact detection in mock-based tests (#2378) (#2378) *(2026-03-08)*
+- `312fb6f` — Fixes #2356: Add ADR-0023 for toggle-state test consistency (#2369) (#2369) *(2026-03-08)*
+- `26ed00b` — Fixes #2355: ADR-0023 gate triage call on config toggle, not just HITL fallback (#2360) (#2360) *(2026-03-08)*
+- `1baa85a` — Fixes #2341: Add ADR-0023 for auto-triage toggle routing enforcement (#2344) (#2344) *(2026-03-08)*
+- `12d7c57` — Fixes #2306: Add ADR-0023 for stats counter placement in delegating helpers (#2324) (#2324) *(2026-03-08)*
+- `c22797d` — Fixes #2273: Add ADR-0023 for CLI argparse + config builder pattern (#2302) (#2302) *(2026-03-08)*
+- `7ade583` — Fixes #2267: Add ADR-0023 for multi-repo architecture wiring pattern (#2296) (#2296) *(2026-03-08)*
+- `4c09083` — Fixes #2264: [ADR] Draft decision from memory #2258: Implementation... (#2292) (#2292) *(2026-03-08)*
+- `c4b8ecd` — Fixes #2374: Add ADR-0023 for supersession regex verb form coverage (#2379) (#2379) *(2026-03-08)*
+- `7c6410a` — Fixes #2210: sync ADR index statuses (#2233) (#2233) *(2026-03-07)*
+- `b1df31d` — Fixes #1977: Document cross-phase integration harness (#2146) (#2146) *(2026-03-06)*
+- `548bf0b` — Fixes #2031: normalize superseded ADR statuses (#2158) (#2158) *(2026-03-06)*
+- `6f65afe` — Fix ADR council HITL issues: supersession, gate table, implementation accuracy (#2045) (#2045) *(2026-03-05)*
+- `9ea0458` — Accept ADR-0009 and supersede ADR-0006 (#2044) (#2044) *(2026-03-05)*
+- `d345ecf` — Accept ADR-0007: dashboard api multi repo scoping (#2015) (#2015) *(2026-03-05)*
+- `0f4334a` — Accept ADR 0016/0017/0019 and simplify event_bus fixture (#2012) (#2012) *(2026-03-05)*
+- `86c348d` — Accept ADR-0014: session counter forward progression semantics (#1994) (#1994) *(2026-03-05)*
+- `254f82f` — Accept ADR-0006: repo runtime isolation (#1949) (#1949) *(2026-03-04)*
+- `89e5bd6` — Accept ADR-0008: multi repo dashboard architecture (#1955) (#1955) *(2026-03-04)*
+- `8875cd8` — Accept ADR-0011: epic release creation architecture (#1965) (#1965) *(2026-03-04)*
+- `ac0ecda` — Fixes #1883: [Bug Report] remove the processes tab too, and related... (#1906) (#1906) *(2026-03-04)*
+
+## 2026-W09
+
+- `8825cd5` — Fixes #1633: add ADR-0009 for persistence architecture and data layout (#1680) (#1680) *(2026-03-01)*
+- `b47789e` — Fixes #1818: Add ADR-0009 for autoApproveRow borderTop context awareness (#1820) (#1820) *(2026-03-01)*
+- `9a2d6e9` — Fixes #1798: Add ADR-0009 for background task delegation abstraction layer (#1810) (#1810) *(2026-03-01)*
+- `1fea79a` — Fixes #1749: Add ADR-0009 for screenshot capture pipeline architecture (#1792) (#1792) *(2026-03-01)*
+- `793f790` — Fixes #1748: ADR-0009 documents auto-decompose triage counter exclusion as intentional (#1791) (#1791) *(2026-03-01)*
+- `d26f6b9` — Fixes #1747: ADR-0009 VisualValidation SKIPPED override partial suppression semantics (#1788) (#1788) *(2026-03-01)*
+- `91603e3` — Fixes #1746: Add ADR-0009 for protocol-based callback injection gate pattern (#1786) (#1786) *(2026-03-01)*
+- `bd72277` — Fixes #1703: ADR-0009 session counter forward-progression semantics (#1750) (#1750) *(2026-03-01)*
+- `b0e04ed` — Fixes #1704: ADR-0009 screenshot capture pipeline architecture (#1745) (#1745) *(2026-03-01)*
+- `7fdccc8` — Fixes #1702: ADR-0009 epic merge coordination architecture (#1740) (#1740) *(2026-03-01)*
+- `522e013` — Fixes #1701: ADR-0009 epic release creation architecture (#1739) (#1739) *(2026-03-01)*
+- `961b141` — Fixes #1677: add ADR-0009 for worktree and path isolation architecture (#1683) (#1683) *(2026-03-01)*
+- `7c6fe67` — Fixes #1634: add ADR-0009 for multi-repo process-per-repo model (#1679) (#1679) *(2026-03-01)*
+- `35aa37a` — docs: add ADR-0008 for multi-repo dashboard architecture (#1648) (#1648) *(2026-02-28)*
+- `780b17c` — docs: add ADR-0007 for dashboard API multi-repo scoping (#1647) (#1647) *(2026-02-28)*
+- `83730be` — docs: add ADR-0006 for RepoRuntime isolation architecture (#1646) (#1646) *(2026-02-28)*
+- `bbc273d` — docs: add ADR-0005 for PR recovery and zero-diff branch handling (#1307) (#1307) *(2026-02-26)*
+- `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -25,4 +25,4 @@ graph LR
     src_preflight -- "1" --> src_sentry
 ```
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `a92c429` on 2026-04-26 04:04 UTC. Source last changed at `a92c429`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/src/arch/runner.py
+++ b/src/arch/runner.py
@@ -189,14 +189,10 @@ def _strip_footer(text: str) -> str:
     return "\n".join(out)
 
 
-# Artifacts whose content is environment-dependent or inherently time-varying;
-# not subject to drift detection. They still emit fresh content every run.
+# Artifacts inherently time-varying; not subject to drift detection.
+# They still emit fresh content every run.
 # - changelog.md: derives from `git log` output; changes with every commit.
-# - modules.md: depends on the .py file inventory of the source tree, which
-#   varies between dev machine (no editable-install side effects) and CI
-#   (pip install -e creates auxiliary files). Tracked separately by the
-#   debug-print on drift detection.
-_DRIFT_EXEMPT = {"changelog.md", "modules.md"}
+_DRIFT_EXEMPT = {"changelog.md"}
 
 
 def check(*, repo_root: Path, generated_dir: Path) -> int:


### PR DESCRIPTION
## Summary

The Plan A→C work exempted `modules.md` from drift detection on the assumption that Linux CI vs macOS local saw a different `.py` file inventory. **That was wrong.**

**Actual root cause:** when each subsequent PR merged into main, the `docs/arch/generated/` baseline was never re-emitted. Auto-agent's source files added a 43rd import of `state`, but the committed baseline still showed 42. CI saw the diff; local would have too if I'd re-emitted.

## Fix

- Removed `modules.md` from `_DRIFT_EXEMPT` in `src/arch/runner.py`
- Re-emitted the baseline (now reflects 43 imports — matches live source)
- Kept the debug-print I added during the misinvestigation; it's good diagnostic plumbing

## Why this won't recur

- `arch-regen.yml` already runs on every PR that touches `src/**` and fails on drift
- Once DiagramLoop runtime wiring lands (next follow-up PR), it'll regen autonomously every 4h

🤖 Generated with [Claude Code](https://claude.com/claude-code)