### PR TITLE
fix(contract-test): rename set_corrupted_config calls to script_set_corrupted_config

### DIFF
--- a/tests/trust/contracts/test_fake_git_contract.py
+++ b/tests/trust/contracts/test_fake_git_contract.py
@@ -18,7 +18,7 @@ from tests.trust.contracts._schema import Cassette
 _CASSETTE_DIR = Path(__file__).parent / "cassettes" / "git"
 
 
-async def _invoke_fake_git(cassette: Cassette) -> FakeOutput:
+async def _invoke_fake_git(cassette: Cassette) -> FakeOutput:  # noqa: PLR0911
     """Dispatch the cassette input through FakeGit's matching method."""
     fake = FakeGit()
     method = cassette.input.command
@@ -59,13 +59,13 @@ async def _invoke_fake_git(cassette: Cassette) -> FakeOutput:
     if method == "config_unset":
         # Seed the key so there is something to unset, mirroring real usage
         # where a corrupted config entry is cleared.
-        fake.set_corrupted_config(cwd, key=str(args[0]), value="stale")
+        fake.script_set_corrupted_config(cwd, key=str(args[0]), value="stale")
         await fake.config_unset(cwd, key=str(args[0]))
         return FakeOutput(exit_code=0, stdout="", stderr="")
 
     if method == "config_get":
         # Seed the value so config_get has something to return.
-        fake.set_corrupted_config(cwd, key=str(args[0]), value="false")
+        fake.script_set_corrupted_config(cwd, key=str(args[0]), value="false")
         result = await fake.config_get(cwd, str(args[0]))
         if result is None:
             return FakeOutput(exit_code=1, stdout="", stderr="")


### PR DESCRIPTION
## Why

`tests/trust/contracts/test_fake_git_contract.py` dispatches cassettes through `FakeGit` methods. After PR #8695 renamed `FakeGit.set_corrupted_config` → `script_set_corrupted_config` (aligning with the `script_` prefix convention enforced by FakeCoverageAuditorLoop), the contract test's `config_unset` and `config_get` blocks still called the old name. Cassette replay would AttributeError at runtime.

## What

- Rename both call sites in `_invoke_fake_git` to `script_set_corrupted_config`
- Add `# noqa: PLR0911` — the dispatcher grew past the 6-return ceiling as cassettes were added; flattening into a table hurts readability for a typed if-switch

## Test

`uv run pytest tests/trust/contracts/test_fake_git_contract.py` — 8 passed.