### PR TITLE
chore(cleanup): drop redundant docstrings + comments + section markers

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-02T18:32:43.445919+00:00",
-  "commit_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c",
+  "regenerated_at": "2026-05-02T21:24:36.109439+00:00",
+  "commit_sha": "41837000219cff621852f3e4905b5234f2160ebc",
   "artifacts": {
     "loops.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "ports.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "labels.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "modules.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "events.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "adr_xref.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "mockworld.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "changelog.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     },
     "functional_areas.md": {
-      "source_sha": "54f940efbd2fec6ca93647f7a38983aca9fc2d1c"
+      "source_sha": "41837000219cff621852f3e4905b5234f2160ebc"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -150,4 +150,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W18
 
+- `4183700` — fix(contracts): break src→tests import — relocate _schema to src/contracts/ (#8457) (#8457) *(2026-05-02)*
+- `14e066b` — fix(subprocess): timeouts on subprocess.run in async loop paths (#8456) (#8456) *(2026-05-02)*
 - `54f940e` — feat(sandbox): catalog s02-s12 + SandboxFailureFixerLoop + 3-trigger CI (PR C of 3) (#8453) (#8453) *(2026-04-28)*
 - `e1e9c91` — feat(sandbox): docker-compose stack + harness + s01 + ADR-0052 (PR B of 3) (#8452) (#8452) *(2026-04-28)*
 - `32ef615` — feat(mockworld): foundation — Fake relocation + DI plumbing + sandbox entrypoint (PR A of 3) (#8451) (#8451) *(2026-04-28)*
@@ -153,4 +155,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -257,4 +257,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -42,4 +42,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -33,4 +33,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -84,4 +84,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `54f940e` on 2026-05-02 18:32 UTC. Source last changed at `54f940e`. Status: 🟢 fresh._
+_Regenerated from commit `4183700` on 2026-05-02 21:24 UTC. Source last changed at `4183700`. Status: 🟢 fresh._

--- a/src/bug_reproducer.py
+++ b/src/bug_reproducer.py
@@ -41,10 +41,6 @@ from models import (
 logger = logging.getLogger("hydraflow.bug_reproducer")
 
 
-# ---------------------------------------------------------------------------
-# Marker contract
-# ---------------------------------------------------------------------------
-
 REPRO_START = "REPRO_START"
 REPRO_END = "REPRO_END"
 

--- a/src/contract_diff.py
+++ b/src/contract_diff.py
@@ -57,10 +57,6 @@ from contracts._schema import (
     load_cassette,
 )
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-
 # The four recorder-side adapter names. Must stay aligned with
 # ``ADAPTER_PLANS`` in ``src/contract_refresh_loop.py`` and with the
 # three YAML adapters accepted by ``_schema.Cassette._validate_adapter``
@@ -77,10 +73,6 @@ _COMMITTED_DIR_RELPATH: dict[str, str] = {
     "docker": "tests/trust/contracts/cassettes/docker",
     "claude": "tests/trust/contracts/claude_streams",
 }
-
-# ---------------------------------------------------------------------------
-# Reports
-# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -115,11 +107,6 @@ class FleetDriftReport:
 
     reports: list[AdapterDriftReport]
     has_drift: bool
-
-
-# ---------------------------------------------------------------------------
-# Canonicalization
-# ---------------------------------------------------------------------------
 
 
 def _canonical_payload(cassette: Cassette) -> bytes:
@@ -242,11 +229,6 @@ def _canonicalize(adapter: str, path: Path) -> bytes:
     if adapter == "claude":
         return _canonical_jsonl(path)
     return _canonical_yaml(path)
-
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 
 def detect_adapter_drift(

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -16,15 +16,7 @@ from typing import Any
 
 from issue_store import IssueStoreStage
 
-# ---------------------------------------------------------------------------
-# Regex patterns
-# ---------------------------------------------------------------------------
-
 _SAFE_SLUG_COMPONENT = re.compile(r"^[A-Za-z0-9_.\-]+$")
-
-# ---------------------------------------------------------------------------
-# Mapping tables
-# ---------------------------------------------------------------------------
 
 # Interval bounds per editable worker.
 # memory_sync, metrics, pr_unsticker, adr_reviewer bounds must match config.py Field constraints.
@@ -112,10 +104,6 @@ _INFERENCE_COUNTER_KEYS: tuple[str, ...] = (
     "cache_hits",
     "cache_misses",
 )
-
-# ---------------------------------------------------------------------------
-# History helpers
-# ---------------------------------------------------------------------------
 
 _HISTORY_STATUSES: set[str] = {
     "unknown",

--- a/src/epic.py
+++ b/src/epic.py
@@ -223,12 +223,10 @@ class EpicCompletionChecker:
                 )
                 return False
 
-            # Check if sub-issue has the fixed label — normal completion
             if fixed_label and fixed_label in issue.labels:
                 sub_issue_titles.append(issue.title)
                 continue
 
-            # Check if sub-issue is a nested epic that is closed
             if (
                 epic_labels & set(issue.labels)
                 and issue.state == GitHubIssueState.CLOSED
@@ -236,7 +234,6 @@ class EpicCompletionChecker:
                 sub_issue_titles.append(issue.title)
                 continue
 
-            # Check if sub-issue is closed (wontfix/duplicate/invalid)
             if issue.state == GitHubIssueState.CLOSED:
                 excluded_issues.append(issue_number)
                 logger.info(
@@ -247,12 +244,10 @@ class EpicCompletionChecker:
                 )
                 continue
 
-            # Check if sub-issue is escalated to HITL (still open)
             if hitl_labels & set(issue.labels):
                 hitl_blocked.append(issue_number)
                 continue
 
-            # Sub-issue is still open and unresolved
             return False
 
         # Post HITL warnings if any sub-issues are in HITL
@@ -640,7 +635,6 @@ class EpicManager:
         if strategy == MergeStrategy.INDEPENDENT:
             return
 
-        # Check if all siblings are approved or already merged
         progress = self.get_progress(epic_number)
         if progress is None or not progress.ready_to_merge:
             return
@@ -1085,7 +1079,6 @@ class EpicManager:
         if epic.released:
             return {"error": "epic already released", "status": "failed"}
 
-        # Check if a release job is already running
         if epic_number in self._release_jobs:
             return {
                 "job_id": self._release_jobs[epic_number],

--- a/src/events.py
+++ b/src/events.py
@@ -327,7 +327,6 @@ class EventBus:
 
     @property
     def current_session_id(self) -> str | None:
-        """Return the active session ID, if any."""
         return self._active_session_id
 
     async def publish(self, event: HydraFlowEvent) -> None:

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -96,7 +96,6 @@ class ImplementPhase:
 
     @property
     def active_issues(self) -> set[int]:
-        """Return the set of currently active implementation issues."""
         return self._active_issues
 
     async def _post_impl_transcript(self, result: WorkerResult, *, status: str) -> None:

--- a/src/metrics_manager.py
+++ b/src/metrics_manager.py
@@ -51,12 +51,10 @@ class MetricsManager:
 
     @property
     def latest_snapshot(self) -> MetricsSnapshot | None:
-        """Return the most recent in-memory snapshot."""
         return self._latest_snapshot
 
     @property
     def _cache_dir(self) -> Path:
-        """Return the local metrics cache directory for the current repo."""
         return get_metrics_cache_dir(self._config)
 
     async def sync(self, queue_stats: QueueStats | None = None) -> MetricsSyncResult:

--- a/src/models.py
+++ b/src/models.py
@@ -290,7 +290,6 @@ class GitHubIssue(BaseModel):
         return str(value).lower()
 
     def to_task(self) -> Task:
-        """Convert to a source-agnostic :class:`Task`."""
         metadata: dict[str, Any] = {}
         if self.author:
             metadata["author"] = self.author
@@ -310,7 +309,6 @@ class GitHubIssue(BaseModel):
 
     @classmethod
     def from_task(cls, task: Task) -> GitHubIssue:
-        """Reconstruct a :class:`GitHubIssue` from a :class:`Task`."""
         return cls(
             number=task.id,
             title=task.title,

--- a/src/prompt_telemetry.py
+++ b/src/prompt_telemetry.py
@@ -538,7 +538,6 @@ def _as_float(value: object) -> float:
 def _get_or_init_dict(
     parent: dict[str, object], key: str, default: dict[str, object]
 ) -> dict[str, object]:
-    """Get a nested dict value or initialize it with *default*."""
     current = parent.get(key)
     if isinstance(current, dict):
         return current

--- a/src/retrospective.py
+++ b/src/retrospective.py
@@ -217,7 +217,6 @@ class RetrospectiveCollector:
         return sorted(set(files))
 
     async def _get_actual_files(self, pr_number: int) -> list[str]:
-        """Get the list of files actually changed in the PR."""
         return await self._prs.get_pr_diff_names(pr_number)
 
     @staticmethod

--- a/src/review_phase.py
+++ b/src/review_phase.py
@@ -431,7 +431,6 @@ class ReviewPhase:
 
     @property
     def active_issues(self) -> set[int]:
-        """Return the set of currently active review issues."""
         return self._active_issues
 
     async def post_review_transcript_hooks(

--- a/src/server.py
+++ b/src/server.py
@@ -54,7 +54,6 @@ def _init_sentry() -> None:
 
     def _before_send(event, hint):  # type: ignore[no-untyped-def]
         """Drop transient errors, fingerprint bugs, scrub credentials."""
-        # Check if this event has an exception attached
         exc_info = hint.get("exc_info")
         if exc_info:
             exc_type = exc_info[0]

--- a/src/workspace_gc_loop.py
+++ b/src/workspace_gc_loop.py
@@ -176,7 +176,6 @@ class WorkspaceGCLoop(BaseBackgroundLoop):
         return safe_to_gc
 
     async def _issue_has_pipeline_label(self, issue_number: int) -> bool:
-        """Return True when the issue currently carries any pipeline label."""
         pipeline_labels = {
             *(lbl.lower() for lbl in self._config.find_label),
             *(lbl.lower() for lbl in self._config.planner_label),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,8 +159,6 @@ def _disable_hitl_summary_autowarm(config) -> None:
 
 @pytest.fixture
 def config(tmp_path: Path) -> HydraFlowConfig:
-    """A HydraFlowConfig using tmp_path for all file operations."""
-
     return ConfigFactory.create(
         repo_root=tmp_path / "repo",
         workspace_base=tmp_path / "worktrees",
@@ -170,7 +168,6 @@ def config(tmp_path: Path) -> HydraFlowConfig:
 
 @pytest.fixture
 def dry_config(tmp_path: Path) -> HydraFlowConfig:
-    """A HydraFlowConfig in dry-run mode."""
     return ConfigFactory.create(
         dry_run=True,
         repo_root=tmp_path / "repo",
@@ -689,7 +686,6 @@ def state(tmp_path: Path):
 
 
 def make_state(tmp_path: Path) -> StateTracker:
-    """Create a StateTracker backed by a temp file."""
     from state import StateTracker as ST
 
     return ST(tmp_path / "state.json")
@@ -713,7 +709,6 @@ def make_orchestrator_mock(
     running: bool = False,
     run_status: str = "idle",
 ) -> MagicMock:
-    """Return a minimal orchestrator mock."""
     orch = MagicMock()
     orch.human_input_requests = requests if requests is not None else {}
     orch.provide_human_input = MagicMock()


### PR DESCRIPTION
## Summary

Code-cleanup pass — pure deletion of LLM-pattern noise. **Zero behavior change.**

55 LOC removed across 14 source files + \`tests/conftest.py\`:

- **Restated-signature docstrings** on simple methods/fixtures where the docstring just listed the same args/types as the signature.
- **Comments that restate the next line** (e.g. \"# Check if X\" above \`if X:\` in epic.py state-tracking).
- **Section-marker banners** (\`# ---------- xxx ----------\`) in files <500 LOC (bug_reproducer.py, contract_diff.py, _common.py) where the visual divider was noise rather than navigation aid.
- **\"What\" docstrings on test fixtures** where the fixture name + return type already said what was being returned.

## What's preserved

- Module-level docstrings carrying intent/rationale
- Class-level docstrings explaining invariants and design choices
- Comments that explain WHY, not WHAT
- ADR cross-references (\`# ADR-NNNN: ...\`)
- TODO/FIXME/HACK and \`# type: ignore\` / \`# noqa\` markers

## Test plan

- [x] 125 representative tests pass (events + scenarios)
- [x] Pre-commit arch-check OK
- [x] No behavior change (pure deletions)

Skip-ADR: Pure code-readability cleanup; no behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)