### PR TITLE
feat(ul): one-shot entry→term evidence migration script (item 4 of 4)

### DIFF
--- a/scripts/migrate_entries_to_term_evidence.py
+++ b/scripts/migrate_entries_to_term_evidence.py
@@ -1,0 +1,199 @@
+"""One-shot script: wire wiki-entry references into terms' `evidence` lists.
+
+See docs/superpowers/specs/2026-05-08-entry-term-migrator-design.md.
+
+Run from repo root:
+    uv run python scripts/migrate_entries_to_term_evidence.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from execution import get_default_runner  # noqa: E402
+from repo_wiki import RepoWikiStore  # noqa: E402
+from term_proposer_llm import LLMClient  # noqa: E402
+from term_proposer_runtime import ClaudeCLIClient  # noqa: E402
+from ubiquitous_language import (  # noqa: E402
+    Term,
+    TermStore,
+)
+
+PROMPT_TEMPLATE = """You are matching a wiki knowledge entry to ubiquitous-language terms in HydraFlow.
+
+The entry below describes architecture, patterns, gotchas, testing, etc. It MAY reference one or more named domain concepts (the UL terms below) — or it may reference none. Return only the terms the entry GENUINELY discusses or relies on, not terms that just happen to share a name fragment.
+
+Existing UL terms:
+{term_lines}
+
+Wiki entry:
+{entry_body}
+
+Return a strict JSON object — no preamble, no markdown fences:
+{{"term_ids": ["<id1>", "<id2>", ...]}}
+
+term_ids MUST be a subset of the ids listed above. When in doubt, exclude.
+"""
+
+
+@dataclass(frozen=True)
+class EntryReference:
+    """A confirmed (entry_id → term_id) match from the LLM."""
+
+    entry_id: str
+    term_id: str
+
+
+def _build_prompt(entry_text: str, terms: list[Term]) -> str:
+    term_lines = "\n".join(
+        f"- id={t.id} name={t.name} ({t.kind.value}, {t.bounded_context.value}) — {t.definition[:200]}"
+        for t in terms
+    )
+    return PROMPT_TEMPLATE.format(term_lines=term_lines, entry_body=entry_text.strip())
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        raise RuntimeError(f"no JSON object in LLM output: {text[:200]}")
+    return json.loads(match.group(0))
+
+
+async def match_entry(
+    *,
+    llm: LLMClient,
+    entry_id: str,
+    entry_text: str,
+    terms: list[Term],
+    valid_term_ids: set[str],
+) -> list[EntryReference]:
+    """Return validated (entry → term) matches. Skip on LLM/parse error."""
+    prompt = _build_prompt(entry_text, terms)
+    try:
+        raw = await llm.complete_structured(prompt=prompt, schema={})
+    except (RuntimeError, json.JSONDecodeError) as exc:
+        logging.warning("LLM call failed for entry %s: %s", entry_id, exc)
+        return []
+    candidates = raw.get("term_ids") or []
+    return [
+        EntryReference(entry_id=entry_id, term_id=tid)
+        for tid in candidates
+        if isinstance(tid, str) and tid in valid_term_ids
+    ]
+
+
+def _walk_topic_files(wiki_root: Path) -> list[Path]:
+    out = []
+    for p in sorted(wiki_root.glob("*.md")):
+        if p.name == "index.md":
+            continue
+        out.append(p)
+    return out
+
+
+async def run_migration(
+    *, repo_root: Path, llm: LLMClient, dry_run: bool
+) -> dict[str, int]:
+    wiki_root = repo_root / "docs" / "wiki"
+    terms_root = wiki_root / "terms"
+    store = TermStore(terms_root)
+    terms = store.list()
+    valid_term_ids = {t.id for t in terms}
+
+    # `_load_topic_entries` is a method on RepoWikiStore (not a module-level
+    # function); the body operates only on the topic_path argument, so we
+    # construct a throwaway store rooted at wiki_root and call it as a bound
+    # method. This is the documented deviation from the plan.
+    wiki_store = RepoWikiStore(wiki_root)
+
+    topic_files = _walk_topic_files(wiki_root)
+    print(f"loaded {len(terms)} terms; scanning {len(topic_files)} topic files")
+
+    references: list[EntryReference] = []
+    entries_seen = 0
+    entries_unmatched = 0
+
+    for topic_path in topic_files:
+        entries = wiki_store._load_topic_entries(topic_path)  # noqa: SLF001
+        for entry in entries:
+            entries_seen += 1
+            refs = await match_entry(
+                llm=llm,
+                entry_id=entry.id,
+                entry_text=f"# {entry.title}\n\n{entry.content}",
+                terms=terms,
+                valid_term_ids=valid_term_ids,
+            )
+            if refs:
+                references.extend(refs)
+                print(f"  {entry.id} ({entry.title[:60]}) → {len(refs)} terms")
+            else:
+                entries_unmatched += 1
+
+    # Aggregate per-term
+    by_term: dict[str, set[str]] = {}
+    for ref in references:
+        by_term.setdefault(ref.term_id, set()).add(ref.entry_id)
+
+    # Apply set-difference (idempotence)
+    written = 0
+    edges_added = 0
+    for term in terms:
+        new_evidence = by_term.get(term.id, set())
+        if not new_evidence:
+            continue
+        existing = set(term.evidence or [])
+        delta = new_evidence - existing
+        if not delta:
+            continue
+        merged = sorted(existing | new_evidence)
+        data = term.model_dump()
+        data["evidence"] = merged
+        updated = Term.model_validate(data)
+        if not dry_run:
+            store.write(updated)
+        written += 1
+        edges_added += len(delta)
+
+    return {
+        "terms_loaded": len(terms),
+        "topic_files": len(topic_files),
+        "entries_seen": entries_seen,
+        "entries_unmatched": entries_unmatched,
+        "references_total": len(references),
+        "terms_written": written,
+        "edges_added": edges_added,
+    }
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--model", default="claude-sonnet-4-5")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
+
+    runner = get_default_runner()
+    llm: LLMClient = ClaudeCLIClient(runner=runner, model=args.model)
+
+    stats = await run_migration(repo_root=REPO_ROOT, llm=llm, dry_run=args.dry_run)
+    print("\n=== summary ===")
+    for k, v in stats.items():
+        print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_migrate_entries_to_term_evidence.py
+++ b/tests/test_migrate_entries_to_term_evidence.py
@@ -1,0 +1,138 @@
+"""Tests for the entry→term evidence migration script."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make scripts/ importable
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+from migrate_entries_to_term_evidence import (  # noqa: E402
+    EntryReference,
+    match_entry,
+    run_migration,
+)
+
+from ubiquitous_language import (  # noqa: E402
+    BoundedContext,
+    Term,
+    TermKind,
+    TermStore,
+)
+
+
+class FakeLLM:
+    def __init__(self, responses: list[dict]) -> None:
+        self.responses = list(responses)
+        self.calls: list[str] = []
+
+    async def complete_structured(self, *, prompt, schema):
+        self.calls.append(prompt)
+        return self.responses.pop(0) if self.responses else {"term_ids": []}
+
+
+def _make_term(name: str, term_id: str, evidence=None) -> Term:
+    return Term(
+        id=term_id,
+        name=name,
+        kind=TermKind.SERVICE,
+        bounded_context=BoundedContext.SHARED_KERNEL,
+        definition=f"{name} is a test term used in the migrator's fixture corpus.",
+        code_anchor=f"src/{name.lower()}.py:{name}",
+        confidence="accepted",
+        evidence=evidence or [],
+    )
+
+
+class TestMatchEntry:
+    @pytest.mark.asyncio
+    async def test_returns_validated_references(self) -> None:
+        llm = FakeLLM([{"term_ids": ["01H_T1", "01H_T2"]}])
+        refs = await match_entry(
+            llm=llm,
+            entry_id="01H_E1",
+            entry_text="entry text",
+            terms=[_make_term("Alpha", "01H_T1"), _make_term("Bravo", "01H_T2")],
+            valid_term_ids={"01H_T1", "01H_T2"},
+        )
+        assert len(refs) == 2
+        assert refs[0].entry_id == "01H_E1"
+        assert {r.term_id for r in refs} == {"01H_T1", "01H_T2"}
+
+    @pytest.mark.asyncio
+    async def test_filters_invalid_ids(self) -> None:
+        llm = FakeLLM([{"term_ids": ["01H_T1", "01H_BOGUS"]}])
+        refs = await match_entry(
+            llm=llm,
+            entry_id="01H_E1",
+            entry_text="x",
+            terms=[_make_term("A", "01H_T1")],
+            valid_term_ids={"01H_T1"},
+        )
+        assert {r.term_id for r in refs} == {"01H_T1"}
+
+    @pytest.mark.asyncio
+    async def test_empty_term_ids_returns_no_refs(self) -> None:
+        llm = FakeLLM([{"term_ids": []}])
+        refs = await match_entry(
+            llm=llm,
+            entry_id="01H_E1",
+            entry_text="x",
+            terms=[_make_term("A", "01H_T1")],
+            valid_term_ids={"01H_T1"},
+        )
+        assert refs == []
+
+    @pytest.mark.asyncio
+    async def test_llm_failure_skips_entry(self) -> None:
+        class FailingLLM:
+            async def complete_structured(self, *, prompt, schema):
+                raise RuntimeError("boom")
+
+        refs = await match_entry(
+            llm=FailingLLM(),
+            entry_id="01H_E1",
+            entry_text="x",
+            terms=[_make_term("A", "01H_T1")],
+            valid_term_ids={"01H_T1"},
+        )
+        assert refs == []
+
+
+class TestRunMigration:
+    @pytest.mark.asyncio
+    async def test_idempotent_set_difference(self, tmp_path: Path) -> None:
+        # Term with evidence already containing entry-id
+        terms_dir = tmp_path / "docs" / "wiki" / "terms"
+        terms_dir.mkdir(parents=True)
+        store = TermStore(terms_dir)
+        store.write(_make_term("Alpha", "01H_T1", evidence=["01H_E1"]))
+
+        # Topic file with one entry
+        wiki_root = tmp_path / "docs" / "wiki"
+        topic_path = wiki_root / "patterns.md"
+        topic_path.write_text(
+            "# Patterns\n\n## A pattern\n\nSome content.\n\n"
+            "```json:entry\n"
+            '{"id":"01H_E1","title":"A pattern","topic":null,"source_type":"manual",'
+            '"source_issue":null,"source_repo":null,"created_at":"2026-01-01T00:00:00+00:00",'
+            '"updated_at":"2026-01-01T00:00:00+00:00","valid_to":null,"superseded_by":null,'
+            '"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}'
+            "\n```\n"
+        )
+
+        # LLM returns the same term_id; should be deduped
+        llm = FakeLLM([{"term_ids": ["01H_T1"]}])
+        stats = await run_migration(repo_root=tmp_path, llm=llm, dry_run=False)
+        assert stats["terms_written"] == 0  # already had this evidence — idempotent
+        assert stats["edges_added"] == 0
+
+
+def test_entry_reference_is_a_frozen_dataclass() -> None:
+    """Smoke check on the dataclass shape — keeps the import surface honest."""
+    ref = EntryReference(entry_id="01H_E1", term_id="01H_T1")
+    assert ref.entry_id == "01H_E1"
+    assert ref.term_id == "01H_T1"


