### PR TITLE
chore: bump version to 0.9.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["ui*", "templates*", "tests*"]
 
 [project]
 name = "hydraflow"
-version = "0.9.2"
+version = "0.9.3"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "pydantic>=2.0.0",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,4 +3,4 @@
 Canonical repository slug: ``T-rav/hyrdaflow``.
 """
 
-__version__ = "0.9.2"
+__version__ = "0.9.3"

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "hydraflow"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary

Bumps the canonical version from \`0.9.2\` → \`0.9.3\`.

- \`pyproject.toml\` \`project.version\`
- \`src/__init__.py\` \`__version__\`
- \`uv.lock\` auto-resolved hydraflow self-reference

## Untouched

The fixture in \`tests/test_dashboard_routes_control.py\` keeps the \`current_version=0.9.1, latest_version=0.9.2\` scenario as deliberate "update-available" test data, decoupled from the canonical version. No reason to drift it forward each bump.

## Test plan

- [x] \`from src import __version__\` returns \`"0.9.3"\`
- [x] \`tests/test_dashboard_routes_control.py\` — 42 cases pass (covers the version-display path)
- [ ] \`make quality\` running in parallel; will confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)