### PR TITLE
feat(atlas): wiki entries as evidence + Discovered bucket (P3)

### DIFF
--- a/docs/adr/0061-atlas-entries-as-evidence.md
+++ b/docs/adr/0061-atlas-entries-as-evidence.md
@@ -1,0 +1,65 @@
+# ADR-0061: Atlas — Wiki Entries as Term Evidence + Discovered Bucket
+
+## Status
+
+Accepted
+
+## Date
+
+2026-05-09
+
+## Enforced by
+
+`tests/test_atlas_routes.py`, `src/ui/src/components/atlas/__tests__/`
+
+## Context
+
+[ADR-0059](0059-atlas-knowledge-graph-dashboard.md) shipped the Atlas dashboard with a unified `Articles` browser that lists ADRs and wiki entries side-by-side. [ADR-0060](0060-atlas-graph-view-and-provenance.md) added ADR nodes to the graph with `relates_to` edges to terms.
+
+Wiki entries — bot-generated knowledge nuggets captured by `RepoWikiLoop` from review escalations, gotchas, patterns, etc. — are still graph-invisible. The `Term` Pydantic model has carried an `evidence: list[str]` field since [ADR-0053](0053-ubiquitous-language-as-living-artifact.md) and a one-shot migration script (`scripts/migrate_entries_to_term_evidence.py`) populates it via LLM matching, but the dashboard does nothing with it.
+
+This ADR closes that loop. Wiki entries become a third node type in the graph, attached to the term(s) they document. Entries with no term link form a virtual "Discovered" subgraph — visually distinct, but discoverable, so they can be triaged into terms manually or by the next migration run.
+
+## Decision
+
+### Entries as graph nodes
+
+`/api/atlas/graph` gains `?include_entries=true|false` (default `false` for backward compatibility — flips to `true` once the UI ships). When enabled:
+
+- Each wiki entry that appears in some term's `evidence` list is emitted as a node with `type: 'entry'` and `parent: <term_context>` (so it lives inside the same parent box as the term it documents).
+- An `evidence_for` edge connects each entry node to its term node.
+- Entry nodes are visually smaller than term nodes — they are leaves, not concepts.
+
+### Discovered bucket
+
+A new `GET /api/atlas/discovered` returns wiki entries that no term references. The frontend renders these inside a virtual `discovered` parent context — dashed grey border, lower opacity — so the operator can see what knowledge the term proposer hasn't classified yet.
+
+### Term detail panel evidence list
+
+`TermDetailPanel` already had an "Evidence (P3 — 0 today)" placeholder. P3 replaces the placeholder with a real list: each linked entry rendered as a clickable row that selects the entry node in the graph (or, in P4, deep-links to the article view).
+
+### Articles "Linked to term" facet
+
+The unified Articles list gains a third filter dimension alongside `Type` and the wiki filters: `All / Linked / Discovered`. When set to "Linked" only entries that some term references survive; when "Discovered" only the orphans remain.
+
+## Consequences
+
+- The graph payload schema gains a `type: 'entry'` discriminator. P1/P2 consumers that check `type === 'term'` already coexist with the P2 ADR addition; entries follow the same pattern.
+- `include_entries=false` remains available as an escape hatch for callers that want a smaller payload.
+- Phase 4 (polish) builds on the same selection-routing chassis; clicking an entry node will deep-link to its Articles row.
+- The migration script run remains a separate operational step (or, eventually, an autonomous loop). This ADR specifies how the dashboard surfaces what's already in the data — not when the data is computed.
+
+## Alternatives considered
+
+- **Treat entries as edges, not nodes.** Rejected: an entry can document multiple terms (1:N), so an edge model needs join nodes anyway, and entries carry their own selectable detail (the markdown body) which a pure-edge representation hides.
+- **Keep entries hidden, surface only via the Articles list.** Rejected: the user's original goal was to make the term graph navigable to the knowledge that justifies it. Hiding entries from the graph defeats that.
+- **Auto-classify orphan entries into a term inferred at render time.** Rejected: the migration script already exists, runs on a schedule, and can apply LLM judgment. Re-running that logic in the dashboard would duplicate cost and produce inconsistent results vs. the persisted evidence list.
+
+## Related
+
+- [ADR-0053](0053-ubiquitous-language-as-living-artifact.md) — UL terms + `evidence` field
+- [ADR-0054](0054-term-auto-proposer-loop.md) — `TermProposerLoop`
+- [ADR-0059](0059-atlas-knowledge-graph-dashboard.md) — Atlas Phase 1
+- [ADR-0060](0060-atlas-graph-view-and-provenance.md) — Atlas Phase 2 (graph + ADR nodes)
+- `scripts/migrate_entries_to_term_evidence.py` — entry→term linker
+- `src/repo_wiki.py` — `RepoWikiStore`, `WikiEntry`

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T20:19:04.719774+00:00",
-  "commit_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc",
+  "regenerated_at": "2026-05-09T20:31:58.343115+00:00",
+  "commit_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9",
   "artifacts": {
     "loops.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "ports.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "labels.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "modules.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "events.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "adr_xref.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "mockworld.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "changelog.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     },
     "functional_areas.md": {
-      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
+      "source_sha": "364f7a81bffa717a6c1064d6acc28d5472001dd9"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-09T17:21:49.465062+00:00",
-  "commit_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6",
+  "regenerated_at": "2026-05-09T20:19:04.719774+00:00",
+  "commit_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc",
   "artifacts": {
     "loops.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "ports.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "labels.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "modules.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "events.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "adr_xref.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "mockworld.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "changelog.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     },
     "functional_areas.md": {
-      "source_sha": "900a7535fccb06cd2d7c3601ef86899c94ccd6a6"
+      "source_sha": "68c934285ab78c23abf61bd88c3380b641d85fcc"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -176,4 +176,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -68,6 +68,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0058 | `src.edge_proposer_loop`, `src.ubiquitous_language` |
 | ADR-0059 | `src.dashboard_routes._atlas_routes`, `src.ubiquitous_language` |
 | ADR-0060 | `src.dashboard_routes._atlas_routes` |
+| ADR-0061 | `src.repo_wiki` |
 
 ## Module → ADRs
 
@@ -140,7 +141,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.prompt_template` | ADR-0043 |
 | `src.rc_budget_loop` | ADR-0045 |
 | `src.repo_runtime` | ADR-0038 |
-| `src.repo_wiki` | ADR-0032, ADR-0053 |
+| `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031 |
@@ -175,4 +176,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `9a5df5a` — feat(atlas): entries-as-evidence + Discovered bucket endpoints (T3-T4) *(2026-05-09)*
 - `68c9342` — docs(adr): ADR-0061 atlas entries-as-evidence + Discovered bucket *(2026-05-09)*
 - `da05260` — chore(arch): regen artifacts post-quality (P2) *(2026-05-09)*
 - `315b5e4` — feat(atlas): graph + ADRs + term provenance + term-loops status (T4-T6) *(2026-05-09)*
@@ -197,4 +198,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W19
 
+- `68c9342` — docs(adr): ADR-0061 atlas entries-as-evidence + Discovered bucket *(2026-05-09)*
+- `da05260` — chore(arch): regen artifacts post-quality (P2) *(2026-05-09)*
 - `315b5e4` — feat(atlas): graph + ADRs + term provenance + term-loops status (T4-T6) *(2026-05-09)*
 - `f202f81` — docs(adr): ADR-0060 atlas graph view + ADR nodes + term provenance *(2026-05-09)*
 - `f0dc42d` — chore(arch): regen artifacts post-quality (T13) *(2026-05-08)*
@@ -195,4 +197,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -269,4 +269,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -269,4 +269,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -47,4 +47,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -47,4 +47,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -36,4 +36,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._
+_Regenerated from commit `364f7a8` on 2026-05-09 20:31 UTC. Source last changed at `364f7a8`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `900a753` on 2026-05-09 17:21 UTC. Source last changed at `900a753`. Status: 🟢 fresh._
+_Regenerated from commit `68c9342` on 2026-05-09 20:19 UTC. Source last changed at `68c9342`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_atlas_routes.py
+++ b/src/dashboard_routes/_atlas_routes.py
@@ -25,6 +25,16 @@ logger = logging.getLogger("hydraflow.dashboard.atlas")
 
 _ADR_FILENAME_RE = re.compile(r"^(\d{4,5})-(.+)\.md$")
 _ADR_TITLE_RE = re.compile(r"^#\s+ADR-\d{4,5}:\s+(.+?)\s*$", re.MULTILINE)
+# Same shape as _ENTRY_FILENAME_RE in _wiki_routes.py — kept duplicated to
+# avoid coupling _atlas_routes to wiki internals.
+_ENTRY_FILENAME_RE = re.compile(r"^(\d+)-issue-(\S+?)-(.+)\.md$")
+_WIKI_TOPICS: tuple[str, ...] = (
+    "architecture",
+    "patterns",
+    "gotchas",
+    "testing",
+    "dependencies",
+)
 
 
 def _terms_root(ctx: RouteContext) -> Path:
@@ -33,6 +43,44 @@ def _terms_root(ctx: RouteContext) -> Path:
 
 def _adr_root(ctx: RouteContext) -> Path:
     return (ctx.config.repo_root / "docs" / "adr").resolve()
+
+
+def _wiki_root(ctx: RouteContext) -> Path:
+    return (ctx.config.repo_root / ctx.config.repo_wiki_path).resolve()
+
+
+def _iter_wiki_entries(ctx: RouteContext):
+    """Yield {id, owner, repo, topic, filename, status} for every wiki entry.
+
+    Walks the tracked ``repo_wiki/`` layout. Used by the entry-graph and
+    discovered-bucket endpoints. Yields no results when the directory is
+    absent or empty.
+    """
+    root = _wiki_root(ctx)
+    if not root.is_dir():
+        return
+    for owner_dir in sorted(root.iterdir()):
+        if not owner_dir.is_dir():
+            continue
+        for repo_dir in sorted(owner_dir.iterdir()):
+            if not repo_dir.is_dir():
+                continue
+            for topic in _WIKI_TOPICS:
+                topic_dir = repo_dir / topic
+                if not topic_dir.is_dir():
+                    continue
+                for path in sorted(topic_dir.glob("*.md")):
+                    m = _ENTRY_FILENAME_RE.match(path.name)
+                    if m is None:
+                        continue
+                    yield {
+                        "id": m.group(1),
+                        "issue": m.group(2),
+                        "topic": topic,
+                        "owner": owner_dir.name,
+                        "repo": repo_dir.name,
+                        "filename": path.name,
+                    }
 
 
 def _term_summary(term) -> dict[str, Any]:
@@ -156,7 +204,9 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return _term_detail(by_id[term_id], by_id)
 
     @router.get("/api/atlas/graph")
-    def get_atlas_graph(include_adrs: bool = True) -> dict[str, Any]:
+    def get_atlas_graph(
+        include_adrs: bool = True, include_entries: bool = False
+    ) -> dict[str, Any]:
         store = TermStore(_terms_root(ctx))
         terms = store.list()
         contexts_seen: dict[str, dict[str, str]] = {}
@@ -242,11 +292,74 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                                 )
                                 seen_targets.add(term_id)
 
+        if include_entries:
+            # Build a {entry_id: term_id} reverse index from the evidence
+            # lists. Entries that don't appear get routed to the Discovered
+            # bucket; entries with multiple terms attach to the first one
+            # we see (collisions are rare and a single attachment is enough
+            # for graph navigation).
+            entry_to_term: dict[str, str] = {}
+            term_by_id = {t.id: t for t in terms}
+            for term in terms:
+                for entry_id in term.evidence:
+                    entry_to_term.setdefault(entry_id, term.id)
+
+            for entry in _iter_wiki_entries(ctx):
+                eid = entry["id"]
+                term_id = entry_to_term.get(eid)
+                if term_id is None:
+                    # Orphan entries surface via /api/atlas/discovered, not
+                    # the main graph payload — keeps the canvas focused on
+                    # the term-anchored network.
+                    continue
+                anchor = term_by_id.get(term_id)
+                parent = anchor.bounded_context.value if anchor is not None else None
+                node_id = f"entry-{entry['owner']}-{entry['repo']}-{eid}"
+                nodes.append(
+                    {
+                        "id": node_id,
+                        "type": "entry",
+                        "name": entry["filename"],
+                        "topic": entry["topic"],
+                        "parent": parent,
+                        "owner": entry["owner"],
+                        "repo": entry["repo"],
+                        "entry_id": eid,
+                    }
+                )
+                edges.append(
+                    {
+                        "source": node_id,
+                        "target": term_id,
+                        "kind": "evidence_for",
+                    }
+                )
+
         return {
             "nodes": nodes,
             "edges": edges,
             "contexts": list(contexts_seen.values()),
         }
+
+    @router.get("/api/atlas/discovered")
+    def list_atlas_discovered() -> list[dict[str, Any]]:
+        """Wiki entries with no term-evidence backlink (the Discovered bucket).
+
+        The frontend renders these inside a virtual 'discovered' subgraph
+        with dashed-grey styling so operators can see what knowledge the
+        term proposer hasn't classified yet (ADR-0061).
+        """
+        store = TermStore(_terms_root(ctx))
+        linked: set[str] = set()
+        for term in store.list():
+            for entry_id in term.evidence:
+                linked.add(entry_id)
+        out: list[dict[str, Any]] = []
+        for entry in _iter_wiki_entries(ctx):
+            if entry["id"] in linked:
+                continue
+            out.append(entry)
+        return out
 
     @router.get("/api/atlas/adrs")
     def list_atlas_adrs() -> list[dict[str, Any]]:

--- a/src/ui/src/components/atlas/ArticlesView.jsx
+++ b/src/ui/src/components/atlas/ArticlesView.jsx
@@ -6,13 +6,27 @@ import { WikiTopBar } from '../wiki/WikiTopBar'
 
 export function ArticlesView() {
   const [typeFilter, setTypeFilter] = useState('all') // all | adrs | wiki
+  const [linkFilter, setLinkFilter] = useState('all') // all | linked | discovered
   const [adrs, setAdrs] = useState([])
   const [repos, setRepos] = useState([])
   const [selectedRepo, setSelectedRepo] = useState(null)
   const [wikiFilters, setWikiFilters] = useState({ topic: '', status: '', q: '' })
   const [entries, setEntries] = useState([])
+  const [discoveredIds, setDiscoveredIds] = useState(new Set())
   const [selected, setSelected] = useState(null)
   const [bodyDetail, setBodyDetail] = useState(null)
+
+  // Discovered entry IDs (orphans w/ no term evidence). One fetch on mount —
+  // stable enough at the cadence the term-proposer + migration script run at.
+  useEffect(() => {
+    fetch('/api/atlas/discovered')
+      .then((r) => (r.ok ? r.json() : []))
+      .then((d) => {
+        const list = Array.isArray(d) ? d : []
+        setDiscoveredIds(new Set(list.map((e) => e.id)))
+      })
+      .catch(() => setDiscoveredIds(new Set()))
+  }, [])
 
   // ADRs (always loaded — small set)
   useEffect(() => {
@@ -92,18 +106,25 @@ export function ArticlesView() {
         })
     }
     if (typeFilter === 'all' || typeFilter === 'wiki') {
-      for (const e of entries)
+      for (const e of entries) {
+        const isDiscovered = discoveredIds.has(e.id)
+        // Link filter only applies to wiki entries — ADRs are out of scope.
+        if (linkFilter === 'linked' && isDiscovered) continue
+        if (linkFilter === 'discovered' && !isDiscovered) continue
         rows.push({
           key: `wiki-${e.id}-${e.topic}`,
           type: 'wiki',
           id: e.id,
           repo: { owner: e.owner, repo: e.repo },
           title: e.filename,
-          meta: `${e.topic} · ${e.status} · #${e.source_issue ?? '?'}`,
+          meta: `${e.topic} · ${e.status} · #${e.source_issue ?? '?'}${
+            isDiscovered ? ' · discovered' : ''
+          }`,
         })
+      }
     }
     return rows
-  }, [typeFilter, adrs, entries])
+  }, [typeFilter, linkFilter, adrs, entries, discoveredIds])
 
   const showWikiBar = typeFilter === 'all' || typeFilter === 'wiki'
 
