### PR TITLE
docs(memory-backlog): mirror 3 new feedback memories

### DIFF
--- a/docs/wiki/memory-feedback/feedback-check-existing-infra-first.md
+++ b/docs/wiki/memory-feedback/feedback-check-existing-infra-first.md
@@ -1,0 +1,25 @@
+---
+source: feedback_check_existing_infra_first.md
+name: Check existing infrastructure before building parallel solutions
+description: Before writing a new test/lint/loop, grep the codebase for existing infrastructure that already solves the problem — reinventing wastes ~30-45 min of agent dispatches per missed case
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: 2026-05-08
+---
+
+# Check existing infrastructure before building parallel solutions
+
+When a spec calls for a new convention-enforcement (test, lint rule, fixture, loop), grep the codebase first to confirm equivalent infrastructure doesn't already exist. **Reinventing is the more common failure mode than under-building** when working from a multi-item spec.
+
+**Why:** PR #8714 Task 4 ("EventType ↔ reducer parity test") was reinventing `tests/test_event_reducer_coverage.py` (which already implemented parity with a SKIP_LIST mechanism, predating my work). The duplicate test was caught only at `make quality` time when ruff's line-wrapping interaction broke the existing parser. Net cost: 2 agent dispatches building the redundant pieces + 1 cleanup commit reverting them. The existing test had been there for months.
+
+**How to apply:**
+
+- **Before dispatching an agent for a new test:** `rg -l "EventType\|reducer\|parity" tests/` (or analogous keywords for the convention). 30 seconds of grep beats 30 minutes of reinventing.
+- **Before designing a new caretaker loop:** check `find src -name "*loop*.py"` for sibling loops that may already cover the surface. Check `docs/wiki/dark-factory.md` and the functional area map.
+- **At spec-write time:** explicitly note "checked: no existing infrastructure for X" in the spec. Forces the check; documents the search for future readers.
+- **The existing infrastructure may have flaws** (the existing parity test had a brittle regex parser). Fix-in-place beats parallel build — same effective coverage, half the surface area, no duplication tax.
+
+**Pattern recognition signal:** if your spec says "we need a test/check that does X" and X sounds generic enough that someone else might have built it, you're probably right.

--- a/docs/wiki/memory-feedback/feedback-make-quality-pipe-exit-code.md
+++ b/docs/wiki/memory-feedback/feedback-make-quality-pipe-exit-code.md
@@ -1,0 +1,32 @@
+---
+source: feedback_make_quality_pipe_exit_code.md
+name: Piping make to tail masks the make exit code
+description: `make quality | tail -200` returns 0 even when make fails — the run-in-background notification was misleading; check tail content for actual failures
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: 2026-05-08
+---
+
+# Piping make to tail masks the make exit code
+
+When running `make quality 2>&1 | tail -N` (background or otherwise), the **pipe's exit code is `tail`'s, not make's**. So an exit-0 notification can hide a real failure. This burned a real moment in the 2026-05-08 PR #8714 work — the bash notification said "exit code 0" but `make quality` had 3 test failures buried in the tail output.
+
+**Why:** Bash pipelines return the exit status of the last command in the pipeline by default. `tail` always returns 0 (it has no failure mode for normal stdin reads). So `make quality | tail` masks make's failure status.
+
+**How to apply:**
+
+- **Check tail content even on exit-0** — read the last few lines for "FAILED" or "Error" markers when running long pipelines.
+- **Better: `set -o pipefail` at the top of the bash command**:
+  ```bash
+  set -o pipefail; make quality 2>&1 | tail -200
+  ```
+  Now the exit code reflects make's status, not tail's.
+- **Best for run_in_background bash**: capture full output to a file, then tail the file separately:
+  ```bash
+  make quality 2>&1 > /tmp/quality.log; echo "EXIT=$?"; tail -5 /tmp/quality.log
+  ```
+  Now you see both the actual exit code AND the tail without ambiguity. This is the pattern that worked on the second run of PR #8714's quality gate.
+
+**Generalizes to:** any pipeline ending in `tail`, `head`, `cat`, `tee`, `grep` (with --quiet), or anything else that doesn't propagate upstream failures.

