### PR TITLE
fix(tests): set _adr_index/_tribal_store/_bus on __new__-style fixtures (post-#8460)

### DIFF
--- a/scripts/audit_prompts.py
+++ b/scripts/audit_prompts.py
@@ -661,6 +661,11 @@ def render_target(target: AuditTarget) -> str:
             # classified as a bug by is_likely_bug and re-raised.
             instance._insights = None
             instance._context_cache = _NullContextCache()
+            # _adr_index: required since #8460 dropped the getattr defensiveness
+            # in BaseRunner. None is a valid runtime value (loaded lazily).
+            instance._adr_index = None
+            instance._tribal_wiki_store = None
+            instance._bus = None
             callable_obj = getattr(instance, parts[2])
     else:
         raise ValueError(f"unsupported qualname depth: {target.builder_qualname!r}")

--- a/tests/test_repo_wiki_loop_pr.py
+++ b/tests/test_repo_wiki_loop_pr.py
@@ -86,6 +86,10 @@ def _stub_loop(
     loop._open_pr_url = None
     loop._worker_name = "repo_wiki"
     loop._enabled_cb = lambda _name: True
+    # Required since #8460 dropped the getattr defensiveness in
+    # RepoWikiLoop._do_work; the production __init__ always sets these.
+    loop._tribal_store = None
+    loop._bus = None
     return loop
 
 


### PR DESCRIPTION
## Summary

Two test fixtures bypass `__init__` via `cls.__new__(cls)` and inject only the attributes their narrow subject under test needs. #8460 dropped the defensive `getattr(self, \"_attr\", None)` patterns at three production sites (`BaseRunner._adr_index`, `RepoWikiLoop._tribal_store`/`_bus`); the fixtures now `AttributeError` on the same paths.

This has been failing CI for every PR opened since #8460 merged.

## Failures fixed

- **5 in `tests/test_audit_prompts.py`** — `render_target` builds a runner via `cls.__new__(cls)` for prompt-rendering audits; missing `_adr_index` on PlannerRunner / AgentRunner / ReviewRunner / HITLRunner.
- **2 in `tests/test_repo_wiki_loop_pr.py`** — `_stub_loop` builds a `RepoWikiLoop` for tracked-active-lint integration tests; missing `_tribal_store` and `_bus`.

## Fix

Both fixtures now set the attributes to `None` — matches the optional-typed default and avoids reintroducing the defensive `getattr` that #8460 cleaned up.

## Verification

- Before: `pytest tests/test_audit_prompts.py tests/test_repo_wiki_loop_pr.py` → 73 passed / 7 failed
- After:  `pytest tests/test_audit_prompts.py tests/test_repo_wiki_loop_pr.py` → **80 passed**

## Test plan
- [ ] CI passes (especially `Tests` job)
- [ ] Reviewer confirms the choice (fix fixtures vs. restore getattr defensiveness in production) is correct per #8460's intent

Skip-ADR: test-fixture fix only. No production behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)