### PR TITLE
Fixes #7839: Code Quality: workspace._repo_fetch_lock/_repo_workspa...

### DIFF
--- a/docs/architecture/workspace-lock-toctou.likec4
+++ b/docs/architecture/workspace-lock-toctou.likec4
@@ -1,0 +1,160 @@
+// Issue #7839 — TOCTOU on workspace module-level lock dicts
+//
+// Captures the structural and dynamic context around the bug:
+//   src/workspace.py — module-level dicts _FETCH_LOCKS, _WORKTREE_LOCKS
+//                      and the two getter methods that mutate them.
+//
+// The two getters use check-then-set against a plain dict. On a single
+// asyncio event loop, two coroutines can interleave at the `if lock is None`
+// branch and both create a fresh asyncio.Lock(), with one overwriting the
+// other in the dict. Any caller still holding the overwritten Lock no longer
+// contends with new callers — the per-repo serialization guarantee silently
+// breaks.
+
+specification {
+  element actor
+  element module
+  element class
+  element method
+  element data
+
+  tag bug
+  tag fix
+  tag callsite
+}
+
+model {
+  user = actor 'Async caller' {
+    description '
+      Any coroutine on the asyncio loop calling into WorkspaceManager.
+      Examples: sanitize_repo, pre_work_check, create, destroy.
+    '
+  }
+
+  workspace_module = module 'src/workspace.py' {
+    description 'Git workspace lifecycle. Owns the per-repo locks.'
+
+    fetch_locks = data '_FETCH_LOCKS: dict[str, asyncio.Lock]' {
+      description 'Module-level dict, keyed by str(repo_root.resolve()).'
+      #bug
+    }
+    worktree_locks = data '_WORKTREE_LOCKS: dict[str, asyncio.Lock]' {
+      description 'Module-level dict, keyed by f"wt:{repo_slug}".'
+      #bug
+    }
+
+    workspace_manager = class 'WorkspaceManager' {
+      description '
+        Per-repo workspace lifecycle. Multiple instances may target the
+        same repo; the locks must be shared across instances, which is
+        why the dicts live at module scope (see ADR-0072 / wiki entry
+        "Module-Level State via Constructor Injection").
+      '
+
+      repo_fetch_lock = method '_repo_fetch_lock()' {
+        description '
+          Today (lines 74–81): get → if None → assign.
+          Fix: _FETCH_LOCKS.setdefault(key, asyncio.Lock()).
+        '
+        #bug
+      }
+      repo_workspace_lock = method '_repo_workspace_lock()' {
+        description '
+          Today (lines 83–90): same check-then-set pattern.
+          Fix: _WORKTREE_LOCKS.setdefault(key, asyncio.Lock()).
+        '
+        #bug
+      }
+
+      // Selected callsites — these are the consumers that rely on
+      // identity-stable locks for their critical sections.
+      fetch_origin_with_retry = method '_fetch_origin_with_retry()' {
+        #callsite
+      }
+      create_workspace = method 'create()' {
+        #callsite
+      }
+      destroy_workspace = method 'destroy()' {
+        #callsite
+      }
+    }
+  }
+
+  // structural relationships
+  workspace_manager -> fetch_locks 'reads/writes (TOCTOU)' #bug
+  workspace_manager -> worktree_locks 'reads/writes (TOCTOU)' #bug
+
+  workspace_manager.fetch_origin_with_retry -> workspace_manager.repo_fetch_lock
+    'async with self._repo_fetch_lock()'
+  workspace_manager.create_workspace -> workspace_manager.repo_workspace_lock
+    'async with self._repo_workspace_lock()'
+  workspace_manager.destroy_workspace -> workspace_manager.repo_workspace_lock
+    'async with self._repo_workspace_lock()'
+
+  user -> workspace_manager.fetch_origin_with_retry
+  user -> workspace_manager.create_workspace
+  user -> workspace_manager.destroy_workspace
+}
+
+views {
+  view index {
+    title 'Workspace lock TOCTOU — context'
+    include *
+  }
+
+  // Buggy interleave (check-then-set):
+  //   T1 calls get → None
+  //   T2 calls get → None
+  //   T1 creates Lock A, writes A to dict
+  //   T2 creates Lock B, overwrites A in dict
+  //   T1 returns A; T2 returns B; new callers get B → A and B never contend.
+  dynamic view buggy_interleave {
+    title 'Buggy: two coroutines diverge through the TOCTOU window'
+
+    user -> workspace_manager.repo_fetch_lock 'T1: enter' {
+      step 1
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T1: get(key) → None' {
+      step 2
+    }
+    user -> workspace_manager.repo_fetch_lock 'T2: enter (await yields)' {
+      step 3
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T2: get(key) → None' {
+      step 4
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T1: write Lock A' {
+      step 5
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T2: overwrite with Lock B' {
+      step 6
+    }
+    workspace_manager.repo_fetch_lock -> user 'T1 ← A, T2 ← B (split-brain)' {
+      step 7
+    }
+  }
+
+  // Fixed flow (setdefault):
+  //   T1 setdefault → installs Lock A, returns A
+  //   T2 setdefault → finds A, returns A (the Lock B it constructed
+  //   is never installed and is GC'd; no resources leak.)
+  dynamic view fixed_setdefault {
+    title 'Fixed: setdefault is atomic — both callers see the same Lock'
+
+    user -> workspace_manager.repo_fetch_lock 'T1: enter' {
+      step 1
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T1: setdefault(key, Lock A)' {
+      step 2
+    }
+    user -> workspace_manager.repo_fetch_lock 'T2: enter (await yields)' {
+      step 3
+    }
+    workspace_manager.repo_fetch_lock -> fetch_locks 'T2: setdefault(key, Lock B) → A' {
+      step 4
+    }
+    workspace_manager.repo_fetch_lock -> user 'T1 ← A, T2 ← A (single survivor)' {
+      step 5
+    }
+  }
+}

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -74,20 +74,12 @@ class WorkspaceManager:
     def _repo_fetch_lock(self) -> asyncio.Lock:
         """Return a shared lock for git fetch operations in this repo."""
         key = str(self._repo_root.resolve())
