### PR TITLE
Fixes #7997: Code Quality: DockerRunner.__init__ calls docker.from_...

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -692,7 +692,7 @@ def _check_docker_available() -> bool:
     try:
         import docker  # noqa: PLC0415
 
-        client = docker.from_env()
+        client = docker.from_env(timeout=10)
         client.ping()
         return True
     except Exception:
@@ -741,15 +741,25 @@ def get_docker_runner(
 
     _creds = credentials or _Credentials()
     log_dir = config.log_dir
-    return DockerRunner(
-        image=config.docker_image,
-        repo_root=config.repo_root,
-        log_dir=log_dir,
-        gh_token=_creds.gh_token,
-        git_user_name=config.git_user_name,
-        git_user_email=config.git_user_email,
-        spawn_delay=config.docker_spawn_delay,
-        network=config.docker_network,
-        extra_mounts=config.docker_extra_mounts,
-        config=config,
-    )
+    try:
+        return DockerRunner(
+            image=config.docker_image,
+            repo_root=config.repo_root,
+            log_dir=log_dir,
+            gh_token=_creds.gh_token,
+            git_user_name=config.git_user_name,
+            git_user_email=config.git_user_email,
+            spawn_delay=config.docker_spawn_delay,
+            network=config.docker_network,
+            extra_mounts=config.docker_extra_mounts,
+            config=config,
+        )
+    except Exception as exc:
+        from exception_classify import reraise_on_credit_or_bug  # noqa: PLC0415
+
+        reraise_on_credit_or_bug(exc)
+        logger.warning(
+            "DockerRunner construction failed; falling back to host runner",
+            exc_info=True,
+        )
+        return get_default_runner()

--- a/tests/test_docker_runner.py
+++ b/tests/test_docker_runner.py
@@ -934,6 +934,14 @@ class TestCheckDockerAvailable:
         _args, kwargs = mock_logger.debug.call_args
         assert kwargs.get("exc_info") is True
 
+    def test_passes_timeout_to_docker_from_env(self) -> None:
+        """_check_docker_available passes timeout=10 to docker.from_env to avoid hanging."""
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        with patch("docker.from_env", return_value=mock_client) as mock_from_env:
+            _check_docker_available()
+        mock_from_env.assert_called_once_with(timeout=10)
+
 
 # ---------------------------------------------------------------------------
 # Fallback factory tests
@@ -1081,6 +1089,36 @@ class TestGetDockerRunner:
         assert env.get("GIT_COMMITTER_NAME") == "Hydra Bot"
         assert env.get("GIT_AUTHOR_EMAIL") == "hydra-bot@example.com"
         assert env.get("GIT_COMMITTER_EMAIL") == "hydra-bot@example.com"
+
+    def test_falls_back_to_host_when_constructor_raises_docker_exception(
+        self,
+    ) -> None:
+        """get_docker_runner falls back to HostRunner when DockerRunner.__init__ raises."""
+        from tests.helpers import ConfigFactory
+
+        config = ConfigFactory.create(
+            execution_mode="docker", docker_image="hydra:latest"
+        )
+        with patch("docker.from_env", side_effect=Exception("daemon restarting")):
+            runner = get_docker_runner(config, docker_checker=lambda: True)
+        assert isinstance(runner, HostRunner)
+
+    def test_logs_warning_when_constructor_raises_docker_exception(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """get_docker_runner logs a warning when DockerRunner.__init__ raises."""
+        from tests.helpers import ConfigFactory
+
+        config = ConfigFactory.create(
+            execution_mode="docker", docker_image="hydra:latest"
+        )
+        with (
+            patch("docker.from_env", side_effect=Exception("daemon restarting")),
+            caplog.at_level("WARNING"),
+        ):
+            get_docker_runner(config, docker_checker=lambda: True)
+        assert "falling back to host runner" in caplog.text.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #7997.

## Issue

Code Quality: DockerRunner.__init__ calls docker.from_env() without error handling — bypasses retry logic on daemon unavailability

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow