### PR TITLE
fix(dashboard): surface RepoRuntime startup failures so the play button stops flickering

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T07:19:41.895946+00:00",
-  "commit_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5",
+  "regenerated_at": "2026-05-07T18:50:33.291544+00:00",
+  "commit_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "ports.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "labels.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "modules.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "events.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "adr_xref.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "mockworld.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "changelog.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     },
     "functional_areas.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T14:51:36.463443+00:00",
-  "commit_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524",
+  "regenerated_at": "2026-05-07T07:19:41.895946+00:00",
+  "commit_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5",
   "artifacts": {
     "loops.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "ports.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "labels.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "modules.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "events.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "adr_xref.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "mockworld.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "changelog.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "functional_areas.md": {
-      "source_sha": "c45e243b67a9fc8625c0ffcd7f36661341a53524"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -168,4 +168,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -168,4 +168,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,15 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `33b642d` — fix(dashboard): surface RepoRuntime startup failures so the play button stops flickering *(2026-05-07)*
+- `2ffae14` — chore(arch): regenerate arch artifacts after term-proposer-adapters merge *(2026-05-07)*
+- `c45e243` — Merge remote-tracking branch 'origin/feat/term-proposer-adapters' into feat/term-proposer-adapters *(2026-05-07)*
+- `8b62616` — chore: re-regen arch artifacts after rebase onto staging *(2026-05-07)*
+- `c9c5d35` — chore: arch-regen + lint-fix to unblock CI on #8478 *(2026-05-07)*
 - `775eebe` — feat(adr): AdrTouchpointAuditorLoop replaces deleted touchpoint gate (ADR-0056) *(2026-05-06)*
+- `dd9ce56` — feat(pr): rebase-on-conflict for process-driven merges (#8482) (#8482) *(2026-05-06)*
 - `29f2676` — chore(ci): delete the ADR touchpoint gate (replaced by caretaker loop) *(2026-05-06)*
+- `06c3e70` — feat(staging): activate two-tier branch model + repeatable branch-protection standard (#8479) (#8479) *(2026-05-06)*
 - `6d7fe13` — feat(telemetry): OTel Honeycomb instrumentation — Phase A (#8473) (#8473) *(2026-05-06)*
 - `43ffe3d` — feat(ul): TermProposerLoop — auto-grow the ubiquitous-language glossary (ADR-0054 / chunk 2 of 5) (#8477) (#8477) *(2026-05-06)*
 - `9ce2397` — feat(ul): ubiquitous language as a living artifact (ADR-0053 slice 1) (#8474) (#8474) *(2026-05-06)*
@@ -169,4 +176,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,13 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
-- `c45e243` — Merge remote-tracking branch 'origin/feat/term-proposer-adapters' into feat/term-proposer-adapters *(2026-05-07)*
-- `8b62616` — chore: re-regen arch artifacts after rebase onto staging *(2026-05-07)*
-- `c9c5d35` — chore: arch-regen + lint-fix to unblock CI on #8478 *(2026-05-07)*
 - `775eebe` — feat(adr): AdrTouchpointAuditorLoop replaces deleted touchpoint gate (ADR-0056) *(2026-05-06)*
-- `dd9ce56` — feat(pr): rebase-on-conflict for process-driven merges (#8482) (#8482) *(2026-05-06)*
 - `29f2676` — chore(ci): delete the ADR touchpoint gate (replaced by caretaker loop) *(2026-05-06)*
-- `06c3e70` — feat(staging): activate two-tier branch model + repeatable branch-protection standard (#8479) (#8479) *(2026-05-06)*
 - `6d7fe13` — feat(telemetry): OTel Honeycomb instrumentation — Phase A (#8473) (#8473) *(2026-05-06)*
 - `43ffe3d` — feat(ul): TermProposerLoop — auto-grow the ubiquitous-language glossary (ADR-0054 / chunk 2 of 5) (#8477) (#8477) *(2026-05-06)*
 - `9ce2397` — feat(ul): ubiquitous language as a living artifact (ADR-0053 slice 1) (#8474) (#8474) *(2026-05-06)*
@@ -174,4 +169,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -44,4 +44,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -44,4 +44,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -6,6 +6,7 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 
 ```mermaid
 graph LR
+    BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
     IssueStorePort --> CachingIssueStore
@@ -32,7 +33,8 @@ graph LR
 
 - Module: `src.term_proposer_loop`
 - Methods: `open_bot_pr`
-- Adapters: —
+- Adapters:
+  - `OpenAutoPRBotPRPort` (`src.term_proposer_runtime`)
 - Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
 
 ### IssueFetcherPort
@@ -62,7 +64,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -91,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -6,7 +6,6 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 
 ```mermaid
 graph LR
-    BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
     IssueStorePort --> CachingIssueStore
@@ -33,8 +32,7 @@ graph LR
 
 - Module: `src.term_proposer_loop`
 - Methods: `open_bot_pr`
-- Adapters:
-  - `OpenAutoPRBotPRPort` (`src.term_proposer_runtime`)
+- Adapters: —
 - Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
 
 ### IssueFetcherPort
@@ -64,7 +62,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -93,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `c45e243` on 2026-05-07 14:51 UTC. Source last changed at `c45e243`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:19 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_state_routes.py
+++ b/src/dashboard_routes/_state_routes.py
@@ -120,6 +120,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                         session_id=rt.orchestrator.current_session_id
                         if rt.running
                         else None,
+                        last_error=rt.last_error,
                     ).model_dump()
                 )
         return JSONResponse({"runtimes": infos})
@@ -151,6 +152,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             repo=rt.config.repo,
             running=rt.running,
             session_id=rt.orchestrator.current_session_id if rt.running else None,
+            last_error=rt.last_error,
         )
         return JSONResponse(info.model_dump())
 

--- a/src/models.py
+++ b/src/models.py
@@ -1336,6 +1336,7 @@ class RepoRuntimeInfo(BaseModel):
     running: bool = False
     session_id: str | None = None
     uptime_seconds: float = 0.0
+    last_error: str | None = None
 
 
 class IssueOutcomeType(StrEnum):

--- a/src/repo_runtime.py
+++ b/src/repo_runtime.py
@@ -39,6 +39,7 @@ class RepoRuntime:
             state=self._state,
         )
         self._task: asyncio.Task[None] | None = None
+        self._last_error: str | None = None
 
     @classmethod
     async def create(cls, config: HydraFlowConfig) -> RepoRuntime:
@@ -82,6 +83,19 @@ class RepoRuntime:
     def running(self) -> bool:
         return self._orchestrator.running
 
+    @property
+    def last_error(self) -> str | None:
+        """Last exception raised by the orchestrator task, or ``None``.
+
+        Set when the orchestrator background task ends with an exception
+        (e.g. ``sanitize_repo`` fails on a freshly-added repo). Cleared on
+        the next successful ``start()``. Surfaces to the dashboard via
+        :class:`~models.RepoRuntimeInfo` so the UI can show *why* a Play
+        click did not stick — without this the failure was silent and the
+        button appeared to flicker on→off with no explanation.
+        """
+        return self._last_error
+
     # --- Lifecycle ---
 
     async def start(self) -> None:
@@ -89,9 +103,22 @@ class RepoRuntime:
         if self._task and not self._task.done():
             logger.warning("Runtime %r already running", self._slug)
             return
+        self._last_error = None
         logger.info("Starting runtime for %r", self._slug)
         self._task = asyncio.create_task(
             self._orchestrator.run(), name=f"runtime-{self._slug}"
+        )
+        self._task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+        self._last_error = f"{type(exc).__name__}: {exc}"
+        logger.error(
+            "Runtime %r exited with exception: %s", self._slug, self._last_error
         )
 
     async def run(self) -> None:

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -158,6 +158,7 @@ export function SessionSidebar() {
           const isRepoSelected = selectedRepoSlug === entry.filterSlug
           const rt = entry.runtime
           const isRunning = rt?.running ?? entry.info?.running ?? false
+          const lastError = rt?.last_error || null
           const orchRunning = orchestratorStatus === 'running'
           const disabled = !orchRunning && !isRunning
           const slug = entry.repoSlug || entry.displayName
@@ -211,6 +212,15 @@ export function SessionSidebar() {
                   stageStatus={stageStatus}
                 />
               </div>
+              {lastError && !isRunning && (
+                <div
+                  style={styles.repoLastError}
+                  title={lastError}
+                  data-testid="repo-last-error"
+                >
+                  ⚠ {lastError}
+                </div>
+              )}
             </div>
           )
         })}
@@ -260,6 +270,15 @@ const styles = {
     fontSize: 10,
     color: theme.textMuted,
     paddingLeft: 14,
+  },
+  repoLastError: {
+    fontSize: 10,
+    color: theme.red,
+    paddingLeft: 14,
+    paddingTop: 2,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   repoText: {
     display: 'flex',

--- a/tests/test_dashboard_routes_core.py
+++ b/tests/test_dashboard_routes_core.py
@@ -439,6 +439,7 @@ class TestRuntimeLifecycleEndpoints:
         mock_runtime.slug = "org-repo"
         mock_runtime.config.repo = "org/repo"
         mock_runtime.running = True
+        mock_runtime.last_error = None
         mock_runtime.orchestrator = mock_orch
 
         mock_registry = MagicMock()

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -1400,6 +1400,7 @@ class TestRuntimeEndpointsWithRegistry:
         mock_rt.slug = "owner-repo"
         mock_rt.config.repo = "owner/repo"
         mock_rt.running = False
+        mock_rt.last_error = None
 
         mock_registry = MagicMock()
         mock_registry.all = [mock_rt]
@@ -1414,6 +1415,36 @@ class TestRuntimeEndpointsWithRegistry:
         registered = [r for r in data["runtimes"] if r["slug"] == "owner-repo"]
         assert len(registered) == 1
         assert registered[0]["running"] is False
+        assert registered[0]["last_error"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_runtimes_surfaces_runtime_last_error(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        """Regression: runtime that crashed during start exposes last_error.
+
+        Without this, the dashboard showed a Play→Stop→Play flicker with
+        no explanation when a freshly-added repo failed to initialize.
+        """
+        mock_rt = MagicMock()
+        mock_rt.slug = "owner-repo"
+        mock_rt.config.repo = "owner/repo"
+        mock_rt.running = False
+        mock_rt.last_error = "RuntimeError: sanitize_repo failed"
+
+        mock_registry = MagicMock()
+        mock_registry.all = [mock_rt]
+
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=mock_registry
+        )
+        endpoint = find_endpoint(router, "/api/runtimes")
+
+        resp = await endpoint()
+        data = json.loads(resp.body)
+        registered = [r for r in data["runtimes"] if r["slug"] == "owner-repo"]
+        assert len(registered) == 1
+        assert registered[0]["last_error"] == "RuntimeError: sanitize_repo failed"
 
     @pytest.mark.asyncio
     async def test_get_runtime_status_found(
@@ -1423,6 +1454,7 @@ class TestRuntimeEndpointsWithRegistry:
         mock_rt.slug = "owner-repo"
         mock_rt.config.repo = "owner/repo"
         mock_rt.running = False
+        mock_rt.last_error = None
 
         mock_registry = MagicMock()
         mock_registry.get.return_value = mock_rt

--- a/tests/test_repo_runtime.py
+++ b/tests/test_repo_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,6 +33,7 @@ class TestRepoRuntimeInfo:
         assert info.running is False
         assert info.session_id is None
         assert info.uptime_seconds == 0.0
+        assert info.last_error is None
 
     def test_with_values(self):
         info = RepoRuntimeInfo(
@@ -40,9 +42,11 @@ class TestRepoRuntimeInfo:
             running=True,
             session_id="sess-1",
             uptime_seconds=123.4,
+            last_error="boom",
         )
         assert info.running is True
         assert info.session_id == "sess-1"
+        assert info.last_error == "boom"
 
 
 class TestRepoRuntime:
@@ -129,6 +133,59 @@ class TestRepoRuntime:
         # Let the event loop tick so the task runs
         await asyncio.sleep(0)
         mock_orch.run.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_last_error_captures_orchestrator_run_exception(self, tmp_path):
+        """When orchestrator.run() raises during setup, last_error captures it.
+
+        Regression: previously the task exception was silently swallowed, so
+        the dashboard would briefly show "running" then revert to "stopped"
+        with no error surfaced — see UI play-button flicker bug.
+        """
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock(side_effect=RuntimeError("sanitize_repo failed"))
+        mock_orch.running = False
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.build_state_tracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", return_value=mock_orch),
+        ):
+            runtime = RepoRuntime(config)
+
+        assert runtime.last_error is None
+        await runtime.start()
+        assert runtime._task is not None
+        # Wait for the task to finish so the done_callback fires.
+        with contextlib.suppress(RuntimeError):
+            await runtime._task
+
+        assert runtime.last_error is not None
+        assert "sanitize_repo failed" in runtime.last_error
+
+    @pytest.mark.asyncio
+    async def test_start_clears_previous_last_error(self, tmp_path):
+        """Retrying start() after a failure clears the previous error."""
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_orch.running = False
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.build_state_tracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", return_value=mock_orch),
+        ):
+            runtime = RepoRuntime(config)
+        await runtime.start()
+        with contextlib.suppress(RuntimeError):
+            await runtime._task
+        assert runtime.last_error is not None
+
+        mock_orch.run = AsyncMock()  # success on retry
+        await runtime.start()
+        assert runtime.last_error is None
 
     @pytest.mark.asyncio
     async def test_stop_stops_orchestrator(self, tmp_path):


### PR DESCRIPTION
## Summary

When a freshly-added (non-default) repo fails during orchestrator startup (e.g. `sanitize_repo` can't fetch origin, `ensure_labels_exist` throws, session init blows up), `RepoRuntime.start()` previously fire-and-forgets `asyncio.create_task(orchestrator.run())` with no done_callback. The exception is silently swallowed; the UI's optimistic \`running=true\` gets overwritten by the next poll showing \`running=false\` — so the play button visibly flicks on→off and the user has no idea why.

This PR:
- Captures the task exception via `RepoRuntime._on_task_done` and stashes it as `last_error`
- Exposes `last_error` through `RepoRuntimeInfo` and the `/api/runtimes` endpoints
- Renders it under the repo row in the sidebar (red text, hover for full message)
- Clears `last_error` on the next successful `start()` so retry works

The default-repo (host factory) play button uses a different code path (`pipeline_enabled` setter + `_deferred_pipeline_start`) and already publishes `SYSTEM_ALERT` on failure — left alone here.

## Test plan
- [x] Unit: new `test_last_error_captures_orchestrator_run_exception` (RED→GREEN regression)
- [x] Unit: `test_start_clears_previous_last_error` covers retry semantics
- [x] Unit: `test_list_runtimes_surfaces_runtime_last_error` covers the API surface
- [x] All `tests/test_repo_runtime.py` + `tests/test_dashboard_routes_*.py` + `tests/test_ui_repo_parity.py` green (188 tests)
- [x] UI: `src/ui/src/components/__tests__/SessionSidebar.test.jsx` green (6 tests)
- [x] `ruff check` + `pyright` clean on changed files
- [ ] Manual: in the running dashboard, add a fake/broken repo and confirm the error appears under the repo row instead of a silent flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)