-        lock = _FETCH_LOCKS.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _FETCH_LOCKS[key] = lock
-        return lock
+        return _FETCH_LOCKS.setdefault(key, asyncio.Lock())
 
     def _repo_workspace_lock(self) -> asyncio.Lock:
         """Return a per-repo lock for workspace create/destroy operations."""
         key = f"wt:{self._config.repo_slug}"
-        lock = _WORKTREE_LOCKS.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _WORKTREE_LOCKS[key] = lock
-        return lock
+        return _WORKTREE_LOCKS.setdefault(key, asyncio.Lock())
 
     _ORIGIN_HTTPS_RE = re.compile(r"github\.com[/:]([^/]+/[^/.]+?)(?:\.git)?$")
     _ORIGIN_SSH_RE = re.compile(r"git@github\.com:([^/]+/[^/.]+?)(?:\.git)?$")

--- a/tests/regressions/test_issue_7839.py
+++ b/tests/regressions/test_issue_7839.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #7839.
+
+``workspace.py`` lazily populates ``_FETCH_LOCKS`` and ``_WORKTREE_LOCKS`` via a
+check-then-set pattern::
+
+    lock = _FETCH_LOCKS.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _FETCH_LOCKS[key] = lock
+
+Two concurrent callers racing through this window each create a separate
+``asyncio.Lock``, so neither contends with the other — the per-repo
+serialisation guarantee is broken.
+
+Fix: replace check-then-set with ``dict.setdefault`` which is atomic in CPython
+because it holds the GIL across the lookup+insert.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+import workspace
+from tests.helpers import ConfigFactory
+
+
+class _RacyDict(dict):
+    """Dict subclass that forces a context switch after ``get()`` returns None.
+
+    Both threads arrive at the barrier before either stores a new lock,
+    deterministically triggering the TOCTOU window.
+    """
+
+    def __init__(self, barrier: threading.Barrier, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._barrier = barrier
+
+    def get(self, key, default=None):
+        result = super().get(key, default)
+        if result is None:
+            self._barrier.wait(timeout=5)
+        return result
+
+
+class TestIssue7839FetchLockTOCTOU:
+    """_repo_fetch_lock() must return the same Lock for concurrent callers."""
+
+    def test_concurrent_callers_get_same_fetch_lock(self, tmp_path: Path) -> None:
+        """Two threads calling _repo_fetch_lock() for the same repo key must
+        receive the identical asyncio.Lock instance."""
+        barrier = threading.Barrier(2, timeout=5)
+        racy_dict: _RacyDict = _RacyDict(barrier)
+
+        config = ConfigFactory.create(repo_root=tmp_path)
+        results: list[asyncio.Lock | None] = [None, None]
+        errors: list[Exception | None] = [None, None]
+
+        def worker(index: int) -> None:
+            try:
+                mgr = workspace.WorkspaceManager(config)
+                results[index] = mgr._repo_fetch_lock()
+            except Exception as exc:
+                errors[index] = exc
+
+        with patch.object(workspace, "_FETCH_LOCKS", racy_dict):
+            t1 = threading.Thread(target=worker, args=(0,))
+            t2 = threading.Thread(target=worker, args=(1,))
+            t1.start()
+            t2.start()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+
+        for i, err in enumerate(errors):
+            if err is not None:
+                raise AssertionError(f"worker {i} raised: {err}") from err
+
+        assert results[0] is not None, "worker 0 did not return a lock"
+        assert results[1] is not None, "worker 1 did not return a lock"
+
+        assert results[0] is results[1], (
+            f"Two callers got different Lock objects for the same repo key — "
+            f"TOCTOU race in _repo_fetch_lock() (issue #7839). "
+            f"Lock 0: {id(results[0]):#x}, Lock 1: {id(results[1]):#x}"
+        )
+
+
+class TestIssue7839WorkspaceLockTOCTOU:
+    """_repo_workspace_lock() must return the same Lock for concurrent callers."""
+
+    def test_concurrent_callers_get_same_workspace_lock(self, tmp_path: Path) -> None:
+        """Two threads calling _repo_workspace_lock() for the same repo slug
+        must receive the identical asyncio.Lock instance."""
+        barrier = threading.Barrier(2, timeout=5)
+        racy_dict: _RacyDict = _RacyDict(barrier)
+
+        config = ConfigFactory.create(repo_root=tmp_path)
+        results: list[asyncio.Lock | None] = [None, None]
+        errors: list[Exception | None] = [None, None]
+
+        def worker(index: int) -> None:
+            try:
+                mgr = workspace.WorkspaceManager(config)
+                results[index] = mgr._repo_workspace_lock()
+            except Exception as exc:
+                errors[index] = exc
+
+        with patch.object(workspace, "_WORKTREE_LOCKS", racy_dict):
+            t1 = threading.Thread(target=worker, args=(0,))
+            t2 = threading.Thread(target=worker, args=(1,))
+            t1.start()
+            t2.start()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+
+        for i, err in enumerate(errors):
+            if err is not None:
+                raise AssertionError(f"worker {i} raised: {err}") from err
+
+        assert results[0] is not None, "worker 0 did not return a lock"
+        assert results[1] is not None, "worker 1 did not return a lock"
+
+        assert results[0] is results[1], (
+            f"Two callers got different Lock objects for the same repo slug — "
+            f"TOCTOU race in _repo_workspace_lock() (issue #7839). "
+            f"Lock 0: {id(results[0]):#x}, Lock 1: {id(results[1]):#x}"
+        )


### PR DESCRIPTION
## Summary

Closes #7839.

## Issue

Code Quality: workspace._repo_fetch_lock/_repo_workspace_lock TOCTOU when inserting into module-level dicts

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow