### PR TITLE
fix(memory-backlog): commit frontmatter updates per ADR-0057

### DIFF
--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -84,6 +84,7 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
         filed = 0
         skipped = 0
         escalated = 0
+        filed_issue_numbers: list[int] = []
         dedup = self._dedup.get()
         for entry in pending_entries(mirror):
             key = dedup_key_for(entry.slug)
@@ -99,11 +100,15 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
                     issue_num = await self._file_backlog_issue(entry)
                     update_status(entry.path, status="issue-open", issue=issue_num)
                     filed += 1
+                    filed_issue_numbers.append(issue_num)
             except Exception:  # noqa: BLE001
                 logger.exception("filing memory-backlog issue for %s", entry.slug)
                 continue
             dedup.add(key)
             self._dedup.set_all(dedup)
+
+        if filed_issue_numbers:
+            await self._commit_mirror_updates(filed_issue_numbers)
 
         return {
             "status": "ok",
@@ -111,6 +116,72 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
             "skipped": skipped,
             "escalated": escalated,
         }
+
+    async def _commit_mirror_updates(self, issue_numbers: list[int]) -> None:
+        """Commit `pending → issue-open` frontmatter updates to git history.
+
+        Per ADR-0057: the loop commits status transitions so the audit trail
+        lives in git history, not just on-disk frontmatter. Without this,
+        edits to `docs/wiki/memory-feedback/*.md` accumulate as uncommitted
+        modifications in the orchestrator's working tree, conflicting with
+        co-existing loops that operate on git state.
+
+        Failures are logged but do not propagate — the on-disk frontmatter
+        is the primary re-filing guard, so a missed commit doesn't cause
+        duplicate filings on restart. Surfaces as drift in `git status`.
+        """
+        repo_root = str(self._config.repo_root)
+        mirror_relpath = "/".join(_MIRROR_SUBPATH)
+        if len(issue_numbers) == 1:
+            title = f"chore(memory-backlog): file issue #{issue_numbers[0]}"
+        else:
+            joined = ", ".join(f"#{n}" for n in issue_numbers)
+            title = f"chore(memory-backlog): file issues {joined}"
+
+        add_proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            repo_root,
+            "add",
+            mirror_relpath,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, add_err = await add_proc.communicate()
+        if add_proc.returncode != 0:
+            logger.warning(
+                "memory_backlog: git add failed (rc=%s): %s",
+                add_proc.returncode,
+                add_err.decode(errors="replace").strip(),
+            )
+            return
+
+        identity_args = []
+        if self._config.git_user_email:
+            identity_args += ["-c", f"user.email={self._config.git_user_email}"]
+        if self._config.git_user_name:
+            identity_args += ["-c", f"user.name={self._config.git_user_name}"]
+
+        commit_proc = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            repo_root,
+            *identity_args,
+            "commit",
+            "-m",
+            title,
+            "--",
+            mirror_relpath,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, commit_err = await commit_proc.communicate()
+        if commit_proc.returncode != 0:
+            logger.warning(
+                "memory_backlog: git commit failed (rc=%s): %s",
+                commit_proc.returncode,
+                commit_err.decode(errors="replace").strip(),
+            )
 
     async def _file_backlog_issue(self, entry: MirrorEntry) -> int:
         rel = entry.path.relative_to(self._config.repo_root)

