### PR TITLE
fix(preflight): widen gh-auth timeout to 15s, treat timeout as WARN

### DIFF
--- a/src/preflight/__init__.py
+++ b/src/preflight/__init__.py
@@ -14,6 +14,11 @@ from config import HydraFlowConfig
 
 logger = logging.getLogger("hydraflow.preflight")
 
+# `gh auth status` can take 5-10s on first invocation when the OS keychain
+# unlocks the token. Bounded so a stuck process can't block startup forever
+# (#6576). Module-level so tests can patch a smaller value.
+_GH_AUTH_TIMEOUT_S = 15.0
+
 
 class CheckStatus(Enum):
     PASS = "pass"
@@ -80,17 +85,16 @@ async def _check_gh_auth() -> CheckResult:
             stderr=asyncio.subprocess.DEVNULL,
         )
         try:
-            # `gh auth status` can take 5-10s on first invocation when the OS
-            # keychain has to unlock the token. A real hang is rare; treat the
-            # timeout as a WARN (not FAIL) so a slow keychain doesn't block
-            # startup. The process is still killed to avoid orphans (#6576).
-            rc = await asyncio.wait_for(proc.wait(), timeout=15.0)
+            # Timeout WARNs (not FAILs) so a slow keychain doesn't block
+            # startup; downstream gh calls do their own auth handling. The
+            # process is killed on timeout to avoid orphans (#6576).
+            rc = await asyncio.wait_for(proc.wait(), timeout=_GH_AUTH_TIMEOUT_S)
         except TimeoutError:
             proc.kill()
             return CheckResult(
                 "gh-auth",
                 CheckStatus.WARN,
-                "gh auth status did not complete within 15s — gh CLI appears hung; skipping auth verification",
+                f"gh auth status did not complete within {_GH_AUTH_TIMEOUT_S:g}s — gh CLI appears hung; skipping auth verification",
             )
         if rc == 0:
             return CheckResult("gh-auth", CheckStatus.PASS, "gh CLI authenticated")

--- a/src/preflight/__init__.py
+++ b/src/preflight/__init__.py
@@ -80,14 +80,17 @@ async def _check_gh_auth() -> CheckResult:
             stderr=asyncio.subprocess.DEVNULL,
         )
         try:
-            rc = await asyncio.wait_for(proc.wait(), timeout=1.0)
+            # `gh auth status` can take 5-10s on first invocation when the OS
+            # keychain has to unlock the token. A real hang is rare; treat the
+            # timeout as a WARN (not FAIL) so a slow keychain doesn't block
+            # startup. The process is still killed to avoid orphans (#6576).
+            rc = await asyncio.wait_for(proc.wait(), timeout=15.0)
         except TimeoutError:
-            # Kill the hung process so it doesn't linger as an orphan (#6576).
             proc.kill()
             return CheckResult(
                 "gh-auth",
-                CheckStatus.FAIL,
-                "gh auth status timed out after 1s — gh CLI appears hung",
+                CheckStatus.WARN,
+                "gh auth status did not complete within 15s — gh CLI appears hung; skipping auth verification",
             )
         if rc == 0:
             return CheckResult("gh-auth", CheckStatus.PASS, "gh CLI authenticated")

--- a/tests/regressions/test_issue_6576.py
+++ b/tests/regressions/test_issue_6576.py
@@ -1,15 +1,17 @@
 """Regression test for issue #6576.
 
-``_check_gh_auth`` spawns ``gh auth status`` as an async subprocess but calls
-``await proc.wait()`` with no timeout.  If the ``gh`` CLI hangs (network
-proxy issue, credential store deadlock), the preflight check never completes
-and server startup is blocked forever.
+``_check_gh_auth`` spawns ``gh auth status`` as an async subprocess. Without
+a bounded ``proc.wait()``, a hung ``gh`` CLI (network proxy issue, credential
+store deadlock) would block server startup forever.
 
 By contrast, ``_check_docker()`` in the same file correctly uses
 ``subprocess.run(..., timeout=10)``.
 
-These tests will fail (RED) until ``_check_gh_auth`` wraps its
-``proc.wait()`` call in ``asyncio.wait_for`` with a bounded timeout.
+These tests verify that ``_check_gh_auth`` (a) wraps ``proc.wait()`` in
+``asyncio.wait_for`` with a bounded timeout, and (b) kills the hung process
+on timeout. Whether the result is FAIL or WARN is a separate policy choice
+(see ``test_preflight.py``); this file only guards against the unbounded-wait
+regression.
 """
 
 from __future__ import annotations
@@ -19,7 +21,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from preflight import CheckStatus, _check_gh_auth
+from preflight import _check_gh_auth
 
 # ---------------------------------------------------------------------------
 # Test 1 — _check_gh_auth hangs indefinitely when proc.wait() never returns
@@ -31,18 +33,16 @@ class TestGhAuthTimeout:
 
     @pytest.mark.asyncio
     async def test_check_gh_auth_completes_when_process_hangs(self) -> None:
-        """If the gh subprocess hangs forever, _check_gh_auth should still
-        return a FAIL result within a reasonable timeout (not block forever).
+        """If the gh subprocess hangs forever, _check_gh_auth must still
+        return a result within a bounded time, not block forever.
 
-        This test simulates a hung process by making ``proc.wait()`` sleep
-        indefinitely.  We wrap the call in a short external timeout — if
-        ``_check_gh_auth`` has its own internal timeout, it will return a
-        CheckResult before our outer timeout fires.  If it lacks an internal
-        timeout, the outer timeout will fire, proving the bug.
+        Simulates a hung process via a ``proc.wait()`` that sleeps
+        indefinitely. The production timeout is patched to a small value so
+        the test runs quickly; the outer ``asyncio.wait_for`` is the regression
+        guard — if the inner timeout were missing, it would fire.
         """
 
         async def hang_forever() -> int:
-            """Simulate a process that never exits."""
             await asyncio.sleep(3600)
             return 0  # never reached
 
@@ -51,6 +51,7 @@ class TestGhAuthTimeout:
         mock_proc.kill = MagicMock()
 
         with (
+            patch("preflight._GH_AUTH_TIMEOUT_S", 0.1),
             patch("preflight.shutil.which", return_value="/usr/bin/gh"),
             patch(
                 "preflight.asyncio.create_subprocess_exec",
@@ -58,10 +59,6 @@ class TestGhAuthTimeout:
                 return_value=mock_proc,
             ),
         ):
-            # Give _check_gh_auth a generous 2s to respond on its own.
-            # A correct implementation with a 10s timeout would need the mock
-            # to respect cancellation, but since the function currently has
-            # NO timeout at all, even 2s is enough to prove it hangs.
             try:
                 result = await asyncio.wait_for(_check_gh_auth(), timeout=2.0)
             except TimeoutError:
@@ -70,14 +67,10 @@ class TestGhAuthTimeout:
                     "proc.wait() has no timeout (issue #6576)"
                 )
 
-        # If we get here, the function returned before our outer timeout.
-        # Verify it reported the hang as a failure.
-        assert result.status == CheckStatus.FAIL, (
-            "_check_gh_auth should return FAIL when the gh process hangs, "
-            f"but returned {result.status.value}"
-        )
-        assert "timed out" in result.message.lower(), (
-            "_check_gh_auth should mention timeout in its failure message, "
+        # Returning at all (rather than hanging) is the regression guard.
+        # Message must indicate the timeout path was taken.
+        assert "did not complete" in result.message.lower(), (
+            "_check_gh_auth should report the hang via its timeout branch, "
             f"but got: {result.message!r}"
         )
 
@@ -94,8 +87,6 @@ class TestGhAuthKillsHungProcess:
     async def test_hung_process_is_killed_on_timeout(self) -> None:
         """After timing out, the subprocess must be killed so it doesn't
         linger as an orphan.
-
-        Fails until _check_gh_auth calls proc.kill() on timeout.
         """
 
         async def hang_forever() -> int:
@@ -107,6 +98,7 @@ class TestGhAuthKillsHungProcess:
         mock_proc.kill = MagicMock()
 
         with (
+            patch("preflight._GH_AUTH_TIMEOUT_S", 0.1),
             patch("preflight.shutil.which", return_value="/usr/bin/gh"),
             patch(
                 "preflight.asyncio.create_subprocess_exec",

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -108,6 +108,27 @@ async def test_check_gh_auth_oserror() -> None:
     assert "spawn failed" in result.message
 
 
+@pytest.mark.asyncio
+async def test_check_gh_auth_timeout_warns_not_fails() -> None:
+    """Slow `gh auth status` (e.g. keychain unlock) must not abort startup.
+
+    Regression: keychain-backed gh installs can take 5–10s on first call. A
+    1s timeout produced spurious FAILs; the check now WARNs and lets startup
+    proceed since downstream gh calls do their own auth handling.
+    """
+    mock_proc = MagicMock()
+    mock_proc.wait = AsyncMock(side_effect=TimeoutError)
+    mock_proc.kill = MagicMock()
+    with (
+        patch("preflight.shutil.which", return_value="/usr/bin/gh"),
+        patch("preflight.asyncio.create_subprocess_exec", return_value=mock_proc),
+    ):
+        result = await _check_gh_auth()
+    assert result.status == CheckStatus.WARN
+    assert "15s" in result.message
+    mock_proc.kill.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # _check_repo_root
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preflight aborts startup when `gh auth status` doesn't complete in 1s. On macOS with a keychain-backed gh, the first call routinely takes 5-10s while the keychain unlocks (measured 10.2s locally), producing spurious FAILs on fully-authenticated machines.
- Bumped the timeout to 15s and downgraded the timeout branch to WARN. Downstream gh calls do their own auth handling, so a slow keychain shouldn't block startup. A real non-zero exit from `gh auth status` still FAILs.

## Test plan

- [x] `tests/test_preflight.py` — new `test_check_gh_auth_timeout_warns_not_fails` regression covers the WARN-on-timeout path
- [x] Existing gh-auth tests (PASS, FAIL, missing, OSError) still pass
- [ ] CI: full `make quality`