@@ -190,13 +211,26 @@ export function ArticlesView() {
           <option value="wiki">Wiki entries</option>
         </select>
         {showWikiBar && (
-          <WikiTopBar
-            repos={repos}
-            selectedRepo={selectedRepo}
-            onRepoChange={setSelectedRepo}
-            filters={wikiFilters}
-            onFiltersChange={setWikiFilters}
-          />
+          <>
+            <span style={styles.label}>Linked</span>
+            <select
+              aria-label="Linked to term"
+              style={styles.select}
+              value={linkFilter}
+              onChange={(e) => setLinkFilter(e.target.value)}
+            >
+              <option value="all">All</option>
+              <option value="linked">Linked to a term</option>
+              <option value="discovered">Discovered (orphan)</option>
+            </select>
+            <WikiTopBar
+              repos={repos}
+              selectedRepo={selectedRepo}
+              onRepoChange={setSelectedRepo}
+              filters={wikiFilters}
+              onFiltersChange={setWikiFilters}
+            />
+          </>
         )}
       </div>
       <div style={styles.panes}>

--- a/src/ui/src/components/atlas/ArticlesView.jsx
+++ b/src/ui/src/components/atlas/ArticlesView.jsx
@@ -19,13 +19,20 @@ export function ArticlesView() {
   // Discovered entry IDs (orphans w/ no term evidence). One fetch on mount —
   // stable enough at the cadence the term-proposer + migration script run at.
   useEffect(() => {
+    let cancelled = false
     fetch('/api/atlas/discovered')
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => {
+        if (cancelled) return
         const list = Array.isArray(d) ? d : []
         setDiscoveredIds(new Set(list.map((e) => e.id)))
       })
-      .catch(() => setDiscoveredIds(new Set()))
+      .catch(() => {
+        if (!cancelled) setDiscoveredIds(new Set())
+      })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   // ADRs (always loaded — small set)

--- a/src/ui/src/components/atlas/DomainView.jsx
+++ b/src/ui/src/components/atlas/DomainView.jsx
@@ -32,20 +32,49 @@ function applyFilters(payload, filters) {
   }
 }
 
+function mergeDiscovered(graph, discovered) {
+  if (!graph || !Array.isArray(discovered) || discovered.length === 0) {
+    return graph
+  }
+  const extraNodes = discovered.map((entry) => ({
+    id: `entry-${entry.owner}-${entry.repo}-${entry.id}`,
+    type: 'entry',
+    name: entry.filename,
+    topic: entry.topic,
+    parent: 'discovered',
+    owner: entry.owner,
+    repo: entry.repo,
+    entry_id: entry.id,
+  }))
+  return {
+    ...graph,
+    nodes: [...(graph.nodes || []), ...extraNodes],
+    edges: graph.edges || [],
+    contexts: [
+      ...(graph.contexts || []),
+      { id: 'discovered', label: 'discovered' },
+    ],
+  }
+}
+
 export function DomainView({ selectedNodeId, onSelectNode, filters }) {
   const [graph, setGraph] = useState(null)
+  const [discovered, setDiscovered] = useState([])
   const [error, setError] = useState(null)
 
   useEffect(() => {
     let cancelled = false
-    fetch('/api/atlas/graph')
-      .then((r) => {
+    Promise.all([
+      fetch('/api/atlas/graph?include_entries=true').then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
-      })
-      .then((data) => {
+      }),
+      fetch('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
+    ])
+      .then(([graphData, discoveredData]) => {
         if (cancelled) return
-        setGraph(data)
+        setGraph(graphData)
+        setDiscovered(Array.isArray(discoveredData) ? discoveredData : [])
         setError(null)
       })
       .catch((err) => {
@@ -58,7 +87,8 @@ export function DomainView({ selectedNodeId, onSelectNode, filters }) {
     }
   }, [])
 
-  const filtered = applyFilters(graph, filters)
+  const merged = mergeDiscovered(graph, discovered)
+  const filtered = applyFilters(merged, filters)
   const { nodes, edges } = useGraphLayout(filtered, 'domain', selectedNodeId)
 
   if (error) {

--- a/src/ui/src/components/atlas/GraphView.jsx
+++ b/src/ui/src/components/atlas/GraphView.jsx
@@ -30,20 +30,49 @@ function applyFilters(payload, filters) {
   }
 }
 
+function mergeDiscovered(graph, discovered) {
+  if (!graph || !Array.isArray(discovered) || discovered.length === 0) {
+    return graph
+  }
+  const extraNodes = discovered.map((entry) => ({
+    id: `entry-${entry.owner}-${entry.repo}-${entry.id}`,
+    type: 'entry',
+    name: entry.filename,
+    topic: entry.topic,
+    parent: 'discovered',
+    owner: entry.owner,
+    repo: entry.repo,
+    entry_id: entry.id,
+  }))
+  return {
+    ...graph,
+    nodes: [...(graph.nodes || []), ...extraNodes],
+    edges: graph.edges || [],
+    contexts: [
+      ...(graph.contexts || []),
+      { id: 'discovered', label: 'discovered' },
+    ],
+  }
+}
+
 export function GraphView({ selectedNodeId, onSelectNode, filters }) {
   const [graph, setGraph] = useState(null)
+  const [discovered, setDiscovered] = useState([])
   const [error, setError] = useState(null)
 
   useEffect(() => {
     let cancelled = false
-    fetch('/api/atlas/graph')
-      .then((r) => {
+    Promise.all([
+      fetch('/api/atlas/graph?include_entries=true').then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
-      })
-      .then((data) => {
+      }),
+      fetch('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
+    ])
+      .then(([graphData, discoveredData]) => {
         if (cancelled) return
-        setGraph(data)
+        setGraph(graphData)
+        setDiscovered(Array.isArray(discoveredData) ? discoveredData : [])
         setError(null)
       })
       .catch((err) => {
@@ -56,7 +85,8 @@ export function GraphView({ selectedNodeId, onSelectNode, filters }) {
     }
   }, [])
 
-  const filtered = applyFilters(graph, filters)
+  const merged = mergeDiscovered(graph, discovered)
+  const filtered = applyFilters(merged, filters)
   const { nodes, edges } = useGraphLayout(filtered, 'force', selectedNodeId)
 
   if (error) {

--- a/src/ui/src/components/atlas/TermDetailPanel.jsx
+++ b/src/ui/src/components/atlas/TermDetailPanel.jsx
@@ -161,12 +161,14 @@ export function TermDetailPanel({ selectedNodeId }) {
       <div style={styles.label}>Evidence ({term.evidence.length})</div>
       {term.evidence.length === 0 ? (
         <div style={{ color: theme.textMuted, fontStyle: 'italic' }}>
-          No wiki entries linked yet (Phase 3).
+          No wiki entries linked. The migration script
+          (<code>scripts/migrate_entries_to_term_evidence.py</code>)
+          populates this list.
         </div>
       ) : (
         term.evidence.map((id) => (
           <div key={id} style={styles.edgeRow}>
-            {id}
+            <code style={{ color: theme.textBright }}>entry-{id}</code>
           </div>
         ))
       )}

--- a/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
@@ -114,4 +114,34 @@ describe('ArticlesView', () => {
       expect(heading.tagName).toBe('H1')
     })
   })
+
+  it('renders the Linked-to-term filter dropdown when wiki entries are in scope', async () => {
+    render(<ArticlesView />)
+    await waitFor(() =>
+      expect(screen.getByLabelText(/linked to term/i)).toBeInTheDocument(),
+    )
+    const select = screen.getByLabelText(/linked to term/i)
+    expect(select.tagName).toBe('SELECT')
+    // All three options must be available.
+    expect(
+      screen.getByRole('option', { name: /linked to a term/i }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: /discovered \(orphan\)/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('hides the Linked filter when type is set to ADRs only', async () => {
+    render(<ArticlesView />)
+    await waitFor(() =>
+      expect(screen.getByLabelText(/linked to term/i)).toBeInTheDocument(),
+    )
+    fireEvent.change(screen.getByLabelText(/^type$/i), {
+      target: { value: 'adrs' },
+    })
+    // The whole wiki bar (including the link filter) is gated on ADRs/wiki/all.
+    expect(
+      screen.queryByLabelText(/linked to term/i),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/ui/src/components/atlas/useGraphLayout.js
+++ b/src/ui/src/components/atlas/useGraphLayout.js
@@ -50,6 +50,25 @@ function nodeStyle(node, selected) {
       padding: 6,
     }
   }
+  if (node.type === 'entry') {
+    // Entry nodes are leaves — smaller, lower-contrast. Discovered (orphan)
+    // entries get dashed borders so the bot-generated evidence reads as
+    // secondary signal next to the curated term/ADR vocabulary.
+    const dashed = node.parent === 'discovered'
+    return {
+      width: 100,
+      height: 24,
+      background: dashed ? 'transparent' : theme.surfaceInset,
+      border: `1px ${dashed ? 'dashed' : 'solid'} ${
+        selected ? theme.accent : '#555'
+      }`,
+      borderRadius: 2,
+      color: dashed ? theme.textMuted : theme.text,
+      fontSize: 10,
+      padding: 4,
+      opacity: dashed ? 0.7 : 1,
+    }
+  }
   return {
     width: NODE_W,
     height: NODE_H,
@@ -73,8 +92,14 @@ function buildEdges(rawEdges) {
     label: e.kind,
     labelStyle: { fontSize: 10, fill: theme.textMuted },
     style: {
-      stroke: e.kind === 'relates_to' ? '#666' : theme.border,
-      strokeDasharray: e.kind === 'relates_to' ? '4,2' : undefined,
+      stroke:
+        e.kind === 'relates_to' || e.kind === 'evidence_for'
+          ? '#666'
+          : theme.border,
+      strokeDasharray:
+        e.kind === 'relates_to' || e.kind === 'evidence_for'
+          ? '4,2'
+          : undefined,
     },
   }))
 }

--- a/src/ui/src/components/atlas/useGraphLayout.js
+++ b/src/ui/src/components/atlas/useGraphLayout.js
@@ -202,16 +202,18 @@ function layoutForce(payload, selectedId) {
   const flowNodes = simNodes.map((n) => {
     const ctxColor = CONTEXT_COLORS[n.parent] || theme.border
     const baseStyle = nodeStyle(n, n.id === selectedId)
+    // Entry nodes keep the dashed/discovered styling computed by nodeStyle —
+    // overriding their border here would erase the Discovered-bucket signal
+    // (orphans become visually indistinguishable from linked entries).
+    const border =
+      n.type === 'entry'
+        ? baseStyle.border
+        : `1px ${n.confidence === 'proposed' ? 'dashed' : 'solid'} ${ctxColor}`
     return {
       id: n.id,
       position: { x: n.x ?? 0, y: n.y ?? 0 },
       data: { label: n.name, kind: n.kind, type: n.type },
-      style: {
-        ...baseStyle,
-        // In force mode, color the node border by context (not kind) so the
-        // free layout still telegraphs which subgraph each node lives in.
-        border: `1px ${n.confidence === 'proposed' ? 'dashed' : 'solid'} ${ctxColor}`,
-      },
+      style: { ...baseStyle, border },
     }
   })
 

--- a/tests/scenarios/test_atlas_entries_scenario.py
+++ b/tests/scenarios/test_atlas_entries_scenario.py
@@ -1,0 +1,108 @@
+"""MockWorld scenario for the Atlas P3 entries-as-evidence flow (ADR-0061).
+
+Verifies the data path Domain/Graph views consume when ?include_entries=true
+plus /api/atlas/discovered:
+
+1. Seed two terms; only one references a wiki entry via its evidence list.
+2. Seed two wiki entries on disk under config.repo_wiki_path:
+   - One referenced by the term (linked).
+   - One with no term backlink (orphan / discovered bucket).
+3. Hit /api/atlas/graph?include_entries=true. Assert:
+   - The linked entry appears as type='entry' attached to the term's
+     bounded_context parent, with an 'evidence_for' edge.
+   - The orphan entry does NOT appear in the graph payload.
+4. Hit /api/atlas/discovered. Assert it contains only the orphan.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from config import HydraFlowConfig
+from events import EventBus
+from state import StateTracker
+from tests.helpers import find_endpoint, make_dashboard_router
+from ubiquitous_language import (
+    BoundedContext,
+    Term,
+    TermKind,
+    TermStore,
+)
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestAtlasEntriesAsEvidence:
+    def test_graph_separates_linked_from_discovered(self, tmp_path: Path) -> None:
+        # 1. Term store with two terms — only EventBus carries an evidence
+        # backlink to the linked entry id "0001".
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        store.write(
+            Term(
+                id="01TARGET00000000000000",
+                name="EventBus",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="Async pub/sub bus.",
+                code_anchor="src/events.py:EventBus",
+                confidence="accepted",
+                evidence=["0001"],
+            )
+        )
+        store.write(
+            Term(
+                id="01OTHER000000000000000",
+                name="StateTracker",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="Persistence.",
+                code_anchor="src/state.py:StateTracker",
+                confidence="accepted",
+            )
+        )
+
+        # 2. Wiki entries on disk — one linked, one orphan.
+        config = HydraFlowConfig(repo_root=tmp_path)
+        wiki_root = tmp_path / config.repo_wiki_path
+        repo_dir = wiki_root / "acme" / "widget"
+        (repo_dir / "patterns").mkdir(parents=True)
+        (repo_dir / "gotchas").mkdir(parents=True)
+        (repo_dir / "patterns" / "0001-issue-10-linked.md").write_text(
+            "---\nstatus: active\n---\n\nbody.\n"
+        )
+        (repo_dir / "gotchas" / "0002-issue-11-orphan.md").write_text(
+            "---\nstatus: active\n---\n\nbody.\n"
+        )
+
+        state = StateTracker(tmp_path / "state.json")
+        bus = EventBus()
+        router, _ = make_dashboard_router(config, bus, state, tmp_path)
+
+        # 3. Graph payload with entries.
+        graph_endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        graph = graph_endpoint(include_entries=True)
+
+        entry_nodes = [n for n in graph["nodes"] if n.get("type") == "entry"]
+        # Only the linked entry should land in the graph.
+        assert len(entry_nodes) == 1
+        linked = entry_nodes[0]
+        assert linked["entry_id"] == "0001"
+        assert linked["topic"] == "patterns"
+        assert linked["parent"] == "shared-kernel"
+
+        ev_edges = [e for e in graph["edges"] if e["kind"] == "evidence_for"]
+        assert len(ev_edges) == 1
+        assert ev_edges[0]["source"] == linked["id"]
+        assert ev_edges[0]["target"] == "01TARGET00000000000000"
+
+        # 4. Discovered endpoint surfaces the orphan and only the orphan.
+        discovered_endpoint = find_endpoint(
+            router, "/api/atlas/discovered", method="GET"
+        )
+        orphans = discovered_endpoint()
+        orphan_ids = {e["id"] for e in orphans}
+        assert orphan_ids == {"0002"}
+        assert orphans[0]["topic"] == "gotchas"

--- a/tests/test_atlas_routes.py
+++ b/tests/test_atlas_routes.py
@@ -300,6 +300,121 @@ class TestAtlasTermLoopsStatus:
         assert proposer["last_action_count"] == 3
 
 
+def _seed_wiki_entries(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Create two wiki entries on disk under the configured repo_wiki_path.
+
+    Returns (orphan_entry_path, linked_entry_path, repo_dir).
+    """
+    config = HydraFlowConfig(repo_root=tmp_path)
+    wiki_root = tmp_path / config.repo_wiki_path
+    repo_dir = wiki_root / "acme" / "widget"
+    (repo_dir / "patterns").mkdir(parents=True)
+    (repo_dir / "gotchas").mkdir(parents=True)
+    (repo_dir / "index.md").write_text("# wiki\n")
+
+    linked = repo_dir / "patterns" / "0001-issue-10-linked.md"
+    linked.write_text(
+        "---\nstatus: active\nsource_issue: 10\n---\n\n# linked\n\nbody.\n"
+    )
+    orphan = repo_dir / "gotchas" / "0002-issue-11-orphan.md"
+    orphan.write_text(
+        "---\nstatus: active\nsource_issue: 11\n---\n\n# orphan\n\nbody.\n"
+    )
+    return orphan, linked, repo_dir
+
+
+class TestAtlasGraphIncludeEntries:
+    """GET /api/atlas/graph?include_entries=true (P3-T3)."""
+
+    def test_does_not_include_entries_by_default(
+        self, tmp_path: Path, config_with_terms: HydraFlowConfig
+    ) -> None:
+        _seed_wiki_entries(tmp_path)
+        router = _make_router(tmp_path, config_with_terms)
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        result = endpoint()
+        assert all(n.get("type") != "entry" for n in result["nodes"])
+
+    def test_includes_only_entries_referenced_by_term_evidence(
+        self, tmp_path: Path
+    ) -> None:
+        _seed_wiki_entries(tmp_path)
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        store.write(
+            Term(
+                id="01TARGET00000000000000",
+                name="EventBus",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="bus.",
+                code_anchor="src/events.py:EventBus",
+                confidence="accepted",
+                evidence=["0001"],
+            )
+        )
+
+        config = HydraFlowConfig(repo_root=tmp_path)
+        router = _make_router(tmp_path, config)
+        endpoint = find_endpoint(router, "/api/atlas/graph", method="GET")
+        result = endpoint(include_entries=True)
+
+        entry_nodes = [n for n in result["nodes"] if n.get("type") == "entry"]
+        assert len(entry_nodes) == 1
+        e = entry_nodes[0]
+        assert e["entry_id"] == "0001"
+        assert e["topic"] == "patterns"
+        assert e["parent"] == "shared-kernel"
+
+        evidence_edges = [
+            edge for edge in result["edges"] if edge["kind"] == "evidence_for"
+        ]
+        assert len(evidence_edges) == 1
+        assert evidence_edges[0]["source"] == e["id"]
+        assert evidence_edges[0]["target"] == "01TARGET00000000000000"
+
+
+class TestAtlasDiscovered:
+    """GET /api/atlas/discovered — orphan wiki entries (P3-T4)."""
+
+    def test_returns_only_unlinked_entries(self, tmp_path: Path) -> None:
+        _seed_wiki_entries(tmp_path)
+        terms_root = tmp_path / "docs" / "wiki" / "terms"
+        store = TermStore(terms_root)
+        store.write(
+            Term(
+                id="01TARGET00000000000000",
+                name="EventBus",
+                kind=TermKind.SERVICE,
+                bounded_context=BoundedContext.SHARED_KERNEL,
+                definition="bus.",
+                code_anchor="src/events.py:EventBus",
+                confidence="accepted",
+                evidence=["0001"],
+            )
+        )
+
+        config = HydraFlowConfig(repo_root=tmp_path)
+        router = _make_router(tmp_path, config)
+        endpoint = find_endpoint(router, "/api/atlas/discovered", method="GET")
+        assert endpoint is not None
+
+        result = endpoint()
+
+        ids = {e["id"] for e in result}
+        assert ids == {"0002"}
+        orphan = result[0]
+        assert orphan["topic"] == "gotchas"
+        assert orphan["owner"] == "acme"
+        assert orphan["repo"] == "widget"
+
+    def test_returns_empty_when_wiki_root_missing(self, tmp_path: Path) -> None:
+        config = HydraFlowConfig(repo_root=tmp_path)
+        router = _make_router(tmp_path, config)
+        endpoint = find_endpoint(router, "/api/atlas/discovered", method="GET")
+        assert endpoint() == []
+
+
 class TestAtlasAdrsList:
     """GET /api/atlas/adrs — minimal summary records from docs/adr/*.md."""
 


### PR DESCRIPTION
## Summary

Atlas Phase 3 (per ADR-0061): wiki entries become a third graph node type, attached to the term(s) they document via the `evidence` backlink. Entries with no term link surface in a virtual **Discovered** subgraph and a new `Linked-to-term` facet on Articles.

## What changed

**Backend** (`src/dashboard_routes/_atlas_routes.py`):
- `/api/atlas/graph?include_entries=false` (default off). When `true`, wiki entries that some term references via `evidence` become `type: 'entry'` nodes attached to the term's `bounded_context` parent; `evidence_for` edges connect each entry to its term.
- New `GET /api/atlas/discovered` returns wiki entries with no evidence backlink — the Discovered bucket the frontend renders dashed-grey.

**Frontend** (`src/ui/src/components/atlas/`):
- `useGraphLayout` styles entry nodes as smaller leaves; orphan entries in the synthetic `discovered` parent get dashed-grey treatment at 70% opacity.
- DomainView + GraphView fetch both `/api/atlas/graph?include_entries=true` and `/api/atlas/discovered` and merge orphans into a synthetic `discovered` parent context.
- `TermDetailPanel` Evidence section shows linked entry IDs with mono styling and a clearer empty-state pointing at the migration script.
- `ArticlesView` gains a Linked-to-term filter (`All / Linked / Discovered`); discovered entries get a `· discovered` suffix in their meta.

**Docs**: ADR-0061 documents the IA + linking decisions.

## Test plan

- [x] `make quality` green (12,170 passed)
- [x] 4 new pytest cases (graph entries, default-off, discovered endpoint, empty-when-missing)
- [x] New MockWorld scenario `tests/scenarios/test_atlas_entries_scenario.py`
- [x] 2 new vitest cases for the Linked filter dropdown
- [x] Frontend `npm run build` succeeds

## Phase plan

Atlas Phase 3 of 4. Tracked in beads as `hydraflow-02m5` epic.

- P4 `hydraflow-7tkl` — Polish (deep links, focus mode, saved views, keyboard nav, remove old `wiki/` dir)

Note: actually populating term `evidence` lists is an operational step (run `scripts/migrate_entries_to_term_evidence.py`) — the dashboard now surfaces what's already in the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)