--- a/tests/test_memory_backlog_loop.py
+++ b/tests/test_memory_backlog_loop.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -113,6 +114,7 @@ async def test_pending_entry_files_one_issue_and_updates_frontmatter(
     pr.create_issue.return_value = 4242
     loop = _make_loop(env)
     loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._commit_mirror_updates = AsyncMock(return_value=None)
 
     result = await loop._do_work()
 
@@ -204,3 +206,80 @@ def test_default_interval_matches_config(env) -> None:
     loop = _make_loop(env)
     assert loop._get_default_interval() == cfg.memory_backlog_interval_seconds
     assert loop._get_default_interval() == 86_400  # 24h
+
+
+@pytest.mark.asyncio
+async def test_filing_commits_frontmatter_to_git(env) -> None:
+    """The pending → issue-open frontmatter update lands as a git commit.
+
+    Per ADR-0057, status transitions live in git history — not just on
+    disk. Without the commit, frontmatter edits accumulate as unstaged
+    modifications in the orchestrator's working tree.
+    """
+    cfg, _, pr, _, mirror_dir = env
+    # Initialize a real git repo in tmp_path so the loop's git commands work.
+    subprocess.run(["git", "init", "-q"], cwd=cfg.repo_root, check=True)
+    # Stage + commit the mirror dir so subsequent updates are diffable.
+    _write_mirror_entry(mirror_dir, "feedback-zeta")
+    subprocess.run(["git", "add", "-A"], cwd=cfg.repo_root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=cfg.repo_root, check=True)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    pr.create_issue.return_value = 4321
+    loop = _make_loop(env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+
+    await loop._do_work()
+
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head_sha != base_sha, "loop did not create a commit"
+
+    title = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert "memory-backlog" in title
+    assert "#4321" in title
+
+    # Working tree should be clean — the frontmatter update is committed.
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert status == "", f"unexpected dirty working tree: {status}"
+
+
+@pytest.mark.asyncio
+async def test_no_commit_when_nothing_filed(env) -> None:
+    """Tick that filed zero issues should NOT make a git commit."""
+    _, _, pr, dedup, mirror_dir = env
+    _write_mirror_entry(mirror_dir, "feedback-already-open")
+    dedup.get.return_value = {"memory_backlog:feedback-already-open"}  # already filed
+
+    loop = _make_loop(env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._commit_mirror_updates = AsyncMock(return_value=None)
+
+    result = await loop._do_work()
+
+    assert result["filed"] == 0
+    pr.create_issue.assert_not_called()
+    loop._commit_mirror_updates.assert_not_called()


### PR DESCRIPTION
## Summary

Post-merge fix-forward for PR #8714. Fresh-eyes review found that `MemoryBacklogLoop._do_work` writes `pending → issue-open` frontmatter via `update_status(...)` but never commits the change — contradicting ADR-0057's "Update frontmatter and commit the change" decision.

Without this fix, the orchestrator's working tree accumulates uncommitted modifications in `docs/wiki/memory-feedback/`, which can collide with co-existing loops that operate on git state (`RepoWikiLoop`, etc.).

## Implementation

- New `_commit_mirror_updates(issue_numbers)` method called at end of `_do_work` when at least one entry was filed.
- Runs `git add docs/wiki/memory-feedback/` + `git commit -m "chore(memory-backlog): file issue(s) #N[, #M]"` via `asyncio.create_subprocess_exec`.
- Uses `config.git_user_name` / `git_user_email` for commit identity (with `-c` overrides), same pattern as `RepoWikiLoop`.
- Failures log a warning but never propagate — the on-disk frontmatter remains the primary re-filing guard, so a missed commit doesn't cause duplicate filings on restart. Surfaces as drift in `git status`.

## Tests

- **`test_filing_commits_frontmatter_to_git`** — real `git init` in `tmp_path`, runs `_do_work`, asserts HEAD advanced + commit title contains the issue number + working tree is clean.
- **`test_no_commit_when_nothing_filed`** — tick that filed zero issues must NOT call `_commit_mirror_updates`.
- Existing tests updated to mock `_commit_mirror_updates` (no real git repo in their fixtures).

## Test plan

- [x] `uv run pytest tests/test_memory_backlog_loop.py` — 9/9 passed
- [x] `uv run pytest tests/test_loop_wiring_completeness.py tests/architecture/test_curated_drift.py tests/architecture/test_functional_area_coverage.py` — 11/11 passed
- [x] Pre-commit clean (lint + arch-check), no `--no-verify`

## Context

This is the fix-forward path the post-merge fresh-eyes reviewer recommended at 88% confidence ("Important — Acceptable to ship; fix in a follow-up PR"). Filing it now to land before the next RC promotion sweeps PR #8714's merge to main (~4h cadence per ADR-0042).

🤖 Generated with [Claude Code](https://claude.com/claude-code)