### PR DESCRIPTION
## Summary

Final item of the self-maintaining-ontology program close-out. Adds \`scripts/migrate_entries_to_term_evidence.py\` — an operator-run one-shot script that scans the 293 existing wiki entries, asks the LLM which UL terms each entry references, and appends entry ids to those terms' \`evidence\` lists.

This is **item 4 of 4** (final). Items 1-3 already merged: #8706 (CI fix), #8707 (Term-Pruner), #8708 (Edge-Proposer).

## What ships

- \`scripts/migrate_entries_to_term_evidence.py\` — uses chunk-2.5's \`ClaudeCLIClient\` and chunk-1's \`_load_topic_entries\`. Idempotent (set-difference at runtime). Supports \`--dry-run\`.
- \`tests/test_migrate_entries_to_term_evidence.py\` — 6 unit tests (validated references, invalid-id filtering, empty-result, LLM-failure fallback, end-to-end idempotence on fixture corpus, dataclass smoke).

## Why no loop

This is a one-shot operation, not a pattern. New entries flowing through \`RepoWikiLoop\` (chunk 1) will reference terms naturally going forward; this script is for the historical 293-entry corpus that predates the UL artifact.

## Operator workflow (post-merge)

1. Pull main on a clean tree
2. \`uv run python scripts/migrate_entries_to_term_evidence.py --dry-run\` — see proposed diffs
3. If sane, run without \`--dry-run\`
4. Inspect \`git diff docs/wiki/terms/\`
5. Open a separate PR with the migration result for review

Cost: ~293 LLM calls × small prompts ≈ $1-3 of inference. Single run.

## Test plan

- [x] 6 unit tests pass
- [x] ruff + pyright clean
- [x] No source-tree changes other than the new script + tests

## Notable deviation from spec

\`_load_topic_entries\` is a method on \`RepoWikiStore\` (not module-level). Script constructs a throwaway \`RepoWikiStore(wiki_root)\` to invoke it. \`# noqa: SLF001\` on the private-member access; documented in commit message.

## Program closeout

After this merges, the four-loop fleet is complete:
- \`TermProposerLoop\` (auto-grow) — ADR-0054
- \`TermPrunerLoop\` (auto-deprecate) — ADR-0057
- \`EdgeProposerLoop\` (auto-densify graph) — ADR-0058
- (Confidence-Promoter collapsed into TermProposerLoop's \`accepted\`-direct shipping)

Plus the historical migrator from this PR. The dark-factory glossary is fully self-maintaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)