### PR TITLE
fix(wiki): preserve last_lint across rebuild + add wiki-freshness dead-man-switch

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -47,8 +47,11 @@ cd "$REPO_ROOT"
 # test files. See scripts/strip_test_sludge.py for the full pattern list.
 if [ -n "$STAGED_TESTS" ]; then
     echo "pre-commit: running test-sludge check..."
+    # Collapse newlines to spaces — make treats embedded newlines in
+    # variable values as new target lines and chokes on multi-file input.
     # shellcheck disable=SC2086
-    if ! make test-sludge-check FILES="$STAGED_TESTS"; then
+    STAGED_TESTS_ONE_LINE=$(echo $STAGED_TESTS)
+    if ! make test-sludge-check FILES="$STAGED_TESTS_ONE_LINE"; then
         exit 1
     fi
     echo "pre-commit: test-sludge OK"

--- a/docs/wiki/dark-factory.md
+++ b/docs/wiki/dark-factory.md
@@ -1,5 +1,12 @@
 # Dark-factory engineering
 
+> **Doctrinal page — hand-authored, not LLM-maintained.** Unlike the other
+> files in `docs/wiki/`, this page intentionally has no `json:entry`
+> metadata blocks. It is curated prose distilling load-bearing operating
+> doctrine, not auto-ingested per-issue insights. `RepoWikiLoop` does not
+> rewrite this file; the wiki injector still reads it into runner prompts
+> as architectural context.
+
 The lights-off operating contract: any HydraFlow-managed project meeting the
 spec runs autonomously, with humans paged only for raging fires. This entry
 distills the load-bearing conventions that make that contract real, the

--- a/src/config.py
+++ b/src/config.py
@@ -200,6 +200,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         50_000,
     ),
     ("health_monitor_interval", "HYDRAFLOW_HEALTH_MONITOR_INTERVAL", 7200),
+    ("wiki_freshness_stale_days", "HYDRAFLOW_WIKI_FRESHNESS_STALE_DAYS", 7),
     ("stale_issue_interval", "HYDRAFLOW_STALE_ISSUE_INTERVAL", 86400),
     ("sentry_poll_interval", "SENTRY_POLL_INTERVAL", 600),
     ("sentry_min_events", "SENTRY_MIN_EVENTS", 2),
@@ -1664,6 +1665,16 @@ class HydraFlowConfig(BaseModel):
         ge=60,
         le=86400,
         description="Health monitor cycle interval in seconds",
+    )
+    wiki_freshness_stale_days: int = Field(
+        default=7,
+        ge=1,
+        le=365,
+        description=(
+            "Wiki-freshness threshold (days). HealthMonitorLoop files a "
+            "`wiki-stale` issue when docs/wiki/log.jsonl has not moved in "
+            "this many days, surfacing silent RepoWikiLoop stalls."
+        ),
     )
 
     # Config file persistence

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -348,6 +348,12 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         self._sanity_noop_streak: int = 0
         self._pending: list[PendingAdjustment] = []
         self._last_log_scan: datetime | None = None
+        # Dedup for the wiki-freshness dead-man-switch — file one wiki-stale
+        # issue per stall event; clear on recovery.
+        self._wiki_stall_dedup = DedupStore(
+            "health_monitor_wiki_stall",
+            config.data_root / "dedup" / "health_monitor_wiki_stall.json",
+        )
 
     def set_bg_workers(self, bg_workers: BGWorkerManager) -> None:
         """Late-binding for the post-ctor BGWorkerManager wiring."""
@@ -378,6 +384,12 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             await self._check_sanity_loop_staleness()
         except Exception:  # noqa: BLE001
             logger.debug("sanity-loop stall check failed", exc_info=True)
+
+        # Dead-man-switch: detect a stalled RepoWikiLoop via log.jsonl mtime.
+        try:
+            await self._check_wiki_freshness()
+        except Exception:  # noqa: BLE001
+            logger.debug("wiki-freshness check failed", exc_info=True)
 
         metrics = compute_trend_metrics(
             self._outcomes_path, self._scores_path, self._failures_path
@@ -1111,3 +1123,76 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         )
         filed_keys = self._sanity_stall_dedup.get()
         self._sanity_stall_dedup.set_all(filed_keys | {dedup_key})
