### PR TITLE
chore(cleanup): collapse parallel resolved-sub-issue branches in epic.py

### DIFF
--- a/src/epic.py
+++ b/src/epic.py
@@ -223,14 +223,13 @@ class EpicCompletionChecker:
                 )
                 return False
 
-            if fixed_label and fixed_label in issue.labels:
-                sub_issue_titles.append(issue.title)
-                continue
-
-            if (
-                epic_labels & set(issue.labels)
+            issue_labels = set(issue.labels)
+            is_fixed = bool(fixed_label) and fixed_label in issue_labels
+            is_closed_nested_epic = (
+                bool(epic_labels & issue_labels)
                 and issue.state == GitHubIssueState.CLOSED
-            ):
+            )
+            if is_fixed or is_closed_nested_epic:
                 sub_issue_titles.append(issue.title)
                 continue
 
@@ -244,7 +243,7 @@ class EpicCompletionChecker:
                 )
                 continue
 
-            if hitl_labels & set(issue.labels):
+            if hitl_labels & issue_labels:
                 hitl_blocked.append(issue_number)
                 continue
 


### PR DESCRIPTION
## Summary

Audit flagged 3 sequential `if`-blocks in `_do_close_epic`'s sub-issue scan (`src/epic.py:226-248`) as triplicate copy-paste. On inspection, only **branches 1 (`fixed_label`) and 2 (closed nested epic)** are truly parallel — both append `issue.title` to `sub_issue_titles`. **Branch 3 (closed-without-label)** and **Branch 4 (HITL)** have different action shapes (different target list, different value, extra logging), so a tuple-driven loop would have *obscured* them rather than improved the code.

## What changed

- Merged branches 1 and 2 into a single guarded clause (`if is_fixed or is_closed_nested_epic`).
- Hoisted `set(issue.labels)` into a local `issue_labels` so the HITL branch reuses it instead of recomputing.
- Branches 3 and 4 left as discrete branches — their action shapes are genuinely different and a loop wouldn't improve readability.

This is the honest minimum: fix the real duplication, leave the rest alone. No "loops for the sake of loops".

## Test plan

- [x] `tests/test_epic.py` — 106 passed
- [x] All epic-related tests (`-k epic`) — 464 passed, 0 failed
- [x] No behavior change (refactor only)
- [x] Pre-commit lint + arch-check pass

Skip-ADR: Pure code-readability cleanup; no behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)