### PR TITLE
Fixes #8494: Un-cassetted adapter method: FakeGit.reject_next_push

### DIFF
--- a/docs/architecture/audit-misclassification.likec4
+++ b/docs/architecture/audit-misclassification.likec4
@@ -1,0 +1,90 @@
+// Issue #8494 — FakeGit.reject_next_push misclassified as adapter-surface
+//
+// The fake_coverage_auditor_loop walks AST of src/mockworld/fakes/*.py,
+// classifies each public method as adapter-surface (cassette-required) or
+// test-helper (scenario-grep-required). The classifier is name-based:
+// _HELPER_PREFIXES = ("script_",) and _HELPER_NAMES = {fail_service, heal_service, set_state}.
+//
+// FakeGit has a `# --- script API (tests) ---` block holding three helpers
+// that don't carry the script_ prefix and aren't in _HELPER_NAMES:
+//   - reject_next_push   (this issue)
+//   - set_corrupted_config
+//   - active_worktrees
+// All three are misclassified as adapter-surface. The auditor demands cassettes
+// for them, but they have no real-adapter counterpart — they only flip flags
+// inside the in-memory fake. Following the literal "record a cassette" repair
+// would embed a lie in the contract layer.
+
+specification {
+  element system
+  element container
+  element component
+}
+
+model {
+  hydraflow = system 'HydraFlow' {
+    auditor = container 'fake_coverage_auditor_loop' {
+      description: 'Weekly loop (spec §4.7) that audits fake-class method coverage'
+
+      classifier = component '_is_helper(name)' {
+        description: 'Name-only classifier — uses _HELPER_PREFIXES + _HELPER_NAMES'
+      }
+      ast_walker = component 'catalog_fake_methods' {
+        description: 'AST walks fakes/*.py, splits public methods into surface vs helper'
+      }
+      cassette_reader = component 'catalog_cassette_methods' {
+        description: 'Reads input.command from each *.yaml cassette'
+      }
+      grep_helper = component '_grep_scenario_for_helper' {
+        description: 'rg-greps tests/scenarios/ for `<helper>(`'
+      }
+      gap_filer = component '_file_surface_gap / _file_helper_gap' {
+        description: 'Files a hydraflow-find issue per uncovered method'
+      }
+    }
+
+    fakes = container 'src/mockworld/fakes' {
+      fake_git = component 'FakeGit' {
+        description: 'In-memory git CLI surface'
+      }
+      fake_git_script_api = component 'FakeGit script API' {
+        description: 'reject_next_push, set_corrupted_config, active_worktrees — script-only, no real CLI counterpart'
+      }
+      fake_git_port = component 'FakeGit port methods' {
+        description: 'worktree_add, commit, push, status, rev_parse, ... — these DO have real CLI counterparts and need cassettes'
+      }
+    }
+
+    cassettes = container 'tests/trust/contracts/cassettes/git/' {
+      description: 'Recorded git CLI cassettes (input.command names the method)'
+    }
+
+    scenarios = container 'tests/scenarios/' {
+      description: 'Scenario tests; helpers must appear here via grep to be classified covered'
+    }
+
+    auditor.ast_walker -> fakes 'parses *.py'
+    auditor.ast_walker -> auditor.classifier 'classifies each public method'
+    auditor.cassette_reader -> cassettes 'reads input.command'
+    auditor.grep_helper -> scenarios 'rg --fixed-strings'
+    auditor.gap_filer -> hydraflow 'files hydraflow-find issues'
+
+    fake_git -> fake_git_script_api 'has block'
+    fake_git -> fake_git_port 'has block'
+  }
+}
+
+views {
+  view index {
+    title 'Issue #8494 — auditor / FakeGit interaction'
+    include *
+  }
+
+  view audit_flow {
+    title 'Dynamic — audit cycle for FakeGit (current, broken)'
+    include hydraflow.auditor.*, hydraflow.fakes.*, hydraflow.cassettes, hydraflow.scenarios
+
+    // Current behaviour: script-API methods flow into the surface bucket,
+    // hit the cassette miss path, file fake-coverage-gap issues.
+  }
+}

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -42,7 +42,16 @@ logger = logging.getLogger("hydraflow.fake_coverage_auditor_loop")
 
 _MAX_ATTEMPTS = 3
 _HELPER_PREFIXES = ("script_",)
