### PR TITLE
chore(cleanup): drop redundant getattr defensiveness on guaranteed-set attrs

### DIFF
--- a/src/base_runner.py
+++ b/src/base_runner.py
@@ -300,9 +300,9 @@ class BaseRunner:
         any required dependency is missing.
         """
         compiler = getattr(self, "_wiki_compiler", None)
-        tribal = getattr(self, "_tribal_wiki_store", None)
+        tribal = self._tribal_wiki_store
         gh = getattr(self, "_gh_client", None)
-        bus = getattr(self, "_bus", None)
+        bus = self._bus
         if compiler is None or tribal is None or gh is None:
             return
 
@@ -404,7 +404,7 @@ class BaseRunner:
             )
         per_repo_section = _weave_temporal_tags(per_repo_section, tags)
 
-        tribal = getattr(self, "_tribal_wiki_store", None)
+        tribal = self._tribal_wiki_store
         tribal_section = ""
         if tribal is not None:
             tribal_section = tribal.query(
@@ -431,7 +431,7 @@ class BaseRunner:
         Implement/review: titles-only (prompt-size conscious; excludes Superseded).
         Other phases: empty.
         """
-        adr_index = getattr(self, "_adr_index", None)
+        adr_index = self._adr_index
         if adr_index is None:
             return ""
 

--- a/src/events.py
+++ b/src/events.py
@@ -332,7 +332,7 @@ class EventBus:
 
     async def publish(self, event: HydraFlowEvent) -> None:
         """Publish *event* to all subscribers and append to history."""
-        if event.session_id is None and getattr(self, "_active_session_id", None):
+        if event.session_id is None and self._active_session_id:
             event.session_id = self._active_session_id
         if self._active_repo and event.repo is None:
             event.repo = self._active_repo

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -461,7 +461,7 @@ class HealthMonitorLoop(BaseBackgroundLoop):
                     enrich_patterns_with_events,  # noqa: PLC0415
                 )
 
-                history = self._bus.get_history() if hasattr(self, "_bus") else []
+                history = self._bus.get_history()
                 event_dicts = [{"type": e.type.value, "data": e.data} for e in history]
                 enrich_patterns_with_events(patterns, event_dicts)
             except Exception:  # noqa: BLE001

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -434,14 +434,14 @@ class RepoWikiLoop(BaseBackgroundLoop):
         await self._poll_and_merge_open_pr(stats)
         await self._maybe_open_maintenance_pr(stats)
 
-        tribal_store = getattr(self, "_tribal_store", None)
+        tribal_store = self._tribal_store
         if tribal_store is not None and self._wiki_compiler is not None:
             try:
                 await run_generalization_pass(
                     per_repo=self._wiki_store,
                     tribal=tribal_store,
                     compiler=self._wiki_compiler,
-                    event_bus=getattr(self, "_bus", None),
+                    event_bus=self._bus,
                 )
             except Exception:  # noqa: BLE001
                 logger.warning("generalization pass failed", exc_info=True)


### PR DESCRIPTION
## Summary

Code-cleanup pass — replaces redundant `getattr(self, \"_X\", None)` (and one `hasattr(self, \"_X\")`) with direct `self._X` access at sites where the attribute is unconditionally set in the same class hierarchy's `__init__`. **Zero behavior change.**

Trust the type checker. When an attribute is set in `__init__` and typed `X | None`, defensive `getattr(...)` adds nothing — the type system already guarantees the attribute exists, and the explicit `is None` checks downstream still handle the typed-Optional case correctly.

## What's changed (7 sites, 4 files)

- `src/events.py:335` — `_active_session_id` (set in `EventBus.__init__`)
- `src/base_runner.py:303,305` — `_tribal_wiki_store`, `_bus` in `_process_transcript_for_adr_draft`
- `src/base_runner.py:407` — `_tribal_wiki_store` in `_inject_repo_wiki`
- `src/base_runner.py:434` — `_adr_index` in `_inject_adr_index`
- `src/health_monitor_loop.py:464` — `_bus` (set in `BaseBackgroundLoop.__init__`); replaces `hasattr(self, \"_bus\")`
- `src/repo_wiki_loop.py:437,444` — `_tribal_store`, `_bus`

## What's preserved

- `getattr(self, \"_X\", None)` patterns where the attribute is set conditionally on subclasses only (e.g. `_wiki_compiler`, `_gh_client` in `BaseRunner` — only set on phase classes)
- Dynamic lookups (`getattr(self, f\"_{dataset}\", None)` in `GitHubCacheLoop` — runtime-resolved attribute name)
- Attributes bound by separate lifecycle methods (e.g. `_prs`/`_dedup` set by `bind_escalation_deps` in `DiscoverRunner` / `ShapeRunner` — may not be bound yet at call site)
- `hasattr(...)` checks guarding duck-typed protocol method existence (e.g. `WhatsAppBridge.send_shape_turn`)

## Test plan

- [x] `tests/test_events.py`, `tests/test_event_payloads.py`, `tests/scenarios/test_happy.py`, `tests/test_base_runner.py`, `tests/test_repo_wiki_loop.py` — 211 passed
- [x] `ruff check` and `ruff format --check` — clean
- [x] `pyright` on changed files — 0 errors, 0 warnings

Skip-ADR: Pure code-readability cleanup; no behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)