### PR TITLE
fix(staging-promotion): trigger CI on rc/* PRs via synthetic commit (closes #8705)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-07T04:25:30.887595+00:00",
-  "commit_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e",
+  "regenerated_at": "2026-05-08T02:24:29.475066+00:00",
+  "commit_sha": "932466f9889cda358560f4c1d4111914904b71d4",
   "artifacts": {
     "loops.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "ports.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "labels.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "modules.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "events.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "adr_xref.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "mockworld.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "changelog.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     },
     "functional_areas.md": {
-      "source_sha": "06c3e70f313e52c6848cf7b3b42108071f908b3e"
+      "source_sha": "932466f9889cda358560f4c1d4111914904b71d4"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -164,4 +164,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `c681459` — feat(pr): caretaker-loops spec + plan + update_pr_base port method (#8489) (#8489) *(2026-05-07)*
 - `cdb1a31` — feat(testing): document HydraFlow test pyramid + add missing layers for #8482 (#8486) (#8486) *(2026-05-07)*
 - `dd9ce56` — feat(pr): rebase-on-conflict for process-driven merges (#8482) (#8482) *(2026-05-06)*
 - `06c3e70` — feat(staging): activate two-tier branch model + repeatable branch-protection standard (#8479) (#8479) *(2026-05-06)*
@@ -170,4 +171,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -261,4 +261,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -43,4 +43,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -62,7 +62,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `07b3227` on 2026-05-07 06:35 UTC. Source last changed at `07b3227`. Status: 🟢 fresh._
+_Regenerated from commit `932466f` on 2026-05-08 02:24 UTC. Source last changed at `932466f`. Status: 🟢 fresh._

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -617,6 +617,12 @@ class FakeGitHub:
     async def create_rc_branch(self, rc_branch: str) -> str:
         return f"sha-{rc_branch}"
 
+    async def push_synthetic_commit(self, branch: str, message: str) -> str:
+        """Record a synthetic commit; deterministic SHA in scenarios."""
+        _ = (message,)
+        self._maybe_rate_limit()
+        return f"synthetic-sha-{branch}"
+
     async def create_promotion_pr(
         self, *, rc_branch: str, title: str, body: str, **_kw: Any
     ) -> int:

--- a/src/ports.py
+++ b/src/ports.py
@@ -136,6 +136,21 @@ class PRPort(Protocol):
         """
         ...
 
+    async def push_synthetic_commit(self, branch: str, message: str) -> str:
+        """Append a tree-identical synthetic commit on top of *branch*.
+
+        Used by ``StagingPromotionLoop`` to trigger
+        ``pull_request: synchronize`` events on rc/* PRs whose
+        ``pull_request: opened`` events were swallowed by GitHub's
+        bot-PR workflow-suppression heuristic (see issue #8705).
+        Without this, required-status-checks like CodeQL and Browser
+        Scenarios never fire on the PR head SHA, blocking auto-merge.
+
+        Returns the new HEAD SHA. Matches
+        ``pr_manager.PRManager.push_synthetic_commit`` exactly.
+        """
+        ...
+
     async def create_promotion_pr(
         self,
         *,

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -468,6 +468,84 @@ class PRManager:
         )
         return sha
 
+    async def push_synthetic_commit(self, branch: str, message: str) -> str:
+        """Append a tree-identical synthetic commit on top of *branch*.
+
+        Workaround for issue #8705: rc/* branches created via the git/refs
+        REST API and turned into PRs by ``gh pr create`` don't fire
+        ``pull_request: opened`` workflows reliably (CodeQL, Browser
+        Scenarios, etc. never run on the PR head SHA). Pushing a
+        synthetic commit fires ``pull_request: synchronize`` which DOES
+        trigger workflows. The commit's tree is identical to its parent
+        so no real changes are introduced.
+
+        Returns the new HEAD SHA.
+        """
+        if self._config.dry_run:
+            logger.info(
+                "[dry-run] Would push synthetic commit on %s: %s", branch, message
+            )
+            return "dry-run-sha"
+        self._assert_repo()
+
+        head_raw = await self._run_gh(
+            "gh",
+            "api",
+            f"repos/{self._repo}/git/refs/heads/{branch}",
+            "--jq",
+            ".object.sha",
+        )
+        head_sha = head_raw.strip().strip('"')
+        if not head_sha:
+            raise RuntimeError(f"Could not resolve {branch} HEAD sha")
+
+        tree_raw = await self._run_gh(
+            "gh",
+            "api",
+            f"repos/{self._repo}/git/commits/{head_sha}",
+            "--jq",
+            ".tree.sha",
+        )
+        tree_sha = tree_raw.strip().strip('"')
+        if not tree_sha:
+            raise RuntimeError(f"Could not resolve tree sha for {head_sha}")
+
+        new_raw = await self._run_gh(
+            "gh",
+            "api",
+            f"repos/{self._repo}/git/commits",
+            "--method",
+            "POST",
+            "--field",
+            f"message={message}",
+            "--field",
+            f"tree={tree_sha}",
+            "--raw-field",
+            f"parents[]={head_sha}",
+        )
+        try:
+            new_commit = json.loads(new_raw)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Unexpected synthetic-commit POST response: {new_raw[:200]}"
+            ) from exc
+        new_sha = str(new_commit.get("sha", "")).strip()
+        if not new_sha:
+            raise RuntimeError(
+                f"Synthetic commit POST returned no sha: {new_raw[:200]}"
+            )
+
+        await self._run_gh(
+            "gh",
+            "api",
+            f"repos/{self._repo}/git/refs/heads/{branch}",
+            "--method",
+            "PATCH",
+            "--field",
+            f"sha={new_sha}",
+        )
+        return new_sha
+
     async def find_open_promotion_pr(self) -> PRInfo | None:
         """Return the open ``rc/*`` promotion PR targeting ``main_branch``, or None.
 

--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -170,6 +170,25 @@ class StagingPromotionLoop(BaseBackgroundLoop):
             logger.exception("Failed to open promotion PR for %s", rc_branch)
             return {"status": "promotion_pr_failed", "rc_branch": rc_branch}
 
+        # Workaround for issue #8705: PRs whose head branch was created
+        # via the git/refs API don't reliably fire pull_request:opened
+        # workflows (CodeQL, Browser Scenarios, etc.). Push a synthetic
+        # commit to fire pull_request:synchronize, which does trigger
+        # workflows — required-status-checks then bind to the PR head SHA
+        # and the auto-merge path can complete.
+        try:
+            await self._prs.push_synthetic_commit(
+                rc_branch,
+                f"chore(rc): trigger CI for {rc_branch} promotion PR (#{pr_number})",
+            )
+        except RuntimeError:
+            logger.warning(
+                "Failed to push synthetic CI-trigger commit on %s; "
+                "workflows may not fire automatically — see issue #8705",
+                rc_branch,
+                exc_info=True,
+            )
+
         self._record_last_rc(now)
         logger.info("Opened promotion PR #%d for %s", pr_number, rc_branch)
         return {"status": "opened", "pr": pr_number, "rc_branch": rc_branch}

--- a/tests/scenarios/test_caretaker_loops_part2.py
+++ b/tests/scenarios/test_caretaker_loops_part2.py
@@ -485,6 +485,7 @@ class TestL22StagingPromotionLoop:
         prs.find_open_promotion_pr = AsyncMock(return_value=None)
         prs.create_rc_branch = AsyncMock(return_value="sha-abc")
         prs.create_promotion_pr = AsyncMock(return_value=42)
+        prs.push_synthetic_commit = AsyncMock(return_value="synthetic-sha")
         prs.wait_for_ci = AsyncMock(return_value=(True, "all green"))
 
         return StagingPromotionLoop(config=config, prs=prs, deps=deps), prs, config

--- a/tests/test_staging_promotion_loop.py
+++ b/tests/test_staging_promotion_loop.py
@@ -67,6 +67,7 @@ def _make_loop(
     prs.close_issue = AsyncMock()
     prs.create_rc_branch = AsyncMock(return_value="sha123")
     prs.create_promotion_pr = AsyncMock(return_value=42)
+    prs.push_synthetic_commit = AsyncMock(return_value="synthetic-sha-rc")
     prs.create_issue = AsyncMock(return_value=1234)
     prs.list_rc_branches = AsyncMock(return_value=[])
     prs.delete_branch = AsyncMock(return_value=True)
@@ -119,6 +120,15 @@ class TestCadenceGate:
         assert result["pr"] == 42
         prs.create_rc_branch.assert_called_once()
         prs.create_promotion_pr.assert_called_once()
+        # Workflow-trigger workaround for #8705: synthetic commit is pushed
+        # AFTER PR creation so pull_request:synchronize fires the workflows
+        # that pull_request:opened doesn't.
+        prs.push_synthetic_commit.assert_called_once()
+        rc_arg = prs.push_synthetic_commit.call_args.args[0]
+        assert rc_arg.startswith("rc/")
+        msg_arg = prs.push_synthetic_commit.call_args.args[1]
+        assert "trigger CI" in msg_arg
+        assert "(#42)" in msg_arg
 
     @pytest.mark.asyncio
     async def test_cuts_rc_on_first_run_no_timestamp(


### PR DESCRIPTION
## Summary

Closes #8705. PRs whose head branch was created via the git/refs REST API and turned into PRs by \`gh pr create\` don't reliably fire \`pull_request: opened\` workflows. CodeQL, Browser Scenarios, RC Promotion Scenario suite, and the rc/* Sandbox job all skipped firing on rc/* promotion PRs. Result: required-status-checks never bound to PR head SHAs → auto-merge blocked indefinitely.

**Zero rc/* PRs ever merged through the dark-factory path before this fix** — until I manually pushed an empty commit on PR #8491 which fired \`pull_request: synchronize\` and lit up the missing checks. This PR automates that workaround.

## Fix

After \`create_promotion_pr\` returns, push a tree-identical synthetic commit on top of the rc/* branch via GitHub's \`git/commits\` + \`git/refs\` APIs. The commit's tree matches its parent (no real changes) but the SHA differs, firing \`pull_request: synchronize\` which DOES trigger workflows reliably.

## Files

- \`src/ports.py\` — new \`PRPort.push_synthetic_commit(branch, message) -> str\`
- \`src/pr_manager.py\` — concrete impl using \`gh api\`
- \`src/staging_promotion_loop.py\` — call after \`create_promotion_pr\`; warn but don't fail the cycle if the trigger push fails (PR still valid, just won't auto-fire CI)
- \`src/mockworld/fakes/fake_github.py\` — fake conformance
- \`tests/test_staging_promotion_loop.py\` — regression test asserting the synthetic commit fires post-create with PR number in message
- Generated arch docs regenerated

## Test plan

- [x] \`make quality\` clean: 12,062 passed
- [x] Regression test asserts \`push_synthetic_commit\` is called once post-PR-create with the rc/* branch + a message containing \"trigger CI\" and \"(#<pr>)\"
- [ ] Verify on next StagingPromotionLoop tick: rc/* PR opens AND CodeQL + Browser Scenarios + Sandbox + Trust Gate all fire and bind to the PR head SHA without manual intervention.

## Why not fix the workflow files themselves

The workflows are configured correctly (\`pull_request: branches: [main]\` + appropriate job \`if\` conditions). The bug is in how the PR is *created* — GitHub suppresses downstream workflow triggers when the creating actor's token+context matches bot-loop-prevention heuristics. The synthetic-commit workaround sidesteps this entirely without needing to debug GitHub's suppression internals.

Together with #8711 (Playwright cross-platform cache fix), this restores the dark-factory RC chain end-to-end:

\`\`\`
PRs → staging (full CI) → StagingPromotionLoop cuts rc/<date>
   → synthetic-commit poke fires all workflows
   → required-status-checks bind to PR head SHA
   → auto-merge to main when all green
   → StagingBisectLoop watches; auto-reverts on red
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)