### PR TITLE
fix(contract_recording): add timeout + asyncio.to_thread to prevent event-loop deadlock

### DIFF
--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -33,8 +33,13 @@ Design notes
   ``asyncio.create_subprocess_exec`` because the refresh tick runs once
   a week and these calls are dominated by network/IO latency; the
   synchronous form is simpler to mock and simpler to reason about. The
-  loop wraps these calls behind ``asyncio.to_thread`` in Task 20's
-  telemetry instrumentation so the event loop is not blocked.
+  loop wraps these calls behind ``asyncio.to_thread`` so the event
+  loop is not blocked while the recorder runs. As a defence-in-depth
+  measure, every ``subprocess.run`` here passes
+  ``timeout=_RECORDER_SUBPROCESS_TIMEOUT_S`` (120 s) so a hung
+  subprocess (network-degraded host, expired auth, rate-limited
+  ``api.anthropic.com``) cannot deadlock the event loop even if the
+  ``to_thread`` wrapper is bypassed.
 
 Ubiquitous language
 -------------------
@@ -69,6 +74,16 @@ _ALPINE_IMAGE = "alpine:3.19"
 # ``_schema.py`` collapse the volatile bits.
 _CLAUDE_PROMPT = "ping"
 
+# Hard wall-clock cap on every recorder subprocess. 120s is generous
+# enough for a healthy ``gh``/``git``/``docker``/``claude`` round-trip
+# while ensuring a hung subprocess (network-degraded host, expired auth,
+# rate-limited ``api.anthropic.com``, frozen Docker daemon) cannot
+# deadlock the asyncio event loop forever. Originally surfaced by
+# sandbox-tier work (PR #8452 Task 2.5c) where the air-gapped network
+# made ``claude -p ping`` hang indefinitely, freezing the orchestrator
+# (and the dashboard server with it).
+_RECORDER_SUBPROCESS_TIMEOUT_S = 120
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -78,6 +93,11 @@ def _recorder_sha() -> str:
     """Return the short SHA of ``HEAD`` for the recording context, or
     ``"unknown"`` if ``git`` is unavailable. Stamped into every cassette so
     ``git blame`` on a drifted fixture leads back to the recording run.
+
+    A 120-second hard timeout prevents event-loop deadlock when the
+    subprocess hangs (network failure, expired auth, frozen filesystem,
+    etc.). On timeout we degrade gracefully to ``"unknown"`` rather than
+    raise — the cassette payload is best-effort metadata.
     """
     try:
         proc = subprocess.run(
@@ -85,8 +105,9 @@ def _recorder_sha() -> str:
             capture_output=True,
             text=True,
             check=False,
+            timeout=_RECORDER_SUBPROCESS_TIMEOUT_S,
         )
-    except (FileNotFoundError, OSError):
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return "unknown"
     sha = proc.stdout.strip()
     return sha or "unknown"
@@ -140,8 +161,17 @@ def _write_yaml_cassette(path: Path, payload: dict[str, Any]) -> None:
 
 def _run(argv: list[str]) -> subprocess.CompletedProcess[str] | None:
     """Run *argv* with captured text output. Return None on
-    ``FileNotFoundError`` / ``OSError`` / ``SubprocessError`` and warn-log the
-    failure — the caller propagates that as an empty recording list.
+    ``FileNotFoundError`` / ``OSError`` / ``SubprocessError`` /
+    ``TimeoutExpired`` and warn-log the failure — the caller propagates
+    that as an empty recording list.
+
+    A 120-second hard timeout prevents event-loop deadlock when the
+    subprocess hangs (network failure, expired auth, rate-limited
+    ``api.anthropic.com``, frozen Docker daemon, etc.). On timeout we
+    log a warning and return None so the recorder degrades to "no
+    cassette written" rather than freezing the orchestrator's asyncio
+    event loop. ``subprocess.TimeoutExpired`` is a subclass of
+    ``SubprocessError`` but caught explicitly here for clearer logs.
     """
     try:
         return subprocess.run(
@@ -149,9 +179,17 @@ def _run(argv: list[str]) -> subprocess.CompletedProcess[str] | None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=_RECORDER_SUBPROCESS_TIMEOUT_S,
         )
     except FileNotFoundError as exc:
         logger.warning("contract_recording: binary missing for %s: %s", argv[0], exc)
