### PR TITLE
refactor(contract-recording): make record_github explicit no-op + document corpus

### DIFF
--- a/src/contract_recording.py
+++ b/src/contract_recording.py
@@ -218,48 +218,36 @@ def _require_success(
 
 
 def record_github(sandbox_repo: str, tmp_cassette_dir: Path) -> list[Path]:
-    """Record cassettes for the GitHub adapter.
+    """No-op: the GitHub cassette corpus is hand-authored.
 
-    Runs a stable, read-only ``gh pr list`` against *sandbox_repo* (see
-    Task 0 — ``T-rav-Hydra-Ops/hydraflow-contracts-sandbox``) so the shape
-    of ``gh``'s JSON output is captured without side-effects on the
-    sandbox.
+    See ``tests/trust/contracts/cassettes/github/README.md`` for the
+    two-tier corpus design. Briefly: every github cassette is a
+    hand-authored baseline (``recorder_sha: "00000000"``) because the call
+    shapes the fakes contract-test against are predominantly *mutating*
+    ops (``gh pr create``, ``gh pr merge``, ``gh issue create``, ``gh issue
+    close``, ``gh label create``) — recording those live would pollute the
+    shared sandbox repo with every refresh tick.
 
-    Returns the list of YAML cassette paths written to
-    *tmp_cassette_dir*. Returns ``[]`` if ``gh`` is missing, the call
-    exits non-zero, or any other subprocess error occurs.
+    An earlier version of this recorder ran ``gh pr list`` and wrote a
+    ``pr_list.yaml`` tagged ``command: list_issues_by_label`` to the temp
+    dir. Two problems with that: (1) the shape of ``gh pr list`` (PR
+    objects with ``state``) does not align with
+    ``FakeGitHub.list_issues_by_label`` (issue objects), so the cassette
+    could never replay through the fake; (2) no ``pr_list.yaml`` was
+    committed to ``tests/trust/contracts/cassettes/github/``, so the
+    refresh loop would propose ``new_cassettes=[pr_list.yaml]`` and
+    ``deleted_cassettes=[every hand-authored cassette]`` every single
+    tick. Removed.
+
+    Returning ``[]`` here is a deliberate signal to the refresh loop: the
+    github diff bucket is always empty, no refresh PR is opened. The
+    ``sandbox_repo`` and ``tmp_cassette_dir`` parameters are preserved
+    for API stability with sibling recorders. A follow-up will replace
+    this no-op with shape-aligned read-only recordings once the
+    contracts sandbox repo is reliably provisioned in CI.
     """
-    tmp_cassette_dir = Path(tmp_cassette_dir)
-    tmp_cassette_dir.mkdir(parents=True, exist_ok=True)
-
-    argv = [
-        "gh",
-        "pr",
-        "list",
-        "--repo",
-        sandbox_repo,
-        "--json",
-        "number,title,state",
-    ]
-    proc = _run(argv)
-    if not _require_success(proc, label="gh pr list"):
-        return []
-    assert proc is not None  # for the type checker — guarded above
-
-    payload = _build_cassette_payload(
-        adapter="github",
-        interaction="pr_list",
-        fixture_repo=sandbox_repo,
-        command="list_issues_by_label",
-        args=[],
-        exit_code=proc.returncode,
-        stdout=proc.stdout,
-        stderr=proc.stderr,
-        normalizers=["pr_number", "timestamps.ISO8601", "sha:short"],
-    )
-    path = tmp_cassette_dir / "pr_list.yaml"
-    _write_yaml_cassette(path, payload)
-    return [path]
+    del sandbox_repo, tmp_cassette_dir
+    return []
 
 
 def record_git(sandbox_dir: Path, tmp_cassette_dir: Path) -> list[Path]:

--- a/tests/test_contract_recording.py
+++ b/tests/test_contract_recording.py
@@ -70,77 +70,25 @@ def _load_yaml(path: Path) -> dict[str, object]:
 # ---------------------------------------------------------------------------
 
 
-def test_record_github_invokes_gh_api_with_sandbox_repo(tmp_path: Path) -> None:
-    """``record_github`` shells out to ``gh`` against the sandbox repo."""
-    calls: list[list[str]] = []
-
-    def fake_run(argv: list[str], **_: object) -> subprocess.CompletedProcess[str]:
-        calls.append(list(argv))
-        return _completed(argv=argv, stdout='[{"number": 1}]\n')
-
-    with patch("contract_recording.subprocess.run", side_effect=fake_run):
+def test_record_github_is_no_op(tmp_path: Path) -> None:
+    """``record_github`` is intentionally a no-op pending shape-aligned
+    read-only recording. It must return [] without invoking subprocess —
+    github cassettes are hand-authored baselines (see
+    tests/trust/contracts/cassettes/github/README.md)."""
+    with patch("contract_recording.subprocess.run") as run_mock:
         paths = record_github(
             sandbox_repo="T-rav-Hydra-Ops/hydraflow-contracts-sandbox",
             tmp_cassette_dir=tmp_path,
         )
 
-    assert len(paths) == 1
-    # First call must be ``gh`` with the sandbox repo slug — we pin the
-    # subcommand enough that an accidental ``gh repo view`` swap trips this.
-    first = calls[0]
-    assert first[0] == "gh"
-    assert "T-rav-Hydra-Ops/hydraflow-contracts-sandbox" in first
-    assert "--json" in first or "api" in first[1]
-
-
-def test_record_github_writes_schema_valid_cassette(tmp_path: Path) -> None:
-    """The YAML written by ``record_github`` round-trips through ``Cassette``."""
-    with patch(
-        "contract_recording.subprocess.run",
-        side_effect=lambda argv, **_: _completed(
-            argv=argv, stdout='[{"number": 1, "title": "t"}]\n'
-        ),
-    ):
-        paths = record_github(
-            sandbox_repo="T-rav-Hydra-Ops/hydraflow-contracts-sandbox",
-            tmp_cassette_dir=tmp_path,
-        )
-
-    assert paths, "recorder must write at least one cassette"
-    for path in paths:
-        assert path.parent == tmp_path
-        assert path.suffix == ".yaml"
-        cassette = Cassette.model_validate(_load_yaml(path))
-        assert cassette.adapter == "github"
-        assert cassette.fixture_repo == "T-rav-Hydra-Ops/hydraflow-contracts-sandbox"
-
-
-def test_record_github_returns_empty_when_gh_missing(tmp_path: Path) -> None:
-    """``FileNotFoundError`` (missing ``gh``) yields an empty list, not a raise."""
-    with patch(
-        "contract_recording.subprocess.run",
-        side_effect=FileNotFoundError("gh not installed"),
-    ):
-        paths = record_github(
-            sandbox_repo="T-rav-Hydra-Ops/hydraflow-contracts-sandbox",
-            tmp_cassette_dir=tmp_path,
-        )
     assert paths == []
-
-
-def test_record_github_returns_empty_on_nonzero_exit(tmp_path: Path) -> None:
-    """A non-zero ``gh`` exit is treated as a failed recording (empty list)."""
-    with patch(
-        "contract_recording.subprocess.run",
-        side_effect=lambda argv, **_: _completed(
-            argv=argv, stderr="network error\n", returncode=1
-        ),
-    ):
-        paths = record_github(
-            sandbox_repo="T-rav-Hydra-Ops/hydraflow-contracts-sandbox",
-            tmp_cassette_dir=tmp_path,
-        )
-    assert paths == []
+    assert run_mock.call_count == 0, (
+        "record_github must not shell out — github corpus is hand-authored"
+    )
+    # tmp_cassette_dir must remain pristine.
+    assert not any(tmp_path.iterdir()), (
+        f"record_github must not write any files; found {list(tmp_path.iterdir())}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -390,12 +338,8 @@ def test_record_claude_stream_returns_empty_when_stdout_blank(tmp_path: Path) ->
 @pytest.mark.parametrize(
     "recorder_args",
     [
-        (
-            record_github,
-            {
-                "sandbox_repo": "T-rav-Hydra-Ops/hydraflow-contracts-sandbox",
-            },
-        ),
+        # record_github is a no-op (see test_record_github_is_no_op);
+        # it doesn't shell out so it can't log a missing-binary warning.
         (record_docker, {}),
         (record_claude_stream, {}),
     ],
@@ -455,14 +399,9 @@ def test_recorders_invoke_subprocess_run_with_text_capture(tmp_path: Path) -> No
     sandbox = tmp_path / "sbx"
     sandbox.mkdir()
 
+    # record_github is a no-op so subprocess.run is never invoked for it
+    # — exclude from this contract test.
     for recorder, kwargs in (
-        (
-            record_github,
-            {
-                "sandbox_repo": "x/y",
-                "tmp_cassette_dir": cassette_dir,
-            },
-        ),
         (record_git, {"sandbox_dir": sandbox, "tmp_cassette_dir": cassette_dir}),
         (record_docker, {"tmp_cassette_dir": cassette_dir}),
         (record_claude_stream, {"tmp_stream_dir": cassette_dir}),

--- a/tests/trust/contracts/cassettes/github/README.md
+++ b/tests/trust/contracts/cassettes/github/README.md
@@ -1,0 +1,78 @@
+# GitHub cassette corpus
+
+Every cassette in this directory is a **hand-authored baseline** — they are
+not refreshed by `ContractRefreshLoop` against a live `gh` CLI. Identifiable
+by `recorder_sha: "00000000"` in the YAML header.
+
+## Why hand-authored?
+
+The call shapes a `gh`-backed `FakeGitHub` must contract-test against are
+predominantly *mutating* — `gh pr create`, `gh pr merge`, `gh issue create`,
+`gh issue close`, `gh label create`, `gh issue edit --add-label`, etc.
+Refreshing those live every week would pollute the shared sandbox repo
+(`T-rav-Hydra-Ops/hydraflow-contracts-sandbox`) with throwaway PRs and
+issues, and the refresh PR would carry irreversible side effects.
+
+The sibling adapters (git/docker/claude) record live because their fakes
+contract-test against read-only ops (`git commit` is "mutating" but lives
+in a tmp dir that's destroyed after recording — no shared state). See
+`src/contract_recording.py::record_git` / `record_docker` /
+`record_claude_stream` for the live-recording pattern.
+
+## How baselines stay accurate
+
+Two safeguards keep the hand-authored baselines from drifting silently:
+
+1. **Replay gate**: every cassette must be replayable through `FakeGitHub`
+   via `_invoke_fake_github` in
+   `tests/trust/contracts/test_fake_github_contract.py`. A fake
+   implementation change that diverges from the cassette breaks the test
+   in CI — the cassette is the contract.
+2. **FakeCoverageAuditorLoop** (ADR-0045): scans `FakeGitHub` for public
+   methods without a cassette and files `fake-coverage-gap` issues.
+   Adding a method without a baseline is detected, not silent.
+
+## When to add a cassette here
+
+- A new `FakeGitHub` method that emulates a real `gh` call is added.
+- A real `gh` call shape is added to production code paths via
+  `subprocess_util.run_subprocess` and a corresponding fake method exists
+  (or is being added in the same PR).
+
+Always add the dispatcher entry in `_invoke_fake_github` in the same PR
+so the replay test exercises the new cassette end-to-end.
+
+## When NOT to add a cassette here
+
+- A `gh` call shape that isn't backed by a fake method — there's nothing
+  to contract-test. Add the fake method first.
+- An adapter-internal helper (`_run_gh`, `_maybe_rate_limit`) — the
+  contract is at the public method level, not the helper.
+
+## Current corpus
+
+The committed corpus is auto-discovered by
+`tests/trust/contracts/test_fake_github_contract.py` (parametrized over
+`list_cassettes(_CASSETTE_DIR)`). To enumerate it locally:
+
+```bash
+ls tests/trust/contracts/cassettes/github/*.yaml
+```
+
+Each cassette must have a matching dispatcher entry in
+`_invoke_fake_github`. The reverse is also true — a dispatcher entry
+without a cassette (e.g. the historical `merge_pr` orphan) is dead code
+and a fake-coverage signal.
+
+## Future work
+
+Implementing live read-only github recording (a real replacement for the
+no-op `record_github`) needs:
+
+1. A reliably-provisioned sandbox repo accessible from CI and dev hosts.
+2. Shape-alignment between gh JSON output and fake method return types
+   (e.g., `gh pr list --json …` returns dicts with different fields than
+   `FakeGitHub.list_open_prs`'s `PRListItem` objects).
+3. Per-call normalizers for issue/PR numbers, timestamps, label IDs.
+
+Tracked separately.


### PR DESCRIPTION
## Summary

Addresses the **deeper architectural gap** noted in #8754: `record_github` was an orphan code path producing a cassette tagged with the wrong command, never backed by any committed file, and structurally incapable of refreshing the hand-authored github corpus.

## What was wrong

`record_github` called `gh pr list --json number,title,state` and wrote `pr_list.yaml` tagged `command: list_issues_by_label`. Three problems:

| # | Problem |
|---|---|
| 1 | **Shape mismatch** — `gh pr list` returns PR objects; `FakeGitHub.list_issues_by_label` returns issue objects. Cassette could never replay through the fake. |
| 2 | **Filename/command mismatch** — convention elsewhere is `filename === command` (`commit.yaml` → `command: commit`). `pr_list.yaml` claimed to be `list_issues_by_label`. |
| 3 | **Diff churn** — no `pr_list.yaml` is committed, so every refresh tick would propose `new_cassettes=[pr_list.yaml]` AND `deleted_cassettes=[every hand-authored cassette]`. Masked today only because the sandbox repo isn't reachable in this env (recorder silently returns `[]`). |

## Fix

- `record_github` is now an explicit **no-op** with a docstring spelling out the design rationale and the future-work needed for shape-aligned read-only recordings.
- A README at `tests/trust/contracts/cassettes/github/README.md` documents the two-tier corpus design:
  - **Hand-authored baselines** for github (mutating-op contracts, refreshing live would pollute the shared sandbox).
  - **Live-recorded** for git/docker/claude (operate on tmp dirs / pinned images, no shared state).
- Lists the safeguards keeping baselines honest: replay gate (every cassette must dispatch through `_invoke_fake_github`) + `FakeCoverageAuditorLoop` (flags missing baselines).
- Unit tests: 4 stale tests asserting subprocess invocation replaced with `test_record_github_is_no_op` asserting no shell-out + no files written. The two parametrized cross-cutting tests now exclude `record_github` since it doesn't invoke subprocess.

## Test plan

- [x] `tests/test_contract_recording.py` (38 tests) — green
- [x] `tests/trust/contracts/` (17 tests) — green
- [x] `tests/test_contract_refresh_loop.py` + `test_contract_refresh_integration.py` — green (the integration tests already monkeypatched `record_github` to `lambda *_: []`, which is exactly the new default behavior)
- [x] ruff + pyright clean

## What this PR does *not* do

- Add shape-aligned read-only recording — that needs sandbox provisioning + per-call normalizers for issue/PR number distinction. Tracked in #8754 as future work.
- Touch the hand-authored baselines themselves — #8758 backfills 4 high-value ones in parallel.

Refs #8754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)