### PR TITLE
fix(fake-coverage-auditor): register labels via HYDRAFLOW_LABELS

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -714,6 +714,26 @@ class HydraFlowConfig(BaseModel):
         default=["hydraflow-diagnose"],
         description="Labels for issues in diagnostic analysis (OR logic)",
     )
+    hitl_escalation_label: list[str] = Field(
+        default=["hydraflow-hitl-escalation"],
+        description="Labels for stuck-loop HITL escalations (e.g. fake-coverage-auditor)",
+    )
+    fake_coverage_gap_label: list[str] = Field(
+        default=["hydraflow-fake-coverage-gap"],
+        description="Labels for fake-coverage-auditor gap issues (adapter or helper)",
+    )
+    adapter_surface_label: list[str] = Field(
+        default=["hydraflow-adapter-surface"],
+        description="Labels for un-cassetted public adapter methods on Fakes",
+    )
+    test_helper_label: list[str] = Field(
+        default=["hydraflow-test-helper"],
+        description="Labels for un-exercised Fake test helpers (script_*, fail_service, ...)",
+    )
+    fake_coverage_stuck_label: list[str] = Field(
+        default=["hydraflow-fake-coverage-stuck"],
+        description="Labels for stuck fake-coverage gaps (paired with hitl_escalation_label)",
+    )
     max_diagnosticians: int = Field(
         default=1,
         description="Max concurrent diagnostic workers",

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -11,9 +11,11 @@ Spec: `docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md`
   ``fail_service``, ``heal_service``, ``set_state``). Covered by a
   scenario test under ``tests/scenarios/`` that calls the helper.
 
