### PR TITLE
fix(implement): don't publish PRs for failed fresh attempts

### DIFF
--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -727,3 +727,40 @@ Example: Hook fails → fix code → try commit again, not `git commit --no-veri
 ```json:entry
 {"id":"01KQP0HK6TCK1CTRYANSJ8NRTN","title":"Never use git commit --no-verify or --no-hooks","topic":null,"source_type":"compiled","source_issue":null,"source_repo":null,"created_at":"2026-05-03T04:11:32.954849+00:00","updated_at":"2026-05-03T04:11:32.954849+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"medium","stale":false,"corroborations":1}
 ```
+
+
+### Implement-phase: never publish work for `result.success is False`
+
+**Pattern:** A blocking post-implementation skill (`discover-completeness`,
+`scope-check`, `diff-sanity`) trips. The agent returns
+`WorkerResult(success=False, commits=2)`. The implement-phase pushes the
+branch and opens a PR, but the swap to `hydraflow-review` is gated on
+`result.success` — so the PR sits unlabeled and the issue stays at
+`hydraflow-ready`. ADR-0002's "one pipeline label per item" invariant
+holds for each entity in isolation, but the *pair* drifts.
+
+**Rule:** In `_handle_implementation_result` and `_handle_successful_push`,
+gate `push_branch`, `_resolve_pr`, and `transition` on
+`(result.success or is_retry)`. Fresh failed attempts never touch GitHub —
+the attempt-cap mechanism retries with `prior_failure` feedback (which
+also resets the worktree, discarding partial commits).
+
+**Diagnostic signal:** open issues at `hydraflow-ready` whose
+`agent/issue-N` branch has an open non-draft PR.
+
+```json:entry
+{
+  "id": "implement-phase-half-state-on-skill-failure",
+  "topic": "implement_phase",
+  "tags": ["state-machine", "ADR-0002", "skill-failure", "label-drift"],
+  "rule": "Gate push_branch, _resolve_pr, and transition on (result.success or is_retry).",
+  "anti_pattern": "Calling push_branch or create_pr regardless of result.success",
+  "code_refs": [
+    "src/implement_phase.py:_handle_implementation_result",
+    "src/implement_phase.py:_handle_successful_push",
+    "src/implement_phase.py:_resolve_pr"
+  ],
+  "fixed_in_pr": "TBD",
+  "added": "2026-05-07"
+}
+```

--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -760,7 +760,7 @@ also resets the worktree, discarding partial commits).
     "src/implement_phase.py:_handle_successful_push",
     "src/implement_phase.py:_resolve_pr"
   ],
-  "fixed_in_pr": "TBD",
+  "fixed_in_pr": "#8713",
   "added": "2026-05-07"
 }
 ```

--- a/scripts/sync_implement_state.py
+++ b/scripts/sync_implement_state.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""One-shot fleet sync for implement-phase + pr_unsticker drift.
+
+Modes:
+  --mode issue-side  (default) — issues at hydraflow-ready whose PR exists
+                                 with commits → swap both to hydraflow-review.
+  --mode pr-side                — PRs at hydraflow-ready that have commits →
+                                 swap PR to hydraflow-review (issue is left
+                                 at whatever the operator put it at).
+  --mode all                    — both modes in sequence.
+
+Idempotent: re-running is a no-op once the fleet is reconciled.
+
+Usage:
+    python scripts/sync_implement_state.py --repo T-rav/hydraflow [--mode all] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class StuckPair:
+    issue: int
+    pr: int
+    pr_commits: int
+
+
+@dataclass
+class StuckPR:
+    pr: int
+    pr_commits: int
+
+
+def _gh(repo: str, *args: str) -> str:
+    return subprocess.run(
+        ["gh", *args, "--repo", repo],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def find_stuck_issues(repo: str) -> list[StuckPair]:
+    issues_json = _gh(
+        repo,
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--label",
+        "hydraflow-ready",
+        "--limit",
+        "200",
+        "--json",
+        "number",
+    )
+    issues = [i["number"] for i in json.loads(issues_json)]
+    out: list[StuckPair] = []
+    for n in issues:
+        prs_json = _gh(
+            repo,
+            "pr",
+            "list",
+            "--head",
+            f"agent/issue-{n}",
+            "--state",
+            "open",
+            "--json",
+            "number,isDraft,commits",
+        )
+        prs = json.loads(prs_json)
+        if not prs:
+            continue
+        pr = prs[0]
+        commits = len(pr.get("commits") or [])
+        if pr["isDraft"] or commits == 0:
+            continue
+        out.append(StuckPair(issue=n, pr=pr["number"], pr_commits=commits))
+    return out
+
+
+def find_stuck_prs(repo: str) -> list[StuckPR]:
+    # GraphQL aggregate-node limit is hit if we ask for `commits` across all
+    # matching PRs at once. Fetch the lightweight (number, isDraft) shape
+    # first, then resolve commits per PR.
+    prs_json = _gh(
+        repo,
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--label",
+        "hydraflow-ready",
+        "--limit",
+        "200",
+        "--json",
+        "number,isDraft",
+    )
+    prs = json.loads(prs_json)
+    out: list[StuckPR] = []
+    for pr in prs:
+        if pr["isDraft"]:
+            continue
+        try:
+            view_json = _gh(repo, "pr", "view", str(pr["number"]), "--json", "commits")
+        except subprocess.CalledProcessError:
+            continue
+        commits = len(json.loads(view_json).get("commits") or [])
+        if commits == 0:
+            continue
+        out.append(StuckPR(pr=pr["number"], pr_commits=commits))
+    return out
+
+
+def reconcile_pair(repo: str, p: StuckPair, *, dry_run: bool) -> None:
+    if dry_run:
+        print(
+            f"[dry-run] swap #{p.issue} ready→review (PR #{p.pr}, {p.pr_commits} commits)"
+        )
+        return
+    for kind, num in (("issue", p.issue), ("pr", p.pr)):
+        _gh(repo, kind, "edit", str(num), "--add-label", "hydraflow-review")
+        _gh(repo, kind, "edit", str(num), "--remove-label", "hydraflow-ready")
+    print(f"[ok] swapped #{p.issue} ↔ PR #{p.pr} → review")
+
+
+def reconcile_pr(repo: str, p: StuckPR, *, dry_run: bool) -> None:
+    if dry_run:
+        print(f"[dry-run] swap PR #{p.pr} ready→review ({p.pr_commits} commits)")
+        return
+    _gh(repo, "pr", "edit", str(p.pr), "--add-label", "hydraflow-review")
+    _gh(repo, "pr", "edit", str(p.pr), "--remove-label", "hydraflow-ready")
+    print(f"[ok] swapped PR #{p.pr} → review")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/name")
+    parser.add_argument(
+        "--mode", choices=["issue-side", "pr-side", "all"], default="issue-side"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    if shutil.which("gh") is None:
+        print("error: gh CLI not on PATH", file=sys.stderr)
+        return 2
+
+    issue_pairs: list[StuckPair] = []
+    pr_only: list[StuckPR] = []
+
+    if args.mode in ("issue-side", "all"):
+        issue_pairs = find_stuck_issues(args.repo)
+    if args.mode in ("pr-side", "all"):
+        pr_only = find_stuck_prs(args.repo)
+
+    if not issue_pairs and not pr_only:
+        print("fleet is clean — no drift found")
+        return 0
+
+    print(f"found {len(issue_pairs)} issue-side pair(s), {len(pr_only)} PR-side")
+    for p in issue_pairs:
+        print(f"  issue #{p.issue} ↔ PR #{p.pr} ({p.pr_commits} commits)")
+    for p in pr_only:
+        print(f"  PR #{p.pr} alone ({p.pr_commits} commits)")
+
+    if args.dry_run:
+        print("\nrun without --dry-run to apply.")
+        return 0
+
+    for p in issue_pairs:
+        try:
+            reconcile_pair(args.repo, p, dry_run=False)
+        except subprocess.CalledProcessError as e:
+            print(f"  [fail] #{p.issue}: {e.stderr.strip()}", file=sys.stderr)
+    for p in pr_only:
+        try:
+            reconcile_pr(args.repo, p, dry_run=False)
+        except subprocess.CalledProcessError as e:
+            print(f"  [fail] PR #{p.pr}: {e.stderr.strip()}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -618,7 +618,13 @@ class ImplementPhase:
         if self._is_zero_commit_failure(result):
             return await self._handle_zero_commits(issue, result)
 
-        if result.workspace_path:
+        # Fresh failed attempts skip the push entirely — partial commits
+        # never land on origin, so there is no orphan branch and no
+        # opportunity for _handle_successful_push to drift state.
+        # Cycling retries reset the worktree to main, discarding partial
+        # commits anyway. Retries with review feedback push so the
+        # existing PR sees the iteration.
+        if result.workspace_path and (result.success or is_retry):
             pushed = await self._prs.push_branch(
                 Path(result.workspace_path), result.branch
             )
@@ -629,7 +635,6 @@ class ImplementPhase:
                 if early_return is not None:
                     return early_return
 
-        # Post-implementation: flag any requirements gaps discovered
         if result.success and result.transcript:
             await self._flag_requirements_gaps(issue, result.transcript)
 
@@ -725,7 +730,16 @@ class ImplementPhase:
         outcome is fully resolved (PR-less failure or zero-diff escalation).
         Returns ``None`` when the caller should continue to the final
         status-marking step.
+
+        On a fresh attempt with ``result.success`` False, returns ``None``
+        without resolving a PR. Creating a PR for failed work caused
+        state-machine drift: the issue stayed at ``hydraflow-ready`` while
+        the PR sat unlabeled. The attempt-cap mechanism retries with
+        ``prior_failure`` feedback. Retry path is unchanged.
         """
+        if not result.success and not is_retry:
+            return None
+
         pr = await self._resolve_pr(issue, result, is_retry)
 
         if result.success and (pr is None or pr.number <= 0):

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -2510,7 +2510,13 @@ class TestHandleSuccessfulPush:
     async def test_returns_none_when_push_succeeds_but_agent_failed(
         self, config: HydraFlowConfig
     ) -> None:
-        """When push succeeds but result.success=False, no PR actions fire and None is returned."""
+        """When result.success=False on a fresh attempt, no PR is opened.
+
+        Previously this asserted create_pr was awaited (encoding the
+        half-state bug). After the half-state fix, _handle_successful_push
+        bails before _resolve_pr when the implementation failed and we
+        are not on a retry path.
+        """
         issue = TaskFactory.create()
         result = WorkerResultFactory.create(
             issue_number=42,
@@ -2524,9 +2530,9 @@ class TestHandleSuccessfulPush:
 
         early = await phase._handle_successful_push(issue, result, is_retry=False)
 
-        assert early is None  # no early return — caller handles status marking
+        assert early is None
         mock_prs.transition.assert_not_awaited()
-        mock_prs.create_pr.assert_awaited_once()  # PR is still resolved
+        mock_prs.create_pr.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -183,10 +183,16 @@ class TestImplementIncludesPush:
         assert results[0].pr_info.number == 101
 
     @pytest.mark.asyncio
-    async def test_worker_creates_full_pr_on_failure(
+    async def test_worker_does_not_create_pr_on_fresh_failure(
         self, config: HydraFlowConfig
     ) -> None:
-        """When agent fails, PR should still be created as a full (non-draft) PR."""
+        """Fresh attempts that fail must NOT create a PR (state-machine fix).
+
+        Previously this asserted ``create_pr`` was awaited with a non-draft
+        flag, encoding the half-state bug where failed work still landed as
+        a PR with no label transition. After the fix, fresh failures skip
+        push/PR entirely; the attempt-cap mechanism retries.
+        """
         issue = TaskFactory.create()
 
         phase, _, mock_prs = make_implement_phase(
@@ -198,8 +204,7 @@ class TestImplementIncludesPush:
 
         await phase.run_batch()
 
-        call_kwargs = mock_prs.create_pr.call_args
-        assert "draft" not in (call_kwargs.kwargs or {})
+        mock_prs.create_pr.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_worker_no_pr_when_push_fails(self, config: HydraFlowConfig) -> None:

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -2694,4 +2694,105 @@ class TestRetryPrTitleConsistency:
 
         assert pr is not None
         assert pr.number == 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: blocking-skill failure must NOT create a PR or push branch.
+# See docs/superpowers/plans/2026-05-07-implement-phase-state-machine-drift-remediation.md
+# ---------------------------------------------------------------------------
+
+
+class TestBlockingSkillFailureDoesNotCreatePR:
+    """Fresh attempts that fail a blocking skill must not push/PR.
+
+    Before this fix, ``_handle_implementation_result`` would push the
+    branch and ``_handle_successful_push._resolve_pr`` would open a PR
+    regardless of ``result.success``. The swap to ``hydraflow-review``
+    was gated on success, leaving a PR on GitHub with no corresponding
+    label transition — a state-machine half-state.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fresh_attempt_with_skill_failure_skips_push_and_pr(
+        self, config: HydraFlowConfig
+    ) -> None:
+        issue = TaskFactory.create(id=7653)
+        wt_path = config.workspace_path_for_issue(7653)
+        result = WorkerResultFactory.create(
+            issue_number=7653,
+            success=False,
+            error="discover-completeness failed: missing-section:intent",
+            commits=2,
+            workspace_path=str(wt_path),
+        )
+
+        phase, _, mock_prs = make_implement_phase(
+            config, [issue], create_pr_return=PRInfoFactory.create()
+        )
+
+        final = await phase._handle_implementation_result(issue, result, is_retry=False)
+
+        mock_prs.push_branch.assert_not_awaited()
+        mock_prs.create_pr.assert_not_awaited()
+        mock_prs.transition.assert_not_awaited()
+        assert final.success is False
+        assert final.error and "discover-completeness" in final.error
+
+    @pytest.mark.asyncio
+    async def test_retry_with_skill_failure_pushes_but_does_not_create_pr(
+        self, config: HydraFlowConfig
+    ) -> None:
+        issue = TaskFactory.create(id=7653)
+        wt_path = config.workspace_path_for_issue(7653)
+        result = WorkerResultFactory.create(
+            issue_number=7653,
+            success=False,
+            error="diff-sanity failed: Missing implementation",
+            commits=1,
+            workspace_path=str(wt_path),
+        )
+
+        phase, _, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_prs_method("push_branch", AsyncMock(return_value=True))
+            .with_prs_method(
+                "find_open_pr_for_branch",
+                AsyncMock(return_value=PRInfoFactory.create()),
+            )
+            .build()
+        )
+
+        await phase._handle_implementation_result(issue, result, is_retry=True)
+
+        mock_prs.push_branch.assert_awaited_once()
+        mock_prs.create_pr.assert_not_awaited()
+        mock_prs.transition.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fresh_attempt_with_success_still_pushes_and_creates_pr(
+        self, config: HydraFlowConfig
+    ) -> None:
+        issue = TaskFactory.create(id=7653)
+        wt_path = config.workspace_path_for_issue(7653)
+        result = WorkerResultFactory.create(
+            issue_number=7653,
+            success=True,
+            commits=3,
+            workspace_path=str(wt_path),
+        )
+
+        phase, _, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_prs_method("push_branch", AsyncMock(return_value=True))
+            .with_create_pr_return(PRInfoFactory.create())
+            .build()
+        )
+
+        await phase._handle_implementation_result(issue, result, is_retry=False)
+
+        mock_prs.push_branch.assert_awaited_once()
+        mock_prs.create_pr.assert_awaited_once()
+        mock_prs.transition.assert_awaited_once()
         mock_prs.update_pr_title.assert_not_awaited()

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -369,3 +369,57 @@ class TestSwapPipelineLabelsAsync:
         assert swapped_to == [expected_label], (
             f"Stage '{stage}' should swap to '{expected_label}', got {swapped_to}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Cross-entity drift: PR labeled hydraflow-review while linked issue
+# still at hydraflow-ready. See half-state fix plan 2026-05-07.
+# ---------------------------------------------------------------------------
+
+
+class TestPRIssueLabelConsistency:
+    """swap_pipeline_labels lands the new label on both issue AND PR."""
+
+    @pytest.mark.asyncio
+    async def test_swap_to_review_labels_both_pr_and_issue(self) -> None:
+        """When pr_number is given, both issue and PR end at the new label and
+        the old hydraflow-ready label is removed from both.
+
+        Closes a coverage gap that let the half-state bug land undetected:
+        an issue stuck at hydraflow-ready while its PR sat unlabeled (or
+        vice versa). Asserts the post-swap state of both entities, not just
+        the call shape.
+        """
+        from pr_manager import PRManager
+
+        config = _make_config()
+        event_bus = MagicMock()
+        mgr = PRManager(config, event_bus)
+
+        # In-memory label state, keyed by (kind, number).
+        labels: dict[tuple[str, int], list[str]] = {
+            ("issue", 42): ["hydraflow-ready"],
+            ("pr", 101): ["hydraflow-ready"],
+        }
+
+        async def fake_add(kind: str, number: int, new_labels: list[str]) -> None:
+            for lbl in new_labels:
+                if lbl not in labels[(kind, number)]:
+                    labels[(kind, number)].append(lbl)
+
+        async def fake_remove(kind: str, number: int, label: str) -> None:
+            if label in labels[(kind, number)]:
+                labels[(kind, number)].remove(label)
+
+        mgr._add_labels_strict = fake_add  # type: ignore[method-assign]
+        mgr._remove_label = fake_remove  # type: ignore[method-assign]
+
+        await mgr.swap_pipeline_labels(42, "hydraflow-review", pr_number=101)
+
+        issue_labels = labels[("issue", 42)]
+        pr_labels = labels[("pr", 101)]
+
+        assert "hydraflow-review" in issue_labels
+        assert "hydraflow-review" in pr_labels
+        assert "hydraflow-ready" not in issue_labels
+        assert "hydraflow-ready" not in pr_labels


### PR DESCRIPTION
## Summary

- Stops the implement-phase from pushing branches and opening PRs for fresh attempts where ``result.success`` is False (typically blocking-skill failures: ``discover-completeness``, ``scope-check``, ``diff-sanity``).
- Gates ``push_branch``, ``_resolve_pr``, and ``transition`` on ``(result.success or is_retry)``.
- Adds regression tests + flips an existing pinning test that encoded the buggy behavior.
- Adds a positive label-consistency test in ``tests/test_state_machine.py``.
- One-shot reconcile script ``scripts/sync_implement_state.py``.
- Wiki gotcha entry to keep ``_resolve_pr`` from regressing.

## Diagnosis

See full root-cause walk-through: ``docs/superpowers/plans/2026-05-07-implement-phase-state-machine-drift-remediation.md``.

## Test plan

- [x] ``pytest tests/test_implement_phase.py::TestBlockingSkillFailureDoesNotCreatePR``
- [x] ``pytest tests/test_implement_phase.py::TestHandleSuccessfulPush``
- [x] ``pytest tests/test_state_machine.py::TestPRIssueLabelConsistency``
- [x] ``make quality`` — full suite green (12104 passed, 18 skipped, 203 xfailed, 43 xpassed)
- [x] ``python scripts/sync_implement_state.py --repo T-rav/hydraflow --mode all --dry-run`` — fleet snapshot (13 issue-side + 2 PR-side stuck pairs found, then reconciled, dry-run now reports clean)
- [ ] After merge: re-run ``--dry-run`` and confirm "fleet is clean"

🤖 Generated with [Claude Code](https://claude.com/claude-code)