### PR TITLE
fix(bg-loops): YAML resilience + auto-ensure PR labels

### DIFF
--- a/docs/wiki/memory-feedback/feedback-make-quality-pipe-exit-code.md
+++ b/docs/wiki/memory-feedback/feedback-make-quality-pipe-exit-code.md
@@ -1,7 +1,7 @@
 ---
 source: feedback_make_quality_pipe_exit_code.md
 name: Piping make to tail masks the make exit code
-description: `make quality | tail -200` returns 0 even when make fails — the run-in-background notification was misleading; check tail content for actual failures
+description: "`make quality | tail -200` returns 0 even when make fails — the run-in-background notification was misleading; check tail content for actual failures"
 status: pending
 issue: null
 promoted_in: null

--- a/src/auto_pr.py
+++ b/src/auto_pr.py
@@ -45,6 +45,13 @@ BOT_NAME = "HydraFlow"
 # may contain "/" and other characters; sanitize for the worktree dir name.
 _SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
+# Default color/description used when auto-creating PR labels. ``gh label
+# create`` (no ``--force``) only applies these on first creation; if the
+# label already exists, the call fails with "already exists" which we treat
+# as success — existing labels keep their hand-tuned color/description.
+_AUTO_LABEL_COLOR = "ededed"
+_AUTO_LABEL_DESCRIPTION = "Auto-created by HydraFlow"
+
 # Hard timeout for every ``subprocess.run`` invocation in this module.
 # ``open_automated_pr_async`` runs these wrappers under ``asyncio.to_thread``,
 # so an unbounded subprocess (hung ``git push`` against a stale remote, ``gh``