-Files `hydraflow-find` + `fake-coverage-gap` + one of
-`adapter-surface` | `test-helper` per uncovered method. Escalates
-after 3 attempts to `hitl-escalation` + `fake-coverage-stuck`.
+Files ``find_label`` + ``fake_coverage_gap_label`` + one of
+``adapter_surface_label`` | ``test_helper_label`` per uncovered method.
+Escalates after 3 attempts to ``hitl_escalation_label`` +
+``fake_coverage_stuck_label``. All five label fields are registered in
+``HYDRAFLOW_LABELS`` so ``make ensure-labels`` provisions them.
 """
 
 from __future__ import annotations
@@ -200,7 +202,11 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         return await self._pr.create_issue(
             title,
             body,
-            ["hydraflow-find", "fake-coverage-gap", "adapter-surface"],
+            [
+                *self._config.find_label,
+                *self._config.fake_coverage_gap_label,
+                *self._config.adapter_surface_label,
+            ],
         )
 
     async def _file_helper_gap(self, fake: str, method: str) -> int:
@@ -215,7 +221,11 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         return await self._pr.create_issue(
             title,
             body,
-            ["hydraflow-find", "fake-coverage-gap", "test-helper"],
+            [
+                *self._config.find_label,
+                *self._config.fake_coverage_gap_label,
+                *self._config.test_helper_label,
+            ],
         )
 
     async def _file_escalation(self, key: str, attempts: int) -> int:
@@ -226,11 +236,16 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             f"_Spec §3.2: closing this issue clears the dedup key._"
         )
         return await self._pr.create_issue(
-            title, body, ["hitl-escalation", "fake-coverage-stuck"]
+            title,
+            body,
+            [
+                *self._config.hitl_escalation_label,
+                *self._config.fake_coverage_stuck_label,
+            ],
         )
 
     async def _reconcile_closed_escalations(self) -> None:
-        """Clear dedup keys for closed ``fake-coverage-stuck`` escalations."""
+        """Clear dedup keys for closed fake-coverage-stuck escalations."""
         cmd = [
             "gh",
             "issue",
@@ -239,17 +254,22 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             self._config.repo,
             "--state",
             "closed",
-            "--label",
-            "hitl-escalation",
-            "--label",
-            "fake-coverage-stuck",
-            "--author",
-            "@me",
-            "--limit",
-            "100",
-            "--json",
-            "title",
         ]
+        for label in (
+            *self._config.hitl_escalation_label,
+            *self._config.fake_coverage_stuck_label,
+        ):
+            cmd.extend(["--label", label])
+        cmd.extend(
+            [
+                "--author",
+                "@me",
+                "--limit",
+                "100",
+                "--json",
+                "title",
+            ]
+        )
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,

--- a/src/prep.py
+++ b/src/prep.py
@@ -29,6 +29,23 @@ HYDRAFLOW_LABELS: tuple[tuple[str, str, str], ...] = (
     ("verify_label", "c2e0c6", "Post-merge verification pending"),
     ("parked_label", "c5c5c5", "Issue parked — awaiting author clarification"),
     ("diagnose_label", "1d76db", "Issue under diagnostic analysis before HITL"),
+    ("hitl_escalation_label", "b60205", "Stuck-loop HITL escalation (caretaker loops)"),
+    (
+        "fake_coverage_gap_label",
+        "fbca04",
+        "Fake adapter or helper missing from contract coverage",
+    ),
+    ("adapter_surface_label", "c5def5", "Public method on a Fake adapter"),
+    (
+        "test_helper_label",
+        "d4c5f9",
+        "Helper method on a Fake (script_*, fail_service, ...)",
+    ),
+    (
+        "fake_coverage_stuck_label",
+        "e99695",
+        "Fake coverage gap unresolved after retries",
+    ),
 )
 
 

--- a/tests/scenarios/test_fake_coverage_auditor_scenario.py
+++ b/tests/scenarios/test_fake_coverage_auditor_scenario.py
@@ -81,8 +81,8 @@ class TestFakeCoverageAuditor:
         title, _body, labels = args[0], args[1], args[2]
         assert "close_issue" in title
         assert "FakeGitHub" in title
-        assert "adapter-surface" in labels
-        assert "fake-coverage-gap" in labels
+        assert "hydraflow-adapter-surface" in labels
+        assert "hydraflow-fake-coverage-gap" in labels
         assert "hydraflow-find" in labels
 
     async def test_unused_test_helper_files_helper_gap(self, tmp_path) -> None:
@@ -119,6 +119,6 @@ class TestFakeCoverageAuditor:
         title, _body, labels = args[0], args[1], args[2]
         assert "script_run" in title
         assert "FakeDocker" in title
-        assert "test-helper" in labels
-        assert "fake-coverage-gap" in labels
+        assert "hydraflow-test-helper" in labels
+        assert "hydraflow-fake-coverage-gap" in labels
         assert "hydraflow-find" in labels

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -125,8 +125,8 @@ async def test_do_work_files_surface_gap(loop_env, monkeypatch, tmp_path) -> Non
     stats = await loop._do_work()
     assert stats["filed"] == 1
     labels = pr.create_issue.await_args.args[2]
-    assert "adapter-surface" in labels
-    assert "fake-coverage-gap" in labels
+    assert "hydraflow-adapter-surface" in labels
+    assert "hydraflow-fake-coverage-gap" in labels
 
 
 async def test_do_work_files_helper_gap(loop_env, monkeypatch, tmp_path) -> None:
@@ -157,7 +157,7 @@ async def test_do_work_files_helper_gap(loop_env, monkeypatch, tmp_path) -> None
     stats = await loop._do_work()
     assert stats["filed"] == 1
     labels = pr.create_issue.await_args.args[2]
-    assert "test-helper" in labels
+    assert "hydraflow-test-helper" in labels
     title = pr.create_issue.await_args.args[0]
     assert "script_run" in title
 
@@ -190,8 +190,8 @@ async def test_escalation_fires_after_three_attempts(
     stats = await loop._do_work()
     assert stats["escalated"] == 1
     labels = pr.create_issue.await_args.args[2]
-    assert "hitl-escalation" in labels
-    assert "fake-coverage-stuck" in labels
+    assert "hydraflow-hitl-escalation" in labels
+    assert "hydraflow-fake-coverage-stuck" in labels
 
 
 async def test_close_reconcile_clears_dedup_on_closed_escalation(
@@ -232,6 +232,39 @@ async def test_close_reconcile_clears_dedup_on_closed_escalation(
     assert "fake_coverage_auditor:FakeGitHub.other:adapter-surface" in remaining
     state.clear_fake_coverage_attempts.assert_called_once_with(
         "FakeGitHub.missing:adapter-surface"
+    )
+
+
+async def test_all_emitted_labels_are_registered_hydraflow_labels(loop_env) -> None:
+    """Every label the auditor passes to ``pr.create_issue`` must be a registered
+    HydraFlow lifecycle label, so ``make ensure-labels`` provisions it on the repo.
+
+    Regression for "could not add label: 'fake-coverage-gap' not found" — bare
+    labels were silently failing every gap-issue creation. See PR for context.
+    """
+    from prep import HYDRAFLOW_LABELS
+
+    cfg, state, pr, dedup = loop_env
+    registered: set[str] = set()
+    for cfg_field, *_ in HYDRAFLOW_LABELS:
+        registered.update(getattr(cfg, cfg_field))
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    await loop._file_surface_gap("FakeGitHub", "create_issue")
+    await loop._file_helper_gap("FakeDocker", "script_run")
+    await loop._file_escalation("FakeGitHub.missing:adapter-surface", 3)
+
+    emitted: set[str] = set()
+    for call in pr.create_issue.await_args_list:
+        emitted.update(call.args[2])
+
+    unregistered = emitted - registered
+    assert not unregistered, (
+        f"auditor emits unregistered labels: {sorted(unregistered)}"
     )
 
 

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1686,6 +1686,11 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "custom-verify",
         "hydraflow-parked",
         "hydraflow-diagnose",
+        "hydraflow-hitl-escalation",
+        "hydraflow-fake-coverage-gap",
+        "hydraflow-adapter-surface",
+        "hydraflow-test-helper",
+        "hydraflow-fake-coverage-stuck",
     }
 
 


### PR DESCRIPTION
Skip-ADR: bug fix — label-registration drift, no architectural decision

## Summary

- The auditor was emitting bare labels (`fake-coverage-gap`, `adapter-surface`, `test-helper`, `hitl-escalation`, `fake-coverage-stuck`) that were never registered with `make ensure-labels`. `gh issue create` rc=1s whenever any label is unknown, so every gap-issue creation has been failing silently in prod — visible as a flood of `could not add label: 'fake-coverage-gap' not found` warnings every audit cycle.
- Adds 5 `*_label` fields to `HydraFlowConfig` with `hydraflow-`-prefixed defaults, registers them in `prep.HYDRAFLOW_LABELS`, refactors the auditor to read labels from config (matches the rest of the codebase), and adds a regression test asserting every label the auditor emits is a member of the registered HydraFlow label set.

## Why

`make ensure-labels` walks `HYDRAFLOW_LABELS` and `gh label create --force`s each one. Bare labels never made it into that table, so they never existed on the repo, so every issue-create failed. Convention is: every HydraFlow-managed label is `hydraflow-` prefixed and registered via a `*_label` config field.

## Out of scope (follow-up: #8481)

9 other loops still emit bare `"hitl-escalation"` plus per-loop stuck-labels. The new `hitl_escalation_label` field is shared and ready for them to adopt; tracked in #8481.

## Post-merge action

Already completed: `make ensure-labels` ran from the worktree branch and provisioned all 5 new labels on `T-rav/hydraflow`. Verified via `gh label list`.

## Test plan

- [x] Regression test `test_all_emitted_labels_are_registered_hydraflow_labels` — drives all three issue-filing paths and asserts every emitted label is in the registered HydraFlow set.
- [x] Existing auditor tests updated to match new label names (unit + scenario).
- [x] `test_ensure_labels_exist_uses_config_label_names` updated for the 5 new labels.
- [x] `make quality` clean: 12075 passed, 9 skipped.
- [ ] Verify on next `fake_coverage_auditor` cycle (post-merge) that gap-issues actually file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)