### PR TITLE
Fixes #7799: Code Quality: pr_manager._run_with_body_file fd leak w...

### DIFF
--- a/docs/architecture/fd-leak-flow.likec4
+++ b/docs/architecture/fd-leak-flow.likec4
@@ -1,0 +1,66 @@
+// LikeC4 dynamic view of the fd lifecycle around `os.fdopen`.
+// Issue #7799 — leak when `os.fdopen` raises before the `with` block can
+// take ownership of the fd from `tempfile.mkstemp`.
+
+specification {
+  element system
+  element container
+  element component
+  element resource
+}
+
+model {
+  hydraflow = system 'HydraFlow' {
+    pr_manager = container 'src/pr_manager.py' {
+      run_with_body_file = component '_run_with_body_file' {
+        description: 'Writes body to temp .md, calls gh with --body-file'
+      }
+      upload_screenshot_gist = component 'upload_screenshot_gist' {
+        description: 'Writes PNG bytes to temp .png, calls gh gist create'
+      }
+    }
+
+    stdlib = container 'Python stdlib' {
+      mkstemp = component 'tempfile.mkstemp' {
+        description: 'Returns (fd: int, path: str)'
+      }
+      fdopen = component 'os.fdopen' {
+        description: 'Wraps fd into a Python file object'
+      }
+      os_close = component 'os.close' {
+        description: 'Closes a raw OS fd'
+      }
+    }
+
+    os_kernel = resource 'OS kernel fd table' {
+      description: 'Bounded resource — leaked entries never recovered until process exit'
+    }
+
+    // Happy path
+    run_with_body_file -> mkstemp 'allocate fd + path'
+    run_with_body_file -> fdopen 'wrap fd (TODAY: leak window if this raises)'
+    fdopen -> os_kernel 'close fd via context manager exit'
+
+    // Bug — when fdopen raises
+    fdopen -> run_with_body_file 'raises OSError'
+    run_with_body_file -> os_kernel 'fd remains open (BUG)'
+
+    // Fix — explicit os.close on the failure branch
+    run_with_body_file -> os_close 'close fd before re-raise (FIX)'
+    os_close -> os_kernel 'fd released'
+
+    // Path cleanup is unchanged in both shapes
+    run_with_body_file -> stdlib 'Path(tmp_path).unlink(missing_ok=True) in finally'
+
+    // Same shape repeats in upload_screenshot_gist
+    upload_screenshot_gist -> mkstemp 'allocate fd + path'
+    upload_screenshot_gist -> fdopen 'wrap fd (same fix needed)'
+  }
+}
+
+views {
+  view fd_lifecycle of run_with_body_file {
+    title 'Issue #7799 — fd lifecycle and leak window'
+    include *
+  }
+}

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1780,7 +1780,12 @@ class PRManager:
 
         fd, tmp_path = tempfile.mkstemp(suffix=".png", prefix="hydraflow-screenshot-")
         try:
-            with os.fdopen(fd, "wb") as f:
+            try:
+                f = os.fdopen(fd, "wb")
+            except OSError:
+                os.close(fd)
+                raise
+            with f:
                 f.write(png_bytes)
 
             gist_args = [
@@ -2686,7 +2691,12 @@ class PRManager:
         """
         fd, tmp_path = tempfile.mkstemp(suffix=".md", prefix="hydraflow-body-")
         try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
+            try:
+                f = os.fdopen(fd, "w", encoding="utf-8")
+            except OSError:
+                os.close(fd)
+                raise
+            with f:
                 f.write(body)
             return await run_subprocess_with_retry(
                 *cmd,

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -626,6 +626,28 @@ class TestUploadScreenshotGist:
         assert result == ""
         mgr._run_gh.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_closes_fd_when_fdopen_raises(self, config, event_bus):
+        """fd must be closed when os.fdopen raises so the OS fd is not leaked."""
+        import base64
+
+        mgr = make_pr_manager(config, event_bus)
+        fake_fd = 88
+        png_b64 = base64.b64encode(b"\x89PNG fake").decode()
+
+        with (
+            patch(
+                "pr_manager.tempfile.mkstemp",
+                return_value=(fake_fd, "/tmp/fake.png"),
+            ),
+            patch("pr_manager.os.fdopen", side_effect=OSError("cannot open")),
+            patch("pr_manager.os.close") as mock_close,
+        ):
+            result = await mgr.upload_screenshot_gist(png_b64)
+
+        assert result == ""
+        mock_close.assert_called_once_with(fake_fd)
+
 
 # ---------------------------------------------------------------------------
 # _gh_json_query
@@ -1959,6 +1981,24 @@ async def test_run_with_body_file_defaults_cwd_to_repo_root(config, event_bus):
         await mgr._run_with_body_file("gh", "issue", "comment", "1", body="content")
 
     assert str(captured_cwd) == str(config.repo_root)
+
+
+@pytest.mark.asyncio
+async def test_run_with_body_file_closes_fd_when_fdopen_raises(config, event_bus):
+    """fd must be closed when os.fdopen raises so the OS fd is not leaked."""
+
+    mgr = make_pr_manager(config, event_bus)
+    fake_fd = 99
+
+    with (
+        patch("pr_manager.tempfile.mkstemp", return_value=(fake_fd, "/tmp/fake.md")),
+        patch("pr_manager.os.fdopen", side_effect=OSError("cannot open")),
+        patch("pr_manager.os.close") as mock_close,
+        pytest.raises(OSError),
+    ):
+        await mgr._run_with_body_file("gh", "issue", "comment", "1", body="x")
+
+    mock_close.assert_called_once_with(fake_fd)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #7799.

## Issue

Code Quality: pr_manager._run_with_body_file fd leak when os.fdopen raises

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow