### PR TITLE
feat(caretaker): LabelDriftWatcherLoop — periodic drift reconciliation

### DIFF
--- a/docs/adr/0056-label-drift-caretaker-loop.md
+++ b/docs/adr/0056-label-drift-caretaker-loop.md
@@ -1,6 +1,6 @@
 # ADR-0056: LabelDriftWatcherLoop — Cross-Entity State-Machine Drift Caretaker
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-07
 - **Supersedes:** none
 - **Superseded by:** none

--- a/docs/adr/0056-label-drift-caretaker-loop.md
+++ b/docs/adr/0056-label-drift-caretaker-loop.md
@@ -1,0 +1,58 @@
+# ADR-0056: LabelDriftWatcherLoop — Cross-Entity State-Machine Drift Caretaker
+
+- **Status:** Proposed
+- **Date:** 2026-05-07
+- **Supersedes:** none
+- **Superseded by:** none
+- **Related:** [ADR-0002](0002-labels-as-state-machine.md) (label state machine), [ADR-0029](0029-caretaker-loop-pattern.md) (caretaker-loop pattern), [ADR-0049](0049-trust-loop-kill-switch-convention.md) (kill-switch convention). Code: `src/label_drift_watcher_loop.py`, `src/pr_manager.py` (`find_label_drift`), `src/models.py` (`LabelDrift`).
+
+## Context
+
+ADR-0002 enforces "exactly one pipeline label per issue" via the atomic
+`swap_pipeline_labels` primitive and `tests/test_state_machine.py`.
+That invariant is per-entity. In May 2026 we discovered three distinct
+sources of *cross-entity* drift between issues and their linked PRs:
+
+1. `implement_phase` published partial work for failed attempts
+   (fixed in PR-A).
+2. `_is_zero_commit_failure` was too narrowly typed (PR-B).
+3. `pr_unsticker` re-applied issue origin to PR on HITL release (PR-D).
+
+We don't have evidence we've found all the drift sources. A periodic
+scan-and-reconcile loop catches the long tail without us having to
+enumerate every code path.
+
+## Decision
+
+Add `LabelDriftWatcherLoop` extending `BaseBackgroundLoop` per
+ADR-0029 caretaker pattern. Each tick:
+
+1. Query GitHub for open PRs and parse `Fixes #N` from each body.
+2. For each pair, fetch the issue's labels and the PR's commits count.
+3. Detect drift: issue at `hydraflow-ready`/`hydraflow-plan` while
+   PR is at `hydraflow-review` with commits.
+4. Detect drift: PR at `hydraflow-ready`/`hydraflow-plan` with
+   commits (PR-stage labels are review/hitl/fixed, never ready/plan).
+5. Reconcile by calling `swap_pipeline_labels` with the correct
+   per-entity target (mirroring Phase D's split-call pattern).
+
+Default interval: 600s (10 min). Operator-tunable via dashboard.
+
+## Consequences
+
+- Zero new infrastructure: reuses `BaseBackgroundLoop`, `DedupStore`,
+  `ServiceRegistry` plumbing per ADR-0029.
+- One tick is O(open PRs at review). On a fleet of 50 open PRs that's
+  ~50 issue-label fetches + ~50 PR-commit-count fetches per tick.
+- Risk: a misclassified "drift" reconciles a label the operator wanted.
+  Mitigation: the loop logs each reconcile, posts a comment on the
+  issue explaining the swap, and is dashboard-toggleable to off.
+- Caretaker covers gaps; per-call-site fixes (PRs A/B/D) remain the
+  primary defense. The caretaker's job is "we missed one — catch it
+  before a human does."
+
+## Related
+
+- ADR-0002 (label state machine)
+- ADR-0029 (caretaker loop pattern)
+- docs/superpowers/plans/2026-05-07-implement-phase-state-machine-drift-remediation.md

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-08T03:33:43.582164+00:00",
-  "commit_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f",
+  "regenerated_at": "2026-05-09T04:45:56.030755+00:00",
+  "commit_sha": "3a2a939897765df6ca76415ec49f17e1939eef06",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "ports.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "labels.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "modules.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "events.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "adr_xref.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "mockworld.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "changelog.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     },
     "functional_areas.md": {
-      "source_sha": "4c1abadfe1c21ae42b0681de0b4122f111ddf04f"
+      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T04:52:56.414651+00:00",
-  "commit_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878",
+  "regenerated_at": "2026-05-09T04:58:10.291669+00:00",
+  "commit_sha": "907c272ab1b7a671176690633b7560ac52b74ebe",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "ports.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "labels.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "modules.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "events.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "adr_xref.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "mockworld.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "changelog.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     },
     "functional_areas.md": {
-      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
+      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T04:58:10.291669+00:00",
-  "commit_sha": "907c272ab1b7a671176690633b7560ac52b74ebe",
+  "regenerated_at": "2026-05-09T05:19:34.803305+00:00",
+  "commit_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532",
   "artifacts": {
     "loops.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "ports.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "labels.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "modules.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "events.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "adr_xref.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "mockworld.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "changelog.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     },
     "functional_areas.md": {
-      "source_sha": "907c272ab1b7a671176690633b7560ac52b74ebe"
+      "source_sha": "188a51e4c305aa0de6eddee6deadd5c6f390f532"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T04:45:56.030755+00:00",
-  "commit_sha": "3a2a939897765df6ca76415ec49f17e1939eef06",
+  "regenerated_at": "2026-05-09T04:52:56.414651+00:00",
+  "commit_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878",
   "artifacts": {
     "loops.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "ports.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "labels.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "modules.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "events.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "adr_xref.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "mockworld.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "changelog.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     },
     "functional_areas.md": {
-      "source_sha": "3a2a939897765df6ca76415ec49f17e1939eef06"
+      "source_sha": "5b34e92efe9dfa4a82b3824fd861697fc6429878"
     }
   }
 }

--- a/docs/arch/functional_areas.yml
+++ b/docs/arch/functional_areas.yml
@@ -24,6 +24,7 @@ areas:
       - EpicSweeperLoop
       - GitHubCacheLoop
       - HealthMonitorLoop
+      - LabelDriftWatcherLoop
       - MemoryBacklogLoop
       - PRUnstickerLoop
       - PricingRefreshLoop

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -169,4 +169,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -169,4 +169,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -63,6 +63,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0053 | `src.repo_wiki`, `src.repo_wiki_loop` |
 | ADR-0054 | `src.term_proposer_loop`, `src.ubiquitous_language` |
 | ADR-0055 | `src.base_background_loop`, `src.base_runner`, `src.config`, `src.events`, `src.exception_classify`, `src.mockworld.fakes.fake_honeycomb`, `src.pr_manager`, `src.server`, `src.telemetry.__init__`, `src.telemetry.otel`, `src.telemetry.slugs`, `src.telemetry.spans`, `src.telemetry.subprocess_bridge`, `src.trace_collector`, `src.workspace` |
+| ADR-0056 | `src.label_drift_watcher_loop`, `src.models`, `src.pr_manager` |
 | ADR-0057 | `src.memory_backlog_loop`, `src.memory_backlog_mirror` |
 
 ## Module → ADRs
@@ -109,18 +110,19 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.issue_cache` | ADR-0041 |
 | `src.issue_fetcher` | ADR-0019 |
 | `src.issue_store` | ADR-0006, ADR-0022, ADR-0041 |
+| `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.sandbox_main` | ADR-0052 |
-| `src.models` | ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0025, ADR-0031, ADR-0037, ADR-0045, ADR-0050 |
+| `src.models` | ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0025, ADR-0031, ADR-0037, ADR-0045, ADR-0050, ADR-0056 |
 | `src.orchestrator` | ADR-0006, ADR-0009, ADR-0014, ADR-0044, ADR-0045 |
 | `src.path` | ADR-0032 |
 | `src.plan_phase` | ADR-0014, ADR-0031 |
 | `src.ports` | ADR-0003, ADR-0044 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019 |
-| `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055 |
+| `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -167,4 +169,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -169,4 +169,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `5b34e92` — feat(pr-manager): find_label_drift — detects cross-entity drift *(2026-05-08)*
 - `3a2a939` — docs(adr): ADR-0056 LabelDriftWatcherLoop — proposed *(2026-05-08)*
 - `df80b0c` — fix(pr-unsticker): split issue vs PR label targets on HITL release (#8715) (#8715) *(2026-05-08)*
 - `69d9f4a` — feat: tier-2 enforcement batch (mock spec, ci git, memory backlog loop) (#8714) (#8714) *(2026-05-08)*
@@ -176,4 +177,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `907c272` — feat(caretaker): LabelDriftWatcherLoop — detect+reconcile drift *(2026-05-08)*
 - `5b34e92` — feat(pr-manager): find_label_drift — detects cross-entity drift *(2026-05-08)*
 - `3a2a939` — docs(adr): ADR-0056 LabelDriftWatcherLoop — proposed *(2026-05-08)*
 - `df80b0c` — fix(pr-unsticker): split issue vs PR label targets on HITL release (#8715) (#8715) *(2026-05-08)*
@@ -177,4 +178,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,12 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
-- `4c1abad` — chore(arch): regen after cleanup commit (commit-SHA pin update only) *(2026-05-07)*
-- `937ae61` — fix: revert Task 4 (redundant with existing test_event_reducer_coverage) *(2026-05-07)*
-- `eb05faf` — feat(memory-backlog): wire MemoryBacklogLoop into 5 checkpoints + caretaking area *(2026-05-07)*
-- `f4e4f73` — feat(memory-backlog): MemoryBacklogLoop class + integration tests *(2026-05-07)*
-- `fd963e8` — feat(memory-backlog): ADR-0057 + config + state mixin *(2026-05-07)*
-- `db80032` — feat(memory-backlog): in-repo mirror of feedback memories *(2026-05-07)*
+- `3a2a939` — docs(adr): ADR-0056 LabelDriftWatcherLoop — proposed *(2026-05-08)*
+- `df80b0c` — fix(pr-unsticker): split issue vs PR label targets on HITL release (#8715) (#8715) *(2026-05-08)*
+- `69d9f4a` — feat: tier-2 enforcement batch (mock spec, ci git, memory backlog loop) (#8714) (#8714) *(2026-05-08)*
+- `6704c08` — fix(implement): don't publish PRs for failed fresh attempts (#8713) (#8713) *(2026-05-08)*
 - `1966bfd` — fix(staging-promotion): trigger CI on rc/* PRs via synthetic commit *(2026-05-07)*
 - `c681459` — feat(pr): caretaker-loops spec + plan + update_pr_base port method (#8489) (#8489) *(2026-05-07)*
 - `cdb1a31` — feat(testing): document HydraFlow test pyramid + add missing layers for #8482 (#8486) (#8486) *(2026-05-07)*
@@ -178,4 +176,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `b7abdcc` — feat(caretaker): wire LabelDriftWatcherLoop into hygiene registries *(2026-05-08)*
 - `907c272` — feat(caretaker): LabelDriftWatcherLoop — detect+reconcile drift *(2026-05-08)*
 - `5b34e92` — feat(pr-manager): find_label_drift — detects cross-entity drift *(2026-05-08)*
 - `3a2a939` — docs(adr): ADR-0056 LabelDriftWatcherLoop — proposed *(2026-05-08)*
@@ -178,4 +179,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -16,6 +16,7 @@ flowchart LR
         caretaking_EpicSweeperLoop([EpicSweeperLoop])
         caretaking_GitHubCacheLoop([GitHubCacheLoop])
         caretaking_HealthMonitorLoop([HealthMonitorLoop])
+        caretaking_LabelDriftWatcherLoop([LabelDriftWatcherLoop])
         caretaking_MemoryBacklogLoop([MemoryBacklogLoop])
         caretaking_PRUnstickerLoop([PRUnstickerLoop])
         caretaking_PricingRefreshLoop([PricingRefreshLoop])
@@ -92,6 +93,7 @@ Autonomous background loops that maintain the system without human input — wik
 - `EpicSweeperLoop` — `src.epic_sweeper_loop`
 - `GitHubCacheLoop` — `src.github_cache_loop`
 - `HealthMonitorLoop` — `src.health_monitor_loop`
+- `LabelDriftWatcherLoop` — `src.label_drift_watcher_loop`
 - `MemoryBacklogLoop` — `src.memory_backlog_loop`
 - `PRUnstickerLoop` — `src.pr_unsticker_loop`
 - `PricingRefreshLoop` — `src.pricing_refresh_loop`
@@ -263,4 +265,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -263,4 +263,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -45,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -22,6 +22,7 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **FlakeTrackerLoop** | `src.flake_tracker_loop` | — | — | — | — |
 | **GitHubCacheLoop** | `src.github_cache_loop` | — | — | — | — |
 | **HealthMonitorLoop** | `src.health_monitor_loop` | — | — | — | — |
+| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | — | — | — | — |
 | **MemoryBacklogLoop** | `src.memory_backlog_loop` | — | — | — | — |
 | **PRUnstickerLoop** | `src.pr_unsticker_loop` | — | — | — | — |
 | **PricingRefreshLoop** | `src.pricing_refresh_loop` | — | — | — | — |
@@ -44,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -44,4 +44,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -45,4 +45,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._
+_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -62,7 +62,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._
+_Regenerated from commit `5b34e92` on 2026-05-09 04:52 UTC. Source last changed at `5b34e92`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `4c1abad` on 2026-05-08 03:33 UTC. Source last changed at `4c1abad`. Status: 🟢 fresh._
+_Regenerated from commit `3a2a939` on 2026-05-09 04:45 UTC. Source last changed at `3a2a939`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -91,4 +91,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `907c272` on 2026-05-09 04:58 UTC. Source last changed at `907c272`. Status: 🟢 fresh._
+_Regenerated from commit `188a51e` on 2026-05-09 05:19 UTC. Source last changed at `188a51e`. Status: 🟢 fresh._

--- a/src/config.py
+++ b/src/config.py
@@ -242,7 +242,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         86400,
     ),
     ("trust_fleet_sanity_interval", "HYDRAFLOW_TRUST_FLEET_SANITY_INTERVAL", 600),
-    ("label_drift_interval", "HYDRAFLOW_LABEL_DRIFT_INTERVAL", 600),
+    ("label_drift_watcher_interval", "HYDRAFLOW_LABEL_DRIFT_WATCHER_INTERVAL", 600),
     ("loop_anomaly_issues_per_hour", "HYDRAFLOW_LOOP_ANOMALY_ISSUES_PER_HOUR", 10),
     ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 3600),
     ("contract_refresh_interval", "HYDRAFLOW_CONTRACT_REFRESH_INTERVAL", 604800),
@@ -781,7 +781,7 @@ class HydraFlowConfig(BaseModel):
         le=86400,
         description="Stale issue GC loop interval in seconds (default 1 hour)",
     )
-    label_drift_interval: int = Field(
+    label_drift_watcher_interval: int = Field(
         default=600,
         ge=120,
         le=86400,

--- a/src/config.py
+++ b/src/config.py
@@ -242,6 +242,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
         86400,
     ),
     ("trust_fleet_sanity_interval", "HYDRAFLOW_TRUST_FLEET_SANITY_INTERVAL", 600),
+    ("label_drift_interval", "HYDRAFLOW_LABEL_DRIFT_INTERVAL", 600),
     ("loop_anomaly_issues_per_hour", "HYDRAFLOW_LOOP_ANOMALY_ISSUES_PER_HOUR", 10),
     ("corpus_learning_interval", "HYDRAFLOW_CORPUS_LEARNING_INTERVAL", 3600),
     ("contract_refresh_interval", "HYDRAFLOW_CONTRACT_REFRESH_INTERVAL", 604800),
@@ -779,6 +780,12 @@ class HydraFlowConfig(BaseModel):
         ge=300,
         le=86400,
         description="Stale issue GC loop interval in seconds (default 1 hour)",
+    )
+    label_drift_interval: int = Field(
+        default=600,
+        ge=120,
+        le=86400,
+        description="LabelDriftWatcherLoop scan interval in seconds (120-86400).",
     )
     stale_issue_interval: int = Field(
         default=86400,

--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -54,6 +54,7 @@ _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
     "rc_budget": (3600, 604800),  # 1h min, 7d max
     "wiki_rot_detector": (86400, 2_592_000),  # 1d min, 30d max
     "trust_fleet_sanity": (60, 3600),  # 1m min, 1h max
+    "label_drift_watcher": (120, 86400),  # 2m min, 1d max (ADR-0056)
     "contract_refresh": (86400, 2_592_000),  # 1d min, 30d max
     "corpus_learning": (3600, 2_592_000),  # 1h min, 30d max
     "auto_agent_preflight": (60, 600),

--- a/src/label_drift_watcher_loop.py
+++ b/src/label_drift_watcher_loop.py
@@ -1,0 +1,103 @@
+"""LabelDriftWatcherLoop — periodic detect-and-reconcile of cross-entity
+issue/PR label drift.
+
+Per ADR-0056. The loop scans for drift via :meth:`PRPort.find_label_drift`
+and reconciles each pair by per-entity ``swap_pipeline_labels`` calls
+(mirroring the Phase D split-call pattern: issue gets one label, PR gets
+``hydraflow-review``).
+
+Pattern reference: ``src/memory_backlog_loop.py`` (canonical caretaker
+loop). Same shape: tick logic in ``_do_work``, kwargs-only constructor,
+ADR-0049 in-body kill-switch gate via ``self._enabled_cb``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from models import LabelDrift, WorkCycleResult  # noqa: TCH001
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+    from ports import PRPort
+
+logger = logging.getLogger("hydraflow.label_drift_watcher_loop")
+
+
+class LabelDriftWatcherLoop(BaseBackgroundLoop):
+    """Periodic scan for cross-entity label drift; reconcile via two
+    ``swap_pipeline_labels`` calls (issue target may differ from PR target
+    across stages).
+    """
+
+    def __init__(
+        self,
+        *,
+        config: HydraFlowConfig,
+        pr_manager: PRPort,
+        deps: LoopDeps,
+    ) -> None:
+        super().__init__(
+            worker_name="label_drift_watcher",
+            config=config,
+            deps=deps,
+            run_on_startup=False,
+        )
+        self._prs = pr_manager
+
+    def _get_default_interval(self) -> int:
+        return self._config.label_drift_interval
+
+    async def _do_work(self) -> WorkCycleResult:
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+
+        drift = await self._prs.find_label_drift()
+        reconciled = 0
+        for d in drift:
+            try:
+                await self._reconcile(d)
+                reconciled += 1
+            except Exception:
+                logger.warning(
+                    "label_drift_watcher: reconcile failed for issue #%d / PR #%d",
+                    d.issue,
+                    d.pr,
+                    exc_info=True,
+                )
+        return {"detected": len(drift), "reconciled": reconciled}
+
+    async def _reconcile(self, d: LabelDrift) -> None:
+        """Apply per-stage labels mirroring Phase D's split-call pattern.
+
+        - ``pr_ahead_of_issue``: issue lags at ready/plan; pull it forward
+          to ``hydraflow-review`` to match the PR's stage. PR label stays.
+        - ``pr_at_pre_pr_stage``: PR has commits but a pre-PR label
+          (ready/plan/find); push the PR forward to ``hydraflow-review``.
+          Issue label stays.
+        - ``pr_behind_issue``: PR at ready/plan while issue at review;
+          push the PR forward to ``hydraflow-review``.
+        """
+        if d.kind == "pr_ahead_of_issue":
+            await self._prs.swap_pipeline_labels(d.issue, "hydraflow-review")
+        elif d.kind in {"pr_at_pre_pr_stage", "pr_behind_issue"}:
+            await self._prs.swap_pipeline_labels(d.pr, "hydraflow-review")
+
+        await self._prs.post_comment(
+            d.issue,
+            (
+                f"**LabelDriftWatcher** reconciled label drift "
+                f"(issue was at `{d.issue_label}`, PR #{d.pr} was at "
+                f"`{d.pr_label}`, kind={d.kind}). Both should now be aligned "
+                f"at `hydraflow-review`.\n\n"
+                "---\n*Automated by HydraFlow Label Drift Watcher (ADR-0056)*"
+            ),
+        )
+        logger.info(
+            "label_drift_watcher: reconciled issue #%d / PR #%d (kind=%s)",
+            d.issue,
+            d.pr,
+            d.kind,
+        )

--- a/src/label_drift_watcher_loop.py
+++ b/src/label_drift_watcher_loop.py
@@ -48,7 +48,7 @@ class LabelDriftWatcherLoop(BaseBackgroundLoop):
         self._prs = pr_manager
 
     def _get_default_interval(self) -> int:
-        return self._config.label_drift_interval
+        return self._config.label_drift_watcher_interval
 
     async def _do_work(self) -> WorkCycleResult:
         if not self._enabled_cb(self._worker_name):

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from mockworld.fakes._factories import PRInfoFactory
+from models import LabelDrift
 
 if TYPE_CHECKING:
     from mockworld.seed import MockWorldSeed
@@ -61,6 +63,10 @@ class FakePR:
     reviews: list[tuple[str, str]] = field(default_factory=list)
     checks: list[tuple[str, str]] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
+    # Commit count used by ``find_label_drift`` (ADR-0056) to distinguish
+    # zero-commit PRs from real ones. Defaults to 1 so seeded PRs look
+    # "real" without explicit setup.
+    commits: int = 1
 
 
 class FakeGitHub:
@@ -497,6 +503,60 @@ class FakeGitHub:
                     branch=pr.branch,
                     draft=pr.draft,
                     labels=list(pr.labels),
+                )
+            )
+        return out
+
+    async def find_label_drift(self) -> list[LabelDrift]:
+        """In-memory mirror of :meth:`PRPort.find_label_drift` (ADR-0056).
+
+        Walks open, non-merged PRs and pairs each with its linked issue;
+        classifies drift kinds the same way ``PRManager.find_label_drift``
+        classifies them.
+        """
+        self._maybe_rate_limit()
+        pre_pr_labels = {"hydraflow-ready", "hydraflow-plan", "hydraflow-find"}
+        post_pr_labels = {"hydraflow-fixed", "hydraflow-hitl"}
+        out: list[LabelDrift] = []
+        for pr in self._prs.values():
+            if pr.merged:
+                continue
+            issue = self._issues.get(pr.issue_number)
+            if issue is None:
+                continue
+            pr_pipeline = next(
+                (lbl for lbl in pr.labels if lbl.startswith("hydraflow-")),
+                "",
+            )
+            issue_pipeline = next(
+                (lbl for lbl in issue.labels if lbl.startswith("hydraflow-")),
+                "",
+            )
+            commits = pr.commits
+
+            kind: str | None = None
+            if (
+                issue_pipeline in pre_pr_labels
+                and pr_pipeline == "hydraflow-review"
+                and commits > 0
+            ):
+                kind = "pr_ahead_of_issue"
+            elif pr_pipeline in pre_pr_labels and commits > 0:
+                kind = "pr_at_pre_pr_stage"
+            elif pr_pipeline in post_pr_labels and issue_pipeline in pre_pr_labels:
+                kind = "pr_ahead_of_issue"
+
+            if kind is None:
+                continue
+            out.append(
+                LabelDrift(
+                    issue=pr.issue_number,
+                    pr=pr.number,
+                    pr_commits=commits,
+                    issue_label=issue_pipeline,
+                    pr_label=pr_pipeline,
+                    kind=kind,  # type: ignore[arg-type]
+                    detected_at=datetime.now(UTC),
                 )
             )
         return out

--- a/src/models.py
+++ b/src/models.py
@@ -872,6 +872,37 @@ class PRInfo(BaseModel):
     )
 
 
+class LabelDrift(BaseModel):
+    """Cross-entity label drift between an issue and its PR.
+
+    See ADR-0056 for the kinds and reconciliation policy. The
+    ``LabelDriftWatcherLoop`` emits one record per drifted (issue, PR)
+    pair on each tick.
+
+    Kinds:
+        - ``pr_ahead_of_issue``: issue labelled ``hydraflow-ready`` /
+          ``hydraflow-plan`` while the PR is at ``hydraflow-review`` /
+          ``hydraflow-fixed`` / ``hydraflow-hitl`` with commits.
+        - ``pr_behind_issue``: PR at ``hydraflow-ready`` /
+          ``hydraflow-plan`` while issue is at ``hydraflow-review``.
+        - ``pr_at_pre_pr_stage``: PR labelled ``hydraflow-ready`` /
+          ``hydraflow-plan`` / ``hydraflow-find`` while it has commits
+          (PR-stage labels are review/hitl/fixed only).
+    """
+
+    issue: int = Field(description="Linked issue number")
+    pr: int = Field(description="PR number")
+    pr_commits: int = Field(ge=0, description="Number of commits on the PR")
+    issue_label: str = Field(description="Current pipeline label on the issue")
+    pr_label: str = Field(description="Current pipeline label on the PR")
+    kind: Literal["pr_ahead_of_issue", "pr_behind_issue", "pr_at_pre_pr_stage"] = Field(
+        description="Drift category — see ADR-0056"
+    )
+    detected_at: datetime = Field(
+        description="UTC timestamp when the drift was observed"
+    )
+
+
 # --- HITL ---
 
 

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -999,6 +999,7 @@ class HydraFlowOrchestrator:
             ("rc_budget", self._svc.rc_budget_loop.run),
             ("wiki_rot_detector", self._svc.wiki_rot_detector_loop.run),
             ("trust_fleet_sanity", self._svc.trust_fleet_sanity_loop.run),
+            ("label_drift_watcher", self._svc.label_drift_watcher_loop.run),
             ("contract_refresh", self._svc.contract_refresh_loop.run),
             ("corpus_learning", self._svc.corpus_learning_loop.run),
             ("auto_agent_preflight", self._svc.auto_agent_preflight_loop.run),

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -183,6 +183,7 @@ class HydraFlowOrchestrator:
             "rc_budget": svc.rc_budget_loop,
             "wiki_rot_detector": svc.wiki_rot_detector_loop,
             "trust_fleet_sanity": svc.trust_fleet_sanity_loop,
+            "label_drift_watcher": svc.label_drift_watcher_loop,
             "contract_refresh": svc.contract_refresh_loop,
             "corpus_learning": svc.corpus_learning_loop,
             "auto_agent_preflight": svc.auto_agent_preflight_loop,

--- a/src/ports.py
+++ b/src/ports.py
@@ -54,6 +54,7 @@ from models import (
     GitHubIssue,
     GitHubIssueSummary,
     HITLItem,
+    LabelDrift,
     LoopResult,
     PRInfo,
     ReviewVerdict,
@@ -371,6 +372,15 @@ class PRPort(Protocol):
         Used by SandboxFailureFixerLoop to poll PRs that need auto-fix
         intervention. Excludes merged and closed PRs by definition —
         callers wanting closed PRs use a different method.
+        """
+        ...
+
+    async def find_label_drift(self) -> list[LabelDrift]:
+        """Scan open PRs for cross-entity label drift vs their linked issues.
+
+        Returns a list of :class:`LabelDrift` records — one per drifted
+        (issue, PR) pair. See ADR-0056 for the drift kinds and the
+        ``LabelDriftWatcherLoop`` reconciliation policy.
         """
         ...
 

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -29,6 +29,7 @@ from models import (
     HITLItem,
     IssueCreatedPayload,
     LabelCounts,
+    LabelDrift,
     MergeUpdatePayload,
     PRCreatedPayload,
     PRInfo,
@@ -1642,6 +1643,114 @@ class PRManager:
                 await self._remove_label("issue", issue_number, lbl)
                 if pr_number is not None:
                     await self._remove_label("pr", pr_number, lbl)
+
+    async def find_label_drift(self) -> list[LabelDrift]:
+        """Scan open PRs for cross-entity label drift vs their linked issues.
+
+        Returns a list of :class:`LabelDrift` records, one per drifted pair.
+        See ADR-0056 for the drift kinds and reconciliation policy.
+
+        Each tick: fetch open PRs (any state), parse ``Fixes #N`` from the
+        body, fetch the linked issue's labels, then classify the pair.
+        """
+        raw = await self._gh_json_query(
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            self._repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,labels,body,commits",
+            dry_run_return=[],
+            error_log="find_label_drift: pr list failed",
+        )
+        if not isinstance(raw, list):
+            return []
+
+        out: list[LabelDrift] = []
+        pre_pr_labels = {"hydraflow-ready", "hydraflow-plan", "hydraflow-find"}
+        post_pr_labels = {"hydraflow-fixed", "hydraflow-hitl"}
+        fixes_re = re.compile(r"[Ff]ixes\s+#(\d+)")
+
+        for pr in raw:
+            if not isinstance(pr, dict):
+                continue
+            try:
+                pr_n = int(pr.get("number", 0))
+            except (TypeError, ValueError):
+                continue
+            if pr_n <= 0:
+                continue
+            pr_labels = {
+                lbl.get("name", "")
+                for lbl in (pr.get("labels") or [])
+                if isinstance(lbl, dict)
+            }
+            pr_pipeline = next(
+                (lbl for lbl in pr_labels if lbl.startswith("hydraflow-")),
+                "",
+            )
+            commits = len(pr.get("commits") or [])
+            body = pr.get("body") or ""
+            m = fixes_re.search(body)
+            if not m:
+                continue
+            issue_n = int(m.group(1))
+
+            issue_labels_raw = await self._gh_json_query(
+                "gh",
+                "issue",
+                "view",
+                str(issue_n),
+                "--repo",
+                self._repo,
+                "--json",
+                "labels",
+                dry_run_return={"labels": []},
+                error_log=f"find_label_drift: issue {issue_n} fetch failed",
+            )
+            if not isinstance(issue_labels_raw, dict):
+                continue
+            issue_labels = {
+                lbl.get("name", "")
+                for lbl in (issue_labels_raw.get("labels") or [])
+                if isinstance(lbl, dict)
+            }
+            issue_pipeline = next(
+                (lbl for lbl in issue_labels if lbl.startswith("hydraflow-")),
+                "",
+            )
+
+            kind: str | None = None
+            if (
+                issue_pipeline in pre_pr_labels
+                and pr_pipeline == "hydraflow-review"
+                and commits > 0
+            ):
+                kind = "pr_ahead_of_issue"
+            elif pr_pipeline in pre_pr_labels and commits > 0:
+                kind = "pr_at_pre_pr_stage"
+            elif pr_pipeline in post_pr_labels and issue_pipeline in pre_pr_labels:
+                kind = "pr_ahead_of_issue"
+
+            if kind is None:
+                continue
+            out.append(
+                LabelDrift(
+                    issue=issue_n,
+                    pr=pr_n,
+                    pr_commits=commits,
+                    issue_label=issue_pipeline,
+                    pr_label=pr_pipeline,
+                    kind=kind,  # type: ignore[arg-type]
+                    detected_at=datetime.now(UTC),
+                )
+            )
+        return out
 
     async def get_dependabot_alerts(self, state: str = "open") -> list[dict]:
         """Fetch Dependabot alerts for the repository.

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -48,6 +48,7 @@ from implement_phase import ImplementPhase
 from issue_cache import IssueCache
 from issue_fetcher import GitHubTaskFetcher, IssueFetcher
 from issue_store import IssueStore
+from label_drift_watcher_loop import LabelDriftWatcherLoop
 from memory_backlog_loop import MemoryBacklogLoop
 from merge_conflict_resolver import MergeConflictResolver
 from models import StatusCallback
@@ -186,6 +187,7 @@ class ServiceRegistry:
     rc_budget_loop: RCBudgetLoop
     wiki_rot_detector_loop: WikiRotDetectorLoop
     trust_fleet_sanity_loop: TrustFleetSanityLoop
+    label_drift_watcher_loop: LabelDriftWatcherLoop
     contract_refresh_loop: ContractRefreshLoop
     corpus_learning_loop: CorpusLearningLoop
     auto_agent_preflight_loop: AutoAgentPreflightLoop
@@ -1059,6 +1061,12 @@ def build_services(
                 "prs.add_pr_labels into an `open_bot_pr(...)` shape."
             )
 
+    label_drift_watcher_loop = LabelDriftWatcherLoop(  # noqa: F841
+        config=config,
+        pr_manager=prs,
+        deps=loop_deps,
+    )
+
     term_proposer_llm = TermProposerLLM(client=_NotWiredLLMClient())
     term_proposer_pr_port: BotPRPort = _NotWiredBotPRPort()
     term_proposer_loop = TermProposerLoop(  # noqa: F841
@@ -1132,6 +1140,7 @@ def build_services(
         rc_budget_loop=rc_budget_loop,
         wiki_rot_detector_loop=wiki_rot_detector_loop,
         trust_fleet_sanity_loop=trust_fleet_sanity_loop,
+        label_drift_watcher_loop=label_drift_watcher_loop,
         contract_refresh_loop=contract_refresh_loop,
         corpus_learning_loop=corpus_learning_loop,
         auto_agent_preflight_loop=auto_agent_preflight_loop,

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -249,7 +249,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'code_grooming', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -286,6 +286,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   diagram_loop: 14400,
   pricing_refresh: 86400,
   cost_budget_watcher: 300,
+  label_drift_watcher: 600,
 }
 
 /**
@@ -342,6 +343,7 @@ export const BACKGROUND_WORKERS = [
   { key: 'diagram_loop', label: 'Diagram Loop (L24)', description: 'Self-documenting architecture caretaker. Walks src/, tests/, docs/adr/ every 4h; emits regenerated docs/arch/generated/ markdown + opens a PR when the live truth has drifted. Per ADR-0029 (caretaker pattern) and the Architecture Knowledge System spec.', color: theme.cyan, group: 'learning', tags: ['knowledge'] },
   { key: 'pricing_refresh', label: 'Pricing Refresh', description: 'Daily upstream-pricing refresh caretaker. Fetches LiteLLM\'s structured pricing JSON, diffs against src/assets/model_pricing.json, opens a PR if upstream has new or changed Claude models. Bounds-guard rejects suspicious price moves (>+100% or <-50%). Always human-reviewed; never auto-merges.', color: theme.cyan, group: 'learning', tags: ['cost'] },
   { key: 'cost_budget_watcher', label: 'Cost Budget Watcher', description: 'Polls rolling-24h LLM spend every 5 min; disables caretaker loops when daily cap exceeded; auto-recovers as the rolling window drops below the cap. Default unlimited (cap=None).', color: theme.cyan, group: 'operations', tags: ['monitoring'] },
+  { key: 'label_drift_watcher', label: 'Label Drift Watcher', description: 'Periodic scan for cross-entity issue/PR label drift (e.g., issue at hydraflow-ready while linked PR at hydraflow-review with commits); reconciles via per-entity swap_pipeline_labels. See ADR-0056.', color: theme.orange, group: 'repo_health', tags: ['hygiene'] },
 ]
 
 /**

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -496,6 +496,7 @@ def build_scripted_services(
     services.rc_budget_loop = FakeBackgroundLoop()
     services.wiki_rot_detector_loop = FakeBackgroundLoop()
     services.trust_fleet_sanity_loop = FakeBackgroundLoop()
+    services.label_drift_watcher_loop = FakeBackgroundLoop()
     services.corpus_learning_loop = FakeBackgroundLoop()
     services.contract_refresh_loop = FakeBackgroundLoop()
     services.auto_agent_preflight_loop = FakeBackgroundLoop()

--- a/tests/test_label_drift_watcher_integration.py
+++ b/tests/test_label_drift_watcher_integration.py
@@ -1,0 +1,74 @@
+"""End-to-end integration: LabelDriftWatcherLoop against FakeGitHub.
+
+Wires the loop to the in-memory ``FakeGitHub`` (which implements ``PRPort``
+including ``find_label_drift`` and ``swap_pipeline_labels``) and verifies
+a single tick detects+reconciles ``pr_ahead_of_issue`` drift in the
+seeded world.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from events import EventBus
+from label_drift_watcher_loop import LabelDriftWatcherLoop
+from mockworld.fakes import FakeGitHub
+
+
+def _deps(stop: asyncio.Event) -> LoopDeps:
+    return LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *_a, **_k: None,
+        enabled_cb=lambda _name: True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_reconciles_pr_ahead_of_issue_against_fake(tmp_path: Path) -> None:
+    """Seed FakeGitHub with drift; one tick reconciles it; second tick is no-op."""
+    cfg = HydraFlowConfig(data_root=tmp_path, repo="owner/repo", repo_root=tmp_path)
+
+    gh = FakeGitHub()
+    # Issue stuck at hydraflow-ready while linked PR has commits and is
+    # at hydraflow-review — classic pr_ahead_of_issue drift.
+    gh.add_issue(42, "feature work", "body", labels=["hydraflow-ready"])
+    gh.add_pr(number=100, issue_number=42, branch="hf/issue-42")
+    gh.add_pr_label(100, "hydraflow-review")
+
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=gh, deps=_deps(asyncio.Event()))
+
+    first = await loop._do_work()
+    assert first == {"detected": 1, "reconciled": 1}
+    # Issue label pulled forward to hydraflow-review (PR's stage).
+    assert "hydraflow-review" in gh._issues[42].labels
+    assert "hydraflow-ready" not in gh._issues[42].labels
+
+    second = await loop._do_work()
+    assert second == {"detected": 0, "reconciled": 0}, (
+        "second tick must be a no-op once drift is reconciled"
+    )
+
+
+@pytest.mark.asyncio
+async def test_loop_no_op_on_clean_world(tmp_path: Path) -> None:
+    """Aligned issue/PR labels → no drift, no swap, no comment."""
+    cfg = HydraFlowConfig(data_root=tmp_path, repo="owner/repo", repo_root=tmp_path)
+
+    gh = FakeGitHub()
+    gh.add_issue(7, "aligned", "body", labels=["hydraflow-review"])
+    gh.add_pr(number=70, issue_number=7, branch="hf/issue-7")
+    gh.add_pr_label(70, "hydraflow-review")
+
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=gh, deps=_deps(asyncio.Event()))
+
+    stats = await loop._do_work()
+
+    assert stats == {"detected": 0, "reconciled": 0}
+    # No comments posted — quiet on clean worlds.
+    assert gh._comments == []

--- a/tests/test_label_drift_watcher_loop.py
+++ b/tests/test_label_drift_watcher_loop.py
@@ -1,0 +1,185 @@
+"""Tests for LabelDriftWatcherLoop (ADR-0056).
+
+The loop runs ``find_label_drift`` per tick and reconciles each pair via
+two ``swap_pipeline_labels`` calls. We mock the PRPort directly to test
+the loop's reconciliation logic in isolation; ``find_label_drift``
+itself has separate coverage in ``tests/test_pr_manager_drift.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from events import EventBus
+from label_drift_watcher_loop import LabelDriftWatcherLoop
+from models import LabelDrift
+
+
+def _deps(stop: asyncio.Event) -> LoopDeps:
+    return LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+
+
+@pytest.fixture
+def loop_env(tmp_path: Path):
+    cfg = HydraFlowConfig(
+        data_root=tmp_path, repo="hydra/hydraflow", repo_root=tmp_path
+    )
+    pr = AsyncMock()
+    pr.find_label_drift = AsyncMock(return_value=[])
+    pr.swap_pipeline_labels = AsyncMock(return_value=None)
+    pr.post_comment = AsyncMock(return_value=None)
+    return cfg, pr
+
+
+def test_worker_name_and_default_interval(loop_env) -> None:
+    cfg, pr = loop_env
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+    assert loop._worker_name == "label_drift_watcher"
+    assert loop._get_default_interval() == cfg.label_drift_interval
+
+
+@pytest.mark.asyncio
+async def test_no_drift_no_op(loop_env) -> None:
+    """Empty drift list → loop returns zero stats and does not swap labels."""
+    cfg, pr = loop_env
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    stats = await loop._do_work()
+
+    assert stats == {"detected": 0, "reconciled": 0}
+    pr.swap_pipeline_labels.assert_not_awaited()
+    pr.post_comment.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_detects_and_reconciles_pr_ahead_of_issue(loop_env) -> None:
+    """``pr_ahead_of_issue`` drift → swap issue to review + post comment."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=42,
+        pr=100,
+        pr_commits=2,
+        issue_label="hydraflow-ready",
+        pr_label="hydraflow-review",
+        kind="pr_ahead_of_issue",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(return_value=[drift])
+
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    stats = await loop._do_work()
+
+    assert stats == {"detected": 1, "reconciled": 1}
+    pr.swap_pipeline_labels.assert_awaited_once_with(42, "hydraflow-review")
+    pr.post_comment.assert_awaited_once()
+    body = pr.post_comment.await_args.args[1]
+    assert "LabelDriftWatcher" in body
+    assert "pr_ahead_of_issue" in body
+
+
+@pytest.mark.asyncio
+async def test_reconciles_pr_at_pre_pr_stage(loop_env) -> None:
+    """``pr_at_pre_pr_stage`` drift → swap PR (not issue) to review."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=99,
+        pr=200,
+        pr_commits=3,
+        issue_label="hydraflow-review",
+        pr_label="hydraflow-ready",
+        kind="pr_at_pre_pr_stage",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(return_value=[drift])
+
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    stats = await loop._do_work()
+
+    assert stats == {"detected": 1, "reconciled": 1}
+    pr.swap_pipeline_labels.assert_awaited_once_with(200, "hydraflow-review")
+
+
+@pytest.mark.asyncio
+async def test_idempotent_on_second_run(loop_env) -> None:
+    """First run reconciles; second run with empty drift is a no-op."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=42,
+        pr=100,
+        pr_commits=2,
+        issue_label="hydraflow-ready",
+        pr_label="hydraflow-review",
+        kind="pr_ahead_of_issue",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(side_effect=[[drift], []])
+
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    first = await loop._do_work()
+    second = await loop._do_work()
+
+    assert first == {"detected": 1, "reconciled": 1}
+    assert second == {"detected": 0, "reconciled": 0}
+    assert pr.swap_pipeline_labels.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reconcile_failure_counted_separately(loop_env) -> None:
+    """Per-pair reconcile error → detected counts but reconciled does not."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=42,
+        pr=100,
+        pr_commits=2,
+        issue_label="hydraflow-ready",
+        pr_label="hydraflow-review",
+        kind="pr_ahead_of_issue",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(return_value=[drift])
+    pr.swap_pipeline_labels = AsyncMock(side_effect=RuntimeError("api fail"))
+
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    stats = await loop._do_work()
+
+    assert stats == {"detected": 1, "reconciled": 0}
+
+
+@pytest.mark.asyncio
+async def test_disabled_returns_status(loop_env) -> None:
+    """Kill-switch off → loop returns ``{"status": "disabled"}`` without scanning."""
+    cfg, pr = loop_env
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=asyncio.Event(),
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: False,
+    )
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=deps)
+
+    stats = await loop._do_work()
+
+    assert stats == {"status": "disabled"}
+    pr.find_label_drift.assert_not_awaited()

--- a/tests/test_label_drift_watcher_loop.py
+++ b/tests/test_label_drift_watcher_loop.py
@@ -48,7 +48,7 @@ def test_worker_name_and_default_interval(loop_env) -> None:
     stop = asyncio.Event()
     loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
     assert loop._worker_name == "label_drift_watcher"
-    assert loop._get_default_interval() == cfg.label_drift_interval
+    assert loop._get_default_interval() == cfg.label_drift_watcher_interval
 
 
 @pytest.mark.asyncio

--- a/tests/test_pr_manager_drift.py
+++ b/tests/test_pr_manager_drift.py
@@ -1,0 +1,168 @@
+"""PRManager.find_label_drift — detects cross-entity issue/PR drift.
+
+See ADR-0056. Three drift kinds:
+- ``pr_ahead_of_issue``: issue at ready/plan, PR at review with commits
+- ``pr_at_pre_pr_stage``: PR labelled ready/plan but has commits
+- ``pr_behind_issue``: PR at ready/plan while issue at review
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tests.helpers import make_pr_manager
+
+
+def _gh_responder(mapping: dict[tuple[str, ...], str]):
+    """Return an AsyncMock side_effect that dispatches by tuple of cmd args.
+
+    ``mapping`` keys are partial-match tuples (e.g. ("pr", "list")) — the
+    first key whose elements all appear in the call's positional args wins.
+    """
+
+    async def _side_effect(*args, **kwargs):
+        for key, response in mapping.items():
+            if all(part in args for part in key):
+                return response
+        raise AssertionError(f"unexpected gh call: {args}")
+
+    return _side_effect
+
+
+class TestFindLabelDrift:
+    @pytest.mark.asyncio
+    async def test_detects_issue_at_ready_pr_at_review(self, config, event_bus) -> None:
+        """Issue labelled hydraflow-ready while its PR is at hydraflow-review
+        with commits → kind=pr_ahead_of_issue."""
+        mgr = make_pr_manager(config, event_bus)
+
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 100,
+                    "labels": [{"name": "hydraflow-review"}],
+                    "body": "## Summary\n\nFixes #42.\n",
+                    "commits": [{"oid": "a"}, {"oid": "b"}],
+                }
+            ]
+        )
+        issue_json = json.dumps({"labels": [{"name": "hydraflow-ready"}]})
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(
+                side_effect=_gh_responder(
+                    {
+                        ("pr", "list"): prs_json,
+                        ("issue", "view"): issue_json,
+                    }
+                )
+            ),
+        ):
+            drift = await mgr.find_label_drift()
+
+        assert len(drift) == 1
+        assert drift[0].issue == 42
+        assert drift[0].pr == 100
+        assert drift[0].kind == "pr_ahead_of_issue"
+        assert drift[0].issue_label == "hydraflow-ready"
+        assert drift[0].pr_label == "hydraflow-review"
+        assert drift[0].pr_commits == 2
+
+    @pytest.mark.asyncio
+    async def test_detects_pr_at_ready_with_commits(self, config, event_bus) -> None:
+        """PR labelled hydraflow-ready but has commits → kind=pr_at_pre_pr_stage."""
+        mgr = make_pr_manager(config, event_bus)
+
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 200,
+                    "labels": [{"name": "hydraflow-ready"}],
+                    "body": "Fixes #99",
+                    "commits": [{"oid": "a"}, {"oid": "b"}, {"oid": "c"}],
+                }
+            ]
+        )
+        issue_json = json.dumps({"labels": [{"name": "hydraflow-review"}]})
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(
+                side_effect=_gh_responder(
+                    {
+                        ("pr", "list"): prs_json,
+                        ("issue", "view"): issue_json,
+                    }
+                )
+            ),
+        ):
+            drift = await mgr.find_label_drift()
+
+        assert len(drift) == 1
+        assert drift[0].pr == 200
+        assert drift[0].kind == "pr_at_pre_pr_stage"
+        assert drift[0].pr_commits == 3
+
+    @pytest.mark.asyncio
+    async def test_no_drift_when_aligned(self, config, event_bus) -> None:
+        """Issue and PR both at hydraflow-review → empty list."""
+        mgr = make_pr_manager(config, event_bus)
+
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 300,
+                    "labels": [{"name": "hydraflow-review"}],
+                    "body": "Fixes #7",
+                    "commits": [{"oid": "x"}],
+                }
+            ]
+        )
+        issue_json = json.dumps({"labels": [{"name": "hydraflow-review"}]})
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(
+                side_effect=_gh_responder(
+                    {
+                        ("pr", "list"): prs_json,
+                        ("issue", "view"): issue_json,
+                    }
+                )
+            ),
+        ):
+            drift = await mgr.find_label_drift()
+
+        assert drift == []
+
+    @pytest.mark.asyncio
+    async def test_skips_prs_without_fixes_link(self, config, event_bus) -> None:
+        """PR body without 'Fixes #N' is skipped — no linked issue to check."""
+        mgr = make_pr_manager(config, event_bus)
+
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 400,
+                    "labels": [{"name": "hydraflow-review"}],
+                    "body": "no fixes link here",
+                    "commits": [{"oid": "x"}],
+                }
+            ]
+        )
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(side_effect=_gh_responder({("pr", "list"): prs_json})),
+        ):
+            drift = await mgr.find_label_drift()
+
+        assert drift == []


### PR DESCRIPTION
## Summary

- Adds `LabelDriftWatcherLoop` extending `BaseBackgroundLoop` per ADR-0029.
- Periodic scan for cross-entity issue/PR label drift; reconciles by per-entity `swap_pipeline_labels` (mirroring Phase D's split-call pattern, on staging).
- Default interval 600s, operator-tunable via dashboard (bounds 120s-86400s).
- ADR-0056 (accepted).
- Wired into `ServiceRegistry`, `bg_loop_registry`, orchestrator `loop_factories`, `BACKGROUND_WORKERS`, `EDITABLE_INTERVAL_WORKERS`, `SYSTEM_WORKER_INTERVALS`, `_INTERVAL_BOUNDS`, and `functional_areas.yml`.

Skip-ADR: ADR-0056 covers this loop.

## Why this is last in the series

The per-call-site fixes (PRs #8713 / #8719 / #8715) are the primary defenses. This caretaker is the safety net for drift sources we haven't yet enumerated. It depends on:
- PR #8713's `TestPRIssueLabelConsistency` for `swap_pipeline_labels` correctness baseline.
- PR #8719's broadened `_is_zero_commit_failure` so 0-commit PRs don't confuse the scan.
- PR #8715's split-call pattern (the loop reconciles the same way).

## Scope notes

- Deliberately NOT added to `TRUST_LOOP_WORKERS`: that tuple is locked to spec §12.2 (the nine learning trust loops watched by the sanity loop). `LabelDriftWatcherLoop` is a caretaker (per ADR-0029), not a trust-fleet learning loop, so it joins the caretaker registry only.
- `FakeGitHub` gained a `find_label_drift` mirror plus a `commits` field on `FakePR` so the in-memory port↔fake conformance + the integration test stay green.

## Test plan

- [x] Unit tests: `tests/test_pr_manager_drift.py` (4), `tests/test_label_drift_watcher_loop.py` (7)
- [x] Integration: `tests/test_label_drift_watcher_integration.py` (2 — drift seed/reconcile + clean-world no-op against `FakeGitHub`)
- [x] Wiring: `test_orchestrator_integration.py`, `test_loop_wiring_completeness.py`, `test_config_consistency.py`, `test_functional_area_coverage.py`, `test_mockworld_*_conformance.py`
- [x] `make quality` — full suite green (12,115 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)