### PR TITLE
Fixes #8487: Add pre-push hook auto-run for make arch-regen — recur...

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,5 +6,23 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# Arch-regen check — fail-fast when generated docs are stale.
+# No path-filter: push always runs the gate (any commit may touch arch sources).
+# Kill-switch: HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK=1 skips this block.
+if [ "${HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK:-0}" != "1" ]; then
+    echo "pre-push: running make arch-check..."
+    if ! make arch-check >/tmp/hydraflow-pre-push-arch-check.out 2>&1; then
+        echo "❌ docs/arch/generated/ is out of sync with source." >&2
+        echo "" >&2
+        echo "Run:" >&2
+        echo "  make arch-regen && git add docs/arch/ && git commit --amend --no-edit" >&2
+        echo "" >&2
+        echo "First 20 lines of arch-check output:" >&2
+        head -20 /tmp/hydraflow-pre-push-arch-check.out >&2
+        exit 1
+    fi
+    echo "pre-push: arch-check OK"
+fi
+
 echo "pre-push: running make quality-lite..."
 make quality-lite

--- a/docs/architecture/component-hook.likec4
+++ b/docs/architecture/component-hook.likec4
@@ -1,0 +1,41 @@
+// Component view: the pre-push hook script and the targets it invokes
+specification {
+  element component
+  element file
+  element target
+}
+
+model {
+  prePush = component "pre-push" {
+    description ".githooks/pre-push — bash script run by `git push`."
+
+    archCheckBlock = file "arch-check block (NEW)" {
+      description "Invokes `make arch-check`; on failure prints remediation and exits 1. Skippable via HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK=1."
+    }
+    qualityLiteBlock = file "quality-lite block (existing)" {
+      description "Runs `make quality-lite` (lint + typecheck + security)."
+    }
+  }
+
+  archCheck = target "make arch-check" {
+    description "Wraps `python -m arch.runner --check`. Strips per-run footer before diffing. ~2.4s."
+  }
+  qualityLite = target "make quality-lite" {
+    description "Wraps lint-check + typecheck + security audits. Multi-second."
+  }
+  runner = component "arch.runner.check()" {
+    description "Regenerates to tmpdir; diffs against committed docs/arch/generated/. Excludes changelog.md (drift-exempt)."
+  }
+
+  prePush.archCheckBlock -> archCheck "shell"
+  prePush.qualityLiteBlock -> qualityLite "shell"
+  archCheck -> runner "python -m arch.runner --check"
+}
+
+views {
+  view hookComponent of prePush {
+    title "pre-push hook composition"
+    include *
+    autoLayout TopBottom
+  }
+}

--- a/docs/architecture/context.likec4
+++ b/docs/architecture/context.likec4
@@ -1,0 +1,49 @@
+// Context: where the pre-push arch-check hook fits in the developer-tools surface
+specification {
+  element actor
+  element system
+  element component
+}
+
+model {
+  contributor = actor "Human Contributor" {
+    description "Pushes feature branches; subject to local hooks."
+  }
+
+  bot = actor "HydraFlow Bot" {
+    description "PR-creating loops. Pushes via --no-verify; bypasses hooks by design."
+  }
+
+  hf = system "HydraFlow Repo" {
+    githooks = component "Local Git Hooks" {
+      description ".githooks/pre-commit + .githooks/pre-push (active when core.hooksPath=.githooks)."
+    }
+    archRunner = component "arch.runner (--check / --emit)" {
+      description "Regenerates docs/arch/generated/ from source; --check strips footers and diffs."
+    }
+    diagramLoop = component "DiagramLoop (L24)" {
+      description "Caretaker; auto-regens every 4h and opens chore(arch): regenerate PR."
+    }
+    archRegenWorkflow = component "arch-regen.yml CI" {
+      description "GitHub Action: runs arch.runner --check on every PR. Source of truth."
+    }
+    p5Audit = component "Audit P5.8" {
+      description "Asserts .githooks/pre-push exists and references quality-lite."
+    }
+  }
+
+  contributor -> githooks "git push triggers pre-push"
+  githooks -> archRunner "make arch-check (planned addition)"
+  bot -> archRegenWorkflow "git push --no-verify -> CI runs check"
+  diagramLoop -> archRunner "--emit on 4h cadence"
+  archRegenWorkflow -> contributor "Fails PR if drift; contributor must amend"
+  p5Audit -> githooks "validates hook content"
+}
+
+views {
+  view contextView of hf {
+    title "Pre-push arch-check: developer-tools context"
+    include *
+    autoLayout TopBottom
+  }
+}

