### PR TITLE
fix(scenarios): cross-platform Playwright browsers cache path

### DIFF
--- a/tests/scenarios/browser/conftest.py
+++ b/tests/scenarios/browser/conftest.py
@@ -39,6 +39,7 @@ PLAYWRIGHT_BROWSERS_PATH when starting the driver.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -48,10 +49,33 @@ from tests.scenarios.fakes.mock_world import MockWorld
 
 pytestmark = pytest.mark.scenario_browser
 
-# Captured at import time, before HOME is overridden.
-_REAL_PLAYWRIGHT_BROWSERS_PATH: str = str(
-    Path.home() / "Library" / "Caches" / "ms-playwright"
-)
+
+def _platform_playwright_browsers_path() -> Path:
+    """Return Playwright's platform-default browsers cache path.
+
+    macOS: ``~/Library/Caches/ms-playwright``
+    Linux: ``~/.cache/ms-playwright``
+    Windows: ``%LOCALAPPDATA%\\ms-playwright``
+
+    A pre-set ``PLAYWRIGHT_BROWSERS_PATH`` env var wins over the default,
+    matching Playwright's own discovery rules.
+    """
+    explicit = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
+    if explicit:
+        return Path(explicit)
+    home = Path.home()
+    if sys.platform == "darwin":
+        return home / "Library" / "Caches" / "ms-playwright"
+    if sys.platform == "win32":
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        if local_appdata:
+            return Path(local_appdata) / "ms-playwright"
+        return home / "AppData" / "Local" / "ms-playwright"
+    return home / ".cache" / "ms-playwright"
+
+
+# Captured at import time, before HOME is overridden by the root conftest.
+_REAL_PLAYWRIGHT_BROWSERS_PATH: str = str(_platform_playwright_browsers_path())
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

\`tests/scenarios/browser/conftest.py\` hardcoded the macOS-only \`~/Library/Caches/ms-playwright\` path. On Linux CI runners that path doesn't exist, so Playwright fails to find Chromium even after the workflow's \`uv run python -m playwright install\` step (which installs to the platform-correct \`~/.cache/ms-playwright\`).

## Symptom

Every Browser Scenarios run on rc/* promotion PRs failed with:

\`\`\`
playwright._impl._errors.Error: BrowserType.launch:
Executable doesn't exist at /home/runner/Library/Caches/ms-playwright/chromium_headless_shell-1208/...
\`\`\`

Browser Scenarios is a required-status-check on the \`main\` ruleset, so this silently blocked **every** RC promotion to main. PR #8491 (Promote rc/2026-05-07-0648 → main) was the visible symptom.

## Fix

Replaced the hardcoded macOS path with a small \`_platform_playwright_browsers_path()\` helper that:

1. Honors a pre-set \`PLAYWRIGHT_BROWSERS_PATH\` env var (matches Playwright's own discovery)
2. macOS → \`~/Library/Caches/ms-playwright\`
3. Linux → \`~/.cache/ms-playwright\`
4. Windows → \`%LOCALAPPDATA%\\ms-playwright\`

## Why this stayed broken

Browser Scenarios was historically required but never reliably bound to PR head SHAs (workflow-trigger bug, tracked as #8705). When I dropped it from required-checks last night to unblock #8491, I inadvertently masked this real test bug too. After restoring required-checks, the failure surfaced — which led to this fix.

## Test plan

- [x] Local \`from tests.scenarios.browser.conftest import _REAL_PLAYWRIGHT_BROWSERS_PATH\` returns \`/Users/.../Library/Caches/ms-playwright\` on macOS dev.
- [ ] CI Browser Scenarios on this PR will run (once it triggers on this branch — note that Browser Scenarios fires only on rc/\\* head, so it'll pass through CI on regular workflows here, then will be re-validated on the next RC promotion).
- [ ] Watch next RC promotion PR's Browser Scenarios go green.

## Related

- #8705 — workflow-trigger binding bug (separate fix; rc/* PRs from StagingPromotionLoop don't fire workflows on \`opened\`, only on \`synchronize\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)