### PR TITLE
feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing)

### DIFF
--- a/docs/adr/0050-auto-agent-hitl-preflight.md
+++ b/docs/adr/0050-auto-agent-hitl-preflight.md
@@ -76,18 +76,20 @@ tile + `/api/diagnostics/auto-agent` endpoint surface the relevant data.
 - Runaway cost. Mitigations: caps wired into code paths (default off);
   audit + dashboard surface unusual spend immediately.
 
-**Partial landing — production HITLRunner spawn deferred:**
-The first PR landing this ADR ships the full pipeline (poll → context →
-agent → decision → audit), the prompt envelope + 9 sub-label playbooks,
-the dashboard + /api/diagnostics/auto-agent endpoint, and the adversarial
-corpus harness — but `_build_spawn_fn` in `src/auto_agent_preflight_loop.py`
-is a placeholder that always returns `needs_human` with $0 cost. The
-production wiring (HITLRunner subclass that actually spawns Claude Code in
-the issue's worktree) is the next PR. While the placeholder is in effect,
-every escalation will surface to `human-required` immediately — operationally
-identical to the pre-auto-agent behavior, just with one extra cycle of
-latency. The dashboard's `resolution_rate=0` and `spend_usd=$0` will signal
-the placeholder is still in place.
+**Production subprocess wiring — landed in follow-up PR:**
+The initial PR landing this ADR shipped the full pipeline scaffolding
+(poll → context → agent → decision → audit), the prompt envelope + 9
+sub-label playbooks, the dashboard + `/api/diagnostics/auto-agent`
+endpoint, and the adversarial corpus harness — but `_build_spawn_fn`
+was a placeholder. The follow-up PR replaced that placeholder with
+`AutoAgentRunner` (`src/preflight/auto_agent_runner.py`), which spawns
+the real Claude Code subprocess via `stream_claude_process`,
+captures cost via `prompt_telemetry`, applies the spec §5.2 tool
+restrictions (`--disallowedTools=WebFetch` at the CLI; path-level
+restrictions enforced post-hoc by the principles audit), and resolves
+to per-issue worktrees via the injected `WorkspacePort`. The dashboard
+will now show real spend and resolution rate as escalations flow
+through the loop.
 
 ## Alternatives Considered
 
@@ -114,11 +116,12 @@ The following files carry this ADR's decisions and must be kept in sync with any
 - `src/preflight/decision.py` — `PreflightResult` + `apply_decision()` pure label state machine for all 6 statuses.
 - `src/preflight/agent.py` — `PreflightAgent` + `run_preflight` + cost/wall-clock cap watchers.
 - `src/preflight/runner.py` — prompt rendering helpers + `parse_agent_response`.
+- `src/preflight/auto_agent_runner.py` — `AutoAgentRunner` real Claude Code subprocess spawn (production `_build_spawn_fn`) + per-attempt telemetry to `inferences.jsonl` + cost estimate via `model_pricing`.
 - `src/sentry/reverse_lookup.py` — `query_sentry_by_title()` (never-raises).
 - `src/auto_agent_preflight_loop.py` — `AutoAgentPreflightLoop._do_work` pipeline + reconcile-on-close.
 - `prompts/auto_agent/` — shared envelope (`_envelope.md`) + `_default.md` + 9 sub-label prompt files.
 - `src/dashboard_routes/_diagnostics_routes.py` — `/api/diagnostics/auto-agent` endpoint.
 - `src/ui/src/components/diagnostics/AutoAgentStats.jsx` — System tab tile.
-- `tests/test_auto_agent_preflight_loop.py` + `tests/test_auto_agent_close_reconciliation.py` + `tests/test_auto_agent_loop_wiring.py` — unit + wiring tests.
+- `tests/test_auto_agent_preflight_loop.py` + `tests/test_auto_agent_close_reconciliation.py` + `tests/test_auto_agent_loop_wiring.py` + `tests/test_preflight_auto_agent_runner.py` — unit + wiring + runner tests.
 - `tests/scenarios/test_auto_agent_preflight.py` — full-loop scenario tests.
 - `tests/auto_agent/adversarial/test_corpus.py` + `tests/auto_agent/adversarial/corpus/` — 9-entry adversarial corpus + harness (run via `make auto-agent-adversarial`).

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T16:20:34.423126+00:00",
-  "commit_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6",
+  "regenerated_at": "2026-04-26T16:39:00.973692+00:00",
+  "commit_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313",
   "artifacts": {
     "loops.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "ports.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "labels.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "modules.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "events.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "adr_xref.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "mockworld.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "changelog.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     },
     "functional_areas.md": {
-      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
+      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T16:39:00.973692+00:00",
-  "commit_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313",
+  "regenerated_at": "2026-04-26T17:31:19.043371+00:00",
+  "commit_sha": "ff75db08d0ad889064583c3c1a79e003924a6115",
   "artifacts": {
     "loops.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "ports.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "labels.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "modules.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "events.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "adr_xref.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "mockworld.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "changelog.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     },
     "functional_areas.md": {
-      "source_sha": "e8cf734e591313dd2f8a3de19197cec0e96af313"
+      "source_sha": "ff75db08d0ad889064583c3c1a79e003924a6115"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,6 +1,6 @@
 {
-  "regenerated_at": "2026-04-26T17:10:52.972963+00:00",
-  "commit_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba",
+  "regenerated_at": "2026-04-26T16:20:34.423126+00:00",
+  "commit_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6",
   "artifacts": {
     "loops.md": {
       "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -57,7 +57,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0047 | `src.contract_diff`, `src.contract_recording`, `src.contract_refresh_loop` |
 | ADR-0048 | `src.staging_bisect_loop` |
 | ADR-0049 | `src.base_background_loop`, `src.bg_worker_manager` |
-| ADR-0050 | `src.auto_agent_preflight_loop`, `src.config`, `src.dashboard_routes._diagnostics_routes`, `src.models`, `src.preflight.agent`, `src.preflight.audit`, `src.preflight.context`, `src.preflight.decision`, `src.preflight.runner`, `src.sentry.reverse_lookup`, `src.state._auto_agent` |
+| ADR-0050 | `src.auto_agent_preflight_loop`, `src.config`, `src.dashboard_routes._diagnostics_routes`, `src.models`, `src.preflight.agent`, `src.preflight.audit`, `src.preflight.auto_agent_runner`, `src.preflight.context`, `src.preflight.decision`, `src.preflight.runner`, `src.sentry.reverse_lookup`, `src.state._auto_agent` |
 
 ## Module → ADRs
 
@@ -114,6 +114,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
 | `src.preflight.audit` | ADR-0050 |
+| `src.preflight.auto_agent_runner` | ADR-0050 |
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
@@ -146,4 +147,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -147,4 +147,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -147,4 +147,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
+- `172149d` — feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing) *(2026-04-26)*
 - `5837a29` — feat(arch): trust fleet topology page (curated) (#8438) (#8438) *(2026-04-26)*
 - `64e9f31` — fix(arch): lift modules.md drift exemption (root cause: stale baseline) (#8437) (#8437) *(2026-04-26)*
 - `67079aa` — docs(spec): Auto-Agent HITL pre-flight loop design (#8431) (#8431) *(2026-04-25)*
@@ -139,4 +140,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -139,4 +139,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
-- `172149d` — feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing) *(2026-04-26)*
+- `65fade3` — chore(arch): regen generated docs after rebase onto main *(2026-04-26)*
+- `146b6f8` — feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing) *(2026-04-26)*
+- `204084a` — feat(loop): wire DiagramLoop (L24) into runtime — five-checkpoint pattern (#8440) (#8440) *(2026-04-26)*
 - `5837a29` — feat(arch): trust fleet topology page (curated) (#8438) (#8438) *(2026-04-26)*
 - `64e9f31` — fix(arch): lift modules.md drift exemption (root cause: stale baseline) (#8437) (#8437) *(2026-04-26)*
 - `67079aa` — docs(spec): Auto-Agent HITL pre-flight loop design (#8431) (#8431) *(2026-04-25)*
@@ -140,4 +142,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -25,4 +25,4 @@ graph LR
     src_preflight -- "1" --> src_sentry
 ```
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -25,4 +25,4 @@ graph LR
     src_preflight -- "1" --> src_sentry
 ```
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,7 +16,7 @@ graph LR
     src_state["src.state"]
     src -- "4" --> src_arch
     src -- "3" --> src_dashboard_routes
-    src -- "9" --> src_preflight
+    src -- "10" --> src_preflight
     src -- "43" --> src_state
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "10" --> src_arch
@@ -25,4 +25,4 @@ graph LR
     src_preflight -- "1" --> src_sentry
 ```
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._
+_Regenerated from commit `ff75db0` on 2026-04-26 17:31 UTC. Source last changed at `ff75db0`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `e8cf734` on 2026-04-26 16:39 UTC. Source last changed at `e8cf734`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._
+_Regenerated from commit `67079aa` on 2026-04-26 16:20 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._

--- a/prompts/auto_agent/_envelope.md
+++ b/prompts/auto_agent/_envelope.md
@@ -48,11 +48,15 @@ honor-system but **violations will be caught post-hoc** by the principles
 audit and the resulting PR will fail CI — so a "fix" that modifies any of
 these will not actually merge.
 
-**Enforced by the Claude Code CLI (will return an error):**
+**Enforced by the Claude Code CLI when the implementation tool is `claude`
+(will return an error). For `codex` / `gemini` backends, the CLI flag is
+silently dropped — the runner emits a WARNING log when this happens, and
+this restriction becomes honor-system + post-hoc CI for that run.**
 
-- `WebFetch` — disabled via `--disallowedTools`. You must reason from the
-  context the loop already gathered (issue body, comments, escalation
-  context, wiki, sentry events, recent commits). Do not chase external URLs.
+- `WebFetch` — disabled via `--disallowedTools` on Claude. You must reason
+  from the context the loop already gathered (issue body, comments,
+  escalation context, wiki, sentry events, recent commits). Do not chase
+  external URLs regardless of which backend is in effect.
 
 **Enforced post-hoc by CI / principles audit (honor in your edits):**
 

--- a/prompts/auto_agent/_envelope.md
+++ b/prompts/auto_agent/_envelope.md
@@ -43,19 +43,35 @@ a precise diagnosis so a human can pick up where you left off.
 
 ## Tool restrictions
 
-You are NOT permitted to:
+The following restrictions apply. Some are enforced by the runtime; others are
+honor-system but **violations will be caught post-hoc** by the principles
+audit and the resulting PR will fail CI — so a "fix" that modifies any of
+these will not actually merge.
 
-- Modify any file under `.github/workflows/`
-- Modify branch protection or repo settings
-- Force-push, delete branches, or rewrite history
-- Read or write any file matching the secrets-allowlist (`.env`, `secrets.*`, etc.)
-- Approve or merge your own PR
-- Modify `src/principles_audit_loop.py`, `src/auto_agent_preflight_loop.py`, or
-  any ADR-0044 / ADR-0049 implementation file (recursion guard — you must not
-  modify the system that judges or governs you)
+**Enforced by the Claude Code CLI (will return an error):**
 
-These restrictions are enforced at the worktree-tool layer; calling forbidden
-tools will return errors. Do not attempt to circumvent them.
+- `WebFetch` — disabled via `--disallowedTools`. You must reason from the
+  context the loop already gathered (issue body, comments, escalation
+  context, wiki, sentry events, recent commits). Do not chase external URLs.
+
+**Enforced post-hoc by CI / principles audit (honor in your edits):**
+
+- Do not modify any file under `.github/workflows/`.
+- Do not modify branch protection or repo settings.
+- Do not force-push, delete branches, or rewrite history.
+- Do not read or write any file matching the secrets-allowlist
+  (`.env`, `secrets.*`, anything caught by the pre-commit secret scanner).
+- Do not approve or merge your own PR.
+- Do not modify `src/principles_audit_loop.py`,
+  `src/auto_agent_preflight_loop.py`, `src/preflight/auto_agent_runner.py`,
+  or any ADR-0044 / ADR-0049 / ADR-0050 implementation file. This is the
+  recursion guard: you must not modify the system that judges or governs
+  you. The principles audit will block any PR that touches these files
+  without an ADR amendment.
+
+If a fix genuinely requires touching one of the honor-system paths, return
+`needs_human` with a precise diagnosis of the constraint conflict. Do not
+attempt to work around the restriction.
 
 ## Decision protocol
 

--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -31,6 +31,7 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         wiki_store: Any | None,
         audit_store: Any,
         deps: LoopDeps,
+        workspaces: Any | None = None,
     ) -> None:
         super().__init__(
             worker_name="auto_agent_preflight",
@@ -42,6 +43,7 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         self._prs = pr_manager
         self._wiki_store = wiki_store
         self._audit_store = audit_store
+        self._workspaces = workspaces
 
     def _get_default_interval(self) -> int:
         return self._config.auto_agent_preflight_interval
@@ -215,51 +217,56 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         return {"status": result.status, "issue": issue_number}
 
     def _build_spawn_fn(self, issue_number: int):
-        """Returns the actual subprocess-spawning callable. Replaced in tests.
+        """Returns the spawn callable that runs the auto-agent subprocess.
 
-        **PARTIAL LANDING — placeholder, not the production HITLRunner spawn.**
-
-        In production this should subclass HITLRunner (per ADR-0050) and spawn
-        a Claude Code subprocess with the auto-agent prompt envelope + tool
-        restrictions. Wiring that subprocess is deferred to a follow-up PR
-        (tracked under ADR-0050 §Consequences). Until then, every pre-flight
-        attempt returns `needs_human` with $0 cost — which is observable on the
-        dashboard (resolution_rate stays at 0 and spend_usd stays at $0) so
-        operators can see the placeholder is in effect.
-
-        Tests monkeypatch this to inject a cassette `PreflightSpawn` so the
-        full pipeline can be exercised end-to-end without a real subprocess.
+        Each call constructs a fresh `AutoAgentRunner` (lifetime bounded by
+        the single attempt) so the runner's internal subprocess set doesn't
+        leak across attempts. Tests monkeypatch this method to inject a
+        cassette `PreflightSpawn` and skip the real subprocess.
         """
         from preflight.agent import PreflightSpawn
+        from preflight.auto_agent_runner import AutoAgentRunner
 
-        async def _placeholder(prompt: str, worktree_path: str) -> PreflightSpawn:
-            # See class docstring above — when dashboard shows zero spend +
-            # zero resolved, the production wiring is still pending.
-            return PreflightSpawn(
-                process=None,
-                output_text=(
-                    "<status>needs_human</status>"
-                    "<diagnosis>auto-agent spawn_fn is a placeholder; "
-                    "production HITLRunner integration pending (ADR-0050 §Consequences)."
-                    "</diagnosis>"
-                ),
-                cost_usd=0.0,
-                tokens=0,
-                crashed=False,
+        runner = AutoAgentRunner(config=self._config, event_bus=self._bus)
+
+        async def _spawn(prompt: str, worktree_path: str) -> PreflightSpawn:
+            return await runner.run(
+                prompt=prompt,
+                worktree_path=worktree_path,
+                issue_number=issue_number,
             )
 
-        return _placeholder
+        return _spawn
 
     async def _resolve_worktree(self, issue_number: int) -> str:
-        """Return worktree path for the issue.
+        """Return the path to the per-issue worktree.
 
-        Currently returns the main repo root as a placeholder. Once
-        `_build_spawn_fn` is upgraded to the real HITLRunner integration
-        (see ADR-0050 §Partial landing), this should resolve to the
-        per-issue worktree managed by `WorkspacePort` so the agent operates
-        on the issue's own branch instead of main.
+        Mirrors the diagnostic-loop pattern: use the conventional
+        `workspace_path_for_issue` and create on demand if a `WorkspacePort`
+        was injected and the path doesn't exist. Falls back to `repo_root`
+        when no port is wired (test fixtures, dry-run mode).
         """
-        return str(self._config.repo_root)
+        if self._workspaces is None:
+            return str(self._config.repo_root)
+        wt_path = self._config.workspace_path_for_issue(issue_number)
+        if wt_path.exists():
+            return str(wt_path)
+        branch = f"agent/auto-agent-{issue_number}"
+        try:
+            created = await self._workspaces.create(issue_number, branch)
+            return str(created)
+        except Exception as exc:
+            # Workspace creation can fail (concurrent worktree, branch
+            # collision, disk pressure). Degrade to repo_root so the
+            # agent still gets a valid cwd; the agent itself can handle
+            # the lack of a per-issue branch by reporting needs_human.
+            logger.warning(
+                "auto-agent worktree creation failed for #%d: %s — "
+                "falling back to repo_root",
+                issue_number,
+                exc,
+            )
+            return str(self._config.repo_root)
 
 
 def _skip_audit(issue: int, sub_label: str, reason: str):

--- a/src/preflight/auto_agent_runner.py
+++ b/src/preflight/auto_agent_runner.py
@@ -171,7 +171,6 @@ class AutoAgentRunner:
                     issue_number,
                     exc,
                 )
-                last_auth_error = None
                 break
 
         if last_auth_error is not None:

--- a/src/preflight/auto_agent_runner.py
+++ b/src/preflight/auto_agent_runner.py
@@ -1,0 +1,187 @@
+"""AutoAgentRunner — Claude Code subprocess spawn for AutoAgentPreflightLoop.
+
+Wraps the standard `stream_claude_process` subprocess pattern with the
+auto-agent-specific:
+
+- tool restrictions (spec §5.2 — `--disallowedTools` flag carries the CLI
+  restrictions; file-path restrictions are reinforced in the prompt envelope).
+- prompt-hash + cost-capture for the `PreflightSpawn` return contract.
+- telemetry recording so dashboard cost rollups include auto-agent runs
+  alongside other phases (`source="auto_agent_preflight"`).
+
+This module replaces the placeholder `_build_spawn_fn` in
+`src/auto_agent_preflight_loop.py`. Tests for this module monkeypatch
+`stream_claude_process` to avoid real subprocess invocation; the
+end-to-end scenario tests still mock at the `_build_spawn_fn` layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from pathlib import Path
+
+from agent_cli import build_agent_command
+from config import HydraFlowConfig
+from events import EventBus
+from model_pricing import load_pricing
+from preflight.agent import PreflightSpawn, hash_prompt
+from prompt_telemetry import PromptTelemetry
+from runner_utils import StreamConfig, stream_claude_process
+
+logger = logging.getLogger("hydraflow.preflight.auto_agent_runner")
+
+
+# Spec §5.2 — tools the auto-agent must NOT use.
+#
+# The Claude Code CLI's `--disallowedTools` flag enforces tool-name
+# restrictions. File-path restrictions (no `.github/workflows/`, no
+# secrets, no auto-agent self-modification, etc.) are enforced in the
+# prompt envelope (`prompts/auto_agent/_envelope.md`) and rely on the
+# agent honouring the constraint — there is no path-level CLI gate.
+#
+# `WebFetch` is disabled because the auto-agent should reason from the
+# context the loop gathered (wiki + sentry + recent commits + escalation
+# context), not chase arbitrary external URLs that could leak issue
+# content or pull in malicious instructions.
+_AUTO_AGENT_DISALLOWED_TOOLS = "WebFetch"
+
+
+def _coerce_int(value: object) -> int:
+    """Best-effort int coercion for usage_stats values from streaming parsers.
+
+    Stream parsers may emit ints, strings, or even Decimal — coerce safely
+    and clamp to >= 0 since negative token counts are nonsense.
+    """
+    try:
+        return max(0, int(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+class AutoAgentRunner:
+    """Spawns a Claude Code subprocess for one auto-agent attempt.
+
+    One instance per attempt; lifetime is bounded by `run()`.
+    """
+
+    def __init__(self, *, config: HydraFlowConfig, event_bus: EventBus) -> None:
+        self._config = config
+        self._bus = event_bus
+        self._active_procs: set[asyncio.subprocess.Process] = set()
+        self._telemetry = PromptTelemetry(config)
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        worktree_path: str,
+        issue_number: int,
+    ) -> PreflightSpawn:
+        """Run one attempt; return a `PreflightSpawn` with cost + crash status.
+
+        Never raises — any subprocess failure is collapsed into
+        `PreflightSpawn(crashed=True, ...)` so the upstream PreflightAgent
+        can map it to a `fatal` PreflightResult.
+        """
+        cmd = build_agent_command(
+            tool=self._config.implementation_tool,
+            model=self._config.model,
+            disallowed_tools=_AUTO_AGENT_DISALLOWED_TOOLS,
+        )
+        usage_stats: dict[str, object] = {}
+        prompt_hash = hash_prompt(prompt)
+        # Wall-clock cap defaults to the loop-wide config; if the operator
+        # has set `auto_agent_wall_clock_cap_s`, honour it as the subprocess
+        # timeout. None → fall back to the codebase-wide `agent_timeout`.
+        timeout_s = (
+            self._config.auto_agent_wall_clock_cap_s or self._config.agent_timeout
+        )
+        start = time.monotonic()
+        crashed = False
+        transcript = ""
+        try:
+            transcript = await stream_claude_process(
+                cmd=cmd,
+                prompt=prompt,
+                cwd=Path(worktree_path),
+                active_procs=self._active_procs,
+                event_bus=self._bus,
+                event_data={
+                    "issue": issue_number,
+                    "source": "auto_agent_preflight",
+                },
+                logger=logger,
+                config=StreamConfig(
+                    timeout=timeout_s,
+                    usage_stats=usage_stats,
+                ),
+            )
+        except Exception as exc:
+            crashed = True
+            # Preserve any partial transcript captured before the failure
+            # plus the exception message for the diagnosis comment.
+            tail = transcript[-2000:] if transcript else ""
+            transcript = f"{tail}\n\nspawn error: {exc}"
+            logger.warning(
+                "auto-agent subprocess failed for issue #%d: %s",
+                issue_number,
+                exc,
+            )
+        wall_s = time.monotonic() - start
+
+        # Telemetry — best-effort write to the inferences.jsonl stream so
+        # dashboard cost rollups include auto-agent attempts.
+        try:
+            self._telemetry.record(
+                source="auto_agent_preflight",
+                tool=self._config.implementation_tool,
+                model=self._config.model,
+                issue_number=issue_number,
+                pr_number=None,
+                session_id=self._bus.current_session_id,
+                prompt_chars=len(prompt),
+                transcript_chars=len(transcript),
+                duration_seconds=wall_s,
+                success=not crashed,
+                stats=usage_stats,
+            )
+        except Exception as exc:
+            logger.warning("auto-agent telemetry write failed: %s", exc)
+
+        cost_usd = self._estimate_cost(usage_stats)
+        tokens = _coerce_int(usage_stats.get("total_tokens"))
+
+        return PreflightSpawn(
+            process=None,
+            output_text=transcript,
+            cost_usd=cost_usd,
+            tokens=tokens,
+            crashed=crashed,
+            prompt_hash=prompt_hash,
+        )
+
+    def _estimate_cost(self, usage_stats: dict[str, object]) -> float:
+        """Best-effort cost estimate from the usage_stats the parser populated.
+
+        Returns 0.0 when the model isn't in the pricing table or stats are
+        missing — avoids breaking the loop on a pricing-table miss.
+        """
+        try:
+            pricing = load_pricing()
+            estimate = pricing.estimate_cost(
+                model=self._config.model,
+                input_tokens=_coerce_int(usage_stats.get("input_tokens")),
+                output_tokens=_coerce_int(usage_stats.get("output_tokens")),
+                cache_write_tokens=_coerce_int(
+                    usage_stats.get("cache_creation_input_tokens")
+                ),
+                cache_read_tokens=_coerce_int(
+                    usage_stats.get("cache_read_input_tokens")
+                ),
+            )
+            return float(estimate or 0.0)
+        except Exception as exc:
+            logger.warning("auto-agent cost estimate failed: %s", exc)
+            return 0.0

--- a/src/preflight/auto_agent_runner.py
+++ b/src/preflight/auto_agent_runner.py
@@ -25,12 +25,19 @@ from pathlib import Path
 from agent_cli import build_agent_command
 from config import HydraFlowConfig
 from events import EventBus
+from exception_classify import reraise_on_credit_or_bug
 from model_pricing import load_pricing
 from preflight.agent import PreflightSpawn, hash_prompt
 from prompt_telemetry import PromptTelemetry
-from runner_utils import StreamConfig, stream_claude_process
+from runner_utils import AuthenticationRetryError, StreamConfig, stream_claude_process
 
 logger = logging.getLogger("hydraflow.preflight.auto_agent_runner")
+
+
+# Match BaseRunner's auth-retry budget so transient OAuth blips don't burn
+# the per-issue attempt cap. Three tries with exponential backoff: 5s, 10s, 20s.
+_AUTH_RETRY_MAX = 3
+_AUTH_RETRY_BASE_DELAY = 5.0  # seconds
 
 
 # Spec §5.2 — tools the auto-agent must NOT use.
@@ -85,6 +92,19 @@ class AutoAgentRunner:
         `PreflightSpawn(crashed=True, ...)` so the upstream PreflightAgent
         can map it to a `fatal` PreflightResult.
         """
+        # `--disallowedTools=WebFetch` is silently dropped by build_agent_command
+        # for codex/gemini backends (they don't take that flag). Warn so the
+        # operator knows the CLI-level guard isn't active for that backend —
+        # the path-level honor-system in the prompt envelope is the only
+        # remaining restriction layer.
+        if self._config.implementation_tool != "claude":
+            logger.warning(
+                "auto-agent: --disallowedTools is only enforced for the claude "
+                "backend; current implementation_tool=%s — WebFetch restriction "
+                "is honor-system + post-hoc CI for this run",
+                self._config.implementation_tool,
+            )
+
         cmd = build_agent_command(
             tool=self._config.implementation_tool,
             model=self._config.model,
@@ -92,42 +112,78 @@ class AutoAgentRunner:
         )
         usage_stats: dict[str, object] = {}
         prompt_hash = hash_prompt(prompt)
-        # Wall-clock cap defaults to the loop-wide config; if the operator
-        # has set `auto_agent_wall_clock_cap_s`, honour it as the subprocess
-        # timeout. None → fall back to the codebase-wide `agent_timeout`.
         timeout_s = (
             self._config.auto_agent_wall_clock_cap_s or self._config.agent_timeout
         )
         start = time.monotonic()
         crashed = False
         transcript = ""
-        try:
-            transcript = await stream_claude_process(
-                cmd=cmd,
-                prompt=prompt,
-                cwd=Path(worktree_path),
-                active_procs=self._active_procs,
-                event_bus=self._bus,
-                event_data={
-                    "issue": issue_number,
-                    "source": "auto_agent_preflight",
-                },
-                logger=logger,
-                config=StreamConfig(
-                    timeout=timeout_s,
-                    usage_stats=usage_stats,
-                ),
-            )
-        except Exception as exc:
+
+        # Auth-retry loop — mirrors BaseRunner._execute. AuthenticationRetryError
+        # is a transient OAuth blip; retry up to _AUTH_RETRY_MAX times with
+        # exponential backoff before giving up. CreditExhaustedError and
+        # AuthenticationError (terminal) propagate via reraise_on_credit_or_bug
+        # so the caretaker loop's outer handler can suspend ticking.
+        last_auth_error: AuthenticationRetryError | None = None
+        for attempt in range(1, _AUTH_RETRY_MAX + 1):
+            try:
+                transcript = await stream_claude_process(
+                    cmd=cmd,
+                    prompt=prompt,
+                    cwd=Path(worktree_path),
+                    active_procs=self._active_procs,
+                    event_bus=self._bus,
+                    event_data={
+                        "issue": issue_number,
+                        "source": "auto_agent_preflight",
+                    },
+                    logger=logger,
+                    config=StreamConfig(
+                        timeout=timeout_s,
+                        usage_stats=usage_stats,
+                    ),
+                )
+                last_auth_error = None
+                break
+            except AuthenticationRetryError as exc:
+                last_auth_error = exc
+                if attempt < _AUTH_RETRY_MAX:
+                    delay = _AUTH_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                    logger.warning(
+                        "auto-agent auth retry %d/%d for issue #%d, sleeping %.0fs: %s",
+                        attempt,
+                        _AUTH_RETRY_MAX,
+                        issue_number,
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+            except Exception as exc:
+                # Credit exhaustion / terminal auth / programming bugs propagate
+                # so the loop can suspend or surface the bug; everything else
+                # collapses to crashed=True with a partial transcript.
+                reraise_on_credit_or_bug(exc)
+                crashed = True
+                tail = transcript[-2000:] if transcript else ""
+                transcript = f"{tail}\n\nspawn error: {exc}"
+                logger.warning(
+                    "auto-agent subprocess failed for issue #%d: %s",
+                    issue_number,
+                    exc,
+                )
+                last_auth_error = None
+                break
+
+        if last_auth_error is not None:
             crashed = True
-            # Preserve any partial transcript captured before the failure
-            # plus the exception message for the diagnosis comment.
-            tail = transcript[-2000:] if transcript else ""
-            transcript = f"{tail}\n\nspawn error: {exc}"
-            logger.warning(
-                "auto-agent subprocess failed for issue #%d: %s",
+            transcript = (
+                f"{transcript}\n\nauth retry exhausted after "
+                f"{_AUTH_RETRY_MAX} attempts: {last_auth_error}"
+            )
+            logger.error(
+                "auto-agent auth retry exhausted for issue #%d after %d attempts",
                 issue_number,
-                exc,
+                _AUTH_RETRY_MAX,
             )
         wall_s = time.monotonic() - start
 

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -868,6 +868,7 @@ def build_services(
         wiki_store=repo_wiki_store,
         audit_store=auto_agent_audit_store,
         deps=loop_deps,
+        workspaces=workspaces,
     )
 
     return ServiceRegistry(

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -594,6 +594,7 @@ def _build_auto_agent_preflight(ports: dict[str, Any], config: Any, deps: Any) -
         wiki_store=ports.get("repo_wiki_store"),
         audit_store=audit_store,
         deps=deps,
+        workspaces=ports.get("workspaces"),
     )
 
 

--- a/tests/test_auto_agent_preflight_loop.py
+++ b/tests/test_auto_agent_preflight_loop.py
@@ -150,3 +150,94 @@ async def test_attempt_cap_marks_exhausted(tmp_path: Path) -> None:
         1, ["human-required", "auto-agent-exhausted"]
     )
     assert result["result_status"] == "skipped_exhausted"
+
+
+@pytest.mark.asyncio
+async def test_resolve_worktree_no_workspaces_falls_back_to_repo_root(
+    tmp_path: Path,
+) -> None:
+    """Without an injected WorkspacePort, _resolve_worktree returns repo_root."""
+    loop, _ = _make_loop(tmp_path)
+    assert loop._workspaces is None
+    out = await loop._resolve_worktree(42)
+    assert out == str(loop._config.repo_root)
+
+
+@pytest.mark.asyncio
+async def test_resolve_worktree_uses_existing_path(tmp_path: Path) -> None:
+    """If the conventional worktree path already exists, return it without
+    calling workspaces.create (mirrors diagnostic_loop pattern)."""
+    deps = make_bg_loop_deps(tmp_path)
+    workspaces = AsyncMock()
+    # Pre-create the conventional path so .exists() returns True.
+    wt_path = deps.config.workspace_path_for_issue(42)
+    wt_path.mkdir(parents=True, exist_ok=True)
+
+    state = MagicMock()
+    state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
+    audit = MagicMock()
+    loop = AutoAgentPreflightLoop(
+        config=deps.config,
+        state=state,
+        pr_manager=AsyncMock(),
+        wiki_store=None,
+        audit_store=audit,
+        deps=deps.loop_deps,
+        workspaces=workspaces,
+    )
+    out = await loop._resolve_worktree(42)
+    assert out == str(wt_path)
+    workspaces.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_worktree_creates_when_missing(tmp_path: Path) -> None:
+    """When the worktree path is absent and a WorkspacePort is wired, the
+    loop calls workspaces.create with the auto-agent branch convention."""
+    deps = make_bg_loop_deps(tmp_path)
+    workspaces = AsyncMock()
+    created_path = tmp_path / "new-worktree"
+    created_path.mkdir()
+    workspaces.create = AsyncMock(return_value=created_path)
+
+    state = MagicMock()
+    state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
+    audit = MagicMock()
+    loop = AutoAgentPreflightLoop(
+        config=deps.config,
+        state=state,
+        pr_manager=AsyncMock(),
+        wiki_store=None,
+        audit_store=audit,
+        deps=deps.loop_deps,
+        workspaces=workspaces,
+    )
+    out = await loop._resolve_worktree(99)
+    assert out == str(created_path)
+    workspaces.create.assert_awaited_with(99, "agent/auto-agent-99")
+
+
+@pytest.mark.asyncio
+async def test_resolve_worktree_falls_back_on_create_failure(
+    tmp_path: Path,
+) -> None:
+    """workspaces.create() failure (e.g., concurrent worktree, branch
+    collision) gracefully degrades to repo_root rather than crashing the loop."""
+    deps = make_bg_loop_deps(tmp_path)
+    workspaces = AsyncMock()
+    workspaces.create = AsyncMock(side_effect=RuntimeError("worktree busy"))
+
+    state = MagicMock()
+    state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
+    audit = MagicMock()
+    loop = AutoAgentPreflightLoop(
+        config=deps.config,
+        state=state,
+        pr_manager=AsyncMock(),
+        wiki_store=None,
+        audit_store=audit,
+        deps=deps.loop_deps,
+        workspaces=workspaces,
+    )
+    out = await loop._resolve_worktree(99)
+    assert out == str(deps.config.repo_root)

--- a/tests/test_preflight_auto_agent_runner.py
+++ b/tests/test_preflight_auto_agent_runner.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -207,3 +207,88 @@ async def test_zero_usage_stats_yields_zero_cost(tmp_path: Path) -> None:
         )
     assert spawn.cost_usd == 0.0
     assert spawn.tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_credit_exhausted_propagates(tmp_path: Path) -> None:
+    """CreditExhaustedError must propagate so the caretaker loop can suspend.
+
+    Catching it inside the broad `except Exception` would silently burn the
+    attempt budget while the credit balance was already gone — exactly the
+    regression that PR review C1 caught.
+    """
+    from subprocess_util import CreditExhaustedError
+
+    async def credit_exhausted(**kwargs: Any) -> str:
+        raise CreditExhaustedError("api credits at zero")
+
+    runner = _make_runner()
+    with (
+        patch(
+            "preflight.auto_agent_runner.stream_claude_process",
+            side_effect=credit_exhausted,
+        ),
+        pytest.raises(CreditExhaustedError),
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
+
+
+@pytest.mark.asyncio
+async def test_auth_retry_then_success(tmp_path: Path) -> None:
+    """First two AuthenticationRetryError attempts retry with backoff; third
+    succeeds. Final spawn must NOT be marked crashed.
+    """
+    from runner_utils import AuthenticationRetryError
+
+    call_count = 0
+
+    async def fake_stream(**kwargs: Any) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise AuthenticationRetryError("transient OAuth blip")
+        return "<status>resolved</status><pr_url>x</pr_url><diagnosis>ok</diagnosis>"
+
+    runner = _make_runner()
+    with (
+        patch(
+            "preflight.auto_agent_runner.stream_claude_process",
+            side_effect=fake_stream,
+        ),
+        patch(
+            "preflight.auto_agent_runner.asyncio.sleep",  # skip backoff in tests
+            new_callable=AsyncMock,
+        ),
+    ):
+        spawn = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert call_count == 3
+    assert spawn.crashed is False
+    assert "<status>resolved</status>" in spawn.output_text
+
+
+@pytest.mark.asyncio
+async def test_auth_retry_exhausted_marks_crashed(tmp_path: Path) -> None:
+    """Three consecutive AuthenticationRetryError exhausts retries → crashed."""
+    from runner_utils import AuthenticationRetryError
+
+    async def always_auth_fail(**kwargs: Any) -> str:
+        raise AuthenticationRetryError("OAuth token refresh broken")
+
+    runner = _make_runner()
+    with (
+        patch(
+            "preflight.auto_agent_runner.stream_claude_process",
+            side_effect=always_auth_fail,
+        ),
+        patch(
+            "preflight.auto_agent_runner.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        spawn = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert spawn.crashed is True
+    assert "auth retry exhausted" in spawn.output_text

--- a/tests/test_preflight_auto_agent_runner.py
+++ b/tests/test_preflight_auto_agent_runner.py
@@ -1,0 +1,209 @@
+"""AutoAgentRunner tests (spec §3.3, §5.2; ADR-0050).
+
+Mocks `stream_claude_process` at the module boundary so no real Claude
+Code subprocess is spawned. Verifies:
+
+- the command carries `--disallowedTools=WebFetch` (spec §5.2);
+- the wall-clock cap from config flows into StreamConfig.timeout;
+- `cwd` is the worktree path the loop resolved;
+- `event_data.source == "auto_agent_preflight"` so dashboard cost rollups
+  attribute spend correctly;
+- usage_stats parsed by stream_claude_process flow into PreflightSpawn
+  (cost_usd, tokens, prompt_hash);
+- subprocess crashes collapse to `crashed=True` with a partial transcript
+  preserved — never raises;
+- telemetry write failure is logged but doesn't fail the run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from preflight.auto_agent_runner import AutoAgentRunner
+from tests.helpers import ConfigFactory
+
+
+def _make_runner(**config_overrides: Any) -> AutoAgentRunner:
+    config = ConfigFactory.create(**config_overrides)
+    bus = MagicMock()
+    bus.current_session_id = "test-session"
+    return AutoAgentRunner(config=config, event_bus=bus)
+
+
+@pytest.mark.asyncio
+async def test_run_returns_spawn_with_cost_and_tokens(tmp_path: Path) -> None:
+    """Happy path: streamer populates usage_stats; cost + tokens flow into spawn."""
+
+    async def fake_stream(*, config, **kwargs: Any) -> str:
+        # Mimic StreamParser populating usage_stats during streaming.
+        config.usage_stats["input_tokens"] = 1000
+        config.usage_stats["output_tokens"] = 500
+        config.usage_stats["total_tokens"] = 1500
+        return "<status>resolved</status><pr_url>https://x/pr/1</pr_url><diagnosis>fixed</diagnosis>"
+
+    runner = _make_runner()
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=fake_stream,
+    ):
+        spawn = await runner.run(
+            prompt="hello",
+            worktree_path=str(tmp_path),
+            issue_number=42,
+        )
+    assert spawn.crashed is False
+    assert spawn.tokens == 1500
+    assert spawn.prompt_hash.startswith("sha256:")
+    assert "<status>resolved</status>" in spawn.output_text
+    # cost_usd may be 0 if the test config's model isn't in the pricing
+    # table; the contract is that it's a non-negative float.
+    assert spawn.cost_usd >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_run_passes_disallowed_tools_to_command(tmp_path: Path) -> None:
+    """Spec §5.2: WebFetch must be in --disallowedTools so the agent can't
+    chase arbitrary URLs (issue-content leak / prompt-injection vector)."""
+    captured: dict[str, Any] = {}
+
+    async def capture_stream(*, cmd, **kwargs: Any) -> str:
+        captured["cmd"] = cmd
+        return ""
+
+    runner = _make_runner()
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=capture_stream,
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
+
+    cmd = captured["cmd"]
+    # --disallowedTools value must be the next arg after the flag.
+    assert "--disallowedTools" in cmd
+    idx = cmd.index("--disallowedTools")
+    assert "WebFetch" in cmd[idx + 1]
+
+
+@pytest.mark.asyncio
+async def test_run_passes_wall_clock_cap_to_stream_timeout(tmp_path: Path) -> None:
+    """auto_agent_wall_clock_cap_s flows into StreamConfig.timeout so the
+    subprocess is killed at the operator-set bound, not the codebase
+    default (1h)."""
+    captured: dict[str, Any] = {}
+
+    async def capture_stream(*, config, **kwargs: Any) -> str:
+        captured["timeout"] = config.timeout
+        return ""
+
+    runner = _make_runner(auto_agent_wall_clock_cap_s=180)
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=capture_stream,
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
+
+    assert captured["timeout"] == 180
+
+
+@pytest.mark.asyncio
+async def test_run_passes_worktree_as_cwd(tmp_path: Path) -> None:
+    """The agent must execute inside the issue's worktree, not the main repo."""
+    captured: dict[str, Any] = {}
+
+    async def capture_stream(*, cwd, **kwargs: Any) -> str:
+        captured["cwd"] = cwd
+        return ""
+
+    runner = _make_runner()
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=capture_stream,
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
+    assert captured["cwd"] == tmp_path
+
+
+@pytest.mark.asyncio
+async def test_run_event_data_source_is_auto_agent_preflight(tmp_path: Path) -> None:
+    """Telemetry source string must be 'auto_agent_preflight' so cost
+    rollups attribute spend correctly."""
+    captured: dict[str, Any] = {}
+
+    async def capture_stream(*, event_data, **kwargs: Any) -> str:
+        captured["event_data"] = event_data
+        return ""
+
+    runner = _make_runner()
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=capture_stream,
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=99)
+    assert captured["event_data"]["source"] == "auto_agent_preflight"
+    assert captured["event_data"]["issue"] == 99
+
+
+@pytest.mark.asyncio
+async def test_subprocess_exception_collapses_to_crashed_spawn(tmp_path: Path) -> None:
+    """Spec contract: AutoAgentRunner.run never raises — every failure is a
+    PreflightSpawn(crashed=True). Upstream PreflightAgent maps to fatal."""
+
+    async def boom(**kwargs: Any) -> str:
+        raise RuntimeError("subprocess oom")
+
+    runner = _make_runner()
+    with patch("preflight.auto_agent_runner.stream_claude_process", side_effect=boom):
+        spawn = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert spawn.crashed is True
+    assert "spawn error" in spawn.output_text
+    assert "subprocess oom" in spawn.output_text
+
+
+@pytest.mark.asyncio
+async def test_telemetry_write_failure_does_not_break_run(tmp_path: Path) -> None:
+    """If PromptTelemetry.record raises, the loop must still get a usable
+    PreflightSpawn back. We don't want a JSONL write hiccup to wedge the
+    auto-agent loop."""
+
+    async def stream_ok(**kwargs: Any) -> str:
+        return "<status>needs_human</status><diagnosis>x</diagnosis>"
+
+    runner = _make_runner()
+    runner._telemetry = MagicMock()
+    runner._telemetry.record = MagicMock(side_effect=OSError("disk full"))
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=stream_ok,
+    ):
+        spawn = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    # Run completed even though telemetry failed.
+    assert spawn.crashed is False
+    assert spawn.output_text
+
+
+@pytest.mark.asyncio
+async def test_zero_usage_stats_yields_zero_cost(tmp_path: Path) -> None:
+    """When the streamer doesn't populate usage_stats (e.g., stream parse
+    failure), cost defaults to 0.0 — never a negative or NaN."""
+
+    async def stream_no_stats(**kwargs: Any) -> str:
+        return ""
+
+    runner = _make_runner()
+    with patch(
+        "preflight.auto_agent_runner.stream_claude_process",
+        side_effect=stream_no_stats,
+    ):
+        spawn = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert spawn.cost_usd == 0.0
+    assert spawn.tokens == 0


### PR DESCRIPTION
## Summary

Replaces the placeholder \`_build_spawn_fn\` in the Auto-Agent HITL pre-flight loop (PR #8431) with the production-ready Claude Code subprocess spawner. The loop will now actually attempt to fix issues — flips Auto-Agent from \"shipped, observable, idle\" to \"actively resolving\".

## What lands

- **\`src/preflight/auto_agent_runner.py\`** — new \`AutoAgentRunner\` module. Wraps \`stream_claude_process\` for the auto-agent: \`--disallowedTools=WebFetch\` per spec §5.2, telemetry to \`inferences.jsonl\` with \`source=\"auto_agent_preflight\"\` so cost rollups attribute correctly, model-pricing-derived cost in the \`PreflightSpawn\`. Never raises — subprocess failures collapse to \`crashed=True\`.
- **\`AutoAgentPreflightLoop\`** — \`_build_spawn_fn\` constructs the runner per attempt; \`_resolve_worktree\` now uses the injected \`WorkspacePort\` (mirrors \`diagnostic_loop\` pattern) with graceful fallback to \`repo_root\` if worktree creation fails.
- **\`service_registry.py\`** — wires \`workspaces=workspaces\` into the loop constructor.
- **\`prompts/auto_agent/_envelope.md\`** — accuracy pass on the tool-restrictions block. \`WebFetch\` is genuinely enforced at the CLI level; path-level restrictions (\`.github/workflows\`, secrets, self-modification, ADR-0044/49/50 files) are honor-system + post-hoc CI / principles-audit enforcement. Previous wording overclaimed runtime enforcement.
- **ADR-0050 §Consequences** — \"Partial landing\" note replaced with \"Production subprocess wiring — landed\".

## Test plan

- [x] \`uv run pytest tests/test_preflight_auto_agent_runner.py\` — 8 new runner tests pass (happy path, \`--disallowedTools\` wiring, wall-clock cap → timeout, worktree as cwd, telemetry source, crash → \`crashed=True\`, telemetry-write tolerance, zero-stats → zero cost).
- [x] All 121 auto-agent + scenario + integration tests pass.
- [x] \`make quality\` — **11,711 passed**, 7 skipped, 0 failures.
- [x] \`make arch-regen\` ran; generated docs updated.

## Operational notes

After merge, the dashboard's \`resolution_rate\` and \`spend_usd\` will start showing real values. Operators can:
- Set caps via \`HYDRAFLOW_AUTO_AGENT_COST_CAP_USD\` / \`HYDRAFLOW_AUTO_AGENT_DAILY_BUDGET_USD\` if they want bounds (default unlimited; observability-first per spec §5.1).
- Set \`HYDRAFLOW_AUTO_AGENT_PREFLIGHT_ENABLED=false\` to deploy-time disable.
- Watch the \`Auto-Agent\` System tab tile for cost / resolution-rate visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Skip-ADR: src/service_registry.py change is purely wiring (one line: pass workspaces=workspaces into the AutoAgentPreflightLoop constructor) for the ADR-0050 follow-up. It does not modify the trust-fleet architecture that ADR-0045 governs — the same loop registration pattern as every other caretaker loop in the registry.
