### PR TITLE
fix(auto_pr): add subprocess timeouts to _run_git/_run_gh — close audit gap from PR #8456

### DIFF
--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -45,6 +45,17 @@ BOT_NAME = "HydraFlow"
 # may contain "/" and other characters; sanitize for the worktree dir name.
 _SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
+# Hard timeout for every ``subprocess.run`` invocation in this module.
+# ``open_automated_pr_async`` runs these wrappers under ``asyncio.to_thread``,
+# so an unbounded subprocess (hung ``git push`` against a stale remote, ``gh``
+# blocking on auth refresh, pre-push hook deadlock, etc.) leaks the worker
+# thread and eventually exhausts the asyncio thread pool. Same deadlock class
+# as PR #8454 / regression test ``test_async_subprocess_timeouts.py``.
+# 120 s comfortably covers the slowest legitimate operation (a ``git push``
+# that triggers a slow pre-push hook against origin); anything beyond is a
+# hang we want to surface, not wait on.
+_SUBPROCESS_TIMEOUT_S = 120
+
 
 # ---------------------------------------------------------------------------
 # Public types
@@ -90,6 +101,7 @@ def _run_git(
         check=check,
         capture_output=True,
         text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
     )
 
 
@@ -105,6 +117,7 @@ def _run_gh(cmd: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
         check=False,
         capture_output=True,
         text=True,
+        timeout=_SUBPROCESS_TIMEOUT_S,
     )
 
 

--- a/tests/regressions/test_async_subprocess_timeouts.py
+++ b/tests/regressions/test_async_subprocess_timeouts.py
@@ -29,15 +29,19 @@ _REPO = Path(__file__).resolve().parent.parent.parent
 # (contract_recording event-loop fix). Wrap-in-``asyncio.to_thread``
 # alone is not enough; an unbounded subprocess will leak the worker
 # thread and exhaust the pool.
-#
-# Note: ``src/contract_recording.py`` is hardened in PR #8454 itself
-# (a sibling PR off the same convergence review). Once that lands,
-# add it here to extend coverage.
 _ASYNC_SUBPROCESS_MODULES = [
     "src/diagram_loop.py",
     "src/repo_wiki.py",
     "src/repo_wiki_loop.py",
     "src/arch/runner.py",
+    # PR #8454 hardened these wrappers; PR #8456 covered the rest of the
+    # async paths; this PR closes the audit by adding the two sites the
+    # original audit missed.
+    "src/contract_recording.py",
+    # ``_run_git`` / ``_run_gh`` wrappers run under ``asyncio.to_thread``
+    # from ``open_automated_pr_async``; without ``timeout=`` a stale
+    # ``git push`` or ``gh`` auth-refresh hang leaks a thread-pool worker.
+    "src/auto_pr.py",
 ]
 
 


### PR DESCRIPTION
## Summary

Closes the audit gap left by PR #8456 (subprocess timeouts in async loop paths). `open_automated_pr_async` calls `_run_git` and `_run_gh` (both `subprocess.run` wrappers) under `asyncio.to_thread` — without `timeout=`, a stale `git push`, slow pre-push hook, or `gh` auth-refresh hang leaks the asyncio thread-pool worker. Same deadlock class as PR #8454 / #8456.

## Why this was missed

The original PR #8456 audit (which hardened `diagram_loop.py`, `repo_wiki.py`, `repo_wiki_loop.py`, `arch/runner.py`) walked async-loop modules directly. `auto_pr.py` is called BY async loops but its own definition is sync wrappers — easy to miss in a "find async modules with subprocess.run" sweep. The dashboard-binding investigation traced through the call graph and surfaced this gap.

## Changes

- `src/auto_pr.py`: introduce `_SUBPROCESS_TIMEOUT_S = 120` constant, apply to both `_run_git` and `_run_gh` wrappers
- `tests/regressions/test_async_subprocess_timeouts.py`:
  - add `src/auto_pr.py` to coverage list
  - add `src/contract_recording.py` to coverage list (was a TODO in the test from PR #8456 — TODO closed)

## Sizing

120s comfortably covers the slowest legitimate operation (`git push` against a remote with a slow pre-push hook). Anything beyond is a hang we want to surface, not wait on.

## Skip-ADR

Production hardening following existing pattern (PR #8454, PR #8456). No new architectural decision.

## Test plan

- [x] `pytest tests/regressions/test_async_subprocess_timeouts.py -v` — 6/6 pass (4 prior + 2 new)
- [x] `pytest tests/test_auto_pr.py -v` — 15/15 pass
- [x] `make quality` — full suite, 11909 passed, 7 skipped, 204 xfailed (expected) in 8m25s
- [x] Pre-commit hooks (lint, arch-check) pass on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)