### PR TITLE
chore(audit): drop legacy fakes path — ADR-0052 canonical

### DIFF
--- a/scripts/hydraflow_audit/checks/p3_testing.py
+++ b/scripts/hydraflow_audit/checks/p3_testing.py
@@ -66,18 +66,14 @@ def _mock_world_fixture(ctx: CheckContext) -> Finding:
 _FAKE_CLASS_RE = re.compile(r"^class\s+(Fake\w+|Mock\w+)", re.MULTILINE)
 
 
-# Canonical Fake locations. Fakes were originally housed exclusively
-# under ``tests/scenarios/fakes/`` (per ADR-0022). They were promoted
-# to first-class adapters under ``src/mockworld/fakes/`` by the
-# sandbox-tier scenario testing track (spec
-# 2026-04-26-sandbox-tier-scenarios-design.md, ADR-0052). The audit
-# accepts Fakes at EITHER location during the transition; once
-# ADR-0022 is amended to declare ``src/mockworld/fakes/`` canonical,
-# the legacy path can be dropped.
-_FAKE_DIRS_REL: tuple[tuple[str, ...], ...] = (
-    ("src", "mockworld", "fakes"),
-    ("tests", "scenarios", "fakes"),
-)
+# Canonical Fake location: ``src/mockworld/fakes/`` (per ADR-0052,
+# Sandbox-tier scenario testing). Fakes were originally housed under
+# ``tests/scenarios/fakes/``; PR #8451 promoted them to first-class
+# adapters in ``src/mockworld/`` so they can be imported by production
+# code paths (the sandbox entrypoint). The legacy directory now only
+# holds orchestration scaffolding (``mock_world.py``,
+# ``scenario_result.py``) — no actual ``Fake*`` adapter classes.
+_FAKE_DIRS_REL: tuple[tuple[str, ...], ...] = (("src", "mockworld", "fakes"),)
 
 
 def _collect_fake_classes(ctx: CheckContext) -> set[str]:

--- a/tests/test_hydraflow_audit_p3_checks.py
+++ b/tests/test_hydraflow_audit_p3_checks.py
@@ -75,7 +75,7 @@ def test_mock_world_fixture_missing_fails(tmp_path: Path) -> None:
 
 def test_scenario_fakes_count(tmp_path: Path) -> None:
     _write(
-        tmp_path / "tests" / "scenarios" / "fakes" / "f.py",
+        tmp_path / "src" / "mockworld" / "fakes" / "f.py",
         "class FakeVCS: ...\nclass FakeLLM: ...\nclass FakeClock: ...\n",
     )
     assert _run("P3.3", _ctx(tmp_path)).status is Status.PASS
@@ -83,7 +83,7 @@ def test_scenario_fakes_count(tmp_path: Path) -> None:
 
 def test_scenario_fakes_under_three_fails(tmp_path: Path) -> None:
     _write(
-        tmp_path / "tests" / "scenarios" / "fakes" / "f.py",
+        tmp_path / "src" / "mockworld" / "fakes" / "f.py",
         "class FakeOnly: ...\n",
     )
     assert _run("P3.3", _ctx(tmp_path)).status is Status.FAIL
@@ -117,7 +117,7 @@ def test_fake_clock_missing_fails(tmp_path: Path) -> None:
 
 def test_mock_inheritance_warns(tmp_path: Path) -> None:
     _write(
-        tmp_path / "tests" / "scenarios" / "fakes" / "bad.py",
+        tmp_path / "src" / "mockworld" / "fakes" / "bad.py",
         "from unittest.mock import AsyncMock\n\nclass FakeVCS(AsyncMock): ...\n",
     )
     assert _run("P3.14", _ctx(tmp_path)).status is Status.WARN
@@ -125,7 +125,7 @@ def test_mock_inheritance_warns(tmp_path: Path) -> None:
 
 def test_stateful_fakes_pass(tmp_path: Path) -> None:
     _write(
-        tmp_path / "tests" / "scenarios" / "fakes" / "good.py",
+        tmp_path / "src" / "mockworld" / "fakes" / "good.py",
         "class FakeVCS:\n    def __init__(self): self.issues = {}\n",
     )
     assert _run("P3.14", _ctx(tmp_path)).status is Status.PASS


### PR DESCRIPTION
## Summary

Closes a transitional loose end from the sandbox-tier track (PRs #8451-#8453, ADR-0052).

The audit's \`_FAKE_DIRS_REL\` was searching BOTH \`src/mockworld/fakes/\` (canonical post-ADR-0052) AND \`tests/scenarios/fakes/\` (legacy) during the transition. The legacy directory now only holds orchestration scaffolding — no actual \`Fake*\` adapter classes — so the dual-path search is no longer useful.

## Changes

- \`scripts/hydraflow_audit/checks/p3_testing.py\`: drop the \`(\"tests\",\"scenarios\",\"fakes\")\` entry from \`_FAKE_DIRS_REL\`. Comment now correctly cites ADR-0052 (was \"ADR-0022\" — wrong; ADR-0022 is the pipeline-harness ADR).
- \`tests/test_hydraflow_audit_p3_checks.py\`: 4 fixture sites updated to seed Fakes at the new canonical path.

## Test plan

- [x] All 38 audit unit tests pass
- [x] Lint OK

Skip-ADR: Closes a transitional cleanup loose end; no behaviors codified by ADRs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)