### PR TITLE
chore(wiki): slim json:entry blocks (drop content+valid_from) + tighten compiler doc-voice prompt

### DIFF
--- a/docs/wiki/architecture-async-control.md
+++ b/docs/wiki/architecture-async-control.md
@@ -1,181 +1,181 @@
-# Architecture Async Control
+# Architecture-Async-Control
+
 
 ## Async Patterns: Wrappers, Context Managers, Callbacks, and Resource Lifecycle
 
-
-
 When adding async support to sync I/O code, keep all sync methods unchanged and add a-prefixed async wrappers that delegate to sync methods via asyncio.to_thread(). This pattern (established in events.py) centralizes blocking-operation wrapping and preserves backward compatibility—existing sync callers continue unchanged while new async callers gradually migrate. Implement async context managers by adding `__aenter__` (return self), `__aexit__` (call close()), and `_closed: bool` flag in `__init__`. This pattern (established in DockerRunner) ensures clean resource shutdown semantics when wrapping clients that need guaranteed cleanup. When extracting async helpers, shared resources (like background tasks) may be awaited on the happy path but must be cancelled in the coordinator's error handler. Design the helper to handle its portion cleanly; keep lifecycle cleanup in the coordinator's `finally` block to ensure it runs regardless of how the helper exits. For done callbacks, follow the events.py pattern of defining module-level callback functions (e.g., _log_task_failure) rather than methods. This keeps callback logic portable, testable in isolation, and consistent across the codebase. Document expected signature and side effects clearly. See also: Orchestrator/Sequencer Design for coordinating async stages.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WB","title":"Async Patterns: Wrappers, Context Managers, Callbacks, and Resource Lifecycle","content":"When adding async support to sync I/O code, keep all sync methods unchanged and add a-prefixed async wrappers that delegate to sync methods via asyncio.to_thread(). This pattern (established in events.py) centralizes blocking-operation wrapping and preserves backward compatibility—existing sync callers continue unchanged while new async callers gradually migrate. Implement async context managers by adding `__aenter__` (return self), `__aexit__` (call close()), and `_closed: bool` flag in `__init__`. This pattern (established in DockerRunner) ensures clean resource shutdown semantics when wrapping clients that need guaranteed cleanup. When extracting async helpers, shared resources (like background tasks) may be awaited on the happy path but must be cancelled in the coordinator's error handler. Design the helper to handle its portion cleanly; keep lifecycle cleanup in the coordinator's `finally` block to ensure it runs regardless of how the helper exits. For done callbacks, follow the events.py pattern of defining module-level callback functions (e.g., _log_task_failure) rather than methods. This keeps callback logic portable, testable in isolation, and consistent across the codebase. Document expected signature and side effects clearly. See also: Orchestrator/Sequencer Design for coordinating async stages.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852290+00:00","updated_at":"2026-04-10T03:41:18.852298+00:00","valid_from":"2026-04-10T03:41:18.852290+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WB","title":"Async Patterns: Wrappers, Context Managers, Callbacks, and Resource Lifecycle","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852290+00:00","updated_at":"2026-04-10T03:41:18.852298+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Background Loops and Skill Infrastructure: Audit Patterns and Wiring
 
-
-
 Background loops (BaseBackgroundLoop subclasses) follow a standard pattern established by CodeGroomingLoop: (1) _run_audit() invokes a slash command; (2) parse severity-headed output into findings; (3) deduplicate via DedupStore per loop type (e.g., architecture_audit_dedup.json, test_audit_dedup.json); (4) file GitHub issues for Critical/High findings. Discovery via class definition pattern (BaseBackgroundLoop subclass with worker_name kwarg). Wiring requires 5 synchronized locations: config (interval + env override), service_registry (instantiation), orchestrator (bg_loop_registry dict), dashboard UI (_INTERVAL_BOUNDS and BACKGROUND_WORKERS), and constants.js. Omitting any location causes incomplete registration. Test discovery via test_loop_wiring_completeness.py. Skip sets track intentional deviations. Distinguish from per-PR skills: per-PR skills (architecture_compliance.py, test_quality.py) are lightweight single-prompt diff reviews focused on clear violations. Background loops invoke full multi-agent slash commands. Phase-filtered skill injection separates via registry (TOOL_PHASE_MAP data), injection (base runner coordination), execution unchanged. Tool presentation to LLM is filtered by phase but execution remains unchanged. Skills in multiple backends handled via marker-based checks (substring matching for '## Output') rather than exact structure enforcement. Two-file consolidation: Pydantic model definition for structure validation and dynamic JSONL writing for persistence must stay synchronized. Operator review gates dynamic skills due to prompt injection risk. See also: Layer Architecture for placement, Dynamic Discovery for command discovery.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VW","title":"Background Loops and Skill Infrastructure: Audit Patterns and Wiring","content":"Background loops (BaseBackgroundLoop subclasses) follow a standard pattern established by CodeGroomingLoop: (1) _run_audit() invokes a slash command; (2) parse severity-headed output into findings; (3) deduplicate via DedupStore per loop type (e.g., architecture_audit_dedup.json, test_audit_dedup.json); (4) file GitHub issues for Critical/High findings. Discovery via class definition pattern (BaseBackgroundLoop subclass with worker_name kwarg). Wiring requires 5 synchronized locations: config (interval + env override), service_registry (instantiation), orchestrator (bg_loop_registry dict), dashboard UI (_INTERVAL_BOUNDS and BACKGROUND_WORKERS), and constants.js. Omitting any location causes incomplete registration. Test discovery via test_loop_wiring_completeness.py. Skip sets track intentional deviations. Distinguish from per-PR skills: per-PR skills (architecture_compliance.py, test_quality.py) are lightweight single-prompt diff reviews focused on clear violations. Background loops invoke full multi-agent slash commands. Phase-filtered skill injection separates via registry (TOOL_PHASE_MAP data), injection (base runner coordination), execution unchanged. Tool presentation to LLM is filtered by phase but execution remains unchanged. Skills in multiple backends handled via marker-based checks (substring matching for '## Output') rather than exact structure enforcement. Two-file consolidation: Pydantic model definition for structure validation and dynamic JSONL writing for persistence must stay synchronized. Operator review gates dynamic skills due to prompt injection risk. See also: Layer Architecture for placement, Dynamic Discovery for command discovery.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849543+00:00","updated_at":"2026-04-10T03:41:18.849544+00:00","valid_from":"2026-04-10T03:41:18.849543+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VW","title":"Background Loops and Skill Infrastructure: Audit Patterns and Wiring","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849543+00:00","updated_at":"2026-04-10T03:41:18.849544+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Label-Based Async Loop Routing via GitHub Labels
 
-
-
 The system routes work through distinct concurrent async polling loops via GitHub issue labels (hydraflow-plan, hydraflow-discover, hydraflow-shape, etc.). Each loop: fetches issues with its label, processes them, swaps the label to route to the next phase. This pattern avoids persistent state management by leveraging GitHub as the queue and label transitions as the state machine. Event types (triage_routed, discover_complete, etc.) publish to EventLog and trigger state transitions. Source fields in events (discover, shape, plan) establish cross-references for worker creation and transcript routing. New event types require multi-layer synchronization: reducer event handlers (worker creation), EVENT_TO_STAGE mapping, SOURCE_TO_STAGE routing, and transcript routing logic. See also: Orchestrator/Sequencer Design for coordination patterns, Layer Architecture for event handling placement.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VX","title":"Label-Based Async Loop Routing via GitHub Labels","content":"The system routes work through distinct concurrent async polling loops via GitHub issue labels (hydraflow-plan, hydraflow-discover, hydraflow-shape, etc.). Each loop: fetches issues with its label, processes them, swaps the label to route to the next phase. This pattern avoids persistent state management by leveraging GitHub as the queue and label transitions as the state machine. Event types (triage_routed, discover_complete, etc.) publish to EventLog and trigger state transitions. Source fields in events (discover, shape, plan) establish cross-references for worker creation and transcript routing. New event types require multi-layer synchronization: reducer event handlers (worker creation), EVENT_TO_STAGE mapping, SOURCE_TO_STAGE routing, and transcript routing logic. See also: Orchestrator/Sequencer Design for coordination patterns, Layer Architecture for event handling placement.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849547+00:00","updated_at":"2026-04-10T03:41:18.849548+00:00","valid_from":"2026-04-10T03:41:18.849547+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VX","title":"Label-Based Async Loop Routing via GitHub Labels","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849547+00:00","updated_at":"2026-04-10T03:41:18.849548+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Idempotency Guards Prevent Redundant Side Effects
 
-
-
 Add idempotency guards by checking outcome state at handler entry: `if state.get_outcome(issue_number) == MERGED: return`. This prevents redundant side effects (label swaps, counter increments, hook re-execution) from race conditions or retries. Log at info level when guard triggers for observability. Test three cases: (1) outcome already exists—side effects don't execute, (2) no prior outcome—normal flow, (3) non-MERGED outcome—normal flow. Use test helper pattern: `_setup_*()` method returning setup object with `.call()` method for test invocation. This pattern ensures idempotent handlers don't over-suppress valid operations. See also: Pre-Flight Validation for related validation patterns, State Persistence for outcome storage.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VY","title":"Idempotency Guards Prevent Redundant Side Effects","content":"Add idempotency guards by checking outcome state at handler entry: `if state.get_outcome(issue_number) == MERGED: return`. This prevents redundant side effects (label swaps, counter increments, hook re-execution) from race conditions or retries. Log at info level when guard triggers for observability. Test three cases: (1) outcome already exists—side effects don't execute, (2) no prior outcome—normal flow, (3) non-MERGED outcome—normal flow. Use test helper pattern: `_setup_*()` method returning setup object with `.call()` method for test invocation. This pattern ensures idempotent handlers don't over-suppress valid operations. See also: Pre-Flight Validation for related validation patterns, State Persistence for outcome storage.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849551+00:00","updated_at":"2026-04-10T03:41:18.849552+00:00","valid_from":"2026-04-10T03:41:18.849551+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VY","title":"Idempotency Guards Prevent Redundant Side Effects","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849551+00:00","updated_at":"2026-04-10T03:41:18.849552+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Clarity Score Routing: Fast Path vs Multi-Stage Maturation
 
-
-
 The discovery phase routes issues in two tracks based on clarity_score: (1) clarity_score >= 7: skip Discover and Shape, go directly from Triage to Plan (fast path); (2) clarity_score < 7: route through Discover → Shape pipeline for multi-turn maturation (slow path). Three-stage pipeline design: Discover gathers product research context, Shape runs multi-turn design conversation and presents options for human selection, Plan begins after direction is chosen. This staged approach separates research, synthesis, and planning concerns with human decision points between stages.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VZ","title":"Clarity Score Routing: Fast Path vs Multi-Stage Maturation","content":"The discovery phase routes issues in two tracks based on clarity_score: (1) clarity_score >= 7: skip Discover and Shape, go directly from Triage to Plan (fast path); (2) clarity_score < 7: route through Discover → Shape pipeline for multi-turn maturation (slow path). Three-stage pipeline design: Discover gathers product research context, Shape runs multi-turn design conversation and presents options for human selection, Plan begins after direction is chosen. This staged approach separates research, synthesis, and planning concerns with human decision points between stages.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849555+00:00","updated_at":"2026-04-10T03:41:18.849557+00:00","valid_from":"2026-04-10T03:41:18.849555+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VZ","title":"Clarity Score Routing: Fast Path vs Multi-Stage Maturation","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849555+00:00","updated_at":"2026-04-10T03:41:18.849557+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Side Effect Consumption Pattern for Context Threading
 
-
-
 Runners capture mutable side effects (e.g., `_last_recalled_items`, `_last_context_stats`) that must be explicitly consumed via getter methods after execution and cleared at method entry. This pattern prevents item leakage when runner instances are reused concurrently across issues. Pattern: (1) initialize side-effect variable in __init__ or at method entry; (2) populate during execution; (3) expose via `_consume_*()` method returning the value; (4) clear state after consumption in caller. Phases consume runner outputs, convert to domain models, and persist. This separates data production (runners) from I/O (phases) while threading context between stages via explicit consumption. See also: Functional Design for pure data threading, State Persistence for persistence patterns.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WD","title":"Side Effect Consumption Pattern for Context Threading","content":"Runners capture mutable side effects (e.g., `_last_recalled_items`, `_last_context_stats`) that must be explicitly consumed via getter methods after execution and cleared at method entry. This pattern prevents item leakage when runner instances are reused concurrently across issues. Pattern: (1) initialize side-effect variable in __init__ or at method entry; (2) populate during execution; (3) expose via `_consume_*()` method returning the value; (4) clear state after consumption in caller. Phases consume runner outputs, convert to domain models, and persist. This separates data production (runners) from I/O (phases) while threading context between stages via explicit consumption. See also: Functional Design for pure data threading, State Persistence for persistence patterns.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852318+00:00","updated_at":"2026-04-10T03:41:18.852320+00:00","valid_from":"2026-04-10T03:41:18.852318+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WD","title":"Side Effect Consumption Pattern for Context Threading","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852318+00:00","updated_at":"2026-04-10T03:41:18.852320+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Callback Construction Order: State → Snapshot → Router → Tracker
-
-
 
 `_publish_queue_update_nowait` callback invokes `self._snapshot.get_queue_stats()`. Sub-components are constructed in order of dependency: state dicts first, then snapshot (used by publish_fn), then router and tracker (which receive publish_fn as a callback). Reordering breaks with AttributeError.
 
 _Source: #6327 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X6","title":"Callback Construction Order: State → Snapshot → Router → Tracker","content":"`_publish_queue_update_nowait` callback invokes `self._snapshot.get_queue_stats()`. Sub-components are constructed in order of dependency: state dicts first, then snapshot (used by publish_fn), then router and tracker (which receive publish_fn as a callback). Reordering breaks with AttributeError.","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384592+00:00","updated_at":"2026-04-10T05:07:55.384593+00:00","valid_from":"2026-04-10T05:07:55.384592+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X6","title":"Callback Construction Order: State → Snapshot → Router → Tracker","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384592+00:00","updated_at":"2026-04-10T05:07:55.384593+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Use callbacks to decouple isolated components from orchestrator state
-
-
 
 CreditPauseManager accepts `cancel_fn` and `resume_fn` callbacks instead of directly accessing loop task dicts. This avoids circular dependencies between manager and supervisor while allowing the manager to trigger orchestration actions (pause all loops, recreate them on resume). Apply this pattern whenever an extracted component needs to coordinate with the orchestration layer.
 
 _Source: #6323 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X0","title":"Use callbacks to decouple isolated components from orchestrator state","content":"CreditPauseManager accepts `cancel_fn` and `resume_fn` callbacks instead of directly accessing loop task dicts. This avoids circular dependencies between manager and supervisor while allowing the manager to trigger orchestration actions (pause all loops, recreate them on resume). Apply this pattern whenever an extracted component needs to coordinate with the orchestration layer.","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630696+00:00","updated_at":"2026-04-10T04:47:03.630699+00:00","valid_from":"2026-04-10T04:47:03.630696+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X0","title":"Use callbacks to decouple isolated components from orchestrator state","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630696+00:00","updated_at":"2026-04-10T04:47:03.630699+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Return Value Threading in Orchestrator Pattern
-
-
 
 When extracting helpers from a large method, extracted helpers should return values needed by downstream logic. The orchestrator captures these returns and threads them to consuming functions (e.g., metrics collection). This maintains clean value flow without side effects.
 
 _Source: #6355 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPX","title":"Return Value Threading in Orchestrator Pattern","content":"When extracting helpers from a large method, extracted helpers should return values needed by downstream logic. The orchestrator captures these returns and threads them to consuming functions (e.g., metrics collection). This maintains clean value flow without side effects.","topic":null,"source_type":"plan","source_issue":6355,"source_repo":null,"created_at":"2026-04-10T07:14:58.678259+00:00","updated_at":"2026-04-10T07:14:58.678259+00:00","valid_from":"2026-04-10T07:14:58.678259+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPX","title":"Return Value Threading in Orchestrator Pattern","topic":null,"source_type":"plan","source_issue":6355,"source_repo":null,"created_at":"2026-04-10T07:14:58.678259+00:00","updated_at":"2026-04-10T07:14:58.678259+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Config tuples enable clean parameterized loops
-
-
 
 Replace copy-paste blocks with a list-of-tuples configuration like `[(Bank.TRIBAL, "learnings", "memory"), ...]` where each tuple drives one loop iteration. Each position in the tuple holds enum value, display label, and dict key. This pattern scales to N similar blocks and makes the parameterization explicit and maintainable.
 
 _Source: #6350 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPQ","title":"Config tuples enable clean parameterized loops","content":"Replace copy-paste blocks with a list-of-tuples configuration like `[(Bank.TRIBAL, \"learnings\", \"memory\"), ...]` where each tuple drives one loop iteration. Each position in the tuple holds enum value, display label, and dict key. This pattern scales to N similar blocks and makes the parameterization explicit and maintainable.","topic":null,"source_type":"plan","source_issue":6350,"source_repo":null,"created_at":"2026-04-10T06:55:39.084060+00:00","updated_at":"2026-04-10T06:55:39.084061+00:00","valid_from":"2026-04-10T06:55:39.084060+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPQ","title":"Config tuples enable clean parameterized loops","topic":null,"source_type":"plan","source_issue":6350,"source_repo":null,"created_at":"2026-04-10T06:55:39.084060+00:00","updated_at":"2026-04-10T06:55:39.084061+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Polling loops must sleep when service disabled
-
-
 
 Polling loops that run against a service should always check a boolean flag (e.g., _pipeline_enabled) and sleep when disabled. This prevents tight loops that attempt operations against uninitialized resources. See _polling_loop (line 940) pattern.
 
 _Source: #6360 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ2","title":"Polling loops must sleep when service disabled","content":"Polling loops that run against a service should always check a boolean flag (e.g., _pipeline_enabled) and sleep when disabled. This prevents tight loops that attempt operations against uninitialized resources. See _polling_loop (line 940) pattern.","topic":null,"source_type":"plan","source_issue":6360,"source_repo":null,"created_at":"2026-04-10T07:37:26.758846+00:00","updated_at":"2026-04-10T07:37:26.758853+00:00","valid_from":"2026-04-10T07:37:26.758846+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ2","title":"Polling loops must sleep when service disabled","topic":null,"source_type":"plan","source_issue":6360,"source_repo":null,"created_at":"2026-04-10T07:37:26.758846+00:00","updated_at":"2026-04-10T07:37:26.758853+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Context manager protocol for async resource pooling
-
-
 
 Add `__aenter__`/`__aexit__` to classes wrapping `httpx.AsyncClient`, delegating `__aexit__` to an existing `close()` method. Follow the exact pattern from `DockerRunner` (src/docker_runner.py:357-361) for type-safe implementation. This enables `async with` syntax and proper cleanup.
 
 _Source: #6362 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ3","title":"Context manager protocol for async resource pooling","content":"Add `__aenter__`/`__aexit__` to classes wrapping `httpx.AsyncClient`, delegating `__aexit__` to an existing `close()` method. Follow the exact pattern from `DockerRunner` (src/docker_runner.py:357-361) for type-safe implementation. This enables `async with` syntax and proper cleanup.","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400349+00:00","updated_at":"2026-04-10T07:44:23.400389+00:00","valid_from":"2026-04-10T07:44:23.400349+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ3","title":"Context manager protocol for async resource pooling","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400349+00:00","updated_at":"2026-04-10T07:44:23.400389+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## httpx.AsyncClient.aclose() is idempotent and safe
-
-
 
 httpx clients handle multiple `aclose()` calls gracefully (no-op on already-closed). Safe for multiple cleanup paths (e.g., orchestrator and ServiceRegistry both closing hindsight). Eliminates need for guard flags or state tracking.
 
 _Source: #6362 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ4","title":"httpx.AsyncClient.aclose() is idempotent and safe","content":"httpx clients handle multiple `aclose()` calls gracefully (no-op on already-closed). Safe for multiple cleanup paths (e.g., orchestrator and ServiceRegistry both closing hindsight). Eliminates need for guard flags or state tracking.","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400455+00:00","updated_at":"2026-04-10T07:44:23.400460+00:00","valid_from":"2026-04-10T07:44:23.400455+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ4","title":"httpx.AsyncClient.aclose() is idempotent and safe","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400455+00:00","updated_at":"2026-04-10T07:44:23.400460+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Service composition root needs async cleanup method
-
-
 
 ServiceRegistry (composition root) should have an `async def aclose()` method that closes owned resources like `self.hindsight`. Keep it as the first method on the dataclass. Enables caller to clean up composition root in one call.
 
 _Source: #6362 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ7","title":"Service composition root needs async cleanup method","content":"ServiceRegistry (composition root) should have an `async def aclose()` method that closes owned resources like `self.hindsight`. Keep it as the first method on the dataclass. Enables caller to clean up composition root in one call.","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400484+00:00","updated_at":"2026-04-10T07:44:23.400487+00:00","valid_from":"2026-04-10T07:44:23.400484+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ7","title":"Service composition root needs async cleanup method","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400484+00:00","updated_at":"2026-04-10T07:44:23.400487+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Sentry integration: ERROR+ only triggers alerts
-
-
 
 LoggingIntegration(event_level=logging.ERROR) in server.py means only ERROR and above are sent to Sentry. WARNING-level records bypass Sentry entirely. Use this configuration pattern to prevent false-positive alerts from transient/handled errors while preserving them in structured logs.
 
 _Source: #6359 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ0","title":"Sentry integration: ERROR+ only triggers alerts","content":"LoggingIntegration(event_level=logging.ERROR) in server.py means only ERROR and above are sent to Sentry. WARNING-level records bypass Sentry entirely. Use this configuration pattern to prevent false-positive alerts from transient/handled errors while preserving them in structured logs.","topic":null,"source_type":"plan","source_issue":6359,"source_repo":null,"created_at":"2026-04-10T07:33:04.050924+00:00","updated_at":"2026-04-10T07:33:04.050927+00:00","valid_from":"2026-04-10T07:33:04.050924+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ0","title":"Sentry integration: ERROR+ only triggers alerts","topic":null,"source_type":"plan","source_issue":6359,"source_repo":null,"created_at":"2026-04-10T07:33:04.050924+00:00","updated_at":"2026-04-10T07:33:04.050927+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Fatal error hierarchy—propagate vs. suppress
-
-
 
 AuthenticationError and CreditExhaustedError are fatal and must propagate; all other exceptions are suppressed. This pattern is canonical across the codebase (base_background_loop.py:141, orchestrator.py:948, phase_utils.py:392). Always catch fatal errors first in except clauses before a generic Exception fallback.
 
 _Source: #6360 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ1","title":"Fatal error hierarchy—propagate vs. suppress","content":"AuthenticationError and CreditExhaustedError are fatal and must propagate; all other exceptions are suppressed. This pattern is canonical across the codebase (base_background_loop.py:141, orchestrator.py:948, phase_utils.py:392). Always catch fatal errors first in except clauses before a generic Exception fallback.","topic":null,"source_type":"plan","source_issue":6360,"source_repo":null,"created_at":"2026-04-10T07:37:26.758732+00:00","updated_at":"2026-04-10T07:37:26.758748+00:00","valid_from":"2026-04-10T07:37:26.758732+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ1","title":"Fatal error hierarchy—propagate vs. suppress","topic":null,"source_type":"plan","source_issue":6360,"source_repo":null,"created_at":"2026-04-10T07:37:26.758732+00:00","updated_at":"2026-04-10T07:37:26.758748+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture-imports-types.md
+++ b/docs/wiki/architecture-imports-types.md
@@ -1,201 +1,201 @@
-# Architecture Imports Types
+# Architecture-Imports-Types
+
 
 ## Deferred Imports, Type Checking, and Testing
 
-
-
 Import optional or circular-dependent modules inside function bodies rather than at module level to break circular import chains. Use `from __future__ import annotations` globally to enable TYPE_CHECKING guards for import-time-only types without runtime overhead. Use Protocol types in TYPE_CHECKING blocks while concrete implementations are imported normally. Keep deferred imports inside the specific method that uses them—do not hoist to module level, even if multiple methods use the same import (annotate with `# noqa: PLC0415` to suppress linting). Exception classification functions import specific exception types in the function body to prevent circular imports while keeping type-checking available. In tests, patch at the source module level where the deferred import happens. Use pytest monkeypatch.delitem() with raising=False for sys.modules manipulation to handle both existing and missing keys safely. Never import optional dependencies at test module level; use deferred imports inside test methods. Critical for optional services (hindsight, docker, file_util) and cross-module utilities, avoiding import-time side effects and enabling graceful degradation. See also: Layer Architecture for module organization, Optional Dependencies for service handling.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VP","title":"Deferred Imports, Type Checking, and Testing","content":"Import optional or circular-dependent modules inside function bodies rather than at module level to break circular import chains. Use `from __future__ import annotations` globally to enable TYPE_CHECKING guards for import-time-only types without runtime overhead. Use Protocol types in TYPE_CHECKING blocks while concrete implementations are imported normally. Keep deferred imports inside the specific method that uses them—do not hoist to module level, even if multiple methods use the same import (annotate with `# noqa: PLC0415` to suppress linting). Exception classification functions import specific exception types in the function body to prevent circular imports while keeping type-checking available. In tests, patch at the source module level where the deferred import happens. Use pytest monkeypatch.delitem() with raising=False for sys.modules manipulation to handle both existing and missing keys safely. Never import optional dependencies at test module level; use deferred imports inside test methods. Critical for optional services (hindsight, docker, file_util) and cross-module utilities, avoiding import-time side effects and enabling graceful degradation. See also: Layer Architecture for module organization, Optional Dependencies for service handling.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849500+00:00","updated_at":"2026-04-10T03:41:18.849508+00:00","valid_from":"2026-04-10T03:41:18.849500+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VP","title":"Deferred Imports, Type Checking, and Testing","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849500+00:00","updated_at":"2026-04-10T03:41:18.849508+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Optional Dependencies: Graceful Degradation and Safe Handling
 
-
-
 Services like Hindsight, Docker, and others may be unavailable or disabled. Design via: (1) **Never-raise pattern**: wrap all calls to optional features in try/except blocks that return safe defaults rather than raising. Catch broad exception types (Exception, OSError, ConnectionError) instead of importing optional module exception types. (2) **Graceful degradation**: when unavailable, fall back to JSONL file storage or no-op behavior; use dual-write pattern during migration. (3) **Explicit None checks**: guard with `if hindsight is not None:` (never falsy checks, as MagicMock can be falsy-but-not-None). (4) **Fire-and-forget async variants**: wrap blocking I/O without blocking callers. (5) **Property-based access**: expose optional services via properties rather than constructor parameters. Core principle: failures in non-critical or optional features must never crash the pipeline. See also: Feature Gates for feature flags that gate incomplete features, Deferred Imports for import-time handling.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VQ","title":"Optional Dependencies: Graceful Degradation and Safe Handling","content":"Services like Hindsight, Docker, and others may be unavailable or disabled. Design via: (1) **Never-raise pattern**: wrap all calls to optional features in try/except blocks that return safe defaults rather than raising. Catch broad exception types (Exception, OSError, ConnectionError) instead of importing optional module exception types. (2) **Graceful degradation**: when unavailable, fall back to JSONL file storage or no-op behavior; use dual-write pattern during migration. (3) **Explicit None checks**: guard with `if hindsight is not None:` (never falsy checks, as MagicMock can be falsy-but-not-None). (4) **Fire-and-forget async variants**: wrap blocking I/O without blocking callers. (5) **Property-based access**: expose optional services via properties rather than constructor parameters. Core principle: failures in non-critical or optional features must never crash the pipeline. See also: Feature Gates for feature flags that gate incomplete features, Deferred Imports for import-time handling.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849518+00:00","updated_at":"2026-04-10T03:41:18.849521+00:00","valid_from":"2026-04-10T03:41:18.849518+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VQ","title":"Optional Dependencies: Graceful Degradation and Safe Handling","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849518+00:00","updated_at":"2026-04-10T03:41:18.849521+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## TYPE_CHECKING guard pattern for type-only imports
-
-
 
 Use TYPE_CHECKING-guarded imports to avoid circular dependencies and runtime costs for type annotations. When a type is only needed for annotations (enabled by PEP 563 via `from __future__ import annotations`), import it under `if TYPE_CHECKING:` to prevent runtime import. This pattern is used consistently across 8+ files in the codebase and prevents the annotated name from triggering an actual import at runtime.
 
 _Source: #6326 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X3","title":"TYPE_CHECKING guard pattern for type-only imports","content":"Use TYPE_CHECKING-guarded imports to avoid circular dependencies and runtime costs for type annotations. When a type is only needed for annotations (enabled by PEP 563 via `from __future__ import annotations`), import it under `if TYPE_CHECKING:` to prevent runtime import. This pattern is used consistently across 8+ files in the codebase and prevents the annotated name from triggering an actual import at runtime.","topic":null,"source_type":"plan","source_issue":6326,"source_repo":null,"created_at":"2026-04-10T04:56:50.953037+00:00","updated_at":"2026-04-10T04:56:50.953047+00:00","valid_from":"2026-04-10T04:56:50.953037+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X3","title":"TYPE_CHECKING guard pattern for type-only imports","topic":null,"source_type":"plan","source_issue":6326,"source_repo":null,"created_at":"2026-04-10T04:56:50.953037+00:00","updated_at":"2026-04-10T04:56:50.953047+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## noqa: TCH004 required for TYPE_CHECKING imports
-
-
 
 When using TYPE_CHECKING imports, always append `# noqa: TCH004` to suppress ruff's rule about imports appearing only in type checking. This is intentional and required for the pattern to work correctly. Omitting this comment will cause lint failures in the quality gates.
 
 _Source: #6326 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X4","title":"noqa: TCH004 required for TYPE_CHECKING imports","content":"When using TYPE_CHECKING imports, always append `# noqa: TCH004` to suppress ruff's rule about imports appearing only in type checking. This is intentional and required for the pattern to work correctly. Omitting this comment will cause lint failures in the quality gates.","topic":null,"source_type":"plan","source_issue":6326,"source_repo":null,"created_at":"2026-04-10T04:56:50.953061+00:00","updated_at":"2026-04-10T04:56:50.953062+00:00","valid_from":"2026-04-10T04:56:50.953061+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X4","title":"noqa: TCH004 required for TYPE_CHECKING imports","topic":null,"source_type":"plan","source_issue":6326,"source_repo":null,"created_at":"2026-04-10T04:56:50.953061+00:00","updated_at":"2026-04-10T04:56:50.953062+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## TYPE_CHECKING prevents circular imports on cross-module TypedDicts
-
-
 
 When a TypedDict is shared between a loop module and service module (ADRReviewResult in adr_reviewer_loop.py used by adr_reviewer.py), import under TYPE_CHECKING guard to avoid circular imports while preserving type information for static analysis. Codebase already uses this pattern extensively.
 
 _Source: #6331 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XC","title":"TYPE_CHECKING prevents circular imports on cross-module TypedDicts","content":"When a TypedDict is shared between a loop module and service module (ADRReviewResult in adr_reviewer_loop.py used by adr_reviewer.py), import under TYPE_CHECKING guard to avoid circular imports while preserving type information for static analysis. Codebase already uses this pattern extensively.","topic":null,"source_type":"plan","source_issue":6331,"source_repo":null,"created_at":"2026-04-10T05:23:05.143432+00:00","updated_at":"2026-04-10T05:23:05.143433+00:00","valid_from":"2026-04-10T05:23:05.143432+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XC","title":"TYPE_CHECKING prevents circular imports on cross-module TypedDicts","topic":null,"source_type":"plan","source_issue":6331,"source_repo":null,"created_at":"2026-04-10T05:23:05.143432+00:00","updated_at":"2026-04-10T05:23:05.143433+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Preserve deferred imports for optional dependencies
-
-
 
 Use deferred imports (import inside method body, not module-level) for optional or infrequently-used dependencies like `prompt_dedup`. This avoids startup cost and avoids hard dependency failures in unrelated code paths. When refactoring such code, preserve the deferred import pattern.
 
 _Source: #6332 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XG","title":"Preserve deferred imports for optional dependencies","content":"Use deferred imports (import inside method body, not module-level) for optional or infrequently-used dependencies like `prompt_dedup`. This avoids startup cost and avoids hard dependency failures in unrelated code paths. When refactoring such code, preserve the deferred import pattern.","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098298+00:00","updated_at":"2026-04-10T05:33:08.098299+00:00","valid_from":"2026-04-10T05:33:08.098298+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XG","title":"Preserve deferred imports for optional dependencies","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098298+00:00","updated_at":"2026-04-10T05:33:08.098299+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Deferred Imports Must Remain Inside Helpers
-
-
 
 Optional module imports that live inside a method should stay inside extracted helpers, not moved to module level. This preserves graceful degradation when optional modules are missing. Moving deferred imports breaks the intent of the original error-isolation pattern.
 
 _Source: #6355 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPW","title":"Deferred Imports Must Remain Inside Helpers","content":"Optional module imports that live inside a method should stay inside extracted helpers, not moved to module level. This preserves graceful degradation when optional modules are missing. Moving deferred imports breaks the intent of the original error-isolation pattern.","topic":null,"source_type":"plan","source_issue":6355,"source_repo":null,"created_at":"2026-04-10T07:14:58.678248+00:00","updated_at":"2026-04-10T07:14:58.678250+00:00","valid_from":"2026-04-10T07:14:58.678248+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPW","title":"Deferred Imports Must Remain Inside Helpers","topic":null,"source_type":"plan","source_issue":6355,"source_repo":null,"created_at":"2026-04-10T07:14:58.678248+00:00","updated_at":"2026-04-10T07:14:58.678250+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Deferred imports in helper methods avoid circular dependencies
-
-
 
 When extracting helper methods that need imports like trace_rollup, tracing_context, or phase_utils, place deferred imports (with # noqa: PLC0415) at the start of each helper's method body rather than hoisting to module level. This prevents circular import chains while keeping dependencies explicit and scoped to the methods that use them.
 
 _Source: #6356 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPY","title":"Deferred imports in helper methods avoid circular dependencies","content":"When extracting helper methods that need imports like trace_rollup, tracing_context, or phase_utils, place deferred imports (with # noqa: PLC0415) at the start of each helper's method body rather than hoisting to module level. This prevents circular import chains while keeping dependencies explicit and scoped to the methods that use them.","topic":null,"source_type":"plan","source_issue":6356,"source_repo":null,"created_at":"2026-04-10T07:18:10.589088+00:00","updated_at":"2026-04-10T07:18:10.589099+00:00","valid_from":"2026-04-10T07:18:10.589088+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPY","title":"Deferred imports in helper methods avoid circular dependencies","topic":null,"source_type":"plan","source_issue":6356,"source_repo":null,"created_at":"2026-04-10T07:18:10.589088+00:00","updated_at":"2026-04-10T07:18:10.589099+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Deferred imports remain at usage sites with lint suppression
-
-
 
 Deferred imports (MemoryScorer, CompletedTimeline, json) must stay inside method bodies where used, not hoisted to module level. Annotate with `# noqa: PLC0415` to suppress linting warnings. This keeps import coupling local to method scope and avoids unintended module-level dependencies.
 
 _Source: #6358 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPZ","title":"Deferred imports remain at usage sites with lint suppression","content":"Deferred imports (MemoryScorer, CompletedTimeline, json) must stay inside method bodies where used, not hoisted to module level. Annotate with `# noqa: PLC0415` to suppress linting warnings. This keeps import coupling local to method scope and avoids unintended module-level dependencies.","topic":null,"source_type":"plan","source_issue":6358,"source_repo":null,"created_at":"2026-04-10T07:30:03.436784+00:00","updated_at":"2026-04-10T07:30:03.436785+00:00","valid_from":"2026-04-10T07:30:03.436784+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPZ","title":"Deferred imports remain at usage sites with lint suppression","topic":null,"source_type":"plan","source_issue":6358,"source_repo":null,"created_at":"2026-04-10T07:30:03.436784+00:00","updated_at":"2026-04-10T07:30:03.436785+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Deferred imports preserve test mocking patterns
-
-
 
 Import hindsight and recall_tracker inside method bodies (not module-level) to allow `patch("hindsight.recall_safe", ...)` to intercept calls correctly. When imports are at the top of the file, patches may not apply to the actual import binding used by the method. This pattern is critical for testing async helpers that depend on external services.
 
 _Source: #6350 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPP","title":"Deferred imports preserve test mocking patterns","content":"Import hindsight and recall_tracker inside method bodies (not module-level) to allow `patch(\"hindsight.recall_safe\", ...)` to intercept calls correctly. When imports are at the top of the file, patches may not apply to the actual import binding used by the method. This pattern is critical for testing async helpers that depend on external services.","topic":null,"source_type":"plan","source_issue":6350,"source_repo":null,"created_at":"2026-04-10T06:55:39.084035+00:00","updated_at":"2026-04-10T06:55:39.084043+00:00","valid_from":"2026-04-10T06:55:39.084035+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPP","title":"Deferred imports preserve test mocking patterns","topic":null,"source_type":"plan","source_issue":6350,"source_repo":null,"created_at":"2026-04-10T06:55:39.084035+00:00","updated_at":"2026-04-10T06:55:39.084043+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Preserve lazy imports to avoid module-level coupling
-
-
 
 When extracting a helper that imports heavy or optional dependencies like `PromptDeduplicator`, keep the import lazy inside the method body, not at module level. This matches existing patterns in the codebase and avoids import-time coupling to utilities that may not be needed on every execution path.
 
 _Source: #6340 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP3","title":"Preserve lazy imports to avoid module-level coupling","content":"When extracting a helper that imports heavy or optional dependencies like `PromptDeduplicator`, keep the import lazy inside the method body, not at module level. This matches existing patterns in the codebase and avoids import-time coupling to utilities that may not be needed on every execution path.","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699159+00:00","updated_at":"2026-04-10T06:11:06.699162+00:00","valid_from":"2026-04-10T06:11:06.699159+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP3","title":"Preserve lazy imports to avoid module-level coupling","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699159+00:00","updated_at":"2026-04-10T06:11:06.699162+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Logger names resolve to full module path from __name__
-
-
 
 Modules using logging.getLogger(__name__) resolve to the full dotted module path (e.g., hydraflow.shape_phase), not just the filename (shape_phase). Tests that capture logs must use the full module path or logger name matchers will fail to find the expected logs.
 
 _Source: #6325 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X2","title":"Logger names resolve to full module path from __name__","content":"Modules using logging.getLogger(__name__) resolve to the full dotted module path (e.g., hydraflow.shape_phase), not just the filename (shape_phase). Tests that capture logs must use the full module path or logger name matchers will fail to find the expected logs.","topic":null,"source_type":"plan","source_issue":6325,"source_repo":null,"created_at":"2026-04-10T04:51:52.058659+00:00","updated_at":"2026-04-10T04:51:52.058666+00:00","valid_from":"2026-04-10T04:51:52.058659+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X2","title":"Logger names resolve to full module path from __name__","topic":null,"source_type":"plan","source_issue":6325,"source_repo":null,"created_at":"2026-04-10T04:51:52.058659+00:00","updated_at":"2026-04-10T04:51:52.058666+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Environment Override Validation via get_args() for Literal Types
-
-
 
 The `_ENV_LITERAL_OVERRIDES` table and its validation handler use `get_args()` to extract allowed values from Literal types and validate environment variable inputs at startup. This pattern decouples override validation from field defaults, enabling a cleaner separation between string overrides (with defaults) and literal overrides (options only). Enables dynamic validation of environment overrides without hardcoding literal values in validation code.
 
 _Source: #6310 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WE","title":"Environment Override Validation via get_args() for Literal Types","content":"The `_ENV_LITERAL_OVERRIDES` table and its validation handler use `get_args()` to extract allowed values from Literal types and validate environment variable inputs at startup. This pattern decouples override validation from field defaults, enabling a cleaner separation between string overrides (with defaults) and literal overrides (options only). Enables dynamic validation of environment overrides without hardcoding literal values in validation code.","topic":null,"source_type":"plan","source_issue":6310,"source_repo":null,"created_at":"2026-04-10T03:41:18.852325+00:00","updated_at":"2026-04-10T03:41:18.852328+00:00","valid_from":"2026-04-10T03:41:18.852325+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WE","title":"Environment Override Validation via get_args() for Literal Types","topic":null,"source_type":"plan","source_issue":6310,"source_repo":null,"created_at":"2026-04-10T03:41:18.852325+00:00","updated_at":"2026-04-10T03:41:18.852328+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Distinguish similarly-named modules during cleanup
-
-
 
 When removing dead code, watch for naming collisions—e.g., `verification.py` (orphaned formatter) vs `verification_judge.py` (active production code with real callers). Confusion between them can lead to removing live code or missing dependencies. Always verify caller graphs and module purpose separately.
 
 _Source: #6365 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ9","title":"Distinguish similarly-named modules during cleanup","content":"When removing dead code, watch for naming collisions—e.g., `verification.py` (orphaned formatter) vs `verification_judge.py` (active production code with real callers). Confusion between them can lead to removing live code or missing dependencies. Always verify caller graphs and module purpose separately.","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461030+00:00","updated_at":"2026-04-10T07:59:04.461033+00:00","valid_from":"2026-04-10T07:59:04.461030+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ9","title":"Distinguish similarly-named modules during cleanup","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461030+00:00","updated_at":"2026-04-10T07:59:04.461033+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Import-site patch targets must migrate with extracted functions
-
-
 
 When tests patch functions at import sites (e.g., `patch('review_phase.analyze_patterns')`), extracting those functions to new modules breaks the patch. Update test patches to target the new module where the function is now imported: `patch('review_insight_recorder.analyze_patterns')`. Attribute mocking via instance assignment (e.g., `phase.attr = Mock()`) continues to work unchanged.
 
 _Source: #6321 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WV","title":"Import-site patch targets must migrate with extracted functions","content":"When tests patch functions at import sites (e.g., `patch('review_phase.analyze_patterns')`), extracting those functions to new modules breaks the patch. Update test patches to target the new module where the function is now imported: `patch('review_insight_recorder.analyze_patterns')`. Attribute mocking via instance assignment (e.g., `phase.attr = Mock()`) continues to work unchanged.","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375232+00:00","updated_at":"2026-04-10T04:19:28.375235+00:00","valid_from":"2026-04-10T04:19:28.375232+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WV","title":"Import-site patch targets must migrate with extracted functions","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375232+00:00","updated_at":"2026-04-10T04:19:28.375235+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Strict no-circular-import rule for extracted coordinators
-
-
 
 Extracted coordinator classes must never import the original ReviewPhase class. Coordinators should only import domain modules, models, config, and phase_utils. Back-references to ReviewPhase methods must flow through callback parameters passed at construction time. Violating this creates circular imports that break the extraction.
 
 _Source: #6321 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WW","title":"Strict no-circular-import rule for extracted coordinators","content":"Extracted coordinator classes must never import the original ReviewPhase class. Coordinators should only import domain modules, models, config, and phase_utils. Back-references to ReviewPhase methods must flow through callback parameters passed at construction time. Violating this creates circular imports that break the extraction.","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375241+00:00","updated_at":"2026-04-10T04:19:28.375243+00:00","valid_from":"2026-04-10T04:19:28.375241+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WW","title":"Strict no-circular-import rule for extracted coordinators","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375241+00:00","updated_at":"2026-04-10T04:19:28.375243+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Restrict extracted component imports to prevent circular dependencies
-
-
 
 Extracted modules (PipelineStatsBuilder, CreditPauseManager, LoopSupervisor) must only import from a safe set: config, events, models, subprocess_util, service_registry, bg_worker_manager. Never import from orchestrator.py, even transitively. This strict boundary prevents import-time deadlocks and keeps extracted components independently testable and reusable.
 
 _Source: #6323 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X1","title":"Restrict extracted component imports to prevent circular dependencies","content":"Extracted modules (PipelineStatsBuilder, CreditPauseManager, LoopSupervisor) must only import from a safe set: config, events, models, subprocess_util, service_registry, bg_worker_manager. Never import from orchestrator.py, even transitively. This strict boundary prevents import-time deadlocks and keeps extracted components independently testable and reusable.","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630704+00:00","updated_at":"2026-04-10T04:47:03.630706+00:00","valid_from":"2026-04-10T04:47:03.630704+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X1","title":"Restrict extracted component imports to prevent circular dependencies","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630704+00:00","updated_at":"2026-04-10T04:47:03.630706+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture-layers.md
+++ b/docs/wiki/architecture-layers.md
@@ -1,187 +1,187 @@
-# Architecture Layers
+# Architecture-Layers
+
 
 ## Layer Architecture: Four-Layer Model with Structural Typing
 
-
-
 HydraFlow uses a 4-layer architecture with strict downward-only import direction: L1 (Utilities: subprocess_util, file_util, state) → L2 (Application: phases, runners, background loops) → L3 (Agents: specialized LLM runners) → L4 (Infrastructure: HTTP routes, FastAPI, CLI). TYPE_CHECKING imports and protocol abstractions enable type safety without runtime layer violations. Use @runtime_checkable Protocol abstractions (AgentPort, PRPort, IssueStorePort, OrchestratorPort) to decouple layers via structural typing—concrete implementations automatically satisfy protocols via duck typing. Service registry (service_registry.py) is the single architecturally-exempt composition root: instantiate dependencies in correct order, annotate fields with port types for abstraction but instantiate with concrete classes, thread shared dependencies through all consumers. Background loops require 5-point wiring synchronization: config fields, service_registry imports, instantiation, orchestrator bg_loop_registry dict, and dashboard constants. Layer assignments tracked in arch_compliance.py MODULE_LAYERS and validated via static checkers (check_layer_imports.py) and LLM-based compliance skills. Pattern-based inference: *_loop.py→L2, *_runner.py→L3, *_scaffold.py→L4. Bidirectional cross-cutting modules (state, events, ports) can be imported by any layer but must only import from L1. See also: Architecture Compliance for validation, Orchestrator/Sequencer Design for L2 patterns.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VR","title":"Layer Architecture: Four-Layer Model with Structural Typing","content":"HydraFlow uses a 4-layer architecture with strict downward-only import direction: L1 (Utilities: subprocess_util, file_util, state) → L2 (Application: phases, runners, background loops) → L3 (Agents: specialized LLM runners) → L4 (Infrastructure: HTTP routes, FastAPI, CLI). TYPE_CHECKING imports and protocol abstractions enable type safety without runtime layer violations. Use @runtime_checkable Protocol abstractions (AgentPort, PRPort, IssueStorePort, OrchestratorPort) to decouple layers via structural typing—concrete implementations automatically satisfy protocols via duck typing. Service registry (service_registry.py) is the single architecturally-exempt composition root: instantiate dependencies in correct order, annotate fields with port types for abstraction but instantiate with concrete classes, thread shared dependencies through all consumers. Background loops require 5-point wiring synchronization: config fields, service_registry imports, instantiation, orchestrator bg_loop_registry dict, and dashboard constants. Layer assignments tracked in arch_compliance.py MODULE_LAYERS and validated via static checkers (check_layer_imports.py) and LLM-based compliance skills. Pattern-based inference: *_loop.py→L2, *_runner.py→L3, *_scaffold.py→L4. Bidirectional cross-cutting modules (state, events, ports) can be imported by any layer but must only import from L1. See also: Architecture Compliance for validation, Orchestrator/Sequencer Design for L2 patterns.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849524+00:00","updated_at":"2026-04-10T03:41:18.849525+00:00","valid_from":"2026-04-10T03:41:18.849524+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VR","title":"Layer Architecture: Four-Layer Model with Structural Typing","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849524+00:00","updated_at":"2026-04-10T03:41:18.849525+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Functional Design: Pure Functions and Module-Level Utilities
 
-
-
 Extract pure functions (taking primitives, returning primitives or tuples) for reusable business logic that should be independently testable. Pattern: classify_merge_outcome(verdict_score, comment_count, ...) → (outcome, confidence). Pure functions isolate rules from service coupling, enable unit testing without mocks, and clarify logic intent. Pass config objects as parameters to access configuration-dependent values. When scoring classification logic is split across modules, consolidate by creating a pure function in the domain module with named threshold constants. Simple tuple returns (3 elements) are preferable to new dataclasses. Prefer module-level utility functions (e.g., retain_safe(client, bank, content, metadata=...)) over instance methods. This pattern is more testable, avoids tight coupling, and provides cleaner APIs. Module-level functions accept the object as first argument. When converting a closure to a standalone function, convert each `nonlocal` variable to either a function parameter (input) or a field in a returned NamedTuple (output). This eliminates implicit state sharing and makes the function's dependencies explicit—critical for testing and reasoning about behavior.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VV","title":"Functional Design: Pure Functions and Module-Level Utilities","content":"Extract pure functions (taking primitives, returning primitives or tuples) for reusable business logic that should be independently testable. Pattern: classify_merge_outcome(verdict_score, comment_count, ...) → (outcome, confidence). Pure functions isolate rules from service coupling, enable unit testing without mocks, and clarify logic intent. Pass config objects as parameters to access configuration-dependent values. When scoring classification logic is split across modules, consolidate by creating a pure function in the domain module with named threshold constants. Simple tuple returns (3 elements) are preferable to new dataclasses. Prefer module-level utility functions (e.g., retain_safe(client, bank, content, metadata=...)) over instance methods. This pattern is more testable, avoids tight coupling, and provides cleaner APIs. Module-level functions accept the object as first argument. When converting a closure to a standalone function, convert each `nonlocal` variable to either a function parameter (input) or a field in a returned NamedTuple (output). This eliminates implicit state sharing and makes the function's dependencies explicit—critical for testing and reasoning about behavior.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849538+00:00","updated_at":"2026-04-10T03:41:18.849540+00:00","valid_from":"2026-04-10T03:41:18.849538+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VV","title":"Functional Design: Pure Functions and Module-Level Utilities","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849538+00:00","updated_at":"2026-04-10T03:41:18.849540+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Layer 1 assignment for pure data constants
-
-
 
 Pure string/data constants with no imports can safely be assigned to Layer 1 (runner_constants module). This avoids circular dependencies while keeping data-only definitions accessible. Layer assignment is architecturally sound when the module has no external dependencies.
 
 _Source: #6295 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WJ","title":"Layer 1 assignment for pure data constants","content":"Pure string/data constants with no imports can safely be assigned to Layer 1 (runner_constants module). This avoids circular dependencies while keeping data-only definitions accessible. Layer assignment is architecturally sound when the module has no external dependencies.","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097407+00:00","updated_at":"2026-04-10T03:47:50.097411+00:00","valid_from":"2026-04-10T03:47:50.097407+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WJ","title":"Layer 1 assignment for pure data constants","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097407+00:00","updated_at":"2026-04-10T03:47:50.097411+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Layer checker must track newly added data modules
-
-
 
 When creating new constant/data modules at a given layer, update the layer import checker to recognize them. This prevents false positives and ensures the layer checker stays current as the codebase grows.
 
 _Source: #6295 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WN","title":"Layer checker must track newly added data modules","content":"When creating new constant/data modules at a given layer, update the layer import checker to recognize them. This prevents false positives and ensures the layer checker stays current as the codebase grows.","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097432+00:00","updated_at":"2026-04-10T03:47:50.097438+00:00","valid_from":"2026-04-10T03:47:50.097432+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WN","title":"Layer checker must track newly added data modules","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097432+00:00","updated_at":"2026-04-10T03:47:50.097438+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Backward Compatibility and Refactoring via Facades and Re-Exports
 
-
-
 When splitting large classes or moving code, preserve backward compatibility using three strategies: (1) **Re-exports**: move implementation to canonical location, re-export from original module, ensuring `isinstance()` checks and existing imports work unchanged. Test re-exports with identity checks (`assert Class1 is Class2`). (2) **Optional parameters with None defaults**: add new functionality as optional kwargs, allowing callers to omit them with fallback behavior matching the old implementation. (3) **Facade + composition for large classes**: when splitting classes with 20+ importing modules and 50+ test mock targets, keep delegation stubs on original class so all existing import paths, isinstance checks, and mock targets continue working. Extract to sub-clients inheriting a shared base class. Fix encapsulation violations by defining proper public API methods on the base class. These patterns enable incremental migration and prevent breaking 40+ existing import sites across the codebase. See also: Consolidation Patterns for handling multiple refactoring scenarios.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VT","title":"Backward Compatibility and Refactoring via Facades and Re-Exports","content":"When splitting large classes or moving code, preserve backward compatibility using three strategies: (1) **Re-exports**: move implementation to canonical location, re-export from original module, ensuring `isinstance()` checks and existing imports work unchanged. Test re-exports with identity checks (`assert Class1 is Class2`). (2) **Optional parameters with None defaults**: add new functionality as optional kwargs, allowing callers to omit them with fallback behavior matching the old implementation. (3) **Facade + composition for large classes**: when splitting classes with 20+ importing modules and 50+ test mock targets, keep delegation stubs on original class so all existing import paths, isinstance checks, and mock targets continue working. Extract to sub-clients inheriting a shared base class. Fix encapsulation violations by defining proper public API methods on the base class. These patterns enable incremental migration and prevent breaking 40+ existing import sites across the codebase. See also: Consolidation Patterns for handling multiple refactoring scenarios.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849534+00:00","updated_at":"2026-04-10T03:41:18.849536+00:00","valid_from":"2026-04-10T03:41:18.849534+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VT","title":"Backward Compatibility and Refactoring via Facades and Re-Exports","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849534+00:00","updated_at":"2026-04-10T03:41:18.849536+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Facade Exception: Public Method Limits for Behavioral Classes
-
-
 
 The ≤7 public method / ≤200 line constraints apply to extracted behavioral classes (ActiveIssueTracker, IssueSnapshotBuilder, IssueQueueRouter). The facade necessarily retains 25 delegation stubs for backward compatibility per the documented pattern — this is not a violation of the rule, but a documented exception to preserve import paths and external consumers.
 
 _Source: #6327 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X8","title":"Facade Exception: Public Method Limits for Behavioral Classes","content":"The ≤7 public method / ≤200 line constraints apply to extracted behavioral classes (ActiveIssueTracker, IssueSnapshotBuilder, IssueQueueRouter). The facade necessarily retains 25 delegation stubs for backward compatibility per the documented pattern — this is not a violation of the rule, but a documented exception to preserve import paths and external consumers.","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384601+00:00","updated_at":"2026-04-10T05:07:55.384602+00:00","valid_from":"2026-04-10T05:07:55.384601+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X8","title":"Facade Exception: Public Method Limits for Behavioral Classes","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384601+00:00","updated_at":"2026-04-10T05:07:55.384602+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Facade + Composition for Large Class Refactoring
-
-
 
 When decomposing a large class (e.g., 947 lines, 37 methods) into focused sub-modules, use a facade + composition pattern: keep the original class as a thin public-facing facade with delegation stubs, move implementation to stateless or single-concern sub-modules. This preserves all import paths, isinstance checks, and mock targets, enabling zero-test-breakage refactors. All existing callers continue working unchanged.
 
 _Source: #6338 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNV","title":"Facade + Composition for Large Class Refactoring","content":"When decomposing a large class (e.g., 947 lines, 37 methods) into focused sub-modules, use a facade + composition pattern: keep the original class as a thin public-facing facade with delegation stubs, move implementation to stateless or single-concern sub-modules. This preserves all import paths, isinstance checks, and mock targets, enabling zero-test-breakage refactors. All existing callers continue working unchanged.","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037220+00:00","updated_at":"2026-04-10T05:56:11.037230+00:00","valid_from":"2026-04-10T05:56:11.037220+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNV","title":"Facade + Composition for Large Class Refactoring","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037220+00:00","updated_at":"2026-04-10T05:56:11.037230+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Acceptance Criteria: Distinguish Public Facades from Implementation
-
-
 
 When refactoring with a facade pattern, acceptance criteria like "no class exceeds N public methods" should apply to *implementation classes*, not the facade. The facade may have many public methods (e.g., 12+) as delegation stubs—each stub is 1-2 lines. Implementation classes extracted into sub-modules stay under 7-8 public methods and 230 lines. Clarify this distinction upfront to avoid criteria conflicts.
 
 _Source: #6338 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNW","title":"Acceptance Criteria: Distinguish Public Facades from Implementation","content":"When refactoring with a facade pattern, acceptance criteria like \"no class exceeds N public methods\" should apply to *implementation classes*, not the facade. The facade may have many public methods (e.g., 12+) as delegation stubs—each stub is 1-2 lines. Implementation classes extracted into sub-modules stay under 7-8 public methods and 230 lines. Clarify this distinction upfront to avoid criteria conflicts.","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037241+00:00","updated_at":"2026-04-10T05:56:11.037242+00:00","valid_from":"2026-04-10T05:56:11.037241+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNW","title":"Acceptance Criteria: Distinguish Public Facades from Implementation","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037241+00:00","updated_at":"2026-04-10T05:56:11.037242+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Template method exception to 50-line logic limit
-
-
 
 Methods containing static prompt templates or configuration strings can exceed 50 lines of text while maintaining good design if the logic content is minimal (<5 lines). `_assemble_plan_prompt` will be ~110 lines but acceptable because it's an f-string template with variable interpolation only. Splitting such templates across multiple methods reduces readability of the full prompt.
 
 _Source: #6332 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XE","title":"Template method exception to 50-line logic limit","content":"Methods containing static prompt templates or configuration strings can exceed 50 lines of text while maintaining good design if the logic content is minimal (<5 lines). `_assemble_plan_prompt` will be ~110 lines but acceptable because it's an f-string template with variable interpolation only. Splitting such templates across multiple methods reduces readability of the full prompt.","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098270+00:00","updated_at":"2026-04-10T05:33:08.098279+00:00","valid_from":"2026-04-10T05:33:08.098270+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XE","title":"Template method exception to 50-line logic limit","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098270+00:00","updated_at":"2026-04-10T05:33:08.098279+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Coordinator + focused helpers decomposition pattern
-
-
 
 Decompose oversized methods by creating a lean coordinator (30-50 lines) that delegates to focused single-concern helpers (12-45 lines each). This pattern applies when a method mixes concerns like prompt assembly, retry coordination, and validation. Each helper encapsulates one concern; the coordinator orchestrates them without duplicating logic.
 
 _Source: #6332 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XF","title":"Coordinator + focused helpers decomposition pattern","content":"Decompose oversized methods by creating a lean coordinator (30-50 lines) that delegates to focused single-concern helpers (12-45 lines each). This pattern applies when a method mixes concerns like prompt assembly, retry coordination, and validation. Each helper encapsulates one concern; the coordinator orchestrates them without duplicating logic.","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098291+00:00","updated_at":"2026-04-10T05:33:08.098292+00:00","valid_from":"2026-04-10T05:33:08.098291+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XF","title":"Coordinator + focused helpers decomposition pattern","topic":null,"source_type":"plan","source_issue":6332,"source_repo":null,"created_at":"2026-04-10T05:33:08.098291+00:00","updated_at":"2026-04-10T05:33:08.098292+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Orchestrator pattern composes modules via deferred registration calls
-
-
 
 A factory function can become a thin orchestrator (~80 lines) that creates a shared context object and delegates route registration to ~12 sub-modules via a consistent `register(router, ctx)` signature. Each sub-module owns 50–200 lines; the factory merely composes them. This pattern decouples endpoint logic from factory complexity and enables parallel implementation.
 
 _Source: #6336 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP1","title":"Orchestrator pattern composes modules via deferred registration calls","content":"A factory function can become a thin orchestrator (~80 lines) that creates a shared context object and delegates route registration to ~12 sub-modules via a consistent `register(router, ctx)` signature. Each sub-module owns 50–200 lines; the factory merely composes them. This pattern decouples endpoint logic from factory complexity and enables parallel implementation.","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732554+00:00","updated_at":"2026-04-10T05:57:03.732557+00:00","valid_from":"2026-04-10T05:57:03.732554+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP1","title":"Orchestrator pattern composes modules via deferred registration calls","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732554+00:00","updated_at":"2026-04-10T05:57:03.732557+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Avoid thin-wrapper abstractions—target concrete duplication
-
-
 
 Rejected a `_build_base_prompt_context()` wrapper returning a tuple, noting it would create coupling without eliminating real duplication. Instead, target specific repeated code: only 4 runners share the memory query context string, only 2 share the dedup pattern. Extract only where there is genuine repeated code, not perceived similarity.
 
 _Source: #6340 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP2","title":"Avoid thin-wrapper abstractions—target concrete duplication","content":"Rejected a `_build_base_prompt_context()` wrapper returning a tuple, noting it would create coupling without eliminating real duplication. Instead, target specific repeated code: only 4 runners share the memory query context string, only 2 share the dedup pattern. Extract only where there is genuine repeated code, not perceived similarity.","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699114+00:00","updated_at":"2026-04-10T06:11:06.699131+00:00","valid_from":"2026-04-10T06:11:06.699114+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP2","title":"Avoid thin-wrapper abstractions—target concrete duplication","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699114+00:00","updated_at":"2026-04-10T06:11:06.699131+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Move generic utilities to module-level functions to keep classes small
-
-
 
 Rather than making `polling_loop` an instance method of LoopSupervisor, extract it as a module-level async function (~80 lines). This keeps the supervisor class under 200 lines while keeping polling logic independently testable. Orchestrator retains `_polling_loop()` as a thin wrapper for backward compatibility with existing mocks. This pattern aligns with codebase wiki guidance: 'Prefer module-level utility functions over instance methods.'
 
 _Source: #6323 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WY","title":"Move generic utilities to module-level functions to keep classes small","content":"Rather than making `polling_loop` an instance method of LoopSupervisor, extract it as a module-level async function (~80 lines). This keeps the supervisor class under 200 lines while keeping polling logic independently testable. Orchestrator retains `_polling_loop()` as a thin wrapper for backward compatibility with existing mocks. This pattern aligns with codebase wiki guidance: 'Prefer module-level utility functions over instance methods.'","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630680+00:00","updated_at":"2026-04-10T04:47:03.630683+00:00","valid_from":"2026-04-10T04:47:03.630680+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WY","title":"Move generic utilities to module-level functions to keep classes small","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630680+00:00","updated_at":"2026-04-10T04:47:03.630683+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Use sibling file patterns as architectural reference for consistency
-
-
 
 When implementing a change, reference similar patterns in sibling files (e.g., _control_routes.py) to ensure consistency. This provides evidence that the pattern is established and approved in the codebase, reducing design ambiguity and potential review friction.
 
 _Source: #6333 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XD","title":"Use sibling file patterns as architectural reference for consistency","content":"When implementing a change, reference similar patterns in sibling files (e.g., _control_routes.py) to ensure consistency. This provides evidence that the pattern is established and approved in the codebase, reducing design ambiguity and potential review friction.","topic":null,"source_type":"plan","source_issue":6333,"source_repo":null,"created_at":"2026-04-10T05:32:01.385950+00:00","updated_at":"2026-04-10T05:32:01.385951+00:00","valid_from":"2026-04-10T05:32:01.385950+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XD","title":"Use sibling file patterns as architectural reference for consistency","topic":null,"source_type":"plan","source_issue":6333,"source_repo":null,"created_at":"2026-04-10T05:32:01.385950+00:00","updated_at":"2026-04-10T05:32:01.385951+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Module-Level State via Constructor Injection
-
-
 
 When extracted classes need access to module-level state (e.g., `_FETCH_LOCKS` dict for regression test patching), pass it via constructor injection (e.g., `fetch_lock_fn: Callable[[], asyncio.Lock]`) rather than direct imports. This avoids circular dependencies between the facade and extracted modules while preserving the ability to patch module-level state in tests.
 
 _Source: #6338 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNX","title":"Module-Level State via Constructor Injection","content":"When extracted classes need access to module-level state (e.g., `_FETCH_LOCKS` dict for regression test patching), pass it via constructor injection (e.g., `fetch_lock_fn: Callable[[], asyncio.Lock]`) rather than direct imports. This avoids circular dependencies between the facade and extracted modules while preserving the ability to patch module-level state in tests.","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037248+00:00","updated_at":"2026-04-10T05:56:11.037249+00:00","valid_from":"2026-04-10T05:56:11.037248+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNX","title":"Module-Level State via Constructor Injection","topic":null,"source_type":"plan","source_issue":6338,"source_repo":null,"created_at":"2026-04-10T05:56:11.037248+00:00","updated_at":"2026-04-10T05:56:11.037249+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Preserve organizational comments during dead code removal
-
-
 
 Section heading comments (e.g., '# --- reset ---', '# --- threshold tracking ---') and blank-line separators maintain code structure and readability. Preserve these markers even when adjacent dead methods are removed. They signal logical grouping to future readers and should survive refactoring.
 
 _Source: #6345 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPB","title":"Preserve organizational comments during dead code removal","content":"Section heading comments (e.g., '# --- reset ---', '# --- threshold tracking ---') and blank-line separators maintain code structure and readability. Preserve these markers even when adjacent dead methods are removed. They signal logical grouping to future readers and should survive refactoring.","topic":null,"source_type":"plan","source_issue":6345,"source_repo":null,"created_at":"2026-04-10T06:35:05.468491+00:00","updated_at":"2026-04-10T06:35:05.468493+00:00","valid_from":"2026-04-10T06:35:05.468491+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPB","title":"Preserve organizational comments during dead code removal","topic":null,"source_type":"plan","source_issue":6345,"source_repo":null,"created_at":"2026-04-10T06:35:05.468491+00:00","updated_at":"2026-04-10T06:35:05.468493+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture-patterns-practices.md
+++ b/docs/wiki/architecture-patterns-practices.md
@@ -1,259 +1,259 @@
-# Architecture Patterns Practices
+# Architecture-Patterns-Practices
+
 
 ## Testing Patterns: Mocking, Parametrized Assertions, and Test Helpers
 
-
-
 For test isolation with sys.modules manipulation, use pytest's monkeypatch.delitem() with raising=False to handle both existing and missing keys, and monkeypatch guarantees cleanup on teardown. Save original module state via `had = k in sys.modules; original = sys.modules.get(k)`, then restore with monkeypatch. Use parametrized tests with dual lists (_REQUIRED_METHODS, _SIGNED_METHODS) to validate interface conformance via set subtraction. Tests should check presence via content assertion, not just structure (verify specific module names, not just that labels exist). Follow existing test class patterns (TestBuildStage, TestEdgeCases, TestPartialTimelines) when adding similar validators. Conftest at session scope handles sys.path setup, making explicit sys.path.insert calls in test modules redundant. For deferred imports in tests, see Deferred Imports, Type Checking, and Testing.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W0","title":"Testing Patterns: Mocking, Parametrized Assertions, and Test Helpers","content":"For test isolation with sys.modules manipulation, use pytest's monkeypatch.delitem() with raising=False to handle both existing and missing keys, and monkeypatch guarantees cleanup on teardown. Save original module state via `had = k in sys.modules; original = sys.modules.get(k)`, then restore with monkeypatch. Use parametrized tests with dual lists (_REQUIRED_METHODS, _SIGNED_METHODS) to validate interface conformance via set subtraction. Tests should check presence via content assertion, not just structure (verify specific module names, not just that labels exist). Follow existing test class patterns (TestBuildStage, TestEdgeCases, TestPartialTimelines) when adding similar validators. Conftest at session scope handles sys.path setup, making explicit sys.path.insert calls in test modules redundant. For deferred imports in tests, see Deferred Imports, Type Checking, and Testing.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849559+00:00","updated_at":"2026-04-10T03:41:18.849561+00:00","valid_from":"2026-04-10T03:41:18.849559+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W0","title":"Testing Patterns: Mocking, Parametrized Assertions, and Test Helpers","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849559+00:00","updated_at":"2026-04-10T03:41:18.849561+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Dynamic Discovery with Convention-Based Naming
 
-
-
 Avoid import-time registry population; instead call discovery functions on-demand (e.g., `discover_skills(repo_root)` per call without caching). Discovery must happen at runtime not import-time to stay fresh and avoid blocking startup. Establish reversible naming conventions: hf.diff-sanity command → diff_sanity module with `build_diff_sanity_prompt()` and `parse_diff_sanity_result()` functions. This eliminates need for separate registry mapping files. Lightweight frontmatter parsing (split on `---` delimiters) avoids adding parser dependencies. Catch broad exceptions during module imports (not just ImportError) to handle syntax errors, missing dependencies, and other runtime errors. Dynamic skill definitions in JSONL use generic templated builders (functools.partial) + result markers. Multiple registration mechanisms (bg_loop_registry dict, loop_factories tuple) require unified discovery via set union. See also: Workspace Isolation for command discovery patterns, Background Loops for registration.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W1","title":"Dynamic Discovery with Convention-Based Naming","content":"Avoid import-time registry population; instead call discovery functions on-demand (e.g., `discover_skills(repo_root)` per call without caching). Discovery must happen at runtime not import-time to stay fresh and avoid blocking startup. Establish reversible naming conventions: hf.diff-sanity command → diff_sanity module with `build_diff_sanity_prompt()` and `parse_diff_sanity_result()` functions. This eliminates need for separate registry mapping files. Lightweight frontmatter parsing (split on `---` delimiters) avoids adding parser dependencies. Catch broad exceptions during module imports (not just ImportError) to handle syntax errors, missing dependencies, and other runtime errors. Dynamic skill definitions in JSONL use generic templated builders (functools.partial) + result markers. Multiple registration mechanisms (bg_loop_registry dict, loop_factories tuple) require unified discovery via set union. See also: Workspace Isolation for command discovery patterns, Background Loops for registration.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849563+00:00","updated_at":"2026-04-10T03:41:18.849564+00:00","valid_from":"2026-04-10T03:41:18.849563+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W1","title":"Dynamic Discovery with Convention-Based Naming","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849563+00:00","updated_at":"2026-04-10T03:41:18.849564+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Coordinator pattern with call-order sensitivity
-
-
 
 When extracting sub-methods from a large method, the original method becomes a thin orchestrator calling extracted methods in sequence. Execution order is critical—e.g., builder.record_history() must happen before builder.build_stats(). Preserve exact call order in the coordinator; tests should verify this order is maintained after extraction.
 
 _Source: #6330 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X9","title":"Coordinator pattern with call-order sensitivity","content":"When extracting sub-methods from a large method, the original method becomes a thin orchestrator calling extracted methods in sequence. Execution order is critical—e.g., builder.record_history() must happen before builder.build_stats(). Preserve exact call order in the coordinator; tests should verify this order is maintained after extraction.","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124008+00:00","updated_at":"2026-04-10T05:17:59.124009+00:00","valid_from":"2026-04-10T05:17:59.124008+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X9","title":"Coordinator pattern with call-order sensitivity","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124008+00:00","updated_at":"2026-04-10T05:17:59.124009+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## NamedTuple for multi-return extracted methods
-
-
 
 When an extracted method returns multiple related values (like _build_context_sections returning multiple section strings), use a lightweight NamedTuple instead of creating a dataclass or new class. This avoids test infrastructure breakage while providing named access and self-documenting return types.
 
 _Source: #6330 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XA","title":"NamedTuple for multi-return extracted methods","content":"When an extracted method returns multiple related values (like _build_context_sections returning multiple section strings), use a lightweight NamedTuple instead of creating a dataclass or new class. This avoids test infrastructure breakage while providing named access and self-documenting return types.","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124011+00:00","updated_at":"2026-04-10T05:17:59.124012+00:00","valid_from":"2026-04-10T05:17:59.124011+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XA","title":"NamedTuple for multi-return extracted methods","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124011+00:00","updated_at":"2026-04-10T05:17:59.124012+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Parameter threading across extracted methods
-
-
 
 Some parameters (like bead_mapping) appear as arguments to multiple extracted methods across different extraction phases. Watch for these cross-cutting parameters during design—they indicate a concern that spans multiple extracted methods and should be threaded consistently through the coordinator to avoid silent bugs from missing arguments.
 
 _Source: #6330 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XB","title":"Parameter threading across extracted methods","content":"Some parameters (like bead_mapping) appear as arguments to multiple extracted methods across different extraction phases. Watch for these cross-cutting parameters during design—they indicate a concern that spans multiple extracted methods and should be threaded consistently through the coordinator to avoid silent bugs from missing arguments.","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124014+00:00","updated_at":"2026-04-10T05:17:59.124016+00:00","valid_from":"2026-04-10T05:17:59.124014+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XB","title":"Parameter threading across extracted methods","topic":null,"source_type":"plan","source_issue":6330,"source_repo":null,"created_at":"2026-04-10T05:17:59.124014+00:00","updated_at":"2026-04-10T05:17:59.124016+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Structured transcript parsing: markers, summaries, and item lists
-
-
 
 Transcripts can be parsed via three markers: result key (OK/RETRY status), summary section (captured text), and item list (extracted from bullet points). Case-insensitive matching and whitespace-tolerant list parsing make this pattern robust across variations in formatting and capitalization.
 
 _Source: #6349 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPH","title":"Structured transcript parsing: markers, summaries, and item lists","content":"Transcripts can be parsed via three markers: result key (OK/RETRY status), summary section (captured text), and item list (extracted from bullet points). Case-insensitive matching and whitespace-tolerant list parsing make this pattern robust across variations in formatting and capitalization.","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972424+00:00","updated_at":"2026-04-10T06:47:04.972425+00:00","valid_from":"2026-04-10T06:47:04.972424+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPH","title":"Structured transcript parsing: markers, summaries, and item lists","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972424+00:00","updated_at":"2026-04-10T06:47:04.972425+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Separate parsing utilities from subprocess and streaming concerns
-
-
 
 Create new utility modules with clear, single responsibilities. Transcript parsing belongs in its own module, distinct from runner_utils which handles subprocess/streaming. This boundary prevents utility modules from becoming dumping grounds and keeps dependencies focused.
 
 _Source: #6349 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPJ","title":"Separate parsing utilities from subprocess and streaming concerns","content":"Create new utility modules with clear, single responsibilities. Transcript parsing belongs in its own module, distinct from runner_utils which handles subprocess/streaming. This boundary prevents utility modules from becoming dumping grounds and keeps dependencies focused.","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972432+00:00","updated_at":"2026-04-10T06:47:04.972433+00:00","valid_from":"2026-04-10T06:47:04.972432+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPJ","title":"Separate parsing utilities from subprocess and streaming concerns","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972432+00:00","updated_at":"2026-04-10T06:47:04.972433+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Thin public wrappers replace private method access
-
-
 
 When internal callers (e.g., `stale_issue_loop`, `sentry_loop`) access private methods on a façaded class (`_run_gh`, `_repo`), add thin public wrapper methods on the appropriate sub-client rather than exposing infrastructure. Example: add `list_open_issues_raw()` to `IssueClient` for `stale_issue_loop` to call instead of `_run_gh`. This maintains encapsulation boundaries while serving legitimate internal dependencies.
 
 _Source: #6348 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPK","title":"Thin public wrappers replace private method access","content":"When internal callers (e.g., `stale_issue_loop`, `sentry_loop`) access private methods on a façaded class (`_run_gh`, `_repo`), add thin public wrapper methods on the appropriate sub-client rather than exposing infrastructure. Example: add `list_open_issues_raw()` to `IssueClient` for `stale_issue_loop` to call instead of `_run_gh`. This maintains encapsulation boundaries while serving legitimate internal dependencies.","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638890+00:00","updated_at":"2026-04-10T06:49:24.638891+00:00","valid_from":"2026-04-10T06:49:24.638890+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPK","title":"Thin public wrappers replace private method access","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638890+00:00","updated_at":"2026-04-10T06:49:24.638891+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Line/method budgets force better decomposition
-
-
 
 Hard constraints (≤200 lines, ~7 public methods per class) push better architectural decisions than soft targets. During this refactor, the large query methods didn't fit in a single 200-line `PRQueryClient`, forcing a split into `PRQueryClient` and `DashboardQueryClient`. The constraint prevented a bloated compromise class and revealed natural subdomain boundaries.
 
 _Source: #6348 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPM","title":"Line/method budgets force better decomposition","content":"Hard constraints (≤200 lines, ~7 public methods per class) push better architectural decisions than soft targets. During this refactor, the large query methods didn't fit in a single 200-line `PRQueryClient`, forcing a split into `PRQueryClient` and `DashboardQueryClient`. The constraint prevented a bloated compromise class and revealed natural subdomain boundaries.","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638893+00:00","updated_at":"2026-04-10T06:49:24.638894+00:00","valid_from":"2026-04-10T06:49:24.638893+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPM","title":"Line/method budgets force better decomposition","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638893+00:00","updated_at":"2026-04-10T06:49:24.638894+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Selective EventBus threading by behavioral side effects
-
-
 
 Not all sub-clients need the same dependencies. Only sub-clients with behavioral side effects (publishing events: `PRLifecycle`, `IssueClient`, `CIStatusClient`) receive `EventBus` in `__init__`. Pure query clients (`PRQueryClient`, `MetricsClient`) don't. This selective dependency injection pattern avoids threading unnecessary dependencies through constructors and signals intent about what each component does.
 
 _Source: #6348 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPN","title":"Selective EventBus threading by behavioral side effects","content":"Not all sub-clients need the same dependencies. Only sub-clients with behavioral side effects (publishing events: `PRLifecycle`, `IssueClient`, `CIStatusClient`) receive `EventBus` in `__init__`. Pure query clients (`PRQueryClient`, `MetricsClient`) don't. This selective dependency injection pattern avoids threading unnecessary dependencies through constructors and signals intent about what each component does.","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638897+00:00","updated_at":"2026-04-10T06:49:24.638897+00:00","valid_from":"2026-04-10T06:49:24.638897+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPN","title":"Selective EventBus threading by behavioral side effects","topic":null,"source_type":"plan","source_issue":6348,"source_repo":null,"created_at":"2026-04-10T06:49:24.638897+00:00","updated_at":"2026-04-10T06:49:24.638897+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Never-raise contract uses broad exception catching
-
-
 
 Health checks and diagnostic functions should catch `Exception` (not specific types like `httpx.HTTPError`) and return False/safe default rather than propagate. Matches the `*_safe` pattern used for functions that must not raise (e.g., `retain_safe`, `recall_safe`).
 
 _Source: #6362 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ6","title":"Never-raise contract uses broad exception catching","content":"Health checks and diagnostic functions should catch `Exception` (not specific types like `httpx.HTTPError`) and return False/safe default rather than propagate. Matches the `*_safe` pattern used for functions that must not raise (e.g., `retain_safe`, `recall_safe`).","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400476+00:00","updated_at":"2026-04-10T07:44:23.400479+00:00","valid_from":"2026-04-10T07:44:23.400476+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ6","title":"Never-raise contract uses broad exception catching","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400476+00:00","updated_at":"2026-04-10T07:44:23.400479+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## exc_info=True parameter preserves full tracebacks at lower levels
-
-
 
 logger.warning(..., exc_info=True) captures the full exception traceback in logs (visible in structured logs and observability tools) while downgrading the severity level. This enables post-incident debugging without triggering alerting systems designed for ERROR-level events.
 
 _Source: #6363 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ8","title":"exc_info=True parameter preserves full tracebacks at lower levels","content":"logger.warning(..., exc_info=True) captures the full exception traceback in logs (visible in structured logs and observability tools) while downgrading the severity level. This enables post-incident debugging without triggering alerting systems designed for ERROR-level events.","topic":null,"source_type":"plan","source_issue":6363,"source_repo":null,"created_at":"2026-04-10T07:48:21.129667+00:00","updated_at":"2026-04-10T07:48:21.129669+00:00","valid_from":"2026-04-10T07:48:21.129667+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ8","title":"exc_info=True parameter preserves full tracebacks at lower levels","topic":null,"source_type":"plan","source_issue":6363,"source_repo":null,"created_at":"2026-04-10T07:48:21.129667+00:00","updated_at":"2026-04-10T07:48:21.129669+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Test class names describe scenarios, not test subjects
-
-
 
 Test class names like `TestGCLoopNoCircuitBreaker` describe the scenario being tested (GC loop behavior without circuit breaking) rather than the code under test. When removing a module, check whether test classes with that name actually import or test it, or are simply documenting a test scenario.
 
 _Source: #6365 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQA","title":"Test class names describe scenarios, not test subjects","content":"Test class names like `TestGCLoopNoCircuitBreaker` describe the scenario being tested (GC loop behavior without circuit breaking) rather than the code under test. When removing a module, check whether test classes with that name actually import or test it, or are simply documenting a test scenario.","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461043+00:00","updated_at":"2026-04-10T07:59:04.461045+00:00","valid_from":"2026-04-10T07:59:04.461043+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQA","title":"Test class names describe scenarios, not test subjects","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461043+00:00","updated_at":"2026-04-10T07:59:04.461045+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Inline implementations preferred over extracted utility classes
-
-
 
 The orchestrator implements its own circuit-breaking logic (consecutive-failure counter at :926-1026) rather than using the extracted `CircuitBreaker` class. This suggests the project favors inline implementations for simple patterns over shared utility classes, reducing coupling and import complexity.
 
 _Source: #6365 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQB","title":"Inline implementations preferred over extracted utility classes","content":"The orchestrator implements its own circuit-breaking logic (consecutive-failure counter at :926-1026) rather than using the extracted `CircuitBreaker` class. This suggests the project favors inline implementations for simple patterns over shared utility classes, reducing coupling and import complexity.","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461047+00:00","updated_at":"2026-04-10T07:59:04.461048+00:00","valid_from":"2026-04-10T07:59:04.461047+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQB","title":"Inline implementations preferred over extracted utility classes","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461047+00:00","updated_at":"2026-04-10T07:59:04.461048+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Prompt Deduplication and Memory Context Capping
 
-
-
 Multi-bank Hindsight recall causes duplicate or overlapping memories in prompts. Deduplication strategy: (1) Pool items from all banks, track via exact-text matching with character counts; (2) Deduplicate via PromptDeduplicator.dedup_bank_items() which merges duplicate text and tracks which banks contributed; (3) Rebuild per-bank strings avoiding exact-string set-rebuilding (which fails for merged items)—instead return per-bank surviving items directly from dedup; (4) Cap memory injection with multi-tier limits: max_recall_thread_items_per_phase (5), max_inherited_memory_chars (2000), max_memory_prompt_chars (4000). Semantic vs exact matching: dedup removes exact duplicates while preserving content overlap between banks (acceptable). Text-based dedup respects display modifications (e.g., prefixes like **AVOID:**). Antipatterns use 1.15x boost multiplier for recall priority, but must be tuned if antipatterns dominate results. See also: Optional Dependencies for Hindsight service handling, Side Effect Consumption for context threading.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WC","title":"Prompt Deduplication and Memory Context Capping","content":"Multi-bank Hindsight recall causes duplicate or overlapping memories in prompts. Deduplication strategy: (1) Pool items from all banks, track via exact-text matching with character counts; (2) Deduplicate via PromptDeduplicator.dedup_bank_items() which merges duplicate text and tracks which banks contributed; (3) Rebuild per-bank strings avoiding exact-string set-rebuilding (which fails for merged items)—instead return per-bank surviving items directly from dedup; (4) Cap memory injection with multi-tier limits: max_recall_thread_items_per_phase (5), max_inherited_memory_chars (2000), max_memory_prompt_chars (4000). Semantic vs exact matching: dedup removes exact duplicates while preserving content overlap between banks (acceptable). Text-based dedup respects display modifications (e.g., prefixes like **AVOID:**). Antipatterns use 1.15x boost multiplier for recall priority, but must be tuned if antipatterns dominate results. See also: Optional Dependencies for Hindsight service handling, Side Effect Consumption for context threading.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852310+00:00","updated_at":"2026-04-10T03:41:18.852312+00:00","valid_from":"2026-04-10T03:41:18.852310+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WC","title":"Prompt Deduplication and Memory Context Capping","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.852310+00:00","updated_at":"2026-04-10T03:41:18.852312+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Strategy dispatcher pattern for conditional behavior branches
-
-
 
 For methods with conditional logic based on an enum (e.g., release strategy: BUNDLED vs ORDERED vs HITL), create a single dispatcher method (`handle_ready(strategy)`) that routes to private strategy handlers. This centralizes the branching logic and makes it testable without exposing individual handlers.
 
 _Source: #6339 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP6","title":"Strategy dispatcher pattern for conditional behavior branches","content":"For methods with conditional logic based on an enum (e.g., release strategy: BUNDLED vs ORDERED vs HITL), create a single dispatcher method (`handle_ready(strategy)`) that routes to private strategy handlers. This centralizes the branching logic and makes it testable without exposing individual handlers.","topic":null,"source_type":"plan","source_issue":6339,"source_repo":null,"created_at":"2026-04-10T06:19:03.788199+00:00","updated_at":"2026-04-10T06:19:03.788202+00:00","valid_from":"2026-04-10T06:19:03.788199+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP6","title":"Strategy dispatcher pattern for conditional behavior branches","topic":null,"source_type":"plan","source_issue":6339,"source_repo":null,"created_at":"2026-04-10T06:19:03.788199+00:00","updated_at":"2026-04-10T06:19:03.788202+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Export widely-reused constants without underscore prefix
-
-
 
 Time duration constants imported across multiple modules (config.py, _common.py, tests/) should use public names without underscore prefix (ONE_DAY_SECS, not _ONE_DAY_SECS). Reserve underscore prefix for file-local-only constants to signal scope.
 
 _Source: #6341 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP8","title":"Export widely-reused constants without underscore prefix","content":"Time duration constants imported across multiple modules (config.py, _common.py, tests/) should use public names without underscore prefix (ONE_DAY_SECS, not _ONE_DAY_SECS). Reserve underscore prefix for file-local-only constants to signal scope.","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281145+00:00","updated_at":"2026-04-10T06:22:03.281148+00:00","valid_from":"2026-04-10T06:22:03.281145+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP8","title":"Export widely-reused constants without underscore prefix","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281145+00:00","updated_at":"2026-04-10T06:22:03.281148+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Document variant patterns; resist premature parameterization
-
-
 
 The plan notes that `triage.py` uses a similar memory context pattern but with space separator instead of newline. Rather than force parameterization to handle both, the plan keeps scope narrow and documents the variant for future follow-up. Over-parameterizing early adds complexity without immediate need.
 
 _Source: #6340 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP4","title":"Document variant patterns; resist premature parameterization","content":"The plan notes that `triage.py` uses a similar memory context pattern but with space separator instead of newline. Rather than force parameterization to handle both, the plan keeps scope narrow and documents the variant for future follow-up. Over-parameterizing early adds complexity without immediate need.","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699170+00:00","updated_at":"2026-04-10T06:11:06.699173+00:00","valid_from":"2026-04-10T06:11:06.699170+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP4","title":"Document variant patterns; resist premature parameterization","topic":null,"source_type":"plan","source_issue":6340,"source_repo":null,"created_at":"2026-04-10T06:11:06.699170+00:00","updated_at":"2026-04-10T06:11:06.699173+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Dependency injection + re-export for backward-compatible class splits
-
-
 
 When splitting a large class into focused subclasses, inject the new dependencies into the parent constructor and re-export the new classes from the original module. This maintains API compatibility (`from epic import EpicStatusReporter` works) while separating concerns. Wiring happens in `ServiceRegistry`, not in the class constructors.
 
 _Source: #6339 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP5","title":"Dependency injection + re-export for backward-compatible class splits","content":"When splitting a large class into focused subclasses, inject the new dependencies into the parent constructor and re-export the new classes from the original module. This maintains API compatibility (`from epic import EpicStatusReporter` works) while separating concerns. Wiring happens in `ServiceRegistry`, not in the class constructors.","topic":null,"source_type":"plan","source_issue":6339,"source_repo":null,"created_at":"2026-04-10T06:19:03.788137+00:00","updated_at":"2026-04-10T06:19:03.788154+00:00","valid_from":"2026-04-10T06:19:03.788137+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP5","title":"Dependency injection + re-export for backward-compatible class splits","topic":null,"source_type":"plan","source_issue":6339,"source_repo":null,"created_at":"2026-04-10T06:19:03.788137+00:00","updated_at":"2026-04-10T06:19:03.788154+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Sub-factory coordination via intermediate frozen dataclass
-
-
 
 When decomposing a large factory function, bundle frequently-shared infrastructure (10+) into a frozen dataclass (e.g., `_CoreDeps`) and pass it to downstream sub-factories. This pattern, inherited from `LoopDeps` in `base_background_loop.py`, reduces parameter explosion and makes dependency ownership explicit without requiring typed classes for every service group.
 
 _Source: #6334 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XN","title":"Sub-factory coordination via intermediate frozen dataclass","content":"When decomposing a large factory function, bundle frequently-shared infrastructure (10+) into a frozen dataclass (e.g., `_CoreDeps`) and pass it to downstream sub-factories. This pattern, inherited from `LoopDeps` in `base_background_loop.py`, reduces parameter explosion and makes dependency ownership explicit without requiring typed classes for every service group.","topic":null,"source_type":"plan","source_issue":6334,"source_repo":null,"created_at":"2026-04-10T05:40:10.652297+00:00","updated_at":"2026-04-10T05:40:10.652309+00:00","valid_from":"2026-04-10T05:40:10.652297+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XN","title":"Sub-factory coordination via intermediate frozen dataclass","topic":null,"source_type":"plan","source_issue":6334,"source_repo":null,"created_at":"2026-04-10T05:40:10.652297+00:00","updated_at":"2026-04-10T05:40:10.652309+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Distinguish local wiring from cross-group wiring at architecture boundary
-
-
 
 Post-construction mutations fall into two categories: local (both objects created in same sub-factory, e.g., `shape_phase._council = ExpertCouncil(...)`) and cross-group (objects from different sub-factories, e.g., `agents._insights = review_insights`). Local wiring stays in the sub-factory; cross-group wiring moves to the thin orchestrator. This boundary clarifies dependency coupling.
 
 _Source: #6334 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XP","title":"Distinguish local wiring from cross-group wiring at architecture boundary","content":"Post-construction mutations fall into two categories: local (both objects created in same sub-factory, e.g., `shape_phase._council = ExpertCouncil(...)`) and cross-group (objects from different sub-factories, e.g., `agents._insights = review_insights`). Local wiring stays in the sub-factory; cross-group wiring moves to the thin orchestrator. This boundary clarifies dependency coupling.","topic":null,"source_type":"plan","source_issue":6334,"source_repo":null,"created_at":"2026-04-10T05:40:10.652318+00:00","updated_at":"2026-04-10T05:40:10.652320+00:00","valid_from":"2026-04-10T05:40:10.652318+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XP","title":"Distinguish local wiring from cross-group wiring at architecture boundary","topic":null,"source_type":"plan","source_issue":6334,"source_repo":null,"created_at":"2026-04-10T05:40:10.652318+00:00","updated_at":"2026-04-10T05:40:10.652320+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## AST-based regression tests are fragile to refactoring
-
-
 
 Tests that walk the AST looking for specific function/variable names and nesting patterns break if code is renamed, wrapped, or restructured. Keep cleanup calls simple and direct—no indirection, no renaming, no extra nesting. Fragility is the cost of catching accidental refactorings.
 
 _Source: #6362 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQ5","title":"AST-based regression tests are fragile to refactoring","content":"Tests that walk the AST looking for specific function/variable names and nesting patterns break if code is renamed, wrapped, or restructured. Keep cleanup calls simple and direct—no indirection, no renaming, no extra nesting. Fragility is the cost of catching accidental refactorings.","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400467+00:00","updated_at":"2026-04-10T07:44:23.400470+00:00","valid_from":"2026-04-10T07:44:23.400467+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQ5","title":"AST-based regression tests are fragile to refactoring","topic":null,"source_type":"plan","source_issue":6362,"source_repo":null,"created_at":"2026-04-10T07:44:23.400467+00:00","updated_at":"2026-04-10T07:44:23.400470+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture-refactoring.md
+++ b/docs/wiki/architecture-refactoring.md
@@ -1,249 +1,249 @@
-# Architecture Refactoring
+# Architecture-Refactoring
+
 
 ## Consolidation Patterns for Duplicate Code
 
-
-
 Three similar items (e.g., Handlers, Runners, Loops) warrant consolidation if the same pattern exists elsewhere (e.g., 8 runners total vs 3 currently refactored). Partial migrations create maintenance burden. Extract duplicated path patterns into module-level constants and shared helper functions. Consolidate label field lists via module-level constants (ALL_LIFECYCLE_LABEL_FIELDS) to allow cross-module imports without circular dependencies. When extracting methods from large classes, preserve original public API via thin delegation methods to avoid cascading changes across callers. Backward-compatible JSONL schema evolution: add optional fields with sensible defaults that existing consumers handle automatically. Example: fixing one missing label field requires fixing all missing label fields at once, not just the mentioned ones, to prevent latent bugs. See also: Backward Compatibility for preservation strategies, Dead Code Removal for cleanup verification.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W4","title":"Consolidation Patterns for Duplicate Code","content":"Three similar items (e.g., Handlers, Runners, Loops) warrant consolidation if the same pattern exists elsewhere (e.g., 8 runners total vs 3 currently refactored). Partial migrations create maintenance burden. Extract duplicated path patterns into module-level constants and shared helper functions. Consolidate label field lists via module-level constants (ALL_LIFECYCLE_LABEL_FIELDS) to allow cross-module imports without circular dependencies. When extracting methods from large classes, preserve original public API via thin delegation methods to avoid cascading changes across callers. Backward-compatible JSONL schema evolution: add optional fields with sensible defaults that existing consumers handle automatically. Example: fixing one missing label field requires fixing all missing label fields at once, not just the mentioned ones, to prevent latent bugs. See also: Backward Compatibility for preservation strategies, Dead Code Removal for cleanup verification.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849574+00:00","updated_at":"2026-04-10T03:41:18.849575+00:00","valid_from":"2026-04-10T03:41:18.849574+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W4","title":"Consolidation Patterns for Duplicate Code","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849574+00:00","updated_at":"2026-04-10T03:41:18.849575+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Dead Code Removal Verification and Code Cleanup
 
-
-
 Verify dead code removal via: (1) `make test` confirms no hidden dependencies, (2) `make quality-lite` for lint/type/security, (3) `make layer-check` validates layer boundaries, (4) comprehensive grep -r across src/ and tests/ for remaining references. When removing modules: update scripts/check_layer_imports.py MODULE_LAYERS dict, verify all imports are removed, delete entire files not stubs. Empty files create ambiguity—delete them entirely. Layer checker warns about nonexistent modules if entries aren't removed from MODULE_LAYERS. When deleting code from a subsection, preserve section heading comments (e.g., '# --- Structured Return Types ---') if other items in that section remain. The comment applies to all remaining members and improves navigation for future readers. ADR Superseding Pattern: when a planned feature documented in an ADR is removed as dead code (never implemented), update the ADR status to 'Superseded by removal' and cross-reference the removal issue. This preserves architectural decision history and clarifies for future reimplementation attempts.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W5","title":"Dead Code Removal Verification and Code Cleanup","content":"Verify dead code removal via: (1) `make test` confirms no hidden dependencies, (2) `make quality-lite` for lint/type/security, (3) `make layer-check` validates layer boundaries, (4) comprehensive grep -r across src/ and tests/ for remaining references. When removing modules: update scripts/check_layer_imports.py MODULE_LAYERS dict, verify all imports are removed, delete entire files not stubs. Empty files create ambiguity—delete them entirely. Layer checker warns about nonexistent modules if entries aren't removed from MODULE_LAYERS. When deleting code from a subsection, preserve section heading comments (e.g., '# --- Structured Return Types ---') if other items in that section remain. The comment applies to all remaining members and improves navigation for future readers. ADR Superseding Pattern: when a planned feature documented in an ADR is removed as dead code (never implemented), update the ADR status to 'Superseded by removal' and cross-reference the removal issue. This preserves architectural decision history and clarifies for future reimplementation attempts.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849578+00:00","updated_at":"2026-04-10T03:41:18.849579+00:00","valid_from":"2026-04-10T03:41:18.849578+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W5","title":"Dead Code Removal Verification and Code Cleanup","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849578+00:00","updated_at":"2026-04-10T03:41:18.849579+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Dead-code removal: three-phase decomposition pattern
-
-
 
 Systematic approach: P1 removes core methods and constructor plumbing; P2 removes dependent tests and updates helpers; P3 verifies via grep and type checking. This phased structure prevents partial removals and ensures all callers are updated before verification.
 
 _Source: #6315 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WG","title":"Dead-code removal: three-phase decomposition pattern","content":"Systematic approach: P1 removes core methods and constructor plumbing; P2 removes dependent tests and updates helpers; P3 verifies via grep and type checking. This phased structure prevents partial removals and ensures all callers are updated before verification.","topic":null,"source_type":"plan","source_issue":6315,"source_repo":null,"created_at":"2026-04-10T03:43:46.872729+00:00","updated_at":"2026-04-10T03:43:46.872755+00:00","valid_from":"2026-04-10T03:43:46.872729+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WG","title":"Dead-code removal: three-phase decomposition pattern","topic":null,"source_type":"plan","source_issue":6315,"source_repo":null,"created_at":"2026-04-10T03:43:46.872729+00:00","updated_at":"2026-04-10T03:43:46.872755+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Wire unconnected config parameters to existing consumers
-
-
 
 When a consumer (e.g., StateTracker) already accepts constructor parameters matching config fields, but the wiring is missing from the service builder, this is a low-risk one-line fix. Check StateTracker's signature before assuming the parameter doesn't exist; it often does with sensible defaults.
 
 _Source: #6314 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WH","title":"Wire unconnected config parameters to existing consumers","content":"When a consumer (e.g., StateTracker) already accepts constructor parameters matching config fields, but the wiring is missing from the service builder, this is a low-risk one-line fix. Check StateTracker's signature before assuming the parameter doesn't exist; it often does with sensible defaults.","topic":null,"source_type":"plan","source_issue":6314,"source_repo":null,"created_at":"2026-04-10T03:45:26.654545+00:00","updated_at":"2026-04-10T03:45:26.654546+00:00","valid_from":"2026-04-10T03:45:26.654545+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WH","title":"Wire unconnected config parameters to existing consumers","topic":null,"source_type":"plan","source_issue":6314,"source_repo":null,"created_at":"2026-04-10T03:45:26.654545+00:00","updated_at":"2026-04-10T03:45:26.654546+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Visual consistency outweighs functional correctness
-
-
 
 Code dict entries should visually align with their layer assignment comment blocks, not with the layer they logically belong to. Even when functionally harmless, misalignment is visually misleading and reduces code clarity for future maintainers.
 
 _Source: #6295 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WK","title":"Visual consistency outweighs functional correctness","content":"Code dict entries should visually align with their layer assignment comment blocks, not with the layer they logically belong to. Even when functionally harmless, misalignment is visually misleading and reduces code clarity for future maintainers.","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097416+00:00","updated_at":"2026-04-10T03:47:50.097419+00:00","valid_from":"2026-04-10T03:47:50.097416+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WK","title":"Visual consistency outweighs functional correctness","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097416+00:00","updated_at":"2026-04-10T03:47:50.097419+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Define explicit scope for extraction refactors
-
-
 
 Extraction issues should explicitly name the target files/functions in scope. This prevents scope creep and clarifies what duplicates are intentionally excluded (e.g., similar patterns in other modules). Scope clarity prevents false-positive review flags.
 
 _Source: #6295 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WM","title":"Define explicit scope for extraction refactors","content":"Extraction issues should explicitly name the target files/functions in scope. This prevents scope creep and clarifies what duplicates are intentionally excluded (e.g., similar patterns in other modules). Scope clarity prevents false-positive review flags.","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097424+00:00","updated_at":"2026-04-10T03:47:50.097427+00:00","valid_from":"2026-04-10T03:47:50.097424+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WM","title":"Define explicit scope for extraction refactors","topic":null,"source_type":"review","source_issue":6295,"source_repo":null,"created_at":"2026-04-10T03:47:50.097424+00:00","updated_at":"2026-04-10T03:47:50.097427+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Plan line numbers become stale; search by pattern instead
-
-
 
 When implementing a plan generated in a prior session, files may have been modified since the plan was written. Prefer searching for method signature patterns rather than relying on exact line numbers provided in the plan.
 
 _Source: #6317 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WP","title":"Plan line numbers become stale; search by pattern instead","content":"When implementing a plan generated in a prior session, files may have been modified since the plan was written. Prefer searching for method signature patterns rather than relying on exact line numbers provided in the plan.","topic":null,"source_type":"plan","source_issue":6317,"source_repo":null,"created_at":"2026-04-10T03:55:35.397280+00:00","updated_at":"2026-04-10T03:55:35.397281+00:00","valid_from":"2026-04-10T03:55:35.397280+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WP","title":"Plan line numbers become stale; search by pattern instead","topic":null,"source_type":"plan","source_issue":6317,"source_repo":null,"created_at":"2026-04-10T03:55:35.397280+00:00","updated_at":"2026-04-10T03:55:35.397281+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Cross-cutting methods as callbacks, not new classes
-
-
 
 Methods called by 4+ concerns (like `_escalate_to_hitl` and `_publish_review_status`) should stay on the origin class and be passed as bound-method callbacks to extracted coordinators. This avoids creating yet another coordinator just for common operations and matches the established PostMergeHandler/MergeApprovalContext callback pattern.
 
 _Source: #6321 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WT","title":"Cross-cutting methods as callbacks, not new classes","content":"Methods called by 4+ concerns (like `_escalate_to_hitl` and `_publish_review_status`) should stay on the origin class and be passed as bound-method callbacks to extracted coordinators. This avoids creating yet another coordinator just for common operations and matches the established PostMergeHandler/MergeApprovalContext callback pattern.","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375208+00:00","updated_at":"2026-04-10T04:19:28.375220+00:00","valid_from":"2026-04-10T04:19:28.375208+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WT","title":"Cross-cutting methods as callbacks, not new classes","topic":null,"source_type":"plan","source_issue":6321,"source_repo":null,"created_at":"2026-04-10T04:19:28.375208+00:00","updated_at":"2026-04-10T04:19:28.375220+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Regex-based test parsing creates hard constraints on source structure
-
-
 
 `test_loop_wiring_completeness.py` uses regex to parse `orchestrator.py` source for patterns like `('triage', self._triage_loop)` in loop_factories. Refactoring must preserve both the physical location and format of these definitions in orchestrator.py, not just the functionality. Any change to how loop_factories is defined will break the regex match and cause test failures, making this a critical constraint.
 
 _Source: #6323 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WZ","title":"Regex-based test parsing creates hard constraints on source structure","content":"`test_loop_wiring_completeness.py` uses regex to parse `orchestrator.py` source for patterns like `('triage', self._triage_loop)` in loop_factories. Refactoring must preserve both the physical location and format of these definitions in orchestrator.py, not just the functionality. Any change to how loop_factories is defined will break the regex match and cause test failures, making this a critical constraint.","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630689+00:00","updated_at":"2026-04-10T04:47:03.630691+00:00","valid_from":"2026-04-10T04:47:03.630689+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WZ","title":"Regex-based test parsing creates hard constraints on source structure","topic":null,"source_type":"plan","source_issue":6323,"source_repo":null,"created_at":"2026-04-10T04:47:03.630689+00:00","updated_at":"2026-04-10T04:47:03.630691+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Grep-based verification validates dead code removal completeness
-
-
 
 After removing orphaned modules, use systematic grep for `from X import` patterns across src/ and tests/ to confirm no remaining references. This catches both direct imports and transitive dependencies, and serves as the acceptance criterion for cleanup completeness.
 
 _Source: #6365 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQC","title":"Grep-based verification validates dead code removal completeness","content":"After removing orphaned modules, use systematic grep for `from X import` patterns across src/ and tests/ to confirm no remaining references. This catches both direct imports and transitive dependencies, and serves as the acceptance criterion for cleanup completeness.","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461050+00:00","updated_at":"2026-04-10T07:59:04.461051+00:00","valid_from":"2026-04-10T07:59:04.461050+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQC","title":"Grep-based verification validates dead code removal completeness","topic":null,"source_type":"plan","source_issue":6365,"source_repo":null,"created_at":"2026-04-10T07:59:04.461050+00:00","updated_at":"2026-04-10T07:59:04.461051+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Dead code removal verification via grep across codebase
-
-
 
 When removing unused functions, verify with grep across both src/ and tests/ directories to ensure no remaining references. Pattern: grep -rn "symbol_name" src/ and grep -rn "symbol_name" tests/ should both return zero results after removal.
 
 _Source: #6366 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQD","title":"Dead code removal verification via grep across codebase","content":"When removing unused functions, verify with grep across both src/ and tests/ directories to ensure no remaining references. Pattern: grep -rn \"symbol_name\" src/ and grep -rn \"symbol_name\" tests/ should both return zero results after removal.","topic":null,"source_type":"plan","source_issue":6366,"source_repo":null,"created_at":"2026-04-10T08:02:02.177024+00:00","updated_at":"2026-04-10T08:02:02.177033+00:00","valid_from":"2026-04-10T08:02:02.177024+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQD","title":"Dead code removal verification via grep across codebase","topic":null,"source_type":"plan","source_issue":6366,"source_repo":null,"created_at":"2026-04-10T08:02:02.177024+00:00","updated_at":"2026-04-10T08:02:02.177033+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Audit __all__ exports when removing public functions
-
-
 
 When removing public functions, check for stale __all__ exports or module re-exports that might still reference the removed symbols. This prevents subtle import errors and keeps the public API surface clean and explicit.
 
 _Source: #6366 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQQE","title":"Audit __all__ exports when removing public functions","content":"When removing public functions, check for stale __all__ exports or module re-exports that might still reference the removed symbols. This prevents subtle import errors and keeps the public API surface clean and explicit.","topic":null,"source_type":"plan","source_issue":6366,"source_repo":null,"created_at":"2026-04-10T08:02:02.177061+00:00","updated_at":"2026-04-10T08:02:02.177063+00:00","valid_from":"2026-04-10T08:02:02.177061+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQQE","title":"Audit __all__ exports when removing public functions","topic":null,"source_type":"plan","source_issue":6366,"source_repo":null,"created_at":"2026-04-10T08:02:02.177061+00:00","updated_at":"2026-04-10T08:02:02.177063+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Preserve module-specific guards when extracting duplicated logic
-
-
 
 When consolidating duplicated parsing patterns, keep module-specific behavior (e.g., empty-transcript guards) outside the shared helper. In plan_compliance.py, the early-return guard precedes the shared pattern and must not be folded into the helper function. Extract only the common logic, leaving module-specific pre- or post-conditions in place.
 
 _Source: #6349 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPG","title":"Preserve module-specific guards when extracting duplicated logic","content":"When consolidating duplicated parsing patterns, keep module-specific behavior (e.g., empty-transcript guards) outside the shared helper. In plan_compliance.py, the early-return guard precedes the shared pattern and must not be folded into the helper function. Extract only the common logic, leaving module-specific pre- or post-conditions in place.","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972401+00:00","updated_at":"2026-04-10T06:47:04.972412+00:00","valid_from":"2026-04-10T06:47:04.972401+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPG","title":"Preserve module-specific guards when extracting duplicated logic","topic":null,"source_type":"plan","source_issue":6349,"source_repo":null,"created_at":"2026-04-10T06:47:04.972401+00:00","updated_at":"2026-04-10T06:47:04.972412+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Grep word-boundary verification for constant extraction refactors
-
-
 
 After extracting magic numbers, verify completeness using grep word-boundary searches: grep -rn '\\b<literal>\\b' src/ tests/ should return exactly 1 match (the constant definition). Catches incomplete replacements and is language-agnostic, working across files and modules.
 
 _Source: #6341 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP9","title":"Grep word-boundary verification for constant extraction refactors","content":"After extracting magic numbers, verify completeness using grep word-boundary searches: grep -rn '\\\\b<literal>\\\\b' src/ tests/ should return exactly 1 match (the constant definition). Catches incomplete replacements and is language-agnostic, working across files and modules.","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281162+00:00","updated_at":"2026-04-10T06:22:03.281163+00:00","valid_from":"2026-04-10T06:22:03.281162+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP9","title":"Grep word-boundary verification for constant extraction refactors","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281162+00:00","updated_at":"2026-04-10T06:22:03.281163+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Design extracted methods for future integration without implementing it
-
-
 
 Accept parameters that aren't currently used (e.g., `release_url` in `_build_close_comment()` is always passed as empty string) if they enable future feature work without forcing changes later. This is the inverse of premature abstraction: you're adding a seam, not a full feature.
 
 _Source: #6342 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPA","title":"Design extracted methods for future integration without implementing it","content":"Accept parameters that aren't currently used (e.g., `release_url` in `_build_close_comment()` is always passed as empty string) if they enable future feature work without forcing changes later. This is the inverse of premature abstraction: you're adding a seam, not a full feature.","topic":null,"source_type":"plan","source_issue":6342,"source_repo":null,"created_at":"2026-04-10T06:32:57.301525+00:00","updated_at":"2026-04-10T06:32:57.301526+00:00","valid_from":"2026-04-10T06:32:57.301525+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPA","title":"Design extracted methods for future integration without implementing it","topic":null,"source_type":"plan","source_issue":6342,"source_repo":null,"created_at":"2026-04-10T06:32:57.301525+00:00","updated_at":"2026-04-10T06:32:57.301526+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Backward-compat layers require individual liveness evaluation
-
-
 
 Backward-compatibility property collections may contain both live and dead items that cannot be blanket-evaluated. Example: review_phase.py has active _run_post_merge_hooks alongside dead _save_conflict_transcript. Verify each property individually rather than assuming a layer is wholly live or wholly dead.
 
 _Source: #6345 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPC","title":"Backward-compat layers require individual liveness evaluation","content":"Backward-compatibility property collections may contain both live and dead items that cannot be blanket-evaluated. Example: review_phase.py has active _run_post_merge_hooks alongside dead _save_conflict_transcript. Verify each property individually rather than assuming a layer is wholly live or wholly dead.","topic":null,"source_type":"plan","source_issue":6345,"source_repo":null,"created_at":"2026-04-10T06:35:05.468495+00:00","updated_at":"2026-04-10T06:35:05.468496+00:00","valid_from":"2026-04-10T06:35:05.468495+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPC","title":"Backward-compat layers require individual liveness evaluation","topic":null,"source_type":"plan","source_issue":6345,"source_repo":null,"created_at":"2026-04-10T06:35:05.468495+00:00","updated_at":"2026-04-10T06:35:05.468496+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Use method names not line numbers for refactoring plans
-
-
 
 Identify code to remove by symbol name (def method_name) rather than line numbers. Files drift; methods remain stable. This reduces off-by-N errors and makes plans self-correcting when file structure changes.
 
 _Source: #6346 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPD","title":"Use method names not line numbers for refactoring plans","content":"Identify code to remove by symbol name (def method_name) rather than line numbers. Files drift; methods remain stable. This reduces off-by-N errors and makes plans self-correcting when file structure changes.","topic":null,"source_type":"plan","source_issue":6346,"source_repo":null,"created_at":"2026-04-10T06:38:22.369945+00:00","updated_at":"2026-04-10T06:38:22.369947+00:00","valid_from":"2026-04-10T06:38:22.369945+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPD","title":"Use method names not line numbers for refactoring plans","topic":null,"source_type":"plan","source_issue":6346,"source_repo":null,"created_at":"2026-04-10T06:38:22.369945+00:00","updated_at":"2026-04-10T06:38:22.369947+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Document trade-off when removing implicit documentation
-
-
 
 When a method like invalidate() serves as implicit documentation (its list of attributes documents cache structure), note that removal trades explicitness for simplicity. The data structure remains self-documenting through __init__ and usage patterns.
 
 _Source: #6346 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPE","title":"Document trade-off when removing implicit documentation","content":"When a method like invalidate() serves as implicit documentation (its list of attributes documents cache structure), note that removal trades explicitness for simplicity. The data structure remains self-documenting through __init__ and usage patterns.","topic":null,"source_type":"plan","source_issue":6346,"source_repo":null,"created_at":"2026-04-10T06:38:22.369952+00:00","updated_at":"2026-04-10T06:38:22.369953+00:00","valid_from":"2026-04-10T06:38:22.369952+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPE","title":"Document trade-off when removing implicit documentation","topic":null,"source_type":"plan","source_issue":6346,"source_repo":null,"created_at":"2026-04-10T06:38:22.369952+00:00","updated_at":"2026-04-10T06:38:22.369953+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Line number shifts in multi-PR merges break implementation plans
-
-
 
 When a plan specifies exact line numbers for edits, document the search pattern (e.g., `def approve_count`) as a fallback. If other PRs merge first, line numbers shift—search-based edits remain valid and reduce merge conflicts.
 
 _Source: #6347 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPF","title":"Line number shifts in multi-PR merges break implementation plans","content":"When a plan specifies exact line numbers for edits, document the search pattern (e.g., `def approve_count`) as a fallback. If other PRs merge first, line numbers shift—search-based edits remain valid and reduce merge conflicts.","topic":null,"source_type":"plan","source_issue":6347,"source_repo":null,"created_at":"2026-04-10T06:40:05.820990+00:00","updated_at":"2026-04-10T06:40:05.820992+00:00","valid_from":"2026-04-10T06:40:05.820990+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPF","title":"Line number shifts in multi-PR merges break implementation plans","topic":null,"source_type":"plan","source_issue":6347,"source_repo":null,"created_at":"2026-04-10T06:40:05.820990+00:00","updated_at":"2026-04-10T06:40:05.820992+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Use underscore prefix for local implementation details in functions
-
-
 
 When defining intermediate variables in module-level functions (e.g., `_runner_kwargs`), use leading underscore to signal they are private implementation details, not public API. This convention improves readability and signals intent to future readers that the variable is not meant for external use.
 
 _Source: #6354 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPV","title":"Use underscore prefix for local implementation details in functions","content":"When defining intermediate variables in module-level functions (e.g., `_runner_kwargs`), use leading underscore to signal they are private implementation details, not public API. This convention improves readability and signals intent to future readers that the variable is not meant for external use.","topic":null,"source_type":"plan","source_issue":6354,"source_repo":null,"created_at":"2026-04-10T07:09:55.773138+00:00","updated_at":"2026-04-10T07:09:55.773141+00:00","valid_from":"2026-04-10T07:09:55.773138+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPV","title":"Use underscore prefix for local implementation details in functions","topic":null,"source_type":"plan","source_issue":6354,"source_repo":null,"created_at":"2026-04-10T07:09:55.773138+00:00","updated_at":"2026-04-10T07:09:55.773141+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Partial migrations of similar components create maintenance burden
-
-
 
 When multiple similar classes share the same pattern (e.g., 8 runner instantiations with identical kwargs), refactoring only some of them creates future maintenance risk. Always refactor all instances together, even if some seem unnecessary. Use explicit line-number lists to catch all occurrences and prevent partial migrations.
 
 _Source: #6354 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPT","title":"Partial migrations of similar components create maintenance burden","content":"When multiple similar classes share the same pattern (e.g., 8 runner instantiations with identical kwargs), refactoring only some of them creates future maintenance risk. Always refactor all instances together, even if some seem unnecessary. Use explicit line-number lists to catch all occurrences and prevent partial migrations.","topic":null,"source_type":"plan","source_issue":6354,"source_repo":null,"created_at":"2026-04-10T07:09:55.773107+00:00","updated_at":"2026-04-10T07:09:55.773111+00:00","valid_from":"2026-04-10T07:09:55.773107+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPT","title":"Partial migrations of similar components create maintenance burden","topic":null,"source_type":"plan","source_issue":6354,"source_repo":null,"created_at":"2026-04-10T07:09:55.773107+00:00","updated_at":"2026-04-10T07:09:55.773111+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture-state-persistence.md
+++ b/docs/wiki/architecture-state-persistence.md
@@ -1,223 +1,223 @@
-# Architecture State Persistence
+# Architecture-State-Persistence
+
 
 ## State Persistence: Atomic Writes and Backup Recovery
 
-
-
 All critical file operations use atomic write patterns to prevent partial corruption on crash: write to temp file, fsync for durability, then os.replace() for atomic swap. Use centralized utilities: `file_util.atomic_write()` for entire file rewrites (e.g., JSONL rotations) and `file_util.append_jsonl()` for crash-safe appends with automatic mkdir, flush, and fsync. For JSONL rotation/trimming: read, filter, write atomically; acquire exclusive file lock (.{filename}.lock) for the entire read-filter-write cycle to prevent TOCTOU bugs. Cache JSONL parsing results with TTL patterns for HTTP handlers. StateTracker uses backup pattern: save .bak backup before overwriting; restore from backup if main file corrupts. Single-writer assumption (async orchestrator) eliminates need for write-ahead logging. Applies to WAL files, state snapshots, JSONL stores, and configuration.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0VS","title":"State Persistence: Atomic Writes and Backup Recovery","content":"All critical file operations use atomic write patterns to prevent partial corruption on crash: write to temp file, fsync for durability, then os.replace() for atomic swap. Use centralized utilities: `file_util.atomic_write()` for entire file rewrites (e.g., JSONL rotations) and `file_util.append_jsonl()` for crash-safe appends with automatic mkdir, flush, and fsync. For JSONL rotation/trimming: read, filter, write atomically; acquire exclusive file lock (.{filename}.lock) for the entire read-filter-write cycle to prevent TOCTOU bugs. Cache JSONL parsing results with TTL patterns for HTTP handlers. StateTracker uses backup pattern: save .bak backup before overwriting; restore from backup if main file corrupts. Single-writer assumption (async orchestrator) eliminates need for write-ahead logging. Applies to WAL files, state snapshots, JSONL stores, and configuration.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849528+00:00","updated_at":"2026-04-10T03:41:18.849529+00:00","valid_from":"2026-04-10T03:41:18.849528+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0VS","title":"State Persistence: Atomic Writes and Backup Recovery","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849528+00:00","updated_at":"2026-04-10T03:41:18.849529+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## In-Place Mutation Requirement for Shared Dicts
-
-
 
 If any sub-component reassigns a dict (e.g., `self._queues = {}`) instead of mutating in-place (e.g., `self._queues[stage].clear()`), the shared reference breaks and mutations become invisible to other components. This is the central risk — all state mutations in extracted classes must be in-place, not reassignment.
 
 _Source: #6327 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X5","title":"In-Place Mutation Requirement for Shared Dicts","content":"If any sub-component reassigns a dict (e.g., `self._queues = {}`) instead of mutating in-place (e.g., `self._queues[stage].clear()`), the shared reference breaks and mutations become invisible to other components. This is the central risk — all state mutations in extracted classes must be in-place, not reassignment.","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384588+00:00","updated_at":"2026-04-10T05:07:55.384589+00:00","valid_from":"2026-04-10T05:07:55.384588+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X5","title":"In-Place Mutation Requirement for Shared Dicts","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384588+00:00","updated_at":"2026-04-10T05:07:55.384589+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Immutable Scalars in Shared State Pattern
-
-
 
 `_last_poll_ts` (a string) cannot be shared by reference like dicts — reassignment on the facade doesn't propagate to sub-components. Solution: snapshot's `get_queue_stats()` accepts `last_poll_ts` as a parameter; the facade passes `self._last_poll_ts` at call time. This pattern applies to any immutable scalar in shared state.
 
 _Source: #6327 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0X7","title":"Immutable Scalars in Shared State Pattern","content":"`_last_poll_ts` (a string) cannot be shared by reference like dicts — reassignment on the facade doesn't propagate to sub-components. Solution: snapshot's `get_queue_stats()` accepts `last_poll_ts` as a parameter; the facade passes `self._last_poll_ts` at call time. This pattern applies to any immutable scalar in shared state.","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384597+00:00","updated_at":"2026-04-10T05:07:55.384598+00:00","valid_from":"2026-04-10T05:07:55.384597+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0X7","title":"Immutable Scalars in Shared State Pattern","topic":null,"source_type":"plan","source_issue":6327,"source_repo":null,"created_at":"2026-04-10T05:07:55.384597+00:00","updated_at":"2026-04-10T05:07:55.384598+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Feature Gates and Configuration-Driven Behavior
 
-
-
 When a feature depends on unimplemented prerequisites, gate the entire feature behind a config flag (default False) rather than attempting runtime degradation. This isolates incomplete work, prevents confusing partial-state behavior, and makes the feature truly opt-in until dependencies land. Example: `post_acceptance_tracking_enabled` in config. Test both enabled and disabled paths separately. For optional allocations, add feature functionality via `get_allocation(label, fallback_cap)` method that returns config-defined caps when feature enabled, falling back to fallback_cap when no budget set. This ensures zero behavioral change when feature disabled and allows safe feature rollout without regressions. Individual section caps serve as `max_chars` overrides, preserving existing guardrails. Backward compatibility is preserved: old code paths continue unchanged when feature is disabled. See also: Optional Dependencies for runtime service handling.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W2","title":"Feature Gates and Configuration-Driven Behavior","content":"When a feature depends on unimplemented prerequisites, gate the entire feature behind a config flag (default False) rather than attempting runtime degradation. This isolates incomplete work, prevents confusing partial-state behavior, and makes the feature truly opt-in until dependencies land. Example: `post_acceptance_tracking_enabled` in config. Test both enabled and disabled paths separately. For optional allocations, add feature functionality via `get_allocation(label, fallback_cap)` method that returns config-defined caps when feature enabled, falling back to fallback_cap when no budget set. This ensures zero behavioral change when feature disabled and allows safe feature rollout without regressions. Individual section caps serve as `max_chars` overrides, preserving existing guardrails. Backward compatibility is preserved: old code paths continue unchanged when feature is disabled. See also: Optional Dependencies for runtime service handling.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849567+00:00","updated_at":"2026-04-10T03:41:18.849568+00:00","valid_from":"2026-04-10T03:41:18.849567+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W2","title":"Feature Gates and Configuration-Driven Behavior","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849567+00:00","updated_at":"2026-04-10T03:41:18.849568+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Dataclass Design for Schema Evolution and Backward Compatibility
 
-
-
 Use TypedDict with total=False or Pydantic dataclasses with optional fields for backward-compatible schema evolution. Missing fields handled gracefully with .get(key, default). Use frozen dataclasses (`@dataclass(frozen=True, slots=True)`) to bundle context parameters that won't change at runtime. Include optional fields with empty string defaults for fields not yet populated, preventing accidental mutation and making contracts explicit. Placeholder fields anticipate feature extension points: add fields for planned features even if data sources don't exist yet, defaulting to empty strings with docstring notes. Model fields should include optional metadata that can be populated opportunistically, avoiding breaking changes later. Ensure all fields have non-empty defaults if parametrized tests override individual fields. String annotations and `from __future__ import annotations` enable Literal and forward references without runtime overhead. For JSONL records, add new fields as optional with sensible defaults; existing consumers tolerate extra keys automatically. Legacy records without new fields remain valid via fallback logic.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W3","title":"Dataclass Design for Schema Evolution and Backward Compatibility","content":"Use TypedDict with total=False or Pydantic dataclasses with optional fields for backward-compatible schema evolution. Missing fields handled gracefully with .get(key, default). Use frozen dataclasses (`@dataclass(frozen=True, slots=True)`) to bundle context parameters that won't change at runtime. Include optional fields with empty string defaults for fields not yet populated, preventing accidental mutation and making contracts explicit. Placeholder fields anticipate feature extension points: add fields for planned features even if data sources don't exist yet, defaulting to empty strings with docstring notes. Model fields should include optional metadata that can be populated opportunistically, avoiding breaking changes later. Ensure all fields have non-empty defaults if parametrized tests override individual fields. String annotations and `from __future__ import annotations` enable Literal and forward references without runtime overhead. For JSONL records, add new fields as optional with sensible defaults; existing consumers tolerate extra keys automatically. Legacy records without new fields remain valid via fallback logic.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849570+00:00","updated_at":"2026-04-10T03:41:18.849572+00:00","valid_from":"2026-04-10T03:41:18.849570+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W3","title":"Dataclass Design for Schema Evolution and Backward Compatibility","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849570+00:00","updated_at":"2026-04-10T03:41:18.849572+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Annotated[str, Validator] pattern for backward-compatible type narrowing
-
-
 
 Use `Annotated[str, AfterValidator(...)]` to add runtime validation to string fields while maintaining serialization compatibility. This pattern serializes identically to bare `str` in JSON output, enabling strict validation at construction time without breaking existing JSON schema or client contracts. Useful for retrofitting validation onto existing fields across Pydantic models.
 
 _Source: #6318 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WQ","title":"Annotated[str, Validator] pattern for backward-compatible type narrowing","content":"Use `Annotated[str, AfterValidator(...)]` to add runtime validation to string fields while maintaining serialization compatibility. This pattern serializes identically to bare `str` in JSON output, enabling strict validation at construction time without breaking existing JSON schema or client contracts. Useful for retrofitting validation onto existing fields across Pydantic models.","topic":null,"source_type":"plan","source_issue":6318,"source_repo":null,"created_at":"2026-04-10T04:05:05.202950+00:00","updated_at":"2026-04-10T04:05:05.202964+00:00","valid_from":"2026-04-10T04:05:05.202950+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WQ","title":"Annotated[str, Validator] pattern for backward-compatible type narrowing","topic":null,"source_type":"plan","source_issue":6318,"source_repo":null,"created_at":"2026-04-10T04:05:05.202950+00:00","updated_at":"2026-04-10T04:05:05.202964+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Use Literal types for bounded enum-like fields
-
-
 
 Model fields with known bounded values should use Literal types rather than bare str. The codebase establishes this pattern (VisualEvidenceItem.status, Release.status). This provides compile-time validation and IDE autocomplete, catching invalid values at construction rather than runtime.
 
 _Source: #6320 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WS","title":"Use Literal types for bounded enum-like fields","content":"Model fields with known bounded values should use Literal types rather than bare str. The codebase establishes this pattern (VisualEvidenceItem.status, Release.status). This provides compile-time validation and IDE autocomplete, catching invalid values at construction rather than runtime.","topic":null,"source_type":"plan","source_issue":6320,"source_repo":null,"created_at":"2026-04-10T04:14:20.752849+00:00","updated_at":"2026-04-10T04:14:20.752855+00:00","valid_from":"2026-04-10T04:14:20.752849+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WS","title":"Use Literal types for bounded enum-like fields","topic":null,"source_type":"plan","source_issue":6320,"source_repo":null,"created_at":"2026-04-10T04:14:20.752849+00:00","updated_at":"2026-04-10T04:14:20.752855+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Dict-to-Model Conversion Pattern for Type Safety
-
-
 
 When callers use `.get()` on return values, convert the return type from `list[dict[str, Any]]` to a typed Pydantic model like `list[GitHubIssue]`. This eliminates fragile dict access and enables type checking. Update all callers together—avoid partial migrations where some code uses attributes and some uses `.get()`.
 
 _Source: #6322 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WX","title":"Dict-to-Model Conversion Pattern for Type Safety","content":"When callers use `.get()` on return values, convert the return type from `list[dict[str, Any]]` to a typed Pydantic model like `list[GitHubIssue]`. This eliminates fragile dict access and enables type checking. Update all callers together—avoid partial migrations where some code uses attributes and some uses `.get()`.","topic":null,"source_type":"plan","source_issue":6322,"source_repo":null,"created_at":"2026-04-10T04:31:05.960687+00:00","updated_at":"2026-04-10T04:31:05.960695+00:00","valid_from":"2026-04-10T04:31:05.960687+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WX","title":"Dict-to-Model Conversion Pattern for Type Safety","topic":null,"source_type":"plan","source_issue":6322,"source_repo":null,"created_at":"2026-04-10T04:31:05.960687+00:00","updated_at":"2026-04-10T04:31:05.960695+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Empty String Sentinel with Union Type Annotation
-
-
 
 To allow a default empty string while maintaining type safety for valid values, use `FieldType | Literal[""]`. This pattern enables optional/unset states in strongly-typed fields without sacrificing validation of non-empty values.
 
 _Source: #6335 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNQ","title":"Empty String Sentinel with Union Type Annotation","content":"To allow a default empty string while maintaining type safety for valid values, use `FieldType | Literal[\"\"]`. This pattern enables optional/unset states in strongly-typed fields without sacrificing validation of non-empty values.","topic":null,"source_type":"plan","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T05:43:58.108257+00:00","updated_at":"2026-04-10T05:43:58.108261+00:00","valid_from":"2026-04-10T05:43:58.108257+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNQ","title":"Empty String Sentinel with Union Type Annotation","topic":null,"source_type":"plan","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T05:43:58.108257+00:00","updated_at":"2026-04-10T05:43:58.108261+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## StrEnum Fields Serialize Without Migration
-
-
 
 StrEnum fields serialize to the same string values already persisted in storage (state.json, etc.). Converting a bare `str` field to StrEnum is schema-additive and requires no data migration per ADR-0021 (persistence architecture).
 
 _Source: #6335 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNR","title":"StrEnum Fields Serialize Without Migration","content":"StrEnum fields serialize to the same string values already persisted in storage (state.json, etc.). Converting a bare `str` field to StrEnum is schema-additive and requires no data migration per ADR-0021 (persistence architecture).","topic":null,"source_type":"plan","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T05:43:58.108275+00:00","updated_at":"2026-04-10T05:43:58.108277+00:00","valid_from":"2026-04-10T05:43:58.108275+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNR","title":"StrEnum Fields Serialize Without Migration","topic":null,"source_type":"plan","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T05:43:58.108275+00:00","updated_at":"2026-04-10T05:43:58.108277+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Naming conventions are pipeline-layer scoped
-
-
 
 The GitHub-issue pipeline layer uses `issue_number` naming convention, but other domains (caching, memory scoring, review) intentionally keep `issue_id`. Don't over-generalize renames across modules—respect domain boundaries and only align naming where architectural layers actually overlap.
 
 _Source: #6337 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNS","title":"Naming conventions are pipeline-layer scoped","content":"The GitHub-issue pipeline layer uses `issue_number` naming convention, but other domains (caching, memory scoring, review) intentionally keep `issue_id`. Don't over-generalize renames across modules—respect domain boundaries and only align naming where architectural layers actually overlap.","topic":null,"source_type":"plan","source_issue":6337,"source_repo":null,"created_at":"2026-04-10T05:49:11.253569+00:00","updated_at":"2026-04-10T05:49:11.253573+00:00","valid_from":"2026-04-10T05:49:11.253569+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNS","title":"Naming conventions are pipeline-layer scoped","topic":null,"source_type":"plan","source_issue":6337,"source_repo":null,"created_at":"2026-04-10T05:49:11.253569+00:00","updated_at":"2026-04-10T05:49:11.253573+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## f-string output decoupled from parameter naming
-
-
 
 Directory path format `issue-{N}` comes from f-string template, not the parameter name. Renaming the parameter doesn't affect directory structure, making the rename purely cosmetic at the output level.
 
 _Source: #6337 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNT","title":"f-string output decoupled from parameter naming","content":"Directory path format `issue-{N}` comes from f-string template, not the parameter name. Renaming the parameter doesn't affect directory structure, making the rename purely cosmetic at the output level.","topic":null,"source_type":"plan","source_issue":6337,"source_repo":null,"created_at":"2026-04-10T05:49:11.253590+00:00","updated_at":"2026-04-10T05:49:11.253591+00:00","valid_from":"2026-04-10T05:49:11.253590+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNT","title":"f-string output decoupled from parameter naming","topic":null,"source_type":"plan","source_issue":6337,"source_repo":null,"created_at":"2026-04-10T05:49:11.253590+00:00","updated_at":"2026-04-10T05:49:11.253591+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## FastAPI route registration order affects specificity matching
-
-
 
 In FastAPI, routes are matched in registration order. Generic routes like `/{path:path}` (SPA catch-all) must be registered last or they shadow more specific routes. When decomposing monolithic route handlers into sub-modules, document the required registration order and verify catch-all placement during refactoring.
 
 _Source: #6336 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNY","title":"FastAPI route registration order affects specificity matching","content":"In FastAPI, routes are matched in registration order. Generic routes like `/{path:path}` (SPA catch-all) must be registered last or they shadow more specific routes. When decomposing monolithic route handlers into sub-modules, document the required registration order and verify catch-all placement during refactoring.","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732493+00:00","updated_at":"2026-04-10T05:57:03.732510+00:00","valid_from":"2026-04-10T05:57:03.732493+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNY","title":"FastAPI route registration order affects specificity matching","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732493+00:00","updated_at":"2026-04-10T05:57:03.732510+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Convert closure mutable state to class-based encapsulation
-
-
 
 When extracting stateful closures (e.g., cache dicts, timestamp lists, file paths) into separate modules, convert them into a class that encapsulates mutable state and provides methods. This replaces closure-scoped variables with instance state and makes cache invalidation logic explicit and testable rather than implicit in helper functions.
 
 _Source: #6336 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQNZ","title":"Convert closure mutable state to class-based encapsulation","content":"When extracting stateful closures (e.g., cache dicts, timestamp lists, file paths) into separate modules, convert them into a class that encapsulates mutable state and provides methods. This replaces closure-scoped variables with instance state and makes cache invalidation logic explicit and testable rather than implicit in helper functions.","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732527+00:00","updated_at":"2026-04-10T05:57:03.732530+00:00","valid_from":"2026-04-10T05:57:03.732527+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQNZ","title":"Convert closure mutable state to class-based encapsulation","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732527+00:00","updated_at":"2026-04-10T05:57:03.732530+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Endpoint path preservation enables test reuse across refactors
-
-
 
 When refactoring monolithic route handlers into sub-modules, if endpoint paths remain unchanged, existing test files need no modification—they match endpoints by HTTP path, not by internal function structure. This allows high-confidence refactoring with zero test churn, since `make test` validates the entire endpoint surface area automatically.
 
 _Source: #6336 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP0","title":"Endpoint path preservation enables test reuse across refactors","content":"When refactoring monolithic route handlers into sub-modules, if endpoint paths remain unchanged, existing test files need no modification—they match endpoints by HTTP path, not by internal function structure. This allows high-confidence refactoring with zero test churn, since `make test` validates the entire endpoint surface area automatically.","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732536+00:00","updated_at":"2026-04-10T05:57:03.732539+00:00","valid_from":"2026-04-10T05:57:03.732536+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP0","title":"Endpoint path preservation enables test reuse across refactors","topic":null,"source_type":"plan","source_issue":6336,"source_repo":null,"created_at":"2026-04-10T05:57:03.732536+00:00","updated_at":"2026-04-10T05:57:03.732539+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Pydantic Field() accepts module-level int constants safely
-
-
 
 Pydantic Field(le=...), Field(default=...), and Field(ge=...) accept plain int constants identically to literals. When extracting magic numbers into module-level constants for config classes, substitution is type-correct and requires no Pydantic-specific handling or adaptation.
 
 _Source: #6341 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQP7","title":"Pydantic Field() accepts module-level int constants safely","content":"Pydantic Field(le=...), Field(default=...), and Field(ge=...) accept plain int constants identically to literals. When extracting magic numbers into module-level constants for config classes, substitution is type-correct and requires no Pydantic-specific handling or adaptation.","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281124+00:00","updated_at":"2026-04-10T06:22:03.281131+00:00","valid_from":"2026-04-10T06:22:03.281124+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQP7","title":"Pydantic Field() accepts module-level int constants safely","topic":null,"source_type":"plan","source_issue":6341,"source_repo":null,"created_at":"2026-04-10T06:22:03.281124+00:00","updated_at":"2026-04-10T06:22:03.281131+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Path prefix pattern for hierarchical object keys
-
-
 
 When building dotted paths for nested objects, use `f"{path_prefix}.{key}" if path_prefix else key` to correctly handle both root-level (`key`) and nested (`parent.key`) cases. This avoids leading dots and false positives in path matching.
 
 _Source: #6352 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPS","title":"Path prefix pattern for hierarchical object keys","content":"When building dotted paths for nested objects, use `f\"{path_prefix}.{key}\" if path_prefix else key` to correctly handle both root-level (`key`) and nested (`parent.key`) cases. This avoids leading dots and false positives in path matching.","topic":null,"source_type":"plan","source_issue":6352,"source_repo":null,"created_at":"2026-04-10T07:02:55.409396+00:00","updated_at":"2026-04-10T07:02:55.409404+00:00","valid_from":"2026-04-10T07:02:55.409396+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPS","title":"Path prefix pattern for hierarchical object keys","topic":null,"source_type":"plan","source_issue":6352,"source_repo":null,"created_at":"2026-04-10T07:02:55.409396+00:00","updated_at":"2026-04-10T07:02:55.409404+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Accept typed enums, call .value internally
-
-
 
 Helper methods should accept typed enums (ReviewerStatus, ReviewVerdict) at the signature level for caller type safety, then call `.value` internally when building string-keyed payloads. This pattern improves type checking at call sites without forcing callers to extract enum values manually.
 
 _Source: #6351 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G8FNMGPZN5Y298JQPR","title":"Accept typed enums, call .value internally","content":"Helper methods should accept typed enums (ReviewerStatus, ReviewVerdict) at the signature level for caller type safety, then call `.value` internally when building string-keyed payloads. This pattern improves type checking at call sites without forcing callers to extract enum values manually.","topic":null,"source_type":"plan","source_issue":6351,"source_repo":null,"created_at":"2026-04-10T06:58:24.321769+00:00","updated_at":"2026-04-10T06:58:24.321771+00:00","valid_from":"2026-04-10T06:58:24.321769+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G8FNMGPZN5Y298JQPR","title":"Accept typed enums, call .value internally","topic":null,"source_type":"plan","source_issue":6351,"source_repo":null,"created_at":"2026-04-10T06:58:24.321769+00:00","updated_at":"2026-04-10T06:58:24.321771+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Parametrized validation rejection tests follow annotated-type pattern
-
-
 
 Test annotated types by extending existing validation test classes with parametrized tests covering malformed inputs (rejection) and valid inputs (acceptance). This pattern isolates validation logic testing and reuses test infrastructure for new validators across multiple models.
 
 _Source: #6318 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WR","title":"Parametrized validation rejection tests follow annotated-type pattern","content":"Test annotated types by extending existing validation test classes with parametrized tests covering malformed inputs (rejection) and valid inputs (acceptance). This pattern isolates validation logic testing and reuses test infrastructure for new validators across multiple models.","topic":null,"source_type":"plan","source_issue":6318,"source_repo":null,"created_at":"2026-04-10T04:05:05.202985+00:00","updated_at":"2026-04-10T04:05:05.202986+00:00","valid_from":"2026-04-10T04:05:05.202985+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WR","title":"Parametrized validation rejection tests follow annotated-type pattern","topic":null,"source_type":"plan","source_issue":6318,"source_repo":null,"created_at":"2026-04-10T04:05:05.202985+00:00","updated_at":"2026-04-10T04:05:05.202986+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -1,168 +1,167 @@
 # Architecture
 
+
 ## ADR Documentation: Format, Citations, Validation, and Superseding
-
-
 
 ADRs use markdown with structured sections: Date, Status, Title, Context, Decision, Rationale, Consequences. Validation checklist: structural checks first (missing sections, status format), then semantic checks (scope significance, contradiction audit). Source citations use module:function format without line numbers per CLAUDE.md. Set status to Accepted for documenting existing implicit patterns, not just new proposals. Reference authoritative runtime sources (e.g., src/config.py:all_pipeline_labels) instead of copying definitions to avoid drift. Skip TYPE_CHECKING imports in citations since they're compile-time-only. Ghost entries (README listing files that don't exist) indicate stale migrations—validate documentation against filesystem reality. ADR Superseding Pattern: when a planned feature documented in an ADR is removed as dead code (never implemented), update the ADR status to 'Superseded by removal' and cross-reference the removal issue. This preserves architectural decision history and clarifies for future reimplementation attempts without duplicating work.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W6","title":"ADR Documentation: Format, Citations, Validation, and Superseding","content":"ADRs use markdown with structured sections: Date, Status, Title, Context, Decision, Rationale, Consequences. Validation checklist: structural checks first (missing sections, status format), then semantic checks (scope significance, contradiction audit). Source citations use module:function format without line numbers per CLAUDE.md. Set status to Accepted for documenting existing implicit patterns, not just new proposals. Reference authoritative runtime sources (e.g., src/config.py:all_pipeline_labels) instead of copying definitions to avoid drift. Skip TYPE_CHECKING imports in citations since they're compile-time-only. Ghost entries (README listing files that don't exist) indicate stale migrations—validate documentation against filesystem reality. ADR Superseding Pattern: when a planned feature documented in an ADR is removed as dead code (never implemented), update the ADR status to 'Superseded by removal' and cross-reference the removal issue. This preserves architectural decision history and clarifies for future reimplementation attempts without duplicating work.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849581+00:00","updated_at":"2026-04-10T03:41:18.849582+00:00","valid_from":"2026-04-10T03:41:18.849581+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W6","title":"ADR Documentation: Format, Citations, Validation, and Superseding","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849581+00:00","updated_at":"2026-04-10T03:41:18.849582+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Architecture Compliance and Quality Enforcement
 
-
-
 LLM-based architecture checks (arch_compliance.py, hf.audit-architecture skill) risk blocking every PR if prompts are too aggressive. Mitigations: (1) use conservative language ('only flag clear violations'); (2) default disable-friendly config (max_attempts=1); (3) exempt composition root (service_registry.py) explicitly; (4) focus on judgment-based checks that static tools cannot detect. Deferred imports are intentional per CLAUDE.md and should never be flagged. Async read-then-write patterns (fetch state, modify, write back) are a pre-existing limitation from original _run_gh calls and acceptable as known-constraint. Tests checking presence must assert content, not just structure (e.g., verify module names in layer assignments, not just that layer labels exist). Complement with defense-in-depth enforcement via three layers: linter rules (ruff T20/T10 for debug code), AST-based validation scripts (per-function test coverage), git hooks (commit message format). Pre-commit hook runs only make lint-check (intentional gap—agent pipeline and pre-push hook cover push path). This progressive hardening pattern prevents enforcement from blocking developers while maintaining quality standards. See also: Layer Architecture for compliance targets.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W7","title":"Architecture Compliance and Quality Enforcement","content":"LLM-based architecture checks (arch_compliance.py, hf.audit-architecture skill) risk blocking every PR if prompts are too aggressive. Mitigations: (1) use conservative language ('only flag clear violations'); (2) default disable-friendly config (max_attempts=1); (3) exempt composition root (service_registry.py) explicitly; (4) focus on judgment-based checks that static tools cannot detect. Deferred imports are intentional per CLAUDE.md and should never be flagged. Async read-then-write patterns (fetch state, modify, write back) are a pre-existing limitation from original _run_gh calls and acceptable as known-constraint. Tests checking presence must assert content, not just structure (e.g., verify module names in layer assignments, not just that layer labels exist). Complement with defense-in-depth enforcement via three layers: linter rules (ruff T20/T10 for debug code), AST-based validation scripts (per-function test coverage), git hooks (commit message format). Pre-commit hook runs only make lint-check (intentional gap—agent pipeline and pre-push hook cover push path). This progressive hardening pattern prevents enforcement from blocking developers while maintaining quality standards. See also: Layer Architecture for compliance targets.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849585+00:00","updated_at":"2026-04-10T03:41:18.849586+00:00","valid_from":"2026-04-10T03:41:18.849585+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W7","title":"Architecture Compliance and Quality Enforcement","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849585+00:00","updated_at":"2026-04-10T03:41:18.849586+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Workspace Isolation and Command Discovery via CWD
 
-
-
 Claude Code discovers commands from subprocess cwd's .claude/commands/, not from invoking process. Commands must be installed into every workspace, not just source repo. Pre-flight validation (before subprocess launch) catches stale commands due to external state changes. Defense-in-depth prevents agent commits to target repos: combine .gitignore hf.*.md entries + hf.* prefix namespace isolation. Built-in hf.* patterns always take priority over extra patterns in deduplication. Multiple registration mechanisms (bg_loop_registry dict, loop_factories tuple) require unified discovery via set union. Path traversal guard required for extra_tool_dirs to verify they don't escape repo boundary. See also: Dynamic Discovery for convention patterns.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W8","title":"Workspace Isolation and Command Discovery via CWD","content":"Claude Code discovers commands from subprocess cwd's .claude/commands/, not from invoking process. Commands must be installed into every workspace, not just source repo. Pre-flight validation (before subprocess launch) catches stale commands due to external state changes. Defense-in-depth prevents agent commits to target repos: combine .gitignore hf.*.md entries + hf.* prefix namespace isolation. Built-in hf.* patterns always take priority over extra patterns in deduplication. Multiple registration mechanisms (bg_loop_registry dict, loop_factories tuple) require unified discovery via set union. Path traversal guard required for extra_tool_dirs to verify they don't escape repo boundary. See also: Dynamic Discovery for convention patterns.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849589+00:00","updated_at":"2026-04-10T03:41:18.849590+00:00","valid_from":"2026-04-10T03:41:18.849589+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W8","title":"Workspace Isolation and Command Discovery via CWD","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849589+00:00","updated_at":"2026-04-10T03:41:18.849590+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Pre-Flight Validation and Escalation Pattern
 
-
-
 Insert validation checks after environment setup but before main work. Return early with WorkerResult(success=False) on failure and escalate to HITL via escalator. This pattern cleanly separates precondition checking from implementation logic without entangling them. See also: Idempotency Guards for post-execution validation, Prevent Scope Creep for validation as design constraint.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0W9","title":"Pre-Flight Validation and Escalation Pattern","content":"Insert validation checks after environment setup but before main work. Return early with WorkerResult(success=False) on failure and escalate to HITL via escalator. This pattern cleanly separates precondition checking from implementation logic without entangling them. See also: Idempotency Guards for post-execution validation, Prevent Scope Creep for validation as design constraint.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849593+00:00","updated_at":"2026-04-10T03:41:18.849594+00:00","valid_from":"2026-04-10T03:41:18.849593+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0W9","title":"Pre-Flight Validation and Escalation Pattern","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849593+00:00","updated_at":"2026-04-10T03:41:18.849594+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Prevent Scope Creep While Maintaining Correctness
 
-
-
 Implementation plans are guidelines, not barriers. If necessary correctness fixes fall outside plan scope, document the deviation and rationale. Scope deferral with tracking issues prevents scope creep: defer separate problems to future issues rather than expanding current scope. However, never defer fixes when partial/incomplete fixes leave latent bugs. Example: fixing one missing label field requires fixing all missing label fields at once, not just the mentioned ones. Pre-mortem identification of failure modes helps design mitigations upfront and prevents rework.
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WA","title":"Prevent Scope Creep While Maintaining Correctness","content":"Implementation plans are guidelines, not barriers. If necessary correctness fixes fall outside plan scope, document the deviation and rationale. Scope deferral with tracking issues prevents scope creep: defer separate problems to future issues rather than expanding current scope. However, never defer fixes when partial/incomplete fixes leave latent bugs. Example: fixing one missing label field requires fixing all missing label fields at once, not just the mentioned ones. Pre-mortem identification of failure modes helps design mitigations upfront and prevents rework.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849596+00:00","updated_at":"2026-04-10T03:41:18.849597+00:00","valid_from":"2026-04-10T03:41:18.849596+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WA","title":"Prevent Scope Creep While Maintaining Correctness","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T03:41:18.849596+00:00","updated_at":"2026-04-10T03:41:18.849597+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Model Duplication Across Codebase Suggests Ownership Clarity Issue
-
-
 
 Duplicate Pydantic/dataclass versions exist in separate files (adr_pre_validator.py, precheck.py) with canonical dataclasses in models.py. This pattern suggests either missing consolidation or unclear model ownership. Technical debt observation: future work should establish which file owns each model and whether duplicates indicate technical debt or deliberate isolation boundaries. Consider this during next refactoring pass or architectural review.
 
 _Source: #6312 (plan)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0WF","title":"Model Duplication Across Codebase Suggests Ownership Clarity Issue","content":"Duplicate Pydantic/dataclass versions exist in separate files (adr_pre_validator.py, precheck.py) with canonical dataclasses in models.py. This pattern suggests either missing consolidation or unclear model ownership. Technical debt observation: future work should establish which file owns each model and whether duplicates indicate technical debt or deliberate isolation boundaries. Consider this during next refactoring pass or architectural review.","topic":null,"source_type":"plan","source_issue":6312,"source_repo":null,"created_at":"2026-04-10T03:41:18.852333+00:00","updated_at":"2026-04-10T03:41:18.852336+00:00","valid_from":"2026-04-10T03:41:18.852333+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0WF","title":"Model Duplication Across Codebase Suggests Ownership Clarity Issue","topic":null,"source_type":"plan","source_issue":6312,"source_repo":null,"created_at":"2026-04-10T03:41:18.852333+00:00","updated_at":"2026-04-10T03:41:18.852336+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Validate diagram references point to existing code
-
-
 
 Architecture diagrams (e.g., .likec4 files) can reference non-existent test files or code paths, creating confusion about implementation status. Before merging diagram changes, validate that all references (test files, classes, modules) actually exist in the codebase. This caught tests referenced but never created.
 
 _Source: #6296 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XH","title":"Validate diagram references point to existing code","content":"Architecture diagrams (e.g., .likec4 files) can reference non-existent test files or code paths, creating confusion about implementation status. Before merging diagram changes, validate that all references (test files, classes, modules) actually exist in the codebase. This caught tests referenced but never created.","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671687+00:00","updated_at":"2026-04-10T05:36:08.671694+00:00","valid_from":"2026-04-10T05:36:08.671687+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XH","title":"Validate diagram references point to existing code","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671687+00:00","updated_at":"2026-04-10T05:36:08.671694+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Hindsight client cleanup ownership must be explicit
-
-
 
 HindsightClient instances used in server modules need clear ownership semantics and cleanup paths. Resource leaks in clients compound across request lifecycles. Scope clients tightly and ensure they're explicitly closed, don't rely on GC.
 
 _Source: #6296 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XJ","title":"Hindsight client cleanup ownership must be explicit","content":"HindsightClient instances used in server modules need clear ownership semantics and cleanup paths. Resource leaks in clients compound across request lifecycles. Scope clients tightly and ensure they're explicitly closed, don't rely on GC.","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671709+00:00","updated_at":"2026-04-10T05:36:08.671710+00:00","valid_from":"2026-04-10T05:36:08.671709+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XJ","title":"Hindsight client cleanup ownership must be explicit","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671709+00:00","updated_at":"2026-04-10T05:36:08.671710+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Create regression test files before documentation reference
-
-
 
 Don't reference regression test files in architecture documentation before they exist. Create the actual test file first, then reference it. Dangling references in diagrams signal incomplete implementation and confuse future maintainers.
 
 _Source: #6296 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XK","title":"Create regression test files before documentation reference","content":"Don't reference regression test files in architecture documentation before they exist. Create the actual test file first, then reference it. Dangling references in diagrams signal incomplete implementation and confuse future maintainers.","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671712+00:00","updated_at":"2026-04-10T05:36:08.671713+00:00","valid_from":"2026-04-10T05:36:08.671712+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XK","title":"Create regression test files before documentation reference","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671712+00:00","updated_at":"2026-04-10T05:36:08.671713+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Architecture diagram scope can exceed implementation plan
-
-
 
 Diagrams may be updated during implementation (e.g., adding .likec4 files) without being listed in the original plan. This is acceptable but should be tracked as documentation scope, not core implementation. Separate architectural updates from feature code in review.
 
 _Source: #6296 (review)_
 
+
 ```json:entry
-{"id":"01KQ11A4G7XE7SDHTKBKF7S0XM","title":"Architecture diagram scope can exceed implementation plan","content":"Diagrams may be updated during implementation (e.g., adding .likec4 files) without being listed in the original plan. This is acceptable but should be tracked as documentation scope, not core implementation. Separate architectural updates from feature code in review.","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671715+00:00","updated_at":"2026-04-10T05:36:08.671716+00:00","valid_from":"2026-04-10T05:36:08.671715+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G7XE7SDHTKBKF7S0XM","title":"Architecture diagram scope can exceed implementation plan","topic":null,"source_type":"review","source_issue":6296,"source_repo":null,"created_at":"2026-04-10T05:36:08.671715+00:00","updated_at":"2026-04-10T05:36:08.671716+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Trust Fleet — Lights-Off Background Loop Pattern
 
-
-
 HydraFlow runs 10 autonomous trust loops + 2 non-loop subsystems (ADR-0045) that make every automated concern individually observable, killable, and escalatable without a human in the loop. The 10 loops: corpus_learning (skill-escape synthesis), contract_refresh (cassette refresh PRs), staging_bisect (auto-revert on RC red), principles_audit (ADR-0044 drift), flake_tracker (RC flake detection), skill_prompt_eval (weekly adversarial gate), fake_coverage_auditor (un-cassetted methods), rc_budget (wall-clock bloat), wiki_rot_detector (broken cites), trust_fleet_sanity (meta-observer). The 2 subsystems: discover-completeness/shape-coherence evaluator gates (§4.10) and the cost-rollups + diagnostics waterfall (§4.11). Every loop must (1) be a BaseBackgroundLoop subclass with the standard 8-checkpoint wiring; (2) gate every tick on LoopDeps.enabled_cb (ADR-0049); (3) persist dedup via DedupStore keyed on the anomaly; (4) escalate only via the hitl-escalation label; (5) tolerate environment imperfection on startup (broken gh, missing Makefile target, stale credentials → log + skip, never raise). The dark-factory property: no single loop failure can kill the orchestrator; the meta-observer + dead-man-switch make the fleet self-supervising through one bounded meta-layer. See also: Kill-Switch Convention; DedupStore + Reconcile Pattern; Five-Checkpoint Loop Wiring; Meta-Observability with Bounded Recursion.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XHY","title":"Trust Fleet — Lights-Off Background Loop Pattern","content":"HydraFlow runs 10 autonomous trust loops + 2 non-loop subsystems (ADR-0045) that make every automated concern individually observable, killable, and escalatable without a human in the loop. The 10 loops: corpus_learning (skill-escape synthesis), contract_refresh (cassette refresh PRs), staging_bisect (auto-revert on RC red), principles_audit (ADR-0044 drift), flake_tracker (RC flake detection), skill_prompt_eval (weekly adversarial gate), fake_coverage_auditor (un-cassetted methods), rc_budget (wall-clock bloat), wiki_rot_detector (broken cites), trust_fleet_sanity (meta-observer). The 2 subsystems: discover-completeness/shape-coherence evaluator gates (§4.10) and the cost-rollups + diagnostics waterfall (§4.11). Every loop must (1) be a BaseBackgroundLoop subclass with the standard 8-checkpoint wiring; (2) gate every tick on LoopDeps.enabled_cb (ADR-0049); (3) persist dedup via DedupStore keyed on the anomaly; (4) escalate only via the hitl-escalation label; (5) tolerate environment imperfection on startup (broken gh, missing Makefile target, stale credentials → log + skip, never raise). The dark-factory property: no single loop failure can kill the orchestrator; the meta-observer + dead-man-switch make the fleet self-supervising through one bounded meta-layer. See also: Kill-Switch Convention; DedupStore + Reconcile Pattern; Five-Checkpoint Loop Wiring; Meta-Observability with Bounded Recursion.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022648+00:00","updated_at":"2026-04-25T00:40:54.022794+00:00","valid_from":"2026-04-25T00:40:54.022648+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XHY","title":"Trust Fleet — Lights-Off Background Loop Pattern","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022648+00:00","updated_at":"2026-04-25T00:40:54.022794+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## DedupStore + Reconcile-on-Close Pattern
 
-
-
 Trust loops file one issue per anomaly (not one per tick). Pattern: (1) compute a stable dedup_key on the anomaly (test_id, sha, plan_name, etc.); (2) check if key in self._dedup.get(); if so, skip filing; (3) on file success, self._dedup.add(key); (4) every tick first calls _reconcile_closed_escalations: lists closed hitl-escalation issues via gh issue list, parses the dedup key from the issue title/body, removes those keys from DedupStore so the next anomaly with the same key re-files. The DedupStore is a filesystem-backed JSON set under .hydraflow/<loop>/dedup.json. Always wrap self._dedup.get() in set(...) before mutating in a loop body — DedupStore returns the backing set, not a copy. Loops that handle terminal events (corpus_learning consumes skill-escape issues; staging_bisect processes a red SHA) don't need reconcile-on-close — once processed, stays processed. Loops that handle ongoing anomalies (flake_tracker, rc_budget, wiki_rot_detector) MUST reconcile so an operator closing the issue clears the counter and lets the loop refile if the anomaly recurs. See also: HITL Escalation Channel; Trust Fleet Pattern.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ0","title":"DedupStore + Reconcile-on-Close Pattern","content":"Trust loops file one issue per anomaly (not one per tick). Pattern: (1) compute a stable dedup_key on the anomaly (test_id, sha, plan_name, etc.); (2) check if key in self._dedup.get(); if so, skip filing; (3) on file success, self._dedup.add(key); (4) every tick first calls _reconcile_closed_escalations: lists closed hitl-escalation issues via gh issue list, parses the dedup key from the issue title/body, removes those keys from DedupStore so the next anomaly with the same key re-files. The DedupStore is a filesystem-backed JSON set under .hydraflow/<loop>/dedup.json. Always wrap self._dedup.get() in set(...) before mutating in a loop body — DedupStore returns the backing set, not a copy. Loops that handle terminal events (corpus_learning consumes skill-escape issues; staging_bisect processes a red SHA) don't need reconcile-on-close — once processed, stays processed. Loops that handle ongoing anomalies (flake_tracker, rc_budget, wiki_rot_detector) MUST reconcile so an operator closing the issue clears the counter and lets the loop refile if the anomaly recurs. See also: HITL Escalation Channel; Trust Fleet Pattern.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022843+00:00","updated_at":"2026-04-25T00:40:54.022844+00:00","valid_from":"2026-04-25T00:40:54.022843+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ0","title":"DedupStore + Reconcile-on-Close Pattern","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022843+00:00","updated_at":"2026-04-25T00:40:54.022844+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Eight-Checkpoint Loop Wiring
 
-
-
 Adding a new BaseBackgroundLoop requires synchronized edits in eight places — miss one and the loop may not run, may not be operator-controllable, may not be tested, or will trip a CI drift gate. The eight checkpoints: (1) src/service_registry.py — dataclass field + build_services instantiation; (2) src/orchestrator.py bg_loop_registry dict + loop_factories tuple; (3) src/ui/src/constants.js EDITABLE_INTERVAL_WORKERS set + SYSTEM_WORKER_INTERVALS dict; (4) src/dashboard_routes/_common.py _INTERVAL_BOUNDS dict; (5) tests/scenarios/catalog/test_loop_instantiation.py + test_loop_registrations.py loops list + a tests/scenarios/test_<name>_scenario.py file + tests/scenarios/catalog/loop_registrations.py `_BUILDERS` entry + tests/orchestrator_integration_utils.py SimpleNamespace `services.<name>_loop = FakeBackgroundLoop()`; (6) src/dashboard_routes/_control_routes.py _bg_worker_defs entry (label + description) AND _INTERVAL_WORKERS membership — without this, /api/system/workers won't return the loop and the System tab UI won't render its kill-switch toggle (missed in PR #8390, fixed in #8416); (7) **docs/arch/functional_areas.yml** — the loop's class name MUST appear under exactly one area's `loops:` list; tests/architecture/test_functional_area_coverage.py is a hard gate (introduced PR #8434 with the Architecture Knowledge System; missed in PR #8447 follow-up, caught in `make quality` on PricingRefreshLoop branch); (8) **`uv run python -m arch.runner --emit`** to regenerate docs/arch/generated/* after step (7); the curated/generated drift guard (tests/architecture/test_curated_drift.py, also from PR #8434) is a hard gate that fails CI if generated docs don't match the source-of-truth extractors. Auto-discovery test at tests/test_loop_wiring_completeness.py walks src/*_loop.py and asserts every loop is wired in all checkpoints — run it to catch drift. See also: Kill-Switch Convention; Background Loops and Skill Infrastructure.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ2","title":"Eight-Checkpoint Loop Wiring","content":"Adding a new BaseBackgroundLoop requires synchronized edits in eight places — miss one and the loop may not run, may not be operator-controllable, may not be tested, or will trip a CI drift gate. The eight checkpoints: (1) src/service_registry.py — dataclass field + build_services instantiation; (2) src/orchestrator.py bg_loop_registry dict + loop_factories tuple; (3) src/ui/src/constants.js EDITABLE_INTERVAL_WORKERS set + SYSTEM_WORKER_INTERVALS dict; (4) src/dashboard_routes/_common.py _INTERVAL_BOUNDS dict; (5) tests/scenarios/catalog/test_loop_instantiation.py + test_loop_registrations.py loops list + a tests/scenarios/test_<name>_scenario.py file + tests/scenarios/catalog/loop_registrations.py _BUILDERS entry + tests/orchestrator_integration_utils.py SimpleNamespace services.<name>_loop = FakeBackgroundLoop(); (6) src/dashboard_routes/_control_routes.py _bg_worker_defs entry (label + description) AND _INTERVAL_WORKERS membership — without this, /api/system/workers won't return the loop and the System tab UI won't render its kill-switch toggle (missed in PR #8390, fixed in #8416); (7) docs/arch/functional_areas.yml — the loop's class name MUST appear under exactly one area's loops: list; tests/architecture/test_functional_area_coverage.py is a hard gate (PR #8434 + PR #8447 follow-up); (8) uv run python -m arch.runner --emit to regenerate docs/arch/generated/* after step (7); the curated/generated drift guard (tests/architecture/test_curated_drift.py, PR #8434) is a hard gate that fails CI if generated docs don't match the source-of-truth extractors. Auto-discovery test at tests/test_loop_wiring_completeness.py walks src/*_loop.py and asserts every loop is wired in all checkpoints — run it to catch drift. See also: Kill-Switch Convention; Background Loops and Skill Infrastructure.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022859+00:00","updated_at":"2026-04-26T20:55:00.000000+00:00","valid_from":"2026-04-25T00:40:54.022859+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":2}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ2","title":"Eight-Checkpoint Loop Wiring","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022859+00:00","updated_at":"2026-04-26T20:55:00.000000+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":2}
 ```
+
 
 ## Auto-Revert on RC Red — Four-Guardrail Policy
 
-
-
 StagingBisectLoop auto-reverts on confirmed RC red with four guardrails (ADR-0048, extends ADR-0042's two-tier branch model). (1) Flake filter: re-run `make bisect-probe` against the same SHA; if the probe passes, increment flake_reruns_total, dedup the SHA, no revert. (2) Bisect attribution: git bisect between last_green_rc_sha and red SHA with `make bisect-probe` as the is-broken predicate, yielding a culprit SHA written into the revert PR body. (3) One auto-revert per cycle: state.get_auto_reverts_in_cycle(); after the first revert, _check_guardrail_and_maybe_escalate fires hitl-escalation + rc-red-attribution-unsafe (matching ADR-0048 §3 exactly — earlier code used the wrong label `rc-red-bisect-exhausted`, fixed in #8390). (4) Revert PR auto-merge: labels `[hydraflow-find, auto-revert, rc-red-attribution]`, flows through the standard reviewer + auto-merge path with no special privileges; an 8-hour watchdog (_check_pending_watchdog) fires rc-red-verify-timeout if the next RC isn't green. The probe MUST use asyncio.create_subprocess_exec (not subprocess.run) because long probes (up to 2700s) on a sync call freeze the event loop — caught in #8390 review. See also: Trust Fleet Pattern; Two-Tier Branch Model.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ5","title":"Auto-Revert on RC Red — Four-Guardrail Policy","content":"StagingBisectLoop auto-reverts on confirmed RC red with four guardrails (ADR-0048, extends ADR-0042's two-tier branch model). (1) Flake filter: re-run `make bisect-probe` against the same SHA; if the probe passes, increment flake_reruns_total, dedup the SHA, no revert. (2) Bisect attribution: git bisect between last_green_rc_sha and red SHA with `make bisect-probe` as the is-broken predicate, yielding a culprit SHA written into the revert PR body. (3) One auto-revert per cycle: state.get_auto_reverts_in_cycle(); after the first revert, _check_guardrail_and_maybe_escalate fires hitl-escalation + rc-red-attribution-unsafe (matching ADR-0048 §3 exactly — earlier code used the wrong label `rc-red-bisect-exhausted`, fixed in #8390). (4) Revert PR auto-merge: labels `[hydraflow-find, auto-revert, rc-red-attribution]`, flows through the standard reviewer + auto-merge path with no special privileges; an 8-hour watchdog (_check_pending_watchdog) fires rc-red-verify-timeout if the next RC isn't green. The probe MUST use asyncio.create_subprocess_exec (not subprocess.run) because long probes (up to 2700s) on a sync call freeze the event loop — caught in #8390 review. See also: Trust Fleet Pattern; Two-Tier Branch Model.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022885+00:00","updated_at":"2026-04-25T00:40:54.022886+00:00","valid_from":"2026-04-25T00:40:54.022885+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ5","title":"Auto-Revert on RC Red — Four-Guardrail Policy","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022885+00:00","updated_at":"2026-04-25T00:40:54.022886+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Per-Loop Telemetry — emit_loop_subprocess_trace
 
-
-
 Trust loops emit a JSON trace per subprocess call via trace_collector.emit_loop_subprocess_trace(loop, command, duration_ms, returncode). The trace flows through the same telemetry pipeline as inference traces, joined by timestamp in build_per_loop_cost (src/dashboard_routes/_cost_rollups.py) to attribute LLM cost + wall-clock seconds back to the originating loop. The waterfall view at /api/diagnostics/waterfall shows per-loop overlay. The per-loop cost row joins into /api/trust/fleet's loops array (cost_usd, tokens_in, tokens_out, llm_calls fields) so operators see fleet operability + machinery cost on the same pane (spec §4.11.3). Cost rollup failures are caught and reported as zero — an outage in the cost pipeline never takes down the trust dashboard. See also: Trust Fleet Pattern; Meta-Observability.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ6","title":"Per-Loop Telemetry — emit_loop_subprocess_trace","content":"Trust loops emit a JSON trace per subprocess call via trace_collector.emit_loop_subprocess_trace(loop, command, duration_ms, returncode). The trace flows through the same telemetry pipeline as inference traces, joined by timestamp in build_per_loop_cost (src/dashboard_routes/_cost_rollups.py) to attribute LLM cost + wall-clock seconds back to the originating loop. The waterfall view at /api/diagnostics/waterfall shows per-loop overlay. The per-loop cost row joins into /api/trust/fleet's loops array (cost_usd, tokens_in, tokens_out, llm_calls fields) so operators see fleet operability + machinery cost on the same pane (spec §4.11.3). Cost rollup failures are caught and reported as zero — an outage in the cost pipeline never takes down the trust dashboard. See also: Trust Fleet Pattern; Meta-Observability.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022895+00:00","updated_at":"2026-04-25T00:40:54.022896+00:00","valid_from":"2026-04-25T00:40:54.022895+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ6","title":"Per-Loop Telemetry — emit_loop_subprocess_trace","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022895+00:00","updated_at":"2026-04-25T00:40:54.022896+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Spawning background sleep loops to poll for results
-
-
 
 Never write `sleep(N)` inside a loop waiting for a test suite or background process to finish.
 
@@ -180,13 +179,13 @@ while not result_file.exists():
 
 **Why:** Sleep loops waste wall clock, mask failures, and provide no structured feedback. The harness exposes explicit background-task primitives for this exact purpose — use them.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBD","title":"Spawning background sleep loops to poll for results","content":"Never write `sleep(N)` inside a loop waiting for a test suite or background process to finish.\n\n**Wrong:**\n\n```python\nwhile not result_file.exists():\n    time.sleep(5)\n```\n\n**Right:**\n\n- Use `run_in_background` with a single command and wait on the notification.\n- Run the command in the foreground and await its completion directly.\n\n**Why:** Sleep loops waste wall clock, mask failures, and provide no structured feedback. The harness exposes explicit background-task primitives for this exact purpose — use them.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793224+00:00","updated_at":"2026-04-25T00:47:19.793225+00:00","valid_from":"2026-04-25T00:47:19.793224+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBD","title":"Spawning background sleep loops to poll for results","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793224+00:00","updated_at":"2026-04-25T00:47:19.793225+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Mocking at the wrong level
-
-
 
 Patch functions at their **import site**, not their **definition site**.
 
@@ -208,13 +207,13 @@ with patch("base_runner.recall_safe") as mock_recall:
 
 **Why:** Python imports bind names into the importing module's namespace. A patch at the definition module only affects callers that go through that module explicitly, not callers that imported the name locally.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBE","title":"Mocking at the wrong level","content":"Patch functions at their **import site**, not their **definition site**.\n\nIf `src/base_runner.py` contains `from hindsight import recall_safe`, then within `base_runner` the name `recall_safe` is a local binding. Patching `hindsight.recall_safe` at the definition module leaves the local binding unchanged and the mock is never hit.\n\n**Wrong:**\n\n```python\nwith patch(\"hindsight.recall_safe\") as mock_recall:\n    runner.run()  # runner's local `recall_safe` binding is unaffected\n```\n\n**Right:**\n\n```python\nwith patch(\"base_runner.recall_safe\") as mock_recall:\n    runner.run()  # patches the binding the runner actually calls\n```\n\n**Why:** Python imports bind names into the importing module's namespace. A patch at the definition module only affects callers that go through that module explicitly, not callers that imported the name locally.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793237+00:00","updated_at":"2026-04-25T00:47:19.793238+00:00","valid_from":"2026-04-25T00:47:19.793237+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBE","title":"Mocking at the wrong level","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793237+00:00","updated_at":"2026-04-25T00:47:19.793238+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Hardcoded path lists that duplicate filesystem state
-
-
 
 When multiple files (Dockerfile, Python constant, documentation) must agree on a list of paths or names, scan the authoritative source at runtime instead of hardcoding a parallel list that can drift.
 
@@ -251,13 +250,13 @@ def _plugin_dir_flags() -> list[str]:
 
 **How to check:** Any hardcoded list that mirrors filesystem layout, Dockerfile state, or config file contents should raise a flag — can it be computed at runtime from the source of truth?
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBK","title":"Hardcoded path lists that duplicate filesystem state","content":"When multiple files (Dockerfile, Python constant, documentation) must agree on a list of paths or names, scan the authoritative source at runtime instead of hardcoding a parallel list that can drift.\n\n**Wrong:**\n\n```python\n# src/agent_cli.py\n_DOCKER_PLUGIN_DIRS: tuple[str, ...] = (\n    \"/opt/plugins/claude-plugins-official\",\n    \"/opt/plugins/superpowers\",\n    \"/opt/plugins/lightfactory\",\n)\n# Dockerfile.agent-base clones these three — but if a fourth is added\n# there, this tuple silently stays wrong.\n```\n\n**Right:**\n\n```python\n# src/agent_cli.py\n_PRE_CLONED_PLUGIN_ROOT = Path(\"/opt/plugins\")\n\ndef _plugin_dir_flags() -> list[str]:\n    if not _PRE_CLONED_PLUGIN_ROOT.is_dir():\n        return []\n    flags: list[str] = []\n    for entry in sorted(_PRE_CLONED_PLUGIN_ROOT.iterdir()):\n        if entry.is_dir():\n            flags.extend([\"--plugin-dir\", str(entry)])\n    return flags\n```\n\n**Why:** Two sources of truth decay. Every time someone edits the Dockerfile, CI passes but the Python list falls behind. Dynamic enumeration of the filesystem (or a single config source) eliminates the drift.\n\n**How to check:** Any hardcoded list that mirrors filesystem layout, Dockerfile state, or config file contents should raise a flag — can it be computed at runtime from the source of truth?","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793271+00:00","updated_at":"2026-04-25T00:47:19.793272+00:00","valid_from":"2026-04-25T00:47:19.793271+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBK","title":"Hardcoded path lists that duplicate filesystem state","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793271+00:00","updated_at":"2026-04-25T00:47:19.793272+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Adding a new avoided pattern
-
-
 
 When you observe a new recurring agent failure:
 
@@ -267,13 +266,13 @@ When you observe a new recurring agent failure:
 
 Documenting the pattern once in this file propagates it to all three surfaces.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBN","title":"Adding a new avoided pattern","content":"When you observe a new recurring agent failure:\n\n1. Add a new `##` section to this doc with the same structure (wrong example, right example, why).\n2. Consider adding a rule to `src/sensor_rules.py` so the sensor enricher surfaces the hint automatically on matching failures.\n3. Consider whether `.claude/commands/hf.audit-code.md` Agent 5 (convention drift) should check for this pattern on its next sweep.\n\nDocumenting the pattern once in this file propagates it to all three surfaces.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793282+00:00","updated_at":"2026-04-25T00:47:19.793283+00:00","valid_from":"2026-04-25T00:47:19.793282+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBN","title":"Adding a new avoided pattern","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793282+00:00","updated_at":"2026-04-25T00:47:19.793283+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Background Loop Guidelines
-
-
 
 When creating a new background loop (`BaseBackgroundLoop` subclass):
 
@@ -293,21 +292,19 @@ When creating a new background loop (`BaseBackgroundLoop` subclass):
 
 Missing any of these five entries will cause `test_loop_wiring_completeness` to fail. Add them all in the same commit.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBP","title":"Background Loop Guidelines","content":"When creating a new background loop (`BaseBackgroundLoop` subclass):\n\n1. **Use `make scaffold-loop`** to generate boilerplate — it handles all wiring.\n\n2. **Restart safety.** Any `self._` state that affects behavior across cycles must either:\n   - Be persisted via `StateTracker` or `DedupStore` (survives restart)\n   - Be rehydrated from an external source (GitHub API) on first `_do_work()` cycle\n   - Be explicitly documented as ephemeral with a `# ephemeral: lost on restart` comment\n\n3. **Wiring checklist** (automated by `tests/test_loop_wiring_completeness.py`):\n   - `src/service_registry.py` — dataclass field + `build_services()` instantiation\n   - `src/orchestrator.py` — entry in `bg_loop_registry` dict\n   - `src/ui/src/constants.js` — entry in `BACKGROUND_WORKERS`\n   - `src/dashboard_routes/_common.py` — entry in `_INTERVAL_BOUNDS`\n   - `src/config.py` — interval Field + `_ENV_INT_OVERRIDES` entry\n\nMissing any of these five entries will cause `test_loop_wiring_completeness` to fail. Add them all in the same commit.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793357+00:00","updated_at":"2026-04-25T00:47:19.793358+00:00","valid_from":"2026-04-25T00:47:19.793357+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBP","title":"Background Loop Guidelines","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793357+00:00","updated_at":"2026-04-25T00:47:19.793358+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Daily Cost-Cap Kill-Switch
-
-
 
 HydraFlow honors a global `HYDRAFLOW_DAILY_COST_BUDGET_USD` env var. When the rolling-24h LLM spend exceeds the cap, `CostBudgetWatcherLoop` (5-min tick) calls `BGWorkerManager.set_enabled(name, False)` for ~23 caretaker workers (the curated `_TARGET_WORKERS` list) — only those that were enabled at kill time, so operator-pre-disabled workers are skipped and not claimed. It records the disabled set in `state.cost_budget_killed_workers` so that recovery (rolling-24h sliding window drops back below cap, typically as old high-cost inferences age out) re-enables ONLY the loops it killed. Default `daily_cost_budget_usd = None` means unlimited (no kills). The watcher itself is not in the target set so it can detect recovery; the pipeline loops (triage/plan/implement/review) are also not gated — their cost discipline is via per-issue caps, not the global gate.
 
 **Operator-conflation gotcha:** while the cap is breached, all gated workers appear as ‘disabled’ in the dashboard worker toggles (the watcher’s kills go through the same `set_enabled` path operators use). If an operator manually re-enables a worker during the kill window, the watcher will re-kill it on the next tick. If an operator manually disables a worker AFTER the watcher has killed it, the watcher will still re-enable it on recovery — there’s no way to distinguish "operator disabled this after our kill" from "this was just our kill" without an event log of (name, source, timestamp). Operators wanting a permanent off should set the loop’s per-loop kill-switch env var in addition to the dashboard toggle. See also: Eight-Checkpoint Loop Wiring; cost_budget_alerts.py (alert-only sibling).
 
+
 ```json:entry
-{"id":"01KQ6EM4XSPGH58SJXRA27YBDR","title":"Daily Cost-Cap Kill-Switch","content":"HydraFlow honors a global HYDRAFLOW_DAILY_COST_BUDGET_USD env var. CostBudgetWatcherLoop polls cost_rollups.build_rolling_24h every 5 min; over cap → BGWorkerManager.set_enabled(name, False) for ~23 caretaker workers in _TARGET_WORKERS; records the killed set in state.cost_budget_killed_workers; recovery (rolling drops below cap) re-enables only watcher-killed loops, preserving operator overrides. Default cap=None = unlimited. Watcher excluded from gating to detect recovery. Pipeline loops (triage/plan/implement/review) gated separately by per-issue caps. See also: Eight-Checkpoint Loop Wiring; cost_budget_alerts.py.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-26T00:00:00.000000+00:00","updated_at":"2026-04-26T00:00:00.000000+00:00","valid_from":"2026-04-26T00:00:00.000000+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
-```
-
-
+{"id":"01KQ6EM4XSPGH58SJXRA27YBDR","title":"Daily Cost-Cap Kill-Switch","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-26T00:00:00.000000+00:00","updated_at":"2026-04-26T00:00:00.000000+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/dependencies.md
+++ b/docs/wiki/dependencies.md
@@ -17,7 +17,7 @@ See also: Type Signatures as Backward-Compatibility Contracts — for communicat
 
 
 ```json:entry
-{"id":"01KQ11NX7QNTT50G9SENE613W0","title":"Circular Dependencies & Import Management","content":"Use TYPE_CHECKING guards and deferred imports (PEP 563) to break circular dependencies at the import level. For runtime circular references between extracted classes, inject callback functions instead of class references (e.g., `get_progress=epic_reporter.get_progress`) to avoid circular imports and make dependency direction explicit in constructor signatures.\n\nManage optional dependencies through three-level degradation, structural typing with Protocols, and explicit API composition via optional parameters. When a helper feeds data into a pipeline (e.g., memory injection), wrap the entire body in `except Exception: # noqa: BLE001` with no re-raise—return a safe default instead. Failures in optional data collection must not interrupt the pipeline itself; this is especially important for optional features like Hindsight recall that degrade gracefully. Use modern generic syntax with `from __future__ import annotations` on Python 3.9+.\n\nWhen extracting multiple coordinators from a god class, identify those with zero cross-dependencies and extract in parallel phases. Dependencies between extracted classes (e.g., 'ReviewVerdictHandler uses CIFixCoordinator') create phase ordering constraints. Map this as a task graph to prevent parallel work from being blocked.\n\nAfter extracting duplicated code and removing unused imports, verify extraction completeness through two-stage verification: (1) check function signatures, return type hints, and other locations across the file to confirm imports are truly unused; (2) use targeted grep across the codebase for old names in imports, documentation, comments, dynamic imports, and test fixtures to prevent false positives. Deferred imports become cleanup signals when removing code—look for these as dead code markers.\n\nApply the single update point pattern: define artifacts once and import everywhere to prevent divergence. For FastAPI, register catch-all `/{path:path}` route last.\n\nSee also: Type Signatures as Backward-Compatibility Contracts — for communicating contract changes before implementation changes.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T06:57:24.154748+00:00","updated_at":"2026-04-10T06:57:24.154755+00:00","valid_from":"2026-04-10T06:57:24.154748+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7QNTT50G9SENE613W0","title":"Circular Dependencies & Import Management","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T06:57:24.154748+00:00","updated_at":"2026-04-10T06:57:24.154755+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -27,7 +27,7 @@ Manage data schemas through changes using: embed schema_version in each JSON lin
 
 
 ```json:entry
-{"id":"01KQ11NX7QNTT50G9SENE613W1","title":"Data Schema Evolution & Transitive Dependency Tracking","content":"Manage data schemas through changes using: embed schema_version in each JSON line for self-describing records; use Pydantic defaults so old records missing new fields deserialize without migration code. Scan transitive dependencies recursively when invalidating items, updating all ancestors to point to final successors with depth limits to prevent infinite loops. Format complete content before truncating to character limits; use unconditional overwrite for small files; use atomic writes with rotate_backups for natural versioning and recovery. For external APIs not returning memory IDs, use sha256(text)[:16] as synthetic content hashes for temporal tracking.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T06:57:24.154763+00:00","updated_at":"2026-04-10T06:57:24.154764+00:00","valid_from":"2026-04-10T06:57:24.154763+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7QNTT50G9SENE613W1","title":"Data Schema Evolution & Transitive Dependency Tracking","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-10T06:57:24.154763+00:00","updated_at":"2026-04-10T06:57:24.154764+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -39,7 +39,7 @@ _Source: #6335 (review)_
 
 
 ```json:entry
-{"id":"01KQ11NX7QNTT50G9SENE613W2","title":"Type Signatures as Backward-Compatibility Contracts","content":"Update function signatures to reflect new stricter types (e.g., `phase: PipelineStage | Literal[\"\"]`) before modifying callers. Existing call sites with hardcoded string literals continue working via StrEnum coercion, making the signature change the primary integration point. Type signatures communicate contract changes to callers before implementation changes are made.","topic":null,"source_type":"review","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T06:57:24.154767+00:00","updated_at":"2026-04-10T06:57:24.154768+00:00","valid_from":"2026-04-10T06:57:24.154767+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7QNTT50G9SENE613W2","title":"Type Signatures as Backward-Compatibility Contracts","topic":null,"source_type":"review","source_issue":6335,"source_repo":null,"created_at":"2026-04-10T06:57:24.154767+00:00","updated_at":"2026-04-10T06:57:24.154768+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -72,7 +72,7 @@ class TestSomething:
 
 
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBC","title":"Top-level imports of optional dependencies in test files","content":"Never write `from hindsight import Bank` at module level in tests. `httpx`, `hindsight`, and similar optional packages are not guaranteed to be installed in every environment.\n\n**Wrong:**\n\n```python\n# tests/test_something.py\nfrom hindsight import Bank  # module-level — fails import if hindsight not installed\n\nclass TestSomething:\n    def test_x(self):\n        bank = Bank()\n```\n\n**Right:**\n\n```python\n# tests/test_something.py\nclass TestSomething:\n    def test_x(self):\n        from hindsight import Bank  # deferred — only imports when the test runs\n        bank = Bank()\n```\n\n**Why:** Top-level imports run at collection time. If the optional dep is missing, the entire test file fails to collect, hiding every test in it from the report.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793217+00:00","updated_at":"2026-04-25T00:47:19.793218+00:00","valid_from":"2026-04-25T00:47:19.793217+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBC","title":"Top-level imports of optional dependencies in test files","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793217+00:00","updated_at":"2026-04-25T00:47:19.793218+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -82,7 +82,7 @@ This branch imports selected assets from `affaan-m/everything-claude-code` and w
 
 
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249Q","title":"Self-Improving Harness","content":"This branch imports selected assets from `affaan-m/everything-claude-code` and wires them into HydraFlow's existing hook discipline.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794385+00:00","updated_at":"2026-04-25T00:47:19.794386+00:00","valid_from":"2026-04-25T00:47:19.794385+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249Q","title":"Self-Improving Harness","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794385+00:00","updated_at":"2026-04-25T00:47:19.794386+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -98,7 +98,7 @@ Installed under `.codex/skills/`:
 
 
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249R","title":"Imported Skills","content":"Installed under `.codex/skills/`:\n\n- `continuous-learning-v2`\n- `eval-harness`\n- `verification-loop`\n- `strategic-compact`\n- `skill-stocktake`","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794392+00:00","updated_at":"2026-04-25T00:47:19.794393+00:00","valid_from":"2026-04-25T00:47:19.794392+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249R","title":"Imported Skills","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794392+00:00","updated_at":"2026-04-25T00:47:19.794393+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
 
@@ -118,5 +118,5 @@ Runtime artifacts are ignored via `.gitignore` (`.claude/state/`).
 
 
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249S","title":"Runtime Loop","content":"HydraFlow now runs two additional hooks:\n\n- `PostToolUse` -> `.claude/hooks/hf.observe-session.sh`\n  - Captures minimal tool metadata (tool, file path, bash verb, session ID)\n  - Writes JSONL to `.claude/state/self-improve/observations.jsonl`\n- `Stop` -> `.claude/hooks/hf.session-retro.sh`\n  - Generates per-session retros in `.claude/state/self-improve/session-retros/`\n  - Appends index entries to `.claude/state/self-improve/memory-candidates.md`\n  - Emits actionable suggestions tied to imported skills\n\nRuntime artifacts are ignored via `.gitignore` (`.claude/state/`).","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794397+00:00","updated_at":"2026-04-25T00:47:19.794398+00:00","valid_from":"2026-04-25T00:47:19.794397+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249S","title":"Runtime Loop","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794397+00:00","updated_at":"2026-04-25T00:47:19.794398+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -1,7 +1,7 @@
 # Gotchas
 
-## Code Quality, Imports, Types, and Refactoring
 
+## Code Quality, Imports, Types, and Refactoring
 
 Verify imports are present and not circular before adding type annotations. Use TYPE_CHECKING guards with `from __future__ import annotations` for forward references. Before removing imports, grep for runtime references (isinstance, assignments) to prevent NameError. Run ruff to auto-fix import ordering.
 
@@ -13,12 +13,13 @@ Preserve edge cases like label ordering and removal order semantics. When removi
 
 See also: Testing — validate type changes with ruff and typecheck; Infrastructure — type-checking applies to parser signatures.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPT","title":"Code Quality, Imports, Types, and Refactoring","content":"Verify imports are present and not circular before adding type annotations. Use TYPE_CHECKING guards with `from __future__ import annotations` for forward references. Before removing imports, grep for runtime references (isinstance, assignments) to prevent NameError. Run ruff to auto-fix import ordering.\n\nImport ordering follows isort rules: stdlib (alphabetically, including pathlib), then third-party, then local. Use `is None` and `is not None` for optional objects, especially callables and stores. Type ignore comments can hide real bugs—investigate before suppressing.\n\nProtocol conformance: method signatures must exactly match protocol definitions. When updating port signatures, sync all implementations simultaneously—one task, not staggered. When refactoring classes, enforce acceptance criteria of ≤400 lines and ≤15 public methods. Count carefully: remaining non-delegated methods + delegation stubs can exceed budget even after extraction.\n\nPreserve edge cases like label ordering and removal order semantics. When removing multiple code blocks from same file, delete bottom-to-top (highest line numbers first) to avoid line-number shifting.\n\nSee also: Testing — validate type changes with ruff and typecheck; Infrastructure — type-checking applies to parser signatures.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674355+00:00","updated_at":"2026-04-18T15:40:17.674424+00:00","valid_from":"2026-04-18T15:40:17.674355+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPT","title":"Code Quality, Imports, Types, and Refactoring","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674355+00:00","updated_at":"2026-04-18T15:40:17.674424+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Testing — Mocking, Serialization, and File Verification
 
+## Testing — Mocking, Serialization, and File Verification
 
 Always patch functions at their definition site (e.g., `hindsight.retain_safe`), not import site. Deferred imports break module-level mocks. Never attach methods dynamically to mock objects; use unittest.mock.patch() at definition site to validate actual function signatures and catch keyword argument typos.
 
@@ -32,12 +33,13 @@ When removing test imports/files referencing deleted code, run tests to surface 
 
 See also: Code Quality — type-checking applies to validators and imports; ID Generation — ID extraction and generation must be consistent; Infrastructure — parser assertions validate against realistic multi-paragraph output.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPV","title":"Testing — Mocking, Serialization, and File Verification","content":"Always patch functions at their definition site (e.g., `hindsight.retain_safe`), not import site. Deferred imports break module-level mocks. Never attach methods dynamically to mock objects; use unittest.mock.patch() at definition site to validate actual function signatures and catch keyword argument typos.\n\nFiles referenced in issues may not exist (e.g., shared_prompt_prefix.py). Always verify file existence before planning changes using git history and grep.\n\nFor serialization testing, validate both model_dump_json()→model_validate_json() (serialization fidelity) and save/load cycles (full integration). JSON tests catch serialization bugs; integration tests catch type coercion and persistence issues.\n\nUse explicit assertions on structured markers rather than narrative content to ensure test stability across agent output format changes. ID generation must have test coverage verifying consistency across lookups—ensure plans_dir keys and filename extractions use the same ID logic. Join factory metrics by issue_number, not pr_number.\n\nWhen removing test imports/files referencing deleted code, run tests to surface incomplete cleanup. Always run `make test` and `make quality-lite` before declaring work complete—test failures naturally surface incomplete cleanup and hidden dependencies.\n\nSee also: Code Quality — type-checking applies to validators and imports; ID Generation — ID extraction and generation must be consistent; Infrastructure — parser assertions validate against realistic multi-paragraph output.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674453+00:00","updated_at":"2026-04-18T15:40:17.674457+00:00","valid_from":"2026-04-18T15:40:17.674453+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPV","title":"Testing — Mocking, Serialization, and File Verification","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674453+00:00","updated_at":"2026-04-18T15:40:17.674457+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Exception Classification, Logging, and Error Handling
 
+## Exception Classification, Logging, and Error Handling
 
 Distinguish bug exceptions (TypeError, AttributeError, KeyError, ValueError, IndexError) from transient errors (RuntimeError, OSError, CalledProcessError, httpx network exceptions) using log_exception_with_bug_classification() or is_likely_bug(). Use logger.exception() only for genuine bugs; transient operational failures use logger.warning(..., exc_info=True). In finally blocks, use log_exception_with_bug_classification() instead of reraise to preserve finally semantics.
 
@@ -53,12 +55,13 @@ Async/await: Omitting await on async methods returns unawaited coroutines that s
 
 See also: Telemetry — apply exception classification to distinguish bugs from transient errors; Memory System — apply same classification during memory injection; State Persistence — exception handling during state transitions.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPW","title":"Exception Classification, Logging, and Error Handling","content":"Distinguish bug exceptions (TypeError, AttributeError, KeyError, ValueError, IndexError) from transient errors (RuntimeError, OSError, CalledProcessError, httpx network exceptions) using log_exception_with_bug_classification() or is_likely_bug(). Use logger.exception() only for genuine bugs; transient operational failures use logger.warning(..., exc_info=True). In finally blocks, use log_exception_with_bug_classification() instead of reraise to preserve finally semantics.\n\nFor HTTP errors, use reraise_on_credit_or_bug() to selectively re-raise critical exceptions (AuthenticationError, CreditExhaustedError, MemoryError) while logging transient failures. Subprocess exceptions: TimeoutExpired and CalledProcessError are siblings, not parent-child—both must be caught separately. Read-path methods return safe defaults; write-path methods propagate TimeoutExpired to prevent silent data loss.\n\nLogging strategy follows docs/agents/sentry.md: transient failures log at WARNING; LoggingIntegration(event_level=logging.ERROR) prevents spurious Sentry alerts. Data-integrity violations log at ERROR. Avoid silent `except Exception: pass`; use reraise_on_credit_or_bug(exc) + logger.warning(..., exc_info=True). When migrating from logger.exception() to logger.warning(), explicitly add exc_info=True or tracebacks disappear.\n\nIn retry loops, wrap per-item API calls in try/except so one item's failure doesn't abort the cycle. In background loops, classify exceptions: fatal (auth/credit) propagates, bugs (local logic) propagate, transient (per-item runtime) logged as warnings. When a loop encounters 5 consecutive failures of the same type, circuit breaker publishes SYSTEM_ALERT exactly once.\n\nPost-merge orchestration runs sequential operations: merge→verify→retrospect→epic check→state record→event publish→cleanup. Exception handling only catches (RuntimeError, OSError, ValueError); others propagate. Use run_with_fatal_guard pattern from phase_utils for consistent logging.\n\nAsync/await: Omitting await on async methods returns unawaited coroutines that silently never execute—Pyright flags these during make typecheck. asyncio.create_task() calls without stored references get garbage-collected, silently dropping exceptions. Store all create_task results and add done callbacks for logging. Implement safe background task pattern: add private `_background_tasks: set[asyncio.Task[None]]`. Register cleanup callback before logging callback. When re-raising fatal errors from async tasks, revert dependent state flags (e.g., _pipeline_enabled = False) BEFORE raising to ensure state consistency.\n\nSee also: Telemetry — apply exception classification to distinguish bugs from transient errors; Memory System — apply same classification during memory injection; State Persistence — exception handling during state transitions.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674465+00:00","updated_at":"2026-04-18T15:40:17.674467+00:00","valid_from":"2026-04-18T15:40:17.674465+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPW","title":"Exception Classification, Logging, and Error Handling","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674465+00:00","updated_at":"2026-04-18T15:40:17.674467+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## State Persistence, Configuration, and Resource Cleanup
 
+## State Persistence, Configuration, and Resource Cleanup
 
 Config validators (e.g., labels_must_not_be_empty covering all label fields) serve as source of truth for audit fields. Mismatch between validator field set and audit field enumeration indicates a bug. When fixing label removal bugs, add regression tests explicitly verifying those fields by name. Fixing code doesn't retroactively clean existing issues—post-deployment manual cleanup may be needed.
 
@@ -76,12 +79,13 @@ When extracting methods that compute intermediate state needed by failure paths,
 
 See also: Exception Classification — exception handling during state transitions; Testing — validate schema evolution with serialization tests.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPX","title":"State Persistence, Configuration, and Resource Cleanup","content":"Config validators (e.g., labels_must_not_be_empty covering all label fields) serve as source of truth for audit fields. Mismatch between validator field set and audit field enumeration indicates a bug. When fixing label removal bugs, add regression tests explicitly verifying those fields by name. Fixing code doesn't retroactively clean existing issues—post-deployment manual cleanup may be needed.\n\nWhen adding new list[str] label fields to HydraFlowConfig, always add as optional ConfigFactory.create() parameters with sensible defaults. Omitting causes TypeError. Add test that ConfigFactory.create() accepts all label fields. Validate collection fields accessed by index—downstream code accesses [0] without null-checking. Constructor parameters must require before optional: use `param: Type | None = None` with fallback logic.\n\nFor state persistence, use append-only reflection files (JSONL) to accumulate data across retries, avoiding schema migrations. Mark entries with structural boundaries (timestamps, phase separators). Implement explicit cleanup methods at logical boundaries to prevent unbounded growth. Wrap all JSONL I/O in try/except OSError; append operations must be idempotent to survive partial writes. Use file_util.atomic_write() instead of Path.write_text() to prevent JSON corruption from crashes mid-write. Hard size caps (e.g., 10MB) provide secondary guards. trim_jsonl operates on raw lines without JSON parsing; corrupt/malformed records survive trimming intentionally.\n\nFor schema evolution, new Pydantic model fields with `field: Type = default_value` allow existing state files to load without error. TypedDict(total=False) enables backward-compatible event payloads where all fields are optional. Frozen Pydantic models require object.__setattr__ for mutation—critical in overrides (numeric, bool, literal) to avoid breaking setter logic. Cross-field validation must run after numeric overrides but before bool/literal overrides.\n\nWhen persisting to multiple banks (repo-specific + universal), use single Write-Ahead Log (WAL) to capture all writes together for atomic failure recovery. Type coercion across serialization boundaries: HindsightClient coerces metadata values to strings during retain while local JSONL keeps int. Wrap type conversions in try/except catching (TypeError, ValueError) with fallback to None.\n\nIdempotency guards protect against duplicate calls and retries, not concurrent execution. Per-issue locking at orchestrator level prevents true concurrency. When removing config fields, removed env-var overrides should be silently ignored. Validate field removal by letting tests fail on missing attributes. When HydraFlow manages itself (repo_root == HydraFlow repo), use hash-based or idempotent installation to skip if identical. Critical in multi-execution-mode systems.\n\nWhen extracting methods that compute intermediate state needed by failure paths, return tuples `(success, mergeable)` rather than recomputing. State transitions create atomicity windows for exceptions: when exceptions occur after successful state transition (e.g., label swap) but before cleanup, issues can get stuck in intermediate states. Mitigation: wrap transition+operation+cleanup in try/except that reverses transitions on non-fatal exceptions. Track resource creation state to enable safe cleanup—only attempt destroy if setup successfully created the resource. HITL workflows should destroy worktrees only on success, preserving them on failure to enable post-mortem debugging.\n\nSee also: Exception Classification — exception handling during state transitions; Testing — validate schema evolution with serialization tests.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674477+00:00","updated_at":"2026-04-18T15:40:17.674480+00:00","valid_from":"2026-04-18T15:40:17.674477+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPX","title":"State Persistence, Configuration, and Resource Cleanup","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674477+00:00","updated_at":"2026-04-18T15:40:17.674480+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## ID Generation, Representation, and Pipeline Ordering
 
+## ID Generation, Representation, and Pipeline Ordering
 
 Use consistent ID generation logic everywhere files are keyed (e.g., plans_dir / f'issue-{issue.id}.md') to avoid silent lookup failures. Define prefix lengths as constants (discover=9, shape=6) and centralize extraction to prevent off-by-one slice errors that silently produce NaN. Join factory metrics and reviews by issue_number (not pr_number). Issue number propagation before memory injection enables outcome correlation across phases; reset to 0 after injection.
 
@@ -97,12 +101,13 @@ Phase progression occurs via predictable label mutations (discover→shape, shap
 
 See also: Testing — ID generation must have test coverage verifying consistency across lookups.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPY","title":"ID Generation, Representation, and Pipeline Ordering","content":"Use consistent ID generation logic everywhere files are keyed (e.g., plans_dir / f'issue-{issue.id}.md') to avoid silent lookup failures. Define prefix lengths as constants (discover=9, shape=6) and centralize extraction to prevent off-by-one slice errors that silently produce NaN. Join factory metrics and reviews by issue_number (not pr_number). Issue number propagation before memory injection enables outcome correlation across phases; reset to 0 after injection.\n\nAvoid implicit heuristics like `if fname not in content` for self-exclusion. Pass explicit parameters (self_fname) to filter functions instead—this makes logic clearer and prevents silent edge cases. Collision detection must explicitly exclude self before reporting to avoid misleading messages.\n\nRepresentation gaps indicate multiple object models in codebase. Example: ReviewRunner uses Task.id while phase_utils.publish_review_status uses pr.issue_number for same concept. Document which representation a helper uses and scope it appropriately. Mixed usage should be consolidated to single representation or explicitly mapped.\n\nStage progression logic relying on array indices (currentStage from PIPELINE_STAGES position) is fragile. New stages inserted at incorrect positions silently break progression if only status values are verified in tests. When adding pipeline stages, verify both stage ordering and progression logic—order matters even if status values are correct.\n\nFor skip detection, only trigger when stage at index ≥3 (plan or later) has non-pending status. If issue is in triage (triage=active, discover/shape=pending), discover/shape must remain pending, not marked skipped.\n\nPhase progression occurs via predictable label mutations (discover→shape, shape→plan). Clarity scoring gates entry: high-clarity issues (≥7) go directly to planning; vague issues route to discovery first. This deterministic approach makes phase progression observable in issue history, eliminating hidden state and making system auditable.\n\nSee also: Testing — ID generation must have test coverage verifying consistency across lookups.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674486+00:00","updated_at":"2026-04-18T15:40:17.674492+00:00","valid_from":"2026-04-18T15:40:17.674486+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPY","title":"ID Generation, Representation, and Pipeline Ordering","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674486+00:00","updated_at":"2026-04-18T15:40:17.674492+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Telemetry — Sample Size Validation and Outcome Tracking
 
+## Telemetry — Sample Size Validation and Outcome Tracking
 
 Minimum sample sizes prevent statistical misleading and enable reliable recommendations. For telemetry, use thresholds like 10 for regressions and window_size for rolling averages; for memory quality assessment, return empty results when recall data is insufficient. Always expose sample_size alongside metrics (fp_rate, recall quality) to flag sparse data—1/2=50% is noisy with high over-interpretation risk.
 
@@ -112,12 +117,13 @@ Outcomes attach to digest snapshots, not individual recalled items. Cap issue_id
 
 See also: Exception Classification — classify failures to distinguish bugs from transient errors.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCPZ","title":"Telemetry — Sample Size Validation and Outcome Tracking","content":"Minimum sample sizes prevent statistical misleading and enable reliable recommendations. For telemetry, use thresholds like 10 for regressions and window_size for rolling averages; for memory quality assessment, return empty results when recall data is insufficient. Always expose sample_size alongside metrics (fp_rate, recall quality) to flag sparse data—1/2=50% is noisy with high over-interpretation risk.\n\nRecord each retry attempt separately to capture timing and retry patterns, but aggregate using (skill_name, issue_number) with only final attempt's outcome for pass-rate calculations. Naive per-attempt counting inflates failure rates. In retry loops with state accumulators, pass current-attempt to telemetry (not accumulator) to avoid contaminating aggregates with stale failure signals from previous attempts.\n\nOutcomes attach to digest snapshots, not individual recalled items. Cap issue_ids per recall hit at 50 entries to bridge outcomes with actual recall events. Blocking skill failures trigger agent retries until they pass, so passed=False records are rare; non-blocking skills are primary false-positive candidates.\n\nSee also: Exception Classification — classify failures to distinguish bugs from transient errors.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674498+00:00","updated_at":"2026-04-18T15:40:17.674501+00:00","valid_from":"2026-04-18T15:40:17.674498+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCPZ","title":"Telemetry — Sample Size Validation and Outcome Tracking","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674498+00:00","updated_at":"2026-04-18T15:40:17.674501+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Memory System — Filtering, Budget Allocation, and Query Optimization
 
+## Memory System — Filtering, Budget Allocation, and Query Optimization
 
 Filter evicted memories on both content prefix ('[EVICTED]') AND metadata status ('status: evicted'). Dual filtering ensures tombstones never leak into agent prompts even if one filter has bugs. Apply filters at recall time in _inject_memory() before formatting. Treat budget allocation as cap, not target. Cross-section dedup runs after truncation, so final prompt may be smaller than allocated budget. Dedup savings below budget ceiling are acceptable and expected—not failure case.
 
@@ -125,12 +131,13 @@ For prompt feedback sections with exemplars, place exemplars before remediation 
 
 See also: Exception Classification — classify failures in memory injection to distinguish bugs from transient errors.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCQ0","title":"Memory System — Filtering, Budget Allocation, and Query Optimization","content":"Filter evicted memories on both content prefix ('[EVICTED]') AND metadata status ('status: evicted'). Dual filtering ensures tombstones never leak into agent prompts even if one filter has bugs. Apply filters at recall time in _inject_memory() before formatting. Treat budget allocation as cap, not target. Cross-section dedup runs after truncation, so final prompt may be smaller than allocated budget. Dedup savings below budget ceiling are acceptable and expected—not failure case.\n\nFor prompt feedback sections with exemplars, place exemplars before remediation hints to ensure exemplars survive truncation. Phase-specific query customization should prepend context (`f\"{prefix}, {context}\"`) rather than replace it. Narrowing queries too much degrades recall quality. Additive prefixes guide semantic search while preserving original issue context needed for relevance matching. Relevance score boost uses in-place mutation (mem.relevance_score *= 1.15)—monitor this constraint during dependency upgrades.\n\nSee also: Exception Classification — classify failures in memory injection to distinguish bugs from transient errors.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674506+00:00","updated_at":"2026-04-18T15:40:17.674509+00:00","valid_from":"2026-04-18T15:40:17.674506+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCQ0","title":"Memory System — Filtering, Budget Allocation, and Query Optimization","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674506+00:00","updated_at":"2026-04-18T15:40:17.674509+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## ADR Enforcement, Commit Hooks, and Skills Management
 
+## ADR Enforcement, Commit Hooks, and Skills Management
 
 Enforcement ADRs need explicit tier-to-mechanism mapping (pre-commit hook, linter, test suite, manual review) with distinct statuses for items with tracking issues vs. those requiring new issues. Consequences sections must cross-check tracking status against decision tables—verify item-by-item that all proposed items have clear tracking. Avoid conflating 'tracked' with 'needs issue'.
 
@@ -140,12 +147,13 @@ New dynamic skills start with blocking=False to avoid breaking workflows. Skills
 
 Extract workflow concepts (TDD, systematic debugging, review rigor) and hardcode them in PHASE_SKILL_GUIDANCE dict rather than dynamically loading from filesystem. This avoids dependency on superpowers installation path and keeps system self-contained. New phases need dict entries, not filesystem discovery. TOOL_PHASE_MAP registration is ongoing maintenance burden—add lint test warning on unknown commands in .claude/commands/ to catch unregistered tools before shipping.
 
+
 ```json:entry
-{"id":"01KQ11NX7WPWJKP571R69KMCQ1","title":"ADR Enforcement, Commit Hooks, and Skills Management","content":"Enforcement ADRs need explicit tier-to-mechanism mapping (pre-commit hook, linter, test suite, manual review) with distinct statuses for items with tracking issues vs. those requiring new issues. Consequences sections must cross-check tracking status against decision tables—verify item-by-item that all proposed items have clear tracking. Avoid conflating 'tracked' with 'needs issue'.\n\nCommit message validation should only block commits that *attempt* specific format incorrectly (e.g., Fix instead of Fixes). Allow plain commits without issue refs, WIP prefixes, merge commits, reverts, and auto-generated commits. This avoids blocking agents that make multiple intermediate commits during implementation.\n\nNew dynamic skills start with blocking=False to avoid breaking workflows. Skills graduate to blocking=True only after ≥20 runs with ≥95% success rate. This policy ensures new automated checks are proven before failing builds.\n\nExtract workflow concepts (TDD, systematic debugging, review rigor) and hardcode them in PHASE_SKILL_GUIDANCE dict rather than dynamically loading from filesystem. This avoids dependency on superpowers installation path and keeps system self-contained. New phases need dict entries, not filesystem discovery. TOOL_PHASE_MAP registration is ongoing maintenance burden—add lint test warning on unknown commands in .claude/commands/ to catch unregistered tools before shipping.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674515+00:00","updated_at":"2026-04-18T15:40:17.674517+00:00","valid_from":"2026-04-18T15:40:17.674515+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7WPWJKP571R69KMCQ1","title":"ADR Enforcement, Commit Hooks, and Skills Management","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674515+00:00","updated_at":"2026-04-18T15:40:17.674517+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Infrastructure — Events, Dispatch, and Parser Implementation
 
+## Infrastructure — Events, Dispatch, and Parser Implementation
 
 Alpine's minimal tooling excludes Python and standard utilities. Use portable shell commands like `dd if=/dev/zero bs=1M count=32 of=/dev/null` or `head -c` to consume memory in constrained environments, avoiding allocation failures from missing interpreter tools.
 
@@ -163,12 +171,13 @@ CLI command framework passes $ARGUMENTS as everything after command name—verif
 
 See also: Code Quality — type-checking applies to parser signatures; Testing — parser assertions validate against realistic multi-paragraph output.
 
+
 ```json:entry
-{"id":"01KQ11NX7X22EWJCR8DMZTS2PG","title":"Infrastructure — Events, Dispatch, and Parser Implementation","content":"Alpine's minimal tooling excludes Python and standard utilities. Use portable shell commands like `dd if=/dev/zero bs=1M count=32 of=/dev/null` or `head -c` to consume memory in constrained environments, avoiding allocation failures from missing interpreter tools.\n\nEvent dispatch dicts benefit from separating truly silent events from events that produce no display output but set a result value (e.g., agent_end, turn_end set result but print nothing). Use _SILENT_WITH_RESULT frozenset checked before _SILENT_EVENTS to correctly route these cases. Handlers must have uniform signatures (event: dict) -> str to avoid type checker errors. This pattern complements exception-based signaling in background loops where fatal errors propagate via exception and supervisor routes the outcome.\n\nWhen a general method returns insufficient data for specific use case, create separate specialized method rather than overloading general one. Example: `list_issues_by_label` returns basic issue metadata; `get_issue_updated_at()` handles timestamps separately. This keeps methods focused and avoids coupling unrelated concerns.\n\nExplicitly document top 3-5 failure risks in plan phase before implementation. This identifies potential issues early and guides implementer decisions. Pre-mortems catch mistakes before code review and establish concrete failure modes to guard against during implementation.\n\nValidate parsers against realistic multi-paragraph agent output containing both prose and structured markers—not bare marker strings. Test assertions focus on markers themselves, not prose wording, so transcript updates don't break tests. Maintain explicit assertions on structured markers rather than narrative content. Explicit `## Output Format` sections in markdown skill definitions (with 'do not modify without updating parser' warnings) make the contract visible. Maintain SKILL_MARKERS mapping for consistency and add test cases verifying all 4 backend copies match.\n\nWhen extracting from Claude CLI transcripts, modified files, or external formats, use best-effort regex with try/except wrapping—never raise on parse failure. Log warnings when extraction finds zero matches on non-empty input to catch format drift early. Fall back to empty lists or default values on JSONDecodeError and other parsing errors. Leverage existing utilities like delta_verifier.parse_file_delta() and task_graph.extract_phases() instead of reimplementing.\n\nCLI command framework passes $ARGUMENTS as everything after command name—verify scope routing with both single-word and multi-word arguments. Markdown splitting on '\\n- ' double-prefixes first item ('- - ')—_split_md_items() helper must explicitly fix this edge case.\n\nSee also: Code Quality — type-checking applies to parser signatures; Testing — parser assertions validate against realistic multi-paragraph output.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674522+00:00","updated_at":"2026-04-18T15:40:17.674525+00:00","valid_from":"2026-04-18T15:40:17.674522+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7X22EWJCR8DMZTS2PG","title":"Infrastructure — Events, Dispatch, and Parser Implementation","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:40:17.674522+00:00","updated_at":"2026-04-18T15:40:17.674525+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## `logger.error(value)` without a format string
 
+## `logger.error(value)` without a format string
 
 Logging calls must pass a format string as the first argument and the variable as the second. Passing a variable directly treats the variable as the format template — if it ever contains `%s`, `%d`, or `{...}`, logging either misformats or raises `TypeError` at runtime.
 
@@ -190,12 +199,13 @@ for failure in failures:
 
 **How to check:** `rg "logger\.(error|warning|info|debug)\(\w+\)" src/` — every match should have a literal string as the first argument.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBJ","title":"`logger.error(value)` without a format string","content":"Logging calls must pass a format string as the first argument and the variable as the second. Passing a variable directly treats the variable as the format template — if it ever contains `%s`, `%d`, or `{...}`, logging either misformats or raises `TypeError` at runtime.\n\n**Wrong:**\n\n```python\nfor failure in failures:\n    logger.error(failure)  # failure is the format string — unsafe\n```\n\n**Right:**\n\n```python\nfor failure in failures:\n    logger.error(\"%s\", failure)\n```\n\n**Why:** Latent logging-injection bug. `logger.error(\"got error: %s\")` with a user-controlled string containing `%d` raises `TypeError: not enough arguments for format string` at runtime, not during testing. The `logger.error(\"%s\", value)` form defers formatting to the logging machinery which handles it safely.\n\n**How to check:** `rg \"logger\\.(error|warning|info|debug)\\(\\w+\\)\" src/` — every match should have a literal string as the first argument.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793265+00:00","updated_at":"2026-04-25T00:47:19.793266+00:00","valid_from":"2026-04-25T00:47:19.793265+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBJ","title":"`logger.error(value)` without a format string","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793265+00:00","updated_at":"2026-04-25T00:47:19.793266+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Per-worker model overrides
 
+## Per-worker model overrides
 
 Each background worker that dispatches an LLM call has its own `HYDRAFLOW_*_MODEL` env var so it can be tuned independently for cost. Most loops are logic-only (no LLM call) and don't appear here.
 
@@ -214,12 +224,13 @@ Each background worker that dispatches an LLM call has its own `HYDRAFLOW_*_MODE
 
 When adding a new loop that makes LLM calls, add its own `HYDRAFLOW_<NAME>_MODEL` field to `src/config.py` and `_ENV_STR_OVERRIDES` — don't reuse an existing loop's field.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBQ","title":"Per-worker model overrides","content":"Each background worker that dispatches an LLM call has its own `HYDRAFLOW_*_MODEL` env var so it can be tuned independently for cost. Most loops are logic-only (no LLM call) and don't appear here.\n\n| Loop | Config field | Env var | Default |\n|------|--------------|---------|---------|\n| `report_issue_loop` | `report_issue_model` | `HYDRAFLOW_REPORT_ISSUE_MODEL` | `opus` |\n| `sentry_loop` | `sentry_model` | `HYDRAFLOW_SENTRY_MODEL` | `opus` |\n| `code_grooming_loop` | `code_grooming_model` | `HYDRAFLOW_CODE_GROOMING_MODEL` | `sonnet` |\n| `adr_reviewer_loop` (council) | `adr_review_model` | `HYDRAFLOW_ADR_REVIEW_MODEL` | `sonnet` |\n| tribal-memory judge | `memory_judge_model` | `HYDRAFLOW_MEMORY_JUDGE_MODEL` | `haiku` |\n| memory_sync compaction | `memory_compaction_model` | `HYDRAFLOW_MEMORY_COMPACTION_MODEL` | `haiku` |\n| wiki compaction | `wiki_compilation_model` | `HYDRAFLOW_WIKI_COMPILATION_MODEL` | `haiku` |\n| transcript summarizer | `transcript_summary_model` | `HYDRAFLOW_TRANSCRIPT_SUMMARY_MODEL` | `haiku` |\n\n`HYDRAFLOW_BACKGROUND_MODEL` is a cascade: when non-empty it applies to every field above that still equals its own default (`triage_model`, `transcript_summary_model`, `report_issue_model`, `sentry_model`, `code_grooming_model`). Per-worker overrides always win over the cascade.\n\nWhen adding a new loop that makes LLM calls, add its own `HYDRAFLOW_<NAME>_MODEL` field to `src/config.py` and `_ENV_STR_OVERRIDES` — don't reuse an existing loop's field.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793363+00:00","updated_at":"2026-04-25T00:47:19.793364+00:00","valid_from":"2026-04-25T00:47:19.793363+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBQ","title":"Per-worker model overrides","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793363+00:00","updated_at":"2026-04-25T00:47:19.793364+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Hindsight recall — disable / re-enable
 
+## Hindsight recall — disable / re-enable
 
 Phase 3 PR 9 ships with `hindsight_recall_enabled=True` by default. To
 flip off during the 2-week observation window while validating that the
@@ -262,12 +273,13 @@ If divergence or regressions appear, unset the env var and file an
 issue; do not proceed to the Hindsight deletion (Phase 3 PR 10) until
 the gap is understood.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBZ","title":"Hindsight recall — disable / re-enable","content":"Phase 3 PR 9 ships with `hindsight_recall_enabled=True` by default. To\nflip off during the 2-week observation window while validating that the\nwiki-based system catches everything Hindsight was catching:\n\n```bash\nexport HYDRAFLOW_HINDSIGHT_RECALL_ENABLED=false\n```\n\nTo re-enable (rollback):\n\n```bash\nunset HYDRAFLOW_HINDSIGHT_RECALL_ENABLED\n```\n\nRetains (writes to Hindsight) remain active — only reads are gated. The\narchive keeps accumulating so nothing is lost during the observation\nwindow.\n\nMetrics to watch on the dashboard (`/api/wiki/metrics`):\n\n- `wiki_entries_ingested` should climb at approximately the rate of\n  plan/implement/review cycles.\n- `wiki_supersedes` should be non-zero within a few days (proves the\n  contradiction detector is active).\n- `tribal_promotions` will be zero until ≥2 active target repos share\n  a principle (may stay zero indefinitely with only one managed repo).\n- `reflections_bridged` should increment once per target-repo issue\n  merge.\n- `adr_drafts_judged` / `adr_drafts_opened` are non-zero only when\n  agents have emitted `ADR_DRAFT_SUGGESTION` blocks.\n\nAlso watch `/api/wiki/health` — `store: populated` and (with ≥2 repos)\n`tribal: populated` indicate the stores are being used.\n\nIssue auto-merge rate should be stable within ±10% of the pre-change\nbaseline. Error rate should not change.\n\nIf divergence or regressions appear, unset the env var and file an\nissue; do not proceed to the Hindsight deletion (Phase 3 PR 10) until\nthe gap is understood.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793474+00:00","updated_at":"2026-04-25T00:47:19.793475+00:00","valid_from":"2026-04-25T00:47:19.793474+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBZ","title":"Hindsight recall — disable / re-enable","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793474+00:00","updated_at":"2026-04-25T00:47:19.793475+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Code review before merge
 
+## Code review before merge
 
 **After creating a PR, always self-review it for gaps, bugs, and test coverage before declaring it done.** Use `/superpowers:requesting-code-review` to run a structured review that checks:
 
@@ -277,12 +289,13 @@ the gap is understood.
 
 Do not present a PR as ready until the review passes and any findings are addressed.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC3","title":"Code review before merge","content":"**After creating a PR, always self-review it for gaps, bugs, and test coverage before declaring it done.** Use `/superpowers:requesting-code-review` to run a structured review that checks:\n\n- **Gaps** — Missing edge cases, unhandled error paths, callers not updated for API changes\n- **Bugs** — Logic errors, off-by-one, race conditions, injection risks\n- **Test coverage** — Missing boundary tests, untested code paths, missing negative cases\n\nDo not present a PR as ready until the review passes and any findings are addressed.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793553+00:00","updated_at":"2026-04-25T00:47:19.793554+00:00","valid_from":"2026-04-25T00:47:19.793553+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC3","title":"Code review before merge","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793553+00:00","updated_at":"2026-04-25T00:47:19.793554+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Reasoning triggers
 
+## Reasoning triggers
 
 For analysis-heavy tasks (architecture decisions, debugging, code review), use explicit reasoning prompts to trigger deeper analysis:
 
@@ -292,43 +305,47 @@ For analysis-heavy tasks (architecture decisions, debugging, code review), use e
 
 Simple mechanical tasks (rename, format, move) don't need these — just do them.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC4","title":"Reasoning triggers","content":"For analysis-heavy tasks (architecture decisions, debugging, code review), use explicit reasoning prompts to trigger deeper analysis:\n\n- \"Think through the tradeoffs of this approach before implementing\"\n- \"Consider what could go wrong and what edge cases exist\"\n- \"Explain your reasoning before making changes\"\n\nSimple mechanical tasks (rename, format, move) don't need these — just do them.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793559+00:00","updated_at":"2026-04-25T00:47:19.793559+00:00","valid_from":"2026-04-25T00:47:19.793559+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC4","title":"Reasoning triggers","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793559+00:00","updated_at":"2026-04-25T00:47:19.793559+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Sentry Error Tracking
 
-
 HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rules to keep Sentry signal-to-noise high.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC6","title":"Sentry Error Tracking","content":"HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rules to keep Sentry signal-to-noise high.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793626+00:00","updated_at":"2026-04-25T00:47:19.793627+00:00","valid_from":"2026-04-25T00:47:19.793626+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC6","title":"Sentry Error Tracking","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793626+00:00","updated_at":"2026-04-25T00:47:19.793627+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## What goes to Sentry
 
+## What goes to Sentry
 
 - **Real code bugs only.** `TypeError`, `KeyError`, `AttributeError`, `ValueError`, `IndexError`, `NotImplementedError`.
 - The `before_send` filter in `src/server.py` drops all exceptions that are NOT in the bug-types tuple.
 - `LoggingIntegration` captures `logger.error()` calls — these also go through the `before_send` filter.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC7","title":"What goes to Sentry","content":"- **Real code bugs only.** `TypeError`, `KeyError`, `AttributeError`, `ValueError`, `IndexError`, `NotImplementedError`.\n- The `before_send` filter in `src/server.py` drops all exceptions that are NOT in the bug-types tuple.\n- `LoggingIntegration` captures `logger.error()` calls — these also go through the `before_send` filter.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793632+00:00","updated_at":"2026-04-25T00:47:19.793633+00:00","valid_from":"2026-04-25T00:47:19.793632+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC7","title":"What goes to Sentry","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793632+00:00","updated_at":"2026-04-25T00:47:19.793633+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## What does NOT go to Sentry
 
+## What does NOT go to Sentry
 
 - **Transient errors** — network timeouts, auth failures, rate limits, subprocess crashes. These are operational, not bugs.
 - **Handled exceptions** — if you catch an error and handle it, use `logger.warning()`, not `logger.error()` or `logger.exception()`.
 - **Test mock exceptions** — never let test mocks raise through code paths that log at `error` level when `SENTRY_DSN` is set.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC8","title":"What does NOT go to Sentry","content":"- **Transient errors** — network timeouts, auth failures, rate limits, subprocess crashes. These are operational, not bugs.\n- **Handled exceptions** — if you catch an error and handle it, use `logger.warning()`, not `logger.error()` or `logger.exception()`.\n- **Test mock exceptions** — never let test mocks raise through code paths that log at `error` level when `SENTRY_DSN` is set.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793638+00:00","updated_at":"2026-04-25T00:47:19.793639+00:00","valid_from":"2026-04-25T00:47:19.793638+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC8","title":"What does NOT go to Sentry","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793638+00:00","updated_at":"2026-04-25T00:47:19.793639+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Rules for new code
 
+## Rules for new code
 
 1. Use `logger.warning()` for expected or transient failures (network, auth, rate limit).
 2. Use `logger.error()` or `logger.exception()` ONLY for unexpected code bugs you want Sentry to capture.
@@ -337,21 +354,23 @@ HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rule
 5. The `_before_send` callback in `src/server.py` is the gatekeeper — if you add new exception types that indicate real bugs, add them to `_BUG_TYPES`.
 6. The `SentryIngestLoop` in `src/sentry_loop.py` polls Sentry for unresolved issues and files them as GitHub issues — avoid creating noise that feeds back into this loop.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC9","title":"Rules for new code","content":"1. Use `logger.warning()` for expected or transient failures (network, auth, rate limit).\n2. Use `logger.error()` or `logger.exception()` ONLY for unexpected code bugs you want Sentry to capture.\n3. Never use bare `except: pass` — always log at `warning` level minimum.\n4. When adding a new background loop, catch operational errors and log at `warning`; let real bugs propagate to the base class error handler which logs at `error`.\n5. The `_before_send` callback in `src/server.py` is the gatekeeper — if you add new exception types that indicate real bugs, add them to `_BUG_TYPES`.\n6. The `SentryIngestLoop` in `src/sentry_loop.py` polls Sentry for unresolved issues and files them as GitHub issues — avoid creating noise that feeds back into this loop.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793644+00:00","updated_at":"2026-04-25T00:47:19.793646+00:00","valid_from":"2026-04-25T00:47:19.793644+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC9","title":"Rules for new code","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793644+00:00","updated_at":"2026-04-25T00:47:19.793646+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Never skip commit hooks
 
-
 **NEVER** use `git commit --no-verify` or `--no-hooks` flags. If a hook fails, investigate and fix the underlying issue — do not bypass it.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCP","title":"Never skip commit hooks","content":"**NEVER** use `git commit --no-verify` or `--no-hooks` flags. If a hook fails, investigate and fix the underlying issue — do not bypass it.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793878+00:00","updated_at":"2026-04-25T00:47:19.793879+00:00","valid_from":"2026-04-25T00:47:19.793878+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCP","title":"Never skip commit hooks","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793878+00:00","updated_at":"2026-04-25T00:47:19.793879+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Scenario Matrix
 
+## Scenario Matrix
 
 ### Happy Paths (`test_happy.py`)
 
@@ -397,12 +416,13 @@ HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rule
 | L7 | DependabotMerge | Auto-merges bot PR on CI pass | PR approved, merged, processed set updated |
 | L8 | DependabotMerge | Skips bot PR on CI failure | PR not merged, skip recorded |
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2494","title":"Scenario Matrix","content":"### Happy Paths (`test_happy.py`)\n\n| # | Scenario | Asserts |\n|---|----------|---------|\n| H1 | Single issue end-to-end | find -> triage -> plan -> implement -> review -> done, PR merged |\n| H2 | Multi-issue concurrent batch (3 issues) | All complete independently, no cross-contamination |\n| H3 | HITL round-trip | Issue escalates to HITL, correction submitted, resumes |\n| H4 | Review approve + merge | APPROVE verdict, CI passes, PR merged, cleanup runs |\n| H5 | Plan produces sub-issues | Planner returns `new_issues`, sub-issues created |\n\n### Sad Paths (`test_sad.py`)\n\n| # | Scenario | Asserts |\n|---|----------|---------|\n| S1 | Plan fails then succeeds on retry | First plan `success=False`, retry succeeds |\n| S2 | Implement exhausts attempts | Docker fails N times, issue does not complete |\n| S3 | Review rejects -> route-back | REQUEST_CHANGES, routes back, re-review approves |\n| S4 | GitHub API 5xx during PR creation | `fail_service(\"github\")` mid-implement, recovery on heal |\n| S5 | Hindsight down -> pipeline continues | Memory calls fail, pipeline completes without writes |\n| S6 | CI fails -> auto-fix -> CI passes | `wait_for_ci` returns failure first, then passes |\n\n### Edge Cases (`test_edge.py`)\n\n| # | Scenario | Asserts |\n|---|----------|---------|\n| E1 | Duplicate issues (same title/body) | Both tracked by number, no crash |\n| E2 | Issue relabeled mid-flight | `on_phase` hook fires, pipeline continues |\n| E3 | Stale worktree during active processing | GC skips actively-processing issues |\n| E4 | Epic with child ordering | Parent waits for children, dependency order |\n| E5 | Zero-diff implement (already satisfied) | Agent produces 0 commits, `success=True` |\n\n### Background Loop Scenarios (`test_loops.py`)\n\n| # | Loop | Scenario | Asserts |\n|---|------|----------|---------|\n| L1 | HealthMonitor | Low first_pass_rate triggers config bump | `max_quality_fix_attempts` increased, decision audit written |\n| L2 | WorkspaceGC | Cleans stale worktrees | Closed-issue worktrees destroyed, active preserved |\n| L3 | StaleIssueGC | Closes inactive HITL issues | Old HITL issues auto-closed with comment, fresh untouched |\n| L4 | PRUnsticker | Processes HITL items with open PRs | Unstick attempted on qualifying items |\n| L5 | CIMonitor | CI failure creates issue | GitHub issue created with `hydraflow-ci-failure` label |\n| L6 | CIMonitor | CI recovery closes issue | Failure issue auto-closed on green CI |\n| L7 | DependabotMerge | Auto-merges bot PR on CI pass | PR approved, merged, processed set updated |\n| L8 | DependabotMerge | Skips bot PR on CI failure | PR not merged, skip recorded |","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794046+00:00","updated_at":"2026-04-25T00:47:19.794047+00:00","valid_from":"2026-04-25T00:47:19.794046+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2494","title":"Scenario Matrix","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794046+00:00","updated_at":"2026-04-25T00:47:19.794047+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Scenario Catalog (Extended)
 
+## Scenario Catalog (Extended)
 
 ### Realistic-Agent Scenarios (`test_agent_realistic.py`)
 
@@ -485,23 +505,25 @@ HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rule
 
 ---
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2499","title":"Scenario Catalog (Extended)","content":"### Realistic-Agent Scenarios (`test_agent_realistic.py`)\n\n| ID | Test | What it covers |\n|----|------|----------------|\n| A0 | `test_A0_happy_path_realistic_agent` | Base happy path: one issue, real AgentRunner, FakeDocker commits, merges. |\n| A1 | `test_A1_docker_timeout_fails_issue_no_retry` | Docker timeout — production does NOT retry; issue fails with `worker_result.success=False`. |\n| A2 | `test_A2_oom_fails_issue` | OOM (exit_code=137) causes agent failure; zero commits → `_verify_result` fails. |\n| A3 | `test_A3_malformed_stream_recovers_to_failure` | Garbage stream events plus exit_code=1 — StreamParser skips unknowns, result is failure. |\n| A4 | `test_A4_unknown_event_type_ignored_stream_continues` | `auth_retry_required` event silently skipped; trailing `result:success` still merges issue. |\n| A5 | `test_A5_token_budget_exceeded_halts_implement` | Stream-level `budget_exceeded` event plus failure result → issue fails without merge. |\n| A6 | `test_A6_github_rate_limit_at_triage_halts_pipeline` | Rate-limit armed before triage (remaining=0) — first GitHub call raises, pool absorbs, no PR created. |\n| A7 | `test_A7_github_secondary_rate_limit_surfaces` | Secondary (abuse-detection) rate-limit is also absorbed; issue never progresses. |\n| A8 | `test_A8_find_stage_to_done_realistic_agent` | Full pipeline from `hydraflow-find` through triage→plan→implement→review; issue merges. |\n| A9 | `test_A9_hindsight_failure_realistic_agent_still_succeeds` | `fail_service('hindsight')` during realistic-agent run does not halt pipeline; issue merges. |\n| A10 | `test_A10_quality_fix_loop_retries_then_passes` | `make quality` fails on first attempt; quality-fix agent commits fix; second quality run passes; merges. |\n| A11 | `test_A11_review_fix_ci_loop_resolves` | CI fails after PR creation; `fix_ci` loop resolves it; CI passes; merge proceeds. |\n| A12 | `test_A12_multi_commit_implement` | Real agent produces 3 commits; `git rev-list --count` confirms all three on branch. |\n| A13 | `test_A13_zero_diff_fails_without_merge` | Agent claims success but writes no commits; `_verify_result` fails on commit count; no merge. |\n| A14 | `test_A14_three_issues_concurrent_realistic` | Three issues processed concurrently via real AgentRunner; all merge; worktree isolation verified. |\n| A15 | `test_A15_epic_decomposition_creates_children` | High-complexity issue decomposed via EpicManager stub; two child issues created in FakeGitHub. |\n| A16 | `test_A16_credit_exhausted_halts_pipeline` | `CreditExhaustedError` from `_execute` propagates out of `run_pipeline` (re-raise allowlist). |\n| A17 | `test_A17_authentication_error_halts_pipeline` | `AuthenticationError` from `_execute` propagates out of `run_pipeline` (re-raise allowlist). |\n| A18 | `test_A18_rate_limit_heals_mid_pipeline` | Rate-limit armed with remaining=5; `on_phase(\"implement\")` heals before it matters; merges. |\n| A19 | `test_A19_code_scanning_alerts_reach_reviewer` | `add_alerts(branch=...)` seeds alerts; ReviewPhase fetches by branch; reviewer receives them unchanged. |\n| A20 | `test_A20_workspace_create_permission_failure` | `PermissionError` from workspace creation is swallowed; issue does not merge; run_pipeline returns normally. |\n| A20b | `test_A20b_workspace_create_disk_full` | `OSError(ENOSPC)` from FakeWorkspace is swallowed gracefully; issue does not merge. |\n| A20c | `test_A20c_workspace_create_branch_conflict` | `RuntimeError` (\"worktree already exists\") from FakeWorkspace is swallowed; issue does not merge. |\n| A21 | `test_A21_state_json_corruption_graceful_fallback` | Corrupt state.json before run; `StateTracker.load` falls back to empty `StateData()`; pipeline continues. |\n| A22 | `test_A22_wiki_populated_plan_consults_it` | Pre-populated `RepoWikiStore` wired to `PlanPhase`; wiki accessible; pipeline completes without crash. |\n\n**Boot smoke** (`test_realistic_agent_boot_smoke.py`): `test_real_agent_runner_single_event_smoke` — single invocation with tool_use + message + result events; proves the AgentRunner wiring stack boots.\n\n### Bead Workflow Scenarios (`test_bead_workflow.py`)\n\n| ID | Test | What it covers |\n|----|------|----------------|\n| B1 | `test_B1_bead_workflow_end_to_end` | Plan with Task Graph headers creates 2 beads; implement calls `init`; tasks stay open (claim/close are agent-subprocess concerns). |\n| B1b | `test_B1_no_beads_without_task_graph_headers` | Plan text without `### P{N}` headers → `extract_phases` returns []; no beads created; `_initialized` stays False. |\n\n### Background Loop Scenarios (`test_loops.py` + `test_caretaker_loops.py` + `test_caretaker_loops_part2.py`)\n\n#### L1–L8 (`test_loops.py`)\n\n| # | Loop | Scenario | Asserts |\n|---|------|----------|---------|\n| L1 | HealthMonitor | Low first_pass_rate triggers config bump | `max_quality_fix_attempts` increased, decision audit written |\n| L2 | WorkspaceGC | Cleans stale worktrees | Closed-issue worktrees destroyed, active preserved |\n| L3 | StaleIssueGC | Closes inactive HITL issues | Old HITL issues auto-closed with comment, fresh untouched |\n| L4 | PRUnsticker | Processes HITL items with open PRs | Unstick attempted on qualifying items |\n| L5 | CIMonitor | CI failure creates issue | GitHub issue created with `hydraflow-ci-failure` label |\n| L6 | CIMonitor | CI recovery closes issue | Failure issue auto-closed on green CI |\n| L7 | DependabotMerge | Auto-merges bot PR on CI pass | PR approved, merged, processed set updated |\n| L8 | DependabotMerge | Skips bot PR on CI failure | PR not merged, skip recorded |\n\n#### L9–L13 (`test_caretaker_loops.py`)\n\n| ID | Class | What it covers |\n|----|-------|----------------|\n| L9 | `TestL9ADRReviewerLoop` | `ADRReviewerLoop._do_work` delegates to `adr_reviewer.review_proposed_adrs`; stats pass through; None passthrough preserved. |\n| L10 | `TestL10MemorySyncLoop` | `MemorySyncLoop._do_work` calls `sync()` then `publish_sync_event(result)`; returned stats are a fresh copy. |\n| L11 | `TestL11RetrospectiveLoop` | `RetrospectiveLoop` drains queue; empty queue → zero stats; `RETRO_PATTERNS` item → processed=1, acknowledged. |\n| L12 | `TestL12EpicSweeperLoop` | `EpicSweeperLoop` sweeps open epics; no epics → zero counts; epic with all closed sub-issues auto-closed. |\n| L13 | `TestL13SecurityPatchLoop` | `SecurityPatchLoop` files issues from Dependabot alerts; no alerts → filed=0; high-severity fixable → filed=1; dry_run → None. |\n\n#### L14–L23 (`test_caretaker_loops_part2.py`)\n\n| ID | Class | What it covers |\n|----|-------|----------------|\n| L14 | `TestL14CodeGrooming` | `CodeGroomingLoop`: disabled → `{\"skipped\": \"disabled\"}`; dry_run → None; enabled with no findings → stats shape with `\"filed\"` key. |\n| L15 | `TestL15DiagnosticLoop` | `DiagnosticLoop` polls `hydraflow-diagnose` issues; no issues → zero counts; issue without escalation context → escalated=1. |\n| L16 | `TestL16EpicMonitorLoop` | `EpicMonitorLoop` delegates to `EpicManager`; no stale epics → stale_count=0; 3 stale + 5 tracked → stats match. |\n| L17 | `TestL17GitHubCacheLoop` | `GitHubCacheLoop` calls `cache.poll()` and forwards its stats; empty dict result → None (falsy guard). |\n| L18 | `TestL18RepoWikiLoop` | `RepoWikiLoop` lints per-repo wikis; no repos → zero stats; one repo → `active_lint` called, stale_entries reflected. |\n| L19 | `TestL19ReportIssueLoop` | `ReportIssueLoop` processes queued bug reports; dry_run → None; empty queue → None. |\n| L20 | `TestL20RunsGCLoop` | `RunsGCLoop` purges expired/oversized runs; no artifacts → zero purge; 3 expired + 1 oversized → stats match. |\n| L21 | `TestL21SentryLoop` | `SentryLoop` skips gracefully without credentials; empty org or empty token → `skipped=True` with reason. |\n| L22 | `TestL22StagingPromotionLoop` | `StagingPromotionLoop`: disabled → `status=staging_disabled`; cadence not elapsed → `status=cadence_not_elapsed`; elapsed → RC branch cut, promotion PR opened. |\n| L23 | `TestL23StaleIssueLoop` | `StaleIssueLoop` auto-closes stale issues; no issues → zero; fresh issue → scanned but not closed; stale + dry_run → closed=1, no API call; fetch failure → zero stats. |\n\n---","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794072+00:00","updated_at":"2026-04-25T00:47:19.794073+00:00","valid_from":"2026-04-25T00:47:19.794072+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2499","title":"Scenario Catalog (Extended)","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794072+00:00","updated_at":"2026-04-25T00:47:19.794073+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Notes
 
+## Notes
 
 - `make audit` exits non-zero today (Error 1) due to a real WARN finding: P5.5 reports `main` branch on `T-rav/hydraflow` lacks branch protection (HTTP 404 from `gh`). This is a legitimate audit signal, not a prerequisite gap. The CI job will need to tolerate WARN exit codes or the underlying protection must be enabled — to be resolved in Task 17a wiring.
 - Wall-clock was captured via `/usr/bin/time -p make audit > /dev/null 2>bench-$i.txt` per plan Task 0 Step 1.
 - Runtime variance across 5 runs is ~0.28s (7%), well within a single CI-budget bucket; no additional warmup runs needed.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249M","title":"Notes","content":"- `make audit` exits non-zero today (Error 1) due to a real WARN finding: P5.5 reports `main` branch on `T-rav/hydraflow` lacks branch protection (HTTP 404 from `gh`). This is a legitimate audit signal, not a prerequisite gap. The CI job will need to tolerate WARN exit codes or the underlying protection must be enabled — to be resolved in Task 17a wiring.\n- Wall-clock was captured via `/usr/bin/time -p make audit > /dev/null 2>bench-$i.txt` per plan Task 0 Step 1.\n- Runtime variance across 5 runs is ~0.28s (7%), well within a single CI-budget bucket; no additional warmup runs needed.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794278+00:00","updated_at":"2026-04-25T00:47:19.794279+00:00","valid_from":"2026-04-25T00:47:19.794278+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249M","title":"Notes","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794278+00:00","updated_at":"2026-04-25T00:47:19.794279+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Recommended Alerts
 
+## Recommended Alerts
 
 ### Error Alerts
 | Alert | Query | Threshold | Action |
@@ -525,6 +547,7 @@ HydraFlow uses **Sentry** (`sentry_sdk`) for error monitoring. Follow these rule
 3. Configure threshold and action channels
 4. Set environment filter to match HYDRAFLOW_ENV
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249P","title":"Recommended Alerts","content":"### Error Alerts\n| Alert | Query | Threshold | Action |\n|-------|-------|-----------|--------|\n| Pipeline error spike | `event.type:error` | >5 in 10 min | Slack #hydraflow-alerts |\n| Credit exhaustion | `CreditExhaustedError` | Any occurrence | Immediate Slack + email |\n| New error type | First seen | Any | Slack |\n\n### Performance Alerts\n| Alert | Metric | Threshold | Action |\n|-------|--------|-----------|--------|\n| Slow agent | `memory.first_pass_rate` | <0.2 for 1 hour | Slack |\n| Score drift | `memory.avg_score` | Drops >15% in 24h | Slack |\n| Learning stall | `memory.stale_items` | >20 for 48h | Slack |\n| Adjustment storm | Auto-adjustment count | >5 in 24h | Slack + HITL |\n| Factory divergence | Per-project first_pass_rate | Diverges >30% from avg | Investigate |\n\n### Setup Instructions\n1. Go to Sentry → Alerts → Create Alert\n2. Select \"Custom Metric\" for performance alerts\n3. Configure threshold and action channels\n4. Set environment filter to match HYDRAFLOW_ENV","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794333+00:00","updated_at":"2026-04-25T00:47:19.794334+00:00","valid_from":"2026-04-25T00:47:19.794333+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249P","title":"Recommended Alerts","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794333+00:00","updated_at":"2026-04-25T00:47:19.794334+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/patterns.md
+++ b/docs/wiki/patterns.md
@@ -1,20 +1,19 @@
 # Patterns
 
+
 ## Backward compatibility and schema evolution
-
-
 
 Schema changes must preserve backward compatibility through optional fields with sensible defaults, type narrowing on bare strings (safe if values already conform), and StrEnum coercion for auto-conversion. Pydantic v2 auto-coerces raw dicts from state.json into typed models with no migration validators. Distinguish bare `str` fields (safe to narrow) from union types like `str | None` (require union narrowing) and verify all call sites before narrowing types via exhaustive grep-based audits. Establish single source of truth via canonical constants (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`); functions derive from this single source rather than duplicating label lists. Use metadata tags instead of enum variants for categorizing items in shared banks (e.g., `{"source": "adr_council"}`)—avoids syncing enum changes across type checks, prompts, and display order. Make new fields optional with sensible defaults on read (e.g., `.get("scope", "repo")`); no migration needed. Reference canonical constants in reset code, never magic numbers. Preserve exact retry counter state and escalation conditions during schema evolution when refactoring state machine dispatchers.
 
 See also: Refactoring and testing practices — call site verification; Concurrency and I/O safety — metadata tag usage and atomic write patterns; Memory management — metadata tag usage and schema versioning.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9Q","title":"Backward compatibility and schema evolution","content":"Schema changes must preserve backward compatibility through optional fields with sensible defaults, type narrowing on bare strings (safe if values already conform), and StrEnum coercion for auto-conversion. Pydantic v2 auto-coerces raw dicts from state.json into typed models with no migration validators. Distinguish bare `str` fields (safe to narrow) from union types like `str | None` (require union narrowing) and verify all call sites before narrowing types via exhaustive grep-based audits. Establish single source of truth via canonical constants (e.g., `ALL_LIFECYCLE_LABEL_FIELDS`); functions derive from this single source rather than duplicating label lists. Use metadata tags instead of enum variants for categorizing items in shared banks (e.g., `{\"source\": \"adr_council\"}`)—avoids syncing enum changes across type checks, prompts, and display order. Make new fields optional with sensible defaults on read (e.g., `.get(\"scope\", \"repo\")`); no migration needed. Reference canonical constants in reset code, never magic numbers. Preserve exact retry counter state and escalation conditions during schema evolution when refactoring state machine dispatchers.\n\nSee also: Refactoring and testing practices — call site verification; Concurrency and I/O safety — metadata tag usage and atomic write patterns; Memory management — metadata tag usage and schema versioning.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766106+00:00","updated_at":"2026-04-18T15:38:18.766115+00:00","valid_from":"2026-04-18T15:38:18.766106+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9Q","title":"Backward compatibility and schema evolution","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766106+00:00","updated_at":"2026-04-18T15:38:18.766115+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Refactoring and testing practices
-
-
 
 **Refactoring**: Before changing function signatures, grep the codebase to find all call sites and confirm scope. For public functions, use `git grep` to verify zero remaining matches after refactoring. Changes to widely-used utilities require exhaustive caller audits—missing even one call site causes `TypeError` at runtime. When return types change (e.g., `str | None` → `dict | None`), all callers must be updated atomically in a single commit. Preserve public/semi-public method signatures using thin delegation stubs, `__getattr__` facades, or mixin inheritance from shared base clients when tests/external code depend on extracted code; use optional parameters to gate composition logic when decomposing large methods. Extract pure transform functions first—they lack mutable closure state and are lowest-risk candidates. Error isolation preservation: preserve per-concern try/except blocks exactly as-is to prevent failures in one concern from blocking others. Keep early-return cases inline in parent rather than extracting. Extract to pure module-level functions before moving to new classes for independent testability. Pre-compute loop variables outside iteration (e.g., `event_type = str(...)`). Remove vestigial variables from incomplete features, guards for dead paths, and functions with trivial implementations if they have no production callers. Extract duplicated JSONL-reading logic to shared `_load_jsonl(path, label)` helpers to prevent divergence and ensure consistency across refactors.
 
@@ -22,13 +21,13 @@ See also: Refactoring and testing practices — call site verification; Concurre
 
 See also: Backward compatibility and schema evolution — type narrowing and state preservation; Concurrency and I/O safety — error isolation and crash-safe patterns; State machine transitions — test preservation and dispatcher refactoring.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9R","title":"Refactoring and testing practices","content":"**Refactoring**: Before changing function signatures, grep the codebase to find all call sites and confirm scope. For public functions, use `git grep` to verify zero remaining matches after refactoring. Changes to widely-used utilities require exhaustive caller audits—missing even one call site causes `TypeError` at runtime. When return types change (e.g., `str | None` → `dict | None`), all callers must be updated atomically in a single commit. Preserve public/semi-public method signatures using thin delegation stubs, `__getattr__` facades, or mixin inheritance from shared base clients when tests/external code depend on extracted code; use optional parameters to gate composition logic when decomposing large methods. Extract pure transform functions first—they lack mutable closure state and are lowest-risk candidates. Error isolation preservation: preserve per-concern try/except blocks exactly as-is to prevent failures in one concern from blocking others. Keep early-return cases inline in parent rather than extracting. Extract to pure module-level functions before moving to new classes for independent testability. Pre-compute loop variables outside iteration (e.g., `event_type = str(...)`). Remove vestigial variables from incomplete features, guards for dead paths, and functions with trivial implementations if they have no production callers. Extract duplicated JSONL-reading logic to shared `_load_jsonl(path, label)` helpers to prevent divergence and ensure consistency across refactors.\n\n**Testing**: Mock at the definition site (e.g., `hindsight.tombstone_safe`) not the import site, combined with deferred imports inside test methods—prevents import-time failures and keeps optional dependencies truly optional. When testing dependency injection, explicitly verify that the injected dependency is used instead of self-constructed. Verify protocol implementation via structural subtype checks (signature inspection with `inspect.signature()`) rather than `isinstance()`. When methods are moved during refactoring, retarget mock patches to the new location before refactoring to preserve mock interception at the facade level. Both parametrized tests and explicit named spot-check methods improve readability. Supply async variants of sync methods with a-prefix (arecord_outcome, aupdate_scores) following Python conventions. Generated content (test skeletons, comments) must not reference line numbers—use exact function/class names and string search for stability across refactors. Meta-tests scan the codebase for anti-patterns and fail if found (e.g., `sys.path.insert` outside conftest.py). Run existing tests unchanged after refactoring as the primary regression test.\n\nSee also: Backward compatibility and schema evolution — type narrowing and state preservation; Concurrency and I/O safety — error isolation and crash-safe patterns; State machine transitions — test preservation and dispatcher refactoring.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766124+00:00","updated_at":"2026-04-18T15:38:18.766125+00:00","valid_from":"2026-04-18T15:38:18.766124+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9R","title":"Refactoring and testing practices","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766124+00:00","updated_at":"2026-04-18T15:38:18.766125+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Concurrency and I/O safety
-
-
 
 Use `threading.Lock` when code runs in a thread pool (via `asyncio.to_thread()`) or is called from both sync and async contexts—`asyncio.Lock` is not thread-safe. Use `asyncio.Lock` only for coordinating pure coroutines without thread-pool involvement. For concurrent file I/O with brief lock hold times, `threading.Lock` is appropriate. Extract `_unlocked()` helper variants to prevent re-entrant lock attempts when lock-holding methods call each other. For crash-safe I/O: use `file_util.append_jsonl()` wrapped in `file_lock()` for JSONL appends (includes `flush()` and `os.fsync()`). Use `file_util.atomic_write()` for critical state file updates (writes to temp, then `os.replace()` atomically). Use `os.replace()` for atomic JSONL rewrites when content is small. All three patterns prevent partial writes and crash-induced corruption. Lock files (zero-byte sentinels) are durable and not cleaned up—overhead is negligible. Concurrent append-while-rewrite races are accepted at low frequency (hourly) but document as a load-bearing constraint.
 
@@ -36,25 +35,25 @@ For state mutations in asyncio (e.g., StateTracker), synchronous methods guarant
 
 See also: Refactoring and testing practices — error isolation preservation; Memory management — atomic write patterns and crash-safe file operations.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9S","title":"Concurrency and I/O safety","content":"Use `threading.Lock` when code runs in a thread pool (via `asyncio.to_thread()`) or is called from both sync and async contexts—`asyncio.Lock` is not thread-safe. Use `asyncio.Lock` only for coordinating pure coroutines without thread-pool involvement. For concurrent file I/O with brief lock hold times, `threading.Lock` is appropriate. Extract `_unlocked()` helper variants to prevent re-entrant lock attempts when lock-holding methods call each other. For crash-safe I/O: use `file_util.append_jsonl()` wrapped in `file_lock()` for JSONL appends (includes `flush()` and `os.fsync()`). Use `file_util.atomic_write()` for critical state file updates (writes to temp, then `os.replace()` atomically). Use `os.replace()` for atomic JSONL rewrites when content is small. All three patterns prevent partial writes and crash-induced corruption. Lock files (zero-byte sentinels) are durable and not cleaned up—overhead is negligible. Concurrent append-while-rewrite races are accepted at low frequency (hourly) but document as a load-bearing constraint.\n\nFor state mutations in asyncio (e.g., StateTracker), synchronous methods guarantee safe interleaving—locking is needed at the file level (via `file_lock()`), not the in-memory object level. Claim-then-merge for async queue processing: atomically claim items (clear/load), release lock, perform async work, re-acquire lock, reload for new items, merge with remaining, atomically write. Prevents lost entries when `write_all` overwrites file during async gap. Preserved tracing context lifecycle: set/clear or begin/end pairs MUST execute within single try/finally block to prevent trace state leaks. If accidentally split during refactoring, trace state leaks across issues/iterations. Fast synchronous I/O safe directly in async context when latency is negligible and lock contention is low. Call state cleanup unconditionally to purge stale state even when primary work set is empty. Event publishing stays coupled with condition checks in the same method—separating event logic from condition checks creates code paths where gates block but events don't fire, breaking observability.\n\nSee also: Refactoring and testing practices — error isolation preservation; Memory management — atomic write patterns and crash-safe file operations.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766127+00:00","updated_at":"2026-04-18T15:38:18.766128+00:00","valid_from":"2026-04-18T15:38:18.766127+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9S","title":"Concurrency and I/O safety","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766127+00:00","updated_at":"2026-04-18T15:38:18.766128+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## State machine transitions
-
-
 
 When extracting phase result classification or handling logic, preserve exact retry counter state and escalation conditions (like epic-child label swaps) from the original flow. These behavioral subtleties directly impact correctness of phase state transitions. Dry-run mode must not emit state-changing events (e.g., TRIAGE_ROUTING) to ensure dry-run has no observable side effects. Phase result routing through dispatch patterns must maintain the immutable return contract exactly (tuple[str, str | None] for parse()). Event/worker mappings must precede skip detection—EVENT_TO_STAGE and SOURCE_TO_STAGE mappings must be implemented together with skip detection logic. Run existing tests unchanged after refactoring as the primary regression test to validate behavior preservation.
 
 See also: Backward compatibility and schema evolution — retry counter state preservation; Refactoring and testing practices — call site verification and test preservation; Concurrency and I/O safety — state mutation patterns.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9T","title":"State machine transitions","content":"When extracting phase result classification or handling logic, preserve exact retry counter state and escalation conditions (like epic-child label swaps) from the original flow. These behavioral subtleties directly impact correctness of phase state transitions. Dry-run mode must not emit state-changing events (e.g., TRIAGE_ROUTING) to ensure dry-run has no observable side effects. Phase result routing through dispatch patterns must maintain the immutable return contract exactly (tuple[str, str | None] for parse()). Event/worker mappings must precede skip detection—EVENT_TO_STAGE and SOURCE_TO_STAGE mappings must be implemented together with skip detection logic. Run existing tests unchanged after refactoring as the primary regression test to validate behavior preservation.\n\nSee also: Backward compatibility and schema evolution — retry counter state preservation; Refactoring and testing practices — call site verification and test preservation; Concurrency and I/O safety — state mutation patterns.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766130+00:00","updated_at":"2026-04-18T15:38:18.766131+00:00","valid_from":"2026-04-18T15:38:18.766130+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9T","title":"State machine transitions","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766130+00:00","updated_at":"2026-04-18T15:38:18.766131+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Memory management
-
-
 
 **Budget allocation**: Must be pre-allocated upfront before prompt assembly in `_inject_memory()` since post-hoc surplus reclamation is impossible. Use a two-round allocator: round one gives each section its minimum, round two distributes remaining budget proportionally by label-keyed priority (from `_DEFAULT_PRIORITIES`). The allocator sets budget caps as hard maxes, not predicted lengths—sections may use less due to summarization wrapping. Budget allocations must be explicitly consumed after calling `get_allocation()`. Wiki budget (`max_repo_wiki_chars`) is separate from memory budget and must be deducted from memory surplus BEFORE redistributing. Accept minor waste from unused memory budget rather than implementing complex multi-pass strategies.
 
@@ -72,57 +71,57 @@ See also: Backward compatibility and schema evolution — retry counter state pr
 
 See also: Concurrency and I/O safety — atomic write patterns and crash-safe file operations; Backward compatibility and schema evolution — metadata tag usage.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9V","title":"Memory management","content":"**Budget allocation**: Must be pre-allocated upfront before prompt assembly in `_inject_memory()` since post-hoc surplus reclamation is impossible. Use a two-round allocator: round one gives each section its minimum, round two distributes remaining budget proportionally by label-keyed priority (from `_DEFAULT_PRIORITIES`). The allocator sets budget caps as hard maxes, not predicted lengths—sections may use less due to summarization wrapping. Budget allocations must be explicitly consumed after calling `get_allocation()`. Wiki budget (`max_repo_wiki_chars`) is separate from memory budget and must be deducted from memory surplus BEFORE redistributing. Accept minor waste from unused memory budget rather than implementing complex multi-pass strategies.\n\n**Loading and caching**: Lazy-load memory context on explicit user action (section expand) rather than pre-fetching—avoids N+1 API calls on HITL list views. Use lazy-load-first (Hindsight recall) + append-only (JSONL events) for separated concerns over unified storage. In-memory cache, not file-backed, for process-lifetime scope. Client-side filtering compensates for server API limitations: over-request (limit + flagged count, capped at 2x) and discard stale locally.\n\n**Deduplication and scoring**: Use consistent SHA-256 hashing (truncated to 16 chars) for dedup keys and recall hit tracking. Optional dedup parameter with `None` default preserves legacy behavior; passing `bank_labels=None` triggers original first-seen-wins logic. Dedup via asymmetric similarity `len(words & existing) / max(len(words), 1)` with configurable threshold (default 0.85, word-set overlap >70% avoids semantic LLM calls); higher threshold means fewer items removed. Batch load scoring data once per operation (call `MemoryScorer.load_item_scores()` once, reuse for all items) rather than per-item. Use consistent integer ID mapping across MemoryScorer.evict_items and MemorySyncWorker via formula: `abs(hash(str(item.get(\"id\", \"\"))) % (10**9))`. Stable sort preserves original relevance order for equal combined scores.\n\n**Preference learning**: Full preference learning pathway: regex match → ConversationTurn.signal → MEMORY_SUGGESTION block → MemorySuggester → dual-write (JSONL + Hindsight) → Bank.LEARNINGS → recall_safe wrapper → turn 0 prompt injection. Regex signal classification has documented priority-ordering bias (first-match-wins) causing false positives; future improvements could use LLM-based classification. Use full preference stats method (expose via public `get_preference_stats()`) to avoid route coupling to ShapePhase internal counters. Distinguish ephemeral vs persistent metrics in dashboard: recall attempt/hit counters are session-level (reset on restart), while signal distribution derives from persisted state.json. In-memory ephemeral metrics acceptable for operational dashboards; defer to StateTracker if persistence becomes required. Recall hit rate is simple proxy: recall_hits when Bank.LEARNINGS returns results, misses when empty.\n\n**Hindsight integration**: `HindsightClient.retain()` coerces all metadata values via `str(v)`, so warnings/flags must be string `\"true\"`, not boolean `True`. Check via `metadata.get(\"warning\") == \"true\"` which safely handles missing keys. Metadata-based filtering in sync workers uses tags (e.g., `adr_status: \"superseded\"`) to exclude items. When source is missing in historical entries, apply Tier 3 default (1.0x weight) via bank-based heuristics. Central injection in `retain_safe()` and `schedule_retain()` uses `setdefault`-style logic to avoid scattered coupling and non-breaking schema versioning.\n\n**Staleness and contradiction**: Conservative contradiction detection: keyword heuristics with first-match-wins bias and 40% topic overlap threshold to reduce false positives. O(n²) pairwise comparison acceptable when n ≤ 50 items across 5 banks. Resolution priority: (1) provenance—human-sourced wins over agent-sourced regardless of timestamp; (2) recency—newer wins when equal provenance. Staleness detection emits events/logs rather than mutating state, allowing reversibility and operator visibility. Skip resources without timestamp metadata rather than flagging as stale. Stale store cleanup during periodic audits removes entries that no longer match current JSONL index to bound storage growth.\n\n**Eviction and cleanup**: Memory eviction must update both item_scores.json and items.jsonl atomically. Operator-friendly admin output (e.g., `run_compact()`) should include total counts, candidate counts, and per-category breakdowns (auto_evict=N, needs_curation=N, keep=N). Track original positions before re-ranking to compute boost/demotion statistics. Metrics definition must sync across all computation paths (compute_rolling_averages, detect_regressions, and any other consumers). Establish consistent data enrichment expectations: functions should have consistent requirements about whether input is pre-enriched or self-enriching. Complete resource cleanup before setting closed flags (e.g., set cleanup state flags only after `aclose()` completes). Idempotent `close()` via `_closed` flag guard prevents double cleanup. Memory fingerprinting via `SHA-256(memory.display_text[:500])[:16]` is stable but monitors for orphan fingerprints if formatting changes. Dual-file persistence: JSONL for append-only logs, atomic JSON for computed state. Best-effort consistency for concurrent file-backed state: threading.Lock prevents corruption within single process, multi-process races acceptable since metrics are advisory.\n\nSee also: Concurrency and I/O safety — atomic write patterns and crash-safe file operations; Backward compatibility and schema evolution — metadata tag usage.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766132+00:00","updated_at":"2026-04-18T15:38:18.766133+00:00","valid_from":"2026-04-18T15:38:18.766132+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9V","title":"Memory management","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766132+00:00","updated_at":"2026-04-18T15:38:18.766133+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Documentation and ADR consistency
-
-
 
 Keep CLAUDE.md and README in sync—they may diverge on details (e.g., 'five concurrent async loops' vs actual implementation). ADR files must have corresponding README entries to be canonically referenceable—files without README entries become invisible. When renaming fixtures/command files, preserve namespace prefixes (hf. or hf-) for consistency. Skill prompts replicated across four backend locations (src/diff_sanity.py, .claude/commands/, .pi/skills/, .codex/skills/) must stay in sync; missed updates cause inconsistent LLM behavior.
 
 See also: Backward compatibility and schema evolution — schema documentation; Refactoring and testing practices — documentation standards.
 
+
 ```json:entry
-{"id":"01KQ11A4G90JQVA2ZA7FT25K9W","title":"Documentation and ADR consistency","content":"Keep CLAUDE.md and README in sync—they may diverge on details (e.g., 'five concurrent async loops' vs actual implementation). ADR files must have corresponding README entries to be canonically referenceable—files without README entries become invisible. When renaming fixtures/command files, preserve namespace prefixes (hf. or hf-) for consistency. Skill prompts replicated across four backend locations (src/diff_sanity.py, .claude/commands/, .pi/skills/, .codex/skills/) must stay in sync; missed updates cause inconsistent LLM behavior.\n\nSee also: Backward compatibility and schema evolution — schema documentation; Refactoring and testing practices — documentation standards.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766135+00:00","updated_at":"2026-04-18T15:38:18.766136+00:00","valid_from":"2026-04-18T15:38:18.766135+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G90JQVA2ZA7FT25K9W","title":"Documentation and ADR consistency","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T15:38:18.766135+00:00","updated_at":"2026-04-18T15:38:18.766136+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Kill-Switch Convention — enabled_cb at Top of _do_work
 
-
-
 Every BaseBackgroundLoop subclass MUST gate _do_work on self._enabled_cb(self._worker_name) at the top of the method and return {'status': 'disabled'} when the callback returns False (ADR-0049). The base class's run() loop already gates enabled_cb before scheduling work, but that guard is bypassed in three real scenarios: (1) startup catchup path (_should_run_catchup → _execute_cycle calls _do_work without the sleep-time enabled_cb check); (2) direct test invocations of _do_work; (3) any future scheduler refactor. The in-body check makes the kill-switch behavior visible in tests that invoke _do_work directly via enabled_cb=lambda _: False. A config field (e.g. staging_enabled) may exist for dark-launch but must be an AND with enabled_cb, not a replacement; enabled_cb is the FIRST check. Verification: grep -l 'async def _do_work' src/*_loop.py | xargs grep -L 'self._enabled_cb' — any loop in the output is violating. See also: Trust Fleet Pattern; HITL Escalation Channel.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XHZ","title":"Kill-Switch Convention — enabled_cb at Top of _do_work","content":"Every BaseBackgroundLoop subclass MUST gate _do_work on self._enabled_cb(self._worker_name) at the top of the method and return {'status': 'disabled'} when the callback returns False (ADR-0049). The base class's run() loop already gates enabled_cb before scheduling work, but that guard is bypassed in three real scenarios: (1) startup catchup path (_should_run_catchup → _execute_cycle calls _do_work without the sleep-time enabled_cb check); (2) direct test invocations of _do_work; (3) any future scheduler refactor. The in-body check makes the kill-switch behavior visible in tests that invoke _do_work directly via enabled_cb=lambda _: False. A config field (e.g. staging_enabled) may exist for dark-launch but must be an AND with enabled_cb, not a replacement; enabled_cb is the FIRST check. Verification: grep -l 'async def _do_work' src/*_loop.py | xargs grep -L 'self._enabled_cb' — any loop in the output is violating. See also: Trust Fleet Pattern; HITL Escalation Channel.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022832+00:00","updated_at":"2026-04-25T00:40:54.022833+00:00","valid_from":"2026-04-25T00:40:54.022832+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XHZ","title":"Kill-Switch Convention — enabled_cb at Top of _do_work","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022832+00:00","updated_at":"2026-04-25T00:40:54.022833+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## HITL Escalation Channel — `hitl-escalation` Label
 
-
-
 Trust loops never page humans by any channel other than filing a GitHub issue with the `hitl-escalation` label (ADR-0045). A loop that cannot recover files exactly one escalation issue and stops re-filing until the operator resolves it. The escalation body must promise: 'closing this issue clears the attempt counter (§3.2 lifecycle)' — the promise is honored by _reconcile_closed_escalations on the next tick (which calls clear/reset on the relevant state counter when it sees the closed issue). Threshold-based escalation (e.g. principles_audit fires once at attempt threshold, not every tick after) requires checking the current counter BEFORE incrementing — past-threshold ticks must be no-ops until reconcile resets. Anomalies file with specific sub-labels (rc-red-attribution-unsafe, principles-stuck, flake-tracker-stuck, etc.) so operator queries can target a class. See also: DedupStore + Reconcile Pattern; Kill-Switch Convention.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ1","title":"HITL Escalation Channel — `hitl-escalation` Label","content":"Trust loops never page humans by any channel other than filing a GitHub issue with the `hitl-escalation` label (ADR-0045). A loop that cannot recover files exactly one escalation issue and stops re-filing until the operator resolves it. The escalation body must promise: 'closing this issue clears the attempt counter (§3.2 lifecycle)' — the promise is honored by _reconcile_closed_escalations on the next tick (which calls clear/reset on the relevant state counter when it sees the closed issue). Threshold-based escalation (e.g. principles_audit fires once at attempt threshold, not every tick after) requires checking the current counter BEFORE incrementing — past-threshold ticks must be no-ops until reconcile resets. Anomalies file with specific sub-labels (rc-red-attribution-unsafe, principles-stuck, flake-tracker-stuck, etc.) so operator queries can target a class. See also: DedupStore + Reconcile Pattern; Kill-Switch Convention.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022851+00:00","updated_at":"2026-04-25T00:40:54.022852+00:00","valid_from":"2026-04-25T00:40:54.022851+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ1","title":"HITL Escalation Channel — `hitl-escalation` Label","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022851+00:00","updated_at":"2026-04-25T00:40:54.022852+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Avoided Patterns
-
-
 
 Common mistakes agents make in the HydraFlow codebase. These are semantic rules that linters and type checkers cannot catch — they require understanding the project's conventions and prior incidents. Read this doc before editing the areas each rule calls out.
 
 This is the canonical location for avoided patterns. `CLAUDE.md` links here; do not duplicate rules back into `CLAUDE.md`. Sensors (`src/sensor_enricher.py`) and audit agents (`.claude/commands/hf.audit-code.md`) read this doc to coach agents during failures.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBA","title":"Avoided Patterns","content":"Common mistakes agents make in the HydraFlow codebase. These are semantic rules that linters and type checkers cannot catch — they require understanding the project's conventions and prior incidents. Read this doc before editing the areas each rule calls out.\n\nThis is the canonical location for avoided patterns. `CLAUDE.md` links here; do not duplicate rules back into `CLAUDE.md`. Sensors (`src/sensor_enricher.py`) and audit agents (`.claude/commands/hf.audit-code.md`) read this doc to coach agents during failures.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793202+00:00","updated_at":"2026-04-25T00:47:19.793203+00:00","valid_from":"2026-04-25T00:47:19.793202+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBA","title":"Avoided Patterns","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793202+00:00","updated_at":"2026-04-25T00:47:19.793203+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Underscore-prefixed names imported across modules
-
-
 
 If a symbol is imported from another module, it is part of that module's public API and must not start with `_`. The leading underscore is Python's "module-internal" convention; crossing the boundary lies about the contract and trips pyright's `reportPrivateUsage` / unused-symbol warnings.
 
@@ -150,13 +149,13 @@ from plugin_skill_registry import parse_plugin_spec
 
 **How to check:** Any symbol imported across module boundaries must not start with `_`. If it does, rename or refactor in the same change.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBG","title":"Underscore-prefixed names imported across modules","content":"If a symbol is imported from another module, it is part of that module's public API and must not start with `_`. The leading underscore is Python's \"module-internal\" convention; crossing the boundary lies about the contract and trips pyright's `reportPrivateUsage` / unused-symbol warnings.\n\n**Wrong:**\n\n```python\n# src/plugin_skill_registry.py\ndef _parse_plugin_spec(spec: str) -> tuple[str, str]: ...\n\n# src/preflight.py\nfrom plugin_skill_registry import _parse_plugin_spec  # crosses the boundary\n```\n\n**Right:**\n\n```python\n# src/plugin_skill_registry.py\ndef parse_plugin_spec(spec: str) -> tuple[str, str]: ...\n\n# src/preflight.py\nfrom plugin_skill_registry import parse_plugin_spec\n```\n\n**Why:** Pyright flags private-symbol imports and \"defined but not used\" warnings for `_`-prefixed names whose only consumers are other modules. Promotion to public is also a signal to future readers that the symbol is a load-bearing contract, not an implementation detail.\n\n**How to check:** Any symbol imported across module boundaries must not start with `_`. If it does, rename or refactor in the same change.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793253+00:00","updated_at":"2026-04-25T00:47:19.793254+00:00","valid_from":"2026-04-25T00:47:19.793253+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBG","title":"Underscore-prefixed names imported across modules","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793253+00:00","updated_at":"2026-04-25T00:47:19.793254+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## `_name` for unused loop variables (prefer bare `_`)
-
-
 
 Python's informal "unused by intent" convention is a bare `_`, not `_name`. Pyright and some strict linters treat `_name` as a named variable that happens to start with `_` and flag it as unused regardless.
 
@@ -181,13 +180,13 @@ for _, name, marketplace in specs:
 
 ---
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBM","title":"`_name` for unused loop variables (prefer bare `_`)","content":"Python's informal \"unused by intent\" convention is a bare `_`, not `_name`. Pyright and some strict linters treat `_name` as a named variable that happens to start with `_` and flag it as unused regardless.\n\n**Wrong:**\n\n```python\nfor _lang, name, marketplace in specs:\n    install(name, marketplace)\n# Pyright: \"_lang\" is not accessed\n```\n\n**Right:**\n\n```python\nfor _, name, marketplace in specs:\n    install(name, marketplace)\n```\n\n**Why:** Bare `_` is universally understood as \"throwaway\"; `_name` is not. Reserve `_name` only when documentation value is meaningful enough to keep a name alive. Otherwise use bare `_`.\n\n**How to check:** `rg \"for _[a-z]\" src/` — each match should justify why the underscore-prefixed name is more readable than bare `_`.\n\n---","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793276+00:00","updated_at":"2026-04-25T00:47:19.793277+00:00","valid_from":"2026-04-25T00:47:19.793276+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBM","title":"`_name` for unused loop variables (prefer bare `_`)","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793276+00:00","updated_at":"2026-04-25T00:47:19.793277+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Development and Local Testing Workflow
 
-
+## Run and dev
 
 ```bash
 make run            # Start backend + Vite frontend dev server
@@ -197,36 +196,36 @@ make status         # Show current HydraFlow state
 make hot            # Send config update to running instance
 ```
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBS","title":"Run and dev","content":"```bash\nmake run            # Start backend + Vite frontend dev server\nmake dry-run        # Dry run (log actions without executing)\nmake clean          # Remove all worktrees and state\nmake status         # Show current HydraFlow state\nmake hot            # Send config update to running instance\n```","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793441+00:00","updated_at":"2026-04-25T00:47:19.793443+00:00","valid_from":"2026-04-25T00:47:19.793441+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBS","title":"Run and dev","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793441+00:00","updated_at":"2026-04-25T00:47:19.793443+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## UI Development Standards
 
-
-
 The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCE","title":"UI Development Standards","content":"The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793785+00:00","updated_at":"2026-04-25T00:47:19.793786+00:00","valid_from":"2026-04-25T00:47:19.793785+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCE","title":"UI Development Standards","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793785+00:00","updated_at":"2026-04-25T00:47:19.793786+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## DRY principle
-
-
 
 - Shared constants (`ACTIVE_STATUSES`, `PIPELINE_STAGES`) live in `ui/src/constants.js` — never duplicate.
 - Type definitions in `ui/src/types.js`.
 - Colors are CSS custom properties in `ui/index.html` `:root`, accessed via `ui/src/theme.js` — always use `theme.*` tokens, never raw hex or rgb values.
 - Extract shared styles to reusable objects when used 3+ times.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCG","title":"DRY principle","content":"- Shared constants (`ACTIVE_STATUSES`, `PIPELINE_STAGES`) live in `ui/src/constants.js` — never duplicate.\n- Type definitions in `ui/src/types.js`.\n- Colors are CSS custom properties in `ui/index.html` `:root`, accessed via `ui/src/theme.js` — always use `theme.*` tokens, never raw hex or rgb values.\n- Extract shared styles to reusable objects when used 3+ times.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793796+00:00","updated_at":"2026-04-25T00:47:19.793797+00:00","valid_from":"2026-04-25T00:47:19.793796+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCG","title":"DRY principle","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793796+00:00","updated_at":"2026-04-25T00:47:19.793797+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Workflow for every code change
-
-
 
 1. Create a worktree: `git worktree add ../hydraflow-worktrees/<name> origin/main`
 2. Create a branch in the worktree: `git checkout -b <branch-name> origin/main`
@@ -236,13 +235,13 @@ The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.
 
 **Do NOT use the `EnterWorktree` tool** — it auto-cleans up and loses work. Use manual `git worktree add` commands.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCM","title":"Workflow for every code change","content":"1. Create a worktree: `git worktree add ../hydraflow-worktrees/<name> origin/main`\n2. Create a branch in the worktree: `git checkout -b <branch-name> origin/main`\n3. Make changes, commit, and push the branch\n4. Create a PR via `gh pr create`\n5. Clean up: `git worktree remove ../hydraflow-worktrees/<name>`\n\n**Do NOT use the `EnterWorktree` tool** — it auto-cleans up and loses work. Use manual `git worktree add` commands.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793868+00:00","updated_at":"2026-04-25T00:47:19.793868+00:00","valid_from":"2026-04-25T00:47:19.793868+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCM","title":"Workflow for every code change","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793868+00:00","updated_at":"2026-04-25T00:47:19.793868+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Conventions
-
-
 
 - **Default location:** `../hydraflow-worktrees/` (sibling to repo root)
 - **Naming:** `issue-{issue_number}/` for issue work, descriptive names for other changes
@@ -251,29 +250,30 @@ The React dashboard (`ui/`) uses inline styles in JSX. Follow these conventions.
 - Worktrees get independent venvs (`uv sync`), symlinked `.env`, and pre-commit hooks
 - Stale worktrees from merged PRs should be periodically pruned with `git worktree prune`
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCN","title":"Conventions","content":"- **Default location:** `../hydraflow-worktrees/` (sibling to repo root)\n- **Naming:** `issue-{issue_number}/` for issue work, descriptive names for other changes\n- **Config:** `worktree_base` field in `HydraFlowConfig` (`src/config.py`)\n- **Cleanup:** `make clean` removes all worktrees and state\n- Worktrees get independent venvs (`uv sync`), symlinked `.env`, and pre-commit hooks\n- Stale worktrees from merged PRs should be periodically pruned with `git worktree prune`","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793873+00:00","updated_at":"2026-04-25T00:47:19.793874+00:00","valid_from":"2026-04-25T00:47:19.793873+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCN","title":"Conventions","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793873+00:00","updated_at":"2026-04-25T00:47:19.793874+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Sentry Alert Configuration for HydraFlow
 
-
-
 # Sentry Alert Configuration for HydraFlow
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249N","title":"Sentry Alert Configuration for HydraFlow","content":"# Sentry Alert Configuration for HydraFlow","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794326+00:00","updated_at":"2026-04-25T00:47:19.794327+00:00","valid_from":"2026-04-25T00:47:19.794326+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249N","title":"Sentry Alert Configuration for HydraFlow","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794326+00:00","updated_at":"2026-04-25T00:47:19.794327+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Why This Is "Harnessed"
-
-
 
 - No autonomous mutation of prompts/skills in-repo.
 - Observation data is lightweight and local to the project.
 - Retros produce explicit artifacts for human review.
 - Promotion into durable memory still goes through `/hf.memory` and HITL.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249T","title":"Why This Is \"Harnessed\"","content":"- No autonomous mutation of prompts/skills in-repo.\n- Observation data is lightweight and local to the project.\n- Retros produce explicit artifacts for human review.\n- Promotion into durable memory still goes through `/hf.memory` and HITL.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794403+00:00","updated_at":"2026-04-25T00:47:19.794403+00:00","valid_from":"2026-04-25T00:47:19.794403+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249T","title":"Why This Is \"Harnessed\"","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794403+00:00","updated_at":"2026-04-25T00:47:19.794403+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,8 +1,7 @@
 # Testing
 
+
 ## Core Testing Strategy and Design for Testability
-
-
 
 Function structure limits: Enforce 50-line limit on handler functions and 30-line limit on registration wiring; extract nested closures into instance methods to flatten nesting to ≤3 levels.
 
@@ -32,13 +31,13 @@ Frontend and browser testing: Server-side rendering via Django/FastAPI TestClien
 
 See also: Type System and Data Model Consistency Testing — mock return values must match TypedDict structure.
 
+
 ```json:entry
-{"id":"01KQ11A4GE861157N0A89NAN4P","title":"Core Testing Strategy and Design for Testability","content":"Function structure limits: Enforce 50-line limit on handler functions and 30-line limit on registration wiring; extract nested closures into instance methods to flatten nesting to ≤3 levels.\n\nMocking strategy: Mock at definition site, not usage site. For module-level imports, patch the assignment; for deferred imports, patch the definition module. For optional dependencies (sentry_sdk), use `unittest.mock.patch.dict(\"sys.modules\", ...)` to guarantee cleanup. Mock sub-modules explicitly (both 'sentry_sdk' and 'sentry_sdk.integrations'). Mock return values must use identical keys and structure as actual TypedDict definitions.\n\nIntegration testing markers: Mark tests `@pytest.mark.integration` only if they exercise real external dependencies (Docker, network, filesystem, worktrees, service instances). Tests with `spec=AsyncMock` for all deps are unit/functional. Use `pytest.mark.skipif` with `shutil.which()` for optional CLI tools.\n\nAsync patterns: Use `AsyncMock` with explicit `assert_called_with()`. For fire-and-forget tasks via `create_task()`, call `await asyncio.sleep(0)` before assertions. Test async context managers in three scenarios: idempotent close, context manager triggers close on exit, returns self. Verify fatal exceptions propagate through multi-phase loops by mocking internal methods to raise specific types.\n\nSubprocess/CLI testing: Create small Python scripts acting as CLI stand-ins, logging invocations to JSON-lines files for post-hoc assertions.\n\nConftest and fixtures: Session-scoped fixtures load before test modules. Use conftest.py as single source of truth for sys.path manipulation and autouse fixtures for state cleanup. Global/module-level state (e.g., `_gh_semaphore`, `_rate_limit_until`) must be reset completely in both setup and teardown. File-based test I/O must use `tmp_path` fixture with `ConfigFactory.create()` to avoid polluting project state. Export additive seed state variants (e.g., `seedStateWithHumanInput`) from conftest.py. Verify sys.modules cleanup with `pytest --randomly-seed` using multiple seeds.\n\nIntegration testing with phase runners: Wire real business logic (StateTracker, EventBus, VerificationJudge, RetrospectiveCollector) but mock only the `_execute()` subprocess boundary. Provide configurable transcript strings for real runner parsing, exposing mismatches fully-mocked runners hide. Validate state via StateTracker APIs and EventBus.get_history().\n\nProtocol satisfaction: Use two complementary approaches: (1) Structural typing with `isinstance(concrete_instance, ProtocolName)` and `@runtime_checkable` to ensure contract satisfaction; (2) Duck-typing assertions using `hasattr(obj, 'method_name')` for loose coupling. Use `inspect.signature()` comparison to catch parameter drift. Parametrize tests for each protocol method.\n\nFaçaded refactors: Verify `__getattr__` correctly routes methods to sub-clients, raises `AttributeError` for nonexistent methods, the façade satisfies protocols via delegation, and existing tests that mock the original class still work. Sub-components receive mutable dict/set references (not copies) to shared state owned by the facade.\n\nTesting during refactoring: When extracting private methods with unchanged public API, existing tests provide complete coverage (no new tests needed). When extracting prompt-building methods, run prompt-assertion tests in isolation immediately after extraction. Parameter renames are low-risk when all callers use positional arguments. For dead code removal, update all related test classes and helpers. When refactoring duplicated code, keep existing tests as regression checks. For documenting known broken behavior, use `@pytest.mark.skip(reason=\"documenting bug: [issue number]\")` for removal after fix.\n\nTelemetry and Sentry testing: Use `patch.dict(\"sys.modules\", ...)` to mock sentry_sdk imports, then assert actual numeric values in breadcrumbs/metrics, not just presence of keys. When testing log output with pytest's `caplog` fixture, always specify exact logger name: `caplog.at_level(level, logger=\"module.name\")`. Clear caplog before the action and assert on message substrings specific to logged values.\n\nAssertion and test precision: For AST-based regression tests, parse source file ASTs to verify code structure assertions, allowing ±3 line drift tolerance. Tests asserting exact query strings are brittle; instead assert that specific key terms appear. Use f-strings to embed constants in assertions. Use `is` operator to verify runners share the same subprocess_runner instance. Substring matching in coverage checks produces false positives when short names collide; use word-boundary or full-name matching.\n\nFrontend and browser testing: Server-side rendering via Django/FastAPI TestClient only sees the initial HTML shell, not attributes rendered by JavaScript. Accessibility attributes like `aria-labelledby` and other client-rendered properties require Playwright or browser-based testing. Dead Python tests attempting to verify these should be deleted in favor of browser-based tests. Browser tests are slower than TestClient but catch rendering-specific bugs that server-side tests miss. Organize browser test fixtures (e.g., `seedStateWithHumanInput`) in conftest.py for reuse.\n\nSee also: Type System and Data Model Consistency Testing — mock return values must match TypedDict structure.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908932+00:00","updated_at":"2026-04-18T14:53:08.908940+00:00","valid_from":"2026-04-18T14:53:08.908932+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4GE861157N0A89NAN4P","title":"Core Testing Strategy and Design for Testability","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908932+00:00","updated_at":"2026-04-18T14:53:08.908940+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Type System and Data Model Consistency Testing
-
-
 
 Schema evolution and field synchronization: Global singletons like `_event_counter` are shared across all instances. Tests must never assert on absolute ID values—only on relative ordering and uniqueness within a single test. This prevents test pollution and ensures event ordering is the actual concern. Before property-based tests exercise a transition graph, add structural tests: every target is a valid stage, every stage has a transition entry, no dangling references. Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) serve as both test oracles and executable documentation—keep them synchronized. Direct-swap labels (hitl-active, hitl-autofix, fixed, verify) are set via `swap_pipeline_labels()` calls, not transitions. STAGE_ORDER gates full lifecycle tests; new stages require STAGE_ORDER updates. Test both EVENT_TYPE_TO_STAGE and SOURCE_TO_STAGE paths independently. When related data structures must stay in sync, add dedicated sync tests asserting set equality via dynamic field extraction. Use `len(LABELS) == 13` instead of hardcoding. Validate explicitly that each label field is present in `all_pipeline_labels`.
 
@@ -50,13 +49,13 @@ Feature toggle implementation: Feature toggles require both a config field defin
 
 See also: Core Testing Strategy and Design for Testability — mock return values must match TypedDict structure.
 
+
 ```json:entry
-{"id":"01KQ11A4GE861157N0A89NAN4Q","title":"Type System and Data Model Consistency Testing","content":"Schema evolution and field synchronization: Global singletons like `_event_counter` are shared across all instances. Tests must never assert on absolute ID values—only on relative ordering and uniqueness within a single test. This prevents test pollution and ensures event ordering is the actual concern. Before property-based tests exercise a transition graph, add structural tests: every target is a valid stage, every stage has a transition entry, no dangling references. Test constants (`ALL_PIPELINE_LABELS`, `VALID_STAGES`, `VALID_TRANSITIONS`) serve as both test oracles and executable documentation—keep them synchronized. Direct-swap labels (hitl-active, hitl-autofix, fixed, verify) are set via `swap_pipeline_labels()` calls, not transitions. STAGE_ORDER gates full lifecycle tests; new stages require STAGE_ORDER updates. Test both EVENT_TYPE_TO_STAGE and SOURCE_TO_STAGE paths independently. When related data structures must stay in sync, add dedicated sync tests asserting set equality via dynamic field extraction. Use `len(LABELS) == 13` instead of hardcoding. Validate explicitly that each label field is present in `all_pipeline_labels`.\n\nModel and TypedDict field changes: Adding fields to Pydantic models or TypedDict structures breaks tests with exact field sets or exact equality assertions. Required updates: model definition, test factory defaults, field assertions in all_fields tests, state assertions, serialization/deserialization round-trips. Grep the test suite for each model name before committing. For TypedDict fields marked `NotRequired`, update exact-match assertions but not missing-key assertions. When changing internal dict key types (e.g., `int` → `str`), test both old format and new format loading without crashes. When narrowing field types with validators, accept empty strings explicitly to preserve backward compatibility. When adding Literal constraints to Pydantic fields, test both valid and invalid values. Use `total=False` Pydantic models to conditionally include fields like `verdict` and `duration` only when provided (non-None), not as None values.\n\nType annotation changes: TypedDicts are dicts at runtime, so existing test assertions work identically. Migrating from dict[str, Any] to TypedDict returns requires no test changes—the value is purely in static type validation. When narrowing function parameter types from `Any` to specific types, callers passing `Any`-typed values will still type-check successfully. `Any` is compatible with all types in pyright, enabling safe gradual type annotation migrations. Type annotation changes without runtime behavior modifications can be verified entirely through existing test suites and type checkers; new test additions are unnecessary. Verify via `make quality-lite` and `make test`.\n\nFeature toggle implementation: Feature toggles require both a config field definition in `src/config.py` AND an `_ENV_INT_OVERRIDES` entry to support environment-variable override. Both are necessary for the toggle to be runtime-configurable. Each toggle field must be tested for both default value and environment-variable override behavior.\n\nSee also: Core Testing Strategy and Design for Testability — mock return values must match TypedDict structure.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908950+00:00","updated_at":"2026-04-18T14:53:08.908951+00:00","valid_from":"2026-04-18T14:53:08.908950+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4GE861157N0A89NAN4Q","title":"Type System and Data Model Consistency Testing","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908950+00:00","updated_at":"2026-04-18T14:53:08.908951+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Multi-Location Consistency and Concurrent File I/O Testing
-
-
 
 Concurrent file operations: Test concurrent file operations using `concurrent.futures.ThreadPoolExecutor` with fixed thread counts and deterministic iterations (e.g., 10 threads × 20 events = 200 total). Assert exact event counts rather than timing. `append_jsonl` has no file locking, but POSIX guarantees atomicity for writes under ~4KB (pipe buffer). Each JSON line is well under 4KB, so concurrent appends should be safe—validate empirically. If concurrent appends produce corrupt lines, locking or buffering becomes necessary.
 
@@ -66,55 +65,55 @@ Skill definition multi-location replication: HydraFlow skills are replicated acr
 
 Cross-location key consistency principle: Both memory deduplication and skill definition replication depend on consistent naming across multiple locations. If location names or field names differ across copies, data will be silently missed during validation or deduplication. Always verify that bank_order keys match dict keys and skill markers are present in all 4 backend copies with identical text.
 
+
 ```json:entry
-{"id":"01KQ11A4GE861157N0A89NAN4R","title":"Multi-Location Consistency and Concurrent File I/O Testing","content":"Concurrent file operations: Test concurrent file operations using `concurrent.futures.ThreadPoolExecutor` with fixed thread counts and deterministic iterations (e.g., 10 threads × 20 events = 200 total). Assert exact event counts rather than timing. `append_jsonl` has no file locking, but POSIX guarantees atomicity for writes under ~4KB (pipe buffer). Each JSON line is well under 4KB, so concurrent appends should be safe—validate empirically. If concurrent appends produce corrupt lines, locking or buffering becomes necessary.\n\nMemory deduplication and bank consistency: Memory deduplication uses a priority mapping: LEARNINGS (memory) = 5, TROUBLESHOOTING = 4, RETROSPECTIVES = 3, REVIEW_INSIGHTS = 2, HARNESS_INSIGHTS = 1. When two near-duplicate items collide, the higher-priority bank's item survives. Bank key consistency across dedup and assembly pipelines is critical—if `bank_order` uses different key names than dict keys, banks will be silently missed. Use consistent string keys throughout (memory, troubleshooting, review_insights, etc.). Different memory banks use different JSONL record formats. Fallback recall functions must try multiple field names (`learning`, `text`, `content`, `display_text`, `description`) to extract the text payload.\n\nSkill definition multi-location replication: HydraFlow skills are replicated across 4 backend locations (.claude/commands/, .pi/skills/, .codex/skills/, src/*.py). Use a manual SKILL_MARKERS mapping (not regex introspection) to validate that all copies contain matching output markers. Consistency tests should check marker presence via substring search to tolerate minor markdown structure differences across backends. Each skill removal or addition requires updating all test fixtures and assertions across multiple test files—a single skill change can require updates across 3+ test files. Before committing skill changes, verify that all 4 backend copies have been updated with consistent marker text.\n\nCross-location key consistency principle: Both memory deduplication and skill definition replication depend on consistent naming across multiple locations. If location names or field names differ across copies, data will be silently missed during validation or deduplication. Always verify that bank_order keys match dict keys and skill markers are present in all 4 backend copies with identical text.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908953+00:00","updated_at":"2026-04-18T14:53:08.908955+00:00","valid_from":"2026-04-18T14:53:08.908953+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4GE861157N0A89NAN4R","title":"Multi-Location Consistency and Concurrent File I/O Testing","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908953+00:00","updated_at":"2026-04-18T14:53:08.908955+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## ADR Testing Patterns: Conservative Pattern Matching and Validation
-
-
 
 Extract only high-confidence invariant patterns (4 baseline: uniqueness, usage, negative, coverage) from ADR Decision sections. Generate all tests with `@pytest.mark.skip(reason="skeleton: requires human review")` by default, deferring validation to humans. This prevents over-matching ambiguous language while supporting future pattern refinement.
 
 ADR validation: ADRs must pass `tests/test_adr_pre_validator.py` which enforces required sections (Status, Context, Decision, Consequences), valid status values, and correct markdown formatting. Validate that each ADR's status is one of: Proposed, Accepted, Deprecated, Superseded. Markdown formatting must follow the standard ADR template.
 
+
 ```json:entry
-{"id":"01KQ11A4GE861157N0A89NAN4S","title":"ADR Testing Patterns: Conservative Pattern Matching and Validation","content":"Extract only high-confidence invariant patterns (4 baseline: uniqueness, usage, negative, coverage) from ADR Decision sections. Generate all tests with `@pytest.mark.skip(reason=\"skeleton: requires human review\")` by default, deferring validation to humans. This prevents over-matching ambiguous language while supporting future pattern refinement.\n\nADR validation: ADRs must pass `tests/test_adr_pre_validator.py` which enforces required sections (Status, Context, Decision, Consequences), valid status values, and correct markdown formatting. Validate that each ADR's status is one of: Proposed, Accepted, Deprecated, Superseded. Markdown formatting must follow the standard ADR template.","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908957+00:00","updated_at":"2026-04-18T14:53:08.908958+00:00","valid_from":"2026-04-18T14:53:08.908957+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4GE861157N0A89NAN4S","title":"ADR Testing Patterns: Conservative Pattern Matching and Validation","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-04-18T14:53:08.908957+00:00","updated_at":"2026-04-18T14:53:08.908958+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Meta-Observability with Bounded Recursion
 
-
-
 Trust loops watch managed work; the meta-observer watches trust loops; the dead-man-switch watches the meta-observer (ADR-0046). One bounded meta-layer — no meta-meta. TrustFleetSanityLoop monitors the 9 trust loops (corpus_learning, contract_refresh, staging_bisect, principles_audit, flake_tracker, skill_prompt_eval, fake_coverage_auditor, rc_budget, wiki_rot_detector — itself explicitly excluded) for 5 anomaly kinds: issues_per_hour, repair_ratio, tick_error_ratio, staleness, cost_spike. Files hitl-escalation + trust-loop-anomaly issues per anomaly. HealthMonitorLoop._check_sanity_loop_staleness is the dead-man-switch — fires if TrustFleetSanityLoop hasn't ticked in >= 3× its configured interval. Recursion is bounded because (a) TRUST_LOOP_WORKERS is a frozen list verified by test_trust_loop_workers_contains_nine_spec_workers; (b) HealthMonitorLoop is not a 'trust loop' subject to sanity-loop watching — it pre-dates trust-fleet and watches trust-fleet from outside. Every operability question above the trust-fleet floor is answerable at /api/trust/fleet (per-loop ticks, errors, escalations, cost; anomalies_recent; escape_closure success metric). See also: Trust Fleet Pattern; Kill-Switch Convention.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ3","title":"Meta-Observability with Bounded Recursion","content":"Trust loops watch managed work; the meta-observer watches trust loops; the dead-man-switch watches the meta-observer (ADR-0046). One bounded meta-layer — no meta-meta. TrustFleetSanityLoop monitors the 9 trust loops (corpus_learning, contract_refresh, staging_bisect, principles_audit, flake_tracker, skill_prompt_eval, fake_coverage_auditor, rc_budget, wiki_rot_detector — itself explicitly excluded) for 5 anomaly kinds: issues_per_hour, repair_ratio, tick_error_ratio, staleness, cost_spike. Files hitl-escalation + trust-loop-anomaly issues per anomaly. HealthMonitorLoop._check_sanity_loop_staleness is the dead-man-switch — fires if TrustFleetSanityLoop hasn't ticked in >= 3× its configured interval. Recursion is bounded because (a) TRUST_LOOP_WORKERS is a frozen list verified by test_trust_loop_workers_contains_nine_spec_workers; (b) HealthMonitorLoop is not a 'trust loop' subject to sanity-loop watching — it pre-dates trust-fleet and watches trust-fleet from outside. Every operability question above the trust-fleet floor is answerable at /api/trust/fleet (per-loop ticks, errors, escalations, cost; anomalies_recent; escape_closure success metric). See also: Trust Fleet Pattern; Kill-Switch Convention.","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022865+00:00","updated_at":"2026-04-25T00:40:54.022866+00:00","valid_from":"2026-04-25T00:40:54.022865+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ3","title":"Meta-Observability with Bounded Recursion","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022865+00:00","updated_at":"2026-04-25T00:40:54.022866+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Cassette-Based Fake Adapter Contract Testing
 
-
-
 Fake adapters in tests/scenarios/fakes/ avoid AsyncMock fragility by recording cassettes against live github/git/docker/claude (ADR-0047), normalizing volatile fields (timestamps, PR numbers, SHAs), and replaying them in tests via tests/trust/contracts/_replay.py. Cassettes are Pydantic v2 YAML files (Cassette model in _schema.py) for github/git/docker; .jsonl streams for claude (which has hundreds of events per stream and a different normalization model — _canonical_jsonl in src/contract_diff.py). ContractRefreshLoop weekly: re-records → detect_fleet_drift → if drift, opens auto-merge PR labeled `contract-refresh`; the replay gate (300s subprocess timeout) verifies the refreshed cassettes still match fake behavior before merge. FakeCoverageAuditorLoop scans Fake* classes and flags methods that have no cassette (adapter-surface gaps) and helpers no scenario uses (test-helper gaps). See also: MockWorld Scenario Pattern; Trust Fleet Pattern.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ4","title":"Cassette-Based Fake Adapter Contract Testing","content":"Fake adapters in tests/scenarios/fakes/ avoid AsyncMock fragility by recording cassettes against live github/git/docker/claude (ADR-0047), normalizing volatile fields (timestamps, PR numbers, SHAs), and replaying them in tests via tests/trust/contracts/_replay.py. Cassettes are Pydantic v2 YAML files (Cassette model in _schema.py) for github/git/docker; .jsonl streams for claude (which has hundreds of events per stream and a different normalization model — _canonical_jsonl in src/contract_diff.py). ContractRefreshLoop weekly: re-records → detect_fleet_drift → if drift, opens auto-merge PR labeled `contract-refresh`; the replay gate (300s subprocess timeout) verifies the refreshed cassettes still match fake behavior before merge. FakeCoverageAuditorLoop scans Fake* classes and flags methods that have no cassette (adapter-surface gaps) and helpers no scenario uses (test-helper gaps). See also: MockWorld Scenario Pattern; Trust Fleet Pattern.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022872+00:00","updated_at":"2026-04-25T00:40:54.022873+00:00","valid_from":"2026-04-25T00:40:54.022872+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ4","title":"Cassette-Based Fake Adapter Contract Testing","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022872+00:00","updated_at":"2026-04-25T00:40:54.022873+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Kill-Switch Tests — Direct _do_work Invocation
 
-
-
 Per ADR-0049, every BaseBackgroundLoop subclass needs a unit test that asserts disabling the loop short-circuits _do_work to {'status': 'disabled'} without side effects. Test pattern: construct LoopDeps with enabled_cb=lambda name: name != '<worker_name>'; build the loop; mock dependent methods with AsyncMock(side_effect=AssertionError('must not run when disabled')); await loop._do_work() and assert the return dict equals {'status': 'disabled'}. The base class's run() loop has its own gate but the in-body check is what unit tests can deterministically exercise. Pattern lives in tests/test_<loop>_loop.py::test_kill_switch_short_circuits_do_work for all 10 trust loops + health_monitor + ci_monitor (added in #8390 + #8416). See also: Kill-Switch Convention; DedupStore + Reconcile Pattern.
 
+
 ```json:entry
-{"id":"01KQ11A4G670SNNXM1DDZ98XJ7","title":"Kill-Switch Tests — Direct _do_work Invocation","content":"Per ADR-0049, every BaseBackgroundLoop subclass needs a unit test that asserts disabling the loop short-circuits _do_work to {'status': 'disabled'} without side effects. Test pattern: construct LoopDeps with enabled_cb=lambda name: name != '<worker_name>'; build the loop; mock dependent methods with AsyncMock(side_effect=AssertionError('must not run when disabled')); await loop._do_work() and assert the return dict equals {'status': 'disabled'}. The base class's run() loop has its own gate but the in-body check is what unit tests can deterministically exercise. Pattern lives in tests/test_<loop>_loop.py::test_kill_switch_short_circuits_do_work for all 10 trust loops + health_monitor + ci_monitor (added in #8390 + #8416). See also: Kill-Switch Convention; DedupStore + Reconcile Pattern.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022902+00:00","updated_at":"2026-04-25T00:40:54.022903+00:00","valid_from":"2026-04-25T00:40:54.022902+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11A4G670SNNXM1DDZ98XJ7","title":"Kill-Switch Tests — Direct _do_work Invocation","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:40:54.022902+00:00","updated_at":"2026-04-25T00:40:54.022903+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Pydantic field additions without updating serialization tests
-
-
 
 When you add a field to any model in `src/models.py` (e.g., `PRListItem`, `StateData`), grep `tests/` for the model name and update ALL exact-match serialization tests.
 
@@ -126,13 +125,13 @@ When you add a field to any model in `src/models.py` (e.g., `PRListItem`, `State
 
 **How to check:** After editing `models.py`, run `rg "<ModelName>" tests/` and confirm every match still passes.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBB","title":"Pydantic field additions without updating serialization tests","content":"When you add a field to any model in `src/models.py` (e.g., `PRListItem`, `StateData`), grep `tests/` for the model name and update ALL exact-match serialization tests.\n\n- `model_dump()` assertions\n- Expected key sets in smoke tests\n- Any `assert result == {...}` that hard-codes the full model shape\n\n**Why:** HydraFlow has strict exact-match tests that assert on the complete serialized dict. A new field breaks them silently during unrelated refactors, and CI flags it later as a mysterious regression.\n\n**How to check:** After editing `models.py`, run `rg \"<ModelName>\" tests/` and confirm every match still passes.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793211+00:00","updated_at":"2026-04-25T00:47:19.793212+00:00","valid_from":"2026-04-25T00:47:19.793211+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBB","title":"Pydantic field additions without updating serialization tests","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793211+00:00","updated_at":"2026-04-25T00:47:19.793212+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Falsy checks on optional objects
-
-
 
 Never write `if not self._hindsight` to test whether an optional object is present. Falsy checks can fire unexpectedly on mock objects, empty collections, and objects that implement `__bool__`.
 
@@ -152,13 +151,13 @@ if self._hindsight is None:
 
 **Why:** `Mock()` objects are truthy by default, but a `Mock()` configured with `spec=SomeClass` that has `__bool__` can be falsy, and ordinary values like empty lists or dicts trigger the wrong branch. Explicit `is None` makes the intent unambiguous and matches the type annotation contract (`X | None`).
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBF","title":"Falsy checks on optional objects","content":"Never write `if not self._hindsight` to test whether an optional object is present. Falsy checks can fire unexpectedly on mock objects, empty collections, and objects that implement `__bool__`.\n\n**Wrong:**\n\n```python\nif not self._hindsight:\n    return None\n```\n\n**Right:**\n\n```python\nif self._hindsight is None:\n    return None\n```\n\n**Why:** `Mock()` objects are truthy by default, but a `Mock()` configured with `spec=SomeClass` that has `__bool__` can be falsy, and ordinary values like empty lists or dicts trigger the wrong branch. Explicit `is None` makes the intent unambiguous and matches the type annotation contract (`X | None`).","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793246+00:00","updated_at":"2026-04-25T00:47:19.793247+00:00","valid_from":"2026-04-25T00:47:19.793246+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBF","title":"Falsy checks on optional objects","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793246+00:00","updated_at":"2026-04-25T00:47:19.793247+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Writing a new test helper without checking conftest
-
-
 
 Before adding a helper function to a test file, grep `tests/conftest.py` (and any `tests/helpers*.py`) for similar helpers. Shared test fixtures belong in conftest; duplicating a helper locally causes drift when one copy is updated and the other is not.
 
@@ -185,13 +184,13 @@ from tests.conftest import write_plugin_skill
 
 **How to check:** Before adding any `def _<something>` in a test file, run `rg "def <name>" tests/conftest.py tests/helpers*.py` for semantically-similar helpers.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBH","title":"Writing a new test helper without checking conftest","content":"Before adding a helper function to a test file, grep `tests/conftest.py` (and any `tests/helpers*.py`) for similar helpers. Shared test fixtures belong in conftest; duplicating a helper locally causes drift when one copy is updated and the other is not.\n\n**Wrong:**\n\n```python\n# tests/test_my_feature.py\ndef _write_fake_skill(cache_root, marketplace, plugin, skill):\n    skill_dir = cache_root / marketplace / plugin / \"1.0.0\" / \"skills\" / skill\n    skill_dir.mkdir(parents=True, exist_ok=True)\n    (skill_dir / \"SKILL.md\").write_text(f\"---\\nname: {skill}\\n---\\nbody\\n\")\n```\n\n(while `tests/conftest.py:write_plugin_skill` already does exactly this.)\n\n**Right:**\n\n```python\n# tests/test_my_feature.py\nfrom tests.conftest import write_plugin_skill\n```\n\n**Why:** Duplicated helpers drift silently. If `write_plugin_skill` in conftest gains a new parameter or changes its on-disk layout, the local copy stays stale and tests pass against a fiction.\n\n**How to check:** Before adding any `def _<something>` in a test file, run `rg \"def <name>\" tests/conftest.py tests/helpers*.py` for semantically-similar helpers.","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793259+00:00","updated_at":"2026-04-25T00:47:19.793260+00:00","valid_from":"2026-04-25T00:47:19.793259+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBH","title":"Writing a new test helper without checking conftest","topic":"gotchas","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793259+00:00","updated_at":"2026-04-25T00:47:19.793260+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Test Environment Setup and Scaffolding
 
-
+## Setup and scaffolding
 
 ```bash
 make setup          # Install hooks, assets, config, labels
@@ -201,13 +200,13 @@ make ensure-labels  # Create HydraFlow lifecycle labels
 make deps           # Sync dependencies via uv
 ```
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PBW","title":"Setup and scaffolding","content":"```bash\nmake setup          # Install hooks, assets, config, labels\nmake prep           # Sync agent assets + run full repo prep (labels, audit, CI/tests)\nmake scaffold       # Generate baseline tests and CI configuration only (no asset sync)\nmake ensure-labels  # Create HydraFlow lifecycle labels\nmake deps           # Sync dependencies via uv\n```","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793459+00:00","updated_at":"2026-04-25T00:47:19.793459+00:00","valid_from":"2026-04-25T00:47:19.793459+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PBW","title":"Setup and scaffolding","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793459+00:00","updated_at":"2026-04-25T00:47:19.793459+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Quick validation loop
-
-
 
 ```bash
 # After small changes
@@ -217,23 +216,23 @@ make lint && make test
 make quality
 ```
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC2","title":"Quick validation loop","content":"```bash\n# After small changes\nmake lint && make test\n\n# Before committing\nmake quality\n```","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793548+00:00","updated_at":"2026-04-25T00:47:19.793549+00:00","valid_from":"2026-04-25T00:47:19.793548+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC2","title":"Quick validation loop","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793548+00:00","updated_at":"2026-04-25T00:47:19.793549+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Quality Gates
 
-
-
 **Always run lint and tests before declaring work complete or committing.** Do not present implementation as "done" until quality checks pass.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PC0","title":"Quality Gates","content":"**Always run lint and tests before declaring work complete or committing.** Do not present implementation as \"done\" until quality checks pass.","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793537+00:00","updated_at":"2026-04-25T00:47:19.793538+00:00","valid_from":"2026-04-25T00:47:19.793537+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PC0","title":"Quality Gates","topic":"patterns","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793537+00:00","updated_at":"2026-04-25T00:47:19.793538+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
-## Required Testing Coverage and Validation
 
-
+## Testing Is Mandatory
 
 **ALWAYS write unit tests for code changes before committing.** Every new function, class, or feature modification MUST include comprehensive tests.
 
@@ -244,47 +243,47 @@ make quality
 - Never commit untested code
 - Coverage threshold: **70%**
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCB","title":"Testing Is Mandatory","content":"**ALWAYS write unit tests for code changes before committing.** Every new function, class, or feature modification MUST include comprehensive tests.\n\n- Tests live in `tests/` following the pattern `tests/test_<module>.py`\n- New features: Write tests BEFORE committing\n- Bug fixes: Add regression tests that reproduce the bug\n- Refactoring: Ensure existing tests pass, add tests for new paths\n- Never commit untested code\n- Coverage threshold: **70%**","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793713+00:00","updated_at":"2026-04-25T00:47:19.793715+00:00","valid_from":"2026-04-25T00:47:19.793713+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCB","title":"Testing Is Mandatory","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793713+00:00","updated_at":"2026-04-25T00:47:19.793715+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## ADR testing rules
-
-
 
 - **Never write tests for ADR markdown content.** ADRs are documentation, not code. Do not create `test_adr_NNNN_*.py` files that assert on markdown headings, status fields, or prose content — these break whenever the document is edited and provide no value. Only test ADR-related *code* (e.g., `test_adr_reviewer.py` tests the reviewer logic).
 - **Never include line numbers in ADR source citations.** Throughout ADR documents (Related, Context, Decision, Consequences sections), cite source files by function or class name only (e.g., `src/config.py:_resolve_base_paths`). Do NOT add `(line 42)` or similar anywhere — line numbers drift as the source file is edited and council reviews will flag them as stale.
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCC","title":"ADR testing rules","content":"- **Never write tests for ADR markdown content.** ADRs are documentation, not code. Do not create `test_adr_NNNN_*.py` files that assert on markdown headings, status fields, or prose content — these break whenever the document is edited and provide no value. Only test ADR-related *code* (e.g., `test_adr_reviewer.py` tests the reviewer logic).\n- **Never include line numbers in ADR source citations.** Throughout ADR documents (Related, Context, Decision, Consequences sections), cite source files by function or class name only (e.g., `src/config.py:_resolve_base_paths`). Do NOT add `(line 42)` or similar anywhere — line numbers drift as the source file is edited and council reviews will flag them as stale.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793719+00:00","updated_at":"2026-04-25T00:47:19.793720+00:00","valid_from":"2026-04-25T00:47:19.793719+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCC","title":"ADR testing rules","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793719+00:00","updated_at":"2026-04-25T00:47:19.793720+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Related
-
-
 
 - [`gotchas.md`](gotchas.md) — recurring test-side mistakes (top-level imports of optional deps, wrong-level mocks, falsy optional checks)
 - [`patterns.md`](patterns.md) — the full quality sequence to run before committing
 - [`docs/adr/0022-integration-test-architecture-cross-phase.md`](../adr/0022-integration-test-architecture-cross-phase.md) — integration test architecture
 - [`docs/adr/0035-tests-must-match-toggle-state-they-assert.md`](../adr/0035-tests-must-match-toggle-state-they-assert.md) — toggle/test alignment
 
+
 ```json:entry
-{"id":"01KQ11NX7HJCH34WSSAFMB0PCD","title":"Related","content":"- [`avoided-patterns.md`](avoided-patterns.md) — recurring test-side mistakes (top-level imports of optional deps, wrong-level mocks, falsy optional checks)\n- [`quality-gates.md`](quality-gates.md) — the full quality sequence to run before committing\n- [`docs/adr/0022-integration-test-architecture-cross-phase.md`](../adr/0022-integration-test-architecture-cross-phase.md) — integration test architecture\n- [`docs/adr/0035-tests-must-match-toggle-state-they-assert.md`](../adr/0035-tests-must-match-toggle-state-they-assert.md) — toggle/test alignment","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793726+00:00","updated_at":"2026-04-25T00:47:19.793727+00:00","valid_from":"2026-04-25T00:47:19.793726+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7HJCH34WSSAFMB0PCD","title":"Related","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.793726+00:00","updated_at":"2026-04-25T00:47:19.793727+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
 
 ## Scenario Testing Framework
 
-
-
 Release-gating scenario tests that prove the full pipeline and background loops work before shipping.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2491","title":"Scenario Testing Framework","content":"Release-gating scenario tests that prove the full pipeline and background loops work before shipping.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794030+00:00","updated_at":"2026-04-25T00:47:19.794031+00:00","valid_from":"2026-04-25T00:47:19.794030+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2491","title":"Scenario Testing Framework","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794030+00:00","updated_at":"2026-04-25T00:47:19.794031+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Architecture
-
-
 
 Two layers: a **MockWorld** fixture that composes all external fakes into a controllable environment, and **scenario test files** grouped by happy/sad/edge/loop paths.
 
@@ -344,13 +343,13 @@ world.github.pr_for_issue(1).merged
 world.hindsight.bank_entries("learnings")
 ```
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2492","title":"Architecture","content":"Two layers: a **MockWorld** fixture that composes all external fakes into a controllable environment, and **scenario test files** grouped by happy/sad/edge/loop paths.\n\n### MockWorld\n\nA single test fixture that wires up every external service as a stateful fake, builds on top of `PipelineHarness`, and exposes a fluent API for seeding state and running the pipeline.\n\n```\ntests/scenarios/\n  conftest.py              # MockWorld fixture\n  fakes/\n    mock_world.py          # MockWorld — composes all fakes\n    fake_github.py         # Issues, PRs, labels, CI status, comments\n    fake_llm.py            # Scripted triage/plan/implement/review results\n    fake_hindsight.py      # Memory bank retain/recall with fail mode\n    fake_workspace.py      # Worktree lifecycle tracking\n    fake_sentry.py         # Breadcrumb/event capture\n    fake_clock.py          # Deterministic time control\n    scenario_result.py     # IssueOutcome + ScenarioResult dataclasses\n  test_happy.py            # Happy path scenarios (mark: scenario)\n  test_sad.py              # Failure + recovery scenarios (mark: scenario)\n  test_edge.py             # Race conditions, mid-flight mutations (mark: scenario)\n  test_loops.py            # Background loop scenarios (mark: scenario_loops)\n```\n\n### Stateful Fakes\n\nEach fake is a real Python class with in-memory state (not `AsyncMock`). Assertions inspect the world's final state directly (e.g. `world.github.issue(1).labels`) rather than checking mock call counts.\n\n| Fake | Replaces | State It Tracks |\n|------|----------|----------------|\n| `FakeGitHub` | `PRManager`, `IssueFetcher` | Issues, PRs, labels, CI, comments |\n| `FakeLLM` | All 4 runners | Per-phase, per-issue scripted results (supports retry sequences) |\n| `FakeHindsight` | `HindsightClient` | Per-bank memory entries, fail mode |\n| `FakeWorkspace` | `WorkspaceManager` | Created/destroyed worktrees |\n| `FakeSentry` | `sentry_sdk` | Breadcrumbs and events |\n| `FakeClock` | `time.time` | Controllable time for TTL/staleness |\n\n### MockWorld API\n\n```python\n# Seed the world (fluent, returns self)\nworld.add_issue(number, title, body, labels=...)\nworld.set_phase_result(phase, issue, result)\nworld.set_phase_results(phase, issue, [result1, result2])  # retry sequences\nworld.on_phase(phase, callback)                            # mid-flight hooks\nworld.fail_service(name)\nworld.heal_service(name)\n\n# Run\nresult = await world.run_pipeline()              # pipeline phases\nstats  = await world.run_with_loops([\"ci_monitor\"], cycles=1)  # background loops\n\n# Inspect\nworld.github.issue(1).labels\nworld.github.pr_for_issue(1).merged\nworld.hindsight.bank_entries(\"learnings\")\n```","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794036+00:00","updated_at":"2026-04-25T00:47:19.794037+00:00","valid_from":"2026-04-25T00:47:19.794036+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2492","title":"Architecture","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794036+00:00","updated_at":"2026-04-25T00:47:19.794037+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Running
-
-
 
 ```bash
 make scenario          # pipeline scenarios (pytest -m scenario)
@@ -358,25 +357,25 @@ make scenario-loops    # background loop scenarios (pytest -m scenario_loops)
 make quality           # includes both in the quality gate
 ```
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2493","title":"Running","content":"```bash\nmake scenario          # pipeline scenarios (pytest -m scenario)\nmake scenario-loops    # background loop scenarios (pytest -m scenario_loops)\nmake quality           # includes both in the quality gate\n```","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794041+00:00","updated_at":"2026-04-25T00:47:19.794042+00:00","valid_from":"2026-04-25T00:47:19.794041+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2493","title":"Running","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794041+00:00","updated_at":"2026-04-25T00:47:19.794042+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Relationship to Existing Tests
-
-
 
 - **Unit tests (9K+):** Unchanged. Test individual functions/methods.
 - **Integration tests (`PipelineHarness`):** Unchanged. Test phase wiring with mocked runners.
 - **Scenario tests (this):** Test complete flows with stateful fakes. Additive, not replacing.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2495","title":"Relationship to Existing Tests","content":"- **Unit tests (9K+):** Unchanged. Test individual functions/methods.\n- **Integration tests (`PipelineHarness`):** Unchanged. Test phase wiring with mocked runners.\n- **Scenario tests (this):** Test complete flows with stateful fakes. Additive, not replacing.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794052+00:00","updated_at":"2026-04-25T00:47:19.794052+00:00","valid_from":"2026-04-25T00:47:19.794052+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2495","title":"Relationship to Existing Tests","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794052+00:00","updated_at":"2026-04-25T00:47:19.794052+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Future: v2 Observability-Driven Scenarios
-
-
 
 Auto-generation from production run traces:
 1. Production run recorder captures external interactions
@@ -387,13 +386,13 @@ Out of scope for v1. MockWorld API is designed to support it.
 
 ---
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2497","title":"Future: v2 Observability-Driven Scenarios","content":"Auto-generation from production run traces:\n1. Production run recorder captures external interactions\n2. Trace-to-scenario converter builds MockWorld seed + assertions\n3. Self-improvement loop adds scenarios when production diverges\n\nOut of scope for v1. MockWorld API is designed to support it.\n\n---","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794062+00:00","updated_at":"2026-04-25T00:47:19.794063+00:00","valid_from":"2026-04-25T00:47:19.794062+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2497","title":"Future: v2 Observability-Driven Scenarios","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794062+00:00","updated_at":"2026-04-25T00:47:19.794063+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Conventions (Tier 1 / 2 / 3 Helpers)
-
-
 
 ### Test Helpers
 
@@ -427,13 +426,13 @@ Out of scope for v1. MockWorld API is designed to support it.
 
 ---
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ2498","title":"Conventions (Tier 1 / 2 / 3 Helpers)","content":"### Test Helpers\n\n- **`init_test_worktree(path, *, branch=\"agent/issue-1\", origin=None)`** — Helper at `tests/scenarios/helpers/git_worktree_fixture.py`. Initializes a git repo with a bare origin, main branch, and feature branch. Use for any realistic-agent scenario that runs `_count_commits`. Pass `origin=...` when multiple worktrees share a parent directory.\n\n- **`seed_ports(world, **ports)`** — Helper at `tests/scenarios/helpers/loop_port_seeding.py`. Pre-seeds `world._loop_ports` with `AsyncMock` variants before `run_with_loops` runs the catalog builder. Use when a caretaker-loop scenario needs to observe calls on an inner delegate.\n\n### MockWorld Constructor Flags\n\n- **`MockWorld(use_real_agent_runner=True)`** — Opt-in flag that replaces the scripted `FakeLLM.agents` with a real production `AgentRunner` wired to `FakeDocker` via `FakeSubprocessRunner`. Default `False` preserves scripted-mode behavior.\n\n- **`MockWorld(wiki_store=..., beads_manager=...)`** — Thread `RepoWikiStore` and `FakeBeads` into `PlanPhase`/`ImplementPhase`.\n\n### MockWorld Methods\n\n- **`MockWorld.fail_service(\"docker\" | \"github\" | \"hindsight\")`** — Arms fault injection on the corresponding fake. Mirrored `heal_service(...)` clears.\n\n### FakeDocker Scripting\n\n- **`FakeDocker.script_run_with_commits(events, commits, cwd)`** — Script agent run events plus one commit to the worktree repo at `cwd`.\n\n- **`FakeDocker.script_run_with_multiple_commits(events, commit_batches, cwd)`** — Script agent run events plus N separate commits, respectively. Use when the scenario must verify multi-commit push behavior.\n\n### FakeGitHub Fault Injection\n\n- **`FakeGitHub.add_alerts(*, branch, alerts)`** — Script code-scanning alerts for a branch. Keys by branch string to match `PRPort.fetch_code_scanning_alerts(branch)`.\n\n### FakeWorkspace Fault Injection\n\n- **`FakeWorkspace.fail_next_create(kind)`** — Single-shot fault: `permission | disk_full | branch_conflict`. The workspace raises on the next `create()` call then resets, so subsequent calls succeed.\n\n---","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794067+00:00","updated_at":"2026-04-25T00:47:19.794068+00:00","valid_from":"2026-04-25T00:47:19.794067+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ2498","title":"Conventions (Tier 1 / 2 / 3 Helpers)","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794067+00:00","updated_at":"2026-04-25T00:47:19.794068+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Caretaker-Loop Authoring Patterns
-
-
 
 ### Pattern A — Catalog-Driven (preferred)
 
@@ -461,13 +460,13 @@ await loop.run_once()
 
 Pattern A is simpler; use Pattern B only when Pattern A cannot accommodate the scenario.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249A","title":"Caretaker-Loop Authoring Patterns","content":"### Pattern A — Catalog-Driven (preferred)\n\nUse `await world.run_with_loops([\"loop_name\"], cycles=1)`. Works when the loop is registered in `tests/scenarios/catalog/loop_registrations.py`. Minimal boilerplate.\n\n```python\nstats = await world.run_with_loops([\"ci_monitor\"], cycles=1)\nassert stats[\"ci_monitor\"][\"cycles_completed\"] == 1\n```\n\n### Pattern B — Direct Instantiation\n\nUse `_make_loop_deps` from `tests/helpers.py` and construct the loop class directly. Required when:\n- Config flags differ from catalog defaults, or\n- The loop is not yet registered in the catalog (e.g. `staging_promotion_loop` as of this writing).\n\n```python\nfrom tests.helpers import _make_loop_deps\nfrom src.loops.staging_promotion import StagingPromotionLoop\n\ndeps = _make_loop_deps(world, config_overrides={\"staging_branch\": \"staging\"})\nloop = StagingPromotionLoop(**deps)\nawait loop.run_once()\n```\n\nPattern A is simpler; use Pattern B only when Pattern A cannot accommodate the scenario.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794077+00:00","updated_at":"2026-04-25T00:47:19.794078+00:00","valid_from":"2026-04-25T00:47:19.794077+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249A","title":"Caretaker-Loop Authoring Patterns","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794077+00:00","updated_at":"2026-04-25T00:47:19.794078+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## `make audit` runtime benchmark
-
-
 
 Captured: 2026-04-22
 Runs: 5
@@ -494,13 +493,13 @@ Host: Darwin mac.lan 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:56:34 PS
 
 **Rationale:** Measured p95 of 3.80s is ~8x under the 30s per-PR budget. Running `make audit` on every PR gives fastest feedback with negligible CI cost. Task 17a applies.
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249K","title":"`make audit` runtime benchmark","content":"Captured: 2026-04-22\nRuns: 5\nHost: Darwin mac.lan 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:56:34 PST 2026; root:xnu-12377.91.3~2/RELEASE_ARM64_T8112 arm64\n\n| Run | Wall-clock (s) |\n|---|---|\n| 1 | 3.66 |\n| 2 | 3.52 |\n| 3 | 3.52 |\n| 4 | 3.80 |\n| 5 | 3.68 |\n\n**p50:** 3.66s\n**p95:** 3.80s\n\n**Budget:** 30s (spec §4.4 \"Runtime budget for the CI gate\").\n\n**Decision:**\n- p95 ≤ 30s → add `audit` job to `.github/workflows/ci.yml` (Task 17a).\n- p95 > 30s → add `audit` job to `.github/workflows/rc-promotion-scenario.yml` instead (Task 17b).\n\n**Selected:** ci.yml\n\n**Rationale:** Measured p95 of 3.80s is ~8x under the 30s per-PR budget. Running `make audit` on every PR gives fastest feedback with negligible CI cost. Task 17a applies.","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794272+00:00","updated_at":"2026-04-25T00:47:19.794273+00:00","valid_from":"2026-04-25T00:47:19.794272+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249K","title":"`make audit` runtime benchmark","topic":"testing","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794272+00:00","updated_at":"2026-04-25T00:47:19.794273+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
 
+
 ## Usage
-
-
 
 1. Use HydraFlow normally.
 2. At session end, inspect latest retro:
@@ -511,6 +510,7 @@ Host: Darwin mac.lan 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:56:34 PS
    - `verification-loop` skill
    - `eval-harness` skill
 
+
 ```json:entry
-{"id":"01KQ11NX7JR1QGCQ279PEQ249V","title":"Usage","content":"1. Use HydraFlow normally.\n2. At session end, inspect latest retro:\n   - `.claude/state/self-improve/session-retros/<timestamp>-<session>.md`\n3. Promote durable learnings using:\n   - `/hf.memory`\n4. Run structured quality checks when suggested:\n   - `verification-loop` skill\n   - `eval-harness` skill","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794408+00:00","updated_at":"2026-04-25T00:47:19.794409+00:00","valid_from":"2026-04-25T00:47:19.794408+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
+{"id":"01KQ11NX7JR1QGCQ279PEQ249V","title":"Usage","topic":"architecture","source_type":"manual","source_issue":null,"source_repo":null,"created_at":"2026-04-25T00:47:19.794408+00:00","updated_at":"2026-04-25T00:47:19.794409+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```

--- a/scripts/wiki_schema_slim_migration.py
+++ b/scripts/wiki_schema_slim_migration.py
@@ -1,0 +1,91 @@
+# One-shot migration to the slim wiki schema (PR #8462+).
+#
+# Loads every wiki entry under docs/wiki/*.md via RepoWikiStore, then
+# rewrites each topic file using the new write path. The new path drops
+# the duplicated `content` field (and `valid_from`, which always equals
+# `created_at`) from inline json:entry blocks. The reader reconstructs
+# `content` from the prose section above each block.
+#
+# Idempotent: re-running on already-migrated files is a no-op.
+# Verifies a round-trip read after each rewrite to guarantee no entry is
+# lost in translation.
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from repo_wiki import RepoWikiStore  # noqa: E402
+
+logger = logging.getLogger("wiki_schema_slim")
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+REPO_SLUG = "T-rav/hydraflow"
+WIKI_ROOT = Path("docs/wiki")
+
+
+def migrate() -> int:
+    if not WIKI_ROOT.exists():
+        logger.error("docs/wiki/ not found — run from repo root")
+        return 1
+
+    store = RepoWikiStore(WIKI_ROOT.parent)
+    repo_dir = store._repo_dir(REPO_SLUG)
+    if not repo_dir.exists():
+        repo_dir = WIKI_ROOT
+        store._repo_dir = lambda _slug: WIKI_ROOT  # type: ignore[method-assign]
+
+    total_in = 0
+    total_out = 0
+    files_rewritten = 0
+
+    md_files = sorted(repo_dir.glob("*.md"))
+    for md_file in md_files:
+        if md_file.stem == "index":
+            continue
+        before = md_file.read_text()
+        entries = store._load_topic_entries(md_file)
+        if not entries:
+            continue
+
+        store._write_topic_page(md_file, md_file.stem, entries)
+        after = md_file.read_text()
+
+        roundtrip = store._load_topic_entries(md_file)
+        if len(roundtrip) != len(entries):
+            logger.error(
+                "MIGRATION FAILED for %s: %d in → %d out (round-trip lost entries)",
+                md_file.name,
+                len(entries),
+                len(roundtrip),
+            )
+            return 1
+
+        if before != after:
+            files_rewritten += 1
+            saved = len(before) - len(after)
+            logger.info(
+                "%s: %d entries, %d bytes saved (%.0f%%)",
+                md_file.name,
+                len(entries),
+                saved,
+                100 * saved / len(before) if before else 0,
+            )
+        total_in += len(entries)
+        total_out += len(roundtrip)
+
+    logger.info(
+        "Migration complete: %d files rewritten, %d entries preserved (in=%d out=%d)",
+        files_rewritten,
+        total_out,
+        total_in,
+        total_out,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(migrate())

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -172,6 +172,20 @@ def classify_topic(entry: WikiEntry) -> str:
     return best_topic
 
 
+_SOURCE_FOOTER_RE = re.compile(r"^_Source:[^\n]*_\s*$", re.MULTILINE)
+
+
+def _strip_prose_chrome(body: str) -> str:
+    """Strip the optional ``_Source: ..._`` footer and surrounding blank
+    lines from a parsed entry body, leaving the prose content.
+
+    Used by ``_load_topic_entries`` to reconstruct ``WikiEntry.content``
+    from the prose section above each ``json:entry`` metadata block.
+    """
+    cleaned = _SOURCE_FOOTER_RE.sub("", body)
+    return cleaned.strip()
+
+
 def _sanitize_body_for_frontmatter(content: str) -> str:
     """Prevent a leading ``---`` in body content from being parsed as a
     second YAML document.
@@ -1385,7 +1399,15 @@ class RepoWikiStore:
     def _load_topic_entries(self, topic_path: Path) -> list[WikiEntry]:
         """Parse a topic markdown file back into entries.
 
-        Each entry is stored as a JSON code block under an H3 heading.
+        Schema-slim layout: each entry is rendered as a `## Title`
+        section followed by prose, an optional `_Source: #N (kind)_`
+        footer, and a `json:entry` code block carrying metadata WITHOUT
+        the `content` field. The reader reconstructs ``WikiEntry.content``
+        from the prose section above the metadata block.
+
+        Legacy entries that still embed ``content`` in the JSON continue
+        to load — the prose section overrides if present, otherwise the
+        JSON-embedded copy is used.
         """
         if not topic_path.exists():
             return []
@@ -1393,9 +1415,19 @@ class RepoWikiStore:
         text = topic_path.read_text()
         entries: list[WikiEntry] = []
 
-        for match in re.finditer(r"```json:entry\n(.+?)\n```", text, re.DOTALL):
+        for match in re.finditer(
+            r"## (?P<title>[^\n]+)\n(?P<body>.*?)```json:entry\n(?P<meta>.+?)\n```",
+            text,
+            re.DOTALL,
+        ):
             try:
-                entries.append(WikiEntry.model_validate_json(match.group(1)))
+                metadata = json.loads(match.group("meta"))
+                prose = _strip_prose_chrome(match.group("body"))
+                if prose:
+                    metadata["content"] = prose
+                elif "content" not in metadata:
+                    metadata["content"] = ""
+                entries.append(WikiEntry.model_validate(metadata))
             except Exception:  # noqa: BLE001
                 logger.warning("Skipping malformed entry in %s", topic_path)
 
@@ -1407,7 +1439,12 @@ class RepoWikiStore:
         topic_name: str,
         entries: list[WikiEntry],
     ) -> None:
-        """Write a topic page with entries stored as JSON code blocks."""
+        """Write a topic page with slim per-entry metadata blocks.
+
+        The `content` field is stored only in the prose section (not
+        duplicated inside the json:entry block) — see _load_topic_entries
+        for the read-side contract.
+        """
         lines = [f"# {topic_name.replace('_', ' ').title()}\n"]
 
         if not entries:
@@ -1420,8 +1457,8 @@ class RepoWikiStore:
                     lines.append(
                         f"_Source: #{entry.source_issue} ({entry.source_type})_\n"
                     )
-                # Store structured data for round-tripping
-                lines.append(f"\n```json:entry\n{entry.model_dump_json()}\n```\n")
+                slim = entry.model_dump_json(exclude={"content", "valid_from"})
+                lines.append(f"\n```json:entry\n{slim}\n```\n")
 
         topic_path.write_text("\n".join(lines))
 

--- a/src/wiki_compiler.py
+++ b/src/wiki_compiler.py
@@ -108,11 +108,43 @@ Your job is to compile them into a clean, deduplicated set of entries.
 4. **Remove stale content**: If an entry's insight has been superseded by a newer one, drop it.
 5. **Preserve source attribution**: Keep source_issue and source_type from the original entries.
 
+## Voice and structure (load-bearing — do not skip)
+
+Each entry's `content` field MUST be **scannable** documentation, not a wall
+of prose. Agents and humans read the title to decide whether to read the
+entry, then read the entry to apply a rule — both audiences need structure.
+
+Required shape for each entry:
+
+- Open with a one-sentence rule statement (no narrative ramp-up).
+- Follow with a short example (inline code, file path, or 2-3 bullet
+  points) showing the rule in use. If the rule is purely conceptual,
+  skip the example.
+- Close with a `**Why:**` line in one sentence, naming the failure mode
+  or constraint the rule prevents.
+
+Hard length budget per entry:
+
+- `title`: ≤ 80 characters, specific enough that a reader can decide
+  relevance from the title alone (avoid generic labels like "Notes",
+  "Findings", "Background").
+- `content`: ≤ 150 words. If the source material exceeds this, **split
+  into multiple entries** rather than producing a single long blob.
+
+Anti-patterns to avoid:
+
+- Long single-paragraph dumps with no structure.
+- Retrospective voice ("This entry captures the lesson that…", "We
+  learned in PR #N that…"). Write in rule voice ("Use X. Avoid Y.").
+- Restating the title in the first sentence.
+- Inline JSON or code fences spanning more than 5 lines (link to the
+  source instead).
+
 ## Output format
 
 Return a JSON array of compiled entries. Each entry must be a JSON object with these fields:
-- "title": string (short, descriptive)
-- "content": string (the compiled insight, with cross-references)
+- "title": string (short, descriptive — see length budget above)
+- "content": string (rule + example + Why; see structure above)
 - "source_type": string (plan, implement, review, hitl, or "compiled")
 - "source_issue": number or null
 - "stale": false

--- a/tests/test_repo_wiki.py
+++ b/tests/test_repo_wiki.py
@@ -310,6 +310,53 @@ class TestRoundTrip:
         assert entries[0].content == original.content
         assert entries[0].source_issue == 99
 
+    def test_inline_metadata_omits_duplicated_content_field(
+        self, store: RepoWikiStore
+    ) -> None:
+        # Schema-slim: the inline json:entry block must NOT carry the content
+        # field — it is reconstructed from the prose section above the block.
+        # This keeps topic files ~50% smaller and human-readable.
+        entry = WikiEntry(
+            title="Schema check",
+            content="The point of this entry is to verify the metadata block "
+            "stays slim and does not double-store the prose.",
+            source_type="implement",
+            source_issue=7,
+        )
+        store.ingest(REPO, [entry])
+        repo_dir = store._repo_dir(REPO)
+        topic = store._classify_topic(entry)
+        topic_path = repo_dir / f"{topic}.md"
+        text = topic_path.read_text()
+        # Prose appears once (above the json:entry block).
+        assert text.count("The point of this entry is to verify") == 1
+        # Metadata block exists but does not carry the content field.
+        assert "```json:entry" in text
+        assert '"content"' not in text
+
+    def test_round_trip_with_slim_schema_preserves_content(
+        self, store: RepoWikiStore
+    ) -> None:
+        # The reader reconstructs `content` from the prose section even though
+        # it is no longer in the json:entry block.
+        entry = WikiEntry(
+            title="Multi-paragraph entry",
+            content=(
+                "First paragraph explaining the rule.\n\n"
+                "Second paragraph with an example: `foo(bar) -> baz`.\n"
+            ),
+            source_type="plan",
+            source_issue=42,
+        )
+        store.ingest(REPO, [entry])
+        repo_dir = store._repo_dir(REPO)
+        topic = store._classify_topic(entry)
+        loaded = store._load_topic_entries(repo_dir / f"{topic}.md")
+        assert len(loaded) == 1
+        assert "First paragraph explaining the rule." in loaded[0].content
+        assert "`foo(bar) -> baz`" in loaded[0].content
+        assert loaded[0].source_issue == 42
+
 
 class TestActiveLint:
     def test_marks_entries_stale_for_closed_issues(self, store: RepoWikiStore) -> None:


### PR DESCRIPTION
## Summary

PR3 of 3 attacking the wiki content-quality issues. Cuts inline metadata size by ~35-45% and reshapes the WikiCompiler prompt so future entries are scannable docs, not walls of prose. Stacked on top of #8462.

## What this PR does

### 1. Schema slim — drop duplicated `content` from inline `json:entry` blocks

Each entry's prose appeared **twice** in every topic file: once as readable markdown above the `json:entry` block, then again verbatim inside the JSON. Duplication added ~35-45% to file sizes and pushed human-readable signal off-screen.

**Fix:**
- `_write_topic_page` now serializes via `model_dump_json(exclude={\"content\", \"valid_from\"})`. The metadata block keeps `id`, `title`, source attribution, dates, supersession state, `confidence`, `stale`, `corroborations`.
- `_load_topic_entries` reconstructs `WikiEntry.content` from the prose section above each metadata block. New `_strip_prose_chrome` helper removes the optional `_Source: #N (kind)_` footer.
- **Backward-compatible**: legacy entries that still embed `content` in JSON continue to load. Prose-section reading takes priority; JSON-embedded copy is fallback.

3 new round-trip tests in `TestRoundTrip`.

### 2. Migration — `scripts/wiki_schema_slim_migration.py`

One-shot pass that loads each topic file via `_load_topic_entries`, rewrites it via the new `_write_topic_page`, and verifies a round-trip read after each rewrite to guarantee no entry is lost in translation.

**Result on the live wiki:**

| File | Entries | Bytes saved |
|---|---|---|
| gotchas.md | 23 | 38,650 (45%) |
| testing.md | 25 | 28,779 (43%) |
| patterns.md | 18 | 21,495 (43%) |
| architecture.md | 21 | 18,143 (40%) |
| dependencies.md | 7 |  5,180 (40%) |
| architecture-async-control.md | 16 |  9,867 (37%) |
| architecture-layers.md | 16 |  9,243 (36%) |
| architecture-imports-types.md | 17 |  8,245 (35%) |
| architecture-state-persistence.md | 19 |  8,831 (34%) |
| architecture-patterns-practices.md | 22 | 10,438 (34%) |
| architecture-refactoring.md | 21 |  8,634 (33%) |

**Total: 11 files rewritten, 167 KB saved, 205 entries preserved (in=205 out=205, zero loss).**

### 3. Compiler prompt — enforce doc-voice over wall-of-prose

`_COMPILE_TOPIC_PROMPT` was producing dense single-paragraph abstracts that read like code-review retrospectives. Added an explicit \"Voice and structure\" section requiring:

- Open with a one-sentence rule (no narrative ramp-up)
- Short example (inline code / file path / 2-3 bullets)
- Close with a `**Why:**` line naming the failure mode
- Title ≤ 80 chars (specific, not generic labels like \"Notes\")
- Content ≤ 150 words — split into multiple entries if longer
- Anti-patterns called out: retrospective voice, restating the title, inline code blocks > 5 lines

Existing entries decay naturally as the loop supersedes them.

## Verification

`make quality` — green for all changes attributable to this PR. The 7 remaining failures (5 in `test_audit_prompts.py`, 2 in `test_repo_wiki_loop_pr.py`) are a pre-existing main regression caused by #8460. Fix is in #8463 (already open).

## Stack

- #8459 (merged) — wiki loop health
- #8462 (open, blocked on #8463) — wiki content quality (parent of this PR)
- **#8465 (this PR, blocked on #8462+#8463)** — wiki schema slim + compiler prompt

## Test plan
- [ ] CI passes once #8463 lands and #8462 is rebased
- [ ] Reviewer spot-checks one of the slimmed topic files (e.g., `gotchas.md`) to confirm prose is intact and the metadata block is human-readable
- [ ] Reviewer reads the new \"Voice and structure\" section of `_COMPILE_TOPIC_PROMPT`

Skip-ADR: schema refinement of an existing layout (ADR-0032) plus a prompt-tuning change. No new architectural decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)