### PR TITLE
fix(trust-fleet): add adr_touchpoint_auditor to BGWorkerManager interval defaults

### DIFF
--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -150,5 +150,6 @@ class BGWorkerManager:
             "rc_budget": self._config.rc_budget_interval,
             "wiki_rot_detector": self._config.wiki_rot_detector_interval,
             "trust_fleet_sanity": self._config.trust_fleet_sanity_interval,
+            "adr_touchpoint_auditor": self._config.adr_touchpoint_auditor_interval,
         }
         return defaults.get(name, self._config.poll_interval)

--- a/src/config.py
+++ b/src/config.py
@@ -234,6 +234,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ),
     ("rc_budget_interval", "HYDRAFLOW_RC_BUDGET_INTERVAL", 14400),
     ("wiki_rot_detector_interval", "HYDRAFLOW_WIKI_ROT_DETECTOR_INTERVAL", 604800),
+    (
+        "adr_touchpoint_auditor_interval",
+        "HYDRAFLOW_ADR_TOUCHPOINT_AUDITOR_INTERVAL",
+        14400,
+    ),
     ("term_proposer_interval", "HYDRAFLOW_TERM_PROPOSER_INTERVAL", 14400),
     ("term_proposer_max_per_tick", "HYDRAFLOW_TERM_PROPOSER_MAX_PER_TICK", 10),
     (
@@ -1973,6 +1978,14 @@ class HydraFlowConfig(BaseModel):
         ge=86400,
         le=2_592_000,
         description="Seconds between WikiRotDetectorLoop ticks (default 7d)",
+    )
+
+    # Caretaker — AdrTouchpointAuditorLoop (ADR-0056)
+    adr_touchpoint_auditor_interval: int = Field(
+        default=14400,
+        ge=900,
+        le=86400,
+        description="Seconds between AdrTouchpointAuditorLoop ticks (default 4h)",
     )
 
     # Trust fleet — TermProposerLoop (ADR-0054)

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -63,6 +63,7 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "pricing_refresh": (86400, 2_592_000),  # 1d min, 30d max (default 1d)
     "cost_budget_watcher": (60, 3600),  # 1m min, 1h max (default 5m)
     "term_proposer": (3600, 86400),  # 1h min, 24h max
+    "adr_touchpoint_auditor": (900, 86400),  # 15m min, 1d max (default 4h)
 }
 
 # Internal pipeline labels that must not be treated as epic names in the history panel.

--- a/tests/test_bg_worker_manager.py
+++ b/tests/test_bg_worker_manager.py
@@ -164,6 +164,16 @@ class TestInterval:
                 f"{manager.get_interval(name)} vs {poll}"
             )
 
+    def test_adr_touchpoint_auditor_uses_config_interval(
+        self, manager: BGWorkerManager
+    ) -> None:
+        # Regression for #8671: missing entry caused poll_interval (30s) to be
+        # returned instead of the 4h config default, firing false staleness alarms.
+        assert (
+            manager.get_interval("adr_touchpoint_auditor")
+            == manager._config.adr_touchpoint_auditor_interval
+        )
+
     def test_persists_to_state(self, manager: BGWorkerManager) -> None:
         manager.set_interval("x", 99)
         saved = manager._state.get_worker_intervals()


### PR DESCRIPTION
## Summary

- `BGWorkerManager.get_interval` lacked an entry for `adr_touchpoint_auditor`, causing it to fall through to `poll_interval` (30s) instead of the configured 4h interval
- `TrustFleetSanityLoop` used this 30s value as the expected tick interval, setting a staleness threshold of 60s instead of 28800s — firing false alarms within minutes of each restart
- Fix adds the interval entry in `bg_worker_manager.py`, config field `adr_touchpoint_auditor_interval` (default 14400s), `_INTERVAL_BOUNDS` entry, and a regression test

Closes #8671

## Test plan

- [ ] `tests/test_bg_worker_manager.py::TestInterval::test_adr_touchpoint_auditor_uses_config_interval` — regression test confirming `get_interval("adr_touchpoint_auditor")` returns the config value, not `poll_interval`
- [ ] `make quality` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)