### PR TITLE
feat(atlas): graph view + ADR nodes + term provenance + filters (P2)

### DIFF
--- a/docs/adr/0060-atlas-graph-view-and-provenance.md
+++ b/docs/adr/0060-atlas-graph-view-and-provenance.md
@@ -1,0 +1,91 @@
+# ADR-0060: Atlas — Graph View, ADR Nodes, and Term Provenance
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Enforced by
+
+`tests/test_atlas_routes.py`, `src/ui/src/components/atlas/__tests__/`
+
+## Context
+
+[ADR-0059](0059-atlas-knowledge-graph-dashboard.md) shipped Atlas Phase 1: a `Domain` view rendering the ubiquitous-language term graph as React Flow parent-grouped nodes, an `Articles` browser unifying ADRs and wiki entries, and a `Maintenance` panel. Five new term + ADR endpoints exposed the data.
+
+Phase 1 deferred three pieces of value that the dataset is now ready to absorb:
+
+1. ADRs are listed in Articles but invisible in the graph itself — there's no way to see which terms an ADR governs without reading prose.
+2. The ubiquitous-language vocabulary now contains both hand-authored terms and proposer-generated ones (`TermProposerLoop`, ADR-0054), but the term detail panel doesn't surface that provenance — every term looks identical regardless of how it entered the glossary.
+3. The grouped layout is good for "what belongs where" but cannot reveal cross-context hubs or dependency clusters; with terms + ADRs combined the dataset is finally large enough that a force-directed layout earns its space.
+
+## Decision
+
+Phase 2 adds three peer surfaces inside Atlas, all driven by the existing `TermStore`, `docs/adr/*.md`, and the running term-loop telemetry — no new persistence.
+
+### A new `Graph` sub-tab
+
+`AtlasExplorer` grows a fourth sub-tab between `Domain` and `Articles`:
+
+```
+┌─ Atlas ──────────────────────────────────────────────────────────┐
+│  ▸ Domain (default)   ▸ Graph   ▸ Articles   ▸ Maintenance       │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+`Graph` and `Domain` share data and selection state through `AtlasExplorer`. They differ only in *layout*:
+- `Domain` keeps its parent-grouped layout (good for "what belongs where").
+- `Graph` runs a `d3-force` (`~30 KB` gz) simulation over the same `nodes`/`edges` payload, free-floating, color-coded by `bounded_context` (good for "what's a hub vs. leaf, where does data flow").
+
+A new hook, `useGraphLayout(payload, mode)` with `mode: 'domain' | 'force'`, returns positioned nodes for either view from a single source. `DomainView` is refactored to consume the hook so the chassis is shared.
+
+### ADRs as graph nodes
+
+`/api/atlas/graph` gains an `?include_adrs` query param (default `true` once this lands). When set:
+- ADR nodes appear in the payload alongside terms. ADR nodes are rendered with a distinct shape (rectangle vs. term ellipse) and a neutral grey to recede visually.
+- Edges are inferred by parsing each ADR's `## Related` section: any line that matches a known term `name` or `alias` produces an `ADR → Term` edge with kind `relates_to`.
+
+Clicking an ADR node opens an `AdrDetailPanel` (markdown body via `react-markdown`), reusing the same shell as `TermDetailPanel`. The shared chassis lives in a new `DetailPanel` wrapper that routes to the right panel by node `type`.
+
+### Term provenance on the detail panel
+
+`/api/atlas/terms/{id}` adds the existing-but-unused fields from the `Term` Pydantic model:
+
+```
+proposed_by, proposed_at, proposal_signals, proposal_imports_seen
+```
+
+These fields are populated by `TermProposerLoop` and are `None` for hand-authored terms. The `TermDetailPanel` gains a **Provenance** section — hidden when `proposed_by` is null, otherwise rendering "Proposed by `TermProposerLoop` on 2026-05-09 — signals: S1, S2 — imports seen: 12".
+
+A new **Confidence** filter chip joins `kind` and `bounded_context` in both `Domain` and `Graph` views (options: `accepted` (default on), `proposed`, `deprecated`). Combined via AND with the other filters.
+
+### Term-loops telemetry in Maintenance
+
+A new endpoint `GET /api/atlas/term-loops/status` reads from the orchestrator's loop registry and returns the last-tick timestamp, last-PR URL, and last-action count for `TermProposerLoop` (ADR-0054), `TermPrunerLoop` (ADR-0057), and `EdgeProposerLoop` (ADR-0058). The Maintenance sub-tab gains a third card consuming this endpoint, putting the dark-factory's glossary work in the operator's eyeline next to the wiki maintenance run-status.
+
+## Consequences
+
+- The graph payload schema gains an optional `type: 'term' | 'adr'` discriminator on nodes; existing P1 consumers default to `'term'` if absent.
+- The frontend gains `d3-force` as a new dependency.
+- The `TermDetailPanel` UI grows by one optional section; existing P1 tests keep passing because the section is hidden for hand-authored terms (the only kind the test fixtures use today).
+- Phase 3 (entries-as-evidence + Discovered bucket) builds on the same `useGraphLayout` chassis without further core refactor.
+
+## Alternatives considered
+
+- **Auto-merge `Graph` and `Domain` into one toggle on a single view.** Rejected: distinct sub-tabs preserve URL state separation (planned in P4 deep links) and let users switch lenses without losing selection context.
+- **Force layout via Cytoscape instead of d3-force.** Rejected: Cytoscape would replace React Flow as the canvas and force a re-render of `Domain` too. d3-force computes positions only; React Flow keeps rendering the result identically across both views.
+- **Use a separate ADR endpoint to avoid mutating `/api/atlas/graph`.** Rejected: the frontend would need to merge two payloads on every render and re-implement the cross-type edge-resolution logic that the server already has the dataset to compute once.
+
+## Related
+
+- [ADR-0059](0059-atlas-knowledge-graph-dashboard.md) — Atlas Phase 1
+- [ADR-0053](0053-ubiquitous-language-as-living-artifact.md) — UL terms
+- [ADR-0054](0054-term-auto-proposer-loop.md) — `TermProposerLoop`
+- [ADR-0057](0057-term-pruner-loop.md) — `TermPrunerLoop`
+- [ADR-0058](0058-edge-proposer-loop.md) — `EdgeProposerLoop`
+- `src/dashboard_routes/_atlas_routes.py` — endpoints
+- `src/ui/src/components/atlas/` — Atlas UI
+- `docs/superpowers/specs/2026-05-08-atlas-design.md` — multi-phase spec

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T05:07:35.885599+00:00",
-  "commit_sha": "61214f18095b0c539f707272b1c393576104df54",
+  "regenerated_at": "2026-05-09T17:08:04.037663+00:00",
+  "commit_sha": "f202f816b4e4f898477557f3304696297d9ebe84",
   "artifacts": {
     "loops.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "ports.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "labels.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "modules.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "events.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "adr_xref.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "mockworld.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "changelog.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     },
     "functional_areas.md": {
-      "source_sha": "61214f18095b0c539f707272b1c393576104df54"
+      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T17:08:04.037663+00:00",
-  "commit_sha": "f202f816b4e4f898477557f3304696297d9ebe84",
+  "regenerated_at": "2026-05-09T17:21:49.465062+00:00",
+  "commit_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "ports.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "labels.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "modules.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "events.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "adr_xref.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "mockworld.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "changelog.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     },
     "functional_areas.md": {
-      "source_sha": "f202f816b4e4f898477557f3304696297d9ebe84"
+      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -67,6 +67,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0057 | `src.term_pruner_loop`, `src.ubiquitous_language` |
 | ADR-0058 | `src.edge_proposer_loop`, `src.ubiquitous_language` |
 | ADR-0059 | `src.dashboard_routes._atlas_routes`, `src.ubiquitous_language` |
+| ADR-0060 | `src.dashboard_routes._atlas_routes` |
 
 ## Module → ADRs
 
@@ -91,7 +92,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
 | `src.dashboard_routes` | ADR-0007, ADR-0008, ADR-0013, ADR-0019, ADR-0038 |
-| `src.dashboard_routes._atlas_routes` | ADR-0059 |
+| `src.dashboard_routes._atlas_routes` | ADR-0059, ADR-0060 |
 | `src.dashboard_routes._cost_rollups` | ADR-0045 |
 | `src.dashboard_routes._diagnostics_routes` | ADR-0050 |
 | `src.dashboard_routes._routes` | ADR-0030 |
@@ -174,4 +175,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -175,4 +175,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `f202f81` — docs(adr): ADR-0060 atlas graph view + ADR nodes + term provenance *(2026-05-09)*
+- `f0dc42d` — chore(arch): regen artifacts post-quality (T13) *(2026-05-08)*
 - `1d0390f` — feat(atlas): UI shell + Domain/Articles/Maintenance views + tab rename (T5-T11) *(2026-05-08)*
 - `634ba7f` — feat(atlas): /api/atlas/* term + ADR endpoints (T2-T4 + T14-T15) *(2026-05-08)*
 - `169ff25` — docs(adr): ADR-0059 atlas knowledge graph dashboard *(2026-05-08)*
@@ -192,4 +194,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `315b5e4` — feat(atlas): graph + ADRs + term provenance + term-loops status (T4-T6) *(2026-05-09)*
 - `f202f81` — docs(adr): ADR-0060 atlas graph view + ADR nodes + term provenance *(2026-05-09)*
 - `f0dc42d` — chore(arch): regen artifacts post-quality (T13) *(2026-05-08)*
 - `1d0390f` — feat(atlas): UI shell + Domain/Articles/Maintenance views + tab rename (T5-T11) *(2026-05-08)*
@@ -194,4 +195,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -269,4 +269,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -269,4 +269,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -47,4 +47,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -47,4 +47,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `61214f1` on 2026-05-09 05:07 UTC. Source last changed at `61214f1`. Status: 🟢 fresh._
+_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `f202f81` on 2026-05-09 17:08 UTC. Source last changed at `f202f81`. Status: 🟢 fresh._
+_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_atlas_routes.py
+++ b/src/dashboard_routes/_atlas_routes.py
@@ -70,7 +70,35 @@ def _term_detail(term, by_id: dict[str, Any]) -> dict[str, Any]:
         "evidence": list(term.evidence),
         "superseded_by": term.superseded_by,
         "superseded_reason": term.superseded_reason,
+        # Provenance fields from TermProposerLoop (ADR-0054). All None for
+        # hand-authored terms; populated when the loop drafted the term.
+        "proposed_by": term.proposed_by,
+        "proposed_at": term.proposed_at,
+        "proposal_signals": (
+            list(term.proposal_signals) if term.proposal_signals is not None else None
+        ),
+        "proposal_imports_seen": term.proposal_imports_seen,
     }
+
+
+def _adr_related_terms(body: str) -> list[str]:
+    """Extract raw lines from the ADR's '## Related' section.
+
+    Returns the line text (without the leading bullet) for each '- ' bullet.
+    Lookup against term names/aliases happens at graph-assembly time.
+    """
+    out: list[str] = []
+    related_match = re.search(r"^##\s+Related\s*$", body, re.MULTILINE)
+    if not related_match:
+        return out
+    rest = body[related_match.end() :].lstrip("\n")
+    for line in rest.splitlines():
+        if line.startswith("## "):
+            break
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            out.append(stripped[2:].strip())
+    return out
 
 
 def _parse_adr_field(body: str, heading: str) -> str:
@@ -128,7 +156,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return _term_detail(by_id[term_id], by_id)
 
     @router.get("/api/atlas/graph")
-    def get_atlas_graph() -> dict[str, Any]:
+    def get_atlas_graph(include_adrs: bool = True) -> dict[str, Any]:
         store = TermStore(_terms_root(ctx))
         terms = store.list()
         contexts_seen: dict[str, dict[str, str]] = {}
@@ -141,6 +169,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             nodes.append(
                 {
                     "id": term.id,
+                    "type": "term",
                     "name": term.name,
                     "kind": term.kind.value,
                     "confidence": term.confidence,
@@ -156,6 +185,56 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                         "kind": rel.kind.value,
                     }
                 )
+
+        if include_adrs:
+            adr_root = _adr_root(ctx)
+            if adr_root.is_dir():
+                # Pre-build a lookup of {lowercased name|alias: term.id}.
+                term_lookup: dict[str, str] = {}
+                for term in terms:
+                    term_lookup[term.name.lower()] = term.id
+                    for alias in term.aliases:
+                        term_lookup.setdefault(alias.lower(), term.id)
+
+                adr_context_added = False
+                for path in sorted(adr_root.glob("*.md")):
+                    summary = _adr_summary_from_path(path)
+                    if summary is None:
+                        continue
+                    if not adr_context_added:
+                        contexts_seen.setdefault(
+                            "adrs", {"id": "adrs", "label": "adrs"}
+                        )
+                        adr_context_added = True
+                    adr_id = f"adr-{summary['number']}"
+                    nodes.append(
+                        {
+                            "id": adr_id,
+                            "type": "adr",
+                            "name": f"ADR-{summary['number']:04d}",
+                            "title": summary["title"],
+                            "status": summary["status"],
+                            "parent": "adrs",
+                        }
+                    )
+                    try:
+                        text = path.read_text(encoding="utf-8")
+                    except OSError:
+                        continue
+                    related_lines = _adr_related_terms(text)
+                    seen_targets: set[str] = set()
+                    for line in related_lines:
+                        line_lower = line.lower()
+                        for needle, term_id in term_lookup.items():
+                            if needle in line_lower and term_id not in seen_targets:
+                                edges.append(
+                                    {
+                                        "source": adr_id,
+                                        "target": term_id,
+                                        "kind": "relates_to",
+                                    }
+                                )
+                                seen_targets.add(term_id)
 
         return {
             "nodes": nodes,
@@ -212,3 +291,30 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 "related": related_lines,
             }
         raise HTTPException(status_code=404, detail="adr not found")
+
+    @router.get("/api/atlas/term-loops/status")
+    def get_term_loops_status() -> dict[str, Any]:
+        """Last-tick snapshot for the term-graph maintenance loops (P2-T6).
+
+        Reads from StateTracker.get_worker_heartbeats() — same source the
+        SystemPanel background-worker tiles consume. Returns one entry per
+        relevant loop. When the orchestrator has never run, every entry is
+        present with last_run=None so the UI can render "never run" without
+        special-casing absence.
+        """
+        loops = ("term_proposer", "term_pruner", "edge_proposer")
+        try:
+            heartbeats = ctx.state.get_worker_heartbeats()
+        except Exception:  # noqa: BLE001 — diagnostics endpoint, never fail
+            heartbeats = {}
+        out: dict[str, Any] = {}
+        for name in loops:
+            hb = heartbeats.get(name) or {}
+            details = hb.get("details") or {}
+            out[name] = {
+                "status": hb.get("status") or "unknown",
+                "last_run": hb.get("last_run"),
+                "last_pr_url": (details.get("open_pr_url") or details.get("pr_url")),
+                "last_action_count": details.get("count"),
+            }
+        return out

--- a/src/dashboard_routes/_atlas_routes.py
+++ b/src/dashboard_routes/_atlas_routes.py
@@ -226,7 +226,13 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                     for line in related_lines:
                         line_lower = line.lower()
                         for needle, term_id in term_lookup.items():
-                            if needle in line_lower and term_id not in seen_targets:
+                            # Word-boundary match — substring matching gave
+                            # spurious edges (e.g., the term "Task" matched
+                            # incidental prose like "this ADR task").
+                            if term_id in seen_targets:
+                                continue
+                            pattern = rf"\b{re.escape(needle)}\b"
+                            if re.search(pattern, line_lower):
                                 edges.append(
                                     {
                                         "source": adr_id,
@@ -268,20 +274,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 if title_match
                 else path.stem.split("-", 1)[-1].replace("-", " ")
             )
-            related_lines: list[str] = []
-            related_match = re.search(
-                r"^##\s+Related\s*$",
-                text,
-                re.MULTILINE,
-            )
-            if related_match:
-                rest = text[related_match.end() :].lstrip("\n")
-                for line in rest.splitlines():
-                    if line.startswith("## "):
-                        break
-                    stripped = line.strip()
-                    if stripped.startswith("- "):
-                        related_lines.append(stripped[2:].strip())
+            related_lines = _adr_related_terms(text)
             return {
                 "number": number,
                 "title": title,

--- a/src/ui/package-lock.json
+++ b/src/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.1",
       "dependencies": {
         "@xyflow/react": "^12.10.2",
+        "d3-force": "^3.0.0",
         "echarts": "^5.5.1",
         "echarts-for-react": "^3.0.2",
         "html2canvas": "^1.4.1",
@@ -1958,6 +1959,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
@@ -1966,6 +1981,15 @@
       "dependencies": {
         "d3-color": "1 - 3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/src/ui/package.json
+++ b/src/ui/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@xyflow/react": "^12.10.2",
+    "d3-force": "^3.0.0",
     "echarts": "^5.5.1",
     "echarts-for-react": "^3.0.2",
     "html2canvas": "^1.4.1",

--- a/src/ui/src/components/atlas/AdrDetailPanel.jsx
+++ b/src/ui/src/components/atlas/AdrDetailPanel.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { theme } from '../../theme'
+
+export function AdrDetailPanel({ selectedNodeId }) {
+  const [adr, setAdr] = useState(null)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!selectedNodeId) {
+      setAdr(null)
+      setError(null)
+      return
+    }
+    // selectedNodeId for an ADR node is "adr-<number>" (e.g., "adr-59").
+    const m = /^adr-(\d+)$/.exec(selectedNodeId)
+    if (!m) {
+      setAdr(null)
+      setError(new Error('not an adr id'))
+      return
+    }
+    const number = m[1]
+    let cancelled = false
+    fetch(`/api/atlas/adrs/${encodeURIComponent(number)}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`status ${r.status}`)
+        return r.json()
+      })
+      .then((data) => {
+        if (cancelled) return
+        setAdr(data)
+        setError(null)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err)
+        setAdr(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedNodeId])
+
+  const styles = {
+    root: {
+      padding: '14px 16px',
+      fontSize: 12,
+      lineHeight: 1.5,
+      color: theme.text,
+    },
+    hint: { color: theme.textMuted, fontSize: 13 },
+    label: {
+      color: theme.textMuted,
+      fontSize: 10,
+      letterSpacing: 0.5,
+      textTransform: 'uppercase',
+    },
+    name: { color: theme.textBright, fontSize: 15, marginTop: 4 },
+    rule: {
+      border: 'none',
+      borderTop: `1px solid ${theme.border}`,
+      margin: '12px 0',
+    },
+    body: {
+      fontSize: 12,
+      lineHeight: 1.55,
+      color: theme.text,
+      background: theme.surfaceInset,
+      border: `1px solid ${theme.border}`,
+      borderRadius: 4,
+      padding: 12,
+    },
+  }
+
+  if (error) {
+    return (
+      <div style={styles.root}>
+        <div style={styles.hint}>Unable to load ADR.</div>
+      </div>
+    )
+  }
+  if (!adr) {
+    return (
+      <div style={styles.root}>
+        <div style={styles.hint}>Loading…</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={styles.root}>
+      <div style={styles.label}>Selected ADR</div>
+      <div style={styles.name}>
+        ADR-{String(adr.number).padStart(4, '0')}: {adr.title}
+      </div>
+      <div style={{ color: theme.textMuted }}>
+        {adr.status} · {adr.date}
+      </div>
+      <hr style={styles.rule} />
+      <div style={styles.body}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{adr.body || ''}</ReactMarkdown>
+      </div>
+    </div>
+  )
+}
+
+export default AdrDetailPanel

--- a/src/ui/src/components/atlas/AtlasExplorer.jsx
+++ b/src/ui/src/components/atlas/AtlasExplorer.jsx
@@ -1,19 +1,118 @@
 import React, { useState } from 'react'
 import { theme } from '../../theme'
 import { DomainView } from './DomainView'
-import { TermDetailPanel } from './TermDetailPanel'
+import { GraphView } from './GraphView'
+import { DetailPanel } from './DetailPanel'
 import { ArticlesView } from './ArticlesView'
 import { MaintenanceView } from './MaintenanceView'
 
 const SUBTABS = [
   { id: 'domain', label: 'Domain' },
+  { id: 'graph', label: 'Graph' },
   { id: 'articles', label: 'Articles' },
   { id: 'maintenance', label: 'Maintenance' },
 ]
 
+const KINDS = [
+  'runner',
+  'service',
+  'port',
+  'adapter',
+  'aggregate',
+  'entity',
+  'value_object',
+  'domain_event',
+  'loop',
+  'bounded_context',
+  'invariant',
+  'policy',
+]
+const CONTEXTS = ['builder', 'caretaker', 'ai-dev-team', 'shared-kernel', 'adrs']
+const CONFIDENCES = ['accepted', 'proposed', 'deprecated']
+
+function GraphFilterBar({ filters, onChange }) {
+  const styles = {
+    bar: {
+      display: 'flex',
+      gap: 12,
+      alignItems: 'center',
+      padding: '8px 16px',
+      borderBottom: `1px solid ${theme.border}`,
+      background: theme.surface,
+      flexWrap: 'wrap',
+      fontSize: 12,
+    },
+    label: {
+      color: theme.textMuted,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      fontSize: 10,
+    },
+    select: {
+      background: theme.surfaceInset,
+      color: theme.text,
+      border: `1px solid ${theme.border}`,
+      borderRadius: 3,
+      padding: '2px 6px',
+      fontSize: 12,
+    },
+  }
+  return (
+    <div style={styles.bar}>
+      <span style={styles.label}>Kind</span>
+      <select
+        aria-label="Kind"
+        style={styles.select}
+        value={filters.kind}
+        onChange={(e) => onChange({ ...filters, kind: e.target.value })}
+      >
+        <option value="">All</option>
+        {KINDS.map((k) => (
+          <option key={k} value={k}>
+            {k}
+          </option>
+        ))}
+      </select>
+      <span style={styles.label}>Context</span>
+      <select
+        aria-label="Context"
+        style={styles.select}
+        value={filters.context}
+        onChange={(e) => onChange({ ...filters, context: e.target.value })}
+      >
+        <option value="">All</option>
+        {CONTEXTS.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+      <span style={styles.label}>Confidence</span>
+      <select
+        aria-label="Confidence"
+        style={styles.select}
+        value={filters.confidence}
+        onChange={(e) => onChange({ ...filters, confidence: e.target.value })}
+      >
+        <option value="">All</option>
+        {CONFIDENCES.map((c) => (
+          <option key={c} value={c}>
+            {c}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
 export function AtlasExplorer() {
   const [activeSubtab, setActiveSubtab] = useState('domain')
   const [selectedNodeId, setSelectedNodeId] = useState(null)
+  const [filters, setFilters] = useState({
+    kind: '',
+    context: '',
+    confidence: '',
+  })
 
   const styles = {
     root: {
@@ -45,12 +144,10 @@ export function AtlasExplorer() {
       overflow: 'auto',
       minHeight: 0,
       display: 'flex',
+      flexDirection: 'column',
     },
-    domainPane: {
-      flex: 1,
-      minWidth: 0,
-      display: 'flex',
-    },
+    graphRow: { flex: 1, display: 'flex', minHeight: 0 },
+    canvasPane: { flex: 1, minWidth: 0, display: 'flex' },
     detailPane: {
       width: '38%',
       minWidth: 280,
@@ -58,6 +155,8 @@ export function AtlasExplorer() {
       overflowY: 'auto',
     },
   }
+
+  const isGraphMode = activeSubtab === 'domain' || activeSubtab === 'graph'
 
   return (
     <div style={styles.root}>
@@ -74,18 +173,36 @@ export function AtlasExplorer() {
         ))}
       </div>
       <div style={styles.content}>
+        {isGraphMode && (
+          <GraphFilterBar filters={filters} onChange={setFilters} />
+        )}
         {activeSubtab === 'domain' && (
-          <>
-            <div style={styles.domainPane}>
+          <div style={styles.graphRow}>
+            <div style={styles.canvasPane}>
               <DomainView
                 selectedNodeId={selectedNodeId}
                 onSelectNode={setSelectedNodeId}
+                filters={filters}
               />
             </div>
             <div style={styles.detailPane}>
-              <TermDetailPanel selectedNodeId={selectedNodeId} />
+              <DetailPanel selectedNodeId={selectedNodeId} />
             </div>
-          </>
+          </div>
+        )}
+        {activeSubtab === 'graph' && (
+          <div style={styles.graphRow}>
+            <div style={styles.canvasPane}>
+              <GraphView
+                selectedNodeId={selectedNodeId}
+                onSelectNode={setSelectedNodeId}
+                filters={filters}
+              />
+            </div>
+            <div style={styles.detailPane}>
+              <DetailPanel selectedNodeId={selectedNodeId} />
+            </div>
+          </div>
         )}
         {activeSubtab === 'articles' && <ArticlesView />}
         {activeSubtab === 'maintenance' && <MaintenanceView />}

--- a/src/ui/src/components/atlas/DetailPanel.jsx
+++ b/src/ui/src/components/atlas/DetailPanel.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { theme } from '../../theme'
+import { TermDetailPanel } from './TermDetailPanel'
+import { AdrDetailPanel } from './AdrDetailPanel'
+
+/**
+ * Routes the selected-node detail render to the right panel by id shape:
+ *   "adr-<n>" → AdrDetailPanel
+ *   anything else → TermDetailPanel
+ *
+ * Lives at this level so DomainView and GraphView can share selection state
+ * without each owning its own panel routing.
+ */
+export function DetailPanel({ selectedNodeId }) {
+  if (!selectedNodeId) {
+    return (
+      <div
+        style={{
+          padding: '14px 16px',
+          fontSize: 13,
+          color: theme.textMuted,
+        }}
+      >
+        Pick a node in the graph to see details.
+      </div>
+    )
+  }
+  if (/^adr-\d+$/.test(selectedNodeId)) {
+    return <AdrDetailPanel selectedNodeId={selectedNodeId} />
+  }
+  return <TermDetailPanel selectedNodeId={selectedNodeId} />
+}
+
+export default DetailPanel

--- a/src/ui/src/components/atlas/GraphView.jsx
+++ b/src/ui/src/components/atlas/GraphView.jsx
@@ -12,8 +12,6 @@ function applyFilters(payload, filters) {
   const safeNodes = Array.isArray(payload.nodes) ? payload.nodes : []
   const keep = (n) => {
     if (n.type === 'adr') {
-      // ADRs survive the term-only filters (kind / confidence) since they
-      // don't carry those fields. Context filter still applies via 'adrs'.
       if (filters.context && n.parent !== filters.context) return false
       return true
     }
@@ -32,7 +30,7 @@ function applyFilters(payload, filters) {
   }
 }
 
-export function DomainView({ selectedNodeId, onSelectNode, filters }) {
+export function GraphView({ selectedNodeId, onSelectNode, filters }) {
   const [graph, setGraph] = useState(null)
   const [error, setError] = useState(null)
 
@@ -59,12 +57,12 @@ export function DomainView({ selectedNodeId, onSelectNode, filters }) {
   }, [])
 
   const filtered = applyFilters(graph, filters)
-  const { nodes, edges } = useGraphLayout(filtered, 'domain', selectedNodeId)
+  const { nodes, edges } = useGraphLayout(filtered, 'force', selectedNodeId)
 
   if (error) {
     return (
       <div
-        data-testid="atlas-domain-view"
+        data-testid="atlas-graph-view"
         style={{ padding: 24, color: theme.textMuted, fontSize: 13 }}
       >
         Unable to load graph data.
@@ -75,7 +73,7 @@ export function DomainView({ selectedNodeId, onSelectNode, filters }) {
   if (!graph) {
     return (
       <div
-        data-testid="atlas-domain-view"
+        data-testid="atlas-graph-view"
         style={{ padding: 24, color: theme.textMuted, fontSize: 13 }}
       >
         Loading…
@@ -85,15 +83,13 @@ export function DomainView({ selectedNodeId, onSelectNode, filters }) {
 
   return (
     <div
-      data-testid="atlas-domain-view"
+      data-testid="atlas-graph-view"
       style={{ height: '100%', width: '100%' }}
     >
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodeClick={(_, n) => {
-          if (n.type !== 'group') onSelectNode(n.id)
-        }}
+        onNodeClick={(_, n) => onSelectNode(n.id)}
         fitView
       >
         <Background />
@@ -104,4 +100,4 @@ export function DomainView({ selectedNodeId, onSelectNode, filters }) {
   )
 }
 
-export default DomainView
+export default GraphView

--- a/src/ui/src/components/atlas/MaintenanceView.jsx
+++ b/src/ui/src/components/atlas/MaintenanceView.jsx
@@ -153,9 +153,9 @@ export function MaintenanceView() {
         >
           {['term_proposer', 'term_pruner', 'edge_proposer'].map((name) => {
             const loop = termLoops?.[name]
-            const status = loop?.status ?? 'unknown'
+            const loopStatus = loop?.status ?? 'unknown'
             const lastRun = loop?.last_run
-            const prUrl = loop?.last_pr_url
+            const loopPrUrl = loop?.last_pr_url
             const count = loop?.last_action_count
             return (
               <div
@@ -168,14 +168,14 @@ export function MaintenanceView() {
               >
                 <div style={{ color: theme.textBright }}>{name}</div>
                 <div style={{ color: theme.textMuted, fontSize: 10 }}>
-                  status: {status}
+                  status: {loopStatus}
                 </div>
                 <div style={{ color: theme.textMuted, fontSize: 10 }}>
                   last run: {lastRun ? lastRun.split('T')[0] : '—'}
                 </div>
-                {prUrl && (
+                {loopPrUrl && (
                   <a
-                    href={prUrl}
+                    href={loopPrUrl}
                     target="_blank"
                     rel="noreferrer"
                     style={{ color: theme.accent, fontSize: 10 }}

--- a/src/ui/src/components/atlas/MaintenanceView.jsx
+++ b/src/ui/src/components/atlas/MaintenanceView.jsx
@@ -4,6 +4,7 @@ import { theme } from '../../theme'
 export function MaintenanceView() {
   const [status, setStatus] = useState(null)
   const [health, setHealth] = useState(null)
+  const [termLoops, setTermLoops] = useState(null)
 
   const refresh = useCallback(() => {
     fetch('/api/wiki/maintenance/status')
@@ -14,6 +15,10 @@ export function MaintenanceView() {
       .then((r) => (r.ok ? r.json() : null))
       .then(setHealth)
       .catch(() => setHealth(null))
+    fetch('/api/atlas/term-loops/status')
+      .then((r) => (r.ok ? r.json() : null))
+      .then(setTermLoops)
+      .catch(() => setTermLoops(null))
   }, [])
 
   useEffect(() => {
@@ -133,6 +138,63 @@ export function MaintenanceView() {
             <span style={{ color: theme.textMuted }}>Tribal store: </span>
             {health?.tribal ?? '—'}
           </div>
+        </div>
+      </div>
+
+      <div style={{ ...styles.card, gridColumn: 'span 2' }}>
+        <div style={styles.label}>Term loops</div>
+        <div
+          style={{
+            marginTop: 6,
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr 1fr',
+            gap: 12,
+          }}
+        >
+          {['term_proposer', 'term_pruner', 'edge_proposer'].map((name) => {
+            const loop = termLoops?.[name]
+            const status = loop?.status ?? 'unknown'
+            const lastRun = loop?.last_run
+            const prUrl = loop?.last_pr_url
+            const count = loop?.last_action_count
+            return (
+              <div
+                key={name}
+                style={{
+                  border: `1px solid ${theme.border}`,
+                  borderRadius: 3,
+                  padding: 8,
+                }}
+              >
+                <div style={{ color: theme.textBright }}>{name}</div>
+                <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                  status: {status}
+                </div>
+                <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                  last run: {lastRun ? lastRun.split('T')[0] : '—'}
+                </div>
+                {prUrl && (
+                  <a
+                    href={prUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={{ color: theme.accent, fontSize: 10 }}
+                  >
+                    last PR
+                  </a>
+                )}
+                {typeof count === 'number' && (
+                  <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                    actions: {count}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+        <div style={{ color: theme.textMuted, fontSize: 10, marginTop: 6 }}>
+          From <code>/api/atlas/term-loops/status</code>. Read-only;
+          loops are governed by the System tab toggles.
         </div>
       </div>
 

--- a/src/ui/src/components/atlas/TermDetailPanel.jsx
+++ b/src/ui/src/components/atlas/TermDetailPanel.jsx
@@ -124,6 +124,25 @@ export function TermDetailPanel({ selectedNodeId }) {
           </div>
         </>
       )}
+      {term.proposed_by && (
+        <>
+          <hr style={styles.rule} />
+          <div style={styles.label}>Provenance</div>
+          <div>
+            Proposed by{' '}
+            <code style={{ color: theme.accent }}>{term.proposed_by}</code>
+            {term.proposed_at && <> on {term.proposed_at.split('T')[0]}</>}
+          </div>
+          {term.proposal_signals && term.proposal_signals.length > 0 && (
+            <div style={{ color: theme.textMuted, marginTop: 2 }}>
+              signals: {term.proposal_signals.join(', ')}
+              {typeof term.proposal_imports_seen === 'number' && (
+                <> · imports seen: {term.proposal_imports_seen}</>
+              )}
+            </div>
+          )}
+        </>
+      )}
       <hr style={styles.rule} />
       <div style={styles.label}>Edges ({term.edges.length})</div>
       {term.edges.length === 0 ? (

--- a/src/ui/src/components/atlas/__tests__/AdrDetailPanel.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/AdrDetailPanel.test.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AdrDetailPanel } from '../AdrDetailPanel'
+
+const ADR = {
+  number: 60,
+  title: 'Atlas graph view',
+  status: 'Accepted',
+  date: '2026-05-09',
+  body: '# ADR-0060: Atlas\n\nDecision text.',
+  related: [],
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(ADR) }),
+  )
+})
+
+describe('AdrDetailPanel', () => {
+  it('renders header + markdown body for an ADR id', async () => {
+    render(<AdrDetailPanel selectedNodeId="adr-60" />)
+    await waitFor(() => screen.getByText(/atlas graph view/i))
+    expect(
+      screen.getByText(/Accepted/),
+    ).toBeInTheDocument()
+    const heading = screen.getByRole('heading', { level: 1, name: /adr-0060/i })
+    expect(heading.tagName).toBe('H1')
+  })
+
+  it('shows error when fetch fails', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 }))
+    render(<AdrDetailPanel selectedNodeId="adr-60" />)
+    await waitFor(() => {
+      expect(screen.getByText(/unable to load adr/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error for non-adr id', async () => {
+    render(<AdrDetailPanel selectedNodeId="not-an-adr" />)
+    await waitFor(() => {
+      expect(screen.getByText(/unable to load adr/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
@@ -74,6 +74,9 @@ describe('ArticlesView', () => {
   it('shows ADR and WIKI type chips on rows', async () => {
     render(<ArticlesView />)
     await waitFor(() => screen.getByText(/atlas knowledge graph/i))
+    await waitFor(() =>
+      screen.getByText('0001-issue-10-first-pattern.md'),
+    )
     expect(screen.getAllByText('ADR').length).toBeGreaterThan(0)
     expect(screen.getAllByText('WIKI').length).toBeGreaterThan(0)
   })

--- a/src/ui/src/components/atlas/__tests__/AtlasExplorer.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/AtlasExplorer.test.jsx
@@ -13,13 +13,23 @@ beforeEach(() => {
 })
 
 describe('AtlasExplorer', () => {
-  it('renders three sub-tab buttons', () => {
+  it('renders four sub-tab buttons', () => {
     render(<AtlasExplorer />)
     expect(screen.getByRole('button', { name: /^domain$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^graph$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^articles$/i })).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /^maintenance$/i }),
     ).toBeInTheDocument()
+  })
+
+  it('switches to Graph view when its tab is clicked', async () => {
+    render(<AtlasExplorer />)
+    fireEvent.click(screen.getByRole('button', { name: /^graph$/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('atlas-graph-view')).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('atlas-domain-view')).not.toBeInTheDocument()
   })
 
   it('shows the Domain view by default', () => {

--- a/src/ui/src/components/atlas/__tests__/DetailPanel.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/DetailPanel.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DetailPanel } from '../DetailPanel'
+
+beforeEach(() => {
+  global.fetch = vi.fn((url) => {
+    if (url.startsWith('/api/atlas/adrs/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            number: 60,
+            title: 'X',
+            status: 'Accepted',
+            date: '2026-05-09',
+            body: '# X\n\nbody',
+            related: [],
+          }),
+      })
+    }
+    if (url.startsWith('/api/atlas/terms/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: 'n1',
+            name: 'AgentRunner',
+            kind: 'runner',
+            bounded_context: 'builder',
+            code_anchor: 'src/agent.py:AgentRunner',
+            confidence: 'accepted',
+            definition: 'A runner.',
+            invariants: [],
+            aliases: [],
+            edges: [],
+            evidence: [],
+            superseded_by: null,
+            superseded_reason: null,
+            proposed_by: null,
+            proposed_at: null,
+            proposal_signals: null,
+            proposal_imports_seen: null,
+          }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  })
+})
+
+describe('DetailPanel', () => {
+  it('shows hint when no node selected', () => {
+    render(<DetailPanel selectedNodeId={null} />)
+    expect(screen.getByText(/pick a node/i)).toBeInTheDocument()
+  })
+
+  it('routes adr-N ids to AdrDetailPanel', async () => {
+    render(<DetailPanel selectedNodeId="adr-60" />)
+    await waitFor(() => screen.getByText(/selected adr/i))
+  })
+
+  it('routes other ids to TermDetailPanel', async () => {
+    render(<DetailPanel selectedNodeId="some-term-id" />)
+    await waitFor(() => screen.getByText(/selected term/i))
+  })
+})

--- a/src/ui/src/components/atlas/__tests__/GraphView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/GraphView.test.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GraphView } from '../GraphView'
+
+const SAMPLE_GRAPH = {
+  nodes: [
+    {
+      id: 'n1',
+      type: 'term',
+      name: 'AgentRunner',
+      kind: 'runner',
+      confidence: 'accepted',
+      parent: 'builder',
+    },
+    {
+      id: 'n2',
+      type: 'term',
+      name: 'EventBus',
+      kind: 'service',
+      confidence: 'accepted',
+      parent: 'shared-kernel',
+    },
+  ],
+  edges: [{ source: 'n1', target: 'n2', kind: 'depends_on' }],
+  contexts: [
+    { id: 'builder', label: 'builder' },
+    { id: 'shared-kernel', label: 'shared-kernel' },
+  ],
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(SAMPLE_GRAPH) }),
+  )
+})
+
+describe('GraphView', () => {
+  it('renders the canvas wrapper after fetch', async () => {
+    render(<GraphView selectedNodeId={null} onSelectNode={() => {}} filters={{}} />)
+    await waitFor(() => {
+      expect(screen.getByTestId('atlas-graph-view')).toBeInTheDocument()
+    })
+  })
+
+  it('shows an error state when the fetch fails', async () => {
+    global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 500 }))
+    render(<GraphView selectedNodeId={null} onSelectNode={() => {}} filters={{}} />)
+    await waitFor(() => {
+      expect(screen.getByText(/unable to load/i)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/ui/src/components/atlas/useGraphLayout.js
+++ b/src/ui/src/components/atlas/useGraphLayout.js
@@ -1,0 +1,202 @@
+import { useMemo } from 'react'
+import {
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  forceCollide,
+} from 'd3-force'
+import { theme } from '../../theme'
+
+const KIND_COLORS = {
+  runner: '#7ec699',
+  service: '#7aa6e0',
+  port: '#c39bd3',
+  adapter: '#f0b27a',
+  aggregate: '#ec7063',
+  entity: '#f7dc6f',
+  value_object: '#aab7b8',
+  domain_event: '#85c1e9',
+  loop: '#bb8fce',
+  bounded_context: '#82e0aa',
+  invariant: '#f1948a',
+  policy: '#5dade2',
+}
+
+const CONTEXT_COLORS = {
+  builder: '#7ec699',
+  caretaker: '#bb8fce',
+  'ai-dev-team': '#7aa6e0',
+  'shared-kernel': '#aab7b8',
+  adrs: '#888888',
+}
+
+const CONTEXT_PADDING = { x: 20, y: 32 }
+const NODE_W = 160
+const NODE_H = 36
+const NODE_GAP_X = 16
+const NODE_GAP_Y = 12
+
+function nodeStyle(node, selected) {
+  if (node.type === 'adr') {
+    return {
+      width: NODE_W,
+      height: NODE_H,
+      background: '#1a1d24',
+      border: `1px solid ${selected ? theme.accent : '#666'}`,
+      borderRadius: 2,
+      color: theme.text,
+      fontSize: 12,
+      padding: 6,
+    }
+  }
+  return {
+    width: NODE_W,
+    height: NODE_H,
+    background: theme.surfaceInset,
+    border: `1px ${node.confidence === 'proposed' ? 'dashed' : 'solid'} ${
+      KIND_COLORS[node.kind] || theme.border
+    }`,
+    borderRadius: 4,
+    color: theme.text,
+    fontSize: 12,
+    padding: 6,
+    boxShadow: selected ? `0 0 0 2px ${theme.accent}` : undefined,
+  }
+}
+
+function buildEdges(rawEdges) {
+  return rawEdges.map((e, i) => ({
+    id: `e${i}`,
+    source: e.source,
+    target: e.target,
+    label: e.kind,
+    labelStyle: { fontSize: 10, fill: theme.textMuted },
+    style: {
+      stroke: e.kind === 'relates_to' ? '#666' : theme.border,
+      strokeDasharray: e.kind === 'relates_to' ? '4,2' : undefined,
+    },
+  }))
+}
+
+function layoutDomain(payload, selectedId) {
+  const safeContexts = Array.isArray(payload?.contexts) ? payload.contexts : []
+  const safeNodes = Array.isArray(payload?.nodes) ? payload.nodes : []
+  const safeEdges = Array.isArray(payload?.edges) ? payload.edges : []
+
+  const byContext = new Map()
+  for (const ctx of safeContexts) {
+    byContext.set(ctx.id, { ...ctx, terms: [] })
+  }
+  for (const node of safeNodes) {
+    if (!byContext.has(node.parent)) {
+      byContext.set(node.parent, {
+        id: node.parent,
+        label: node.parent,
+        terms: [],
+      })
+    }
+    byContext.get(node.parent).terms.push(node)
+  }
+
+  const parents = []
+  const children = []
+  let yCursor = 0
+  for (const ctx of byContext.values()) {
+    if (ctx.terms.length === 0) {
+      continue
+    }
+    const cols = Math.max(1, Math.ceil(Math.sqrt(ctx.terms.length)))
+    const rows = Math.max(1, Math.ceil(ctx.terms.length / cols))
+    const groupW = CONTEXT_PADDING.x * 2 + cols * NODE_W + (cols - 1) * NODE_GAP_X
+    const groupH = CONTEXT_PADDING.y * 2 + rows * NODE_H + (rows - 1) * NODE_GAP_Y
+
+    parents.push({
+      id: ctx.id,
+      type: 'group',
+      data: { label: ctx.label },
+      position: { x: 40, y: yCursor },
+      style: {
+        width: groupW,
+        height: groupH,
+        background: 'transparent',
+        border: `1px dashed ${theme.border}`,
+        borderRadius: 6,
+        color: theme.textMuted,
+        fontSize: 11,
+      },
+    })
+
+    ctx.terms.forEach((node, idx) => {
+      const col = idx % cols
+      const row = Math.floor(idx / cols)
+      children.push({
+        id: node.id,
+        parentId: ctx.id,
+        extent: 'parent',
+        position: {
+          x: CONTEXT_PADDING.x + col * (NODE_W + NODE_GAP_X),
+          y: CONTEXT_PADDING.y + row * (NODE_H + NODE_GAP_Y),
+        },
+        data: { label: node.name, kind: node.kind, type: node.type },
+        style: nodeStyle(node, node.id === selectedId),
+      })
+    })
+
+    yCursor += groupH + 24
+  }
+
+  return { nodes: [...parents, ...children], edges: buildEdges(safeEdges) }
+}
+
+function layoutForce(payload, selectedId) {
+  const safeNodes = Array.isArray(payload?.nodes) ? payload.nodes : []
+  const safeEdges = Array.isArray(payload?.edges) ? payload.edges : []
+  if (safeNodes.length === 0) return { nodes: [], edges: [] }
+
+  // d3-force mutates a copy of the input; we never mutate caller data.
+  const simNodes = safeNodes.map((n) => ({ ...n }))
+  const simLinks = safeEdges.map((e) => ({ source: e.source, target: e.target }))
+
+  const sim = forceSimulation(simNodes)
+    .force(
+      'link',
+      forceLink(simLinks)
+        .id((d) => d.id)
+        .distance(120)
+        .strength(0.5),
+    )
+    .force('charge', forceManyBody().strength(-220))
+    .force('center', forceCenter(0, 0))
+    .force('collide', forceCollide(NODE_W / 2 + 8))
+    .stop()
+
+  // Run the simulation synchronously to convergence (small graph).
+  for (let i = 0; i < 200; i += 1) sim.tick()
+
+  const flowNodes = simNodes.map((n) => {
+    const ctxColor = CONTEXT_COLORS[n.parent] || theme.border
+    const baseStyle = nodeStyle(n, n.id === selectedId)
+    return {
+      id: n.id,
+      position: { x: n.x ?? 0, y: n.y ?? 0 },
+      data: { label: n.name, kind: n.kind, type: n.type },
+      style: {
+        ...baseStyle,
+        // In force mode, color the node border by context (not kind) so the
+        // free layout still telegraphs which subgraph each node lives in.
+        border: `1px ${n.confidence === 'proposed' ? 'dashed' : 'solid'} ${ctxColor}`,
+      },
+    }
+  })
+
+  return { nodes: flowNodes, edges: buildEdges(safeEdges) }
+}
+
+export function useGraphLayout(payload, mode, selectedId) {
+  return useMemo(() => {
+    if (!payload) return { nodes: [], edges: [] }
+    if (mode === 'force') return layoutForce(payload, selectedId)
+    return layoutDomain(payload, selectedId)
+  }, [payload, mode, selectedId])
+}

--- a/tests/scenarios/test_atlas_graph_with_adrs_scenario.py
+++ b/tests/scenarios/test_atlas_graph_with_adrs_scenario.py
@@ -1,0 +1,130 @@
+"""MockWorld scenario for the Atlas P2 graph + ADRs flow (ADR-0060).
+
+Exercises the data path that the Domain/Graph views consume when ADRs
+are included:
+
+1. Seed two terms with an edge.
+2. Seed two ADRs — one whose '## Related' section references a known
+   term by name; one with no related terms.
+3. Hit /api/atlas/graph (default include_adrs=True) and assert:
+   - Both ADR nodes appear with type='adr' and parent='adrs'.
+   - The 'adrs' context is present in `contexts`.
+   - A 'relates_to' edge connects the citing ADR to the matched term.
+4. Hit /api/atlas/graph?include_adrs=False and assert ADRs are absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config import HydraFlowConfig
+from events import EventBus
+from state import StateTracker
+from tests.helpers import find_endpoint, make_dashboard_router
+from ubiquitous_language import (
+    BoundedContext,
+    Term,
+    TermKind,
+    TermRel,
+    TermRelKind,
+    TermStore,
+)
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestAtlasGraphWithAdrs:
+    def test_includes_adr_nodes_and_relates_to_edges(self, tmp_path: Path) -> None:
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        target = Term(
+            id="01TARGET00000000000000",
+            name="EventBus",
+            kind=TermKind.SERVICE,
+            bounded_context=BoundedContext.SHARED_KERNEL,
+            definition="Async pub/sub bus.",
+            invariants=[],
+            code_anchor="src/events.py:EventBus",
+            confidence="accepted",
+        )
+        store.write(target)
+        source = Term(
+            id="01SOURCE00000000000000",
+            name="AgentRunner",
+            kind=TermKind.RUNNER,
+            bounded_context=BoundedContext.BUILDER,
+            definition="Subprocess runner.",
+            code_anchor="src/agent.py:AgentRunner",
+            related=[TermRel(kind=TermRelKind.DEPENDS_ON, target=target.id)],
+            confidence="accepted",
+        )
+        store.write(source)
+
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0042-event-bus.md").write_text(
+            "# ADR-0042: EventBus design\n\n"
+            "## Status\n\nAccepted\n\n"
+            "## Date\n\n2026-01-15\n\n"
+            "## Related\n\n- `EventBus` — the bus itself\n"
+        )
+        (adr_dir / "0050-orphan.md").write_text(
+            "# ADR-0050: Orphan ADR\n\n"
+            "## Status\n\nAccepted\n\n"
+            "## Date\n\n2026-02-15\n\n"
+            "## Related\n\n- something unrelated\n"
+        )
+
+        config = HydraFlowConfig(repo_root=tmp_path)
+        state = StateTracker(tmp_path / "state.json")
+        bus = EventBus()
+        router, _ = make_dashboard_router(config, bus, state, tmp_path)
+
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        assert endpoint is not None
+        graph = endpoint()
+
+        adr_nodes = [n for n in graph["nodes"] if n.get("type") == "adr"]
+        adr_ids = {n["id"] for n in adr_nodes}
+        assert adr_ids == {"adr-42", "adr-50"}
+        assert all(n["parent"] == "adrs" for n in adr_nodes)
+        assert "adrs" in {c["id"] for c in graph["contexts"]}
+
+        relates = [e for e in graph["edges"] if e["kind"] == "relates_to"]
+        assert any(
+            e["source"] == "adr-42" and e["target"] == target.id for e in relates
+        )
+        assert all(e["source"] != "adr-50" for e in relates)
+
+    def test_excludes_adrs_when_disabled(self, tmp_path: Path) -> None:
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        store.write(
+            Term(
+                id="01TARGET00000000000000",
+                name="EventBus",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="x",
+                code_anchor="src/events.py:EventBus",
+                confidence="accepted",
+            )
+        )
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0042-x.md").write_text(
+            "# ADR-0042: X\n\n## Status\n\nAccepted\n\n## Related\n\n- `EventBus`\n"
+        )
+
+        config = HydraFlowConfig(repo_root=tmp_path)
+        state = StateTracker(tmp_path / "state.json")
+        bus = EventBus()
+        router, _ = make_dashboard_router(config, bus, state, tmp_path)
+
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        result = endpoint(include_adrs=False)
+
+        assert all(n.get("type") != "adr" for n in result["nodes"])
+        assert "adrs" not in {c["id"] for c in result["contexts"]}

--- a/tests/test_atlas_routes.py
+++ b/tests/test_atlas_routes.py
@@ -163,6 +163,142 @@ class TestAtlasGraph:
         result = endpoint()
         assert result == {"nodes": [], "edges": [], "contexts": []}
 
+    def test_includes_adrs_with_relates_to_edges_by_default(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0042-event-bus.md").write_text(
+            "# ADR-0042: EventBus design\n\n"
+            "## Status\n\nAccepted\n\n"
+            "## Date\n\n2026-01-15\n\n"
+            "## Related\n\n- `EventBus` — the bus itself\n- something else\n"
+        )
+
+        router = _make_router(tmp_path, config_with_terms)
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        result = endpoint()
+
+        adr_nodes = [n for n in result["nodes"] if n.get("type") == "adr"]
+        assert len(adr_nodes) == 1
+        assert adr_nodes[0]["id"] == "adr-42"
+        assert adr_nodes[0]["parent"] == "adrs"
+        assert "adrs" in {c["id"] for c in result["contexts"]}
+
+        relates_edges = [e for e in result["edges"] if e["kind"] == "relates_to"]
+        assert any(
+            e["source"] == "adr-42" and e["target"] == "01TARGET00000000000000"
+            for e in relates_edges
+        )
+
+    def test_excludes_adrs_when_include_adrs_false(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0042-x.md").write_text(
+            "# ADR-0042: X\n\n## Status\n\nAccepted\n\n## Related\n\n- `EventBus`\n"
+        )
+
+        router = _make_router(tmp_path, config_with_terms)
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        result = endpoint(include_adrs=False)
+
+        assert all(n.get("type") != "adr" for n in result["nodes"])
+        assert all(e.get("kind") != "relates_to" for e in result["edges"])
+        assert "adrs" not in {c["id"] for c in result["contexts"]}
+
+
+class TestAtlasTermDetailProvenance:
+    """GET /api/atlas/terms/{id} — provenance fields from TermProposerLoop (T5)."""
+
+    def test_provenance_fields_null_for_hand_authored_term(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        router = _make_router(tmp_path, config_with_terms)
+        endpoint = find_endpoint(router, "/api/atlas/terms/{term_id}", method="GET")
+        result = endpoint(term_id="01SOURCE00000000000000")
+        assert result["proposed_by"] is None
+        assert result["proposed_at"] is None
+        assert result["proposal_signals"] is None
+        assert result["proposal_imports_seen"] is None
+
+    def test_provenance_fields_populated_for_proposer_term(
+        self, tmp_path: Path
+    ) -> None:
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        store.write(
+            Term(
+                id="01PROPOSED000000000000",
+                name="ProposedThing",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="A proposed term.",
+                code_anchor="src/foo.py:Bar",
+                confidence="proposed",
+                proposed_by="TermProposerLoop",
+                proposed_at="2026-05-09T08:00:00+00:00",
+                proposal_signals=["S1", "S2"],
+                proposal_imports_seen=12,
+            )
+        )
+
+        config = HydraFlowConfig(repo_root=tmp_path)
+        router = _make_router(tmp_path, config)
+        endpoint = find_endpoint(router, "/api/atlas/terms/{term_id}", method="GET")
+        result = endpoint(term_id="01PROPOSED000000000000")
+
+        assert result["proposed_by"] == "TermProposerLoop"
+        assert result["proposed_at"] == "2026-05-09T08:00:00+00:00"
+        assert result["proposal_signals"] == ["S1", "S2"]
+        assert result["proposal_imports_seen"] == 12
+
+
+class TestAtlasTermLoopsStatus:
+    """GET /api/atlas/term-loops/status — last-tick snapshot (T6)."""
+
+    def test_returns_entries_for_all_three_loops_when_never_run(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        router = _make_router(tmp_path, config_with_terms)
+        endpoint = find_endpoint(router, "/api/atlas/term-loops/status", method="GET")
+        assert endpoint is not None
+
+        result = endpoint()
+
+        assert set(result.keys()) == {"term_proposer", "term_pruner", "edge_proposer"}
+        for entry in result.values():
+            assert entry["last_run"] is None
+            assert entry["last_pr_url"] is None
+            assert entry["last_action_count"] is None
+            assert entry["status"] == "unknown"
+
+    def test_reflects_persisted_heartbeat(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        state = StateTracker(tmp_path / "state.json")
+        state._persist_worker_state(  # noqa: SLF001 — exercising the persistence path
+            "term_proposer",
+            "ok",
+            "2026-05-09T08:30:00+00:00",
+            {"open_pr_url": "https://github.com/x/y/pull/1", "count": 3},
+        )
+        state.save()
+
+        bus = EventBus()
+        from tests.helpers import make_dashboard_router as _mdr
+
+        router, _ = _mdr(config_with_terms, bus, state, tmp_path)
+        endpoint = find_endpoint(router, "/api/atlas/term-loops/status", method="GET")
+        result = endpoint()
+
+        proposer = result["term_proposer"]
+        assert proposer["status"] == "ok"
+        assert proposer["last_run"] == "2026-05-09T08:30:00+00:00"
+        assert proposer["last_pr_url"] == "https://github.com/x/y/pull/1"
+        assert proposer["last_action_count"] == 3
+
 
 class TestAtlasAdrsList:
     """GET /api/atlas/adrs — minimal summary records from docs/adr/*.md."""


### PR DESCRIPTION
## Summary

Atlas Phase 2 (per ADR-0060): adds the **Graph** sub-tab (force-directed via `d3-force`), surfaces **ADRs as graph nodes** with relates_to edges to terms, exposes **term provenance** in the detail panel, adds **kind/context/confidence filters** in both graph views, and surfaces **term-loops telemetry** in Maintenance.

## What changed

**Backend** (`src/dashboard_routes/_atlas_routes.py`):
- `/api/atlas/graph?include_adrs=true` (default) — ADR nodes (`type: 'adr'`, `parent: 'adrs'`) appended; `relates_to` edges inferred by parsing each ADR's `## Related` section against term names + aliases
- `/api/atlas/terms/{id}` returns `proposed_by`, `proposed_at`, `proposal_signals`, `proposal_imports_seen` (all `None` for hand-authored terms)
- New `GET /api/atlas/term-loops/status` reads `StateTracker.get_worker_heartbeats()` for `term_proposer` / `term_pruner` / `edge_proposer`

**Frontend** (`src/ui/src/components/atlas/`):
- `useGraphLayout(payload, mode, selectedId)` hook — `mode: 'domain' | 'force'`. DomainView refactored to consume it; new GraphView mirrors structure
- `GraphView.jsx` — d3-force simulation, color-by-context, no parent grouping
- `AdrDetailPanel.jsx` + `DetailPanel.jsx` chassis — routes by node id (`adr-N` → ADR panel, otherwise → Term panel)
- `TermDetailPanel` Provenance section (hidden when `proposed_by` null)
- AtlasExplorer 4-tab strip (Domain · Graph · Articles · Maintenance), shared filter state with kind/context/confidence selects
- MaintenanceView term-loops telemetry card

**Docs**: ADR-0060 documents the IA + data additions.

## Test plan

- [x] `make quality` green (12,166 tests pass)
- [x] 6 new pytest cases in `test_atlas_routes.py` (graph + ADRs, exclude flag, provenance, term-loops)
- [x] New MockWorld scenario `tests/scenarios/test_atlas_graph_with_adrs_scenario.py`
- [x] 3 new vitest test files (GraphView, AdrDetailPanel, DetailPanel) + AtlasExplorer test extended for the 4-tab strip
- [x] Frontend `npm run build` succeeds
- [ ] Manual smoke: open Atlas, click Graph tab, click an ADR node → AdrDetailPanel renders (post-merge)

## Phase plan

This is **Phase 2 of 4**. Tracked in beads as `hydraflow-8k18` epic.

- P3 `hydraflow-02m5` — Wiki entries linked as evidence on terms + Discovered bucket
- P4 `hydraflow-7tkl` — Polish (deep links, focus mode, saved views, keyboard nav, remove old `wiki/` dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)