### PR TITLE
fix(trust-fleet): restrict staleness detection to TRUST_LOOP_WORKERS only

### DIFF
--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -252,25 +252,31 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
             if breached:
                 per_worker_breaches.append(("tick_error_ratio", details))
 
-            hb = heartbeats.get(worker) or {}
-            last_run_iso = hb.get("last_run") if isinstance(hb, dict) else None
-            bg = self._bg_workers
-            interval_s = (
-                int(bg.get_interval(worker))
-                if bg is not None and hasattr(bg, "get_interval")
-                else 86400
-            )
-            is_enabled = bool(enabled_map.get(worker, True))
-            breached, details = detect_staleness(
-                worker,
-                last_run_iso=last_run_iso,
-                interval_s=interval_s,
-                multiplier=cfg.loop_anomaly_staleness_multiplier,
-                is_enabled=is_enabled,
-                now=now,
-            )
-            if breached:
-                per_worker_breaches.append(("staleness", details))
+            # Staleness only applies to registered trust-loop workers.
+            # Non-trust loops (e.g. report_issue) have long-running LLM
+            # work cycles that legitimately exceed 2 × their polling
+            # interval, causing false-positive staleness alerts. Staleness
+            # for non-trust loops is out of scope for this detector.
+            if worker in TRUST_LOOP_WORKERS:
+                hb = heartbeats.get(worker) or {}
+                last_run_iso = hb.get("last_run") if isinstance(hb, dict) else None
+                bg = self._bg_workers
+                interval_s = (
+                    int(bg.get_interval(worker))
+                    if bg is not None and hasattr(bg, "get_interval")
+                    else 86400
+                )
+                is_enabled = bool(enabled_map.get(worker, True))
+                breached, details = detect_staleness(
+                    worker,
+                    last_run_iso=last_run_iso,
+                    interval_s=interval_s,
+                    multiplier=cfg.loop_anomaly_staleness_multiplier,
+                    is_enabled=is_enabled,
+                    now=now,
+                )
+                if breached:
+                    per_worker_breaches.append(("staleness", details))
 
             breached, details = detect_cost_spike(
                 worker,

--- a/tests/regressions/test_issue_8650.py
+++ b/tests/regressions/test_issue_8650.py
@@ -1,0 +1,135 @@
+"""Regression test for issue #8650.
+
+Bug: TrustFleetSanityLoop fires a staleness escalation for non-trust loops
+(e.g. ``report_issue``) that appear in worker heartbeats. The ``report_issue``
+loop polls every 30 s when idle but can legitimately take minutes when
+processing a report via the Claude CLI. The 2 × 30 s = 60 s staleness
+threshold fires as a false positive during normal LLM-driven report processing.
+
+Expected behaviour after fix:
+  - Staleness detection only runs for workers in ``TRUST_LOOP_WORKERS``.
+  - A non-trust loop (e.g. ``report_issue``) with a stale heartbeat does NOT
+    trigger a staleness escalation.
+  - A trust-loop worker (e.g. ``rc_budget``) with a stale heartbeat still
+    triggers a staleness escalation as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from base_background_loop import LoopDeps  # noqa: E402
+from config import HydraFlowConfig  # noqa: E402
+from events import EventBus  # noqa: E402
+from trust_fleet_sanity_loop import TrustFleetSanityLoop  # noqa: E402
+
+
+def _make_env(tmp_path: Path):
+    cfg = HydraFlowConfig(data_root=tmp_path, repo="hydra/hydraflow")
+    state = MagicMock()
+    state.get_trust_fleet_sanity_attempts.return_value = 0
+    state.inc_trust_fleet_sanity_attempts.return_value = 1
+    state.get_worker_heartbeats.return_value = {}
+    bg_workers = MagicMock()
+    bg_workers.worker_enabled = {}
+    bg_workers.get_interval.return_value = 30
+    pr_manager = AsyncMock()
+    pr_manager.create_issue = AsyncMock(return_value=42)
+    dedup = MagicMock()
+    dedup.get.return_value = set()
+    bus = EventBus()
+    return cfg, state, bg_workers, pr_manager, dedup, bus
+
+
+def _loop(env) -> TrustFleetSanityLoop:
+    cfg, state, bg_workers, pr, dedup, bus = env
+    deps = LoopDeps(
+        event_bus=bus,
+        stop_event=asyncio.Event(),
+        status_cb=lambda name, status, details=None: None,  # type: ignore[arg-type]
+        enabled_cb=lambda name: True,
+    )
+    loop = TrustFleetSanityLoop(
+        config=cfg,
+        state=state,
+        bg_workers=bg_workers,
+        pr_manager=pr,
+        dedup=dedup,
+        event_bus=bus,
+        deps=deps,
+    )
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._load_cost_reader = MagicMock(return_value=None)
+    return loop
+
+
+async def _fake_load_empty(_since):  # noqa: ARG001
+    return []
+
+
+@pytest.mark.asyncio
+async def test_non_trust_loop_stale_heartbeat_no_staleness_escalation(
+    tmp_path: Path,
+) -> None:
+    """A stale ``report_issue`` heartbeat must NOT trigger a staleness escalation.
+
+    Before the fix, TrustFleetSanityLoop would scan all heartbeat workers and
+    fire staleness alerts for report_issue when it was processing a long-running
+    report (legitimately taking > 2 × 30 s = 60 s). After the fix, staleness
+    is only checked for TRUST_LOOP_WORKERS.
+    """
+    env = _make_env(tmp_path)
+    _, state, bg_workers, pr, _, _ = env
+
+    # report_issue heartbeat is very old — would breach 2 × 30 s threshold.
+    old_iso = (datetime.now(UTC) - timedelta(seconds=99_999)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "report_issue": {"status": "ok", "last_run": old_iso, "details": {}},
+    }
+    bg_workers.worker_enabled = {"report_issue": True}
+
+    loop = _loop(env)
+    loop._source_bus.load_events_since = _fake_load_empty  # type: ignore[method-assign]
+
+    stats = await loop._do_work()
+    assert stats is not None
+
+    assert stats["anomalies"] == 0
+    pr.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_trust_loop_stale_heartbeat_still_escalates(tmp_path: Path) -> None:
+    """A stale ``rc_budget`` (trust loop) heartbeat still triggers a staleness alert.
+
+    Verify the fix did not accidentally disable staleness detection for real
+    trust-loop workers.
+    """
+    env = _make_env(tmp_path)
+    _, state, bg_workers, pr, _, _ = env
+
+    old_iso = (datetime.now(UTC) - timedelta(seconds=99_999)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "rc_budget": {"status": "ok", "last_run": old_iso, "details": {}},
+    }
+    bg_workers.worker_enabled = {"rc_budget": True}
+    bg_workers.get_interval.return_value = 600
+
+    loop = _loop(env)
+    loop._source_bus.load_events_since = _fake_load_empty  # type: ignore[method-assign]
+
+    stats = await loop._do_work()
+    assert stats is not None
+
+    assert stats["anomalies"] >= 1
+    title = pr.create_issue.await_args.args[0]
+    assert "rc_budget" in title
+    assert "staleness" in title


### PR DESCRIPTION
## Summary

- `TrustFleetSanityLoop` was firing false-positive `staleness` escalations for non-trust loops (e.g. `report_issue`) that appeared in worker heartbeats
- `report_issue` polls every 30 s when idle but can legitimately take minutes to process a report via the Claude CLI; the `2 × 30 s = 60 s` threshold fires during normal LLM-driven processing
- Gate `detect_staleness` to only run for workers in `TRUST_LOOP_WORKERS`; other four anomaly detectors continue scanning all workers

**Root cause**: The broad "union of heartbeat workers" scan was intended to catch new trust loops not yet registered in `TRUST_LOOP_WORKERS`, but it incidentally picked up feature loops like `report_issue` whose latency characteristics are incompatible with the `2 × polling_interval` threshold.

## Test plan

- [ ] New regression `tests/regressions/test_issue_8650.py`: stale `report_issue` heartbeat produces 0 anomalies
- [ ] Existing test `test_do_work_staleness_detector_uses_bg_worker_state` still passes (`rc_budget` trust loop still escalates)
- [ ] Full `make quality`: 12088 passed (1 pre-existing unrelated failure in `test_config_otel_defaults`)

Closes #8650

🤖 Generated with [Claude Code](https://claude.com/claude-code)