### PR TITLE
chore(audit): unblock principles audit (P2.9 split-aware + P10.3 baseline)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,7 +226,6 @@ jolly-sea-65a9/
 
 # HydraFlow hook cache (generated artifacts, machine-specific)
 .hydraflow-hook-cache/
-.hydraflow-audit-baseline
 
 # Claude Code
 .claude/plans/

--- a/.hydraflow-audit-baseline
+++ b/.hydraflow-audit-baseline
@@ -1,0 +1,9 @@
+# Principles-audit baseline. The P10.3 check (regression-test discipline)
+# scans fix commits between this SHA and HEAD; commits before this point
+# are excluded as historical drift predating the rule's adoption.
+#
+# Bumped 2026-05-02 to current main HEAD: ADR-0044 + the P3/P10 audit
+# framework now run on every Python-touching PR (see
+# .github/workflows/ci.yml `audit` job, ADR-0051), so the rule is in
+# effect from this commit forward.
+d0d18382

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -14,7 +14,7 @@ Names that load-bearing pipeline code uses. Use these literal names, not paraphr
 - **RepoWikiLoop** — caretaker loop that keeps `docs/wiki/` fresh from live pipeline events ([ADR-0029](../adr/0029-caretaker-loop-pattern.md), [ADR-0032](../adr/0032-per-repo-wiki-knowledge-base.md)).
 - **RepoWikiStore** — persistence layer for the repo wiki entries (JSONL + Markdown round-trip). See [`architecture-state-persistence.md`](architecture-state-persistence.md).
 - **DiagramLoop** — caretaker loop that regenerates the system-topology Markdown+Mermaid every 4h ([ADR-0029](../adr/0029-caretaker-loop-pattern.md)).
-- **MockWorld** — in-process fake-adapter set (FakeGitHub, FakeWorkspace, FakeLLM, FakeIssueStore, FakeIssueFetcher) used by sandbox-tier scenario tests ([ADR-0052](../adr/0052-sandbox-tier-scenario-testing.md)).
+- **MockWorld** — in-process fake-adapter set (FakeGitHub, FakeWorkspace, FakeLLM, FakeIssueStore, FakeIssueFetcher) used by sandbox-tier scenario tests ([ADR-0052](../adr/0052-sandbox-tier-scenarios.md)).
 
 When CLAUDE.md adds a term to its ubiquitous-language vocabulary, it must show up here so the principles audit (P2.9) and any agent looking it up can resolve to real context.
 

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -1,6 +1,24 @@
 # Architecture
 
 
+## Ubiquitous Language Reference
+
+Names that load-bearing pipeline code uses. Use these literal names, not paraphrases. Each links to the topic file where the concept is treated in depth.
+
+- **HydraFlowConfig** — central Pydantic config (50+ env-var overrides), built by `runtime_config.load_runtime_config()`. See [`architecture-state-persistence.md`](architecture-state-persistence.md).
+- **StateData** — JSON-backed crash-recovery payload for the orchestrator's per-issue state. Carried by `StateTracker`. See [`architecture-state-persistence.md`](architecture-state-persistence.md).
+- **SessionLog** — append-only per-issue session record (phase transitions, runner outputs). See [`architecture-state-persistence.md`](architecture-state-persistence.md).
+- **WorkspacePort** — Port that abstracts the workspace lifecycle (worktree create/destroy, git ops). Adapters implement it; runners call it. See [`architecture-layers.md`](architecture-layers.md).
+- **AgentRunner**, **PlannerRunner**, **ReviewRunner** — three subprocess-spawning runners that drive the implementation, planning, and review phases. Share `BaseSubprocessRunner` plumbing. See [`architecture-async-control.md`](architecture-async-control.md).
+- **WorktreeManager** — owner of git-worktree lifecycle (create, mark in-use, garbage-collect). See [`architecture-async-control.md`](architecture-async-control.md).
+- **RepoWikiLoop** — caretaker loop that keeps `docs/wiki/` fresh from live pipeline events ([ADR-0029](../adr/0029-caretaker-loop-pattern.md), [ADR-0032](../adr/0032-per-repo-wiki-knowledge-base.md)).
+- **RepoWikiStore** — persistence layer for the repo wiki entries (JSONL + Markdown round-trip). See [`architecture-state-persistence.md`](architecture-state-persistence.md).
+- **DiagramLoop** — caretaker loop that regenerates the system-topology Markdown+Mermaid every 4h ([ADR-0029](../adr/0029-caretaker-loop-pattern.md)).
+- **MockWorld** — in-process fake-adapter set (FakeGitHub, FakeWorkspace, FakeLLM, FakeIssueStore, FakeIssueFetcher) used by sandbox-tier scenario tests ([ADR-0052](../adr/0052-sandbox-tier-scenario-testing.md)).
+
+When CLAUDE.md adds a term to its ubiquitous-language vocabulary, it must show up here so the principles audit (P2.9) and any agent looking it up can resolve to real context.
+
+
 ## ADR Documentation: Format, Citations, Validation, and Superseding
 
 ADRs use markdown with structured sections: Date, Status, Title, Context, Decision, Rationale, Consequences. Validation checklist: structural checks first (missing sections, status format), then semantic checks (scope significance, contradiction audit). Source citations use module:function format without line numbers per CLAUDE.md. Set status to Accepted for documenting existing implicit patterns, not just new proposals. Reference authoritative runtime sources (e.g., src/config.py:all_pipeline_labels) instead of copying definitions to avoid drift. Skip TYPE_CHECKING imports in citations since they're compile-time-only. Ghost entries (README listing files that don't exist) indicate stale migrations—validate documentation against filesystem reality. ADR Superseding Pattern: when a planned feature documented in an ADR is removed as dead code (never implemented), update the ADR status to 'Superseded by removal' and cross-reference the removal issue. This preserves architectural decision history and clarifies for future reimplementation attempts without duplicating work.