--- a/docs/architecture/dynamic-flow.likec4
+++ b/docs/architecture/dynamic-flow.likec4
@@ -1,0 +1,37 @@
+// Dynamic view: control flow of `git push` for a human contributor
+specification {
+  element actor
+  element step
+}
+
+model {
+  contributor = actor "Contributor"
+  git = step "git push"
+  hookEnter = step "pre-push hook fires"
+  killCheck = step "HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK set?"
+  archRun = step "make arch-check"
+  archFail = step "Print '❌ docs/arch/generated/ is out of sync', exit 1"
+  archPass = step "Print 'pre-push: arch-check OK'"
+  qualityRun = step "make quality-lite"
+  qualityFail = step "exit 1"
+  pushOK = step "push proceeds"
+
+  contributor -> git "executes"
+  git -> hookEnter "spawns hook"
+  hookEnter -> killCheck "evaluates env"
+  killCheck -> archRun "no -> run check"
+  killCheck -> qualityRun "yes -> skip arch-check"
+  archRun -> archFail "stale"
+  archRun -> archPass "in sync"
+  archPass -> qualityRun "continue"
+  qualityRun -> qualityFail "lint/type/security failure"
+  qualityRun -> pushOK "all green"
+}
+
+views {
+  view pushFlow {
+    title "git push -> pre-push -> arch-check -> quality-lite"
+    include *
+    autoLayout TopBottom
+  }
+}

--- a/tests/test_pre_push_hook_content.py
+++ b/tests/test_pre_push_hook_content.py
@@ -1,0 +1,47 @@
+"""Tests verifying .githooks/pre-push contains the arch-check gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+PRE_PUSH_HOOK = REPO_ROOT / ".githooks" / "pre-push"
+
+
+def _hook_text() -> str:
+    return PRE_PUSH_HOOK.read_text(encoding="utf-8")
+
+
+def _line_number(text: str, needle: str) -> int:
+    for i, line in enumerate(text.splitlines()):
+        if needle in line:
+            return i
+    return -1
+
+
+def test_pre_push_hook_exists() -> None:
+    assert PRE_PUSH_HOOK.exists(), ".githooks/pre-push must exist"
+
+
+def test_pre_push_hook_has_arch_check() -> None:
+    assert "arch-check" in _hook_text(), (
+        ".githooks/pre-push must invoke `make arch-check` to catch stale arch artifacts"
+    )
+
+
+def test_pre_push_hook_has_kill_switch() -> None:
+    assert "HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK" in _hook_text(), (
+        ".githooks/pre-push must honor HYDRAFLOW_DISABLE_PRE_PUSH_ARCH_CHECK=1 kill-switch "
+        "(per ADR-0049 kill-switch convention)"
+    )
+
+
+def test_pre_push_hook_arch_check_runs_before_quality_lite() -> None:
+    text = _hook_text()
+    arch_line = _line_number(text, "arch-check")
+    quality_line = _line_number(text, "quality-lite")
+    assert arch_line != -1, ".githooks/pre-push must reference arch-check"
+    assert quality_line != -1, ".githooks/pre-push must reference quality-lite"
+    assert arch_line < quality_line, (
+        "arch-check must run before quality-lite (faster and more deterministic)"
+    )


### PR DESCRIPTION
## Summary

Closes #8487.

## Issue

Add pre-push hook auto-run for make arch-regen — recurring CI block on stale arch artifacts

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow