### PR TITLE
chore: ignore .superpowers/ visual brainstorming artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,7 @@ docs/superpowers/
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 MagicMock/
+
+# Visual brainstorming companion artifacts
+.superpowers/
+


### PR DESCRIPTION
## Summary

- Adds ``.superpowers/`` to ``.gitignore`` so the visual brainstorming companion's runtime artifact directory doesn't end up tracked.
- Pairs with the existing ``docs/superpowers/`` rule (plan/spec drafts) — this entry covers the runtime working-tree dir.

## Origin

Cherry-picked from local-main commit ``012d995e`` ("gitignore update", reworded to be more descriptive on the way through).

## Test plan

- [x] No code changes; ``.gitignore`` only.
- [x] ``git check-ignore .superpowers/anything`` reports the rule applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)