### PR TITLE
Fixes #7648: Code Quality: Break down phase_utils.run_refilling_poo...

### DIFF
--- a/repo_wiki/T-rav/hydraflow/log/7648.jsonl
+++ b/repo_wiki/T-rav/hydraflow/log/7648.jsonl
@@ -1,0 +1,1 @@
+{"phase": "review", "action": "ingest", "entries": 1, "issue_number": 7648}

--- a/repo_wiki/T-rav/hydraflow/patterns/0007-issue-7648-review-failed-agent-cli-authentication-failed-chec.md
+++ b/repo_wiki/T-rav/hydraflow/patterns/0007-issue-7648-review-failed-agent-cli-authentication-failed-chec.md
@@ -1,0 +1,13 @@
+---
+id: 0007
+topic: patterns
+source_issue: 7648
+source_phase: review
+created_at: 2026-05-07T13:39:00.063893+00:00
+status: active
+corroborations: 1
+---
+
+# Review failed: Agent CLI authentication failed — check the provider's… (#7648)
+
+Review failed: Agent CLI authentication failed — check the provider's auth (ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN / GEMINI_API_KEY / ~/.gemini/settings.json / CODEX_HOME)

--- a/src/phase_utils.py
+++ b/src/phase_utils.py
@@ -44,6 +44,78 @@ def _sentry_transaction(op: str, name: str) -> Generator[None, None, None]:
         yield
 
 
