### PR TITLE
fix(contracts): break src→tests import — relocate _schema to src/contracts/

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-04-29T02:23:59.609203+00:00",
-  "commit_sha": "2f2161bca754b2de757ebe2fd399964e86894561",
+  "regenerated_at": "2026-05-02T18:32:43.445919+00:00",
+  "commit_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c",
   "artifacts": {
     "loops.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "ports.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "labels.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "modules.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "events.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "adr_xref.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "mockworld.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "changelog.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     },
     "functional_areas.md": {
-      "source_sha": "2f2161bca754b2de757ebe2fd399964e86894561"
+      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -150,4 +150,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W18
 
-- `ef73db7` — feat(loop): SandboxFailureFixerLoop — auto-agent self-fix on Trigger 2 failures *(2026-04-28)*
+- `54f940e` — feat(sandbox): catalog s02-s12 + SandboxFailureFixerLoop + 3-trigger CI (PR C of 3) (#8453) (#8453) *(2026-04-28)*
 - `e1e9c91` — feat(sandbox): docker-compose stack + harness + s01 + ADR-0052 (PR B of 3) (#8452) (#8452) *(2026-04-28)*
 - `32ef615` — feat(mockworld): foundation — Fake relocation + DI plumbing + sandbox entrypoint (PR A of 3) (#8451) (#8451) *(2026-04-28)*
 
@@ -153,4 +153,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -257,4 +257,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -42,4 +42,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -10,6 +10,7 @@ graph LR
     src_arch["src.arch"]
     src_arch_extractors["src.arch.extractors"]
     src_arch_generators["src.arch.generators"]
+    src_contracts["src.contracts"]
     src_dashboard_routes["src.dashboard_routes"]
     src_mockworld["src.mockworld"]
     src_mockworld_fakes["src.mockworld.fakes"]
@@ -18,6 +19,7 @@ graph LR
     src_sentry["src.sentry"]
     src_state["src.state"]
     src -- "4" --> src_arch
+    src -- "1" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "12" --> src_preflight
     src -- "44" --> src_state
@@ -31,4 +33,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -84,4 +84,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `2f2161b` on 2026-04-29 02:23 UTC. Source last changed at `2f2161b`. Status: 🟢 fresh._
+_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._

--- a/src/contract_diff.py
+++ b/src/contract_diff.py
@@ -20,7 +20,7 @@ Why normalize before compare
 ----------------------------
 
 Raw YAML bytes would always differ: ``recorded_at`` and ``recorder_sha``
-change every tick. The :mod:`tests.trust.contracts._schema` module
+change every tick. The :mod:`contracts._schema` module
 already defines the normalizer registry used by the replay harness —
 reuse it here so the diff side agrees with the replay side on what
 counts as "the same interaction". A cassette declares its normalizers
@@ -51,7 +51,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from tests.trust.contracts._schema import (
+from contracts._schema import (
     Cassette,
     apply_normalizers,
     load_cassette,

--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -6,7 +6,7 @@
 Each ``record_<adapter>`` function runs the *real* CLI for its adapter
 (``gh`` / ``git`` / ``docker`` / ``claude``) and writes one or more
 cassette fixtures to a caller-supplied temp directory. The shape of the
-YAML payload matches :class:`tests.trust.contracts._schema.Cassette` so
+YAML payload matches :class:`contracts._schema.Cassette` so
 later stages of the ``ContractRefreshLoop`` tick (Tasks 14–18) can diff
 the fresh recordings against the committed cassettes and drive
 refresh-PRs / drift-repair issues.
@@ -40,7 +40,7 @@ Ubiquitous language
 -------------------
 
 ``cassette``, ``adapter``, ``fixture_repo``, ``interaction``,
-``normalizers`` — see ``tests/trust/contracts/_schema.py``.
+``normalizers`` — see ``src/contracts/_schema.py``.
 """
 
 from __future__ import annotations

--- a/src/contracts/__init__.py
+++ b/src/contracts/__init__.py
@@ -1,0 +1,11 @@
+"""Production-side contract schemas.
+
+Lives in ``src/`` so production modules (e.g. ``contract_diff``,
+``contract_recording``) can import without a ``src→tests`` dependency.
+The cassette schema previously lived at ``tests/trust/contracts/_schema.py``;
+it was relocated here as a follow-up to PR A's ``_factories`` move
+(production code should never require ``tests/`` on ``sys.path``).
+
+Spec: docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
+§4.2 "Cassette schema".
+"""

--- a/src/contracts/_schema.py
+++ b/src/contracts/_schema.py
@@ -1,0 +1,131 @@
+"""Cassette YAML schema + normalizer registry for fake contract tests.
+
+Spec: docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
+§4.2 "Cassette schema".
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from datetime import date, datetime
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class CassetteInput(BaseModel):
+    """One-interaction input block."""
+
+    command: str
+    args: list[str] = Field(default_factory=list)
+    stdin: str | None = None
+    env: dict[str, str] = Field(default_factory=dict)
+
+
+class CassetteOutput(BaseModel):
+    """One-interaction output block."""
+
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+class Cassette(BaseModel):
+    """A single recorded interaction between HydraFlow and a real adapter."""
+
+    adapter: str
+    interaction: str
+    recorded_at: str
+    recorder_sha: str
+    fixture_repo: str
+    input: CassetteInput
+    output: CassetteOutput
+    normalizers: list[str] = Field(default_factory=list)
+
+    @field_validator("recorded_at", mode="before")
+    @classmethod
+    def _coerce_recorded_at(cls, v: object) -> str:
+        """yaml.safe_load parses ISO8601 timestamps as datetime — coerce to str."""
+        if isinstance(v, datetime | date):
+            return v.isoformat()
+        return str(v)
+
+    @field_validator("adapter")
+    @classmethod
+    def _validate_adapter(cls, v: str) -> str:
+        if v not in {"github", "git", "docker"}:
+            msg = f"adapter must be one of github|git|docker, got {v!r}"
+            raise ValueError(msg)
+        return v
+
+    @field_validator("normalizers")
+    @classmethod
+    def _validate_normalizers(cls, v: list[str]) -> list[str]:
+        for name in v:
+            if name not in NORMALIZERS:
+                msg = f"unknown normalizer {name!r}; known: {sorted(NORMALIZERS)}"
+                raise ValueError(msg)
+        return v
+
+
+# --- Normalizer registry -----------------------------------------------------
+
+# A normalizer transforms a stdout/stderr string so that volatile bytes
+# (e.g. auto-assigned PR numbers, fresh timestamps) collapse to a stable
+# token before comparison. Both sides of the replay harness run every
+# listed normalizer on both texts before `==`.
+
+_PR_NUMBER_RE = re.compile(
+    r"/pull/(\d+)\b|pr[_ -]?(?:number|num)[:= ]+(\d+)\b", re.IGNORECASE
+)
+_ISO8601_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\b"
+)
+_SHORT_SHA_RE = re.compile(r"\b[0-9a-f]{7,12}\b")
+
+
+def _norm_pr_number(text: str) -> str:
+    return _PR_NUMBER_RE.sub(
+        lambda m: m.group(0).replace(m.group(1) or m.group(2), "<PR_NUMBER>"), text
+    )
+
+
+def _norm_iso8601(text: str) -> str:
+    return _ISO8601_RE.sub("<ISO8601>", text)
+
+
+def _norm_short_sha(text: str) -> str:
+    return _SHORT_SHA_RE.sub("<SHORT_SHA>", text)
+
+
+NORMALIZERS: dict[str, Callable[[str], str]] = {
+    "pr_number": _norm_pr_number,
+    "timestamps.ISO8601": _norm_iso8601,
+    "sha:short": _norm_short_sha,
+}
+
+
+def apply_normalizers(text: str, names: list[str]) -> str:
+    """Apply each named normalizer to *text* in order; return the result."""
+    for name in names:
+        text = NORMALIZERS[name](text)
+    return text
+
+
+def load_cassette(path: Path) -> Cassette:
+    """Parse a YAML cassette file and return a validated Cassette model."""
+    with path.open("r", encoding="utf-8") as fh:
+        raw = yaml.safe_load(fh)
+    if not isinstance(raw, dict):
+        msg = f"cassette {path} did not parse to a mapping: {type(raw).__name__}"
+        raise ValueError(msg)
+    return Cassette.model_validate(raw)
+
+
+def dump_cassette(cassette: Cassette, path: Path) -> None:
+    """Serialize *cassette* to YAML at *path*."""
+    payload = cassette.model_dump(mode="json")
+    with path.open("w", encoding="utf-8") as fh:
+        yaml.safe_dump(payload, fh, sort_keys=False, default_flow_style=False)

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -102,7 +102,7 @@ def catalog_cassette_methods(cassette_dir: Path) -> set[str]:
 
     Each cassette is a YAML file with an ``input.command`` field naming
     the method invoked (per §4.2 cassette schema, landed in
-    `tests/trust/contracts/_schema.py`).
+    `src/contracts/_schema.py`).
     """
     methods: set[str] = set()
     if not cassette_dir.exists():

--- a/tests/trust/contracts/_schema.py
+++ b/tests/trust/contracts/_schema.py
@@ -1,128 +1,21 @@
-"""Cassette YAML schema + normalizer registry for fake contract tests.
+"""Back-compat shim — cassette schema moved to ``src/contracts/_schema.py``.
 
-Spec: docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
-§4.2 "Cassette schema".
+Production code (``src/contract_diff.py``, ``src/contract_refresh_loop.py``)
+must not require ``tests/`` to be on ``sys.path``: the deployed container
+ships ``src/`` only. The schema was therefore relocated to
+``src/contracts/_schema.py`` (mirrors PR A's ``_factories`` move).
+
+Existing test-side call sites continue to work via this re-export.
 """
 
 from __future__ import annotations
 
-import re
-from collections.abc import Callable
-from pathlib import Path
-
-import yaml
-from pydantic import BaseModel, Field, field_validator
-
-
-class CassetteInput(BaseModel):
-    """One-interaction input block."""
-
-    command: str
-    args: list[str] = Field(default_factory=list)
-    stdin: str | None = None
-    env: dict[str, str] = Field(default_factory=dict)
-
-
-class CassetteOutput(BaseModel):
-    """One-interaction output block."""
-
-    exit_code: int
-    stdout: str = ""
-    stderr: str = ""
-
-
-class Cassette(BaseModel):
-    """A single recorded interaction between HydraFlow and a real adapter."""
-
-    adapter: str
-    interaction: str
-    recorded_at: str
-    recorder_sha: str
-    fixture_repo: str
-    input: CassetteInput
-    output: CassetteOutput
-    normalizers: list[str] = Field(default_factory=list)
-
-    @field_validator("recorded_at", mode="before")
-    @classmethod
-    def _coerce_recorded_at(cls, v: object) -> str:
-        """yaml.safe_load parses ISO8601 timestamps as datetime — coerce to str."""
-        return v.isoformat() if hasattr(v, "isoformat") else str(v)
-
-    @field_validator("adapter")
-    @classmethod
-    def _validate_adapter(cls, v: str) -> str:
-        if v not in {"github", "git", "docker"}:
-            msg = f"adapter must be one of github|git|docker, got {v!r}"
-            raise ValueError(msg)
-        return v
-
-    @field_validator("normalizers")
-    @classmethod
-    def _validate_normalizers(cls, v: list[str]) -> list[str]:
-        for name in v:
-            if name not in NORMALIZERS:
-                msg = f"unknown normalizer {name!r}; known: {sorted(NORMALIZERS)}"
-                raise ValueError(msg)
-        return v
-
-
-# --- Normalizer registry -----------------------------------------------------
-
-# A normalizer transforms a stdout/stderr string so that volatile bytes
-# (e.g. auto-assigned PR numbers, fresh timestamps) collapse to a stable
-# token before comparison. Both sides of the replay harness run every
-# listed normalizer on both texts before `==`.
-
-_PR_NUMBER_RE = re.compile(
-    r"/pull/(\d+)\b|pr[_ -]?(?:number|num)[:= ]+(\d+)\b", re.IGNORECASE
+from contracts._schema import (  # noqa: F401
+    NORMALIZERS,
+    Cassette,
+    CassetteInput,
+    CassetteOutput,
+    apply_normalizers,
+    dump_cassette,
+    load_cassette,
 )
-_ISO8601_RE = re.compile(
-    r"\b\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\b"
-)
-_SHORT_SHA_RE = re.compile(r"\b[0-9a-f]{7,12}\b")
-
-
-def _norm_pr_number(text: str) -> str:
-    return _PR_NUMBER_RE.sub(
-        lambda m: m.group(0).replace(m.group(1) or m.group(2), "<PR_NUMBER>"), text
-    )
-
-
-def _norm_iso8601(text: str) -> str:
-    return _ISO8601_RE.sub("<ISO8601>", text)
-
-
-def _norm_short_sha(text: str) -> str:
-    return _SHORT_SHA_RE.sub("<SHORT_SHA>", text)
-
-
-NORMALIZERS: dict[str, Callable[[str], str]] = {
-    "pr_number": _norm_pr_number,
-    "timestamps.ISO8601": _norm_iso8601,
-    "sha:short": _norm_short_sha,
-}
-
-
-def apply_normalizers(text: str, names: list[str]) -> str:
-    """Apply each named normalizer to *text* in order; return the result."""
-    for name in names:
-        text = NORMALIZERS[name](text)
-    return text
-
-
-def load_cassette(path: Path) -> Cassette:
-    """Parse a YAML cassette file and return a validated Cassette model."""
-    with path.open("r", encoding="utf-8") as fh:
-        raw = yaml.safe_load(fh)
-    if not isinstance(raw, dict):
-        msg = f"cassette {path} did not parse to a mapping: {type(raw).__name__}"
-        raise ValueError(msg)
-    return Cassette.model_validate(raw)
-
-
-def dump_cassette(cassette: Cassette, path: Path) -> None:
-    """Serialize *cassette* to YAML at *path*."""
-    payload = cassette.model_dump(mode="json")
-    with path.open("w", encoding="utf-8") as fh:
-        yaml.safe_dump(payload, fh, sort_keys=False, default_flow_style=False)


### PR DESCRIPTION
## Summary

Pre-existing `src→tests` violation in `src/contract_diff.py:54` (introduced by PR #8390, flagged in PR A's pass-2 fresh-eyes review as Minor M5). Production code shouldn't depend on `tests/` being on `sys.path` — the deployed container ships `src/` only.

Same class of bug we fixed for the Fakes in PR A (factories relocated to `src/mockworld/fakes/_factories.py`). Now we apply the same pattern to the contract-cassette schema.

## Approach

- Relocated `tests/trust/contracts/_schema.py` -> `src/contracts/_schema.py` (Option A from the brief).
- Back-compat shim at the old location re-exports `Cassette`, `CassetteInput`, `CassetteOutput`, `NORMALIZERS`, `apply_normalizers`, `load_cassette`, `dump_cassette` so the 8 existing `from tests.trust.contracts._schema import ...` call sites in `tests/` keep working.
- `src/contract_diff.py` now imports from `contracts._schema`.
- Stale docstring path-references in `src/contract_recording.py` and `src/fake_coverage_auditor_loop.py` updated to point at the new location.
- Pyright fix while moving: the `src/` tier is stricter than `tests/`, so the `recorded_at` validator's `hasattr`-based `isoformat` call had to be replaced with `isinstance(v, datetime | date)` — pyright doesn't narrow `object` through `hasattr`.
- `docs/arch/generated/modules.md` regenerated to add the new `src.contracts` package node + the `src -> src.contracts` edge (1 import). Other arch artifacts updated only by the regen footer SHA/timestamp.

## Test plan

- [x] `contract_diff` + `contract_refresh_loop` resolve under `PYTHONPATH=src` alone (no `tests/` on `sys.path`) — verified with the docker-sim import probe.
- [x] All contract-related tests pass: `tests/test_contract_diff.py`, `tests/test_contract_cassette_schema.py`, `tests/test_contract_replay_harness.py`, `tests/test_contract_recording.py`, `tests/trust/contracts/`, `tests/test_contract_refresh_*`, `tests/scenarios/test_contract_refresh_scenario.py`, `tests/test_fake_coverage_auditor_loop.py` (165 tests).
- [x] `tests/architecture/test_curated_drift.py` passes after `make arch-regen`.
- [x] `make quality` clean — `HydraFlow quality pipeline passed` (11871 passed).

Skip-ADR: Internal refactor breaking a `src→tests` dependency. No behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)