+    except subprocess.TimeoutExpired as exc:
+        logger.warning(
+            "contract_recording: subprocess timed out after %ss for %s: %s",
+            _RECORDER_SUBPROCESS_TIMEOUT_S,
+            argv[0],
+            exc,
+        )
     except (OSError, subprocess.SubprocessError) as exc:
         logger.warning("contract_recording: subprocess failed for %s: %s", argv[0], exc)
     return None

--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -170,7 +170,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
     # Recording
     # ------------------------------------------------------------------
 
-    def _record_all(self, tmp_root: Path) -> dict[str, list[Path]]:
+    async def _record_all(self, tmp_root: Path) -> dict[str, list[Path]]:
         """Run each adapter's recorder into a dedicated tmp subdirectory.
 
         Returns a ``{adapter_name: [recorded_paths]}`` mapping suitable
@@ -186,35 +186,44 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         the loop. The synthetic ``command`` identifies the recorder
         symbolically; the real argv lives inside :mod:`contract_recording`
         and does not round-trip here.
+
+        Async (G14): each recorder is dispatched via
+        ``asyncio.to_thread`` so the blocking ``subprocess.run`` calls
+        inside :mod:`contract_recording` do not freeze the event loop
+        for the duration of the recorder. Originally surfaced by
+        sandbox-tier work (PR #8452 Task 2.5c): the ``claude -p ping``
+        recorder hung indefinitely on the air-gapped sandbox network,
+        deadlocking the orchestrator and preventing the dashboard from
+        binding port 5555.
         """
         sandbox_dir = self._config.repo_root / _GIT_SANDBOX_RELPATH
 
         recorded: dict[str, list[Path]] = {}