+def _fill_pending_slots(
+    supply_fn: Callable[[], list[T]],
+    worker_fn: Callable[[int, T], Coroutine[Any, Any, T_Result]],
+    pending: dict[asyncio.Task[T_Result], int],
+    max_concurrent: int,
+    worker_id_counter: int,
+) -> int:
+    """Fill available pool slots from supply_fn, returning updated counter."""
+    while len(pending) < max_concurrent:
+        new_items = supply_fn()
+        if not new_items:
+            break
+        free = max_concurrent - len(pending)
+        for item in new_items[:free]:
+            task = asyncio.create_task(worker_fn(worker_id_counter, item))
+            pending[task] = worker_id_counter
+            worker_id_counter += 1
+    return worker_id_counter
+
+
+async def _cancel_remaining(pending: dict[asyncio.Task[Any], Any]) -> None:
+    """Cancel all tasks in pending and await their completion."""
+    for t in pending:
+        t.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def _process_done_tasks(
+    done: set[asyncio.Task[T_Result]],
+    pending: dict[asyncio.Task[T_Result], int],
+    results: list[T_Result],
+) -> None:
+    """Process completed tasks: collect results or handle exceptions.
+
+    Fatal exceptions (AuthenticationError, CreditExhaustedError, MemoryError)
+    cancel remaining pending tasks and re-raise. Non-fatal exceptions are
+    logged at WARNING; the pool continues.
+    """
+    from subprocess_util import (  # noqa: PLC0415
+        AuthenticationError,
+        CreditExhaustedError,
+    )
+
+    _FATAL = (AuthenticationError, CreditExhaustedError, MemoryError)
+    for task in done:
+        del pending[task]
+        exc = task.exception()
+        if exc is None:
+            results.append(task.result())
+        elif isinstance(exc, _FATAL):
+            await _cancel_remaining(pending)
+            raise exc
+        else:
+            logger.warning("Pool worker failed: %s", exc, exc_info=exc)
+
+
+async def _collect_batch_results(
+    all_tasks: list[asyncio.Task[T_Result]],
+    stop_event: asyncio.Event,
+) -> list[T_Result]:
+    """Iterate as_completed, collecting results; cancel remainder if stop fires."""
+    results: list[T_Result] = []
+    for task in asyncio.as_completed(all_tasks):
+        results.append(await task)
+        if stop_event.is_set():
+            for t in all_tasks:
+                t.cancel()
+            break
+    return results
+
+
 async def run_concurrent_batch(
     items: list[T],
     worker_fn: Callable[[int, T], Coroutine[Any, Any, T_Result]],
@@ -55,22 +127,15 @@ async def run_concurrent_batch(
     and cancels remaining tasks if *stop_event* is set or if this
     coroutine itself is cancelled externally.
     """
-    results: list[T_Result] = []
     all_tasks = [
         asyncio.create_task(worker_fn(i, item)) for i, item in enumerate(items)
     ]
     try:
-        for task in asyncio.as_completed(all_tasks):
-            results.append(await task)
-            if stop_event.is_set():
-                for t in all_tasks:
-                    t.cancel()
-                break
+        return await _collect_batch_results(all_tasks, stop_event)
     finally:
         for t in all_tasks:
             if not t.done():
                 t.cancel()
-    return results
 
 
 async def run_refilling_pool(
@@ -90,54 +155,22 @@ async def run_refilling_pool(
     It is called each time a slot frees up to refill the pool.
     """
     results: list[T_Result] = []
-    pending: dict[asyncio.Task[T_Result], int] = {}  # task -> issue id placeholder
+    pending: dict[asyncio.Task[T_Result], int] = {}  # task -> worker id placeholder
     worker_id_counter = 0
 
     try:
         while not stop_event.is_set():
-            # Fill all empty slots — call supply repeatedly until full or dry
-            while len(pending) < max_concurrent:
-                new_items = supply_fn()
-                if not new_items:
-                    break
-                free = max_concurrent - len(pending)
-                for item in new_items[:free]:
-                    task = asyncio.create_task(worker_fn(worker_id_counter, item))
-                    pending[task] = worker_id_counter
-                    worker_id_counter += 1
-
+            worker_id_counter = _fill_pending_slots(
+                supply_fn, worker_fn, pending, max_concurrent, worker_id_counter
+            )
             if not pending:
                 break
-
             done, _ = await asyncio.wait(
                 pending.keys(), return_when=asyncio.FIRST_COMPLETED
             )
-            for task in done:
-                del pending[task]
-                exc = task.exception()
-                if exc is not None:
-                    from subprocess_util import (  # noqa: PLC0415
-                        AuthenticationError,
-                        CreditExhaustedError,
-                    )
-
-                    if isinstance(
-                        exc,
-                        AuthenticationError | CreditExhaustedError | MemoryError,
-                    ):
-                        for t in pending:
-                            t.cancel()
-                        await asyncio.gather(*pending, return_exceptions=True)
-                        raise exc
-                    logger.warning("Pool worker failed: %s", exc, exc_info=exc)
-                else:
-                    results.append(task.result())
+            await _process_done_tasks(done, pending, results)
     finally:
-        # Cancel stragglers on stop or external cancellation
-        for task in pending:
-            task.cancel()
-        if pending:
-            await asyncio.gather(*pending, return_exceptions=True)
+        await _cancel_remaining(pending)
 
     return results
 

--- a/tests/scenarios/test_agent_realistic.py
+++ b/tests/scenarios/test_agent_realistic.py
@@ -680,7 +680,7 @@ async def test_A17_authentication_error_halts_pipeline(tmp_path) -> None:
     """AuthenticationError from _execute propagates out of run_pipeline.
 
     Like CreditExhaustedError, AuthenticationError is in the re-raise
-    allowlist at src/phase_utils.py:130-137.
+    allowlist in _process_done_tasks at src/phase_utils.py.
     """
     from unittest import mock
 
@@ -743,7 +743,7 @@ async def test_A18_rate_limit_heals_mid_pipeline(tmp_path) -> None:
 async def test_A16_credit_exhausted_halts_pipeline(tmp_path) -> None:
     """CreditExhaustedError from _execute propagates out of run_pipeline.
 
-    run_refilling_pool's re-raise allowlist (src/phase_utils.py:130-137)
+    _process_done_tasks's re-raise allowlist in src/phase_utils.py
     re-raises CreditExhaustedError (along with AuthenticationError and
     MemoryError) after cancelling sibling tasks. Non-allowlisted exceptions
     are swallowed and logged at warning.

--- a/tests/test_phase_utils.py
+++ b/tests/test_phase_utils.py
@@ -845,3 +845,342 @@ class TestPipelineEscalator:
         state.set_hitl_origin.assert_called_once_with(99, "hydraflow-ready")
         record = harness.append_failure.call_args.args[0]
         assert record.stage == PipelineStage.IMPLEMENT
+
+
+# ---------------------------------------------------------------------------
+# _fill_pending_slots (private helper)
+# ---------------------------------------------------------------------------
+
+
+class TestFillPendingSlots:
+    @pytest.mark.asyncio
+    async def test_empty_supply_leaves_pending_empty(self) -> None:
+        """Empty supply_fn leaves pending unchanged and counter unchanged."""
+        from phase_utils import _fill_pending_slots
+
+        async def noop(i: int, x: int) -> int:
+            return x
+
+        pending: dict = {}
+        counter = _fill_pending_slots(lambda: [], noop, pending, 3, 5)
+        assert counter == 5
+        assert not pending
+
+    @pytest.mark.asyncio
+    async def test_creates_tasks_for_available_items(self) -> None:
+        """Tasks are created for each item returned by supply_fn (supply exhausts)."""
+        from phase_utils import _fill_pending_slots
+
+        async def noop(i: int, x: int) -> int:
+            return x
+
+        items = [10, 20]
+
+        def supply_once() -> list[int]:
+            result, items[:] = list(items), []
+            return result
+
+        pending: dict = {}
+        counter = _fill_pending_slots(supply_once, noop, pending, 5, 0)
+        assert len(pending) == 2
+        assert counter == 2
+        for t in pending:
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_respects_max_concurrent_limit(self) -> None:
+        """Does not create more tasks than max_concurrent allows."""
+        from phase_utils import _fill_pending_slots
+
+        async def noop(i: int, x: int) -> int:
+            return x
+
+        pending: dict = {}
+        counter = _fill_pending_slots(lambda: [1, 2, 3, 4, 5], noop, pending, 2, 0)
+        assert len(pending) == 2
+        assert counter == 2
+        for t in pending:
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_increments_worker_id_counter(self) -> None:
+        """Counter increments by the number of tasks created."""
+        from phase_utils import _fill_pending_slots
+
+        async def noop(i: int, x: int) -> int:
+            return i
+
+        items = [1, 2, 3]
+
+        def supply_once() -> list[int]:
+            result, items[:] = list(items), []
+            return result
+
+        pending: dict = {}
+        counter = _fill_pending_slots(supply_once, noop, pending, 5, 10)
+        assert counter == 13  # started at 10, created 3 tasks
+        for t in pending:
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_does_not_exceed_available_slots_in_partial_pending(self) -> None:
+        """If pending already has tasks, only fills remaining slots."""
+        from phase_utils import _fill_pending_slots
+
+        async def noop(i: int, x: int) -> int:
+            return x
+
+        existing_task = asyncio.create_task(noop(0, 0))
+        pending: dict = {existing_task: 0}
+        counter = _fill_pending_slots(lambda: [10, 20, 30], noop, pending, 2, 1)
+        assert len(pending) == 2  # 1 existing + 1 new
+        assert counter == 2
+        for t in list(pending):
+            t.cancel()
+
+
+# ---------------------------------------------------------------------------
+# _cancel_remaining (private helper)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelRemaining:
+    @pytest.mark.asyncio
+    async def test_cancels_all_pending_tasks(self) -> None:
+        """All tasks in the pending dict are cancelled and awaited."""
+        from phase_utils import _cancel_remaining
+
+        async def slow() -> int:
+            await asyncio.sleep(100)
+            return 1
+
+        tasks: dict[asyncio.Task[int], int] = {
+            asyncio.create_task(slow()): 0,
+            asyncio.create_task(slow()): 1,
+        }
+        await _cancel_remaining(tasks)
+
+        for t in tasks:
+            assert t.done()
+
+    @pytest.mark.asyncio
+    async def test_noop_on_empty_pending(self) -> None:
+        """Empty pending dict should not raise."""
+        from phase_utils import _cancel_remaining
+
+        await _cancel_remaining({})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_safe_on_already_done_tasks(self) -> None:
+        """Calling on already-done tasks does not raise."""
+        from phase_utils import _cancel_remaining
+
+        async def quick() -> int:
+            return 42
+
+        task = asyncio.create_task(quick())
+        await asyncio.sleep(0)  # let it complete
+        assert task.done()
+
+        await _cancel_remaining({task: 0})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _process_done_tasks (private helper)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessDoneTasks:
+    @pytest.mark.asyncio
+    async def test_appends_successful_result(self) -> None:
+        """Result from a completed task is appended to results list."""
+        from phase_utils import _process_done_tasks
+
+        async def ok() -> int:
+            return 42
+
+        task: asyncio.Task[int] = asyncio.create_task(ok())
+        await asyncio.sleep(0)  # let it complete
+
+        pending: dict[asyncio.Task[int], int] = {task: 0}
+        results: list[int] = []
+        await _process_done_tasks({task}, pending, results)
+
+        assert results == [42]
+
+    @pytest.mark.asyncio
+    async def test_removes_done_task_from_pending(self) -> None:
+        """Completed tasks are removed from the pending dict."""
+        from phase_utils import _process_done_tasks
+
+        async def ok() -> int:
+            return 1
+
+        task: asyncio.Task[int] = asyncio.create_task(ok())
+        await asyncio.sleep(0)
+
+        pending: dict[asyncio.Task[int], int] = {task: 0}
+        results: list[int] = []
+        await _process_done_tasks({task}, pending, results)
+
+        assert task not in pending
+
+    @pytest.mark.asyncio
+    async def test_nonfatal_exception_is_logged_not_raised(self) -> None:
+        """Non-fatal exceptions are logged; results list stays empty; no raise."""
+        from phase_utils import _process_done_tasks
+
+        async def bad() -> int:
+            raise ValueError("oops")
+
+        task: asyncio.Task[int] = asyncio.create_task(bad())
+        await asyncio.sleep(0)
+
+        pending: dict[asyncio.Task[int], int] = {task: 0}
+        results: list[int] = []
+
+        with patch("phase_utils.logger") as mock_logger:
+            await _process_done_tasks({task}, pending, results)
+
+        assert results == []
+        mock_logger.warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_fatal_auth_error_cancels_pending_and_raises(self) -> None:
+        """AuthenticationError cancels remaining pending tasks and re-raises."""
+        from phase_utils import _process_done_tasks
+        from subprocess_util import AuthenticationError
+
+        async def auth_fail() -> int:
+            raise AuthenticationError("bad token")
+
+        async def slow() -> int:
+            await asyncio.sleep(100)
+            return 1
+
+        failed: asyncio.Task[int] = asyncio.create_task(auth_fail())
+        await asyncio.sleep(0)  # let it fail
+
+        remaining: asyncio.Task[int] = asyncio.create_task(slow())
+        pending: dict[asyncio.Task[int], int] = {failed: 0, remaining: 1}
+        results: list[int] = []
+
+        with pytest.raises(AuthenticationError):
+            await _process_done_tasks({failed}, pending, results)
+
+        assert remaining.done()
+
+    @pytest.mark.asyncio
+    async def test_fatal_credit_error_cancels_pending_and_raises(self) -> None:
+        """CreditExhaustedError cancels remaining pending tasks and re-raises."""
+        from phase_utils import _process_done_tasks
+        from subprocess_util import CreditExhaustedError
+
+        async def credit_fail() -> int:
+            raise CreditExhaustedError("no credits")
+
+        async def slow() -> int:
+            await asyncio.sleep(100)
+            return 1
+
+        failed: asyncio.Task[int] = asyncio.create_task(credit_fail())
+        await asyncio.sleep(0)
+
+        remaining: asyncio.Task[int] = asyncio.create_task(slow())
+        pending: dict[asyncio.Task[int], int] = {failed: 0, remaining: 1}
+        results: list[int] = []
+
+        with pytest.raises(CreditExhaustedError):
+            await _process_done_tasks({failed}, pending, results)
+
+        assert remaining.done()
+
+    @pytest.mark.asyncio
+    async def test_memory_error_cancels_pending_and_raises(self) -> None:
+        """MemoryError cancels remaining pending tasks and re-raises."""
+        from phase_utils import _process_done_tasks
+
+        async def mem_fail() -> int:
+            raise MemoryError("OOM")
+
+        async def slow() -> int:
+            await asyncio.sleep(100)
+            return 1
+
+        failed: asyncio.Task[int] = asyncio.create_task(mem_fail())
+        await asyncio.sleep(0)
+
+        remaining: asyncio.Task[int] = asyncio.create_task(slow())
+        pending: dict[asyncio.Task[int], int] = {failed: 0, remaining: 1}
+        results: list[int] = []
+
+        with pytest.raises(MemoryError):
+            await _process_done_tasks({failed}, pending, results)
+
+        assert remaining.done()
+
+
+# ---------------------------------------------------------------------------
+# _collect_batch_results (private helper)
+# ---------------------------------------------------------------------------
+
+
+class TestCollectBatchResults:
+    @pytest.mark.asyncio
+    async def test_collects_all_results(self) -> None:
+        """All task results are returned."""
+        from phase_utils import _collect_batch_results
+
+        async def worker() -> int:
+            return 42
+
+        tasks = [asyncio.create_task(worker()) for _ in range(3)]
+        stop = asyncio.Event()
+        results = await _collect_batch_results(tasks, stop)
+
+        assert sorted(results) == [42, 42, 42]
+
+    @pytest.mark.asyncio
+    async def test_stops_when_stop_event_fires(self) -> None:
+        """Collection halts and remaining tasks are cancelled when stop fires."""
+        from phase_utils import _collect_batch_results
+
+        stop = asyncio.Event()
+
+        async def fast() -> int:
+            stop.set()
+            return 1
+
+        async def slow() -> int:
+            await asyncio.sleep(100)
+            return 2
+
+        tasks = [asyncio.create_task(fast()), asyncio.create_task(slow())]
+        results = await _collect_batch_results(tasks, stop)
+
+        assert 1 in results
+        assert len(results) < 2
+
+    @pytest.mark.asyncio
+    async def test_propagates_worker_exception(self) -> None:
+        """Exceptions from tasks propagate out of _collect_batch_results."""
+        from phase_utils import _collect_batch_results
+
+        async def fail() -> int:
+            raise ValueError("task failed")
+
+        tasks = [asyncio.create_task(fail())]
+        stop = asyncio.Event()
+
+        with pytest.raises(ValueError, match="task failed"):
+            await _collect_batch_results(tasks, stop)
+
+    @pytest.mark.asyncio
+    async def test_empty_task_list_returns_empty(self) -> None:
+        """Empty task list returns empty results list."""
+        from phase_utils import _collect_batch_results
+
+        stop = asyncio.Event()
+        results = await _collect_batch_results([], stop)
+
+        assert results == []


### PR DESCRIPTION
## Summary

Closes #7648.

## Issue

Code Quality: Break down phase_utils.run_refilling_pool() — nesting-6, mixed concurrency and business logic

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow