### PR TITLE
fix(scaffolding): stub conditional attrs when __init__ is bypassed (hotfix #8460)

### DIFF
--- a/scripts/audit_prompts.py
+++ b/scripts/audit_prompts.py
@@ -661,6 +661,12 @@ def render_target(target: AuditTarget) -> str:
             # classified as a bug by is_likely_bug and re-raised.
             instance._insights = None
             instance._context_cache = _NullContextCache()
+            # _adr_index and _tribal_wiki_store are set in BaseRunner.__init__;
+            # since __new__ bypasses __init__, stub them as None so direct attr
+            # reads in _inject_adr_index / _process_transcript_for_adr_draft don't
+            # AttributeError. Both call sites are None-safe.
+            instance._adr_index = None
+            instance._tribal_wiki_store = None
             callable_obj = getattr(instance, parts[2])
     else:
         raise ValueError(f"unsupported qualname depth: {target.builder_qualname!r}")

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -86,6 +86,11 @@ def _stub_loop(
     loop._open_pr_url = None
     loop._worker_name = "repo_wiki"
     loop._enabled_cb = lambda _name: True
+    # _tribal_store is set in RepoWikiLoop.__init__; since __new__ bypasses
+    # __init__, stub it as None so the direct attr read in _do_work doesn't
+    # AttributeError (the call site is None-safe — generalization pass is
+    # skipped when tribal_store is None).
+    loop._tribal_store = None
     return loop
 
 


### PR DESCRIPTION
## Summary

Hotfix for PR #8460 (cleanup-trust-types). That cleanup correctly removed defensive `getattr(self, "_X", None)` checks at sites where the attrs ARE set unconditionally in `__init__`. The breakage came from **test scaffolding that bypasses `__init__`** via `cls.__new__(cls)` and only sets a curated subset of attrs.

Currently breaking on main:
- `tests/test_audit_prompts.py` — 5 tests (`AttributeError: ... has no attribute '_adr_index'`)
- `tests/test_repo_wiki_loop_pr.py` — 2 tests (`AttributeError: 'RepoWikiLoop' object has no attribute '_tribal_store'`)

## Fix

Stub the missing attrs as `None` in both bypassed-`__init__` paths:
- `scripts/audit_prompts.py::render_target` — also sets `instance._adr_index = None` and `instance._tribal_wiki_store = None`
- `tests/test_repo_wiki_loop_pr.py::_stub_loop` — also sets `loop._tribal_store = None`

The downstream call sites are already None-safe (early-return when the attr is None), so this is functionally equivalent to the old `getattr(...)` guard at the read site, but the defensiveness now lives in the test/scaffolding harness — the only legitimate place it's needed.

## Why this over restoring the `getattr` guards (Strategy A)

1. The cleanup PR was correct: production code paths always go through `__init__`, so the read-site `getattr` was dead defensiveness.
2. The type checker now sees `self._adr_index` / `self._tribal_store` as always-present (typed `X | None`).
3. Only two scaffolding paths bypass `__init__` (prompt-audit fixture renderer + maintenance-PR test stub), and both already enumerate the attrs they need. Adding two more is a minimal ergonomic change.

## Test plan

- [x] Failing tests now pass (`tests/test_audit_prompts.py` 58/58, `tests/test_repo_wiki_loop_pr.py` 22/22)
- [x] Existing `tests/test_base_runner.py` + `tests/test_repo_wiki_loop.py` still pass (broader 117/117 green)
- [x] Pre-commit hooks pass (test-sludge, lint, format, security)

Skip-ADR: Hotfix to a recent cleanup; no behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)