-        recorded["github"] = self._record_with_trace(
+        recorded["github"] = await self._record_with_trace(
             "contract_recording.record_github",
             record_github,
             _SANDBOX_GITHUB_REPO,
             tmp_root / "github",
         )
-        recorded["git"] = self._record_with_trace(
+        recorded["git"] = await self._record_with_trace(
             "contract_recording.record_git",
             record_git,
             sandbox_dir,
             tmp_root / "git",
         )
-        recorded["docker"] = self._record_with_trace(
+        recorded["docker"] = await self._record_with_trace(
             "contract_recording.record_docker",
             record_docker,
             tmp_root / "docker",
         )
-        recorded["claude"] = self._record_with_trace(
+        recorded["claude"] = await self._record_with_trace(
             "contract_recording.record_claude_stream",
             record_claude_stream,
             tmp_root / "claude",
         )
         return recorded
 
-    def _record_with_trace(
+    async def _record_with_trace(
         self,
         label: str,
         recorder: Callable[..., list[Path]],
@@ -229,10 +238,18 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         unhandled exception is surfaced as ``exit_code=2`` + the
         exception message, then re-raised — we refuse to swallow
         recorder crashes but must ensure telemetry sees them first.
+
+        Async (G14): the recorder body is dispatched through
+        :func:`asyncio.to_thread` so the underlying ``subprocess.run``
+        calls do not block the asyncio event loop. The 120-second hard
+        timeout inside :mod:`contract_recording` provides
+        defence-in-depth — even if a future caller forgets the
+        ``to_thread`` wrapper, no recorder can hang the orchestrator
+        forever.
         """
         t0 = time.perf_counter()
         try:
-            result = recorder(*args)
+            result = await asyncio.to_thread(recorder, *args)
         except Exception as exc:
             duration_ms = int((time.perf_counter() - t0) * 1000)
             trace_collector.emit_loop_subprocess_trace(
@@ -592,7 +609,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
 
         tmp_root = self._config.data_root / "contract_refresh" / "recordings"
         tmp_root.mkdir(parents=True, exist_ok=True)
-        recordings = self._record_all(tmp_root)
+        recordings = await self._record_all(tmp_root)
 
         fleet: FleetDriftReport = detect_fleet_drift(recordings, self._config.repo_root)
 

--- a/tests/regressions/test_contract_recording_timeout.py
+++ b/tests/regressions/test_contract_recording_timeout.py
@@ -1,0 +1,44 @@
+"""Regression: contract_recording must not block the asyncio event loop.
+
+Originally surfaced by sandbox-tier work (PR #8452): on the air-gapped
+internal:true network, ContractRefreshLoop's subprocess.run(claude -p ping)
+hung indefinitely, deadlocking the orchestrator's asyncio loop and
+preventing the dashboard from binding port 5555.
+
+Fix:
+1. subprocess.run gets an explicit timeout so it cannot hang forever.
+2. The callers wrap the blocking subprocess.run in asyncio.to_thread.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent.parent
+_RECORDING = _REPO / "src" / "contract_recording.py"
+_LOOP = _REPO / "src" / "contract_refresh_loop.py"
+
+
+def test_contract_recording_subprocess_has_timeout() -> None:
+    """Every subprocess.run call in contract_recording.py must specify a timeout."""
+    src = _RECORDING.read_text()
+    assert "subprocess.run(" in src, "subprocess.run not found in contract_recording.py"
+    pattern = re.compile(r"subprocess\.run\([^)]*timeout=", re.DOTALL)
+    matches = pattern.findall(src)
+    assert matches, (
+        "subprocess.run is called without a timeout argument; this can "
+        "block the asyncio event loop forever on network-hung subprocesses."
+    )
+
+
+def test_contract_refresh_loop_wraps_blocking_call() -> None:
+    """ContractRefreshLoop must wrap the blocking record_claude_stream call
+    in asyncio.to_thread so the event loop is not blocked.
+    """
+    src = _LOOP.read_text()
+    assert "asyncio.to_thread" in src, (
+        "contract_refresh_loop.py does not use asyncio.to_thread anywhere; "
+        "the blocking subprocess.run from record_claude_stream will deadlock "
+        "the asyncio event loop."
+    )


### PR DESCRIPTION
## Summary

Production-latent bug surfaced during sandbox-tier work (PR #8452 Task 2.5c):

`ContractRefreshLoop._record_with_trace` calls `record_claude_stream` (in `contract_recording.py`), which calls `subprocess.run(claude -p ping ...)` synchronously. On any environment where that subprocess hangs — air-gapped network, expired auth, rate-limited `api.anthropic.com` — the entire orchestrator deadlocks, including the dashboard server (port 5555 stops binding).

The sandbox carve-out in PR #8452 disabled `contract_refresh` to work around this. The actual fix has been deferred until now.

## Fix

Two layers:
1. **Hard timeout** on `subprocess.run` (120s) so it cannot hang forever. Applied to both `_run` (the recorder helper) and `_recorder_sha` (the only other `subprocess.run` site in the module). `subprocess.TimeoutExpired` is caught and degrades to the existing "no cassette / unknown sha" path rather than raising into the loop.
2. **`asyncio.to_thread` wrapper** at the loop's call site (`ContractRefreshLoop._record_with_trace`), so the event loop isn't blocked for the subprocess wall-clock. `_record_with_trace` and `_record_all` are now async; `_do_work` awaits them.

## Test plan

- [x] New regression test `tests/regressions/test_contract_recording_timeout.py` asserts both invariants (subprocess.run has timeout, contract_refresh_loop uses asyncio.to_thread).
- [x] `tests/scenarios/test_contract_refresh_scenario.py` still passes.
- [x] `tests/test_contract_refresh_loop.py`, `tests/test_contract_refresh_integration.py`, `tests/test_contract_recording.py` still pass.
- [x] `make quality` clean (11873 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Skip-ADR: This is a hardening fix to existing async-loop behavior; no behaviors codified by ADRs change.