@@ -379,6 +386,47 @@ def _extract_pr_url(stdout: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+async def _ensure_labels_async(
+    labels: list[str], *, cwd: Path, gh_token: str
+) -> list[str]:
+    """Return the subset of ``labels`` that exist on the repo.
+
+    For each requested label: try ``gh label create NAME --color … --desc …``.
+    If gh exits 0 the label was just created; if it exits non-zero with an
+    "already exists" stderr, that's still a success for our purposes.
+    Anything else is logged as a warning and the label is dropped from the
+    returned list, so the downstream ``gh pr create`` doesn't fail wholesale
+    on a label that the repo refuses to host.
+    """
+    from subprocess_util import run_subprocess  # local import: avoids cycles
+
+    ensured: list[str] = []
+    for name in labels:
+        try:
+            await run_subprocess(
+                "gh",
+                "label",
+                "create",
+                name,
+                "--color",
+                _AUTO_LABEL_COLOR,
+                "--description",
+                _AUTO_LABEL_DESCRIPTION,
+                cwd=cwd,
+                gh_token=gh_token,
+            )
+        except RuntimeError as exc:
+            if "already exists" in str(exc).lower():
+                ensured.append(name)
+                continue
+            logger.warning(
+                "could not ensure label %r exists; dropping from PR: %s", name, exc
+            )
+            continue
+        ensured.append(name)
+    return ensured
+
+
 async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guards, each with its own fail path
     *,
     repo_root: Path,
@@ -568,6 +616,16 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
         except RuntimeError as exc:
             return _fail(f"git push failed for {branch!r}: {exc}")
 
+        # Ensure each requested label exists on the repo before pr-create —
+        # otherwise a missing label crashes the whole PR (#6643 / EdgeProposer).
+        ensured_labels = (
+            await _ensure_labels_async(
+                labels or [], cwd=worktree_path, gh_token=gh_token
+            )
+            if labels
+            else []
+        )
+
         # Create the PR.
         create_args: list[str] = [
             "gh",
@@ -582,7 +640,7 @@ async def open_automated_pr_async(  # noqa: PLR0911 — linear step-by-step guar
             "--head",
             branch,
         ]
-        for label in labels or []:
+        for label in ensured_labels:
             create_args.extend(["--label", label])
         try:
             create_stdout = await run_subprocess(

--- a/src/memory_backlog_mirror.py
+++ b/src/memory_backlog_mirror.py
@@ -7,11 +7,14 @@ status state-machine.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import yaml
+
+logger = logging.getLogger("hydraflow.memory_backlog_mirror")
 
 Status = Literal["pending", "issue-open", "promoted", "wontfix"]
 _VALID_STATUS: frozenset[str] = frozenset(
@@ -46,7 +49,13 @@ def load_mirror_entry(path: Path) -> MirrorEntry:
     if end == -1:
         msg = f"unterminated frontmatter in {path}"
         raise ValueError(msg)
-    front = yaml.safe_load(text[4:end]) or {}
+    try:
+        front = yaml.safe_load(text[4:end]) or {}
+    except yaml.YAMLError as exc:
+        # A malformed entry is data corruption, not a loop bug — surface as
+        # ValueError so callers (pending_entries) can skip it uniformly.
+        msg = f"malformed frontmatter in {path}: {exc}"
+        raise ValueError(msg) from exc
     body = text[end + 4 :].lstrip("\n").rstrip() + "\n"
     status = front.get("status", "pending")
     if status not in _VALID_STATUS:
@@ -58,7 +67,7 @@ def load_mirror_entry(path: Path) -> MirrorEntry:
         source=str(front.get("source", "")),
         name=str(front.get("name", path.stem)),
         description=str(front.get("description", "")),
-        status=status,
+        status=cast(Status, status),
         issue=front.get("issue"),
         promoted_in=front.get("promoted_in"),
         wontfix_reason=front.get("wontfix_reason"),
@@ -73,7 +82,8 @@ def pending_entries(mirror_dir: Path) -> list[MirrorEntry]:
             continue
         try:
             entry = load_mirror_entry(path)
-        except ValueError:
+        except ValueError as exc:
+            logger.warning("Skipping malformed mirror entry %s: %s", path, exc)
             continue
         if entry.status == "pending":
             entries.append(entry)

--- a/tests/regressions/test_edge_proposer_label_ensured.py
+++ b/tests/regressions/test_edge_proposer_label_ensured.py
@@ -1,0 +1,201 @@
+"""Regression: a missing PR label must not crash bot-PR loops.
+
+Observed in production (server.log 2026-05-13): ``EdgeProposerLoop`` opened a
+PR with ``--label hydraflow-ul-edges``, but the label did not exist on the
+repo. ``gh pr create`` returned rc=1 (``could not add label: ... not found``),
+which propagated as ``RuntimeError`` and crashed the loop iteration.
+
+The contract for ``auto_pr.open_automated_pr_async``: when ``labels`` are
+supplied, ensure each one exists on the repo (idempotent ``gh label create
+--force``) before ``gh pr create``. A failure to ensure one label must NOT
+fail the whole PR — log a warning, drop that label, continue.
+"""
+
+from __future__ import annotations
+
+import subprocess as _sp
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+
+import pytest
+
+
+def _stub(
+    gh_handler: Callable[[tuple[str, ...]], str | None] | None = None,
+    on_cmd: Callable[[tuple[str, ...]], None] | None = None,
+    fail_on: Callable[[tuple[str, ...]], str | None] | None = None,
+) -> Callable[..., Awaitable[str]]:
+    """Stub that intercepts every `gh` call (label + pr) for tests."""
+
+    async def fake_run(
+        *cmd: str,
+        cwd: Path | None = None,
+        gh_token: str = "",
+        timeout: float = 120.0,
+        runner: object = None,
+    ) -> str:
+        del gh_token, timeout, runner
+        if on_cmd is not None:
+            on_cmd(cmd)
+        if fail_on is not None:
+            err = fail_on(cmd)
+            if err is not None:
+                raise RuntimeError(err)
+        if cmd[:3] == ("gh", "label", "create"):
+            if gh_handler is not None:
+                stdout = gh_handler(cmd)
+                if stdout is None:
+                    raise RuntimeError(f"gh label create failed: {cmd}")
+                return stdout
+            return ""
+        if cmd[:2] == ("gh", "pr") and gh_handler is not None:
+            stdout = gh_handler(cmd)
+            if stdout is None:
+                raise RuntimeError(f"gh command failed: {cmd}")
+            return stdout.strip()
+        try:
+            return _sp.run(  # noqa: S603
+                list(cmd),
+                cwd=str(cwd) if cwd is not None else None,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except _sp.CalledProcessError as exc:
+            raise RuntimeError(exc.stderr or str(exc)) from exc
+
+    return fake_run
+
+
+@pytest.fixture
+def local_repo(tmp_path: Path) -> Path:
+    """A bare-bones repo + origin remote that auto_pr can push to."""
+    origin = tmp_path / "origin.git"
+    _sp.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    _sp.run(["git", "init", "-b", "main", str(work)], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(work), "config", "user.email", "t@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(work), "config", "user.name", "Tester"],
+        check=True,
+        capture_output=True,
+    )
+    (work / "README.md").write_text("init\n")
+    _sp.run(["git", "-C", str(work), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(work), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(work), "remote", "add", "origin", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(work), "push", "-u", "origin", "main"],
+        check=True,
+        capture_output=True,
+    )
+    return work
+
+
+@pytest.mark.asyncio
+async def test_labels_ensured_before_pr_create(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`gh label create --force NAME` must run for each label before `gh pr create`."""
+    from auto_pr import open_automated_pr_async
+
+    calls: list[tuple[str, ...]] = []
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[:3] == ("gh", "pr", "create"):
+            return "https://github.com/x/y/pull/9\n"
+        return ""
+
+    def on_cmd(cmd: tuple[str, ...]) -> None:
+        if cmd[0] == "gh":
+            calls.append(cmd)
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _stub(gh_handler=gh_handler, on_cmd=on_cmd),
+    )
+
+    target = local_repo / "note.txt"
+    target.write_text("hi\n")
+    result = await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="t/labels",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        auto_merge=False,
+        labels=["hydraflow-ul-edges", "another-label"],
+    )
+
+    assert result.status == "opened", result.error
+
+    label_indices = [
+        i for i, c in enumerate(calls) if c[:3] == ("gh", "label", "create")
+    ]
+    pr_create_idx = next(
+        i for i, c in enumerate(calls) if c[:3] == ("gh", "pr", "create")
+    )
+    assert len(label_indices) >= 2, (
+        f"expected at least 2 `gh label create` calls, got {len(label_indices)}: {calls}"
+    )
+    assert all(i < pr_create_idx for i in label_indices), (
+        "all label-create calls must precede pr create"
+    )
+    label_names = {c[3] for c in calls if c[:3] == ("gh", "label", "create")}
+    assert label_names == {"hydraflow-ul-edges", "another-label"}
+
+
+@pytest.mark.asyncio
+async def test_label_ensure_failure_does_not_abort_pr(
+    local_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If `gh label create` fails for one label, the PR opens without it."""
+    from auto_pr import open_automated_pr_async
+
+    pr_create_cmds: list[tuple[str, ...]] = []
+
+    def gh_handler(cmd: tuple[str, ...]) -> str:
+        if cmd[:3] == ("gh", "pr", "create"):
+            pr_create_cmds.append(cmd)
+            return "https://github.com/x/y/pull/10\n"
+        return ""
+
+    def fail_on(cmd: tuple[str, ...]) -> str | None:
+        if cmd[:3] == ("gh", "label", "create") and "broken-label" in cmd:
+            return "label create denied"
+        return None
+
+    monkeypatch.setattr(
+        "subprocess_util.run_subprocess",
+        _stub(gh_handler=gh_handler, fail_on=fail_on),
+    )
+
+    target = local_repo / "note.txt"
+    target.write_text("hi\n")
+    result = await open_automated_pr_async(
+        repo_root=local_repo,
+        branch="t/labels-partial",
+        files=[target],
+        pr_title="t",
+        pr_body="b",
+        auto_merge=False,
+        labels=["broken-label", "good-label"],
+    )
+
+    assert result.status == "opened", result.error
+    assert len(pr_create_cmds) == 1
+    pr_cmd = pr_create_cmds[0]
+    assert "good-label" in pr_cmd
+    assert "broken-label" not in pr_cmd

--- a/tests/regressions/test_memory_backlog_yaml_resilience.py
+++ b/tests/regressions/test_memory_backlog_yaml_resilience.py
@@ -1,0 +1,72 @@
+"""Regression: one malformed mirror entry must not crash MemoryBacklogLoop.
+
+Observed in production (server.log 2026-05-13): a backtick-leading frontmatter
+value in ``docs/wiki/memory-feedback/feedback-make-quality-pipe-exit-code.md``
+raised ``yaml.scanner.ScannerError`` from ``yaml.safe_load`` inside
+``load_mirror_entry``. ``pending_entries`` only caught ``ValueError``, so the
+YAMLError escaped and ``MemoryBacklogLoop._do_work`` failed every cycle —
+the loop logged "iteration failed — will retry next cycle" and processed
+zero entries until restart.
+
+The contract: a single bad on-disk entry is data corruption, not a loop bug.
+``pending_entries`` must skip the bad file and process the rest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from memory_backlog_mirror import load_mirror_entry, pending_entries
+
+
+def _write(path: Path, content: str) -> None:
+    path.write_text(content)
+
+
+def test_pending_entries_skips_yaml_scanner_error(tmp_path: Path) -> None:
+    """A backtick-leading value (YAML 1.1 reserved indicator) must not crash."""
+    bad = tmp_path / "bad.md"
+    _write(
+        bad,
+        "---\n"
+        "source: x.md\n"
+        "name: bad\n"
+        "description: `backtick-leading` is a reserved YAML indicator\n"
+        "status: pending\n"
+        "---\n\nbody\n",
+    )
+    good = tmp_path / "good.md"
+    _write(
+        good,
+        "---\n"
+        "source: y.md\n"
+        "name: good\n"
+        "description: plain text\n"
+        "status: pending\n"
+        "---\n\nbody\n",
+    )
+
+    entries = pending_entries(tmp_path)
+
+    slugs = {e.slug for e in entries}
+    assert "good" in slugs, "the well-formed entry must still be returned"
+    assert "bad" not in slugs, "the malformed entry must be skipped, not raised"
+
+
+def test_load_mirror_entry_raises_value_error_on_yaml_error(tmp_path: Path) -> None:
+    """load_mirror_entry must surface YAML parse failures as ValueError so
+    callers can use a single exception type for "this file is unparseable"."""
+    bad = tmp_path / "bad.md"
+    _write(
+        bad,
+        "---\ndescription: `reserved indicator`\nstatus: pending\n---\n\nbody\n",
+    )
+    try:
+        load_mirror_entry(bad)
+    except ValueError:
+        return  # expected
+    except Exception as exc:  # noqa: BLE001 — test asserts only ValueError reaches caller
+        msg = f"expected ValueError, got {type(exc).__name__}: {exc}"
+        raise AssertionError(msg) from exc
+    msg = "expected ValueError for malformed YAML, got no exception"
+    raise AssertionError(msg)

--- a/tests/scenarios/test_edge_proposer_scenario.py
+++ b/tests/scenarios/test_edge_proposer_scenario.py
@@ -1,0 +1,207 @@
+"""MockWorld scenario for `EdgeProposerLoop` (ADR-0058).
+
+Tier-3 expansion: the loop had neither catalog entry nor scenario coverage
+when the missing-label bug (#?) shipped to production. Per
+``docs/standards/testing/README.md``, a loop-observable bug fix requires a
+scenario layer that exercises the loop through its real adapter.
+
+Pattern B: real ``EdgeProposerLoop`` + real ``OpenAutoPRBotPRPort`` wired
+against a tmp git repo, with ``subprocess_util.run_subprocess`` stubbed at
+the I/O boundary so ``gh`` is never invoked but the auto_pr → label-ensure
+→ pr-create wiring is exercised in full.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess as _sp
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _stub(
+    pr_url: str = "https://github.com/x/y/pull/77",
+    on_cmd: Callable[[tuple[str, ...]], None] | None = None,
+) -> Callable[..., Awaitable[str]]:
+    """`run_subprocess` stub: intercepts gh, lets git run real."""
+
+    async def fake_run(
+        *cmd: str,
+        cwd: Path | None = None,
+        gh_token: str = "",
+        timeout: float = 120.0,
+        runner: object = None,
+    ) -> str:
+        del gh_token, timeout, runner
+        if on_cmd is not None:
+            on_cmd(cmd)
+        if cmd[:3] == ("gh", "label", "create"):
+            return ""
+        if cmd[:3] == ("gh", "pr", "create"):
+            return f"{pr_url}\n"
+        if cmd[:3] == ("gh", "pr", "merge"):
+            return ""
+        try:
+            return _sp.run(  # noqa: S603
+                list(cmd),
+                cwd=str(cwd) if cwd is not None else None,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except _sp.CalledProcessError as exc:
+            raise RuntimeError(exc.stderr or str(exc)) from exc
+
+    return fake_run
+
+
+def _bootstrap_repo(tmp_path: Path) -> Path:
+    """Init a tmp git repo + bare origin so push/worktree work end-to-end."""
+    origin = tmp_path / "origin.git"
+    _sp.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    repo = tmp_path / "repo"
+    _sp.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    for k, v in (
+        ("user.email", "t@example.com"),
+        ("user.name", "Tester"),
+    ):
+        _sp.run(
+            ["git", "-C", str(repo), "config", k, v],
+            check=True,
+            capture_output=True,
+        )
+    (repo / "README.md").write_text("init\n")
+    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(repo), "remote", "add", "origin", str(origin)],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(repo), "push", "-u", "origin", "main"],
+        check=True,
+        capture_output=True,
+    )
+    return repo
+
+
+def _seed_terms(repo: Path) -> None:
+    """Two terms (Alpha, Bravo) and source files where Alpha imports Bravo."""
+    from ubiquitous_language import (  # noqa: PLC0415
+        BoundedContext,
+        Term,
+        TermKind,
+        TermStore,
+    )
+
+    src = repo / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "alpha.py").write_text("from bravo import Bravo\n\nclass Alpha:\n    pass\n")
+    (src / "bravo.py").write_text("class Bravo:\n    pass\n")
+    terms_dir = repo / "docs" / "wiki" / "terms"
+    terms_dir.mkdir(parents=True, exist_ok=True)
+    store = TermStore(terms_dir)
+    store.write(
+        Term(
+            id="01H_ALPHA",
+            name="Alpha",
+            kind=TermKind.SERVICE,
+            bounded_context=BoundedContext.SHARED_KERNEL,
+            definition="Alpha depends on Bravo.",
+            code_anchor="src/alpha.py:Alpha",
+            confidence="accepted",
+        )
+    )
+    store.write(
+        Term(
+            id="01H_BRAVO",
+            name="Bravo",
+            kind=TermKind.SERVICE,
+            bounded_context=BoundedContext.SHARED_KERNEL,
+            definition="Bravo used by Alpha.",
+            code_anchor="src/bravo.py:Bravo",
+            confidence="accepted",
+        )
+    )
+
+
+def _make_loop(repo: Path):
+    from base_background_loop import LoopDeps  # noqa: PLC0415
+    from edge_proposer_loop import EdgeProposerLoop  # noqa: PLC0415
+    from events import EventBus  # noqa: PLC0415
+    from term_proposer_runtime import OpenAutoPRBotPRPort  # noqa: PLC0415
+    from tests.helpers import ConfigFactory  # noqa: PLC0415
+
+    config = ConfigFactory.create(repo_root=repo)
+    bus = EventBus()
+    stop = asyncio.Event()
+    stop.set()
+    deps = LoopDeps(
+        event_bus=bus,
+        stop_event=stop,
+        status_cb=MagicMock(),
+        enabled_cb=lambda _: True,
+        sleep_fn=AsyncMock(),
+    )
+    pr_port = OpenAutoPRBotPRPort(repo_root=repo, gh_token="")
+    return EdgeProposerLoop(config=config, deps=deps, pr_port=pr_port, repo_root=repo)
+
+
+class TestEdgeProposerScenario:
+    async def test_label_is_ensured_before_pr_create(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: loop → BotPRPort → auto_pr → `gh label create` → `gh pr create`.
+
+        Regression for the production crash where the loop's PR label did not
+        exist on the repo and ``gh pr create --label hydraflow-ul-edges`` failed
+        with rc=1 (server.log 2026-05-13).
+        """
+        repo = _bootstrap_repo(tmp_path)
+        _seed_terms(repo)
+        calls: list[tuple[str, ...]] = []
+        monkeypatch.setattr(
+            "subprocess_util.run_subprocess",
+            _stub(on_cmd=lambda cmd: calls.append(cmd) if cmd[0] == "gh" else None),
+        )
+
+        loop = _make_loop(repo)
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["status"] == "ok"
+        assert result["opened_pr"] is True
+
+        label_idx = next(
+            (
+                i
+                for i, c in enumerate(calls)
+                if c[:3] == ("gh", "label", "create") and "hydraflow-ul-edges" in c
+            ),
+            None,
+        )
+        pr_idx = next(
+            (i for i, c in enumerate(calls) if c[:3] == ("gh", "pr", "create")),
+            None,
+        )
+        assert label_idx is not None, f"label-create not called; gh calls: {calls}"
+        assert pr_idx is not None, "pr-create not called"
+        assert label_idx < pr_idx, "label-create must precede pr-create"
+
+    async def test_kill_switch_returns_disabled(self, tmp_path: Path) -> None:
+        repo = _bootstrap_repo(tmp_path)
+        (repo / "src").mkdir(exist_ok=True)
+        loop = _make_loop(repo)
+        loop._config = loop._config.model_copy(update={"edge_proposer_enabled": False})
+        result = await loop._do_work()
+        assert result == {"status": "disabled"}

--- a/tests/scenarios/test_memory_backlog_scenario.py
+++ b/tests/scenarios/test_memory_backlog_scenario.py
@@ -1,0 +1,148 @@
+"""MockWorld scenario for `MemoryBacklogLoop` (ADR-0057).
+
+Tier-3 expansion: the existing builder lives in
+``tests/scenarios/catalog/loop_registrations.py`` but no scenario test
+exercises the loop end-to-end. Per ``docs/standards/testing/README.md``, a
+loop-observable bug fix (YAML-resilience #?) requires a scenario layer
+alongside the unit regression.
+
+Pattern B (direct instantiation): the loop wants fine-grained config
+control (``memory_backlog_label`` / ``find_label`` shaping) and the mirror
+dir is colocated with a real tmp git repo so ``_commit_mirror_updates``
+doesn't warn on every tick.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess as _sp
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _make_repo_with_mirror(tmp_path: Path) -> Path:
+    """Init a throwaway git repo and return the repo root.
+
+    ``MemoryBacklogLoop._commit_mirror_updates`` shells out to ``git add`` /
+    ``git commit``. A real repo lets those calls succeed silently; otherwise
+    the loop logs a WARN per tick, which is fine but noisy in tests.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _sp.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "config", "user.email", "t@example.com"],
+        check=True,
+        capture_output=True,
+    )
+    _sp.run(
+        ["git", "-C", str(repo), "config", "user.name", "Tester"],
+        check=True,
+        capture_output=True,
+    )
+    (repo / "README.md").write_text("init\n")
+    _sp.run(["git", "-C", str(repo), "add", "."], check=True, capture_output=True)
+    _sp.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        check=True,
+        capture_output=True,
+    )
+    (repo / "docs" / "wiki" / "memory-feedback").mkdir(parents=True)
+    return repo
+
+
+def _write_entry(
+    mirror_dir: Path, slug: str, *, status: str = "pending", body: str = "rule body"
+) -> Path:
+    """Write a well-formed mirror entry."""
+    path = mirror_dir / f"{slug}.md"
+    path.write_text(
+        "---\n"
+        f"source: {slug}.md\n"
+        f"name: {slug}\n"
+        f"description: plain description for {slug}\n"
+        f"status: {status}\n"
+        "---\n\n"
+        f"{body}\n"
+    )
+    return path
+
+
+def _make_loop(repo_root: Path):
+    """Build a MemoryBacklogLoop with a real config + mocked PRManager."""
+    from base_background_loop import LoopDeps  # noqa: PLC0415
+    from dedup_store import DedupStore  # noqa: PLC0415
+    from events import EventBus  # noqa: PLC0415
+    from memory_backlog_loop import MemoryBacklogLoop  # noqa: PLC0415
+    from tests.helpers import ConfigFactory  # noqa: PLC0415
+
+    config = ConfigFactory.create(repo_root=repo_root)
+    bus = EventBus()
+    stop = asyncio.Event()
+    stop.set()
+    deps = LoopDeps(
+        event_bus=bus,
+        stop_event=stop,
+        status_cb=MagicMock(),
+        enabled_cb=lambda _: True,
+        sleep_fn=AsyncMock(),
+    )
+
+    state = MagicMock()
+    state.get_memory_backlog_attempts.return_value = 0
+    state.inc_memory_backlog_attempts.return_value = 1
+
+    dedup_path = config.data_root / "dedup" / "memory_backlog.json"
+    dedup_path.parent.mkdir(parents=True, exist_ok=True)
+    dedup = DedupStore("memory_backlog", dedup_path)
+
+    pr_manager = MagicMock()
+    pr_manager.create_issue = AsyncMock(return_value=4242)
+
+    loop = MemoryBacklogLoop(
+        config=config, state=state, pr_manager=pr_manager, dedup=dedup, deps=deps
+    )
+    return loop, pr_manager
+
+
+class TestMemoryBacklogScenario:
+    async def test_pending_entry_files_issue(self, tmp_path: Path) -> None:
+        """Happy path: a single pending entry yields one create_issue call."""
+        repo = _make_repo_with_mirror(tmp_path)
+        _write_entry(repo / "docs" / "wiki" / "memory-feedback", "feedback-alpha")
+        loop, pr_manager = _make_loop(repo)
+
+        result = await loop._do_work()
+
+        assert result == {"status": "ok", "filed": 1, "skipped": 0, "escalated": 0}
+        pr_manager.create_issue.assert_awaited_once()
+
+    async def test_malformed_yaml_does_not_crash_loop(self, tmp_path: Path) -> None:
+        """A malformed mirror entry must not crash the loop — the good entries
+        are still filed. Regression for the YAML-resilience bug observed in
+        ``server.log`` 2026-05-13 (loop logged "iteration failed — will retry
+        next cycle" indefinitely until a manual fix)."""
+        repo = _make_repo_with_mirror(tmp_path)
+        mirror = repo / "docs" / "wiki" / "memory-feedback"
+        _write_entry(mirror, "feedback-good")
+        # Backtick-leading value is a YAML 1.1 reserved indicator — same shape
+        # as the original on-disk corruption in feedback-make-quality-pipe-exit-code.md.
+        (mirror / "feedback-bad.md").write_text(
+            "---\n"
+            "source: feedback-bad.md\n"
+            "name: bad\n"
+            "description: `backtick-leading` is a YAML reserved indicator\n"
+            "status: pending\n"
+            "---\n\nbody\n"
+        )
+        loop, pr_manager = _make_loop(repo)
+
+        result = await loop._do_work()
+
+        assert result["status"] == "ok"
+        assert result["filed"] == 1
+        pr_manager.create_issue.assert_awaited_once()


### PR DESCRIPTION
## Summary

Two bg-loop crashes observed in the 2026-05-13 `server.log` run:

1. **`MemoryBacklogLoop`** — `yaml.YAMLError` from a malformed mirror entry (backtick-leading frontmatter value, a YAML 1.1 reserved indicator) escaped past the `except ValueError` guard in `pending_entries`, killing the loop iteration every cycle. Fix: wrap `yaml.safe_load`, re-raise as `ValueError`, log a WARN on skip so corruption surfaces in ops. Also quoted the offending live data file.
2. **`EdgeProposerLoop`** — `gh pr create --label hydraflow-ul-edges` returned rc=1 because the label didn't exist on the repo. Fix: in `auto_pr.open_automated_pr_async`, ensure each label exists via idempotent `gh label create NAME --color … --description …` (no `--force`, so hand-tuned existing labels keep their styling). Per-label failures log WARN + drop only that label.

## Test plan

Per `docs/standards/testing/README.md` three-layer pyramid:

- [x] **Unit/regression** (`tests/regressions/`):
  - `test_memory_backlog_yaml_resilience.py` — proves `pending_entries` skips bad files and `load_mirror_entry` raises `ValueError`, not `YAMLError`
  - `test_edge_proposer_label_ensured.py` — proves labels are created before pr-create and a single failed label-ensure doesn't abort the PR
- [x] **MockWorld scenario** (`tests/scenarios/`):
  - `test_memory_backlog_scenario.py` — Pattern B end-to-end through real `MemoryBacklogLoop`
  - `test_edge_proposer_scenario.py` — Pattern B through real `EdgeProposerLoop` + real `OpenAutoPRBotPRPort`, `run_subprocess` stubbed at the boundary
- [x] **Sandbox e2e**: not required — neither bug manifests only under docker/UI conditions (per the standard's "bug fix" row).
- [x] Local: 336 tests (regressions + auto_pr + memory_backlog + edge_proposer + new scenarios) green; ruff + pyright clean on all touched files.

## Notes for review

- `make quality` on the branch surfaces two **pre-existing** failures unrelated to this change:
  - `test_planner.py::test_build_prompt_truncates_long_body` — assertion `len(prompt) < 15_000` fails at 15018 on plain `staging` (verified by stashing my changes); a separate fix is needed.
  - `tests/trust/contracts/test_fake_git_contract.py::test_fake_git_matches_cassette[commit]` — caused by `commit.yaml` getting mutated during a local factory run. The committed cassette is unchanged from `staging` in this PR; the recorder edge case (empty-stdout overwrite) is worth a follow-up `hydraflow-find` issue, see below.

## Follow-ups (separate issues, not this PR)

- Add MockWorld scenario for `EdgeProposerLoop` + catalog entry — covered here, but `loop_registrations.py` still has no `_build_edge_proposer`. Filed.
- Cassette/contract-testing depth audit — pre-existing recorder edge cases + thin per-adapter coverage (5 git / 3 github / 1 docker / 3 claude). Filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)