### PR TITLE
chore(sandbox): remove _SANDBOX_DISABLED_WORKERS carve-out (production fixes obsoleted it)

### DIFF
--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -85,28 +85,14 @@ async def main() -> None:
         for issue_number, results in by_issue.items():
             getattr(fake_llm, f"script_{phase}")(issue_number, results)
 
-    # Loops disabled in sandbox because they call out to real CLIs/services
-    # that block the asyncio event loop on an air-gapped (``internal: true``)
-    # network. The classic offender is ``contract_refresh``: its tick calls
-    # synchronous ``subprocess.run(["claude", "-p", "ping", ...])`` (no
-    # timeout) which hangs forever trying to reach ``api.anthropic.com``,
-    # freezing every other task — including the dashboard's uvicorn bind —
-    # until the kernel kills the container. The real fix (wrap in
-    # ``asyncio.to_thread`` and add a hard timeout) lives in production code;
-    # here we just opt out of the caretaker entirely. None of these loops
-    # exercise the issue→PR pipeline that sandbox scenarios validate.
-    _SANDBOX_DISABLED_WORKERS = frozenset(
-        {
-            "contract_refresh",
-        }
-    )
-
-    def _sandbox_is_enabled(worker_name: str, *_a: object, **_kw: object) -> bool:
-        return worker_name not in _SANDBOX_DISABLED_WORKERS
-
+    # Every async-touched ``subprocess.run`` site in production code now
+    # specifies ``timeout=`` (PRs #8454, #8456, #8468 — enforced by
+    # ``tests/regressions/test_async_subprocess_timeouts.py``), so caretaker
+    # loops that try to call out under air-gap fail fast instead of hanging
+    # the dashboard's uvicorn bind. No sandbox-specific carve-out is needed.
     callbacks = WorkerRegistryCallbacks(
         update_status=lambda *_a, **_kw: None,
-        is_enabled=_sandbox_is_enabled,
+        is_enabled=lambda *_a, **_kw: True,
         get_interval=lambda *_a, **_kw: 60,
     )
 


### PR DESCRIPTION
## Summary

Removes the ``_SANDBOX_DISABLED_WORKERS = frozenset({"contract_refresh"})`` carve-out from ``src/mockworld/sandbox_main.py``. It was a tactical workaround that the production fixes have now obsoleted.

## Why it existed

PR #75b7b106 added the carve-out because ``contract_refresh`` synchronously called ``subprocess.run(["claude", "-p", "ping", ...])`` with no timeout. Under ``internal: true``, that call hung trying to reach ``api.anthropic.com``, freezing the asyncio event loop including the dashboard's uvicorn bind. The kernel never killed it, so the healthcheck timed out and the sandbox stack failed to come up.

## Why it is now safe to remove

Three subsequent production PRs closed the underlying class of bug:

| PR | Site |
|----|------|
| #8454 | ``src/contract_recording.py`` wrapped in ``asyncio.to_thread`` + 120s timeout |
| #8456 | ``timeout=`` added to ``subprocess.run`` in ``diagram_loop.py``, ``repo_wiki.py``, ``repo_wiki_loop.py``, ``arch/runner.py`` |
| #8468 | ``timeout=120`` added to ``_run_git`` / ``_run_gh`` in ``auto_pr.py`` |

``tests/regressions/test_async_subprocess_timeouts.py`` now enforces the rule across all six modules — adding a new async-touched ``subprocess.run`` site without a timeout fails the regression.

Caretaker loops that try to call out under air-gap now fail fast (subprocess timeout fires, exception bubbles up, loop logs and re-sleeps) instead of hanging the dashboard. So sandbox doesn't need to skip them.

## Bonus

Removing the carve-out makes the sandbox environment exercise the same loop set as production, which is more honest about what scenarios cover. Previously ``contract_refresh`` was silently absent; now it ticks (and fails harmlessly with a timeout once per interval).

## Skip-ADR

Removing a tactical workaround now that the underlying fix is enforced by regression test. No new architectural decision being introduced.

## Test plan

- [x] ``pytest tests/test_sandbox_main_smoke.py tests/test_mockworld_seed.py tests/regressions/test_async_subprocess_timeouts.py`` — 11/11 pass
- [x] ``pytest tests/ -k "mockworld or sandbox" --ignore=tests/sandbox_scenarios`` — 74 pass / 10 xfailed (expected)
- [x] Pre-commit hooks (lint, arch-check) pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Skip-ADR: Removing tactical workaround obsoleted by PRs #8454, #8456, #8468 + regression-test enforcement. No new architectural decision.