### PR TITLE
test(contracts): backfill 4 high-value FakeGitHub cassettes

### DIFF
--- a/tests/trust/contracts/cassettes/github/add_labels.yaml
+++ b/tests/trust/contracts/cassettes/github/add_labels.yaml
@@ -1,0 +1,18 @@
+adapter: github
+interaction: add_labels
+recorded_at: "2026-05-13T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: add_labels
+  args:
+    - "42"
+    - "in-progress"
+    - "review-requested"
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: ""
+  stderr: ""
+normalizers: []

--- a/tests/trust/contracts/cassettes/github/create_task.yaml
+++ b/tests/trust/contracts/cassettes/github/create_task.yaml
@@ -1,0 +1,18 @@
+adapter: github
+interaction: create_task
+recorded_at: "2026-05-13T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: create_task
+  args:
+    - "Find: contract trail for ensure_labels_exist"
+    - "Body describing the find"
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: "https://github.com/test-org/test-repo/issues/9001\n"
+  stderr: ""
+normalizers:
+  - pr_number

--- a/tests/trust/contracts/cassettes/github/ensure_labels_exist.yaml
+++ b/tests/trust/contracts/cassettes/github/ensure_labels_exist.yaml
@@ -1,0 +1,15 @@
+adapter: github
+interaction: ensure_labels_exist
+recorded_at: "2026-05-13T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: ensure_labels_exist
+  args: []
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: ""
+  stderr: ""
+normalizers: []

--- a/tests/trust/contracts/cassettes/github/merge_pr.yaml
+++ b/tests/trust/contracts/cassettes/github/merge_pr.yaml
@@ -1,0 +1,17 @@
+adapter: github
+interaction: merge_pr
+recorded_at: "2026-05-13T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: merge_pr
+  args:
+    - "42"
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: "merged pull request https://github.com/_/_/pull/42\n"
+  stderr: ""
+normalizers:
+  - pr_number

--- a/tests/trust/contracts/test_fake_github_contract.py
+++ b/tests/trust/contracts/test_fake_github_contract.py
@@ -24,7 +24,7 @@ from tests.trust.contracts._schema import Cassette
 _CASSETTE_DIR = Path(__file__).parent / "cassettes" / "github"
 
 
-async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:
+async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:  # noqa: PLR0911
     """Dispatch the cassette input through FakeGitHub's matching method."""
     fake = FakeGitHub()
     method = cassette.input.command
@@ -56,6 +56,30 @@ async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:
         await fake.close_task(n)
         assert fake._issues[n].state == "closed"
         return FakeOutput(exit_code=0, stdout="", stderr=f"✓ Closed issue #{n}\n")
+
+    if method == "create_task":
+        title = str(args[0])
+        body = str(args[1]) if len(args) > 1 else ""
+        # FakeGitHub.create_task seeds an issue starting at 9001 when the
+        # store is empty; the cassette hard-codes that initial value so the
+        # contract is deterministic.
+        new_number = await fake.create_task(title, body)
+        return FakeOutput(
+            exit_code=0,
+            stdout=f"https://github.com/test-org/test-repo/issues/{new_number}\n",
+            stderr="",
+        )
+
+    if method == "add_labels":
+        issue_number = int(args[0])
+        fake.add_issue(issue_number, "Seed issue", "")
+        labels = [str(a) for a in args[1:]]
+        await fake.add_labels(issue_number, labels)
+        return FakeOutput(exit_code=0, stdout="", stderr="")
+
+    if method == "ensure_labels_exist":
+        await fake.ensure_labels_exist()
+        return FakeOutput(exit_code=0, stdout="", stderr="")
 
     msg = f"FakeGitHub has no contract-tested method {method!r}"
     raise NotImplementedError(msg)


### PR DESCRIPTION
## Summary

Addresses **Gap 2** of #8754 — backfilling the highest-value missing contract-test cassettes for the GitHub adapter.

FakeGitHub exposes ~50 public methods; only 4 had cassette/contract-test coverage (`create_pr`, `merge_pr`-handler-only, `close_issue`, `close_task`). This PR doubles that to **8** by adding hand-authored baselines for the most-used uncovered shapes.

## New cassettes

| Cassette | Why |
|---|---|
| `merge_pr.yaml` | Fixes orphan dispatcher entry (`if method == \"merge_pr\":` existed but had no backing cassette since the original wiring). |
| `ensure_labels_exist.yaml` | Completes the contract trail for the label-ensure flow added in #8753. |
| `create_task.yaml` | Used by every loop that files issues — memory_backlog, pr_manager, hitl, edge_proposer, … |
| `add_labels.yaml` | Used by every transition path (`PRManager.transition`, `swap_pipeline_labels`). |

Each ships with a dispatcher entry in `_invoke_fake_github` so the existing parameterised replay test exercises them through `FakeGitHub` end-to-end.

## Pattern choice

Hand-authored (`recorder_sha: 00000000`), matching the existing `close_issue.yaml` / `close_task.yaml` pattern. The github recorder is deliberately scoped to read-only ops (`gh pr list`) to avoid polluting the shared sandbox repo — refresh of mutating-op cassettes remains a manual baseline rotation. That tradeoff is well-documented in `record_github`'s docstring.

## Out of scope (tracked in #8754)

- The recorder produces `pr_list.yaml` which isn't in the committed corpus — that misalignment is a separate refactor.
- Methods that need fake-side changes first (e.g. some `update_pr_branch` semantics) — future PRs.
- Per-adapter normalizers for fields that aren't yet handled (e.g. issue-number-in-URL vs PR-number).

## Test plan

- [x] `make trust-contracts` equivalent: `tests/trust/contracts/` — 21 tests pass (was 17, now 17 + 4 new).
- [x] No fake-side code changes; no scenario tests affected.
- [x] ruff + pyright clean on touched files.

Refs #8754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)