--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -104,7 +104,7 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
     regression test." Historical drift predates the principle's adoption.
     Two mechanisms keep the check honest:
 
-    1. A `.hydraflow/audit-baseline` file (commit SHA or ISO date) lets a
+    1. A `.hydraflow-audit-baseline` file (commit SHA or ISO date) lets a
        project declare the point at which the rule took effect; earlier
        fix commits are excluded.
     2. The threshold is 60% compliance on *recent* fixes — a project
@@ -162,7 +162,7 @@ def _bug_fixes_land_with_regression_tests(ctx: CheckContext) -> Finding:  # noqa
         "P10.3",
         Status.WARN,
         f"{len(missing)}/{len(fix_commits)} fix commits {scope} without a regression test ({sample}) — "
-        "set .hydraflow/audit-baseline to a post-adoption commit to exclude historical drift",
+        "set .hydraflow-audit-baseline to a post-adoption commit to exclude historical drift",
     )
 
 

--- a/scripts/hydraflow_audit/checks/p2_architecture.py
+++ b/scripts/hydraflow_audit/checks/p2_architecture.py
@@ -255,18 +255,27 @@ def _ubiquitous_language(ctx: CheckContext) -> Finding:
     duplicated architecture content; the new layout intentionally moves
     architecture into the wiki, so the check now flows ToC → wiki.
     """
-    arch = ctx.root / "docs" / "wiki" / "architecture.md"
+    # Architecture content lived in a single ``architecture.md`` until PR
+    # #8462 split it into focused topic files (``architecture-layers.md``,
+    # etc.). Read every ``architecture*.md`` so a term documented in a
+    # sub-topic still resolves. The residual ``architecture.md`` remains
+    # the entry point — it carries the ubiquitous-language reference table
+    # — but is no longer the sole source of truth.
+    wiki = ctx.root / "docs" / "wiki"
+    arch_files = sorted(wiki.glob("architecture*.md"))
     claude = ctx.root / "CLAUDE.md"
-    if not arch.exists() or not claude.exists():
+    if not arch_files or not claude.exists():
         return finding(
             "P2.9",
             Status.NA,
-            "architecture.md or CLAUDE.md missing — upstream P1 checks cover this",
+            "architecture wiki topic or CLAUDE.md missing — upstream P1 checks cover this",
         )
     claude_terms = _capitalised_terms(
         claude.read_text(encoding="utf-8", errors="replace")
     )
-    arch_text = arch.read_text(encoding="utf-8", errors="replace")
+    arch_text = "\n".join(
+        f.read_text(encoding="utf-8", errors="replace") for f in arch_files
+    )
     if len(claude_terms) < 3:
         return finding(
             "P2.9",

--- a/tests/test_hydraflow_audit_p2_checks.py
+++ b/tests/test_hydraflow_audit_p2_checks.py
@@ -227,3 +227,31 @@ def test_ubiquitous_language_warns_on_divergence(tmp_path: Path) -> None:
 
 def test_ubiquitous_language_na_when_docs_missing(tmp_path: Path) -> None:
     assert _run("P2.9", _ctx(tmp_path)).status is Status.NA
+
+
+def test_ubiquitous_language_passes_when_terms_in_split_topic_files(
+    tmp_path: Path,
+) -> None:
+    """Terms scattered across ``architecture-*.md`` topic files still resolve.
+
+    Mirrors the layout introduced by PR #8462 — ``architecture.md`` carries
+    the entry-point reference table for a few terms, the rest live in topic
+    files. The audit must read them all, not just the residual entry file.
+    """
+    _write(
+        tmp_path / "CLAUDE.md",
+        "Key concepts: TaskRunner, IssueTracker, LabelMachine, PhaseGuard.\n",
+    )
+    _write(
+        tmp_path / "docs" / "wiki" / "architecture.md",
+        "Entry-point page; mentions TaskRunner.\n",
+    )
+    _write(
+        tmp_path / "docs" / "wiki" / "architecture-layers.md",
+        "Layer doc covers IssueTracker and LabelMachine in depth.\n",
+    )
+    _write(
+        tmp_path / "docs" / "wiki" / "architecture-state-persistence.md",
+        "PhaseGuard semantics and storage.\n",
+    )
+    assert _run("P2.9", _ctx(tmp_path)).status is Status.PASS


### PR DESCRIPTION
## Summary

Two pre-existing audit WARNs were tripping every Python-touching PR (e.g. surfaced on PR #8468) once the audit job started running again on main. This PR clears both.

## Background

PR #8462 split `docs/wiki/architecture.md` into focused topic files. Two latent issues were introduced:
1. The P2.9 (ubiquitous-language) check was hard-coded to read only the residual `architecture.md`.
2. ~10 ubiquitous-language terms (HydraFlowConfig, StateData, SessionLog, WorkspacePort, AgentRunner, PlannerRunner, ReviewRunner, WorktreeManager, RepoWikiLoop, RepoWikiStore, DiagramLoop, MockWorld) didn't make it into any topic file during the split.

Separately, P10.3 (regression-test discipline) flagged 14/14 historical fix commits without a regression test — exactly the case the documented `.hydraflow-audit-baseline` escape hatch is for.

## Changes

| File | What changed |
|------|---------------|
| `scripts/hydraflow_audit/checks/p2_architecture.py` | P2.9 now scans every `architecture*.md` file (multi-file glob + join) |
| `docs/wiki/architecture.md` | New "Ubiquitous Language Reference" section restores the lost terms with cross-links to topic files |
| `scripts/hydraflow_audit/checks/p10_tdd.py` | Fix misleading docstring/error message that referenced `.hydraflow/audit-baseline` (the actual `_BASELINE_FILE` is `.hydraflow-audit-baseline`) |
| `.hydraflow-audit-baseline` | New tracked file pointing to current main HEAD (d0d18382) — exempts pre-adoption fix commits from P10.3 |
| `.gitignore` | Untrack `.hydraflow-audit-baseline` (the original gitignore from #8417 made the file machine-specific, but the audit's documented mechanism requires it tracked so CI sees the same state) |
| `tests/test_hydraflow_audit_p2_checks.py` | New test exercising the multi-file scan |

## Audit before vs after

```
before:  PASS 88  WARN 2  FAIL 0  NA 5  → exit 1 (CI fails)
after:   PASS 91  WARN 0  FAIL 0  NA 5  → exit 0 (CI passes)
```

## Skip-ADR

Audit-tool maintenance + content backfill into the wiki. No new architectural decision being introduced; restoring the audit's intended behaviour after PR #8462's split.

## Test plan

- [x] `pytest tests/test_hydraflow_audit_p2_checks.py tests/test_hydraflow_audit_p10_checks.py` — 33/33 pass (32 prior + 1 new)
- [x] `uv run python -m scripts.hydraflow_audit .` — exits 0, all WARNs cleared
- [x] Pre-commit hooks (test-sludge, lint-check) pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)