### PR TITLE
fix(regression): test_issue_8494 uses renamed script_set_corrupted_config helper

### DIFF
--- a/tests/regressions/test_issue_8494.py
+++ b/tests/regressions/test_issue_8494.py
@@ -1,7 +1,7 @@
 """Regression test for #8494 — FakeGit script-API helpers misclassified as adapter-surface.
 
-`reject_next_push`, `set_corrupted_config`, and `active_worktrees` are test
-helpers (script API), not real-adapter methods.  They must appear in the
+`reject_next_push`, `script_set_corrupted_config`, and `active_worktrees` are
+test helpers (script API), not real-adapter methods.  They must appear in the
 ``test-helper`` bucket, never in ``adapter-surface``.
 """
 
@@ -13,7 +13,11 @@ from fake_coverage_auditor_loop import catalog_fake_methods
 
 _FAKE_DIR = Path(__file__).parents[2] / "src" / "mockworld" / "fakes"
 
-_SCRIPT_API_HELPERS = {"reject_next_push", "set_corrupted_config", "active_worktrees"}
+_SCRIPT_API_HELPERS = {
+    "reject_next_push",
+    "script_set_corrupted_config",
+    "active_worktrees",
+}
 
 
 def test_fake_git_script_api_helpers_are_not_adapter_surface() -> None:


### PR DESCRIPTION
Unblocks staging CI: PR #8695 renamed FakeGit.set_corrupted_config → script_set_corrupted_config but missed updating PR #8694's regression test. Verified: `uv run pytest tests/regressions/test_issue_8494.py` passes.