--- a/docs/wiki/memory-feedback/feedback-ratchet-pattern.md
+++ b/docs/wiki/memory-feedback/feedback-ratchet-pattern.md
@@ -1,0 +1,40 @@
+---
+source: feedback_ratchet_pattern.md
+name: Ratchet pattern with grandfather YAML for retroactive convention enforcement
+description: When you want to enforce a new convention but bulk-cleanup is too risky, ship a CI-failing detector + grandfather YAML allowlist that locks current state and fails on growth
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: 2026-05-08
+---
+
+# Ratchet pattern with grandfather YAML for retroactive convention enforcement
+
+For retroactive convention enforcement (e.g. "no `AsyncMock(Port)` without `spec=`"), use the **ratchet pattern**: ship a detector + sidecar grandfather YAML that lists existing violations. CI fails when the violation set EXCEEDS the grandfather list, but tolerates current state. List MAY shrink (cleanup welcome), MUST NOT grow.
+
+**Why:** PR #8714 added `tests/test_mock_spec_discipline.py` + `tests/_mock_spec_grandfathered.yaml` for AsyncMock-spec discipline. The grandfather list shipped EMPTY because the codebase was already clean — turning the ratchet into a regression-prevention guard rather than a cleanup mandate. This converts "we should clean up X someday" (which never happens) into "X can't get worse, ever" (which sticks). The ratchet pattern was specifically designed for cases where bulk cleanup of 4000+ call sites would be impractical or risky.
+
+**Pattern shape:**
+
+1. **Pure detector** — AST walker / regex / etc. in `src/_<thing>_detector.py`. Returns a list of `Violation(path, lineno, reason)`.
+2. **Meta-tests** — `tests/meta/test_<thing>_detector.py` with synthetic fixture files under `tests/meta/_<thing>_fixtures/`. Verifies detector logic on synthetic positive + negative cases.
+3. **Grandfather YAML** — `tests/_<thing>_grandfathered.yaml`:
+   ```yaml
+   comment: <thing> ratchet. Generated <date>. MAY shrink. MUST NOT grow.
+   entries:
+     - path: tests/<file>.py
+       line: 42
+       reason: grandfathered at initial scan <date>
+   ```
+4. **Discipline test** — two assertions:
+   - `test_no_new_<thing>_violations` — fails if `current - grandfathered` is non-empty
+   - `test_grandfather_list_does_not_contain_false_positives` — fails if `grandfathered - current` is non-empty (stale entries that no longer violate, signaling cleanup happened — entry should be removed)
+
+**How to apply:**
+
+- Use this pattern for **convention violations the team agrees on but can't bulk-fix** (legacy code, spec drift, lint-rule rollouts).
+- **DON'T use it for new code conventions** — those should fail outright with no grandfather mechanism. Ratchets are specifically for retroactive enforcement.
+- Add fixture files to `pyproject.toml` `[tool.ruff.lint.per-file-ignores]` so ruff doesn't strip the intentional violations during `--fix`.
+- Pyright already excludes `tests/` (per `[tool.pyright]`), so synthetic-fixture noise is silenced.
+- **Edge cases the detector should silently skip rather than flag** when ambiguity exists — false negative > false positive for a ratchet (per Mock-spec spec §3 design).


### PR DESCRIPTION
## Summary

Adds redacted in-repo mirrors for the 3 feedback memories captured during the 2026-05-08 tier-2 enforcement batch session, per the convention established in PR #8714 / ADR-0057.

| Mirror | Source memory | What it captures |
|---|---|---|
| `feedback-check-existing-infra-first.md` | `feedback_check_existing_infra_first.md` | Task 4 of PR #8714 was reinventing `tests/test_event_reducer_coverage.py`; reverted as redundant |
| `feedback-ratchet-pattern.md` | `feedback_ratchet_pattern.md` | Mock-spec ratchet shipped clean (zero entries); pattern generalizes |
| `feedback-make-quality-pipe-exit-code.md` | `feedback_make_quality_pipe_exit_code.md` | `make quality \| tail` always returns 0; use `set -o pipefail` or capture-then-tail |

## What happens next

`MemoryBacklogLoop` (ADR-0057) will pick these up on its next 24h tick and file `hydraflow-find` issues for them. Each becomes a candidate for promotion to structurally-enforced (test/lint/loop), per dark-factory wiki §6.

## Why this is a separate PR

The convention says \"when Claude saves a `feedback_*.md`, also commit a redacted mirror in the next commit.\" After PRs #8714 and #8718 merged, three new memories were created with no follow-up commit pending. This PR closes that gap.

A follow-up will plug the convention gap structurally so this kind of catch-up PR isn't needed (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)