### PR TITLE
feat(loop): wire DiagramLoop (L24) into runtime — five-checkpoint pattern

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T16:10:13.458474+00:00",
-  "commit_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6",
+  "regenerated_at": "2026-04-26T17:10:52.972963+00:00",
+  "commit_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba",
   "artifacts": {
     "loops.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "ports.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "labels.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "modules.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "events.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "adr_xref.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "mockworld.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "changelog.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     },
     "functional_areas.md": {
-      "source_sha": "67079aa8a7db50b530eebd795f8280db8d4019b6"
+      "source_sha": "acc497e087d6fe63c071d6e70809464bbabc39ba"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -146,4 +146,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
+- `5837a29` — feat(arch): trust fleet topology page (curated) (#8438) (#8438) *(2026-04-26)*
+- `64e9f31` — fix(arch): lift modules.md drift exemption (root cause: stale baseline) (#8437) (#8437) *(2026-04-26)*
 - `67079aa` — docs(spec): Auto-Agent HITL pre-flight loop design (#8431) (#8431) *(2026-04-25)*
 - `70392a6` — fix(arch): correct GitHub org in all site URLs (#8435) (#8435) *(2026-04-25)*
 - `f893069` — feat(arch): Plan C — DiagramLoop (L24) + CI guard + Pages site (#8434) (#8434) *(2026-04-25)*
@@ -137,4 +139,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -25,4 +25,4 @@ graph LR
     src_preflight -- "1" --> src_sentry
 ```
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `67079aa` on 2026-04-26 16:10 UTC. Source last changed at `67079aa`. Status: 🟢 fresh._
+_Regenerated from commit `acc497e` on 2026-04-26 17:10 UTC. Source last changed at `acc497e`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -64,6 +64,7 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "contract_refresh": (86400, 2_592_000),  # 1d min, 30d max
     "corpus_learning": (3600, 2_592_000),  # 1h min, 30d max
     "auto_agent_preflight": (60, 600),  # 1m min, 10m max (ADR-0049)
+    "diagram_loop": (3600, 86400),  # 1h min, 1d max (default 4h, ADR-0029)
 }
 
 # Internal pipeline labels that must not be treated as epic names in the history panel.

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -172,6 +172,7 @@ class HydraFlowOrchestrator:
             "contract_refresh": svc.contract_refresh_loop,
             "corpus_learning": svc.corpus_learning_loop,
             "auto_agent_preflight": svc.auto_agent_preflight_loop,
+            "diagram_loop": svc.diagram_loop,
         }
         self._bg_workers = BGWorkerManager(config, self._state, bg_loop_registry)
         # Loops that need a reference to BGWorkerManager cannot take one
@@ -955,6 +956,7 @@ class HydraFlowOrchestrator:
             ("contract_refresh", self._svc.contract_refresh_loop.run),
             ("corpus_learning", self._svc.corpus_learning_loop.run),
             ("auto_agent_preflight", self._svc.auto_agent_preflight_loop.run),
+            ("diagram_loop", self._svc.diagram_loop.run),
         ]
 
         # Hindsight WAL replay loop removed in Phase 3 cutover — the wiki

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -27,6 +27,7 @@ from crate_manager import CrateManager
 from dependabot_merge_loop import DependabotMergeLoop
 from diagnostic_loop import DiagnosticLoop  # noqa: TCH001
 from diagnostic_runner import DiagnosticRunner
+from diagram_loop import DiagramLoop  # noqa: TCH001
 from discover_phase import DiscoverPhase  # noqa: TCH001
 from discover_runner import DiscoverRunner
 from docker_runner import get_docker_runner
@@ -182,6 +183,7 @@ class ServiceRegistry:
     contract_refresh_loop: ContractRefreshLoop
     corpus_learning_loop: CorpusLearningLoop
     auto_agent_preflight_loop: AutoAgentPreflightLoop
+    diagram_loop: DiagramLoop
 
     # Optional integrations
 
@@ -736,6 +738,11 @@ def build_services(
         credentials=credentials,
         tribal_store=tribal_wiki_store,
     )
+    diagram_loop = DiagramLoop(
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
     diagnostic_runner = DiagnosticRunner(config=config, event_bus=event_bus)
     diagnostic_loop = DiagnosticLoop(
         config=config,
@@ -927,4 +934,5 @@ def build_services(
         contract_refresh_loop=contract_refresh_loop,
         corpus_learning_loop=corpus_learning_loop,
         auto_agent_preflight_loop=auto_agent_preflight_loop,
+        diagram_loop=diagram_loop,
     )

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -249,7 +249,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight', 'diagram_loop'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -282,6 +282,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   contract_refresh: 604800,
   corpus_learning: 3600,
   auto_agent_preflight: 120,
+  diagram_loop: 14400,
 }
 
 /**
@@ -332,6 +333,7 @@ export const BACKGROUND_WORKERS = [
   { key: 'contract_refresh', label: 'Contract Refresh', description: 'Weekly refresh of fake-adapter cassettes with autonomous repair dispatch; records live adapters, diffs against committed cassettes, opens auto-merge refresh PRs, and files fake-drift companion issues when replay fails. See spec §4.2.', color: theme.accent, group: 'learning', tags: ['quality'] },
   { key: 'corpus_learning', label: 'Corpus Learning', description: 'Grows the adversarial skill corpus from production escape signals; synthesizes + self-validates before/after cases and files PRs under tests/trust/adversarial/cases/. See spec §4.1 v2.', color: theme.purple, group: 'learning', tags: ['insights'] },
   { key: 'auto_agent_preflight', label: 'Auto-Agent Pre-Flight', description: 'Intercepts hitl-escalation issues; runs an emulated-engineer subprocess to attempt autonomous resolution before the issue surfaces to a human (spec §1–§11; ADR-0050).', color: theme.purple, group: 'autonomy', tags: ['hitl', 'autonomy'] },
+  { key: 'diagram_loop', label: 'Diagram Loop (L24)', description: 'Self-documenting architecture caretaker. Walks src/, tests/, docs/adr/ every 4h; emits regenerated docs/arch/generated/ markdown + opens a PR when the live truth has drifted. Per ADR-0029 (caretaker pattern) and the Architecture Knowledge System spec.', color: theme.cyan, group: 'learning', tags: ['knowledge'] },
 ]
 
 /**

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -498,6 +498,7 @@ def build_scripted_services(
     services.corpus_learning_loop = FakeBackgroundLoop()
     services.contract_refresh_loop = FakeBackgroundLoop()
     services.auto_agent_preflight_loop = FakeBackgroundLoop()
+    services.diagram_loop = FakeBackgroundLoop()
     services.repo_wiki_store = SimpleNamespace(
         is_ingested=MagicMock(return_value=False),
         mark_ingested=MagicMock(),


### PR DESCRIPTION
## Summary

Plan C deferred this. With this commit, the **DiagramLoop now ticks autonomously every 4h in production**, completing the dark-factory loop closure.

### Five-checkpoint wiring

1. `src/service_registry.py` — import + dataclass field + instantiation + constructor argument (4 sites)
2. `src/orchestrator.py` — `bg_loop_registry` mapping + run-task list (2 sites)

### Operator dashboard

- `src/ui/src/constants.js`: BACKGROUND_WORKERS entry (group: 'learning'), EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS (14400s = 4h default)
- `src/dashboard_routes/_common.py`: `_INTERVAL_BOUNDS` (1h min, 1d max)

### Why this matters

The Plan C CI guard already prevents drift on every PR. This commit closes the dark-factory loop by also catching drift autonomously every 4h, so:
- A direct push to main that bypasses the PR flow gets caught by the loop
- Branches that sit unmerged for >4h get refreshed signals
- The system regenerates docs/arch/ on its own cadence, not just human PR cadence

### Test status

- `tests/test_loop_wiring_completeness.py` — passes (auto-discovery sees all 4 wiring sites)
- `tests/test_diagram_loop.py` + `tests/test_diagram_loop_kill_switch.py` — pass
- `tests/test_orchestrator_loops.py` + `test_orchestrator_core.py` + `tests/architecture/` — 196 passed, 1 skipped, 1 xfailed

Refs ADR-0029, ADR-0049.

Skip-ADR: This PR uniformly applies the existing five-checkpoint loop wiring pattern to a new caretaker loop. The cited ADRs (0011/0012/0018/0032/0045) describe per-loop architectural decisions that are unchanged by adding routine plumbing for an additional loop subscriber. ADR-0029 (caretaker pattern) is the governing decision and is honored by following the established convention.