### PR TITLE
docs(claude-md): add Quick Rule — cleanup PRs need full-suite verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ This file is a table of contents. Operational knowledge lives in the wiki at [`d
 - **Always verify subagent DONE claims** with `git status --porcelain` and `git log -1 --stat`. Subagents sometimes report DONE with edits applied but not committed.
 - **Subprocess-spawning runners MUST call `reraise_on_credit_or_bug(exc)`** in their broad `except` block. Without it, `CreditExhaustedError` is silently eaten and the loop burns attempt budget against an exhausted billing signal. See [`docs/wiki/dark-factory.md`](docs/wiki/dark-factory.md) §2.2.
 - **For substantial features, plan for 2–3 fresh-eyes review iterations** before merge. Convergence = next pass finds nothing material. See [`docs/wiki/dark-factory.md`](docs/wiki/dark-factory.md) §3.
+- **Code-cleanup PRs (defensive-guard removal, dead-code drops) MUST be verified with full `make quality`**, not file-targeted test subsets. PR #8460 over-pruned `getattr(self, "_X", None)` checks where `_X` was set conditionally in subclasses or `__new__`-bypassed test scaffolding; the implementer ran 211 tests in three targeted files (all green) and shipped — but `tests/test_audit_prompts.py` and `tests/test_repo_wiki_loop_pr.py` had 7 failures the subset missed. Hotfix PR #8463 followed. Cleanup work has higher blast radius than its diff suggests.
 
 ## Knowledge Lookup
 


### PR DESCRIPTION
## Summary

Adds a single new bullet to `CLAUDE.md`'s **Quick rules (always apply)** section, capturing the lesson learned from PR #8460 → hotfix #8463.

## Context

PR #8460 (cleanup-trust-types) removed `getattr(self, "_X", None)` defensive guards where `_X` was set **conditionally** — in subclasses or in test scaffolding that bypasses `__init__` via `cls.__new__(cls)`. The implementer ran `pytest tests/test_base_runner.py tests/test_repo_wiki_loop.py tests/test_events.py` (211 tests, all green) and shipped — but `tests/test_audit_prompts.py` and `tests/test_repo_wiki_loop_pr.py` had 7 `AttributeError` failures the subset missed. PR #8463 was a hotfix.

## Why this rule belongs at the top of CLAUDE.md

Cleanup PRs (defensive-guard removal, dead-code drops) **look** local — diff is small, "obviously safe". In practice their blast radius is wide, because the deleted code may have been guarding paths reached only by code your subset doesn't exercise. The same lesson lives in my local memory (`feedback_cleanup_prs_need_full_suite.md`), but every Claude session needs the heuristic, not just mine.

## Skip-ADR

Project documentation update; no behaviors codified by ADRs change. The rule is a pre-existing CLAUDE.md convention being extended, not a new policy that warrants an ADR.

## Test plan

- [x] `git diff` confirms single-line change to `CLAUDE.md`
- [x] No code touched; only the prose bullet list extended
- [x] Quality gate via pre-push hook passes (lightweight checks ran on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)