### PR TITLE
Fixes #8496: Un-cassetted adapter method: FakeGit.set_corrupted_config

### DIFF
--- a/docs/architecture/fake_coverage_topology.likec4
+++ b/docs/architecture/fake_coverage_topology.likec4
@@ -1,0 +1,125 @@
+// Issue #8496 — fake-coverage classification topology
+// Captures the auditor + FakeGit + cassette + scenario coverage graph.
+
+specification {
+  element actor
+  element system
+  element container
+  element component
+  element file
+
+  tag classification
+  tag fix
+  tag rename-target
+}
+
+model {
+  auditor = system 'FakeCoverageAuditorLoop' {
+    description '
+      Weekly auditor (src/fake_coverage_auditor_loop.py).
+      Spec §4.7. AST-scans Fake* classes and matches each method
+      to either a cassette (adapter-surface) or a scenario test
+      (test-helper).
+    '
+
+    catalogFakes = component 'catalog_fake_methods()' {
+      description '
+        AST walk of src/mockworld/fakes/*.py.
+        Public methods → adapter-surface, unless they start with
+        _HELPER_PREFIXES = ("script_",) or are in
+        _HELPER_NAMES = {fail_service, heal_service, set_state}.
+      '
+      #classification
+    }
+
+    catalogCassettes = component 'catalog_cassette_methods()' {
+      description 'Reads YAMLs under tests/trust/contracts/cassettes/<adapter>/, returns set of input.command strings.'
+    }
+
+    grepHelper = component '_grep_scenario_for_helper()' {
+      description 'rg --fixed-strings "<helper>(" tests/scenarios/ — returns True iff any scenario calls the helper.'
+    }
+
+    fileSurfaceGap = component '_file_surface_gap()' {
+      description 'Files an "Un-cassetted adapter method: <Fake>.<method>" issue with adapter_surface_label.'
+    }
+
+    fileHelperGap = component '_file_helper_gap()' {
+      description 'Files an "Un-exercised test helper: <Fake>.<method>" issue with test_helper_label.'
+    }
+  }
+
+  fakeGit = container 'FakeGit' {
+    description 'src/mockworld/fakes/fake_git.py — in-memory git CLI surface.'
+
+    scriptApi = component '# --- script API (tests) ---' {
+      description '
+        Block comment at line 19. Three methods sit here, all WITHOUT
+        the script_ prefix today, so the auditor classifies them as
+        adapter-surface (the bug):
+          - set_corrupted_config  (issue #8496)
+          - reject_next_push      (next sweep will file)
+          - active_worktrees      (next sweep will file)
+      '
+      #classification
+    }
+
+    portMethods = component '# --- port methods ---' {
+      description '
+        worktree_add, worktree_remove, worktree_prune, status, commit,
+        push, rev_parse, config_get, config_unset.
+        These are real adapter ports and SHOULD be cassetted.
+      '
+    }
+  }
+
+  cassettes = container 'cassettes/git/' {
+    description 'tests/trust/contracts/cassettes/git/'
+
+    commitYaml = file 'commit.yaml' {
+      description 'Only cassette today; input.command = "commit".'
+    }
+  }
+
+  scenarios = container 'tests/scenarios/' {
+    fakesTest = file 'fakes/test_fake_git.py' {
+      description 'Calls fake.set_corrupted_config(tmp_path, key=..., value=...) at line 34.'
+    }
+    surfaceTest = file 'test_surfaces.py' {
+      description 'TestSG1GitCoreWorktreeCorruption calls mock_world.git.set_corrupted_config(...) at line 54.'
+    }
+  }
+
+  regressionTest = file 'tests/regressions/test_issue_8496.py' {
+    description '
+      RED gate. Self-retires either way:
+        - GREEN if "set_corrupted_config" in helpers (legacy guard, never triggers post-rename), OR
+        - GREEN if cassette exists with input.command=set_corrupted_config, OR
+        - Asserts "no longer appears on FakeGit at all" — meaning rename must update this test too.
+    '
+    #fix
+  }
+
+  wikiSnippet = file 'docs/wiki/testing.md:640' {
+    description 'Stale illustrative snippet referencing fake.set_corrupted_config(cwd, args[0]) — uses positional args even though method is kwargs-only.'
+  }
+
+  // Relationships
+  auditor.catalogFakes -> fakeGit.scriptApi 'parses → classifies as adapter-surface (bug)'
+  auditor.catalogFakes -> fakeGit.portMethods 'parses → classifies as adapter-surface (correct)'
+  auditor.catalogCassettes -> cassettes.commitYaml 'reads input.command'
+  auditor.fileSurfaceGap -> regressionTest 'filed #8496 → triggered this regression test'
+  auditor.grepHelper -> scenarios.fakesTest 'searches for script_* helpers'
+  auditor.grepHelper -> scenarios.surfaceTest 'searches for script_* helpers'
+
+  scenarios.fakesTest -> fakeGit.scriptApi 'calls set_corrupted_config(...) — kwargs'
+  scenarios.surfaceTest -> fakeGit.scriptApi 'calls set_corrupted_config(...) — kwargs'
+  wikiSnippet -> fakeGit.scriptApi 'documents (stale, positional)'
+}
+
+views {
+  view classification {
+    title 'Auditor classification rules → FakeGit script-API methods'
+    include *
+  }
+}

--- a/docs/architecture/rename_fix_flow.likec4
+++ b/docs/architecture/rename_fix_flow.likec4
@@ -1,0 +1,63 @@
+// Issue #8496 — dynamic view: rename-path fix flow
+// Shows the order of edits and how each one re-greens a different gate.
+
+specification {
+  element step
+  element gate
+  element actor
+}
+
+model {
+  implementer = actor 'Implementer'
+
+  step1 = step 'Rename in fake_git.py' {
+    description 'set_corrupted_config → script_set_corrupted_config (line 21)'
+  }
+  step2a = step 'Update caller A' {
+    description 'tests/scenarios/fakes/test_fake_git.py:34 — fake.script_set_corrupted_config(tmp_path, key=..., value=...)'
+  }
+  step2b = step 'Update caller B' {
+    description 'tests/scenarios/test_surfaces.py:54 — mock_world.git.script_set_corrupted_config(tmp_path, key=..., value=...)'
+  }
+  step3 = step 'Update wiki snippet' {
+    description 'docs/wiki/testing.md:642 — fake.script_set_corrupted_config(cwd, key=..., value=...)'
+  }
+  step4 = step 'Update regression test' {
+    description '
+      tests/regressions/test_issue_8496.py — accept "script_set_corrupted_config in helpers"
+      as the green path; otherwise the rename trips the "no longer appears" assertion.
+    '
+  }
+  step5 = step 'make quality' {
+    description 'Full suite (per CLAUDE.md cleanup-PR rule); verify nothing else regressed.'
+  }
+
+  gateAuditor = gate 'AuditorAST' {
+    description 'catalog_fake_methods now classifies script_set_corrupted_config as test-helper (not adapter-surface).'
+  }
+  gateGrep = gate 'AuditorGrep' {
+    description '_grep_scenario_for_helper finds script_set_corrupted_config( in tests/scenarios/.'
+  }
+  gateRegression = gate 'RegressionTest' {
+    description 'tests/regressions/test_issue_8496.py turns GREEN once it learns the renamed form.'
+  }
+
+  implementer -> step1
+  step1 -> gateAuditor 'classification flips: surface → helper'
+  step1 -> step2a 'callers must use new name (Python AttributeError otherwise)'
+  step1 -> step2b
+  step2a -> gateGrep 'rg matches script_set_corrupted_config('
+  step2b -> gateGrep
+  step2a -> step3
+  step3 -> step4
+  step4 -> gateRegression
+  step4 -> step5
+  step5 -> gateRegression 'final pytest run confirms green'
+}
+
+views {
+  view rename_flow {
+    title 'Rename-path fix sequence and which gates each step closes'
+    include *
+  }
+}

--- a/src/mockworld/fakes/fake_git.py
+++ b/src/mockworld/fakes/fake_git.py
@@ -18,7 +18,7 @@ class FakeGit:
 
     # --- script API (tests) ---
 
-    def set_corrupted_config(self, cwd: Path, *, key: str, value: str) -> None:
+    def script_set_corrupted_config(self, cwd: Path, *, key: str, value: str) -> None:
         self._configs.setdefault(cwd, {})[key] = value
 
     def reject_next_push(self) -> None:

--- a/tests/regressions/test_issue_8496.py
+++ b/tests/regressions/test_issue_8496.py
@@ -1,0 +1,51 @@
+"""Regression test for issue #8496.
+
+Bug: FakeGit.set_corrupted_config is classified as `adapter-surface` by
+fake_coverage_auditor because it lacks the `script_` prefix that marks
+test-helper methods.  The auditor then files a spurious cassette-gap issue.
+
+Fix: rename to script_set_corrupted_config so catalog_fake_methods
+classifies it as `test-helper`, and update the two scenario callers.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fake_coverage_auditor_loop import catalog_fake_methods
+from mockworld.fakes.fake_git import FakeGit
+
+
+class TestFakeGitHelperClassification:
+    """FakeGit.script_set_corrupted_config must be a test-helper, not adapter-surface."""
+
+    def test_script_set_corrupted_config_classified_as_helper(
+        self, tmp_path: Path
+    ) -> None:
+        fake_dir = Path(__file__).parent.parent.parent / "src" / "mockworld" / "fakes"
+        catalog = catalog_fake_methods(fake_dir)
+        helpers = catalog.get("FakeGit", {}).get("test-helper", [])
+        assert "script_set_corrupted_config" in helpers, (
+            "script_set_corrupted_config must be in test-helper list so "
+            "the auditor does not file a cassette-gap issue"
+        )
+
+    def test_set_corrupted_config_not_on_adapter_surface(self, tmp_path: Path) -> None:
+        fake_dir = Path(__file__).parent.parent.parent / "src" / "mockworld" / "fakes"
+        catalog = catalog_fake_methods(fake_dir)
+        surface = catalog.get("FakeGit", {}).get("adapter-surface", [])
+        assert "set_corrupted_config" not in surface, (
+            "set_corrupted_config must not appear on adapter-surface after rename"
+        )
+
+    def test_script_set_corrupted_config_seeds_state(self, tmp_path: Path) -> None:
+        fake = FakeGit()
+        fake.script_set_corrupted_config(
+            tmp_path, key="core.worktree", value="/workspace"
+        )
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            fake.config_get(tmp_path, "core.worktree")
+        )
+        assert result == "/workspace"

--- a/tests/scenarios/fakes/test_fake_git.py
+++ b/tests/scenarios/fakes/test_fake_git.py
@@ -31,7 +31,7 @@ async def test_worktree_remove_clears(tmp_path: Path) -> None:
 
 async def test_core_worktree_corruption_detected(tmp_path: Path) -> None:
     fake = FakeGit()
-    fake.set_corrupted_config(tmp_path, key="core.worktree", value="/workspace")
+    fake.script_set_corrupted_config(tmp_path, key="core.worktree", value="/workspace")
     assert await fake.config_get(tmp_path, "core.worktree") == "/workspace"
     await fake.config_unset(tmp_path, "core.worktree")
     assert await fake.config_get(tmp_path, "core.worktree") is None

--- a/tests/scenarios/test_surfaces.py
+++ b/tests/scenarios/test_surfaces.py
@@ -51,7 +51,7 @@ class TestSD3DockerRecordsInvocation:
 
 class TestSG1GitCoreWorktreeCorruption:
     async def test_corrupted_config_detected_and_repaired(self, mock_world, tmp_path):
-        mock_world.git.set_corrupted_config(
+        mock_world.git.script_set_corrupted_config(
             tmp_path, key="core.worktree", value="/workspace"
         )
         assert (


### PR DESCRIPTION
## Summary

Closes #8496.

## Issue

Un-cassetted adapter method: FakeGit.set_corrupted_config

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow