### PR TITLE
feat(caretaker): MergeStateWatcher — auto-rebase or HITL-escalate conflicting PRs

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T07:40:00.828626+00:00",
-  "commit_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5",
+  "regenerated_at": "2026-05-07T18:49:04.840166+00:00",
+  "commit_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "ports.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "labels.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "modules.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "events.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "adr_xref.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "mockworld.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "changelog.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     },
     "functional_areas.md": {
-      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
+      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T18:49:04.840166+00:00",
-  "commit_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9",
+  "regenerated_at": "2026-05-07T19:22:26.174438+00:00",
+  "commit_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec",
   "artifacts": {
     "loops.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "ports.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "labels.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "modules.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "events.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "adr_xref.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "mockworld.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "changelog.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     },
     "functional_areas.md": {
-      "source_sha": "7caf6db086213f4e1a7ef59d4be367c6d159dde9"
+      "source_sha": "b7031b67ea833cccda816e373de1fd5ec5ff36ec"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T18:50:33.291544+00:00",
-  "commit_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea",
+  "regenerated_at": "2026-05-07T07:40:00.828626+00:00",
+  "commit_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5",
   "artifacts": {
     "loops.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "ports.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "labels.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "modules.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "events.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "adr_xref.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "mockworld.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "changelog.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     },
     "functional_areas.md": {
-      "source_sha": "33b642d0cbaeb57e2e4455982f8663a4592328ea"
+      "source_sha": "a6b6ae494a3dff803c9b069ae55ea2b3d1a884f5"
     }
   }
 }

--- a/docs/arch/functional_areas.yml
+++ b/docs/arch/functional_areas.yml
@@ -24,6 +24,7 @@ areas:
       - EpicSweeperLoop
       - GitHubCacheLoop
       - HealthMonitorLoop
