### PR TITLE
fix(implement): broaden zero-commit-failure check (defensive)

### DIFF
--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -644,12 +644,15 @@ class ImplementPhase:
 
     @staticmethod
     def _is_zero_commit_failure(result: WorkerResult) -> bool:
-        """Check whether *result* represents a zero-commit implementation failure."""
-        return (
-            not result.success
-            and result.error == "No commits found on branch"
-            and result.commits == 0
-        )
+        """Check whether *result* represents a zero-commit implementation failure.
+
+        Any failed run with no commits is a zero-commit failure — not just
+        the canonical "No commits found on branch" error. ProcessLookupError
+        (subprocess killed mid-run), AuthenticationRetryError (credentials
+        expired), and any other early-exit Exception path that leaves
+        commits=0 must route to _handle_zero_commits, not push/PR.
+        """
+        return not result.success and result.commits == 0
 
     async def _flag_requirements_gaps(self, issue: Task, transcript: str) -> None:
         """Detect and post requirements gaps discovered during implementation."""

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -2381,7 +2381,11 @@ class TestIsZeroCommitFailure:
 
         assert ImplementPhase._is_zero_commit_failure(result) is False
 
-    def test_returns_false_when_different_error(self) -> None:
+    def test_returns_true_when_different_error(self) -> None:
+        """Any failed run with commits=0 is a zero-commit failure — not just
+        the canonical 'No commits found on branch' error. This test was
+        previously pinning the bug; broadened in PR-B.
+        """
         result = WorkerResultFactory.create(
             issue_number=1,
             branch="agent/issue-1",
@@ -2391,7 +2395,7 @@ class TestIsZeroCommitFailure:
         )
         from implement_phase import ImplementPhase
 
-        assert ImplementPhase._is_zero_commit_failure(result) is False
+        assert ImplementPhase._is_zero_commit_failure(result) is True
 
     def test_returns_false_when_has_commits(self) -> None:
         result = WorkerResultFactory.create(

--- a/tests/test_implement_phase.py
+++ b/tests/test_implement_phase.py
@@ -2405,6 +2405,46 @@ class TestIsZeroCommitFailure:
 
         assert ImplementPhase._is_zero_commit_failure(result) is False
 
+    def test_zero_commits_with_process_killed_is_zero_commit_failure(self) -> None:
+        """ProcessLookupError or any zero-commit failure must hit the
+        zero-commit handler, not push/PR.
+        """
+        result = WorkerResultFactory.create(
+            issue_number=8511,
+            success=False,
+            error="ProcessLookupError()",
+            commits=0,
+        )
+        from implement_phase import ImplementPhase
+
+        assert ImplementPhase._is_zero_commit_failure(result) is True
+
+    def test_zero_commits_with_arbitrary_error_is_zero_commit_failure(self) -> None:
+        """Any failure with commits=0 is a zero-commit failure regardless of error string."""
+        result = WorkerResultFactory.create(
+            issue_number=99,
+            success=False,
+            error="Some unexpected error",
+            commits=0,
+        )
+        from implement_phase import ImplementPhase
+
+        assert ImplementPhase._is_zero_commit_failure(result) is True
+
+    def test_success_with_zero_commits_is_not_zero_commit_failure(self) -> None:
+        """A 'successful' run that produced no commits is a separate concern
+        (the no-PR fallback path). Don't confuse the two.
+        """
+        result = WorkerResultFactory.create(
+            issue_number=99,
+            success=True,
+            error=None,
+            commits=0,
+        )
+        from implement_phase import ImplementPhase
+
+        assert ImplementPhase._is_zero_commit_failure(result) is False
+
 
 # ---------------------------------------------------------------------------
 # _handle_zero_commits


### PR DESCRIPTION
## Summary

- Broadens `ImplementPhase._is_zero_commit_failure` to `not result.success and result.commits == 0` — any failed run with no commits, not just the literal `"No commits found on branch"` error.
- Notes on PR #8703: the empty-PR cleanup case in the plan did not apply — PR #8703 actually has 1 real commit (`e8d1f3a2`, 68 additions) and is already at `hydraflow-review`. `worker_result_meta` reported commits=0 but the branch had landed the work; both PR and issue have already self-corrected via Phase A. No relabel/close needed.

## Why this is separate from PR-A

PR-A's success gate already prevents new occurrences of this exact bug. This change tightens `_is_zero_commit_failure` so the *explicit classifier* matches its name and the failure routes to `_handle_zero_commits` (which marks failed without push/PR) instead of falling through.

## Test plan

- [x] `pytest tests/test_implement_phase.py::TestIsZeroCommitFailure` (7 tests, all green)
- [x] `pytest tests/test_implement_phase.py` (103 tests, all green — no other pinning tests)
- [x] `make quality` (12096 passed, 9 skipped, 206 xfailed)
- [x] PR #8703 inspected — real commit on `agent/issue-8511`, already labeled `hydraflow-review`; left for review loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)