### PR TITLE
Fixes #8509: Un-cassetted adapter method: FakeGitHub.clear_rate_limit

### DIFF
--- a/docs/architecture/01-context.likec4
+++ b/docs/architecture/01-context.likec4
@@ -1,0 +1,53 @@
+// Issue #8509 — context: where FakeCoverageAuditorLoop fits in the
+// trust-architecture loop fleet (ADR-0045 / spec §4.7).
+
+specification {
+  element actor
+  element loop
+  element store
+  element artifact
+}
+
+model {
+  caretaker = actor 'Caretaker (background)' {
+    description 'HydraFlow background fleet — runs weekly auditor ticks'
+  }
+
+  fakeCoverageAuditor = loop 'FakeCoverageAuditorLoop' {
+    description 'AST-scans Fake* classes; files gaps for un-cassetted public methods'
+  }
+
+  fakeFiles = artifact 'src/mockworld/fakes/fake_*.py' {
+    description 'AST sources — public methods classified surface vs helper'
+  }
+
+  cassetteDir = artifact 'tests/trust/contracts/cassettes/<adapter>/' {
+    description 'YAML cassettes — input.command names the adapter method'
+  }
+
+  scenarioDir = artifact 'tests/scenarios/' {
+    description 'Scenarios reach into helpers; grep-based coverage source'
+  }
+
+  ghIssues = store 'GitHub Issues (filed gaps)' {
+    description 'fake-coverage-gap labelled issues — repaired by next loop'
+  }
+
+  state = store 'StateTracker' {
+    description 'inc_fake_coverage_attempts; escalates after 3 attempts'
+  }
+
+  caretaker -> fakeCoverageAuditor 'tick (weekly)'
+  fakeCoverageAuditor -> fakeFiles 'ast.parse + walk classes'
+  fakeCoverageAuditor -> cassetteDir 'glob *.yaml; collect input.command'
+  fakeCoverageAuditor -> scenarioDir 'rg --fixed-strings <method>('
+  fakeCoverageAuditor -> ghIssues 'create gap issue (per uncovered method)'
+  fakeCoverageAuditor -> state 'inc_fake_coverage_attempts(key)'
+}
+
+views {
+  view context {
+    title 'FakeCoverageAuditorLoop — context (issue #8509)'
+    include *
+  }
+}

--- a/docs/architecture/02-component.likec4
+++ b/docs/architecture/02-component.likec4
@@ -1,0 +1,51 @@
+// Issue #8509 — component view: classifier internals inside the auditor.
+// Shows where the fix lands: _is_helper consults a per-fake override map.
+
+specification {
+  element module
+  element function
+  element data
+  element artifact
+}
+
+model {
+  loopFile = module 'src/fake_coverage_auditor_loop.py' {
+    description 'Auditor module — AST scan + classifier + gap-filing'
+  }
+
+  helperPrefixes = data '_HELPER_PREFIXES' {
+    description '("script_",) — name-prefix helper signal'
+  }
+  helperNames = data '_HELPER_NAMES' {
+    description 'frozenset {fail_service, heal_service, set_state}'
+  }
+  helperOverrides = data '_FAKE_HELPER_OVERRIDES (NEW)' {
+    description 'Per-fake helper allowlist — {"FakeGitHub": {"clear_rate_limit", "set_rate_limit_mode"}}'
+  }
+
+  isHelper = function '_is_helper(class_name, name)' {
+    description 'Returns True if name is helper for class. NEW: consults override map.'
+  }
+  catalogFn = function 'catalog_fake_methods(fake_dir)' {
+    description 'Walks AST; calls _is_helper(class_name, child.name); splits surface/helper'
+  }
+
+  fakeGithub = artifact 'FakeGitHub' {
+    description 'src/mockworld/fakes/fake_github.py — host of clear_rate_limit + set_rate_limit_mode'
+  }
+
+  catalogFn -> isHelper 'classify each public method'
+  isHelper -> helperPrefixes 'startswith(p)'
+  isHelper -> helperNames 'name in set'
+  isHelper -> helperOverrides 'name in overrides[class_name]'
+  catalogFn -> fakeGithub 'ast.parse + ClassDef walk'
+  loopFile -> catalogFn 'imports'
+  loopFile -> isHelper 'imports'
+}
+
+views {
+  view component {
+    title 'Auditor classifier (fix lands at _FAKE_HELPER_OVERRIDES)'
+    include *
+  }
+}

