### PR TITLE
fix(pr-unsticker): split issue vs PR label targets on HITL release

### DIFF
--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -764,3 +764,28 @@ also resets the worktree, discarding partial commits).
   "added": "2026-05-07"
 }
 ```
+
+### swap_pipeline_labels: same label to both is wrong for ready/review boundary
+
+**Pattern:** `swap_pipeline_labels(issue_number, label, pr_number=pr)` applies
+the SAME label to issue and PR. For most transitions this is correct (e.g.
+review→fixed, both go fixed). But across the ready/review boundary it
+dragged PRs back to `hydraflow-ready` when an issue was released from HITL
+back to its pre-HITL origin (`pr_unsticker.py:312-322` before fix).
+
+**Rule:** When issue and PR live at *different* pipeline stages (e.g. issue
+at ready waiting for impl, PR at review awaiting human), call
+`swap_pipeline_labels` twice — once for each, with the right target.
+
+```json:entry
+{
+  "id": "swap-pipeline-labels-ready-review-boundary",
+  "topic": "label_state_machine",
+  "tags": ["state-machine", "ADR-0002", "pr-unsticker", "label-drift"],
+  "rule": "Across the ready/review boundary, swap issue and PR with separate calls.",
+  "anti_pattern": "swap_pipeline_labels(issue, ready_label, pr_number=pr) when PR has commits",
+  "code_refs": ["src/pr_unsticker.py:_resolve_or_release_back_to_hitl"],
+  "fixed_in_pr": "#8715",
+  "added": "2026-05-07"
+}
+```

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -310,13 +310,18 @@ class PRUnsticker:
                     # Restore origin label when not auto-merging
                     origin = self._state.get_hitl_origin(issue_number)
                     # Fall back to HITL label so the issue stays visible
-                    target = origin or self._config.hitl_label[0]
-                    origin_kwargs: dict[str, int] = {}
+                    issue_target = origin or self._config.hitl_label[0]
+                    # Issue goes back to its pre-HITL stage. The PR — if one
+                    # exists with commits — belongs at hydraflow-review (PR-
+                    # stage label), regardless of where the issue origin sits.
+                    # Calling swap_pipeline_labels with the same label for both
+                    # produces PR-side drift (PR labeled hydraflow-ready) when
+                    # the issue origin is pre-PR.
+                    await self._prs.swap_pipeline_labels(issue_number, issue_target)
                     if item.pr is not None and item.pr > 0:
-                        origin_kwargs["pr_number"] = item.pr
-                    await self._prs.swap_pipeline_labels(
-                        issue_number, target, **origin_kwargs
-                    )
+                        await self._prs.swap_pipeline_labels(
+                            item.pr, self._config.review_label[0]
+                        )
 
                     self._state.remove_hitl_origin(issue_number)
                     self._state.remove_hitl_cause(issue_number)

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -643,6 +643,66 @@ class TestAutoMergeDisabled:
         h.prs.merge_pr.assert_not_called()
 
 
+class TestReleaseToOriginPRTarget:
+    """Regression: when releasing from HITL with a PR open, the PR target
+    must be hydraflow-review (PR-stage label), not the issue's origin
+    (which is typically hydraflow-ready).
+
+    Real-world drift this caught: PR #8669 (issue #7991) and PR #8653
+    (issue #7644) — both ended up at hydraflow-ready because
+    swap_pipeline_labels was called with the issue's origin and a
+    pr_number, applying the SAME label to both.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pr_lands_at_review_when_origin_is_ready(
+        self, tmp_path: Path
+    ) -> None:
+        issue = IssueFactory.create(
+            title="Test issue", body="body", labels=["hydraflow-hitl"]
+        )
+        h = _make_unsticker(tmp_path, unstick_auto_merge=False)
+
+        h.state.set_hitl_cause(42, "Merge conflict")
+        # Issue's pre-HITL stage was hydraflow-ready (typical for issues
+        # that went HITL pre-implementation). The PR has commits already.
+        h.state.set_hitl_origin(42, "hydraflow-ready")
+
+        h.fetcher.fetch_issue_by_number = AsyncMock(return_value=issue)
+        h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
+        h.prs.push_branch = AsyncMock(return_value=True)
+
+        h.resolver.resolve_merge_conflicts = AsyncMock(
+            return_value=ConflictResolutionResult(success=True, used_rebuild=False)
+        )
+
+        wt_dir = h.unsticker._config.workspace_path_for_issue(42)
+        wt_dir.mkdir(parents=True)
+
+        stats = await h.unsticker.unstick([_make_hitl_item(42, pr=100)])
+
+        assert stats["resolved"] == 1
+        assert stats["merged"] == 0
+
+        # Issue goes back to its pre-HITL origin (hydraflow-ready).
+        h.prs.swap_pipeline_labels.assert_any_call(42, "hydraflow-ready")
+        # PR (with commits) belongs at hydraflow-review, NOT origin.
+        h.prs.swap_pipeline_labels.assert_any_call(100, "hydraflow-review")
+
+        # The buggy single-call shape MUST NOT happen — PR getting the
+        # issue's origin via the pr_number kwarg is the drift.
+        for call in h.prs.swap_pipeline_labels.call_args_list:
+            args, kwargs = call
+            # No call should pair the ready label with a pr_number kwarg.
+            if kwargs.get("pr_number") == 100 and len(args) >= 2:
+                assert args[1] != "hydraflow-ready", (
+                    "PR #100 must not be labeled hydraflow-ready via the "
+                    "swap_pipeline_labels(issue, ready, pr_number=pr) shape"
+                )
+
+        h.prs.merge_pr.assert_not_called()
+
+
 class TestCascadingRebase:
     """Verify _re_rebase_remaining() rebases worktrees after merge."""
 

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -635,10 +635,11 @@ class TestAutoMergeDisabled:
         assert stats["resolved"] == 1
         assert stats["merged"] == 0
 
-        # Should swap back to origin label
-        h.prs.swap_pipeline_labels.assert_any_call(
-            42, "hydraflow-review", pr_number=100
-        )
+        # Issue swaps to its origin (hydraflow-review here).
+        h.prs.swap_pipeline_labels.assert_any_call(42, "hydraflow-review")
+        # PR (with commits) goes to hydraflow-review via a separate call.
+        # See TestReleaseToOriginPRTarget for why issue and PR are split.
+        h.prs.swap_pipeline_labels.assert_any_call(100, "hydraflow-review")
         # merge_pr should NOT have been called
         h.prs.merge_pr.assert_not_called()
 


### PR DESCRIPTION
## Summary

- `pr_unsticker._resolve_or_release_back_to_hitl` was calling `swap_pipeline_labels(issue, target, pr_number=pr)` with the issue's HITL origin as `target`. That dragged PRs back to `hydraflow-ready` when the origin was pre-PR.
- Fix: separate `swap_pipeline_labels` calls for issue (origin) and PR (always `hydraflow-review` when a PR exists with commits).
- New regression test `TestReleaseToOriginPRTarget`.
- Existing `TestAutoMergeDisabled.test_no_merge_when_disabled` updated — it had encoded the buggy single-call shape and was failing legitimately under the corrected behavior.
- Wiki gotcha entry to capture the rule. (`fixed_in_pr` will be back-filled to this PR after open.)

## Real-world drift this caused

PR #8669 (issue #7991) and PR #8653 (issue #7644) both ended up at `hydraflow-ready`. Phase A's `scripts/sync_implement_state.py --mode pr-side` already swept these on `staging`; verified live via `gh pr view` — both now correctly at `hydraflow-review`.

## Phase D of state-machine drift remediation

Plan: `docs/superpowers/plans/2026-05-07-implement-phase-state-machine-drift-remediation.md`. Phase A (PR #8713) and Phase B run in parallel; Phase C blocks on all three.

## Test plan

- [x] `pytest tests/test_pr_unsticker.py::TestReleaseToOriginPRTarget` (RED → GREEN flow)
- [x] `pytest tests/test_pr_unsticker.py` — all 57 pass
- [x] `make quality` — 12063 passed, 9 skipped, 41 xpassed, lint + arch checks green
- [x] PRs #8669 + #8653 confirmed at `hydraflow-review` in production (Phase A's sync already reconciled them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)