### PR TITLE
feat(runners): BaseSubprocessRunner + AutoAgentRunner migration + Port↔Fake signature conformance

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T19:54:04.377831+00:00",
-  "commit_sha": "c214afd1bacbbacad04a75a4e5671d4963822079",
+  "regenerated_at": "2026-04-26T21:04:39.842939+00:00",
+  "commit_sha": "d415312a266905469c9119decad1f3c1c4279533",
   "artifacts": {
     "loops.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "ports.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "labels.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "modules.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "events.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "adr_xref.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "mockworld.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "changelog.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     },
     "functional_areas.md": {
-      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
+      "source_sha": "d415312a266905469c9119decad1f3c1c4279533"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-26T19:27:18.506209+00:00",
-  "commit_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2",
+  "regenerated_at": "2026-04-26T19:54:04.377831+00:00",
+  "commit_sha": "c214afd1bacbbacad04a75a4e5671d4963822079",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "ports.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "labels.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "modules.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "events.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "adr_xref.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "mockworld.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "changelog.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     },
     "functional_areas.md": {
-      "source_sha": "4f6c8e9ca0b42babe7dd1f4400a7b1b7a7f424c2"
+      "source_sha": "c214afd1bacbbacad04a75a4e5671d4963822079"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -148,4 +148,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -148,4 +148,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
+- `d415312` — chore(arch): regen for runners package + Fake conformance fixes *(2026-04-26)*
+- `3af8d25` — feat(infra): dark-factory infrastructure hardening — spec + plan + PR1 (ADR-0051 + pre-commit arch-check) (#8445) (#8445) *(2026-04-26)*
 - `6cd7920` — docs(wiki): dark-factory engineering — distill lessons from auto-agent journey (#8443) (#8443) *(2026-04-26)*
 - `717e68f` — feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing) (#8439) (#8439) *(2026-04-26)*
 - `204084a` — feat(loop): wire DiagramLoop (L24) into runtime — five-checkpoint pattern (#8440) (#8440) *(2026-04-26)*
@@ -142,4 +144,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W17
 
-- `ddc1e2f` — fix(adr): correct ADR-0044 filename reference in ADR-0051 Related field *(2026-04-26)*
-- `29c9198` — docs(adr): ADR-0051 — iterative production-readiness review *(2026-04-26)*
+- `6cd7920` — docs(wiki): dark-factory engineering — distill lessons from auto-agent journey (#8443) (#8443) *(2026-04-26)*
 - `717e68f` — feat(auto-agent): wire real Claude Code subprocess (closes ADR-0050 partial landing) (#8439) (#8439) *(2026-04-26)*
 - `204084a` — feat(loop): wire DiagramLoop (L24) into runtime — five-checkpoint pattern (#8440) (#8440) *(2026-04-26)*
 - `5837a29` — feat(arch): trust fleet topology page (curated) (#8438) (#8438) *(2026-04-26)*
@@ -143,4 +142,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -251,4 +251,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -39,4 +39,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -12,8 +12,8 @@ All fakes under `tests/scenarios/fakes/`, the `*Port` each implements (by name m
 | **FakeClock** | `ClockPort` | `tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/fakes/test_fake_clock.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py`<br>`tests/scenarios/test_fidelity.py` |
 | **FakeDocker** | `DockerPort` | `tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_fake_subprocess_runner.py`<br>`tests/scenarios/fakes/test_port_conformance.py` |
 | **FakeFS** | `FSPort` | `tests/scenarios/fakes/test_fake_fs.py` |
-| **FakeGit** | `GitPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_git.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
-| **FakeGitHub** | `GitHubPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
+| **FakeGit** | `GitPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_git.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fakes/test_port_signature_conformance.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
+| **FakeGitHub** | `GitHubPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fakes/test_port_signature_conformance.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
 | **FakeHTTP** | `HTTPPort` | `tests/scenarios/fakes/test_fake_http.py` |
 | **FakeIssue** | `IssuePort` | — |
 | **FakeLLM** | `LLMPort` | `tests/scenarios/behaviors/test_quota.py`<br>`tests/scenarios/fakes/test_fake_llm.py`<br>`tests/scenarios/fakes/test_fake_llm_streaming.py`<br>`tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fakes/test_prior_failure_propagation.py`<br>`tests/scenarios/test_fidelity.py` |
@@ -21,7 +21,7 @@ All fakes under `tests/scenarios/fakes/`, the `*Port` each implements (by name m
 | **FakeSentry** | `SentryPort` | `tests/scenarios/fakes/test_port_conformance.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py` |
 | **FakeSubprocessRunner** | `SubprocessRunnerPort` | `tests/scenarios/fakes/test_fake_subprocess_runner.py`<br>`tests/scenarios/fakes/test_port_conformance.py` |
 | **FakeWikiCompiler** | `WikiCompilerPort` | `tests/scenarios/test_wiki_evolution_scenarios.py` |
-| **FakeWorkspace** | `WorkspacePort` | `tests/scenarios/fakes/test_supporting_fakes.py` |
+| **FakeWorkspace** | `WorkspacePort` | `tests/scenarios/fakes/test_port_signature_conformance.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py` |
 
 ## Wiring
 
@@ -69,7 +69,8 @@ graph LR
     FakeWikiCompiler -.-> WikiCompilerPort
     tests_scenarios_test_wiki_evolution_scenarios_py([tests/scenarios/test_wiki_evolution_scenarios.py]) --> FakeWikiCompiler
     FakeWorkspace -.-> WorkspacePort
+    tests_scenarios_fakes_test_port_signature_conformance_py([tests/scenarios/fakes/test_port_signature_conformance.py]) --> FakeWorkspace
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -73,4 +73,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -28,4 +28,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -12,6 +12,7 @@ graph LR
     src_arch_generators["src.arch.generators"]
     src_dashboard_routes["src.dashboard_routes"]
     src_preflight["src.preflight"]
+    src_runners["src.runners"]
     src_sentry["src.sentry"]
     src_state["src.state"]
     src -- "4" --> src_arch
@@ -22,7 +23,9 @@ graph LR
     src_arch_generators -- "10" --> src_arch
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
+    src_preflight -- "1" --> src_runners
     src_preflight -- "1" --> src_sentry
+    src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `4f6c8e9` on 2026-04-26 19:27 UTC. Source last changed at `4f6c8e9`. Status: 🟢 fresh._
+_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -82,4 +82,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`tests.scenarios.fakes.fake_workspace`)
 
-_Regenerated from commit `c214afd` on 2026-04-26 19:54 UTC. Source last changed at `c214afd`. Status: 🟢 fresh._
+_Regenerated from commit `d415312` on 2026-04-26 21:04 UTC. Source last changed at `d415312`. Status: 🟢 fresh._

--- a/src/preflight/auto_agent_runner.py
+++ b/src/preflight/auto_agent_runner.py
@@ -1,52 +1,32 @@
 """AutoAgentRunner — Claude Code subprocess spawn for AutoAgentPreflightLoop.
 
-Wraps the standard `stream_claude_process` subprocess pattern with the
-auto-agent-specific:
+Spec §3.1 / ADR-0050. Inherits BaseSubprocessRunner[PreflightSpawn] for
+the load-bearing conventions (auth-retry, reraise_on_credit_or_bug,
+telemetry, never-raises). Auto-agent-specific concerns:
 
-- tool restrictions (spec §5.2 — `--disallowedTools` flag carries the CLI
-  restrictions; file-path restrictions are reinforced in the prompt envelope).
-- prompt-hash + cost-capture for the `PreflightSpawn` return contract.
-- telemetry recording so dashboard cost rollups include auto-agent runs
-  alongside other phases (`source="auto_agent_preflight"`).
-
-This module replaces the placeholder `_build_spawn_fn` in
-`src/auto_agent_preflight_loop.py`. Tests for this module monkeypatch
-`stream_claude_process` to avoid real subprocess invocation; the
-end-to-end scenario tests still mock at the `_build_spawn_fn` layer.
+- tool restrictions (`--disallowedTools=WebFetch` per spec §5.2)
+- backend-mismatch warning when implementation_tool != "claude"
+- wall-clock cap override (auto_agent_wall_clock_cap_s)
+- result shape: PreflightSpawn (with output_text + tokens fields)
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import time
 from pathlib import Path
 
 from agent_cli import build_agent_command
-from config import HydraFlowConfig
-from events import EventBus
-from exception_classify import reraise_on_credit_or_bug
-from model_pricing import load_pricing
-from preflight.agent import PreflightSpawn, hash_prompt
-from prompt_telemetry import PromptTelemetry
-from runner_utils import AuthenticationRetryError, StreamConfig, stream_claude_process
+from preflight.agent import PreflightSpawn
+from runners.base_subprocess_runner import (
+    BaseSubprocessRunner,
+    SpawnOutcome,
+    _coerce_int,
+)
 
 logger = logging.getLogger("hydraflow.preflight.auto_agent_runner")
 
 
-# Match BaseRunner's auth-retry budget so transient OAuth blips don't burn
-# the per-issue attempt cap. Three tries with exponential backoff: 5s, 10s, 20s.
-_AUTH_RETRY_MAX = 3
-_AUTH_RETRY_BASE_DELAY = 5.0  # seconds
-
-
 # Spec §5.2 — tools the auto-agent must NOT use.
-#
-# The Claude Code CLI's `--disallowedTools` flag enforces tool-name
-# restrictions. File-path restrictions (no `.github/workflows/`, no
-# secrets, no auto-agent self-modification, etc.) are enforced in the
-# prompt envelope (`prompts/auto_agent/_envelope.md`) and rely on the
-# agent honouring the constraint — there is no path-level CLI gate.
 #
 # `WebFetch` is disabled because the auto-agent should reason from the
 # context the loop gathered (wiki + sentry + recent commits + escalation
@@ -55,48 +35,32 @@ _AUTH_RETRY_BASE_DELAY = 5.0  # seconds
 _AUTO_AGENT_DISALLOWED_TOOLS = "WebFetch"
 
 
-def _coerce_int(value: object) -> int:
-    """Best-effort int coercion for usage_stats values from streaming parsers.
-
-    Stream parsers may emit ints, strings, or even Decimal — coerce safely
-    and clamp to >= 0 since negative token counts are nonsense.
-    """
-    try:
-        return max(0, int(value))  # type: ignore[arg-type]
-    except (TypeError, ValueError):
-        return 0
-
-
-class AutoAgentRunner:
+class AutoAgentRunner(BaseSubprocessRunner[PreflightSpawn]):
     """Spawns a Claude Code subprocess for one auto-agent attempt.
 
     One instance per attempt; lifetime is bounded by `run()`.
     """
 
-    def __init__(self, *, config: HydraFlowConfig, event_bus: EventBus) -> None:
-        self._config = config
-        self._bus = event_bus
-        self._active_procs: set[asyncio.subprocess.Process] = set()
-        self._telemetry = PromptTelemetry(config)
+    def _telemetry_source(self) -> str:
+        return "auto_agent_preflight"
 
-    async def run(
-        self,
-        *,
-        prompt: str,
-        worktree_path: str,
-        issue_number: int,
-    ) -> PreflightSpawn:
-        """Run one attempt; return a `PreflightSpawn` with cost + crash status.
+    def _build_command(self, prompt: str, worktree: Path) -> list[str]:
+        return build_agent_command(
+            tool=self._config.implementation_tool,
+            model=self._config.model,
+            disallowed_tools=_AUTO_AGENT_DISALLOWED_TOOLS,
+        )
 
-        Never raises — any subprocess failure is collapsed into
-        `PreflightSpawn(crashed=True, ...)` so the upstream PreflightAgent
-        can map it to a `fatal` PreflightResult.
-        """
+    def _default_timeout_s(self) -> int:
+        return int(
+            self._config.auto_agent_wall_clock_cap_s or self._config.agent_timeout
+        )
+
+    def _pre_spawn_hook(self, prompt: str) -> None:
         # `--disallowedTools=WebFetch` is silently dropped by build_agent_command
-        # for codex/gemini backends (they don't take that flag). Warn so the
-        # operator knows the CLI-level guard isn't active for that backend —
-        # the path-level honor-system in the prompt envelope is the only
-        # remaining restriction layer.
+        # for codex/gemini backends. Warn so the operator knows the CLI-level
+        # guard isn't active for that backend — the path-level honor-system
+        # in the prompt envelope is the only remaining restriction layer.
         if self._config.implementation_tool != "claude":
             logger.warning(
                 "auto-agent: --disallowedTools is only enforced for the claude "
@@ -105,138 +69,12 @@ class AutoAgentRunner:
                 self._config.implementation_tool,
             )
 
-        cmd = build_agent_command(
-            tool=self._config.implementation_tool,
-            model=self._config.model,
-            disallowed_tools=_AUTO_AGENT_DISALLOWED_TOOLS,
-        )
-        usage_stats: dict[str, object] = {}
-        prompt_hash = hash_prompt(prompt)
-        timeout_s = (
-            self._config.auto_agent_wall_clock_cap_s or self._config.agent_timeout
-        )
-        start = time.monotonic()
-        crashed = False
-        transcript = ""
-
-        # Auth-retry loop — mirrors BaseRunner._execute. AuthenticationRetryError
-        # is a transient OAuth blip; retry up to _AUTH_RETRY_MAX times with
-        # exponential backoff before giving up. CreditExhaustedError and
-        # AuthenticationError (terminal) propagate via reraise_on_credit_or_bug
-        # so the caretaker loop's outer handler can suspend ticking.
-        last_auth_error: AuthenticationRetryError | None = None
-        for attempt in range(1, _AUTH_RETRY_MAX + 1):
-            try:
-                transcript = await stream_claude_process(
-                    cmd=cmd,
-                    prompt=prompt,
-                    cwd=Path(worktree_path),
-                    active_procs=self._active_procs,
-                    event_bus=self._bus,
-                    event_data={
-                        "issue": issue_number,
-                        "source": "auto_agent_preflight",
-                    },
-                    logger=logger,
-                    config=StreamConfig(
-                        timeout=timeout_s,
-                        usage_stats=usage_stats,
-                    ),
-                )
-                last_auth_error = None
-                break
-            except AuthenticationRetryError as exc:
-                last_auth_error = exc
-                if attempt < _AUTH_RETRY_MAX:
-                    delay = _AUTH_RETRY_BASE_DELAY * (2 ** (attempt - 1))
-                    logger.warning(
-                        "auto-agent auth retry %d/%d for issue #%d, sleeping %.0fs: %s",
-                        attempt,
-                        _AUTH_RETRY_MAX,
-                        issue_number,
-                        delay,
-                        exc,
-                    )
-                    await asyncio.sleep(delay)
-            except Exception as exc:
-                # Credit exhaustion / terminal auth / programming bugs propagate
-                # so the loop can suspend or surface the bug; everything else
-                # collapses to crashed=True with a partial transcript.
-                reraise_on_credit_or_bug(exc)
-                crashed = True
-                tail = transcript[-2000:] if transcript else ""
-                transcript = f"{tail}\n\nspawn error: {exc}"
-                logger.warning(
-                    "auto-agent subprocess failed for issue #%d: %s",
-                    issue_number,
-                    exc,
-                )
-                break
-
-        if last_auth_error is not None:
-            crashed = True
-            transcript = (
-                f"{transcript}\n\nauth retry exhausted after "
-                f"{_AUTH_RETRY_MAX} attempts: {last_auth_error}"
-            )
-            logger.error(
-                "auto-agent auth retry exhausted for issue #%d after %d attempts",
-                issue_number,
-                _AUTH_RETRY_MAX,
-            )
-        wall_s = time.monotonic() - start
-
-        # Telemetry — best-effort write to the inferences.jsonl stream so
-        # dashboard cost rollups include auto-agent attempts.
-        try:
-            self._telemetry.record(
-                source="auto_agent_preflight",
-                tool=self._config.implementation_tool,
-                model=self._config.model,
-                issue_number=issue_number,
-                pr_number=None,
-                session_id=self._bus.current_session_id,
-                prompt_chars=len(prompt),
-                transcript_chars=len(transcript),
-                duration_seconds=wall_s,
-                success=not crashed,
-                stats=usage_stats,
-            )
-        except Exception as exc:
-            logger.warning("auto-agent telemetry write failed: %s", exc)
-
-        cost_usd = self._estimate_cost(usage_stats)
-        tokens = _coerce_int(usage_stats.get("total_tokens"))
-
+    def _make_result(self, outcome: SpawnOutcome) -> PreflightSpawn:
         return PreflightSpawn(
             process=None,
-            output_text=transcript,
-            cost_usd=cost_usd,
-            tokens=tokens,
-            crashed=crashed,
-            prompt_hash=prompt_hash,
+            output_text=outcome.transcript,
+            cost_usd=outcome.cost_usd,
+            tokens=_coerce_int(outcome.usage_stats.get("total_tokens")),
+            crashed=outcome.crashed,
+            prompt_hash=outcome.prompt_hash,
         )
-
-    def _estimate_cost(self, usage_stats: dict[str, object]) -> float:
-        """Best-effort cost estimate from the usage_stats the parser populated.
-
-        Returns 0.0 when the model isn't in the pricing table or stats are
-        missing — avoids breaking the loop on a pricing-table miss.
-        """
-        try:
-            pricing = load_pricing()
-            estimate = pricing.estimate_cost(
-                model=self._config.model,
-                input_tokens=_coerce_int(usage_stats.get("input_tokens")),
-                output_tokens=_coerce_int(usage_stats.get("output_tokens")),
-                cache_write_tokens=_coerce_int(
-                    usage_stats.get("cache_creation_input_tokens")
-                ),
-                cache_read_tokens=_coerce_int(
-                    usage_stats.get("cache_read_input_tokens")
-                ),
-            )
-            return float(estimate or 0.0)
-        except Exception as exc:
-            logger.warning("auto-agent cost estimate failed: %s", exc)
-            return 0.0

--- a/src/runners/__init__.py
+++ b/src/runners/__init__.py
@@ -1,0 +1,1 @@
+"""Runners package — abstract bases for subprocess-spawning runners."""

--- a/src/runners/base_subprocess_runner.py
+++ b/src/runners/base_subprocess_runner.py
@@ -23,14 +23,17 @@ from __future__ import annotations
 import abc
 import asyncio
 import logging
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Generic, TypeVar
 
 from config import HydraFlowConfig
 from events import EventBus
+from exception_classify import reraise_on_credit_or_bug
 from model_pricing import load_pricing
 from prompt_telemetry import PromptTelemetry
+from runner_utils import AuthenticationRetryError, StreamConfig, stream_claude_process
 
 logger = logging.getLogger("hydraflow.runners.base_subprocess_runner")
 
@@ -136,3 +139,121 @@ class BaseSubprocessRunner(abc.ABC, Generic[T_Result]):
         except Exception as exc:
             logger.warning("subprocess runner cost estimate failed: %s", exc)
             return 0.0
+
+    async def run(
+        self,
+        *,
+        prompt: str,
+        worktree_path: str,
+        issue_number: int,
+    ) -> T_Result:
+        """Run one subprocess attempt; never raises.
+
+        Auth blips retry up to _AUTH_RETRY_MAX times. Credit/auth-terminal
+        errors propagate (caretaker loop suspends). Other failures collapse
+        to crashed=True in the SpawnOutcome the subclass converts.
+        """
+        from preflight.agent import hash_prompt  # noqa: PLC0415
+
+        self._pre_spawn_hook(prompt)
+        cmd = self._build_command(prompt, Path(worktree_path))
+
+        usage_stats: dict[str, object] = {}
+        prompt_hash = hash_prompt(prompt)
+        timeout_s = self._default_timeout_s()
+        start = time.monotonic()
+        crashed = False
+        transcript = ""
+
+        last_auth_error: AuthenticationRetryError | None = None
+        for attempt in range(1, self._AUTH_RETRY_MAX + 1):
+            try:
+                transcript = await stream_claude_process(
+                    cmd=cmd,
+                    prompt=prompt,
+                    cwd=Path(worktree_path),
+                    active_procs=self._active_procs,
+                    event_bus=self._bus,
+                    event_data={
+                        "issue": issue_number,
+                        "source": self._telemetry_source(),
+                    },
+                    logger=logger,
+                    config=StreamConfig(
+                        timeout=timeout_s,
+                        usage_stats=usage_stats,
+                    ),
+                )
+                last_auth_error = None
+                break
+            except AuthenticationRetryError as exc:
+                last_auth_error = exc
+                if attempt < self._AUTH_RETRY_MAX:
+                    delay = self._AUTH_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                    logger.warning(
+                        "subprocess runner auth retry %d/%d for issue #%d, "
+                        "sleeping %.0fs: %s",
+                        attempt,
+                        self._AUTH_RETRY_MAX,
+                        issue_number,
+                        delay,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+            except Exception as exc:
+                # Credit / terminal-auth / programming bugs propagate so the
+                # caretaker loop can suspend or surface the bug; everything
+                # else collapses to crashed=True with a partial transcript.
+                reraise_on_credit_or_bug(exc)
+                crashed = True
+                tail = transcript[-2000:] if transcript else ""
+                transcript = f"{tail}\n\nspawn error: {exc}"
+                logger.warning(
+                    "subprocess runner failed for issue #%d: %s",
+                    issue_number,
+                    exc,
+                )
+                break
+
+        if last_auth_error is not None:
+            crashed = True
+            transcript = (
+                f"{transcript}\n\nauth retry exhausted after "
+                f"{self._AUTH_RETRY_MAX} attempts: {last_auth_error}"
+            )
+            logger.error(
+                "subprocess runner auth retry exhausted for issue #%d after %d attempts",
+                issue_number,
+                self._AUTH_RETRY_MAX,
+            )
+        wall_s = time.monotonic() - start
+
+        # Telemetry — best-effort write to inferences.jsonl.
+        try:
+            self._telemetry.record(
+                source=self._telemetry_source(),
+                tool=self._config.implementation_tool,
+                model=self._config.model,
+                issue_number=issue_number,
+                pr_number=None,
+                session_id=self._bus.current_session_id,
+                prompt_chars=len(prompt),
+                transcript_chars=len(transcript),
+                duration_seconds=wall_s,
+                success=not crashed,
+                stats=usage_stats,
+            )
+        except Exception as exc:
+            logger.warning("subprocess runner telemetry write failed: %s", exc)
+
+        cost_usd = self._estimate_cost(usage_stats)
+
+        outcome = SpawnOutcome(
+            transcript=transcript,
+            usage_stats=usage_stats,
+            wall_clock_s=wall_s,
+            crashed=crashed,
+            prompt_hash=prompt_hash,
+            cost_usd=cost_usd,
+        )
+        return self._make_result(outcome)

--- a/src/runners/base_subprocess_runner.py
+++ b/src/runners/base_subprocess_runner.py
@@ -20,8 +20,17 @@ record passed from `base.run()` to `subclass._make_result`.
 
 from __future__ import annotations
 
+import abc
+import asyncio
 import logging
 from dataclasses import dataclass
+from pathlib import Path
+from typing import Generic, TypeVar
+
+from config import HydraFlowConfig
+from events import EventBus
+from model_pricing import load_pricing
+from prompt_telemetry import PromptTelemetry
 
 logger = logging.getLogger("hydraflow.runners.base_subprocess_runner")
 
@@ -53,3 +62,77 @@ def _coerce_int(value: object) -> int:
         return max(0, int(value))  # type: ignore[arg-type]
     except (TypeError, ValueError):
         return 0
+
+
+T_Result = TypeVar("T_Result")
+
+
+class BaseSubprocessRunner(abc.ABC, Generic[T_Result]):
+    """Abstract base for subprocess-spawning runners. See module docstring.
+
+    Subclasses MUST override:
+    - `_telemetry_source()` → str (e.g., "auto_agent_preflight")
+    - `_build_command(prompt, worktree)` → list[str]
+    - `_make_result(outcome)` → T_Result (e.g., PreflightSpawn)
+
+    Subclasses MAY override:
+    - `_default_timeout_s()` → int (default: config.agent_timeout)
+    - `_pre_spawn_hook(prompt)` → None (logging, validation, etc.)
+    - `_estimate_cost(usage_stats)` → float (default: model_pricing lookup)
+    """
+
+    # Match BaseRunner._execute auth-retry budget so transient OAuth blips
+    # don't burn the per-issue attempt cap.
+    _AUTH_RETRY_MAX = 3
+    _AUTH_RETRY_BASE_DELAY = 5.0  # seconds
+
+    def __init__(self, *, config: HydraFlowConfig, event_bus: EventBus) -> None:
+        self._config = config
+        self._bus = event_bus
+        self._active_procs: set[asyncio.subprocess.Process] = set()
+        self._telemetry = PromptTelemetry(config)
+
+    @abc.abstractmethod
+    def _telemetry_source(self) -> str:
+        """Return the source string for PromptTelemetry attribution."""
+
+    @abc.abstractmethod
+    def _build_command(self, prompt: str, worktree: Path) -> list[str]:
+        """Build the CLI command (e.g., via build_agent_command)."""
+
+    @abc.abstractmethod
+    def _make_result(self, outcome: SpawnOutcome) -> T_Result:
+        """Convert the internal SpawnOutcome into the subclass's typed result."""
+
+    def _default_timeout_s(self) -> int:
+        """Default subprocess timeout. Override per subclass for caps."""
+        return int(self._config.agent_timeout)
+
+    def _pre_spawn_hook(self, prompt: str) -> None:
+        """Hook for pre-spawn checks/logging (e.g., warn on backend mismatch)."""
+        # Default: no-op.
+
+    def _estimate_cost(self, usage_stats: dict[str, object]) -> float:
+        """Default cost estimate via model_pricing.
+
+        Returns 0.0 when the model isn't in the pricing table or stats are
+        missing. Subclasses may override for custom pricing or no-op for
+        free-tier runs.
+        """
+        try:
+            pricing = load_pricing()
+            estimate = pricing.estimate_cost(
+                model=self._config.model,
+                input_tokens=_coerce_int(usage_stats.get("input_tokens")),
+                output_tokens=_coerce_int(usage_stats.get("output_tokens")),
+                cache_write_tokens=_coerce_int(
+                    usage_stats.get("cache_creation_input_tokens")
+                ),
+                cache_read_tokens=_coerce_int(
+                    usage_stats.get("cache_read_input_tokens")
+                ),
+            )
+            return float(estimate or 0.0)
+        except Exception as exc:
+            logger.warning("subprocess runner cost estimate failed: %s", exc)
+            return 0.0

--- a/src/runners/base_subprocess_runner.py
+++ b/src/runners/base_subprocess_runner.py
@@ -1,0 +1,55 @@
+"""BaseSubprocessRunner — abstract base for runners that spawn a subprocess.
+
+Spec §3.1. Encapsulates the four conventions PR #8439 surfaced as
+load-bearing across any runner that spawns a Claude Code / codex /
+gemini subprocess:
+
+- 3-attempt auth-retry loop with exponential backoff (5s, 10s, 20s) on
+  AuthenticationRetryError from runner_utils.
+- reraise_on_credit_or_bug propagates CreditExhaustedError + terminal
+  AuthenticationError so caretaker loops can suspend.
+- PromptTelemetry.record() with subclass-provided source attribution.
+- Never-raises contract: every failure path returns a typed result,
+  never propagates a generic RuntimeError to the caller.
+
+Subclasses parameterise their own typed result (e.g.,
+`AutoAgentRunner(BaseSubprocessRunner[PreflightSpawn])`) — the base does
+NOT impose a single shared dataclass. The internal `SpawnOutcome` is the
+record passed from `base.run()` to `subclass._make_result`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger("hydraflow.runners.base_subprocess_runner")
+
+
+@dataclass(frozen=True)
+class SpawnOutcome:
+    """Internal record passed from base.run() to subclass._make_result.
+
+    Internal to BaseSubprocessRunner — not part of any subclass's public
+    API. Subclass converts this into its own dataclass (e.g., PreflightSpawn)
+    via _make_result.
+    """
+
+    transcript: str
+    usage_stats: dict[str, object]
+    wall_clock_s: float
+    crashed: bool
+    prompt_hash: str
+    cost_usd: float
+
+
+def _coerce_int(value: object) -> int:
+    """Best-effort int coercion for usage_stats values from streaming parsers.
+
+    Stream parsers may emit ints, strings, or even Decimal — coerce safely
+    and clamp to >= 0 since negative token counts are nonsense.
+    """
+    try:
+        return max(0, int(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0

--- a/tests/scenarios/fakes/fake_github.py
+++ b/tests/scenarios/fakes/fake_github.py
@@ -204,8 +204,15 @@ class FakeGitHub:
             ]
             issue.labels.append(new_label)
 
-    async def swap_pipeline_labels(self, issue_number: int, new_label: str) -> None:
+    async def swap_pipeline_labels(
+        self,
+        issue_number: int,
+        new_label: str,
+        *,
+        pr_number: int | None = None,
+    ) -> None:
         self._maybe_rate_limit()
+        _ = pr_number
         if issue_number in self._issues:
             issue = self._issues[issue_number]
             issue.labels = [
@@ -237,9 +244,9 @@ class FakeGitHub:
         self._comments.append((pr_number, body))
 
     async def submit_review(
-        self, pr_number: int, verdict_or_body: Any = "", body: str = "", **_kw: Any
+        self, pr_number: int, verdict: Any, body: str, **_kw: Any
     ) -> bool:
-        """Accept both (pr, body, event) from phases and (pr, verdict, body) from loops."""
+        """Submit a formal PR review (no-op stub — always returns True)."""
         self._maybe_rate_limit()
         return True
 
@@ -348,7 +355,7 @@ class FakeGitHub:
         self._maybe_rate_limit()
         return ["octocat"]
 
-    async def fetch_code_scanning_alerts(self, branch: str = "", **_kw: Any) -> list:
+    async def fetch_code_scanning_alerts(self, branch: str, **_kw: Any) -> list:
         self._maybe_rate_limit()
         return list(self._alerts.get(branch, []))
 

--- a/tests/scenarios/fakes/fake_workspace.py
+++ b/tests/scenarios/fakes/fake_workspace.py
@@ -21,7 +21,7 @@ class FakeWorkspace:
         """Inject a single-shot fault into the next create() call."""
         self._next_fault = kind
 
-    async def create(self, issue_number: int, _branch: str) -> Path:
+    async def create(self, issue_number: int, branch: str) -> Path:
         fault = self._next_fault
         self._next_fault = None
         if fault == "permission":
@@ -37,6 +37,32 @@ class FakeWorkspace:
 
     async def destroy(self, issue_number: int) -> None:
         self.destroyed.append(issue_number)
+
+    async def destroy_all(self) -> None:
+        """Remove all managed worktrees (no-op stub)."""
+
+    async def merge_main(self, worktree_path: Path, branch: str) -> bool:
+        """Merge main into the worktree (stub — always succeeds)."""
+        return True
+
+    async def get_conflicting_files(self, worktree_path: Path) -> list[str]:
+        """Return conflicting files in the worktree (stub — always empty)."""
+        return []
+
+    async def reset_to_main(self, worktree_path: Path) -> None:
+        """Hard-reset worktree to origin/main (no-op stub)."""
+
+    async def post_work_cleanup(
+        self, issue_number: int, *, phase: str = "implement"
+    ) -> None:
+        """Clean up after an issue is done (no-op stub)."""
+
+    async def abort_merge(self, worktree_path: Path) -> None:
+        """Abort an in-progress merge (no-op stub)."""
+
+    async def start_merge_main(self, worktree_path: Path, branch: str) -> bool:
+        """Begin merging main into branch (stub — always clean)."""
+        return True
 
     async def sanitize_repo(self) -> None:
         pass

--- a/tests/scenarios/fakes/test_port_signature_conformance.py
+++ b/tests/scenarios/fakes/test_port_signature_conformance.py
@@ -1,0 +1,185 @@
+"""Strict Port↔Fake signature conformance (spec §3.3).
+
+Existing test test_port_conformance.py uses isinstance() against the
+runtime-checkable Protocol — passes when method names match, but
+Python's structural subtyping does NOT compare signatures. C2/C3 from
+PR #8439 (``remove_labels`` plural typo, nonexistent
+``list_issue_comments``) slipped through.
+
+This test fills the Port↔Fake gap: for every (Port, Fake) pair, every
+public Port method must have a Fake method with the same name AND the
+same kwarg signature. tests/test_ports.py already covers Port↔Adapter
+signature parity for IssueStorePort↔IssueStore (the real adapter).
+
+Compatibility rule for ``**kwargs`` / ``*args`` absorb patterns
+---------------------------------------------------------------
+Fakes legitimately use ``**_kw`` or ``*_args`` to absorb extra kwargs
+that phases pass but the Fake doesn't need to track.  A Fake with a
+``**kwargs`` catch-all is considered compatible with any Port method
+whose unmatched named params are all covered by that catch-all.
+Similarly a ``*args`` catch-all absorbs unmatched positional params.
+This allows intentional test-convenience patterns without false failures.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from tests.scenarios.fakes.fake_github import FakeGitHub
+from tests.scenarios.fakes.fake_workspace import FakeWorkspace
+from tests.scenarios.ports import PRPort, WorkspacePort
+
+# Hand-maintained Port↔Fake pair list. Add new pairs as Fakes are
+# introduced. (Auto-discovery via convention ``Fake<PortStem>`` is YAGNI
+# at this scale; ~3 pairs total.)
+_PORT_FAKE_PAIRS: list[tuple[type, type]] = [
+    (PRPort, FakeGitHub),
+    (WorkspacePort, FakeWorkspace),
+    # IssueStorePort: no Fake; covered separately by tests/test_ports.py
+    # against the real IssueStore adapter.
+]
+
+
+def _public_methods(cls: type) -> dict[str, Any]:
+    """Return public methods of cls (skip dunders + private prefix)."""
+    out = {}
+    for name in dir(cls):
+        if name.startswith("_"):
+            continue
+        attr = getattr(cls, name)
+        if not callable(attr):
+            continue
+        out[name] = attr
+    return out
+
+
+def _named_params(sig: inspect.Signature) -> dict[str, inspect.Parameter]:
+    """Return named parameters (exclude self, *args, **kwargs catch-alls)."""
+    return {
+        p: info
+        for p, info in sig.parameters.items()
+        if p != "self"
+        and info.kind
+        not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+
+
+def _has_var_keyword(sig: inspect.Signature) -> bool:
+    """True if the signature has a **kwargs catch-all."""
+    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values())
+
+
+def _has_var_positional(sig: inspect.Signature) -> bool:
+    """True if the signature has a *args catch-all."""
+    return any(
+        p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values()
+    )
+
+
+def _signatures_compatible(
+    port_sig: inspect.Signature, fake_sig: inspect.Signature
+) -> tuple[bool, str]:
+    """Check whether fake_sig is a drop-in-compatible implementation of port_sig.
+
+    Compatibility rules (in priority order):
+
+    1.  Named params that appear on both Port and Fake must agree on
+        required-vs-optional status (default-vs-no-default).  Type
+        annotations are not compared — Python's runtime accepts
+        duck-typed kwargs, and exact type matching would over-constrain
+        Fakes.
+
+    2.  Port params absent from Fake's named params are acceptable if the
+        Fake has a ``**kwargs`` catch-all (VAR_KEYWORD) — the catch-all
+        absorbs them.  Similarly a ``*args`` catch-all (VAR_POSITIONAL)
+        absorbs unmatched positional params.
+
+    3.  Fake params absent from Port's named params are allowed (the Fake
+        may accept extra test-seeding kwargs not on the Port).
+
+    Returns ``(ok: bool, reason: str)``.  ``reason`` is empty when ok.
+    """
+    port_params = _named_params(port_sig)
+    fake_params = _named_params(fake_sig)
+    fake_has_vk = _has_var_keyword(fake_sig)
+    fake_has_vp = _has_var_positional(fake_sig)
+
+    # Port params not covered by Fake's named params.
+    uncovered = set(port_params.keys()) - set(fake_params.keys())
+    if uncovered:
+        if fake_has_vk or fake_has_vp:
+            # Absorbed by *args/**kwargs catch-all — intentional Fake pattern.
+            pass
+        else:
+            return False, (
+                f"Port params not present in Fake and no catch-all to absorb them: "
+                f"{sorted(uncovered)}"
+            )
+
+    # For params that exist on both: check required-vs-optional status.
+    for name in set(port_params.keys()) & set(fake_params.keys()):
+        port_pinfo = port_params[name]
+        fake_pinfo = fake_params[name]
+        port_required = port_pinfo.default is inspect.Parameter.empty
+        fake_required = fake_pinfo.default is inspect.Parameter.empty
+        if port_required != fake_required:
+            return False, (
+                f"Param '{name}': Port required={port_required} but "
+                f"Fake required={fake_required}.  They must agree on "
+                f"required-vs-optional status."
+            )
+
+    return True, ""
+
+
+@pytest.mark.parametrize(
+    "port_cls,fake_cls",
+    _PORT_FAKE_PAIRS,
+    ids=[f"{p.__name__}-{f.__name__}" for p, f in _PORT_FAKE_PAIRS],
+)
+def test_fake_signatures_match_port(port_cls: type, fake_cls: type) -> None:
+    """For every public method on the Port, the Fake must have a method
+    with the same name AND a compatible kwarg signature.
+
+    ``**kwargs`` / ``*args`` catch-alls on the Fake are accepted as
+    intentional absorb patterns (see module docstring for the full rule).
+    """
+    port_methods = _public_methods(port_cls)
+    fake_methods = _public_methods(fake_cls)
+
+    missing = port_methods.keys() - fake_methods.keys()
+    assert not missing, (
+        f"{fake_cls.__name__} is missing methods declared on {port_cls.__name__}: "
+        f"{sorted(missing)}\n\n"
+        f"This catches the C2/C3 class of break from PR #8439 — Fake drift "
+        f"hidden by AsyncMock auto-attribute behavior."
+    )
+
+    failures: list[str] = []
+    for name in sorted(port_methods):
+        try:
+            port_sig = inspect.signature(port_methods[name])
+            fake_sig = inspect.signature(fake_methods[name])
+        except (ValueError, TypeError) as exc:
+            # inspect.signature can fail on some builtins; skip gracefully.
+            failures.append(f"  {name}: could not inspect signature — {exc}")
+            continue
+
+        ok, reason = _signatures_compatible(port_sig, fake_sig)
+        if not ok:
+            failures.append(
+                f"  {name}:\n"
+                f"    Port: {port_sig}\n"
+                f"    Fake: {fake_sig}\n"
+                f"    Reason: {reason}"
+            )
+
+    assert not failures, (
+        f"Signature mismatches on {fake_cls.__name__} vs {port_cls.__name__}:\n"
+        + "\n".join(failures)
+        + "\n\nEither rename the Fake method/param to match the Port, "
+        "or use a **kwargs catch-all for intentional absorb patterns."
+    )

--- a/tests/test_base_subprocess_runner.py
+++ b/tests/test_base_subprocess_runner.py
@@ -1,0 +1,247 @@
+"""BaseSubprocessRunner unit tests (spec §3.1).
+
+Mocks `stream_claude_process` at the module boundary so no real Claude
+Code subprocess is spawned. Verifies:
+
+- subclass abstract methods are required (TypeError on instantiation).
+- happy path: outcome.transcript, usage_stats, prompt_hash flow through.
+- auth-retry loop: transient AuthenticationRetryError retries up to
+  _AUTH_RETRY_MAX times; auth-retry exhausted → crashed=True.
+- credit / terminal-auth errors propagate (loop can suspend).
+- generic exceptions collapse to crashed=True (never-raises contract).
+- telemetry write failure is logged but doesn't fail the run.
+- cost estimate default works against the model_pricing table.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from runners.base_subprocess_runner import (
+    BaseSubprocessRunner,
+    SpawnOutcome,
+    _coerce_int,
+)
+from tests.helpers import ConfigFactory
+
+
+@dataclass(frozen=True)
+class _FakeResult:
+    """Test-only result type satisfying the T_Result contract."""
+
+    crashed: bool
+    transcript: str
+    cost_usd: float
+    tokens: int
+    prompt_hash: str
+
+
+class _FakeRunner(BaseSubprocessRunner[_FakeResult]):
+    """Concrete subclass for tests."""
+
+    def _telemetry_source(self) -> str:
+        return "fake_runner_test"
+
+    def _build_command(self, prompt: str, worktree: Path) -> list[str]:
+        return ["fake-claude", "-p"]
+
+    def _make_result(self, outcome: SpawnOutcome) -> _FakeResult:
+        return _FakeResult(
+            crashed=outcome.crashed,
+            transcript=outcome.transcript,
+            cost_usd=outcome.cost_usd,
+            tokens=_coerce_int(outcome.usage_stats.get("total_tokens")),
+            prompt_hash=outcome.prompt_hash,
+        )
+
+
+def _make_runner(**config_overrides: Any) -> _FakeRunner:
+    config = ConfigFactory.create(**config_overrides)
+    bus = MagicMock()
+    bus.current_session_id = "test-session"
+    return _FakeRunner(config=config, event_bus=bus)
+
+
+def test_abstract_methods_required() -> None:
+    """BaseSubprocessRunner cannot be instantiated without subclass overrides."""
+    config = ConfigFactory.create()
+    bus = MagicMock()
+    with pytest.raises(TypeError):
+        BaseSubprocessRunner(config=config, event_bus=bus)  # type: ignore[abstract]
+
+
+@pytest.mark.asyncio
+async def test_happy_path_yields_outcome(tmp_path: Path) -> None:
+    async def fake_stream(*, config, **kwargs: Any) -> str:
+        config.usage_stats["input_tokens"] = 100
+        config.usage_stats["output_tokens"] = 50
+        config.usage_stats["total_tokens"] = 150
+        return "<status>resolved</status>"
+
+    runner = _make_runner()
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process",
+        side_effect=fake_stream,
+    ):
+        result = await runner.run(
+            prompt="hello", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert result.crashed is False
+    assert "resolved" in result.transcript
+    assert result.tokens == 150
+    assert result.prompt_hash.startswith("sha256:")
+
+
+@pytest.mark.asyncio
+async def test_auth_retry_then_success(tmp_path: Path) -> None:
+    """Two transient AuthenticationRetryErrors retry; third call succeeds."""
+    from runner_utils import AuthenticationRetryError
+
+    call_count = 0
+
+    async def fake_stream(**kwargs: Any) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise AuthenticationRetryError("transient OAuth")
+        return "<status>resolved</status>"
+
+    runner = _make_runner()
+    with (
+        patch(
+            "runners.base_subprocess_runner.stream_claude_process",
+            side_effect=fake_stream,
+        ),
+        patch(
+            "runners.base_subprocess_runner.asyncio.sleep",
+            new_callable=AsyncMock,
+        ),
+    ):
+        result = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert call_count == 3
+    assert result.crashed is False
+
+
+@pytest.mark.asyncio
+async def test_auth_retry_exhausted_marks_crashed(tmp_path: Path) -> None:
+    from runner_utils import AuthenticationRetryError
+
+    async def always_auth_fail(**kwargs: Any) -> str:
+        raise AuthenticationRetryError("OAuth refresh broken")
+
+    runner = _make_runner()
+    with (
+        patch(
+            "runners.base_subprocess_runner.stream_claude_process",
+            side_effect=always_auth_fail,
+        ),
+        patch("runners.base_subprocess_runner.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert result.crashed is True
+    assert "auth retry exhausted" in result.transcript
+
+
+@pytest.mark.asyncio
+async def test_credit_exhausted_propagates(tmp_path: Path) -> None:
+    """CreditExhaustedError must propagate so the caretaker loop suspends."""
+    from subprocess_util import CreditExhaustedError
+
+    async def credit_exhausted(**kwargs: Any) -> str:
+        raise CreditExhaustedError("api credits at zero")
+
+    runner = _make_runner()
+    with (
+        patch(
+            "runners.base_subprocess_runner.stream_claude_process",
+            side_effect=credit_exhausted,
+        ),
+        pytest.raises(CreditExhaustedError),
+    ):
+        await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_collapses_to_crashed(tmp_path: Path) -> None:
+    async def boom(**kwargs: Any) -> str:
+        raise RuntimeError("subprocess oom")
+
+    runner = _make_runner()
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process", side_effect=boom
+    ):
+        result = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert result.crashed is True
+    assert "spawn error" in result.transcript
+
+
+@pytest.mark.asyncio
+async def test_telemetry_failure_does_not_fail_run(tmp_path: Path) -> None:
+    async def stream_ok(**kwargs: Any) -> str:
+        return "<status>needs_human</status>"
+
+    runner = _make_runner()
+    runner._telemetry = MagicMock()
+    runner._telemetry.record = MagicMock(side_effect=OSError("disk full"))
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process",
+        side_effect=stream_ok,
+    ):
+        result = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert result.crashed is False  # run succeeded despite telemetry failure
+
+
+@pytest.mark.asyncio
+async def test_cost_estimate_default_returns_non_negative(tmp_path: Path) -> None:
+    async def fake_stream(*, config, **kwargs: Any) -> str:
+        config.usage_stats["input_tokens"] = 100
+        config.usage_stats["output_tokens"] = 50
+        return ""
+
+    runner = _make_runner()
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process",
+        side_effect=fake_stream,
+    ):
+        result = await runner.run(
+            prompt="x", worktree_path=str(tmp_path), issue_number=1
+        )
+    assert result.cost_usd >= 0.0
+
+
+@pytest.mark.asyncio
+async def test_pre_spawn_hook_is_called(tmp_path: Path) -> None:
+    """Subclass override of _pre_spawn_hook fires once before stream_claude_process."""
+    pre_calls: list[str] = []
+
+    class _HookRunner(_FakeRunner):
+        def _pre_spawn_hook(self, prompt: str) -> None:
+            pre_calls.append(prompt)
+
+    config = ConfigFactory.create()
+    bus = MagicMock()
+    bus.current_session_id = "test-session"
+    runner = _HookRunner(config=config, event_bus=bus)
+
+    async def stream_ok(**kwargs: Any) -> str:
+        return ""
+
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process",
+        side_effect=stream_ok,
+    ):
+        await runner.run(prompt="hi", worktree_path=str(tmp_path), issue_number=1)
+    assert pre_calls == ["hi"]

--- a/tests/test_preflight_auto_agent_runner.py
+++ b/tests/test_preflight_auto_agent_runner.py
@@ -47,7 +47,7 @@ async def test_run_returns_spawn_with_cost_and_tokens(tmp_path: Path) -> None:
 
     runner = _make_runner()
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=fake_stream,
     ):
         spawn = await runner.run(
@@ -76,7 +76,7 @@ async def test_run_passes_disallowed_tools_to_command(tmp_path: Path) -> None:
 
     runner = _make_runner()
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=capture_stream,
     ):
         await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
@@ -101,7 +101,7 @@ async def test_run_passes_wall_clock_cap_to_stream_timeout(tmp_path: Path) -> No
 
     runner = _make_runner(auto_agent_wall_clock_cap_s=180)
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=capture_stream,
     ):
         await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
@@ -120,7 +120,7 @@ async def test_run_passes_worktree_as_cwd(tmp_path: Path) -> None:
 
     runner = _make_runner()
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=capture_stream,
     ):
         await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=1)
@@ -139,7 +139,7 @@ async def test_run_event_data_source_is_auto_agent_preflight(tmp_path: Path) -> 
 
     runner = _make_runner()
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=capture_stream,
     ):
         await runner.run(prompt="x", worktree_path=str(tmp_path), issue_number=99)
@@ -156,7 +156,9 @@ async def test_subprocess_exception_collapses_to_crashed_spawn(tmp_path: Path) -
         raise RuntimeError("subprocess oom")
 
     runner = _make_runner()
-    with patch("preflight.auto_agent_runner.stream_claude_process", side_effect=boom):
+    with patch(
+        "runners.base_subprocess_runner.stream_claude_process", side_effect=boom
+    ):
         spawn = await runner.run(
             prompt="x", worktree_path=str(tmp_path), issue_number=1
         )
@@ -178,7 +180,7 @@ async def test_telemetry_write_failure_does_not_break_run(tmp_path: Path) -> Non
     runner._telemetry = MagicMock()
     runner._telemetry.record = MagicMock(side_effect=OSError("disk full"))
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=stream_ok,
     ):
         spawn = await runner.run(
@@ -199,7 +201,7 @@ async def test_zero_usage_stats_yields_zero_cost(tmp_path: Path) -> None:
 
     runner = _make_runner()
     with patch(
-        "preflight.auto_agent_runner.stream_claude_process",
+        "runners.base_subprocess_runner.stream_claude_process",
         side_effect=stream_no_stats,
     ):
         spawn = await runner.run(
@@ -225,7 +227,7 @@ async def test_credit_exhausted_propagates(tmp_path: Path) -> None:
     runner = _make_runner()
     with (
         patch(
-            "preflight.auto_agent_runner.stream_claude_process",
+            "runners.base_subprocess_runner.stream_claude_process",
             side_effect=credit_exhausted,
         ),
         pytest.raises(CreditExhaustedError),
@@ -252,11 +254,11 @@ async def test_auth_retry_then_success(tmp_path: Path) -> None:
     runner = _make_runner()
     with (
         patch(
-            "preflight.auto_agent_runner.stream_claude_process",
+            "runners.base_subprocess_runner.stream_claude_process",
             side_effect=fake_stream,
         ),
         patch(
-            "preflight.auto_agent_runner.asyncio.sleep",  # skip backoff in tests
+            "runners.base_subprocess_runner.asyncio.sleep",  # skip backoff in tests
             new_callable=AsyncMock,
         ),
     ):
@@ -279,11 +281,11 @@ async def test_auth_retry_exhausted_marks_crashed(tmp_path: Path) -> None:
     runner = _make_runner()
     with (
         patch(
-            "preflight.auto_agent_runner.stream_claude_process",
+            "runners.base_subprocess_runner.stream_claude_process",
             side_effect=always_auth_fail,
         ),
         patch(
-            "preflight.auto_agent_runner.asyncio.sleep",
+            "runners.base_subprocess_runner.asyncio.sleep",
             new_callable=AsyncMock,
         ),
     ):


### PR DESCRIPTION
## Summary

PR 2 of 3 in the dark-factory infrastructure hardening track (spec + plan in PR #8445).

- **`src/runners/base_subprocess_runner.py`** (new) — `BaseSubprocessRunner[T_Result]` abstract class encapsulating auth-retry + reraise_on_credit_or_bug + telemetry + never-raises. Generic over the subclass result type so callers keep their own typed dataclass.
- **`src/preflight/auto_agent_runner.py`** — refactored to inherit `BaseSubprocessRunner[PreflightSpawn]`. **242 → 80 lines (-162).** All 11 existing tests + 39 regression tests pass unchanged in behavior; patch targets updated where the call site moved.
- **`tests/test_base_subprocess_runner.py`** (new) — 9 unit tests (abstract enforcement, happy path, auth-retry success/exhausted, credit propagation, generic-exception → crashed, telemetry-failure tolerance, cost estimate, pre-spawn hook).
- **`tests/scenarios/fakes/test_port_signature_conformance.py`** (new) — strict `inspect.signature` Port↔Fake conformance. Surfaced and fixed **5 pre-existing drifts** that `AsyncMock`-heavy tests had been silently masking (FakeWorkspace missing 7 methods + 1 param rename; FakeGitHub: 3 fixes including `swap_pipeline_labels` missing `pr_number`, spurious `branch=""` default, `submit_review` rename + required-vs-optional drift).

## Test plan

- [x] `make quality` — 11,733 tests pass after arch regen.
- [x] All 11 `AutoAgentRunner` tests + 9 base-class tests + 2 conformance tests green.
- [x] No regressions in existing `test_port_conformance.py` (the older isinstance-based test).
- [x] Lint clean.

## Impact

Closes the C2/C3 class of break that PR #8439 surfaced — `AsyncMock`-hidden Port↔Fake contract drift will now fail at PR time instead of in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Skip-ADR: src/preflight/auto_agent_runner.py change is a pure internal refactor — migrates the existing class to inherit from the new BaseSubprocessRunner abstract base. Behavior is unchanged (all 11 unit tests + 39 loop/scenario/adversarial tests pass post-migration). The migration removes 162 lines of duplicated logic; the public contract (run(prompt, worktree_path, issue_number) -> PreflightSpawn) is identical. ADR-0050's design isn't modified — only the implementation deduplication.