--- a/docs/architecture/03-dynamic-tick.likec4
+++ b/docs/architecture/03-dynamic-tick.likec4
@@ -1,0 +1,32 @@
+// Issue #8509 — dynamic view: one auditor tick after the fix.
+// Shows what changes for clear_rate_limit / set_rate_limit_mode.
+
+specification {
+  element step
+}
+
+model {
+  s1 = step 'tick fires (weekly)'
+  s2 = step 'ast-scan src/mockworld/fakes/*.py'
+  s3 = step 'for each Fake class: _is_helper(class_name, method)'
+  s4 = step 'BEFORE: clear_rate_limit -> adapter-surface (gap filed)'
+  s5 = step 'AFTER: clear_rate_limit -> test-helper (override hit)'
+  s6 = step 'helper coverage gate: rg "clear_rate_limit(" tests/scenarios/'
+  s7 = step 'mock_world.py:446 + test_agent_realistic.py:733 -> COVERED'
+  s8 = step 'no gap issue filed; dedup state untouched'
+
+  s1 -> s2
+  s2 -> s3
+  s3 -> s4 'pre-fix branch'
+  s3 -> s5 'post-fix branch'
+  s5 -> s6
+  s6 -> s7
+  s7 -> s8
+}
+
+views {
+  view tick {
+    title 'Auditor tick — pre vs post fix'
+    include *
+  }
+}

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -44,8 +44,17 @@ _MAX_ATTEMPTS = 3
 _HELPER_PREFIXES = ("script_",)
 _HELPER_NAMES = frozenset({"fail_service", "heal_service", "set_state"})
 
+# Per-class overrides: methods that don't match the generic prefix/name rules
+# but are test-only helpers rather than real adapter-surface methods.
+_FAKE_HELPER_OVERRIDES: dict[tuple[str, str], str] = {
+    ("FakeGitHub", "clear_rate_limit"): "test-helper",
+    ("FakeGitHub", "set_rate_limit_mode"): "test-helper",
+}
 
-def _is_helper(name: str) -> bool:
+
+def _is_helper(name: str, class_name: str = "") -> bool:
+    if class_name and (class_name, name) in _FAKE_HELPER_OVERRIDES:
+        return True
     return any(name.startswith(p) for p in _HELPER_PREFIXES) or name in _HELPER_NAMES
 
 
@@ -86,7 +95,7 @@ def catalog_fake_methods(fake_dir: Path) -> dict[str, dict[str, list[str]]]:
                 name = child.name
                 if name.startswith("_"):
                     continue
-                if _is_helper(name):
+                if _is_helper(name, node.name):
                     helpers.append(name)
                 else:
                     surface.append(name)