+
+    async def _check_wiki_freshness(self) -> None:
+        """Dead-man-switch for `RepoWikiLoop` via `docs/wiki/log.jsonl` mtime.
+
+        The wiki loop appends to `log.jsonl` on every ingest, compile, and
+        active_lint operation. When the file's mtime hasn't moved in
+        `wiki_freshness_stale_days`, file one `wiki-stale` issue per stall
+        event. Clears dedup on recovery (file moves again).
+
+        Quietly no-ops when the wiki directory or log file does not exist —
+        new repos won't have one yet, and that is not a stall.
+        """
+        prs = self._prs
+        if prs is None:
+            return
+
+        log_path = self._config.repo_root / "docs" / "wiki" / "log.jsonl"
+        if not log_path.exists():
+            return
+
+        try:
+            mtime = datetime.fromtimestamp(log_path.stat().st_mtime, tz=UTC)
+        except OSError:
+            return
+
+        elapsed_s = (datetime.now(UTC) - mtime).total_seconds()
+        threshold_s = self._config.wiki_freshness_stale_days * 86400
+
+        dedup_key = "health_monitor:repo_wiki:stalled"
+        filed_keys = self._wiki_stall_dedup.get()
+
+        if elapsed_s < threshold_s:
+            # Recovered — clear dedup so a future stall files a fresh issue.
+            if dedup_key in filed_keys:
+                self._wiki_stall_dedup.set_all(filed_keys - {dedup_key})
+            return
+
+        if dedup_key in filed_keys:
+            # Already filed for the current stall; wait for recovery.
+            return
+
+        elapsed_days = int(elapsed_s // 86400)
+        title = (
+            f"wiki-stale: docs/wiki/log.jsonl has not moved in "
+            f"{elapsed_days}d (threshold {self._config.wiki_freshness_stale_days}d)"
+        )
+        body = (
+            f"## RepoWikiLoop dead-man-switch tripped\n\n"
+            f"`docs/wiki/log.jsonl` is the append-only operation log for the "
+            f"repo wiki. It moves on every ingest, compile, and active_lint "
+            f"tick; an unmoved log indicates the wiki loop has not run "
+            f"successfully in `{elapsed_days}` days.\n\n"
+            f"- Last log entry: `{mtime.isoformat()}`\n"
+            f"- Threshold: `{self._config.wiki_freshness_stale_days}` days "
+            f"(`wiki_freshness_stale_days`)\n"
+            f"- Loop interval: `{self._config.repo_wiki_interval}s`\n\n"
+            f"### Operator playbook\n"
+            f"1. Check the System tab — is `repo_wiki` enabled? If not, "
+            f"flip the kill-switch back on.\n"
+            f"2. Check orchestrator logs for the `repo_wiki` task "
+            f"(uncaught exceptions, credit/auth failures).\n"
+            f"3. Confirm HydraFlow is actually running on this repo "
+            f"(the loop only ticks while the harness is up).\n\n"
+            f"_Auto-filed by HydraFlow `health_monitor` "
+            f"(wiki-freshness dead-man-switch)._"
+        )
+        await prs.create_issue(
+            title,
+            body,
+            ["hydraflow-find", "wiki-stale"],
+        )
+        filed_keys = self._wiki_stall_dedup.get()
+        self._wiki_stall_dedup.set_all(filed_keys | {dedup_key})

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -1458,11 +1458,13 @@ class RepoWikiStore:
                 topics[topic_name] = [e.title for e in entries]
                 total += len(entries)
 
+        prior = self._load_index(repo_slug)
         index = WikiIndex(
             repo_slug=repo_slug,
             topics=topics,
             total_entries=total,
             last_updated=datetime.now(UTC).isoformat(),
+            last_lint=prior.last_lint if prior is not None else None,
         )
 
         # Write JSON index

--- a/tests/test_health_monitor_wiki_stall.py
+++ b/tests/test_health_monitor_wiki_stall.py
@@ -1,0 +1,122 @@
+"""Test HealthMonitor dead-man-switch for RepoWikiLoop via log.jsonl mtime."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from config import HydraFlowConfig
+from health_monitor_loop import HealthMonitorLoop
+
+
+@pytest.fixture
+def hm_env(tmp_path: Path):
+    from dedup_store import DedupStore
+
+    repo_root = tmp_path / "repo"
+    (repo_root / "docs" / "wiki").mkdir(parents=True)
+    cfg = HydraFlowConfig(
+        data_root=tmp_path,
+        repo="hydra/hydraflow",
+        repo_root=repo_root,
+        wiki_freshness_stale_days=7,
+    )
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=42)
+    hm = HealthMonitorLoop.__new__(HealthMonitorLoop)
+    hm._config = cfg
+    hm._prs = prs
+    hm._wiki_stall_dedup = DedupStore(
+        "hm_wiki_stall_test",
+        tmp_path / "dedup" / "hm_wiki_stall_test.json",
+    )
+    return hm, prs, repo_root
+
+
+def _set_mtime(path: Path, age_days: float) -> None:
+    epoch = time.time() - (age_days * 86400)
+    os.utime(path, (epoch, epoch))
+
+
+async def test_no_log_file_is_silent_noop(hm_env) -> None:
+    hm, prs, _repo_root = hm_env
+    await hm._check_wiki_freshness()
+    prs.create_issue.assert_not_awaited()
+
+
+async def test_recent_log_does_not_file_issue(hm_env) -> None:
+    hm, prs, repo_root = hm_env
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=1)
+    await hm._check_wiki_freshness()
+    prs.create_issue.assert_not_awaited()
+
+
+async def test_stale_log_files_wiki_stale_issue(hm_env) -> None:
+    hm, prs, repo_root = hm_env
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+
+    await hm._check_wiki_freshness()
+
+    prs.create_issue.assert_awaited_once()
+    title, _body, labels = prs.create_issue.await_args.args
+    assert "wiki-stale" in title
+    assert "10d" in title
+    assert "hydraflow-find" in labels
+    assert "wiki-stale" in labels
+
+
+async def test_stale_log_dedups_within_same_stall(hm_env) -> None:
+    hm, prs, repo_root = hm_env
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+
+    await hm._check_wiki_freshness()
+    await hm._check_wiki_freshness()
+    await hm._check_wiki_freshness()
+
+    prs.create_issue.assert_awaited_once()
+
+
+async def test_recovery_clears_dedup(hm_env) -> None:
+    hm, prs, repo_root = hm_env
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+    await hm._check_wiki_freshness()
+    assert prs.create_issue.await_count == 1
+
+    _set_mtime(log_path, age_days=0)
+    await hm._check_wiki_freshness()
+
+    _set_mtime(log_path, age_days=10)
+    await hm._check_wiki_freshness()
+
+    assert prs.create_issue.await_count == 2
+
+
+async def test_threshold_respects_config(hm_env) -> None:
+    hm, prs, repo_root = hm_env
+    hm._config = hm._config.model_copy(update={"wiki_freshness_stale_days": 30})
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+    await hm._check_wiki_freshness()
+    prs.create_issue.assert_not_awaited()
+
+
+async def test_no_prs_dependency_is_silent_noop(hm_env) -> None:
+    hm, _prs, repo_root = hm_env
+    hm._prs = None
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+    await hm._check_wiki_freshness()

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -387,6 +387,47 @@ class TestActiveLint:
         assert index is not None
         assert index.last_lint is not None
 
+    def test_rebuild_index_preserves_last_lint(self, store: RepoWikiStore) -> None:
+        # Regression: _rebuild_index used to construct a fresh WikiIndex with
+        # last_lint=None, wiping the recorded lint timestamp on every rebuild.
+        # The post-rebuild write in active_lint masked this most of the time
+        # but lost the value if the second write failed.
+        store._ensure_repo_dir(REPO)
+        store.active_lint(REPO)
+        original = store._load_index(REPO)
+        assert original is not None
+        assert original.last_lint is not None
+        original_lint_ts = original.last_lint
+
+        store._rebuild_index(REPO)
+
+        rebuilt = store._load_index(REPO)
+        assert rebuilt is not None
+        assert rebuilt.last_lint == original_lint_ts
+
+    def test_active_lint_persists_last_lint_across_modification_path(
+        self, store: RepoWikiStore
+    ) -> None:
+        # When active_lint marks an entry stale (any_modified=True), it calls
+        # _rebuild_index then re-writes last_lint. Verify the final on-disk
+        # index has last_lint populated through the rebuild path.
+        store.ingest(
+            REPO,
+            [
+                WikiEntry(
+                    title="Closed source",
+                    content="Stale via close.",
+                    source_type="plan",
+                    source_issue=99,
+                ),
+            ],
+        )
+        result = store.active_lint(REPO, closed_issues={99})
+        assert result.index_rebuilt is True
+        index = store._load_index(REPO)
+        assert index is not None
+        assert index.last_lint is not None
+
     def test_no_rebuild_when_unchanged(self, store: RepoWikiStore) -> None:
         store.ingest(
             REPO,


### PR DESCRIPTION
## Summary

PR1 of 2 attacking the wiki-stall issues the user surfaced. Fixes the silent `last_lint=None` bug and adds proactive detection so future stalls become visible. PR2 will tackle content quality (split overstuffed `architecture.md`, fix the bad-title source, clean existing junk titles).

## What's broken (the symptoms)

The user observed:
- `docs/wiki/index.json` showed `last_lint: None` despite a 4-week-old wiki with 249 entries
- `docs/wiki/log.jsonl` had not moved in 7+ days — silent loop stall, no signal
- 0 of 249 entries marked stale — implausible for a fast-moving repo

## What this PR fixes

### 1. `_rebuild_index` was wiping `last_lint` (P2)

**Root cause**: `RepoWikiStore._rebuild_index` (`src/repo_wiki.py:1438`) constructed a fresh `WikiIndex` without preserving the prior `last_lint`. The follow-up write in `active_lint` (`src/repo_wiki.py:980-985`) re-set it most of the time, but the value was lost permanently if anything between the rebuild and the post-rebuild write errored. Once lost, every subsequent rebuild also wiped it before the recovery write could fire.

**Fix**: Read the prior index before rebuilding; carry `last_lint` forward.

**Tests**: Two new regression tests. `test_rebuild_index_preserves_last_lint` directly proves the fix; `test_active_lint_persists_last_lint_across_modification_path` covers the end-to-end `any_modified=True` path the previous test left uncovered.

### 2. Wiki-freshness dead-man-switch (P3)

**Root cause**: There was no signal when `RepoWikiLoop` stopped ticking. The user lost a week before noticing.

**Fix**: New `_check_wiki_freshness` method on `HealthMonitorLoop`, modeled directly on the existing `_check_sanity_loop_staleness` pattern. Stats `docs/wiki/log.jsonl` mtime; when it has not moved in `wiki_freshness_stale_days` (default 7), files one `[\"hydraflow-find\", \"wiki-stale\"]` issue per stall event. Clears dedup on recovery.

Reuses `DedupStore` and the established escalation pattern — **no new loop**, no 8-checkpoint wiring, no UI changes.

**Config field**: `wiki_freshness_stale_days: int = 7` (1-365 range), env override `HYDRAFLOW_WIKI_FRESHNESS_STALE_DAYS`.

**Tests**: 7 new tests covering the silent-noop paths (no log file, no PR port, recent mtime), the stall path, dedup, recovery, and config-driven threshold.

### 3. `dark-factory.md` schema clarity (P6)

The file is intentionally hand-authored doctrinal prose with no `json:entry` blocks, but its presence in `docs/wiki/` next to LLM-maintained pages was confusing (and tripped the audit). Added a one-paragraph header note clarifying the contract. No behavior change.

### 4. Drive-by: pre-commit test-sludge hook fix

The guard added in #8455 invoked `make test-sludge-check FILES=\"$STAGED_TESTS\"` with newline-separated paths. Make interprets embedded newlines in variable values as new target lines and chokes on multi-file input. Collapse newlines to spaces before passing. Surfaced when this PR's commit was first attempted.

## Verification

- `make quality` — green (lint + typecheck + bandit + tests in parallel)
- **11,899 passed, 7 skipped, 0 failed** (8 min wall)
- Targeted suite (`tests/test_repo_wiki.py` + `tests/test_health_monitor_*.py` + adjacent): 366 passed
- Pre-commit hooks (test-sludge, lint, arch-check) all fired green

## What's next (PR2 preview)

- Content cleanup: ~38 bad-title entries removed/retitled, 9 runbook entries moved to `docs/playbooks/`
- Compiler-prompt fix to stop the bad-title source (`repo_wiki_ingest.py:160` hardcoded `\"Review patterns from #N\"`)
- Split `architecture.md` (170 entries / 258KB) into 6 focused sub-topic files

## Test plan
- [ ] CI passes
- [ ] Reviewer reads `_check_wiki_freshness` for parity with `_check_sanity_loop_staleness`
- [ ] Reviewer confirms the `_rebuild_index` fix preserves `last_lint` and only `last_lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Skip-ADR: bug fix (last_lint preservation) + extension of existing dead-man-switch pattern in HealthMonitorLoop (ADR-0045 §12.1). No new architectural decision — same pattern as _check_sanity_loop_staleness, applied to wiki freshness.