### PR TITLE
fix(trust): correct _FAKE_TO_CASSETTE_DIR key casing + drop stale FakeHindsight entry

### DIFF
--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -148,10 +148,9 @@ _FAKE_TO_CASSETTE_DIR: dict[str, str] = {
     "FakeGit": "git",
     "FakeBeads": "beads",
     "FakeSentry": "sentry",
-    "FakeHindsight": "hindsight",
-    "FakeHttp": "http",
+    "FakeHTTP": "http",
     "FakeSubprocessRunner": "subprocess",
-    "FakeFs": "fs",
+    "FakeFS": "fs",
     "FakeLLM": "llm",
 }
 

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -316,3 +316,34 @@ def test_catalog_fake_methods_applies_class_overrides(tmp_path: Path) -> None:
     assert "set_rate_limit_mode" not in surface
     assert "set_rate_limit_mode" in helpers
     assert "create_issue" in surface
+
+
+def test_fake_to_cassette_dir_keys_match_real_classes() -> None:
+    """Every key in _FAKE_TO_CASSETTE_DIR must be a real Fake* class in the fakes dir.
+
+    Guards against case-mismatch regressions (e.g. 'FakeFs' vs actual 'FakeFS')
+    and stale entries for removed classes.
+    """
+    import ast as _ast
+    from pathlib import Path as _Path
+
+    from fake_coverage_auditor_loop import _FAKE_TO_CASSETTE_DIR
+
+    repo_root = _Path(__file__).parent.parent
+    fake_dir = repo_root / "src" / "mockworld" / "fakes"
+    actual: set[str] = set()
+    for path in fake_dir.glob("*.py"):
+        if path.name.startswith("test_") or path.name == "__init__.py":
+            continue
+        try:
+            tree = _ast.parse(path.read_text())
+        except SyntaxError:
+            continue
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.ClassDef) and node.name.startswith("Fake"):
+                actual.add(node.name)
+
+    stale = set(_FAKE_TO_CASSETTE_DIR) - actual
+    assert not stale, (
+        f"Stale _FAKE_TO_CASSETTE_DIR keys (class no longer exists): {stale}"
+    )


### PR DESCRIPTION
## Summary

- Fixes case mismatches in `_FAKE_TO_CASSETTE_DIR`: `FakeFs` → `FakeFS`, `FakeHttp` → `FakeHTTP` (these must match the actual class names in `fake_fs.py` / `fake_http.py`)
- Removes stale `FakeHindsight` entry — no such class exists in `src/mockworld/fakes/`, causing `"?"` to appear in filed issue bodies
- Adds regression test `test_fake_to_cassette_dir_keys_match_real_classes` that asserts every mapping key corresponds to a real `Fake*` class, preventing future drift

## Root-cause investigation (issue #8648)

`TrustFleetSanityLoop` detected `issues_per_hour=147` for `fake_coverage_auditor`. Investigation findings:

- Only **3 cassette YAML files** exist across the entire fakes directory (`github/pr_create.yaml`, `git/commit.yaml`, `docker/run_alpine_echo.yaml`)
- There are **179 adapter-surface methods** and **9 test-helper methods** across 15 fake classes
- The loop ran for the first time with an empty dedup store and correctly filed ~147 gap issues in one cycle
- **This was expected first-run behavior, not a loop defect.** The dedup store now has 147 keys preventing re-filing on the next weekly cycle.
- The case mismatches found here are the only code defects — cassette dirs named `fs` or `http` would be silently ignored until this fix

## Test plan

- [x] `pytest tests/test_fake_coverage_auditor_loop.py` — all 9 tests pass including new regression test
- [x] `make quality` — 12087 passed (1 pre-existing OTel env-var failure unrelated to this change)

Closes #8648

🤖 Generated with [Claude Code](https://claude.com/claude-code)