### PR TITLE
fix(ci): quality.yml emits SUCCESS on docs-only PRs (unblocks bot-PR auto-merge)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -95,45 +95,56 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     needs: [changes, discover-projects]
-    if: needs.changes.outputs.code == 'true'
+    # Always run so the matrix-named checks (`quality (.)`, `quality (src/ui)`)
+    # register a SUCCESS status on docs-only PRs — branch protection requires
+    # those names; a never-expanded matrix is counted as 'expected'/not-passed.
+    # Heavy steps still gate on `needs.changes.outputs.code == 'true'` below.
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover-projects.outputs.matrix) }}
     steps:
+      - name: Skip-if-no-code-changes
+        if: needs.changes.outputs.code != 'true'
+        shell: bash
+        run: |
+          echo 'No code changes — emitting SUCCESS to satisfy branch protection.'
+          echo 'Heavy quality steps gated below; no-op for docs-only PRs.'
       - uses: actions/checkout@v4
+        if: needs.changes.outputs.code == 'true'
       - name: Set up Python
-        if: ${{ hashFiles(format('{0}/pyproject.toml', matrix.project_dir), format('{0}/requirements.txt', matrix.project_dir), format('{0}/setup.py', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/pyproject.toml', matrix.project_dir), format('{0}/requirements.txt', matrix.project_dir), format('{0}/setup.py', matrix.project_dir)) != '') }}
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Set up uv
-        if: ${{ hashFiles(format('{0}/Makefile', matrix.project_dir), format('{0}/makefile', matrix.project_dir), format('{0}/GNUmakefile', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/Makefile', matrix.project_dir), format('{0}/makefile', matrix.project_dir), format('{0}/GNUmakefile', matrix.project_dir)) != '') }}
         uses: astral-sh/setup-uv@v5
       - name: Set up Node
-        if: ${{ hashFiles(format('{0}/package.json', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/package.json', matrix.project_dir)) != '') }}
         uses: actions/setup-node@v4
         with:
           node-version: '20'
       - name: Set up Java
-        if: ${{ hashFiles(format('{0}/pom.xml', matrix.project_dir), format('{0}/build.gradle', matrix.project_dir), format('{0}/build.gradle.kts', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/pom.xml', matrix.project_dir), format('{0}/build.gradle', matrix.project_dir), format('{0}/build.gradle.kts', matrix.project_dir)) != '') }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '21'
       - name: Set up Ruby
-        if: ${{ hashFiles(format('{0}/Gemfile', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/Gemfile', matrix.project_dir)) != '') }}
         uses: ruby/setup-ruby@v1
       - name: Set up .NET
-        if: ${{ hashFiles(format('{0}/*.sln', matrix.project_dir), format('{0}/*.csproj', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/*.sln', matrix.project_dir), format('{0}/*.csproj', matrix.project_dir)) != '') }}
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
       - name: Set up Go
-        if: ${{ hashFiles(format('{0}/go.mod', matrix.project_dir)) != '' }}
+        if: ${{ needs.changes.outputs.code == 'true' && (hashFiles(format('{0}/go.mod', matrix.project_dir)) != '') }}
         uses: actions/setup-go@v5
         with:
           go-version: '1.22'
       - name: Quality Lite
+        if: needs.changes.outputs.code == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -144,6 +155,7 @@ jobs:
           fi
           echo "No Makefile in ${{ matrix.project_dir }}; skipping make quality-lite."
       - name: Quality Full
+        if: needs.changes.outputs.code == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -154,6 +166,7 @@ jobs:
           fi
           echo "No Makefile in ${{ matrix.project_dir }}; skipping make quality."
       - name: Smoke
+        if: needs.changes.outputs.code == 'true'
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Removes the trigger-commit workaround needed by PR #8681 and any future docs-only PR (bot-authored or human-authored).

The \`quality\` job in \`.github/workflows/quality.yml\` had \`if: needs.changes.outputs.code == 'true'\` at the **job level**. On docs-only PRs:

1. \`changes.outputs.code\` evaluates to \`false\`
2. The job's \`if:\` is false → matrix never expands → \`quality (.)\` and \`quality (src/ui)\` checks never register
3. Branch protection on \`main\` requires those check names → counts the missing checks as \`expected\`/not-passed → merge blocked even with \`--admin\`

## Fix

Restructured the \`quality\` job so the **matrix-named checks always register**, while heavy steps still skip on docs-only PRs:

- Removed the job-level \`if:\` 
- New \`Skip-if-no-code-changes\` step at the top emits an info message + exits SUCCESS when no code changed
- Every heavy step (\`checkout\`, language setups, \`Quality Lite\`, \`Quality Full\`, \`Smoke\`) gates on \`needs.changes.outputs.code == 'true'\`

Net effect: docs-only PRs pay only the runner-startup cost (~5s), produce a SUCCESS for both \`quality (.)\` and \`quality (src/ui)\`, and merge cleanly.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(...)\"\` — file is valid YAML
- [x] Diff is +21/-8 in one file — surgical
- [ ] CI to verify the workflow itself still runs on this PR (which touches \`.github/workflows\` — that path triggers \`code: true\`, so the heavy matrix WILL run on this PR)
- [ ] After merge, the next bot PR from \`TermProposerLoop\` should auto-merge without trigger-commit hacks

## What this unblocks

This is item 1 of the 4-item program close-out. Items 2-4 (Term-Pruner, Edge-Proposer, Entry→Term Migrator) all open auto-merging bot PRs, mostly docs-only. Without this fix, each one would need the same trigger-commit hack PR #8681 needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)