+      - MergeStateWatcherLoop
       - PRUnstickerLoop
       - PricingRefreshLoop
       - RepoWikiLoop

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -168,4 +168,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -168,4 +168,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -168,4 +168,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `7caf6db` — feat(caretaker): MergeStateWatcher loop — auto-rebase or HITL-escalate conflicting PRs *(2026-05-07)*
 - `775eebe` — feat(adr): AdrTouchpointAuditorLoop replaces deleted touchpoint gate (ADR-0056) *(2026-05-06)*
 - `29f2676` — chore(ci): delete the ADR touchpoint gate (replaced by caretaker loop) *(2026-05-06)*
 - `6d7fe13` — feat(telemetry): OTel Honeycomb instrumentation — Phase A (#8473) (#8473) *(2026-05-06)*
@@ -169,4 +170,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,15 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
-- `33b642d` — fix(dashboard): surface RepoRuntime startup failures so the play button stops flickering *(2026-05-07)*
-- `2ffae14` — chore(arch): regenerate arch artifacts after term-proposer-adapters merge *(2026-05-07)*
-- `c45e243` — Merge remote-tracking branch 'origin/feat/term-proposer-adapters' into feat/term-proposer-adapters *(2026-05-07)*
-- `8b62616` — chore: re-regen arch artifacts after rebase onto staging *(2026-05-07)*
-- `c9c5d35` — chore: arch-regen + lint-fix to unblock CI on #8478 *(2026-05-07)*
 - `775eebe` — feat(adr): AdrTouchpointAuditorLoop replaces deleted touchpoint gate (ADR-0056) *(2026-05-06)*
-- `dd9ce56` — feat(pr): rebase-on-conflict for process-driven merges (#8482) (#8482) *(2026-05-06)*
 - `29f2676` — chore(ci): delete the ADR touchpoint gate (replaced by caretaker loop) *(2026-05-06)*
-- `06c3e70` — feat(staging): activate two-tier branch model + repeatable branch-protection standard (#8479) (#8479) *(2026-05-06)*
 - `6d7fe13` — feat(telemetry): OTel Honeycomb instrumentation — Phase A (#8473) (#8473) *(2026-05-06)*
 - `43ffe3d` — feat(ul): TermProposerLoop — auto-grow the ubiquitous-language glossary (ADR-0054 / chunk 2 of 5) (#8477) (#8477) *(2026-05-06)*
 - `9ce2397` — feat(ul): ubiquitous language as a living artifact (ADR-0053 slice 1) (#8474) (#8474) *(2026-05-06)*
@@ -176,4 +169,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,9 +6,18 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
-- `7caf6db` — feat(caretaker): MergeStateWatcher loop — auto-rebase or HITL-escalate conflicting PRs *(2026-05-07)*
+- `1bed223` — chore: register MergeStateWatcherLoop in all loop-hygiene registries *(2026-05-07)*
+- `ac8b047` — feat(caretaker): MergeStateWatcher loop — auto-rebase or HITL-escalate conflicting PRs *(2026-05-07)*
+- `a46fb11` — chore: regen arch artifacts after rebase *(2026-05-07)*
+- `33b642d` — fix(dashboard): surface RepoRuntime startup failures so the play button stops flickering *(2026-05-07)*
+- `2ffae14` — chore(arch): regenerate arch artifacts after term-proposer-adapters merge *(2026-05-07)*
+- `c45e243` — Merge remote-tracking branch 'origin/feat/term-proposer-adapters' into feat/term-proposer-adapters *(2026-05-07)*
+- `8b62616` — chore: re-regen arch artifacts after rebase onto staging *(2026-05-07)*
+- `c9c5d35` — chore: arch-regen + lint-fix to unblock CI on #8478 *(2026-05-07)*
 - `775eebe` — feat(adr): AdrTouchpointAuditorLoop replaces deleted touchpoint gate (ADR-0056) *(2026-05-06)*
+- `dd9ce56` — feat(pr): rebase-on-conflict for process-driven merges (#8482) (#8482) *(2026-05-06)*
 - `29f2676` — chore(ci): delete the ADR touchpoint gate (replaced by caretaker loop) *(2026-05-06)*
+- `06c3e70` — feat(staging): activate two-tier branch model + repeatable branch-protection standard (#8479) (#8479) *(2026-05-06)*
 - `6d7fe13` — feat(telemetry): OTel Honeycomb instrumentation — Phase A (#8473) (#8473) *(2026-05-06)*
 - `43ffe3d` — feat(ul): TermProposerLoop — auto-grow the ubiquitous-language glossary (ADR-0054 / chunk 2 of 5) (#8477) (#8477) *(2026-05-06)*
 - `9ce2397` — feat(ul): ubiquitous language as a living artifact (ADR-0053 slice 1) (#8474) (#8474) *(2026-05-06)*
@@ -170,4 +179,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -265,4 +265,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -16,6 +16,7 @@ flowchart LR
         caretaking_EpicSweeperLoop([EpicSweeperLoop])
         caretaking_GitHubCacheLoop([GitHubCacheLoop])
         caretaking_HealthMonitorLoop([HealthMonitorLoop])
+        caretaking_MergeStateWatcherLoop([MergeStateWatcherLoop])
         caretaking_PRUnstickerLoop([PRUnstickerLoop])
         caretaking_PricingRefreshLoop([PricingRefreshLoop])
         caretaking_RepoWikiLoop([RepoWikiLoop])
@@ -92,6 +93,7 @@ Autonomous background loops that maintain the system without human input — wik
 - `EpicSweeperLoop` — `src.epic_sweeper_loop`
 - `GitHubCacheLoop` — `src.github_cache_loop`
 - `HealthMonitorLoop` — `src.health_monitor_loop`
+- `MergeStateWatcherLoop` — `src.merge_state_watcher_loop`
 - `PRUnstickerLoop` — `src.pr_unsticker_loop`
 - `PricingRefreshLoop` — `src.pricing_refresh_loop`
 - `RepoWikiLoop` — `src.repo_wiki_loop`
@@ -263,4 +265,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -23,6 +23,7 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **FlakeTrackerLoop** | `src.flake_tracker_loop` | — | — | — | — |
 | **GitHubCacheLoop** | `src.github_cache_loop` | — | — | — | — |
 | **HealthMonitorLoop** | `src.health_monitor_loop` | — | — | — | — |
+| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | — | — | — | — |
 | **PRUnstickerLoop** | `src.pr_unsticker_loop` | — | — | — | — |
 | **PricingRefreshLoop** | `src.pricing_refresh_loop` | — | — | — | — |
 | **PrinciplesAuditLoop** | `src.principles_audit_loop` | — | — | — | ADR-0044 |
@@ -44,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -45,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -45,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -6,7 +6,6 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 
 ```mermaid
 graph LR
-    BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
     IssueStorePort --> CachingIssueStore
@@ -33,8 +32,7 @@ graph LR
 
 - Module: `src.term_proposer_loop`
 - Methods: `open_bot_pr`
-- Adapters:
-  - `OpenAutoPRBotPRPort` (`src.term_proposer_runtime`)
+- Adapters: —
 - Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
 
 ### IssueFetcherPort
@@ -64,7 +62,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -93,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `33b642d` on 2026-05-07 18:50 UTC. Source last changed at `33b642d`. Status: 🟢 fresh._
+_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `a6b6ae4` on 2026-05-07 07:40 UTC. Source last changed at `a6b6ae4`. Status: 🟢 fresh._
+_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -6,6 +6,7 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 
 ```mermaid
 graph LR
+    BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
     IssueStorePort --> CachingIssueStore
@@ -32,7 +33,8 @@ graph LR
 
 - Module: `src.term_proposer_loop`
 - Methods: `open_bot_pr`
-- Adapters: —
+- Adapters:
+  - `OpenAutoPRBotPRPort` (`src.term_proposer_runtime`)
 - Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
 
 ### IssueFetcherPort
@@ -91,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `7caf6db` on 2026-05-07 18:49 UTC. Source last changed at `7caf6db`. Status: 🟢 fresh._
+_Regenerated from commit `b7031b6` on 2026-05-07 19:22 UTC. Source last changed at `b7031b6`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -25,6 +25,7 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "memory_sync": (10, 14400),
     "metrics": (30, 14400),
     "pr_unsticker": (60, 86400),
+    "merge_state_watcher": (60, 86400),  # 1m min, 1d max (default 10m)
     "pipeline_poller": (5, 14400),
     "adr_reviewer": (28800, 432000),
     "verify_monitor": (60, 86400),

--- a/src/merge_state_watcher.py
+++ b/src/merge_state_watcher.py
@@ -7,7 +7,8 @@ existing ``PRUnsticker`` + ``MergeConflictResolver`` path takes over.
 
 This closes the gap where RC-promotion PRs (cut by ``StagingPromotionLoop``),
 dependabot PRs, and out-of-date agent PRs sat indefinitely because nothing
-labeled them HITL.
+labeled them HITL. Source-agnostic on purpose — same loop covers RC,
+dependabot, and agent PRs without each originator reimplementing the fix.
 """
 
 from __future__ import annotations

--- a/src/merge_state_watcher.py
+++ b/src/merge_state_watcher.py
@@ -1,0 +1,101 @@
+"""MergeStateWatcher — auto-rebase / HITL-escalate conflicting PRs.
+
+When ``mergeable=CONFLICTING`` shows up on an open PR, this worker tries
+to fix it the cheap way (``gh pr update-branch``, no LLM). If that does
+not resolve the conflict, the PR is labeled ``hydraflow-hitl`` so the
+existing ``PRUnsticker`` + ``MergeConflictResolver`` path takes over.
+
+This closes the gap where RC-promotion PRs (cut by ``StagingPromotionLoop``),
+dependabot PRs, and out-of-date agent PRs sat indefinitely because nothing
+labeled them HITL.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ports import PRPort
+
+logger = logging.getLogger("hydraflow.merge_state_watcher")
+
+# PRs already on these labels are owned by another loop — leave them alone.
+SKIP_LABELS = ("hydraflow-review",)
+
+
+@dataclass(frozen=True)
+class ConflictingPR:
+    """A single PR that ``gh pr list`` flagged as ``mergeable=CONFLICTING``."""
+
+    number: int
+    branch: str = ""
+    labels: list[str] = field(default_factory=list)
+
+
+class MergeStateWatcher:
+    """Find conflicting PRs and either rebase them or escalate to HITL."""
+
+    def __init__(self, *, prs: PRPort, hitl_label: str) -> None:
+        self._prs = prs
+        self._hitl_label = hitl_label
+
+    async def unstick_conflicts(self) -> dict[str, int]:
+        """Single cycle: scan, rebase, escalate.
+
+        Returns counters keyed by ``checked``, ``rebased``, ``escalated``,
+        ``skipped`` for status reporting.
+        """
+        prs = await self._prs.list_conflicting_prs()
+        stats = {"checked": 0, "rebased": 0, "escalated": 0, "skipped": 0}
+
+        for pr in prs:
+            stats["checked"] += 1
+            if self._should_skip(pr):
+                stats["skipped"] += 1
+                logger.debug("Skipping PR #%d (labels=%s)", pr.number, pr.labels)
+                continue
+
+            outcome = await self._handle_pr(pr)
+            stats[outcome] += 1
+
+        if stats["checked"]:
+            logger.info(
+                "merge_state_watcher cycle: %s",
+                {k: v for k, v in stats.items() if v},
+            )
+        return stats
+
+    def _should_skip(self, pr: ConflictingPR) -> bool:
+        labels = {label.lower() for label in pr.labels}
+        if self._hitl_label.lower() in labels:
+            return True
+        return any(skip.lower() in labels for skip in SKIP_LABELS)
+
+    async def _handle_pr(self, pr: ConflictingPR) -> str:
+        """Try to rebase; on failure, escalate. Returns the stats key to bump."""
+        try:
+            update_ok = await self._prs.update_pr_branch(pr.number)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "update_pr_branch raised for PR #%d", pr.number, exc_info=True
+            )
+            update_ok = False
+
+        if update_ok:
+            try:
+                still_mergeable = await self._prs.get_pr_mergeable(pr.number)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "get_pr_mergeable raised for PR #%d", pr.number, exc_info=True
+                )
+                still_mergeable = None
+            if still_mergeable is True:
+                return "rebased"
+
+        try:
+            await self._prs.add_pr_labels(pr.number, [self._hitl_label])
+        except Exception:  # noqa: BLE001
+            logger.warning("add_pr_labels failed for PR #%d", pr.number, exc_info=True)
+        return "escalated"

--- a/src/merge_state_watcher_loop.py
+++ b/src/merge_state_watcher_loop.py
@@ -1,0 +1,47 @@
+"""Background loop wrapping :class:`MergeStateWatcher` (ADR-0029)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from base_background_loop import BaseBackgroundLoop, LoopDeps
+from config import HydraFlowConfig
+from merge_state_watcher import MergeStateWatcher
+
+if TYPE_CHECKING:
+    from ports import PRPort
+
+logger = logging.getLogger("hydraflow.merge_state_watcher_loop")
+
+_DEFAULT_INTERVAL_SECONDS = 600  # 10 minutes
+
+
+class MergeStateWatcherLoop(BaseBackgroundLoop):
+    """Periodically scan open PRs for conflicts and rebase/escalate them.
+
+    Filter is broad on purpose — RC promotion PRs, dependabot bumps, agent
+    PRs, and manual PRs all benefit from auto-rebase when they go DIRTY
+    against ``main``. PRs already labeled ``hydraflow-hitl`` (PRUnsticker
+    on it) or ``hydraflow-review`` (active reviewer worktree) are skipped
+    to avoid stepping on toes.
+    """
+
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        prs: PRPort,
+        deps: LoopDeps,
+    ) -> None:
+        super().__init__(worker_name="merge_state_watcher", config=config, deps=deps)
+        hitl_label = (config.hitl_label or ["hydraflow-hitl"])[0]
+        self._watcher = MergeStateWatcher(prs=prs, hitl_label=hitl_label)
+
+    def _get_default_interval(self) -> int:
+        return _DEFAULT_INTERVAL_SECONDS
+
+    async def _do_work(self) -> dict[str, Any] | None:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        stats = await self._watcher.unstick_conflicts()
+        return dict(stats)

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -595,6 +595,33 @@ class FakeGitHub:
         self._maybe_rate_limit()
         return True
 
+    async def list_conflicting_prs(self) -> list[Any]:
+        """Return PRs flagged as conflicting in the fake state."""
+        from merge_state_watcher import ConflictingPR  # noqa: PLC0415
+
+        self._maybe_rate_limit()
+        results: list[Any] = []
+        for pr in self._prs.values():
+            if getattr(pr, "mergeable", True):
+                continue
+            results.append(
+                ConflictingPR(
+                    number=pr.number,
+                    branch=getattr(pr, "head_ref", "") or "",
+                    labels=list(getattr(pr, "labels", []) or []),
+                )
+            )
+        return results
+
+    async def update_pr_branch(self, pr_number: int) -> bool:
+        """Simulate ``gh pr update-branch``: clear the conflict flag."""
+        self._maybe_rate_limit()
+        pr = self._prs.get(pr_number)
+        if pr is None:
+            return False
+        pr.mergeable = True
+        return True
+
     async def pull_main(self, **_kw: Any) -> None:
         self._maybe_rate_limit()
 

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -613,15 +613,6 @@ class FakeGitHub:
             )
         return results
 
-    async def update_pr_branch(self, pr_number: int) -> bool:
-        """Simulate ``gh pr update-branch``: clear the conflict flag."""
-        self._maybe_rate_limit()
-        pr = self._prs.get(pr_number)
-        if pr is None:
-            return False
-        pr.mergeable = True
-        return True
-
     async def pull_main(self, **_kw: Any) -> None:
         self._maybe_rate_limit()
 
@@ -667,10 +658,14 @@ class FakeGitHub:
         return True
 
     async def update_pr_branch(self, pr_number: int, *, method: str = "rebase") -> bool:
-        """Fake rebase: always succeeds in tests unless overridden via a script."""
+        """Fake rebase: clears mergeable flag, always succeeds when PR exists."""
         _ = (method,)
         self._maybe_rate_limit()
-        return pr_number in self._prs
+        pr = self._prs.get(pr_number)
+        if pr is None:
+            return False
+        pr.mergeable = True
+        return True
 
     async def list_rc_branches(self) -> list[tuple[str, str]]:
         return []

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -156,6 +156,7 @@ class HydraFlowOrchestrator:
         # Extracted component managers
         bg_loop_registry: dict[str, BaseBackgroundLoop] = {
             "pr_unsticker": svc.pr_unsticker_loop,
+            "merge_state_watcher": svc.merge_state_watcher_loop,
             "report_issue": svc.report_issue_loop,
             "epic_monitor": svc.epic_monitor_loop,
             "epic_sweeper": svc.epic_sweeper_loop,
@@ -969,6 +970,7 @@ class HydraFlowOrchestrator:
             ("review", self._review_loop),
             ("hitl", self._hitl_loop),
             ("pr_unsticker", self._svc.pr_unsticker_loop.run),
+            ("merge_state_watcher", self._svc.merge_state_watcher_loop.run),
             ("report_issue", self._svc.report_issue_loop.run),
             ("epic_monitor", self._svc.epic_monitor_loop.run),
             ("epic_sweeper", self._svc.epic_sweeper_loop.run),

--- a/src/ports.py
+++ b/src/ports.py
@@ -335,15 +335,6 @@ class PRPort(Protocol):
         """
         ...
 
-    async def update_pr_branch(self, pr_number: int) -> bool:
-        """Trigger ``gh pr update-branch`` on *pr_number*.
-
-        Returns ``True`` when GitHub accepted the update (rebase/merge with
-        ``main`` was scheduled), ``False`` if the API call failed or the
-        operation hit a conflict that needs HITL.
-        """
-        ...
-
     async def post_pr_comment(self, pr_number: int, body: str) -> None:
         """Post a comment on a GitHub pull request."""
         ...

--- a/src/ports.py
+++ b/src/ports.py
@@ -49,6 +49,7 @@ from typing_extensions import Protocol
 if TYPE_CHECKING:
     from review_insights import ProposalMetadata, ReviewRecord  # noqa: TCH004
 
+from merge_state_watcher import ConflictingPR
 from models import (
     CodeScanningAlert,
     GitHubIssue,
@@ -323,6 +324,24 @@ class PRPort(Protocol):
 
     async def get_pr_mergeable(self, pr_number: int) -> bool | None:
         """Return whether *pr_number* is mergeable. ``None`` if unknown."""
+        ...
+
+    async def list_conflicting_prs(self) -> list[ConflictingPR]:
+        """Return open PRs whose ``mergeable`` field is ``CONFLICTING``.
+
+        Used by ``MergeStateWatcherLoop`` to discover PRs that fell behind
+        ``main`` (RC promotions, dependabot, agent PRs) so they can be
+        auto-rebased or escalated to HITL.
+        """
+        ...
+
+    async def update_pr_branch(self, pr_number: int) -> bool:
+        """Trigger ``gh pr update-branch`` on *pr_number*.
+
+        Returns ``True`` when GitHub accepted the update (rebase/merge with
+        ``main`` was scheduled), ``False`` if the API call failed or the
+        operation hit a conflict that needs HITL.
+        """
         ...
 
     async def post_pr_comment(self, pr_number: int, body: str) -> None:

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -20,6 +20,7 @@ from urllib.parse import quote
 from comment_formatter import CommentFormatter, SelfReviewError
 from config import Credentials, HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
+from merge_state_watcher import ConflictingPR
 from models import (
     CICheckPayload,
     CodeScanningAlert,
@@ -2166,6 +2167,81 @@ class PRManager:
         except RuntimeError:
             logger.debug("Could not fetch mergeable status for PR #%d", pr_number)
             return None
+
+    async def list_conflicting_prs(self) -> list[ConflictingPR]:
+        """Return open PRs whose ``mergeable`` field is ``CONFLICTING``."""
+        if self._config.dry_run:
+            return []
+
+        try:
+            raw = await self._run_gh(
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--limit",
+                "200",
+                "--json",
+                "number,headRefName,labels,mergeable",
+            )
+        except RuntimeError:
+            logger.debug("list_conflicting_prs: gh pr list failed", exc_info=True)
+            return []
+
+        try:
+            payload = json.loads(raw or "[]")
+        except json.JSONDecodeError:
+            logger.warning(
+                "list_conflicting_prs: malformed JSON from gh", exc_info=True
+            )
+            return []
+
+        results: list[ConflictingPR] = []
+        for entry in payload:
+            try:
+                if entry.get("mergeable") != "CONFLICTING":
+                    continue
+                results.append(
+                    ConflictingPR(
+                        number=int(entry["number"]),
+                        branch=str(entry.get("headRefName") or ""),
+                        labels=[
+                            str(lbl.get("name", ""))
+                            for lbl in (entry.get("labels") or [])
+                            if lbl.get("name")
+                        ],
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                logger.debug(
+                    "list_conflicting_prs: skipping malformed entry", exc_info=True
+                )
+                continue
+        return results
+
+    async def update_pr_branch(self, pr_number: int) -> bool:
+        """Trigger ``gh pr update-branch`` for *pr_number*.
+
+        Returns ``True`` when GitHub accepted the update (rebase/merge with
+        ``main`` was scheduled), ``False`` if the API call failed or hit a
+        conflict. Caller is expected to re-check ``get_pr_mergeable`` to
+        confirm the conflict actually cleared.
+        """
+        if self._config.dry_run:
+            logger.info("[dry-run] Would update branch for PR #%d", pr_number)
+            return True
+
+        try:
+            await self._run_gh("gh", "pr", "update-branch", str(pr_number))
+        except RuntimeError:
+            logger.info(
+                "update_pr_branch failed for PR #%d (likely real conflict)",
+                pr_number,
+                exc_info=True,
+            )
+            return False
+        return True
 
     async def get_pr_comments(self, pr_number: int) -> list[dict[str, str]]:
         """Fetch issue-level comments for *pr_number* with author info.

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2220,29 +2220,6 @@ class PRManager:
                 continue
         return results
 
-    async def update_pr_branch(self, pr_number: int) -> bool:
-        """Trigger ``gh pr update-branch`` for *pr_number*.
-
-        Returns ``True`` when GitHub accepted the update (rebase/merge with
-        ``main`` was scheduled), ``False`` if the API call failed or hit a
-        conflict. Caller is expected to re-check ``get_pr_mergeable`` to
-        confirm the conflict actually cleared.
-        """
-        if self._config.dry_run:
-            logger.info("[dry-run] Would update branch for PR #%d", pr_number)
-            return True
-
-        try:
-            await self._run_gh("gh", "pr", "update-branch", str(pr_number))
-        except RuntimeError:
-            logger.info(
-                "update_pr_branch failed for PR #%d (likely real conflict)",
-                pr_number,
-                exc_info=True,
-            )
-            return False
-        return True
-
     async def get_pr_comments(self, pr_number: int) -> list[dict[str, str]]:
         """Fetch issue-level comments for *pr_number* with author info.
 

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -51,6 +51,7 @@ from issue_cache import IssueCache
 from issue_fetcher import GitHubTaskFetcher, IssueFetcher
 from issue_store import IssueStore
 from merge_conflict_resolver import MergeConflictResolver
+from merge_state_watcher_loop import MergeStateWatcherLoop
 from models import StatusCallback
 from plan_phase import PlanPhase
 from plan_reviewer import PlanReviewer
@@ -158,6 +159,7 @@ class ServiceRegistry:
 
     # Background loops
     pr_unsticker_loop: PRUnstickerLoop
+    merge_state_watcher_loop: MergeStateWatcherLoop
     report_issue_loop: ReportIssueLoop
     epic_monitor_loop: EpicMonitorLoop
     epic_sweeper_loop: EpicSweeperLoop
@@ -739,6 +741,9 @@ def build_services(
         interval_cb=callbacks.get_interval,
     )
     pr_unsticker_loop = PRUnstickerLoop(config, pr_unsticker, prs, deps=loop_deps)
+    merge_state_watcher_loop = MergeStateWatcherLoop(
+        config=config, prs=prs, deps=loop_deps
+    )
     report_issue_loop = ReportIssueLoop(
         config=config,
         state=state,
@@ -1090,6 +1095,7 @@ def build_services(
         epic_checker=epic_checker,
         epic_manager=epic_manager,
         pr_unsticker_loop=pr_unsticker_loop,
+        merge_state_watcher_loop=merge_state_watcher_loop,
         report_issue_loop=report_issue_loop,
         epic_monitor_loop=epic_monitor_loop,
         epic_sweeper_loop=epic_sweeper_loop,

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -249,7 +249,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'github_cache', 'runs_gc'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'github_cache', 'runs_gc'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -259,6 +259,7 @@ export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker',
 export const SYSTEM_WORKER_INTERVALS = {
   pipeline_poller: 5,
   pr_unsticker: 3600,
+  merge_state_watcher: 600,
   memory_sync: 3600,
   report_issue: 30,
   worktree_gc: 1800,
@@ -313,6 +314,7 @@ export const BACKGROUND_WORKERS = [
   { key: 'pipeline_poller', label: 'Pipeline Poller', description: 'Refreshes live pipeline snapshots for queue and status visibility.', color: theme.textMuted, system: true, group: 'operations', tags: ['infra'] },
   { key: 'memory_sync',     label: 'Memory Manager', description: 'Ingests memory and transcript issues into durable learnings.', color: theme.accent, system: true, group: 'intake', tags: ['memory'] },
   { key: 'pr_unsticker',    label: 'PR Unsticker',   description: 'Requeues stalled HITL PRs once requirements are actionable.', color: theme.orange, system: true, group: 'operations', tags: ['recovery'] },
+  { key: 'merge_state_watcher', label: 'Merge State Watcher', description: 'Auto-rebases or HITL-escalates open PRs flagged mergeable=CONFLICTING (RC, dependabot, agent).', color: theme.orange, system: true, group: 'operations', tags: ['recovery'] },
   { key: 'report_issue',   label: 'Report Issue',   description: 'Processes queued bug reports into GitHub issues.', color: theme.red, group: 'intake', tags: ['issues'] },
   { key: 'workspace_gc',   label: 'Workspace GC',   description: 'Garbage-collects stale workspaces and orphaned branches.', color: theme.textMuted, system: true, group: 'repo_health', tags: ['hygiene'] },
   { key: 'adr_reviewer',   label: 'ADR Reviewer',   description: 'Reviews proposed ADRs via a 3-judge council and routes to accept, reject, or escalate.', color: theme.accent, group: 'intake', tags: ['review'] },

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1730,6 +1730,7 @@ def mock_fetcher_noop(orch: Any) -> None:
         "github_cache_loop",
         "health_monitor_loop",
         "pr_unsticker_loop",
+        "merge_state_watcher_loop",
         "repo_wiki_loop",
         "report_issue_loop",
         "retrospective_loop",

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -467,6 +467,7 @@ def build_scripted_services(
     services.reviewer = ScriptedReviewPhase(script, github)
     services.memory_sync_bg = FakeBackgroundLoop()
     services.pr_unsticker_loop = FakeBackgroundLoop()
+    services.merge_state_watcher_loop = FakeBackgroundLoop()
     services.report_issue_loop = FakeBackgroundLoop()
     services.epic_manager = MagicMock()
     services.epic_monitor_loop = FakeBackgroundLoop()

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -51,6 +51,16 @@ def _build_dependabot_merge(ports: dict[str, Any], config: Any, deps: Any) -> An
     )
 
 
+def _build_merge_state_watcher(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    from merge_state_watcher_loop import MergeStateWatcherLoop  # noqa: PLC0415
+
+    return MergeStateWatcherLoop(
+        config=config,
+        prs=ports["github"],
+        deps=deps,
+    )
+
+
 def _build_pr_unsticker(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from pr_unsticker_loop import PRUnstickerLoop  # noqa: PLC0415
 
@@ -977,6 +987,7 @@ _BUILDERS: dict[str, Any] = {
     "stale_issue_gc": _build_stale_issue_gc,
     "dependabot_merge": _build_dependabot_merge,
     "pr_unsticker": _build_pr_unsticker,
+    "merge_state_watcher": _build_merge_state_watcher,
     "health_monitor": _build_health_monitor,
     "workspace_gc": _build_workspace_gc,
     # phase 3b

--- a/tests/test_merge_state_watcher.py
+++ b/tests/test_merge_state_watcher.py
@@ -1,0 +1,235 @@
+"""Tests for MergeStateWatcher — auto-rebase / HITL-escalate conflicting PRs.
+
+Closes the gap where PRs with ``mergeable=CONFLICTING`` (e.g. RC promotion
+PRs cut by ``StagingPromotionLoop``, dependabot bumps, agent PRs that fell
+behind ``main``) sat indefinitely because ``PRUnsticker`` only acted on PRs
+already labeled ``hydraflow-hitl``. This watcher is the missing front door.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from merge_state_watcher import ConflictingPR, MergeStateWatcher
+
+
+def _pr(
+    number: int,
+    *,
+    labels: tuple[str, ...] = (),
+    branch: str = "feat/foo",
+) -> ConflictingPR:
+    return ConflictingPR(
+        number=number,
+        branch=branch,
+        labels=list(labels),
+    )
+
+
+@pytest.fixture
+def fake_pr_port():
+    pr = AsyncMock()
+    pr.list_conflicting_prs = AsyncMock(return_value=[])
+    pr.update_pr_branch = AsyncMock(return_value=True)
+    pr.add_pr_labels = AsyncMock()
+    pr.get_pr_mergeable = AsyncMock(return_value=True)
+    return pr
+
+
+async def test_no_conflicting_prs_returns_empty_stats(fake_pr_port) -> None:
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+    assert stats == {"checked": 0, "rebased": 0, "escalated": 0, "skipped": 0}
+    fake_pr_port.update_pr_branch.assert_not_awaited()
+    fake_pr_port.add_pr_labels.assert_not_awaited()
+
+
+async def test_rebases_pr_with_no_relevant_labels(fake_pr_port) -> None:
+    fake_pr_port.list_conflicting_prs.return_value = [_pr(8491, branch="rc/foo")]
+    fake_pr_port.update_pr_branch.return_value = True
+    fake_pr_port.get_pr_mergeable.return_value = True
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    fake_pr_port.update_pr_branch.assert_awaited_once_with(8491)
+    fake_pr_port.add_pr_labels.assert_not_awaited()
+    assert stats == {"checked": 1, "rebased": 1, "escalated": 0, "skipped": 0}
+
+
+async def test_skips_pr_already_labeled_hitl(fake_pr_port) -> None:
+    """PRUnsticker is on it — don't double-act."""
+    fake_pr_port.list_conflicting_prs.return_value = [
+        _pr(8478, labels=("hydraflow-hitl",))
+    ]
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    fake_pr_port.update_pr_branch.assert_not_awaited()
+    fake_pr_port.add_pr_labels.assert_not_awaited()
+    assert stats == {"checked": 1, "rebased": 0, "escalated": 0, "skipped": 1}
+
+
+async def test_skips_pr_in_active_review(fake_pr_port) -> None:
+    """A reviewer's worktree might be in flight — leave it alone for one tick."""
+    fake_pr_port.list_conflicting_prs.return_value = [
+        _pr(8500, labels=("hydraflow-review",))
+    ]
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    fake_pr_port.update_pr_branch.assert_not_awaited()
+    assert stats == {"checked": 1, "rebased": 0, "escalated": 0, "skipped": 1}
+
+
+async def test_escalates_pr_when_rebase_does_not_resolve(fake_pr_port) -> None:
+    """Real conflict — rebase didn't help. Hand to PRUnsticker via HITL label."""
+    fake_pr_port.list_conflicting_prs.return_value = [_pr(8654)]
+    fake_pr_port.update_pr_branch.return_value = False
+    fake_pr_port.get_pr_mergeable.return_value = False
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    fake_pr_port.update_pr_branch.assert_awaited_once_with(8654)
+    fake_pr_port.add_pr_labels.assert_awaited_once_with(8654, ["hydraflow-hitl"])
+    assert stats == {"checked": 1, "rebased": 0, "escalated": 1, "skipped": 0}
+
+
+async def test_escalates_when_rebase_succeeds_but_pr_still_conflicting(
+    fake_pr_port,
+) -> None:
+    """``gh pr update-branch`` returned 0 but mergeable still false — escalate."""
+    fake_pr_port.list_conflicting_prs.return_value = [_pr(8478)]
+    fake_pr_port.update_pr_branch.return_value = True
+    fake_pr_port.get_pr_mergeable.return_value = False
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    fake_pr_port.add_pr_labels.assert_awaited_once_with(8478, ["hydraflow-hitl"])
+    assert stats["escalated"] == 1
+
+
+async def test_handles_three_prs_with_mixed_outcomes(fake_pr_port) -> None:
+    fake_pr_port.list_conflicting_prs.return_value = [
+        _pr(1, branch="rc/foo"),
+        _pr(2, labels=("hydraflow-hitl",)),
+        _pr(3, branch="feat/bar"),
+    ]
+
+    async def update_pr_branch(n: int) -> bool:
+        # PR 1 rebases cleanly, PR 3 fails to rebase
+        return n == 1
+
+    async def get_pr_mergeable(n: int) -> bool | None:
+        return n == 1
+
+    fake_pr_port.update_pr_branch.side_effect = update_pr_branch
+    fake_pr_port.get_pr_mergeable.side_effect = get_pr_mergeable
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    assert stats == {"checked": 3, "rebased": 1, "escalated": 1, "skipped": 1}
+    # PR 1 rebased, PR 2 skipped, PR 3 escalated
+    fake_pr_port.add_pr_labels.assert_awaited_once_with(3, ["hydraflow-hitl"])
+
+
+async def test_continues_after_one_pr_raises(fake_pr_port) -> None:
+    """A failure on one PR doesn't sink the rest of the cycle."""
+    fake_pr_port.list_conflicting_prs.return_value = [_pr(1), _pr(2)]
+
+    async def update_pr_branch(n: int) -> bool:
+        if n == 1:
+            raise RuntimeError("gh blew up")
+        return True
+
+    fake_pr_port.update_pr_branch.side_effect = update_pr_branch
+    fake_pr_port.get_pr_mergeable.return_value = True
+
+    watcher = MergeStateWatcher(prs=fake_pr_port, hitl_label="hydraflow-hitl")
+    stats = await watcher.unstick_conflicts()
+
+    assert stats["checked"] == 2
+    assert stats["rebased"] == 1
+
+
+# --- Loop wiring -------------------------------------------------------------
+
+
+async def test_loop_returns_disabled_when_kill_switch_off() -> None:
+    from base_background_loop import LoopDeps  # noqa: PLC0415
+    from config import HydraFlowConfig  # noqa: PLC0415
+    from events import EventBus  # noqa: PLC0415
+    from merge_state_watcher_loop import MergeStateWatcherLoop  # noqa: PLC0415
+
+    cfg = HydraFlowConfig(repo="acme/widgets")
+    stop = asyncio.Event()
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda name: name != "merge_state_watcher",
+    )
+    pr = AsyncMock()
+    pr.list_conflicting_prs = AsyncMock(return_value=[])
+    pr.update_pr_branch = AsyncMock()
+    pr.add_pr_labels = AsyncMock()
+    pr.get_pr_mergeable = AsyncMock()
+
+    loop = MergeStateWatcherLoop(config=cfg, prs=pr, deps=deps)
+    stats = await loop._do_work()
+    assert stats == {"status": "disabled"}
+    pr.list_conflicting_prs.assert_not_awaited()
+
+
+async def test_loop_default_interval_is_ten_minutes() -> None:
+    from base_background_loop import LoopDeps  # noqa: PLC0415
+    from config import HydraFlowConfig  # noqa: PLC0415
+    from events import EventBus  # noqa: PLC0415
+    from merge_state_watcher_loop import MergeStateWatcherLoop  # noqa: PLC0415
+
+    cfg = HydraFlowConfig(repo="acme/widgets")
+    stop = asyncio.Event()
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+    pr = AsyncMock()
+    loop = MergeStateWatcherLoop(config=cfg, prs=pr, deps=deps)
+    assert loop._worker_name == "merge_state_watcher"
+    assert loop._get_default_interval() == 600
+
+
+async def test_loop_delegates_to_watcher() -> None:
+    from base_background_loop import LoopDeps  # noqa: PLC0415
+    from config import HydraFlowConfig  # noqa: PLC0415
+    from events import EventBus  # noqa: PLC0415
+    from merge_state_watcher_loop import MergeStateWatcherLoop  # noqa: PLC0415
+
+    cfg = HydraFlowConfig(repo="acme/widgets")
+    stop = asyncio.Event()
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+    pr = AsyncMock()
+    pr.list_conflicting_prs = AsyncMock(return_value=[_pr(7, branch="feat/x")])
+    pr.update_pr_branch = AsyncMock(return_value=True)
+    pr.get_pr_mergeable = AsyncMock(return_value=True)
+    pr.add_pr_labels = AsyncMock()
+
+    loop = MergeStateWatcherLoop(config=cfg, prs=pr, deps=deps)
+    stats = await loop._do_work()
+    assert stats["checked"] == 1
+    assert stats["rebased"] == 1

--- a/tests/test_stop_resume.py
+++ b/tests/test_stop_resume.py
@@ -132,6 +132,7 @@ def _make_orchestrator(tmp_path: Path) -> HydraFlowOrchestrator:
         svc.reviewer.active_issues = set()
         svc.memory_sync_bg = MagicMock()
         svc.pr_unsticker_loop = MagicMock()
+        svc.merge_state_watcher_loop = MagicMock()
         svc.fetcher = MagicMock()
         svc.summarizer = MagicMock()
 


### PR DESCRIPTION
## Summary

Closes the gap that left #8491 (RC promotion), #8478, and #8654 stuck in \`mergeable=CONFLICTING\` with nothing acting on them.

\`PRUnsticker\` only touches PRs already labeled \`hydraflow-hitl\`. Nothing was applying that label when a PR fell behind \`main\` — so RC PRs cut by \`StagingPromotionLoop\`, dependabot bumps, and out-of-date agent PRs sat indefinitely.

This caretaker is the missing front door:
1. Polls every 10 min: \`gh pr list --json mergeable\` → filter to \`CONFLICTING\`
2. Skip PRs labeled \`hydraflow-hitl\` (PRUnsticker on it) or \`hydraflow-review\` (active reviewer worktree)
3. \`gh pr update-branch\` (cheap fix for out-of-date branches; no LLM)
4. If still conflicting → label \`hydraflow-hitl\` so PRUnsticker + MergeConflictResolver take over

Source-agnostic on purpose. RC, dependabot, and agent PRs all benefit without each loop reimplementing the same logic — the dark-factory pattern: recurring manual fix → caretaker loop, not bloating the originator.

## Files
- \`src/merge_state_watcher.py\` — worker (separable for testing)
- \`src/merge_state_watcher_loop.py\` — \`BaseBackgroundLoop\` subclass (10 min cadence, kill-switch via \`enabled_cb\`)
- \`src/ports.py\` — two new \`PRPort\` methods: \`list_conflicting_prs\`, \`update_pr_branch\`
- \`src/pr_manager.py\` — concrete impls (gh CLI)
- \`src/mockworld/fakes/fake_github.py\` — fake conformance
- \`src/service_registry.py\` + \`src/orchestrator.py\` — wiring + bg loop registry
- \`tests/test_merge_state_watcher.py\` — 11 unit tests (worker behavior + loop wiring + kill switch)

## Test plan
- [x] \`tests/test_merge_state_watcher.py\` — 11 tests green (worker + loop + kill switch)
- [x] \`tests/test_pr_manager_core.py\`, \`test_dashboard_routes_state.py\`, \`test_repo_runtime.py\`, \`test_pr_unsticker_loop.py\`, \`test_orchestrator_loops.py\`, \`test_orchestrator_core.py\`, \`test_mockworld_runtime_conformance.py\` — all green (286 tests, no regressions)
- [x] \`uv run ruff check\` clean
- [x] \`uv run pyright\` clean on changed files
- [x] \`make arch-regen\` ran (auto-regen artifacts updated)
- [ ] Manual: deploy + verify next cycle picks up #8491/#8478/#8654 (already labeled HITL by hand)

## Why no scenario test in this PR
Scenario coverage will land as a follow-up — the unit tests cover all branch outcomes against a mocked port, and the FakeGitHub conformance tests already exercise the new methods at the protocol boundary. Filing a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)