--- a/tests/regressions/test_issue_8509.py
+++ b/tests/regressions/test_issue_8509.py
@@ -1,0 +1,58 @@
+"""Regression test for issue #8509.
+
+Bug: FakeCoverageAuditorLoop classified FakeGitHub.clear_rate_limit and
+FakeGitHub.set_rate_limit_mode as ``adapter-surface``, causing the auditor
+to file spurious cassette-gap issues for test-only helper methods.
+
+Expected behaviour after fix:
+  - ``clear_rate_limit`` on FakeGitHub classifies as ``test-helper``, not
+    ``adapter-surface``.
+  - ``set_rate_limit_mode`` on FakeGitHub classifies as ``test-helper``, not
+    ``adapter-surface``.
+
+Self-retires: if either method is renamed or removed, its assertion is skipped
+because the method simply won't appear in either bucket — no false failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fake_coverage_auditor_loop import catalog_fake_methods
+
+_FAKES_DIR = Path(__file__).resolve().parents[2] / "src" / "mockworld" / "fakes"
+
+
+class TestClearRateLimitIsHelper:
+    """FakeGitHub.clear_rate_limit must classify as test-helper, not adapter-surface."""
+
+    def test_clear_rate_limit_classifies_as_test_helper(self) -> None:
+        catalog = catalog_fake_methods(_FAKES_DIR)
+        if "FakeGitHub" not in catalog:
+            pytest.skip("FakeGitHub not found in fakes dir")
+        github = catalog["FakeGitHub"]
+        if "clear_rate_limit" not in github["adapter-surface"] + github["test-helper"]:
+            pytest.skip("clear_rate_limit no longer exists — method renamed or removed")
+        assert "clear_rate_limit" not in github["adapter-surface"], (
+            "clear_rate_limit is a test-only helper and must not appear in adapter-surface"
+        )
+        assert "clear_rate_limit" in github["test-helper"]
+
+    def test_set_rate_limit_mode_classifies_as_test_helper(self) -> None:
+        catalog = catalog_fake_methods(_FAKES_DIR)
+        if "FakeGitHub" not in catalog:
+            pytest.skip("FakeGitHub not found in fakes dir")
+        github = catalog["FakeGitHub"]
+        if (
+            "set_rate_limit_mode"
+            not in github["adapter-surface"] + github["test-helper"]
+        ):
+            pytest.skip(
+                "set_rate_limit_mode no longer exists — method renamed or removed"
+            )
+        assert "set_rate_limit_mode" not in github["adapter-surface"], (
+            "set_rate_limit_mode is a test-only helper and must not appear in adapter-surface"
+        )
+        assert "set_rate_limit_mode" in github["test-helper"]

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -15,6 +15,7 @@ from config import HydraFlowConfig
 from events import EventBus
 from fake_coverage_auditor_loop import (
     FakeCoverageAuditorLoop,
+    _is_helper,
     catalog_cassette_methods,
     catalog_fake_methods,
 )
@@ -254,3 +255,36 @@ async def test_kill_switch_short_circuits_do_work(loop_env) -> None:
     assert stats == {"status": "disabled"}
     loop._reconcile_closed_escalations.assert_not_awaited()
     pr.create_issue.assert_not_awaited()
+
+
+def test_is_helper_returns_true_for_class_overrides() -> None:
+    """_FAKE_HELPER_OVERRIDES entries classify as test-helper regardless of prefix/name."""
+    assert _is_helper("clear_rate_limit", "FakeGitHub") is True
+    assert _is_helper("set_rate_limit_mode", "FakeGitHub") is True
+
+
+def test_is_helper_override_does_not_affect_other_classes() -> None:
+    """Override is class-scoped — same method name on another fake is adapter-surface."""
+    assert _is_helper("clear_rate_limit", "FakeDocker") is False
+    assert _is_helper("clear_rate_limit", "") is False
+
+
+def test_catalog_fake_methods_applies_class_overrides(tmp_path: Path) -> None:
+    """Methods in _FAKE_HELPER_OVERRIDES land in test-helper, not adapter-surface."""
+    fake_dir = tmp_path / "fakes"
+    fake_dir.mkdir()
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def create_issue(self, title): ...\n"
+        "    def clear_rate_limit(self): ...\n"
+        "    def set_rate_limit_mode(self, *, remaining=0): ...\n"
+    )
+    cat = catalog_fake_methods(fake_dir)
+    assert "FakeGitHub" in cat
+    surface = set(cat["FakeGitHub"]["adapter-surface"])
+    helpers = set(cat["FakeGitHub"]["test-helper"])
+    assert "clear_rate_limit" not in surface
+    assert "clear_rate_limit" in helpers
+    assert "set_rate_limit_mode" not in surface
+    assert "set_rate_limit_mode" in helpers
+    assert "create_issue" in surface


### PR DESCRIPTION
## Summary

Closes #8509.

## Issue

Un-cassetted adapter method: FakeGitHub.clear_rate_limit

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow