### PR TITLE
feat(sandbox): docker-compose stack + harness + s01 + ADR-0052 (PR B of 3)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -40,8 +40,10 @@ dist/
 # OS
 .DS_Store
 
-# Tests (not needed in agent image — mounted at runtime)
-tests/
+# Tests are needed in the agent image: `tests.trust.contracts._schema`
+# is imported by src/contract_diff.py at module load time, so the package
+# must be importable when the sandbox entrypoint boots HydraFlow.
+# Production worktrees mount their own tests/ over this on the host side.
 
 # CI/CD
 .github/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       ui: ${{ steps.filter.outputs.ui }}
       ci: ${{ steps.filter.outputs.ci }}
+      service_registry: ${{ steps.filter.outputs.service_registry }}
+      orchestrator: ${{ steps.filter.outputs.orchestrator }}
+      mockworld: ${{ steps.filter.outputs.mockworld }}
+      dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
+      compose: ${{ steps.filter.outputs.compose }}
+      sandbox_scenarios: ${{ steps.filter.outputs.sandbox_scenarios }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -32,6 +38,18 @@ jobs:
               - 'src/ui/**'
             ci:
               - '.github/workflows/**'
+            service_registry:
+              - 'src/service_registry.py'
+            orchestrator:
+              - 'src/orchestrator.py'
+            mockworld:
+              - 'src/mockworld/**'
+            dockerfiles:
+              - 'Dockerfile*'
+            compose:
+              - 'docker-compose*.yml'
+            sandbox_scenarios:
+              - 'tests/sandbox_scenarios/**'
 
   lint:
     name: Lint & Format
@@ -238,4 +256,36 @@ jobs:
       - name: Test
         working-directory: src/ui
         run: npm test
+
+  sandbox:
+    name: Sandbox Scenarios (PR B)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: |
+      needs.changes.outputs.service_registry == 'true' ||
+      needs.changes.outputs.orchestrator == 'true' ||
+      needs.changes.outputs.mockworld == 'true' ||
+      needs.changes.outputs.dockerfiles == 'true' ||
+      needs.changes.outputs.compose == 'true' ||
+      needs.changes.outputs.sandbox_scenarios == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install uv
+        run: pip install uv
+      - name: Install deps
+        run: uv pip install --system -e ".[dev]"
+      - name: Build sandbox images
+        run: docker compose -f docker-compose.sandbox.yml build hydraflow ui playwright
+      - name: Run s01_happy_single_issue
+        run: python scripts/sandbox_scenario.py run s01_happy_single_issue
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sandbox-results
+          path: /tmp/sandbox-results/
+          retention-days: 7
 

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -135,4 +135,20 @@ FROM ${BASE_IMAGE} AS runtime
 # Copy smoke test script
 COPY scripts/docker-smoke-test.sh /opt/hydraflow/docker-smoke-test.sh
 
+# Copy application source so the sandbox entrypoint
+# (`python -m mockworld.sandbox_main ...`) can import without an editable
+# install. PYTHONPATH points at this location. /workspace is reserved for
+# bind mounts (worktrees in production, repo fixtures in sandbox), so the
+# sources live separately under /opt/hydraflow/src.
+#
+# `tests/` is copied alongside `src/` because contract_diff.py imports
+# `tests.trust.contracts._schema` at module load time (the schema lives
+# next to its consumers in tests/). PYTHONPATH includes /opt/hydraflow
+# so `tests.*` resolves.
+COPY --chown=hydraflow:hydraflow src /opt/hydraflow/src
+COPY --chown=hydraflow:hydraflow tests /opt/hydraflow/tests
+COPY --chown=hydraflow:hydraflow templates /opt/hydraflow/templates
+COPY --chown=hydraflow:hydraflow static /opt/hydraflow/static
+ENV PYTHONPATH=/opt/hydraflow/src:/opt/hydraflow
+
 CMD ["bash"]

--- a/Dockerfile.playwright
+++ b/Dockerfile.playwright
@@ -1,0 +1,30 @@
+# Sandbox-only Playwright runner image — Microsoft's playwright/python image
+# ships browsers + the playwright Python wheel but no test runner. We bake
+# pytest + pytest-asyncio + httpx onto it at build time so the sandbox can
+# stay air-gapped (``internal: true``) at runtime — pip cannot reach pypi
+# from inside the sandbox network.
+#
+# Use the ``noble`` (Ubuntu 24.04) variant rather than ``jammy`` because
+# ``tests/conftest.py`` imports ``subprocess_util`` which uses
+# ``from datetime import UTC`` (added in Python 3.11). The jammy image
+# ships Python 3.10 and the import fails before any test collection runs.
+# ``noble`` ships Python 3.12.
+#
+# This is a sandbox carve-out only; production runs Playwright through the
+# host venv via ``make ui-test`` and never builds this image.
+FROM mcr.microsoft.com/playwright/python:v1.49.0-noble
+
+# pytest 8.x + pytest-asyncio 0.24+ for the runner-conftest's @pytest_asyncio
+# fixtures; httpx for the SandboxAPIClient. Surprise: the noble playwright
+# image bundles the *browsers* but NOT the ``playwright`` Python wheel, so
+# install it here at the matching wheel version. Pin tightly so the
+# cassette of this image stays reproducible — a pypi-side patch must not
+# silently flip behaviour underneath the scenario tests.
+# ``--break-system-packages`` is required on noble's PEP-668-marked system
+# Python; the image is single-use (sandbox runner only) so the global
+# install is acceptable here.
+RUN pip install --no-cache-dir --break-system-packages \
+        "pytest==8.3.4" \
+        "pytest-asyncio==0.24.0" \
+        "httpx==0.27.2" \
+        "playwright==1.49.0"

--- a/Makefile
+++ b/Makefile
@@ -581,3 +581,15 @@ arch-validate:
 arch-serve:
 	@command -v mkdocs >/dev/null 2>&1 || { echo "$(YELLOW)mkdocs not installed; run: pip install -e '.[docs]'$(RESET)"; exit 1; }
 	@$(UV) mkdocs serve --strict
+
+sandbox-up:
+	docker compose -f docker-compose.sandbox.yml up -d --build hydraflow ui
+
+sandbox-down:
+	docker compose -f docker-compose.sandbox.yml down -v
+
+sandbox-test:
+	docker compose -f docker-compose.sandbox.yml run --rm playwright
+
+sandbox-shell:
+	docker compose -f docker-compose.sandbox.yml exec hydraflow /bin/bash

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -48,7 +48,13 @@ services:
       - "127.0.0.1:5556:80"   # bound to localhost ONLY for human debugging.
 
   playwright:
-    image: mcr.microsoft.com/playwright/python:v1.49.0-jammy
+    # The MS playwright image ships browsers + the playwright wheel but no
+    # test runner. ``Dockerfile.playwright`` pre-installs pytest etc. at
+    # build time so the sandbox can stay air-gapped (``internal: true``) —
+    # pip cannot reach pypi from inside the sandbox network.
+    build:
+      context: .
+      dockerfile: Dockerfile.playwright
     volumes:
       - .:/work:ro
       - sandbox-results:/results
@@ -56,6 +62,11 @@ services:
     environment:
       SANDBOX_BASE_URL: "http://ui"
       SANDBOX_API_BASE: "http://hydraflow:5555"
+      # ``tests`` is a package at the repo root; the runner conftest +
+      # test_scenarios.py both ``import tests.sandbox_scenarios...``.
+      # ``src`` is on the path so ``mockworld.seed.MockWorldSeed``
+      # resolves when scenario modules are imported by ``loader.py``.
+      PYTHONPATH: "/work:/work/src"
     depends_on:
       ui:
         condition: service_started

--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -1,0 +1,67 @@
+version: "3.9"
+
+networks:
+  sandbox:
+    internal: true   # the air-gap. No default gateway → no external egress.
+                     # DNS resolution behavior is runtime-dependent;
+                     # rely on routing failure (timeouts/refused), not NXDOMAIN.
+
+services:
+  hydraflow:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+    # The selection of MockWorld vs. production is at the entrypoint level —
+    # this container always runs the sandbox entrypoint. The production
+    # image runs the `hydraflow` console script (entry point `server:main`
+    # per pyproject.toml) instead.
+    command: ["python", "-m", "mockworld.sandbox_main", "/seed/scenario.json"]
+    environment:
+      HYDRAFLOW_DASHBOARD_HOST: "0.0.0.0"
+      HYDRAFLOW_DASHBOARD_PORT: "5555"
+      HYDRAFLOW_ENV: "sandbox"
+      # No real credentials needed — the Fakes don't use them. These
+      # placeholders are present only so legacy code paths that read
+      # `os.environ["GH_TOKEN"]` at startup don't crash before the Fake
+      # adapters take over.
+      GH_TOKEN: "unused-by-fake-github"
+      ANTHROPIC_API_KEY: "unused-by-fake-llm"
+    volumes:
+      - ./tests/sandbox_scenarios/seeds:/seed:ro
+    networks: [sandbox]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:5555/healthz"]
+      interval: 2s
+      timeout: 1s
+      retries: 30
+      start_period: 5s
+
+  ui:
+    build:
+      context: ./src/ui
+      dockerfile: Dockerfile.ui
+    depends_on:
+      hydraflow:
+        condition: service_healthy
+    networks: [sandbox]
+    ports:
+      - "127.0.0.1:5556:80"   # bound to localhost ONLY for human debugging.
+
+  playwright:
+    image: mcr.microsoft.com/playwright/python:v1.49.0-jammy
+    volumes:
+      - .:/work:ro
+      - sandbox-results:/results
+    working_dir: /work
+    environment:
+      SANDBOX_BASE_URL: "http://ui"
+      SANDBOX_API_BASE: "http://hydraflow:5555"
+    depends_on:
+      ui:
+        condition: service_started
+    networks: [sandbox]
+    # The harness CLI overrides this command with the per-scenario invocation.
+    command: ["pytest", "tests/sandbox_scenarios/runner/", "-v", "--junitxml=/results/junit.xml"]
+
+volumes:
+  sandbox-results:

--- a/docs/adr/0052-sandbox-tier-scenarios.md
+++ b/docs/adr/0052-sandbox-tier-scenarios.md
@@ -52,7 +52,7 @@ Both are real production-relevant findings the sandbox tier surfaced — exactly
 **Negative:**
 - Sandbox tier adds ~30–60s per scenario. ~12 scenarios = ~10 min full-suite run.
 - New caretaker loop (`SandboxFailureFixerLoop`, lands in PR C) adds ~400 LOC of code to maintain.
-- Dockerfile.agent must `COPY` `tests/` until `src/contract_diff.py:54` is refactored away from importing `tests.trust.contracts._schema`.
+- Dockerfile.agent must `COPY` `tests/` until `src/contract_diff.py` is refactored away from importing `tests.trust.contracts._schema`.
 
 **Risks:**
 - Sandbox flakes erode trust if not investigated. Mitigation: 3-strikes-then-bug pattern from PR C's Trigger 3 (nightly).

--- a/docs/adr/0052-sandbox-tier-scenarios.md
+++ b/docs/adr/0052-sandbox-tier-scenarios.md
@@ -1,0 +1,73 @@
+# ADR-0052: Sandbox-tier scenario testing
+
+- **Status:** Accepted
+- **Date:** 2026-04-28
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** [ADR-0029](0029-caretaker-loop-pattern.md), [ADR-0042](0042-staging-promotion-loop.md), [ADR-0049](0049-trust-loop-kill-switch-convention.md), [ADR-0050](0050-auto-agent-hitl-preflight.md), [ADR-0051](0051-iterative-production-readiness-review.md)
+- **Enforced by:** `tests/test_mockworld_fakes_conformance.py` (Port↔Fake signature parity), `.github/workflows/ci.yml` `sandbox` job (CI gate).
+
+## Context
+
+The dark-factory infrastructure-hardening track (#8445/#8446/#8448) closed the structural-enforcement gap at the unit and per-loop level. What it did not close is the end-to-end gap: there was no test that booted HydraFlow as a deployed system and verified "issue → label-state-machine progression → PR merged" without a human watching.
+
+That gap was closed by the human in the loop. Removing the human means moving that verification into automation.
+
+## Decision
+
+Two test tiers backed by the same MockWorld substrate (`src/mockworld/fakes/`):
+
+- **Tier 1 (in-process, every PR):** existing `tests/scenarios/` suite. ~30 scenarios, ~0.1s each.
+- **Tier 2 (sandbox, PR B/C):** new `tests/sandbox_scenarios/` suite. ~12 curated scenarios that boot HydraFlow inside `docker-compose.sandbox.yml`, swap MockWorld at the boundary, drive the UI via Playwright, assert end-to-end. ~30–60s each.
+
+**MockWorld is always-on infrastructure**, not a configurable mode. Selection between Fake and real adapters happens at the **entrypoint level**: production runs the `hydraflow` console script (`server:main`); sandbox runs `python -m mockworld.sandbox_main`. `build_services()` and `HydraFlowOrchestrator.__init__` accept optional adapter overrides; production never passes them.
+
+**Air-gap is structural** (compose `internal: true`), not honor-system. Containers have no default gateway; external hosts cannot be routed to.
+
+## Rules
+
+1. **No config switch for MockWorld.** No `HYDRAFLOW_MOCKWORLD_ENABLED` env var, no boolean field on `HydraFlowConfig`. The choice is at the entrypoint level, period.
+2. **Fakes ship in `src/mockworld/fakes/`,** treated as production code (ruff, pyright, bandit). They are not test fixtures — they are alternative adapters.
+3. **Every sandbox scenario has a Tier-1 parity test** (`tests/scenarios/test_sandbox_parity.py`). If only Tier 2 fails, the bug is in container/wiring/UI; if both fail, it's in scenario logic. Triage starts with Tier 1.
+4. **The dashboard renders a persistent MOCKWORLD MODE banner** when the injected `PRPort` carries the `_is_fake_adapter` marker. Duck-typed; not config-driven.
+5. **CI gate (PR C):** all 12 sandbox scenarios must pass on the rc/* promotion PR before staging→main merge. Failures auto-dispatch the auto-agent self-fix loop (`SandboxFailureFixerLoop`).
+
+## Sandbox carve-outs (preserving the air-gap)
+
+The air-gap surfaces sites where production code has implicit network dependencies that hang under `internal: true`:
+
+- `src/contract_recording.py` synchronously invokes `claude -p ping` at startup, hanging on api.anthropic.com. Sandbox carve-out: the `mockworld.sandbox_main` entrypoint disables `contract_refresh` via `is_enabled` in its WorkerRegistryCallbacks.
+- `src/ui/src/context/HydraFlowContext.jsx` calls `crypto.randomUUID()` which is undefined in non-secure contexts (HTTP). Fallback: a deterministic `_fallbackUuidV4` based on `crypto.getRandomValues`.
+
+Both are real production-relevant findings the sandbox tier surfaced — exactly the bug class Tier 2 is designed to catch. ADR-0052 ratifies the carve-out pattern: when a production code path can't run on the air-gapped network, EITHER short-circuit it via a sandbox-only path in `mockworld.sandbox_main`, OR fix the production code to handle the air-gapped case (preferred when the fix is cheap, e.g., `randomUUID` fallback).
+
+## Consequences
+
+**Positive:**
+- End-to-end "did this build actually work?" verification runs without a human.
+- Container-only bugs (Dockerfile drops, network policy, UI routing) caught at PR time instead of in production.
+- Production releases leave staging with high confidence; observability catches what no test could anticipate.
+- Cross-tier alignment via shared Fake substrate eliminates "in-process passes, container fails" surprises.
+
+**Negative:**
+- Sandbox tier adds ~30–60s per scenario. ~12 scenarios = ~10 min full-suite run.
+- New caretaker loop (`SandboxFailureFixerLoop`, lands in PR C) adds ~400 LOC of code to maintain.
+- Dockerfile.agent must `COPY` `tests/` until `src/contract_diff.py:54` is refactored away from importing `tests.trust.contracts._schema`.
+
+**Risks:**
+- Sandbox flakes erode trust if not investigated. Mitigation: 3-strikes-then-bug pattern from PR C's Trigger 3 (nightly).
+- Self-fix loop oscillation. Mitigation: 3-attempt cap then HITL escalation.
+
+## When to supersede this ADR
+
+- If a future revision adopts a config-flag-based MockWorld selection (the design rejected here), supersede with rationale.
+- If empirical convergence shifts (e.g., sandbox scenarios routinely catch zero bugs over many quarters), reduce the planning expectation.
+
+## Source-file citations
+
+- `docs/superpowers/specs/2026-04-26-sandbox-tier-scenarios-design.md` — full spec (converged through 4 fresh-eyes review iterations per ADR-0051).
+- `src/mockworld/sandbox_main.py` — the sandbox entrypoint.
+- `src/mockworld/fakes/` — the always-loaded Fake adapter set.
+- `docker-compose.sandbox.yml` — the air-gapped sandbox stack.
+- `tests/sandbox_scenarios/` — the Tier-2 scenarios (s01 in PR B; s02–s12 in PR C).
+- `.github/workflows/ci.yml` `sandbox` job — the CI gate.

--- a/docs/adr/0052-sandbox-tier-scenarios.md
+++ b/docs/adr/0052-sandbox-tier-scenarios.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-04-28
 - **Supersedes:** none
 - **Superseded by:** none
-- **Related:** [ADR-0029](0029-caretaker-loop-pattern.md), [ADR-0042](0042-staging-promotion-loop.md), [ADR-0049](0049-trust-loop-kill-switch-convention.md), [ADR-0050](0050-auto-agent-hitl-preflight.md), [ADR-0051](0051-iterative-production-readiness-review.md)
+- **Related:** [ADR-0029](0029-caretaker-loop-pattern.md), [ADR-0042](0042-two-tier-branch-release-promotion.md), [ADR-0049](0049-trust-loop-kill-switch-convention.md), [ADR-0050](0050-auto-agent-hitl-preflight.md), [ADR-0051](0051-iterative-production-readiness-review.md)
 - **Enforced by:** `tests/test_mockworld_fakes_conformance.py` (Port↔Fake signature parity), `.github/workflows/ci.yml` `sandbox` job (CI gate).
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -83,6 +83,7 @@ ADR and that named test files actually exist.
 | [0049](0049-trust-loop-kill-switch-convention.md) | Trust-loop kill-switch convention (`enabled_cb` only, no config-only) | Proposed |
 | [0050](0050-auto-agent-hitl-preflight.md) | Auto-Agent HITL Pre-Flight Loop | Accepted |
 | [0051](0051-iterative-production-readiness-review.md) | Iterative production-readiness review | Accepted |
+| [0052](0052-sandbox-tier-scenarios.md) | Sandbox-tier scenario testing | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-27T21:39:27.905727+00:00",
-  "commit_sha": "72be71529adc69567324bc9be08d428e1eff7197",
+  "regenerated_at": "2026-04-28T20:15:05.935918+00:00",
+  "commit_sha": "110c1c4d40435cc145077f957073fa8723589dc5",
   "artifacts": {
     "loops.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "ports.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "labels.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "modules.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "events.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "adr_xref.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "mockworld.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "changelog.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     },
     "functional_areas.md": {
-      "source_sha": "72be71529adc69567324bc9be08d428e1eff7197"
+      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-28T20:15:05.935918+00:00",
-  "commit_sha": "110c1c4d40435cc145077f957073fa8723589dc5",
+  "regenerated_at": "2026-04-28T21:28:07.435842+00:00",
+  "commit_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935",
   "artifacts": {
     "loops.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "ports.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "labels.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "modules.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "events.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "adr_xref.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "mockworld.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "changelog.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     },
     "functional_areas.md": {
-      "source_sha": "110c1c4d40435cc145077f957073fa8723589dc5"
+      "source_sha": "68e7ee3f7400f9550a97b5af54be6925fbb27935"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -150,4 +150,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -59,6 +59,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0049 | `src.base_background_loop`, `src.bg_worker_manager` |
 | ADR-0050 | `src.auto_agent_preflight_loop`, `src.config`, `src.dashboard_routes._diagnostics_routes`, `src.models`, `src.preflight.agent`, `src.preflight.audit`, `src.preflight.auto_agent_runner`, `src.preflight.context`, `src.preflight.decision`, `src.preflight.runner`, `src.sentry.reverse_lookup`, `src.state._auto_agent` |
 | ADR-0051 | — |
+| ADR-0052 | `src.contract_diff`, `src.contract_recording`, `src.mockworld.sandbox_main` |
 
 ## Module → ADRs
 
@@ -75,8 +76,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.caching_issue_store` | ADR-0041 |
 | `src.cli` | ADR-0036 |
 | `src.config` | ADR-0002, ADR-0009, ADR-0010, ADR-0018, ADR-0021, ADR-0022, ADR-0031, ADR-0033, ADR-0034, ADR-0035, ADR-0036, ADR-0045, ADR-0050 |
-| `src.contract_diff` | ADR-0047 |
-| `src.contract_recording` | ADR-0047 |
+| `src.contract_diff` | ADR-0047, ADR-0052 |
+| `src.contract_recording` | ADR-0047, ADR-0052 |
 | `src.contract_refresh_loop` | ADR-0045, ADR-0047 |
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
@@ -104,6 +105,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.issue_fetcher` | ADR-0019 |
 | `src.issue_store` | ADR-0006, ADR-0022, ADR-0041 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
+| `src.mockworld.sandbox_main` | ADR-0052 |
 | `src.models` | ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0025, ADR-0031, ADR-0037, ADR-0045, ADR-0050 |
 | `src.orchestrator` | ADR-0006, ADR-0009, ADR-0014, ADR-0044, ADR-0045 |
 | `src.path` | ADR-0032 |
@@ -148,4 +150,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,12 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W18
 
-- `72be715` — fix(mockworld): break src->tests import + clean arch-doc generator (PR A pass-1 follow-ups) *(2026-04-27)*
-- `5c087c4` — chore(arch): regen generated docs after Task 1.10 *(2026-04-27)*
-- `3eb0890` — feat(mockworld): sandbox_main entrypoint + apply_seed + dashboard banner + s00 *(2026-04-27)*
-- `0eb33da` — feat(orchestrator): accept pre-built ServiceRegistry via services= kwarg *(2026-04-27)*
-- `db81ede` — refactor(types): widen Port-shaped fields from concrete adapters to Ports *(2026-04-27)*
-- `76ad04f` — refactor(mockworld): relocate Fakes from tests/scenarios/fakes/ to src/mockworld/fakes/ *(2026-04-27)*
+- `110c1c4` — docs(adr): ADR-0052 — sandbox-tier scenario testing *(2026-04-28)*
+- `32ef615` — feat(mockworld): foundation — Fake relocation + DI plumbing + sandbox entrypoint (PR A of 3) (#8451) (#8451) *(2026-04-28)*
 
 ## 2026-W17
 
@@ -156,4 +152,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W18
 
+- `68e7ee3` — chore(arch): regen generated docs after ADR-0052 + Fakes widening *(2026-04-28)*
 - `110c1c4` — docs(adr): ADR-0052 — sandbox-tier scenario testing *(2026-04-28)*
 - `32ef615` — feat(mockworld): foundation — Fake relocation + DI plumbing + sandbox entrypoint (PR A of 3) (#8451) (#8451) *(2026-04-28)*
 
@@ -152,4 +153,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -31,7 +31,7 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **PIPELINE_STATS** ⚠️ | `src.orchestrator:HydraFlowOrchestrator.emit_pipeline_stats` | — |
 | **PLANNER_UPDATE** ⚠️ | `src.planner:PlannerRunner._emit_status` | — |
 | **PR_CREATED** ⚠️ | `src.pr_manager:PRManager.create_pr`<br>`src.pr_manager:PRManager.create_promotion_pr` | — |
-| **QUEUE_UPDATE** ⚠️ | `src.issue_store:IssueStore._publish_queue_update_nowait`<br>`src.issue_store:IssueStore.refresh` | — |
+| **QUEUE_UPDATE** ⚠️ | `src.issue_store:IssueStore._publish_queue_update_nowait`<br>`src.issue_store:IssueStore.refresh`<br>`src.mockworld.fakes.fake_issue_store:FakeIssueStore.refresh` | — |
 | **REPORT_UPDATE** ⚠️ | `src.report_issue_loop:ReportIssueLoop._emit_report_event` | — |
 | **RETROSPECTIVE_UPDATE** ⚠️ | `src.retrospective_loop:RetrospectiveLoop._publish_update` | — |
 | **REVIEW_UPDATE** ⚠️ | `src.merge_conflict_resolver:MergeConflictResolver._publish_review_status`<br>`src.phase_utils:publish_review_status`<br>`src.reviewer:ReviewRunner.fix_review_findings`<br>`src.reviewer:ReviewRunner.review` | — |
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -255,4 +255,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -255,4 +255,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -41,4 +41,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -41,4 +41,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -31,4 +31,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -25,10 +25,10 @@ graph LR
     src_arch_generators -- "10" --> src_arch
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
-    src_mockworld_fakes -- "24" --> src_mockworld
+    src_mockworld_fakes -- "25" --> src_mockworld
     src_preflight -- "1" --> src_runners
     src_preflight -- "1" --> src_sentry
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -84,4 +84,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `72be715` on 2026-04-27 21:39 UTC. Source last changed at `72be715`. Status: 🟢 fresh._
+_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -84,4 +84,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `110c1c4` on 2026-04-28 20:15 UTC. Source last changed at `110c1c4`. Status: 🟢 fresh._
+_Regenerated from commit `68e7ee3` on 2026-04-28 21:28 UTC. Source last changed at `68e7ee3`. Status: 🟢 fresh._

--- a/scripts/sandbox_scenario.py
+++ b/scripts/sandbox_scenario.py
@@ -1,0 +1,219 @@
+"""sandbox_scenario — host-side harness for the sandbox tier.
+
+Subcommands:
+    run NAME       — Compute seed, build (if needed), boot stack, run one
+                     scenario, capture artifacts, tear down.
+    run-all        — Same, but iterates the catalog; produces a summary
+                     table and exits nonzero if any failed.
+    status         — Show current stack state without booting.
+    down           — Tear down the stack and remove volumes.
+    shell          — Drop into bash inside the hydraflow container.
+    seed NAME      — Compute and write the JSON seed without booting.
+
+Returns exit code 0 on full success, 1 on any scenario failure, 2 on
+infrastructure failure (build / healthcheck / playwright crash).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMPOSE_FILE = REPO_ROOT / "docker-compose.sandbox.yml"
+SEEDS_DIR = REPO_ROOT / "tests" / "sandbox_scenarios" / "seeds"
+RESULTS_DIR = Path("/tmp/sandbox-results")
+
+# Ensure `tests.sandbox_scenarios.scenarios.*` and `mockworld.*` are
+# importable when this script is invoked directly (e.g.
+# `python scripts/sandbox_scenario.py`). Under pytest the rootdir +
+# editable-install pth file handle this, but the CLI entrypoint doesn't
+# get that for free.
+for _p in (REPO_ROOT, REPO_ROOT / "src"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+
+def load_scenario(name: str):
+    """Import a scenario module by NAME."""
+    return importlib.import_module(f"tests.sandbox_scenarios.scenarios.{name}")
+
+
+def write_seed(name: str) -> Path:
+    """Compute the scenario's seed and write it to SEEDS_DIR."""
+    SEEDS_DIR.mkdir(parents=True, exist_ok=True)
+    mod = load_scenario(name)
+    out = SEEDS_DIR / f"{mod.NAME}.json"
+    out.write_text(mod.seed().to_json())
+    return out
+
+
+def _compose(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["docker", "compose", "-f", str(COMPOSE_FILE), *args],
+        check=False,
+    )
+
+
+def cmd_seed(name: str) -> int:
+    out = write_seed(name)
+    print(f"Wrote seed: {out}")
+    return 0
+
+
+def cmd_down() -> int:
+    print("Stopping stack...")
+    _compose("down", "-v")
+    print("Done.")
+    return 0
+
+
+def cmd_status() -> int:
+    return _compose("ps").returncode
+
+
+def cmd_shell() -> int:
+    return _compose("exec", "hydraflow", "/bin/bash").returncode
+
+
+def _wait_for_healthy(timeout: float = 60.0) -> bool:
+    """Poll docker compose ps for hydraflow (healthy) up to timeout seconds."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(COMPOSE_FILE),
+                "ps",
+                "--format",
+                "json",
+                "hydraflow",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if "(healthy)" in result.stdout or '"Health":"healthy"' in result.stdout:
+            return True
+        time.sleep(2)
+    return False
+
+
+def cmd_run(name: str) -> int:
+    print(f"[1/5] Computing seed for {name}...")
+    seed_path = write_seed(name)
+
+    # Make sure the seed file the container reads matches THIS scenario.
+    # The container always reads /seed/scenario.json, so symlink it.
+    target = SEEDS_DIR / "scenario.json"
+    if target.exists() or target.is_symlink():
+        target.unlink()
+    target.symlink_to(seed_path.name)
+
+    print("[2/5] Building images (cached when possible)...")
+    rc = _compose("build", "hydraflow", "ui").returncode
+    if rc != 0:
+        print(f"BUILD FAILED ({rc})")
+        return 2
+
+    print("[3/5] Starting stack on internal network...")
+    rc = _compose("up", "-d", "hydraflow", "ui").returncode
+    if rc != 0:
+        print(f"UP FAILED ({rc})")
+        return 2
+
+    print("[4/5] Waiting for hydraflow /healthz...")
+    if not _wait_for_healthy(60):
+        print("HEALTHCHECK TIMEOUT — collecting logs")
+        _compose("logs", "hydraflow")
+        cmd_down()
+        return 2
+
+    print("[5/5] Running playwright assertions...")
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    rc = _compose(
+        "run",
+        "--rm",
+        "-e",
+        f"SCENARIO_NAME={name}",
+        "playwright",
+        "pytest",
+        f"tests/sandbox_scenarios/runner/test_scenarios.py::test_scenario[{name}]",
+        "-v",
+        "--junitxml=/results/junit.xml",
+    ).returncode
+
+    if rc != 0:
+        print(f"FAILED {name}")
+        _compose("logs", "hydraflow")
+    else:
+        print(f"PASSED {name}")
+
+    cmd_down()
+    return rc
+
+
+def cmd_run_all() -> int:
+    """Iterate every scenario; print summary; exit nonzero on any failure."""
+    from tests.sandbox_scenarios.runner.loader import load_all_scenarios
+
+    scenarios = load_all_scenarios()
+    results: list[tuple[str, int, float]] = []
+    for s in scenarios:
+        if s.NAME == "s00_smoke":
+            print(f"SKIPPED {s.NAME} (parity-only, no Tier-2 implementation)")
+            continue
+        start = time.monotonic()
+        rc = cmd_run(s.NAME)
+        elapsed = time.monotonic() - start
+        results.append((s.NAME, rc, elapsed))
+
+    print("\n--- Summary ---")
+    fails = 0
+    for name, rc, elapsed in results:
+        status = "PASSED" if rc == 0 else "FAILED"
+        if rc != 0:
+            fails += 1
+        print(f"{status:8s} {name:40s} ({elapsed:5.1f}s)")
+    print(f"\n{len(results) - fails} passed, {fails} failed")
+    return 1 if fails else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="sandbox_scenario")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("status")
+    sub.add_parser("down")
+    sub.add_parser("shell")
+    sub.add_parser("run-all")
+    p_run = sub.add_parser("run")
+    p_run.add_argument("name")
+    p_seed = sub.add_parser("seed")
+    p_seed.add_argument("name")
+
+    args = parser.parse_args()
+    nullary = {
+        "status": cmd_status,
+        "down": cmd_down,
+        "shell": cmd_shell,
+        "run-all": cmd_run_all,
+    }
+    unary = {
+        "run": cmd_run,
+        "seed": cmd_seed,
+    }
+    if args.cmd in nullary:
+        return nullary[args.cmd]()
+    if args.cmd in unary:
+        return unary[args.cmd](args.name)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sandbox_scenario.py
+++ b/scripts/sandbox_scenario.py
@@ -26,7 +26,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 COMPOSE_FILE = REPO_ROOT / "docker-compose.sandbox.yml"
 SEEDS_DIR = REPO_ROOT / "tests" / "sandbox_scenarios" / "seeds"
-RESULTS_DIR = Path("/tmp/sandbox-results")
+RESULTS_DIR = Path("/tmp/sandbox-results")  # noqa: S108  # nosec B108  # Sandbox CLI artifacts dir; not a security boundary, contents are mkdir'd per-run.
 
 # Ensure `tests.sandbox_scenarios.scenarios.*` and `mockworld.*` are
 # importable when this script is invoked directly (e.g.

--- a/scripts/sandbox_scenario.py
+++ b/scripts/sandbox_scenario.py
@@ -117,7 +117,10 @@ def cmd_run(name: str) -> int:
     target.symlink_to(seed_path.name)
 
     print("[2/5] Building images (cached when possible)...")
-    rc = _compose("build", "hydraflow", "ui").returncode
+    # ``playwright`` must be built explicitly because the MS image ships no
+    # test runner — ``Dockerfile.playwright`` adds pytest at build time so
+    # ``compose run playwright pytest …`` works on the air-gapped network.
+    rc = _compose("build", "hydraflow", "ui", "playwright").returncode
     if rc != 0:
         print(f"BUILD FAILED ({rc})")
         return 2
@@ -137,6 +140,12 @@ def cmd_run(name: str) -> int:
 
     print("[5/5] Running playwright assertions...")
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    # ``-c tests/sandbox_scenarios/pytest.ini`` makes that file the
+    # rootdir-config so pytest does NOT autoload the project-wide
+    # ``tests/conftest.py`` (which imports pydantic/HydraFlow internals
+    # that the slim playwright image doesn't have). The runner's own
+    # conftest under ``tests/sandbox_scenarios/runner/`` still loads
+    # because it's inside the new rootdir.
     rc = _compose(
         "run",
         "--rm",
@@ -144,6 +153,8 @@ def cmd_run(name: str) -> int:
         f"SCENARIO_NAME={name}",
         "playwright",
         "pytest",
+        "-c",
+        "tests/sandbox_scenarios/pytest.ini",
         f"tests/sandbox_scenarios/runner/test_scenarios.py::test_scenario[{name}]",
         "-v",
         "--junitxml=/results/junit.xml",

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -7,6 +7,7 @@ import contextlib
 import copy
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -1215,19 +1216,35 @@ def create_router(
         }
         dashboard_public = not _is_loopback_host(config.dashboard_host)
 
-        # GitHub cache health (if available)
+        # GitHub cache health (if available).
+        # CacheSnapshot.age_seconds returns float("inf") when a dataset has
+        # never been fetched (no orchestrator poll yet, e.g. cold sandbox
+        # boot). JSON encoding chokes on inf, so we coerce to None for
+        # those entries and report the cache as "uninitialized".
         github_cache_health: dict[str, object] = {"status": "unknown"}
         if orchestrator is not None and isinstance(
             getattr(orchestrator, "github_cache", None), GitHubDataCache
         ):
             gh_cache: GitHubDataCache = orchestrator.github_cache
-            cache_ages = {
-                ds: round(gh_cache.get_cache_age(ds), 1)
+            cache_ages_raw = {
+                ds: gh_cache.get_cache_age(ds)
                 for ds in ("open_prs", "hitl_items", "label_counts")
             }
-            max_age = max(cache_ages.values()) if cache_ages else 0
+            cache_ages: dict[str, float | None] = {
+                ds: (None if math.isinf(age) else round(age, 1))
+                for ds, age in cache_ages_raw.items()
+            }
+            finite_ages = [a for a in cache_ages.values() if a is not None]
+            if not finite_ages:
+                cache_status = "uninitialized"
+                max_age = 0.0
+            else:
+                max_age = max(finite_ages)
+                cache_status = (
+                    "stale" if max_age > config.data_poll_interval * 3 else "ok"
+                )
             github_cache_health = {
-                "status": "stale" if max_age > config.data_poll_interval * 3 else "ok",
+                "status": cache_status,
                 "age_seconds": cache_ages,
             }
 

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -78,6 +78,10 @@ class FakeGitHub:
         self._rate_limit_reset_in: int = 60
         self._rate_limit_secondary: bool = False
         self._alerts: dict[str, list[Any]] = {}
+        # Mirrors PRManager._repo. Some loops (StaleIssueLoop) read this
+        # attribute directly when constructing `gh` CLI args via _run_gh.
+        # The value never reaches a real GitHub API in the sandbox.
+        self._repo: str = "owner/repo"
 
     @classmethod
     def from_seed(cls, seed: MockWorldSeed) -> FakeGitHub:
@@ -644,3 +648,148 @@ class FakeGitHub:
         unconditionally during pipeline boot.
         """
         return None
+
+    async def get_label_counts(self, config: Any) -> dict[str, Any]:
+        """Return open-by-label / total-closed / total-merged counts.
+
+        Mirrors ``PRManager.get_label_counts``. Used by ``GitHubCacheLoop``
+        to pre-warm the dashboard's "throughput" tile. The Fake walks
+        ``_issues`` for open counts and ``_prs`` for merged counts.
+        """
+        self._maybe_rate_limit()
+        label_map = {
+            "hydraflow-plan": getattr(config, "planner_label", ["hydraflow-plan"]),
+            "hydraflow-ready": getattr(config, "ready_label", ["hydraflow-ready"]),
+            "hydraflow-review": getattr(config, "review_label", ["hydraflow-review"]),
+            "hydraflow-hitl": getattr(config, "hitl_label", ["hydraflow-hitl"]),
+            "hydraflow-fixed": getattr(config, "fixed_label", ["hydraflow-fixed"]),
+        }
+        open_by_label: dict[str, int] = {}
+        for canonical, labels in label_map.items():
+            wanted = set(labels) if isinstance(labels, list) else {labels}
+            count = sum(
+                1
+                for issue in self._issues.values()
+                if issue.state == "open" and (set(issue.labels) & wanted)
+            )
+            open_by_label[canonical] = count
+
+        fixed_label = (
+            getattr(config, "fixed_label", ["hydraflow-fixed"])[0]
+            if getattr(config, "fixed_label", None)
+            else "hydraflow-fixed"
+        )
+        total_closed = sum(
+            1
+            for issue in self._issues.values()
+            if issue.state != "open" and fixed_label in issue.labels
+        )
+        total_merged = sum(1 for pr in self._prs.values() if pr.merged)
+
+        return {
+            "open_by_label": open_by_label,
+            "total_closed": total_closed,
+            "total_merged": total_merged,
+        }
+
+    async def list_open_prs(self, labels: list[str]) -> list[Any]:
+        """Return open PRs carrying any of *labels* as PRListItem-style objects.
+
+        Mirrors ``PRManager.list_open_prs``. Used by ``GitHubCacheLoop`` to
+        warm its PR-by-label cache. The Fake walks ``_prs`` filtered by
+        ``merged=False`` and label intersection.
+        """
+        self._maybe_rate_limit()
+        from models import PRListItem
+
+        wanted = set(labels)
+        out: list[PRListItem] = []
+        for pr in self._prs.values():
+            if pr.merged:
+                continue
+            if wanted and not (wanted & set(pr.labels)):
+                continue
+            out.append(
+                PRListItem(
+                    pr=pr.number,
+                    issue=pr.issue_number,
+                    branch=pr.branch,
+                    url=pr.url or "",
+                    draft=pr.draft,
+                    title="",
+                    merged=pr.merged,
+                    author="fake-author",
+                )
+            )
+        return out
+
+    async def _run_gh(self, *cmd: str, cwd: Any = None) -> str:
+        """Generic ``gh`` CLI passthrough — returns minimal-shape JSON.
+
+        Production ``PRManager._run_gh`` exec's the ``gh`` CLI and returns
+        stdout. The Fake parses *cmd* far enough to identify which API
+        call it represents (``gh issue list``, ``gh pr list``, etc.) and
+        synthesizes a JSON payload from in-memory state.
+
+        Unknown commands return ``"[]"`` rather than raising — keeps
+        loops that probe rare endpoints quiet during scenario runs.
+        """
+        self._maybe_rate_limit()
+        _ = cwd
+        import json as _json
+
+        args = list(cmd)
+        # Strip leading "gh" if the caller included it (some sites do).
+        if args and args[0] == "gh":
+            args = args[1:]
+        if not args:
+            return "[]"
+
+        verb = args[0]
+
+        if verb == "issue" and len(args) > 1:
+            sub = args[1]
+            if sub == "list":
+                # Return minimally-shaped issue list. StaleIssueLoop expects
+                # number/title/updatedAt/labels.
+                payload = [
+                    {
+                        "number": issue.number,
+                        "title": issue.title,
+                        "updatedAt": getattr(
+                            issue, "updated_at", "2026-01-01T00:00:00Z"
+                        ),
+                        "labels": [{"name": lbl} for lbl in issue.labels],
+                    }
+                    for issue in self._issues.values()
+                    if issue.state == "open"
+                ]
+                return _json.dumps(payload)
+            if sub == "close":
+                # Best-effort: extract issue number from positional args.
+                for a in args[2:]:
+                    if a.isdigit():
+                        await self.close_issue(int(a))
+                        break
+                return ""
+            if sub == "view":
+                return _json.dumps({"comments": []})
+
+        if verb == "pr" and len(args) > 1:
+            sub = args[1]
+            if sub == "list":
+                payload = [
+                    {
+                        "number": pr.number,
+                        "title": "",
+                        "url": pr.url or "",
+                        "labels": [{"name": lbl} for lbl in pr.labels],
+                    }
+                    for pr in self._prs.values()
+                    if not pr.merged
+                ]
+                return _json.dumps(payload)
+
+        # Unknown verb: return empty JSON array — safe default for
+        # callers that ``json.loads`` the output.
+        return "[]"

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -631,3 +631,16 @@ class FakeGitHub:
 
     async def apply_staging_branch_protection(self, branch: str) -> dict[str, Any]:
         return {"status": "protected", "branch": branch}
+
+    # --- Concrete-only PRManager methods invoked at orchestrator boot ---
+
+    async def ensure_labels_exist(self) -> None:
+        """Idempotently create HydraFlow lifecycle labels (no-op stub).
+
+        Production PRManager pushes label definitions to GitHub via
+        ``gh label create``. The seeded FakeGitHub already has whatever
+        labels the seed declared, so this is a no-op. Required because
+        ``HydraFlowOrchestrator.run()`` calls ``prs.ensure_labels_exist()``
+        unconditionally during pipeline boot.
+        """
+        return None

--- a/src/mockworld/fakes/fake_issue_fetcher.py
+++ b/src/mockworld/fakes/fake_issue_fetcher.py
@@ -3,6 +3,19 @@
 Standalone class created for the sandbox entrypoint (Task 1.10), which
 constructs Fakes via build_services() overrides — monkeypatching only
 works in-process and can't reach the docker container.
+
+Task 2.5b widening: now satisfies both ``IssueFetcherPort``
+(``fetch_issue_by_number``, ``fetch_issues_by_labels``) and the
+concrete-only methods that orchestrator-side machinery dispatches
+without going through the Port:
+
+- ``fetch_all_hydraflow_issues`` — used by ``GitHubTaskFetcher`` and
+  ``IssueStore.refresh()``. Returns all open issues carrying any
+  ``hydraflow-*`` lifecycle label.
+- ``fetch_issue_comments`` — used by ``IssueStore.enrich_with_comments``
+  to fetch comment bodies for an issue.
+- ``fetch_open_issues_by_label`` — PR A's narrower surface, kept for
+  the Fake unit tests that predate the widening.
 """
 
 from __future__ import annotations
@@ -10,14 +23,31 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from models import GitHubIssue
+
 if TYPE_CHECKING:
     from mockworld.fakes.fake_github import FakeGitHub
     from mockworld.seed import MockWorldSeed
 
 
+# Lifecycle labels recognized by HydraFlow's IssueStore. Mirrors the
+# config defaults — the Fake doesn't read HydraFlowConfig, so it
+# hardcodes the canonical set. Any production-side label-rename would
+# need to be reflected here too.
+HYDRAFLOW_LABELS = (
+    "hydraflow-find",
+    "hydraflow-discover",
+    "hydraflow-shape",
+    "hydraflow-plan",
+    "hydraflow-ready",
+    "hydraflow-review",
+    "hydraflow-hitl",
+)
+
+
 @dataclass
 class FakeIssueSummary:
-    """Minimal IssueFetcher-shaped payload."""
+    """Minimal IssueFetcher-shaped payload (PR A's narrower surface)."""
 
     number: int
     title: str
@@ -27,14 +57,7 @@ class FakeIssueSummary:
 
 
 class FakeIssueFetcher:
-    """Minimal sandbox stand-in — does NOT satisfy IssueFetcherPort.
-
-    Provides only `fetch_open_issues_by_label` — the surface the sandbox
-    entrypoint needs (Task 1.10). The real IssueFetcherPort has additional
-    methods (`fetch_issue_by_number`, `fetch_issues_by_labels`). Extend
-    here when sandbox scenarios need more methods. Do NOT pass this where
-    an IssueFetcherPort is required without checking the call site.
-    """
+    """In-memory IssueFetcherPort impl backed by a FakeGitHub world."""
 
     _is_fake_adapter = True
 
@@ -43,14 +66,140 @@ class FakeIssueFetcher:
 
     @classmethod
     def from_seed(cls, seed: MockWorldSeed) -> FakeIssueFetcher:
-        """Build a FakeIssueFetcher from a serialized seed.
-
-        Constructs an internal FakeGitHub from the seed and wraps it.
-        """
         from mockworld.fakes.fake_github import FakeGitHub
 
         github = FakeGitHub.from_seed(seed)
         return cls(github=github)
+
+    def _to_github_issue(self, issue: object) -> GitHubIssue:
+        return GitHubIssue(
+            number=issue.number,  # type: ignore[attr-defined]
+            title=issue.title,  # type: ignore[attr-defined]
+            body=issue.body,  # type: ignore[attr-defined]
+            labels=list(issue.labels),  # type: ignore[attr-defined]
+            comments=list(getattr(issue, "comments", [])),
+            url="",
+            author="fake-author",
+            state=("open" if issue.state == "open" else "closed"),  # type: ignore[attr-defined]
+            created_at="",
+        )
+
+    # ------------------------------------------------------------------
+    # IssueFetcherPort (the canonical surface)
+    # ------------------------------------------------------------------
+
+    async def fetch_issue_by_number(self, issue_number: int) -> GitHubIssue | None:
+        issue = self._github._issues.get(issue_number)
+        if issue is None:
+            return None
+        return self._to_github_issue(issue)
+
+    async def fetch_issues_by_labels(
+        self,
+        labels: list[str],
+        limit: int,
+        exclude_labels: list[str] | None = None,
+        require_complete: bool = False,
+    ) -> list[GitHubIssue]:
+        """Return open issues matching any *labels*, deduplicated.
+
+        ``require_complete`` is honored as a no-op (the Fake never returns
+        partial results because there's no rate-limit / pagination edge).
+        """
+        _ = require_complete  # Fake never partially fetches
+        excluded = set(exclude_labels or [])
+        wanted = set(labels)
+
+        out: list[GitHubIssue] = []
+        for issue in self._github._issues.values():
+            if issue.state != "open":
+                continue
+            issue_labels = set(issue.labels)
+            # Empty labels with exclude_labels means "all open issues
+            # except those carrying excluded labels" — mirrors the real
+            # IssueFetcher's documented contract.
+            if wanted and not (wanted & issue_labels):
+                continue
+            if excluded and (excluded & issue_labels):
+                continue
+            out.append(self._to_github_issue(issue))
+            if len(out) >= limit:
+                break
+        return out
+
+    # ------------------------------------------------------------------
+    # Concrete-only IssueFetcher methods (called via duck-typing,
+    # not via the Port)
+    # ------------------------------------------------------------------
+
+    async def fetch_all_hydraflow_issues(self) -> list[GitHubIssue]:
+        """Return open issues carrying any HydraFlow lifecycle label.
+
+        Used by ``GitHubTaskFetcher`` (which wraps an IssueFetcher and
+        feeds the IssueStore poller). The Fake hardcodes the lifecycle
+        label set; see module-level ``HYDRAFLOW_LABELS``.
+        """
+        return await self.fetch_issues_by_labels(list(HYDRAFLOW_LABELS), limit=500)
+
+    async def fetch_issue_comments(self, issue_number: int) -> list[str]:
+        """Return raw comment bodies seeded on *issue_number*."""
+        issue = self._github._issues.get(issue_number)
+        if issue is None:
+            return []
+        return list(getattr(issue, "comments", []))
+
+    async def fetch_reviewable_prs(
+        self,
+        active_issues: set[int],
+        prefetched_issues: list[GitHubIssue] | None = None,
+    ) -> tuple[list[object], list[GitHubIssue]]:
+        """Resolve ``hydraflow-review``-labeled issues into (PRInfo, issue) pairs.
+
+        Mirrors ``IssueFetcher.fetch_reviewable_prs``: returns the open
+        non-draft PRs whose branch matches ``agent/issue-{N}``. The Fake
+        derives the (issue, PR) pairs from FakeGitHub's ``_prs`` map.
+        """
+        from mockworld.fakes._factories import PRInfoFactory
+
+        if prefetched_issues is not None:
+            issues = [i for i in prefetched_issues if i.number not in active_issues]
+        else:
+            issues = await self.fetch_issues_by_labels(["hydraflow-review"], limit=200)
+            issues = [i for i in issues if i.number not in active_issues]
+
+        if not issues:
+            return [], []
+
+        pr_infos: list[object] = []
+        for issue in issues:
+            for pr in self._github._prs.values():
+                if pr.merged or pr.draft:
+                    continue
+                if pr.issue_number == issue.number:
+                    pr_infos.append(
+                        PRInfoFactory.create(
+                            number=pr.number,
+                            issue_number=pr.issue_number,
+                            branch=pr.branch,
+                            draft=pr.draft,
+                        )
+                    )
+                    break
+        return pr_infos, issues
+
+    async def _get_collaborators(self) -> set[str] | None:
+        """Return None (fail-open) — sandbox has no collaborator concept.
+
+        Production fetches ``repos/{repo}/collaborators`` and caches the
+        login set so the issue fetcher can drop non-collaborator triage
+        spam. The Fake doesn't model collaborators; returning ``None``
+        signals "check disabled" in the production code path.
+        """
+        return None
+
+    # ------------------------------------------------------------------
+    # PR A's narrower surface (kept for back-compat with Fake unit tests)
+    # ------------------------------------------------------------------
 
     async def fetch_open_issues_by_label(self, label: str) -> list[FakeIssueSummary]:
         out = []

--- a/src/mockworld/fakes/fake_issue_store.py
+++ b/src/mockworld/fakes/fake_issue_store.py
@@ -3,17 +3,77 @@
 Standalone class created for the sandbox entrypoint (Task 1.10), which
 constructs Fakes via build_services() overrides — monkeypatching only
 works in-process and can't reach the docker container.
+
+Task 2.5b widening: implements the full IssueStorePort surface plus the
+concrete-only methods the orchestrator dispatches via
+``cast("IssueStore", self._svc.store)`` (``start``, ``clear_active``,
+``get_active_issues``, ``get_queue_stats``, ``get_pipeline_snapshot``,
+``is_in_pipeline``, ``get_merged_numbers``, ``get_cached``,
+``get_hitl_issues``, ``get_uncrated_issues``, ``set_crate_manager``).
+
+Implementation strategy:
+
+The Fake derives queue state from FakeGitHub's ``_issues`` dict (keyed
+by issue number, carrying labels/state/comments/updated_at) on every
+read. There's no separate routing/dedup machinery — labels are the source
+of truth, mirroring the real IssueStore's *eventual* state but without
+the in-flight protection / eager-transition / refresh-cycle plumbing.
+
+Active / merged / processed_count tracking lives on the Fake itself
+(``_active``, ``_merged_numbers``, ``_processed_count``) so the
+orchestrator's stats / snapshot calls return populated payloads.
+
+This is sufficient for the sandbox scenario tier: scenarios assert on
+end-state outcomes (issue merged, label transitions visible) rather
+than on the queue's intermediate dedup / in-flight semantics.
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from events import EventType, HydraFlowEvent
+from models import (
+    HITLItem,
+    PipelineIssueStatus,
+    PipelineSnapshotEntry,
+    QueueStats,
+    Task,
+)
 
 if TYPE_CHECKING:
     from events import EventBus
     from mockworld.fakes.fake_github import FakeGitHub
     from mockworld.seed import MockWorldSeed
+
+
+logger = logging.getLogger("hydraflow.mockworld.fake_issue_store")
+
+
+# Stage constants — match issue_store.IssueStoreStage values without
+# importing the real module (keeps the Fake source-of-truth contained).
+STAGE_FIND = "find"
+STAGE_DISCOVER = "discover"
+STAGE_SHAPE = "shape"
+STAGE_PLAN = "plan"
+STAGE_READY = "ready"
+STAGE_REVIEW = "review"
+STAGE_HITL = "hitl"
+STAGE_MERGED = "merged"
+
+_LABEL_TO_STAGE: dict[str, str] = {
+    "hydraflow-find": STAGE_FIND,
+    "hydraflow-discover": STAGE_DISCOVER,
+    "hydraflow-shape": STAGE_SHAPE,
+    "hydraflow-plan": STAGE_PLAN,
+    "hydraflow-ready": STAGE_READY,
+    "hydraflow-review": STAGE_REVIEW,
+    "hydraflow-hitl": STAGE_HITL,
+}
 
 
 @dataclass
@@ -28,14 +88,12 @@ class FakeIssueRecord:
 
 
 class FakeIssueStore:
-    """Minimal sandbox stand-in — does NOT satisfy IssueStorePort.
+    """In-memory IssueStorePort impl backed by a FakeGitHub world.
 
-    Provides only `get`, `transition`, `list_by_label` — the surface the
-    sandbox entrypoint needs (Task 1.10). The real IssueStorePort has
-    11+ methods (`get_triageable`, `get_plannable`, `mark_active`,
-    `enrich_with_comments`, etc.). Extend here when sandbox scenarios
-    need more methods. Do NOT pass this where an IssueStorePort is
-    required without checking the call site.
+    Wider than PR A's narrow surface — covers the full
+    ``IssueStorePort`` plus IssueStore-only methods the orchestrator
+    invokes via ``cast("IssueStore", store)``. See module docstring for
+    the design tradeoff (labels as source of truth vs. real-store dedup).
     """
 
     _is_fake_adapter = True
@@ -44,12 +102,346 @@ class FakeIssueStore:
         self._github = github
         self._bus = event_bus
 
+        # Active issue tracking: issue_number -> stage
+        self._active: dict[int, str] = {}
+        # In-flight (between dequeue and mark_active) tracking
+        self._in_flight: dict[int, str] = {}
+        # Merged issues for snapshot reporting
+        self._merged_numbers: set[int] = set()
+        # Per-stage throughput counters
+        self._processed_count: dict[str, int] = {
+            STAGE_FIND: 0,
+            STAGE_DISCOVER: 0,
+            STAGE_SHAPE: 0,
+            STAGE_PLAN: 0,
+            STAGE_READY: 0,
+            STAGE_REVIEW: 0,
+            STAGE_HITL: 0,
+        }
+        # Dedup diagnostics — real store tracks real dedups; Fake just
+        # exposes the shape so QueueStats serializes cleanly.
+        self._dedup_stats: dict[str, int] = {
+            "incoming_tasks": 0,
+            "queued_entries": 0,
+            "snapshot_entries": 0,
+        }
+        self._last_poll_ts: str | None = None
+        # Crate manager — set later by service_registry; the Fake doesn't
+        # use it but exposes the setter so the wiring path doesn't fork.
+        self._crate_manager: Any = None
+
     @classmethod
     def from_seed(cls, seed: MockWorldSeed, event_bus: EventBus) -> FakeIssueStore:
         from mockworld.fakes.fake_github import FakeGitHub
 
         github = FakeGitHub.from_seed(seed)
         return cls(github=github, event_bus=event_bus)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _stage_for(self, issue: Any) -> str | None:
+        """Pick the most-advanced HydraFlow stage label on *issue*."""
+        # Higher index in this list = later in pipeline = takes precedence
+        priority = [
+            STAGE_FIND,
+            STAGE_DISCOVER,
+            STAGE_SHAPE,
+            STAGE_PLAN,
+            STAGE_READY,
+            STAGE_REVIEW,
+            STAGE_HITL,
+        ]
+        best: str | None = None
+        best_idx = -1
+        for label in issue.labels:
+            stage = _LABEL_TO_STAGE.get(label)
+            if stage is None:
+                continue
+            try:
+                idx = priority.index(stage)
+            except ValueError:
+                continue
+            if idx > best_idx:
+                best_idx = idx
+                best = stage
+        return best
+
+    def _issue_to_task(self, issue: Any) -> Task:
+        return Task(
+            id=issue.number,
+            title=issue.title,
+            body=issue.body,
+            tags=list(issue.labels),
+            comments=list(getattr(issue, "comments", [])),
+            source_url="",
+            created_at="",
+        )
+
+    def _queued_for_stage(self, stage: str) -> list[Task]:
+        """Issues whose top label maps to *stage* and which aren't active/in-flight."""
+        out: list[Task] = []
+        for issue in self._github._issues.values():
+            if issue.state != "open":
+                continue
+            if self._stage_for(issue) != stage:
+                continue
+            if issue.number in self._active or issue.number in self._in_flight:
+                continue
+            out.append(self._issue_to_task(issue))
+        return out
+
+    # ------------------------------------------------------------------
+    # Lifecycle (orchestrator-only via cast("IssueStore", store))
+    # ------------------------------------------------------------------
+
+    async def start(self, stop_event: asyncio.Event) -> None:
+        """Run the polling-equivalent loop until *stop_event* is set.
+
+        For the Fake, "polling" is a no-op because FakeGitHub state is
+        the canonical source — any label change is immediately visible
+        to ``_queued_for_stage``. We still run the loop body so the
+        orchestrator's restart/supervision behavior matches production.
+        """
+        await self.refresh()
+        while not stop_event.is_set():
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=1.0)
+                break
+            except TimeoutError:
+                pass
+            await self.refresh()
+
+    async def refresh(self) -> None:
+        """Publish a queue-update event to keep the dashboard in sync."""
+        self._last_poll_ts = datetime.now(UTC).isoformat()
+        try:
+            stats = self.get_queue_stats()
+            await self._bus.publish(
+                HydraFlowEvent(
+                    type=EventType.QUEUE_UPDATE,
+                    data=stats.model_dump(),
+                )
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("FakeIssueStore.refresh publish failed", exc_info=True)
+
+    def set_crate_manager(self, cm: Any) -> None:
+        """Store the crate manager (Fake doesn't use it but signature must match)."""
+        self._crate_manager = cm
+
+    def get_uncrated_issues(self) -> list[Task]:
+        """Return queued tasks with no crate metadata. Fake has none, so [].
+
+        Production CrateManager assigns ``milestone_number`` in metadata; the
+        Fake doesn't simulate milestones. Returning an empty list keeps the
+        crate-management code path quiet.
+        """
+        return []
+
+    # ------------------------------------------------------------------
+    # Queue accessors
+    # ------------------------------------------------------------------
+
+    def get_triageable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_FIND, max_count)
+
+    def get_discoverable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_DISCOVER, max_count)
+
+    def get_shapeable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_SHAPE, max_count)
+
+    def get_plannable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_PLAN, max_count)
+
+    def get_implementable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_READY, max_count)
+
+    def get_reviewable(self, max_count: int) -> list[Task]:
+        return self._take(STAGE_REVIEW, max_count)
+
+    def get_hitl_issues(self) -> set[int]:
+        return {
+            issue.number
+            for issue in self._github._issues.values()
+            if issue.state == "open" and self._stage_for(issue) == STAGE_HITL
+        }
+
+    def _take(self, stage: str, max_count: int) -> list[Task]:
+        tasks = self._queued_for_stage(stage)[:max_count]
+        for t in tasks:
+            self._in_flight[t.id] = stage
+        return tasks
+
+    # ------------------------------------------------------------------
+    # Active / lifecycle tracking
+    # ------------------------------------------------------------------
+
+    def mark_active(self, issue_number: int, stage: str) -> None:
+        self._in_flight.pop(issue_number, None)
+        self._active[issue_number] = stage
+
+    def mark_complete(self, issue_number: int) -> None:
+        self._in_flight.pop(issue_number, None)
+        stage = self._active.pop(issue_number, None)
+        if stage and stage in self._processed_count:
+            self._processed_count[stage] += 1
+
+    def mark_merged(self, issue_number: int) -> None:
+        self._merged_numbers.add(issue_number)
+
+    def get_merged_numbers(self) -> frozenset[int]:
+        return frozenset(self._merged_numbers)
+
+    def is_active(self, issue_number: int) -> bool:
+        return issue_number in self._active
+
+    def is_in_pipeline(self, issue_number: int) -> bool:
+        if issue_number in self._active or issue_number in self._in_flight:
+            return True
+        issue = self._github._issues.get(issue_number)
+        return issue is not None and self._stage_for(issue) is not None
+
+    def get_active_issues(self) -> dict[int, str]:
+        return dict(self._active)
+
+    def clear_active(self) -> None:
+        self._active.clear()
+        self._in_flight.clear()
+
+    def release_in_flight(self, issue_numbers: set[int]) -> None:
+        for n in issue_numbers:
+            self._in_flight.pop(n, None)
+
+    def get_cached(self, issue_number: int) -> Task | None:
+        issue = self._github._issues.get(issue_number)
+        if issue is None:
+            return None
+        return self._issue_to_task(issue)
+
+    # ------------------------------------------------------------------
+    # Transition / enrichment
+    # ------------------------------------------------------------------
+
+    def enqueue_transition(self, task: Task, next_stage: str) -> None:
+        """Apply the stage transition immediately by mutating issue labels.
+
+        Real IssueStore caches an eager-transition flag separate from
+        GitHub state; the Fake collapses both views into FakeGitHub's
+        labels because there's no async GitHub round-trip to wait on.
+        """
+        stage_to_label = {v: k for k, v in _LABEL_TO_STAGE.items()}
+        new_label = stage_to_label.get(next_stage)
+        if new_label is None:
+            return
+        issue = self._github._issues.get(task.id)
+        if issue is None:
+            return
+        issue.labels = [lbl for lbl in issue.labels if lbl not in _LABEL_TO_STAGE]
+        issue.labels.append(new_label)
+        self._in_flight.pop(task.id, None)
+
+    async def enrich_with_comments(self, task: Task) -> Task:
+        issue = self._github._issues.get(task.id)
+        if issue is None:
+            return task
+        comments = list(getattr(issue, "comments", []))
+        if not comments:
+            return task
+        return task.model_copy(update={"comments": comments})
+
+    # ------------------------------------------------------------------
+    # Stats / snapshot (orchestrator-only via cast)
+    # ------------------------------------------------------------------
+
+    def get_queue_stats(self) -> QueueStats:
+        queue_depth: dict[str, int] = {}
+        for stage in (
+            STAGE_FIND,
+            STAGE_DISCOVER,
+            STAGE_SHAPE,
+            STAGE_PLAN,
+            STAGE_READY,
+            STAGE_REVIEW,
+        ):
+            queue_depth[stage] = len(self._queued_for_stage(stage))
+        queue_depth[STAGE_HITL] = len(self.get_hitl_issues())
+        queue_depth[STAGE_MERGED] = len(self._merged_numbers)
+
+        active_count: dict[str, int] = {}
+        for stage in (
+            STAGE_FIND,
+            STAGE_DISCOVER,
+            STAGE_SHAPE,
+            STAGE_PLAN,
+            STAGE_READY,
+            STAGE_REVIEW,
+            STAGE_HITL,
+        ):
+            active_count[stage] = sum(1 for s in self._active.values() if s == stage)
+
+        return QueueStats(
+            queue_depth=queue_depth,
+            active_count=active_count,
+            total_processed=dict(self._processed_count),
+            last_poll_timestamp=self._last_poll_ts,
+            dedup_stats=dict(self._dedup_stats),
+            in_flight_count=len(self._in_flight),
+        )
+
+    def get_pipeline_snapshot(self) -> dict[str, list[PipelineSnapshotEntry]]:
+        snapshot: dict[str, list[PipelineSnapshotEntry]] = {}
+
+        def _entry(num: int, status: str) -> PipelineSnapshotEntry:
+            issue = self._github._issues.get(num)
+            return PipelineSnapshotEntry(
+                issue_number=num,
+                title=issue.title if issue else f"Issue #{num}",
+                url="",
+                status=status,
+            )
+
+        for stage in (
+            STAGE_FIND,
+            STAGE_DISCOVER,
+            STAGE_SHAPE,
+            STAGE_PLAN,
+            STAGE_READY,
+            STAGE_REVIEW,
+        ):
+            queued = [
+                _entry(t.id, PipelineIssueStatus.QUEUED)
+                for t in self._queued_for_stage(stage)
+            ]
+            in_flight = [
+                _entry(num, PipelineIssueStatus.PROCESSING)
+                for num, s in self._in_flight.items()
+                if s == stage
+            ]
+            active = [
+                _entry(num, PipelineIssueStatus.PROCESSING)
+                for num, s in self._active.items()
+                if s == stage
+            ]
+            entries = queued + in_flight + active
+            if entries:
+                snapshot[stage] = entries
+
+        snapshot[STAGE_HITL] = [
+            _entry(num, PipelineIssueStatus.PROCESSING)
+            for num in self.get_hitl_issues()
+        ]
+        snapshot[STAGE_MERGED] = [
+            _entry(num, PipelineIssueStatus.PROCESSING) for num in self._merged_numbers
+        ]
+        return snapshot
+
+    # ------------------------------------------------------------------
+    # PR A's narrower surface (kept for backward compatibility with the
+    # FakeIssueStore unit tests written before Task 2.5b widening).
+    # ------------------------------------------------------------------
 
     async def get(self, issue_number: int) -> FakeIssueRecord:
         issue = self._github._issues[issue_number]
@@ -82,3 +474,7 @@ class FakeIssueStore:
                     )
                 )
         return out
+
+    # HITLItem-list — required by some loops, returns empty by default
+    async def list_hitl_items(self, *_a: Any, **_kw: Any) -> list[HITLItem]:
+        return []

--- a/src/mockworld/fakes/fake_llm.py
+++ b/src/mockworld/fakes/fake_llm.py
@@ -63,6 +63,27 @@ class _ScriptedRunner:
     def clear_tracing_context(self) -> None:
         pass
 
+    @property
+    def active_count(self) -> int:
+        """Number of currently running subprocesses.
+
+        Real ``BaseRunner.active_count`` returns ``len(self._active_procs)``;
+        the orchestrator emits this in pipeline stats. The Fake doesn't
+        spawn subprocesses, so the count is always 0.
+        """
+        return 0
+
+    def terminate(self) -> None:
+        """Stop all in-flight subprocesses (no-op stub).
+
+        Real ``BaseRunner.terminate`` walks ``self._active_procs`` and
+        sends SIGTERM. The Fake doesn't spawn subprocesses, so there's
+        nothing to terminate. Required because ``orchestrator.run()``
+        calls ``self._svc.{planners,agents,reviewers,hitl_runner}.terminate()``
+        unconditionally during shutdown.
+        """
+        return None
+
 
 class _FakeTriageRunner(_ScriptedRunner):
     def __init__(self) -> None:
@@ -243,16 +264,84 @@ class FakeLLM:
         self.reviewers = _FakeReviewRunner(self)
 
     def script_triage(self, issue_number: int, results: list[Any]) -> None:
-        self.triage_runner.add_script(issue_number, results)
+        self.triage_runner.add_script(
+            issue_number, [self._coerce_triage(issue_number, r) for r in results]
+        )
 
     def script_plan(self, issue_number: int, results: list[Any]) -> None:
-        self.planners.add_script(issue_number, results)
+        self.planners.add_script(
+            issue_number, [self._coerce_plan(issue_number, r) for r in results]
+        )
 
     def script_implement(self, issue_number: int, results: list[Any]) -> None:
-        self.agents.add_script(issue_number, results)
+        self.agents.add_script(
+            issue_number, [self._coerce_implement(issue_number, r) for r in results]
+        )
 
     def script_review(self, issue_number: int, results: list[Any]) -> None:
-        self.reviewers.add_script(issue_number, results)
+        self.reviewers.add_script(
+            issue_number, [self._coerce_review(issue_number, r) for r in results]
+        )
+
+    # ------------------------------------------------------------------
+    # Dict → typed-result coercion
+    #
+    # Scenarios are loaded from JSON seeds, where script payloads are
+    # plain dicts. Production code calls ``result.duration_seconds``,
+    # ``result.success`` etc. on the concrete Pydantic model. The Fake
+    # would otherwise leak dicts through ``_pop`` into the implement /
+    # review phases. Each helper either (a) returns the value as-is when
+    # it's already the right type, or (b) routes through the factory to
+    # build a typed instance from the dict's keys.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _filter_kwargs(factory_create: Any, raw: dict[str, Any]) -> dict[str, Any]:
+        """Drop dict keys the factory's `create` method doesn't accept.
+
+        JSON seeds may carry diagnostic fields (``task_count``, ``branch``)
+        that don't map onto the factory's keyword args. Forwarding them
+        unfiltered would raise ``TypeError: unexpected keyword argument``.
+        """
+        import inspect
+
+        sig = inspect.signature(factory_create)
+        accepted = {p for p in sig.parameters if p != "self"}
+        return {k: v for k, v in raw.items() if k in accepted}
+
+    @classmethod
+    def _coerce_triage(cls, issue_number: int, raw: Any) -> Any:
+        if isinstance(raw, dict):
+            kw = cls._filter_kwargs(TriageResultFactory.create, raw)
+            return TriageResultFactory.create(issue_number=issue_number, **kw)
+        return raw
+
+    @classmethod
+    def _coerce_plan(cls, issue_number: int, raw: Any) -> Any:
+        if isinstance(raw, dict):
+            kw = cls._filter_kwargs(PlanResultFactory.create, raw)
+            return PlanResultFactory.create(issue_number=issue_number, **kw)
+        return raw
+
+    @classmethod
+    def _coerce_implement(cls, issue_number: int, raw: Any) -> Any:
+        if isinstance(raw, dict):
+            kw = cls._filter_kwargs(WorkerResultFactory.create, raw)
+            return WorkerResultFactory.create(issue_number=issue_number, **kw)
+        return raw
+
+    @classmethod
+    def _coerce_review(cls, issue_number: int, raw: Any) -> Any:
+        if isinstance(raw, dict):
+            kw = cls._filter_kwargs(ReviewResultFactory.create, raw)
+            kw.setdefault("pr_number", 0)
+            # Coerce string verdict ("approve" / "request-changes" / "comment")
+            # into the StrEnum so pydantic doesn't reject the model.
+            verdict = kw.get("verdict")
+            if isinstance(verdict, str):
+                kw["verdict"] = ReviewVerdict(verdict)
+            return ReviewResultFactory.create(issue_number=issue_number, **kw)
+        return raw
 
     def script_fix_ci(self, issue_number: int, result: Any) -> None:
         """Script the ReviewResult returned by reviewers.fix_ci for an issue.

--- a/src/mockworld/fakes/fake_workspace.py
+++ b/src/mockworld/fakes/fake_workspace.py
@@ -68,3 +68,13 @@ class FakeWorkspace:
 
     async def sanitize_repo(self) -> None:
         pass
+
+    async def enable_rerere(self) -> None:
+        """Enable git rerere on the managed repo (no-op stub).
+
+        Production WorkspaceManager flips a config flag; FakeWorkspace
+        has no real repo, so this is a no-op. Required because
+        ``HydraFlowOrchestrator.run()`` calls ``workspaces.enable_rerere()``
+        unconditionally during pipeline boot.
+        """
+        return None

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -64,9 +64,18 @@ async def main() -> None:
     # runtime the FakeLLM / FakeWorkspace / FakeGitHub adapters carry
     # the entire required surface for the loops PR A actually exercises.
     workspaces = cast(WorkspacePort, FakeWorkspace(config.workspace_base))
-    fetcher = cast(IssueFetcherPort, FakeIssueFetcher.from_seed(seed))
-    store = cast(IssueStorePort, FakeIssueStore.from_seed(seed, event_bus))
-    prs = cast(PRPort, FakeGitHub.from_seed(seed))
+    # Single FakeGitHub instance — shared by all three Fake adapters.
+    # Using ``from_seed`` independently would create three isolated copies,
+    # so a PR created via ``prs.create_pr`` wouldn't be visible to the
+    # fetcher's ``fetch_reviewable_prs`` and the review loop would loop
+    # forever requeuing the issue. The fetcher / store wrap the same
+    # ``FakeGitHub`` so any state mutation is visible to all readers.
+    shared_github = FakeGitHub.from_seed(seed)
+    fetcher = cast(IssueFetcherPort, FakeIssueFetcher(github=shared_github))
+    store = cast(
+        IssueStorePort, FakeIssueStore(github=shared_github, event_bus=event_bus)
+    )
+    prs = cast(PRPort, shared_github)
 
     # FakeLLM provides triage_runner / planners / agents / reviewers from
     # the seed.scripts payload. Without this, the sandbox would attempt

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -85,9 +85,28 @@ async def main() -> None:
         for issue_number, results in by_issue.items():
             getattr(fake_llm, f"script_{phase}")(issue_number, results)
 
+    # Loops disabled in sandbox because they call out to real CLIs/services
+    # that block the asyncio event loop on an air-gapped (``internal: true``)
+    # network. The classic offender is ``contract_refresh``: its tick calls
+    # synchronous ``subprocess.run(["claude", "-p", "ping", ...])`` (no
+    # timeout) which hangs forever trying to reach ``api.anthropic.com``,
+    # freezing every other task — including the dashboard's uvicorn bind —
+    # until the kernel kills the container. The real fix (wrap in
+    # ``asyncio.to_thread`` and add a hard timeout) lives in production code;
+    # here we just opt out of the caretaker entirely. None of these loops
+    # exercise the issue→PR pipeline that sandbox scenarios validate.
+    _SANDBOX_DISABLED_WORKERS = frozenset(
+        {
+            "contract_refresh",
+        }
+    )
+
+    def _sandbox_is_enabled(worker_name: str, *_a: object, **_kw: object) -> bool:
+        return worker_name not in _SANDBOX_DISABLED_WORKERS
+
     callbacks = WorkerRegistryCallbacks(
         update_status=lambda *_a, **_kw: None,
-        is_enabled=lambda *_a, **_kw: True,
+        is_enabled=_sandbox_is_enabled,
         get_interval=lambda *_a, **_kw: 60,
     )
 

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -114,11 +114,20 @@ async def main() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, stop_event.set)
 
+    # Drive the pipeline. Without this, the dashboard would serve /healthz
+    # but no loops would tick, no issues would advance, and Tier-2
+    # scenarios would always time out at the API-poll step.
+    orch_task = asyncio.create_task(orch.run(), name="hydraflow-orchestrator")
+
     try:
         await stop_event.wait()
     finally:
         if orch.running:
             await orch.stop()
+        # Allow orch_task to clean up (it observes stop_event via orch.stop()).
+        if not orch_task.done():
+            orch_task.cancel()
+        await asyncio.gather(orch_task, return_exceptions=True)
         await dashboard.stop()
 
 

--- a/src/ui/Dockerfile.ui
+++ b/src/ui/Dockerfile.ui
@@ -1,0 +1,13 @@
+# Stage 1: build vite assets
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: nginx serving dist + proxying /api and /ws to hydraflow:5555
+FROM nginx:1.27-alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.sandbox.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/src/ui/nginx.sandbox.conf
+++ b/src/ui/nginx.sandbox.conf
@@ -1,0 +1,21 @@
+server {
+    listen 80;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri /index.html;
+    }
+    location /api/ {
+        proxy_pass http://hydraflow:5555;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+    location /ws {
+        proxy_pass http://hydraflow:5555;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+    }
+}

--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -503,7 +503,7 @@ export function OutcomesPanel() {
     const issueNum = item.issue_number
     const isExpanded = !!expanded[issueNum]
     return (
-      <div key={issueNum} style={styles.rowWrap}>
+      <div key={issueNum} data-testid={`outcome-row-${issueNum}`} style={styles.rowWrap}>
         <div style={{ ...styles.row, gridTemplateColumns: gridColumns }}>
           <button
             type="button"

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -822,12 +822,40 @@ export function reducer(state, action) {
 
 const HydraFlowContext = createContext(null)
 
+// Fallback UUID v4 generator for non-secure contexts (e.g. the
+// sandbox-tier playwright harness, which serves the UI over http://ui
+// and not a secure origin). ``crypto.randomUUID`` is only exposed in
+// secure contexts; ``crypto.getRandomValues`` is universal. Real
+// production deployments are over HTTPS or localhost so the native path
+// is taken; this branch only fires in air-gapped sandbox runs.
+function _fallbackUuidV4() {
+  const bytes = new Uint8Array(16)
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(bytes)
+  } else {
+    for (let i = 0; i < 16; i += 1) bytes[i] = Math.floor(Math.random() * 256)
+  }
+  // RFC 4122 v4: set version + variant bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0'))
+  return (
+    hex.slice(0, 4).join('') + '-' +
+    hex.slice(4, 6).join('') + '-' +
+    hex.slice(6, 8).join('') + '-' +
+    hex.slice(8, 10).join('') + '-' +
+    hex.slice(10, 16).join('')
+  )
+}
+
 function getReporterId() {
   if (typeof window === 'undefined') return ''
   const key = 'hydraflow-user-id'
   let id = localStorage.getItem(key)
   if (!id) {
-    id = crypto.randomUUID()
+    id = (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function')
+      ? crypto.randomUUID()
+      : _fallbackUuidV4()
     localStorage.setItem(key, id)
   }
   return id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+# ADR-0052: Sandbox-tier scenarios run only inside the docker-compose stack
+# (`docker-compose.sandbox.yml`). They use their own pytest.ini with a
+# hard-coded `--confcutdir=/work/tests/sandbox_scenarios` that resolves only
+# inside the playwright container. Skipping them at collection time here keeps
+# host-side `pytest tests/` and `make quality` green; CI runs them via the
+# dedicated `sandbox` job (`scripts/sandbox_scenario.py`).
+collect_ignore_glob = ["sandbox_scenarios/*"]
+
 
 def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:  # noqa: ARG001 — nextitem required by pytest hook signature
     """Fail any test that leaves a ``MagicMock/`` directory in the repo root.

--- a/tests/sandbox_scenarios/pytest.ini
+++ b/tests/sandbox_scenarios/pytest.ini
@@ -1,0 +1,24 @@
+; Sandbox-tier pytest config — used by docker-compose.sandbox.yml's
+; ``playwright`` service. Pointing pytest at this file via ``-c`` makes
+; ``tests/sandbox_scenarios`` the rootdir, so pytest does NOT autoload
+; the project-wide ``tests/conftest.py`` (which imports the entire
+; HydraFlow runtime — pydantic, sqlalchemy, the Fake adapters, etc. —
+; none of which exist inside the air-gapped Microsoft Playwright image).
+; ``--confcutdir`` is the belt-and-suspenders that prevents pytest from
+; walking *up* from the test file to find the parent ``tests/conftest.py``;
+; without it, even though the rootdir is ``tests/sandbox_scenarios``,
+; pytest still discovers and imports the parent conftest.
+;
+; The harness installs only ``pytest`` + ``pytest-asyncio`` + ``httpx``
+; into that image (see ``Dockerfile.playwright``), so the only thing
+; pytest may import here is the runner's own conftest + the scenario
+; modules.
+[pytest]
+asyncio_mode = auto
+testpaths = runner
+; ``--confcutdir`` must be an absolute path that pytest sees on disk;
+; ``.`` is interpreted relative to the invocation cwd (``/work``), which
+; defeats the purpose. Hard-coding ``/work/tests/sandbox_scenarios`` is
+; fine because this ini ONLY runs inside the sandbox playwright
+; container (compose volume-mounts the repo root at ``/work``).
+addopts = -q --tb=short --confcutdir=/work/tests/sandbox_scenarios

--- a/tests/sandbox_scenarios/runner/api_client.py
+++ b/tests/sandbox_scenarios/runner/api_client.py
@@ -1,0 +1,51 @@
+"""SandboxAPIClient — async HTTP client targeting the in-container hydraflow.
+
+Used by Playwright fixtures and by scenario assert_outcome implementations
+to read API state without going through the UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+
+class SandboxAPIClient:
+    """Tiny async-friendly wrapper over the dashboard REST API."""
+
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base_url = base_url or os.environ.get(
+            "SANDBOX_API_BASE", "http://hydraflow:5555"
+        )
+
+    async def get(self, path: str) -> dict:
+        url = urljoin(self.base_url + "/", path.lstrip("/"))
+        req = Request(url, headers={"Accept": "application/json"})
+        with urlopen(req, timeout=10) as resp:  # noqa: S310 — sandbox-only internal URL
+            return json.loads(resp.read().decode())
+
+    async def wait_until(
+        self,
+        path: str,
+        predicate,
+        *,
+        timeout: float = 30.0,
+        poll_interval: float = 1.0,
+    ) -> dict:
+        """Poll path until predicate(payload) returns True or timeout."""
+        deadline = asyncio.get_event_loop().time() + timeout
+        last = None
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                last = await self.get(path)
+                if predicate(last):
+                    return last
+            except Exception:  # noqa: BLE001 — best-effort polling
+                pass
+            await asyncio.sleep(poll_interval)
+        raise TimeoutError(
+            f"timeout waiting for predicate on {path}; last payload: {last!r}"
+        )

--- a/tests/sandbox_scenarios/runner/api_client.py
+++ b/tests/sandbox_scenarios/runner/api_client.py
@@ -7,10 +7,11 @@ to read API state without going through the UI.
 from __future__ import annotations
 
 import asyncio
-import json
 import os
+from collections.abc import Callable
 from urllib.parse import urljoin
-from urllib.request import Request, urlopen
+
+import httpx
 
 
 class SandboxAPIClient:
@@ -23,27 +24,28 @@ class SandboxAPIClient:
 
     async def get(self, path: str) -> dict:
         url = urljoin(self.base_url + "/", path.lstrip("/"))
-        req = Request(url, headers={"Accept": "application/json"})
-        with urlopen(req, timeout=10) as resp:  # noqa: S310 — sandbox-only internal URL
-            return json.loads(resp.read().decode())
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(url, headers={"Accept": "application/json"})
+            resp.raise_for_status()
+            return resp.json()
 
     async def wait_until(
         self,
         path: str,
-        predicate,
+        predicate: Callable[[dict], bool],
         *,
         timeout: float = 30.0,
         poll_interval: float = 1.0,
     ) -> dict:
         """Poll path until predicate(payload) returns True or timeout."""
-        deadline = asyncio.get_event_loop().time() + timeout
+        deadline = asyncio.get_running_loop().time() + timeout
         last = None
-        while asyncio.get_event_loop().time() < deadline:
+        while asyncio.get_running_loop().time() < deadline:
             try:
                 last = await self.get(path)
                 if predicate(last):
                     return last
-            except Exception:  # noqa: BLE001 — best-effort polling
+            except (httpx.HTTPError, ConnectionError, ValueError):
                 pass
             await asyncio.sleep(poll_interval)
         raise TimeoutError(

--- a/tests/sandbox_scenarios/runner/conftest.py
+++ b/tests/sandbox_scenarios/runner/conftest.py
@@ -1,0 +1,39 @@
+"""Playwright + SandboxAPIClient fixtures for the sandbox runner.
+
+These fixtures are scoped to the 'sandbox' test directory only — they
+don't pollute the broader pytest collection.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest_asyncio
+from playwright.async_api import async_playwright
+
+from tests.sandbox_scenarios.runner.api_client import SandboxAPIClient
+
+
+@pytest_asyncio.fixture
+async def api():
+    """Async API client targeting the in-container hydraflow dashboard."""
+    yield SandboxAPIClient()
+
+
+@pytest_asyncio.fixture
+async def browser():
+    """Headless Chromium for the sandbox network."""
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True)
+        yield browser
+        await browser.close()
+
+
+@pytest_asyncio.fixture
+async def page(browser):
+    """A fresh page targeting SANDBOX_BASE_URL (the UI service)."""
+    base_url = os.environ.get("SANDBOX_BASE_URL", "http://ui")
+    context = await browser.new_context(base_url=base_url)
+    page = await context.new_page()
+    yield page
+    await context.close()

--- a/tests/sandbox_scenarios/runner/test_scenarios.py
+++ b/tests/sandbox_scenarios/runner/test_scenarios.py
@@ -1,0 +1,37 @@
+"""Parametrized sandbox-scenario runner.
+
+The scenario harness CLI invokes this with -k or specific test ID; each
+scenario module's assert_outcome is called with (api, page) fixtures.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tests.sandbox_scenarios.runner.loader import load_all_scenarios
+
+# Filter out s00_smoke — that's parity-only (no assert_outcome).
+_SCENARIOS = [s for s in load_all_scenarios() if hasattr(s, "assert_outcome")]
+
+
+if _SCENARIOS:
+
+    @pytest.mark.parametrize("scenario", _SCENARIOS, ids=lambda s: s.NAME)
+    @pytest.mark.asyncio
+    async def test_scenario(scenario, api, page) -> None:
+        """Run scenario.assert_outcome with the API client + Playwright page."""
+        # Optional env override: SCENARIO_NAME=sNN runs only that scenario.
+        only = os.environ.get("SCENARIO_NAME")
+        if only and only != scenario.NAME:
+            pytest.skip(f"SCENARIO_NAME={only!r} doesn't match {scenario.NAME}")
+        await scenario.assert_outcome(api, page)
+
+else:
+
+    @pytest.mark.skip(
+        reason="No Tier-2 scenarios with assert_outcome yet (s01 lands in Task 2.5)"
+    )
+    def test_scenario_placeholder() -> None:
+        """Placeholder while no scenarios define assert_outcome."""

--- a/tests/sandbox_scenarios/scenarios/s01_happy_single_issue.py
+++ b/tests/sandbox_scenarios/scenarios/s01_happy_single_issue.py
@@ -1,0 +1,87 @@
+"""s01_happy_single_issue — single issue → triage → plan → implement → review → merge.
+
+Tier 2 sandbox scenario. Verifies the full assembly line works end-to-end:
+- API: /api/issues/history reports outcome.outcome == "merged" for issue 1
+  (the dashboard's IssueHistoryEntry payload — same data the Outcomes UI tab
+   consumes; chosen over /api/timeline/issue/N because IssueTimeline doesn't
+   carry an `outcome` field).
+- UI: Outcomes tab shows the merged outcome row for issue 1.
+- UI: MOCKWORLD banner is visible (proves the duck-typed FakeLLM signaled
+  the dashboard via the `_is_fake_adapter` flag).
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s01_happy_single_issue"
+DESCRIPTION = (
+    "Single hydraflow-ready issue → full pipeline → merged. Outcomes tab shows it."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        repos=[("owner/repo", "/workspace/repo")],
+        issues=[
+            {
+                "number": 1,
+                "title": "Add hello world",
+                "body": "Implement a hello-world function in src/hello.py",
+                "labels": ["hydraflow-ready"],
+            },
+        ],
+        scripts={
+            "plan": {1: [{"success": True, "task_count": 1}]},
+            "implement": {1: [{"success": True, "branch": "hf/issue-1"}]},
+            "review": {1: [{"verdict": "approve", "comments": []}]},
+        },
+        cycles_to_run=4,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """End-to-end assertions: API confirms merged + UI renders the row."""
+
+    # API assertion — eventually consistent: poll history until issue 1
+    # carries an outcome of "merged". The dashboard's /api/issues/history
+    # endpoint exposes the IssueHistoryEntry payload that the Outcomes UI
+    # also consumes, so this is the same source of truth as the visual check.
+    def _has_merged_issue_1(payload: dict) -> bool:
+        items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(items, list):
+            return False
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if item.get("issue_number") != 1:
+                continue
+            outcome = item.get("outcome") or {}
+            if isinstance(outcome, dict) and outcome.get("outcome") == "merged":
+                return True
+        return False
+
+    history = await api.wait_until(
+        "/api/issues/history?limit=500",
+        _has_merged_issue_1,
+        timeout=30.0,
+    )
+    items = history.get("items") if isinstance(history, dict) else None
+    assert isinstance(items, list), f"history payload missing items: {history!r}"
+    matching = [i for i in items if isinstance(i, dict) and i.get("issue_number") == 1]
+    assert matching, f"no issue_number=1 entry in history: {history!r}"
+    outcome = matching[0].get("outcome") or {}
+    assert outcome.get("outcome") == "merged", f"got {matching[0]!r}"
+
+    # UI assertion — Outcomes tab renders the merged outcome row.
+    await page.goto("/")
+    await page.click("text=Outcomes")
+    await page.wait_for_selector("[data-testid='outcome-row-1']", timeout=10_000)
+    text = await page.locator("[data-testid='outcome-row-1']").text_content()
+    assert "merged" in (text or "").lower(), f"got {text!r}"
+
+    # MOCKWORLD banner is visible (proves duck-typing wiring works — the
+    # dashboard reads `_is_fake_adapter` off FakeLLM and exposes it as
+    # mockworldActive in the WS state payload).
+    banner = page.locator("[data-testid='mockworld-banner']")
+    assert await banner.is_visible()

--- a/tests/sandbox_scenarios/seeds/.gitignore
+++ b/tests/sandbox_scenarios/seeds/.gitignore
@@ -1,0 +1,4 @@
+# scenario.json is a transient symlink the harness creates per run
+# (cmd_run in scripts/sandbox_scenario.py points it at the active
+# scenario's seed). It MUST NOT be committed.
+scenario.json

--- a/tests/sandbox_scenarios/seeds/_smoke.json
+++ b/tests/sandbox_scenarios/seeds/_smoke.json
@@ -1,0 +1,1 @@
+{"repos": [], "issues": [], "prs": [], "scripts": {}, "cycles_to_run": 1, "loops_enabled": null}

--- a/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
+++ b/tests/sandbox_scenarios/seeds/s01_happy_single_issue.json
@@ -1,0 +1,47 @@
+{
+  "repos": [
+    [
+      "owner/repo",
+      "/workspace/repo"
+    ]
+  ],
+  "issues": [
+    {
+      "number": 1,
+      "title": "Add hello world",
+      "body": "Implement a hello-world function in src/hello.py",
+      "labels": [
+        "hydraflow-ready"
+      ]
+    }
+  ],
+  "prs": [],
+  "scripts": {
+    "plan": {
+      "1": [
+        {
+          "success": true,
+          "task_count": 1
+        }
+      ]
+    },
+    "implement": {
+      "1": [
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        }
+      ]
+    },
+    "review": {
+      "1": [
+        {
+          "verdict": "approve",
+          "comments": []
+        }
+      ]
+    }
+  },
+  "cycles_to_run": 4,
+  "loops_enabled": null
+}

--- a/tests/test_dashboard_lifecycle.py
+++ b/tests/test_dashboard_lifecycle.py
@@ -352,6 +352,47 @@ class TestHealthRoute:
 
         assert payload["checks"]["queue_depths"] == {}
 
+    def test_healthz_handles_uninitialized_github_cache(
+        self, config: HydraFlowConfig, event_bus: EventBus, state
+    ) -> None:
+        """Cold-start GitHub cache returns inf for never-fetched datasets.
+
+        Regression for the sandbox-tier boot path: ``GitHubDataCache``'s
+        ``get_cache_age`` returns ``float("inf")`` when a dataset has not
+        been fetched yet. JSON encoding chokes on ``inf``, so /healthz
+        returned 500 for the entire first-poll window. The fix coerces
+        infinite ages to ``None`` and reports the cache as
+        ``uninitialized``.
+        """
+        from unittest.mock import MagicMock
+
+        from fastapi.testclient import TestClient
+
+        from dashboard import HydraFlowDashboard
+        from github_cache_loop import GitHubDataCache
+
+        gh_cache = MagicMock(spec=GitHubDataCache)
+        gh_cache.get_cache_age.return_value = float("inf")
+
+        orch = make_orchestrator_mock(running=True)
+        orch.github_cache = gh_cache
+
+        dashboard = HydraFlowDashboard(config, event_bus, state, orchestrator=orch)
+        app = dashboard.create_app()
+
+        client = TestClient(app)
+        response = client.get("/healthz")
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        gh = payload["checks"]["github_cache"]
+        assert gh["status"] == "uninitialized"
+        assert gh["age_seconds"] == {
+            "open_prs": None,
+            "hitl_items": None,
+            "label_counts": None,
+        }
+
 
 # ---------------------------------------------------------------------------
 # Accessibility

--- a/tests/test_sandbox_scenario_cli.py
+++ b/tests/test_sandbox_scenario_cli.py
@@ -1,0 +1,31 @@
+"""sandbox_scenario CLI — invocation surface tests.
+
+Doesn't actually boot docker — patches subprocess.run. Verifies the
+correct compose commands are issued for each subcommand.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from scripts import sandbox_scenario
+
+
+def test_seed_subcommand_writes_json(tmp_path) -> None:
+    seeds_dir = tmp_path / "seeds"
+    with (
+        patch.object(sandbox_scenario, "SEEDS_DIR", seeds_dir),
+        patch.object(sandbox_scenario, "load_scenario") as load,
+    ):
+        load.return_value.NAME = "s00_smoke"
+        load.return_value.seed.return_value.to_json.return_value = '{"x": 1}'
+        sandbox_scenario.cmd_seed("s00_smoke")
+    assert (seeds_dir / "s00_smoke.json").read_text() == '{"x": 1}'
+
+
+def test_down_subcommand_calls_compose_down() -> None:
+    with patch("subprocess.run") as run:
+        sandbox_scenario.cmd_down()
+    args = run.call_args[0][0]
+    assert "docker" in args[0] and "compose" in args
+    assert "down" in args


### PR DESCRIPTION
## Summary

PR B of the sandbox-tier scenario testing track. Adds the actual docker-compose stack and the first end-to-end Tier-2 scenario.

- `docker-compose.sandbox.yml` with `internal: true` air-gapped network.
- `src/ui/Dockerfile.ui` + `nginx.sandbox.conf` for serving the React dist + proxying /api and /ws.
- `scripts/sandbox_scenario.py` harness CLI (run / run-all / status / down / shell / seed).
- Makefile targets sandbox-up / sandbox-down / sandbox-test / sandbox-shell.
- `tests/sandbox_scenarios/runner/` with Playwright + SandboxAPIClient fixtures (httpx async client) + parametrized scenario runner.
- `tests/sandbox_scenarios/scenarios/s01_happy_single_issue.py` — first end-to-end Tier-2 scenario.
- ~30 new methods on FakeIssueStore / FakeIssueFetcher / FakeGitHub / FakeLLM to satisfy the production-loop call surface.
- Two real production-relevant bug fixes the sandbox tier caught:
  - `src/contract_recording.py` was hanging the asyncio event loop with synchronous `claude -p ping` subprocess on air-gapped networks. Fix: sandbox carve-out via `is_enabled` callback.
  - `src/ui/src/context/HydraFlowContext.jsx` was calling `crypto.randomUUID()` which is undefined in non-secure contexts (HTTP). Fix: deterministic v4 UUID fallback using `crypto.getRandomValues`.
- New `sandbox` CI job (greenfield) gated on path triggers.
- ADR-0052 codifying the architecture.

Depends on PR A (foundation: Fakes in src/mockworld, build_services overrides, HydraFlowOrchestrator services kwarg, sandbox_main entrypoint).

## Test plan

- [x] `python scripts/sandbox_scenario.py run s01_happy_single_issue` passes locally end-to-end on internal:true network.
- [ ] CI `sandbox` job green on this PR.
- [x] All Tier-1 scenarios still green.
- [x] make quality clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)