-_HELPER_NAMES = frozenset({"fail_service", "heal_service", "set_state"})
+_HELPER_NAMES = frozenset(
+    {
+        "fail_service",
+        "heal_service",
+        "set_state",
+        "reject_next_push",
+        "set_corrupted_config",
+        "active_worktrees",
+    }
+)
 
 
 def _is_helper(name: str) -> bool:

--- a/tests/regressions/test_issue_8494.py
+++ b/tests/regressions/test_issue_8494.py
@@ -1,0 +1,32 @@
+"""Regression test for #8494 — FakeGit script-API helpers misclassified as adapter-surface.
+
+`reject_next_push`, `set_corrupted_config`, and `active_worktrees` are test
+helpers (script API), not real-adapter methods.  They must appear in the
+``test-helper`` bucket, never in ``adapter-surface``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fake_coverage_auditor_loop import catalog_fake_methods
+
+_FAKE_DIR = Path(__file__).parents[2] / "src" / "mockworld" / "fakes"
+
+_SCRIPT_API_HELPERS = {"reject_next_push", "set_corrupted_config", "active_worktrees"}
+
+
+def test_fake_git_script_api_helpers_are_not_adapter_surface() -> None:
+    cat = catalog_fake_methods(_FAKE_DIR)
+    assert "FakeGit" in cat, "FakeGit not found — check fake_dir path"
+    surface = set(cat["FakeGit"]["adapter-surface"])
+    helpers = set(cat["FakeGit"]["test-helper"])
+    for method in _SCRIPT_API_HELPERS:
+        assert method not in surface, (
+            f"FakeGit.{method} was classified as adapter-surface; "
+            "it is a script-API test helper and must be in test-helper"
+        )
+        assert method in helpers, (
+            f"FakeGit.{method} was not classified as test-helper; "
+            "it is a script-API test helper"
+        )

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -78,6 +78,34 @@ def test_catalog_fake_methods_splits_surface_vs_helper(tmp_path: Path) -> None:
     assert helpers == {"script_ci", "fail_service"}
 
 
+def test_catalog_fake_methods_fake_git_script_api_helpers_are_test_helpers(
+    tmp_path: Path,
+) -> None:
+    """reject_next_push / set_corrupted_config / active_worktrees must land in test-helper."""
+    fake_dir = tmp_path / "fakes"
+    fake_dir.mkdir()
+    (fake_dir / "fake_git.py").write_text(
+        "class FakeGit:\n"
+        "    def reject_next_push(self): ...\n"
+        "    def set_corrupted_config(self, cwd, *, key, value): ...\n"
+        "    def active_worktrees(self): ...\n"
+        "    async def push(self, cwd, remote, branch): ...\n"
+        "    async def commit(self, cwd, message): ...\n"
+    )
+
+    cat = catalog_fake_methods(fake_dir)
+    assert "FakeGit" in cat
+    surface = set(cat["FakeGit"]["adapter-surface"])
+    helpers = set(cat["FakeGit"]["test-helper"])
+
+    for method in ("reject_next_push", "set_corrupted_config", "active_worktrees"):
+        assert method not in surface, f"{method} must not be adapter-surface"
+        assert method in helpers, f"{method} must be in test-helper"
+
+    assert "push" in surface
+    assert "commit" in surface
+
+
 def test_catalog_cassette_methods_reads_input_command(tmp_path: Path) -> None:
     import yaml
 


### PR DESCRIPTION
## Summary

Closes #8494.

## Issue

Un-cassetted adapter method: FakeGit.reject_next_push

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow