### PR TITLE
fix(trust-fleet): add stale_issue/stale_issue_gc to get_interval defaults

### DIFF
--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -151,5 +151,7 @@ class BGWorkerManager:
             "wiki_rot_detector": self._config.wiki_rot_detector_interval,
             "trust_fleet_sanity": self._config.trust_fleet_sanity_interval,
             "adr_touchpoint_auditor": self._config.adr_touchpoint_auditor_interval,
+            "stale_issue": self._config.stale_issue_interval,
+            "stale_issue_gc": self._config.stale_issue_gc_interval,
         }
         return defaults.get(name, self._config.poll_interval)

--- a/tests/regressions/test_issue_8524.py
+++ b/tests/regressions/test_issue_8524.py
@@ -1,0 +1,63 @@
+"""Regression test for issue #8524.
+
+Bug: ``BGWorkerManager.get_interval`` did not have entries for ``stale_issue``
+or ``stale_issue_gc``, so both workers fell through to ``poll_interval`` (30 s)
+instead of their configured daily/hourly intervals (86400 s / 3600 s).
+
+``TrustFleetSanityLoop`` picks up every worker from heartbeats and checks
+staleness using ``bg.get_interval(worker)``.  With the wrong interval, a
+``stale_issue`` loop that ran hours ago (correctly, once per day) looks
+overdue against a 30 s baseline — triggering a false-positive escalation
+that auto-filed issue #8524.
+
+Fix: add ``stale_issue`` and ``stale_issue_gc`` to the defaults dict in
+``BGWorkerManager.get_interval``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture()
+def manager(tmp_path: Any):
+    from bg_worker_manager import BGWorkerManager
+    from config import HydraFlowConfig
+    from state import StateTracker
+
+    config = HydraFlowConfig()
+    state = StateTracker(tmp_path / "state.json")
+    return BGWorkerManager(config, state, bg_loop_registry={})
+
+
+class TestStaleIssueIntervalDefaults:
+    def test_stale_issue_returns_config_interval_not_poll(self, manager: Any) -> None:
+        interval = manager.get_interval("stale_issue")
+        assert interval == manager._config.stale_issue_interval
+        assert interval != manager._config.poll_interval, (
+            "stale_issue fell through to poll_interval — "
+            "TrustFleetSanityLoop will fire false staleness alerts"
+        )
+
+    def test_stale_issue_gc_returns_config_interval_not_poll(
+        self, manager: Any
+    ) -> None:
+        interval = manager.get_interval("stale_issue_gc")
+        assert interval == manager._config.stale_issue_gc_interval
+        assert interval != manager._config.poll_interval, (
+            "stale_issue_gc fell through to poll_interval — "
+            "TrustFleetSanityLoop will fire false staleness alerts"
+        )
+
+    def test_stale_issue_interval_is_daily(self, manager: Any) -> None:
+        assert manager.get_interval("stale_issue") == 86400
+
+    def test_stale_issue_gc_interval_is_hourly(self, manager: Any) -> None:
+        assert manager.get_interval("stale_issue_gc") == 3600


### PR DESCRIPTION
## Summary

- `BGWorkerManager.get_interval` was missing `stale_issue` and `stale_issue_gc` from its defaults dict, causing both to fall through to `poll_interval` (30s) instead of their actual configured intervals (86400s and 3600s respectively).
- `TrustFleetSanityLoop` picks up every worker from heartbeats and evaluates staleness using `bg.get_interval(worker)`. With a 30s baseline and a 2x multiplier, any daily loop that ran more than 60s ago appears overdue — filing a false-positive escalation (issue #8524).

## Root cause

`src/bg_worker_manager.py:get_interval` has a `defaults` dict for workers whose intervals differ from `poll_interval`. `stale_issue` (daily, 86400s) and `stale_issue_gc` (hourly, 3600s) were both absent, causing the fallthrough.

## Fix

Added the two missing entries to the defaults dict using their config fields (`stale_issue_interval` and `stale_issue_gc_interval`).

## Test plan

- [x] 4 regression tests in `tests/regressions/test_issue_8524.py` — all pass
- [x] `make quality` passes (1 pre-existing env-specific failure in `test_config_otel_defaults` unrelated to this change — confirmed failing identically without these changes)

Closes #8524

🤖 Generated with [Claude Code](https://claude.com/claude-code)