### PR TITLE
fix(loops): canonical _enabled_cb for 6 loops (closes 6 dark-factory-gap beads)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T15:48:30.135263+00:00",
-  "commit_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0",
+  "regenerated_at": "2026-05-18T17:23:22.453754+00:00",
+  "commit_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038",
   "artifacts": {
     "loops.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "ports.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "labels.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "modules.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "events.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "adr_xref.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "mockworld.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "changelog.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "functional_areas.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "ubiquitous-language.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "cbde7f7561802f588ee3699b00c78ff4138586c0"
+      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `cbde7f7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `5a74449` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
 - `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
@@ -284,4 +287,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `cbde7f7` on 2026-05-18 15:48 UTC. Source last changed at `cbde7f7`. Status: 🟢 fresh._
+_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._

--- a/src/cost_budget_watcher_loop.py
+++ b/src/cost_budget_watcher_loop.py
@@ -109,6 +109,10 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
         return 300
 
     async def _do_work(self) -> WorkCycleResult:
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static env-var gate — defense-in-depth (slice #5.0).
         if os.environ.get(_KILL_SWITCH_ENV) == "1":
             return {"skipped": "kill_switch"}
 

--- a/src/cost_budget_watcher_loop.py
+++ b/src/cost_budget_watcher_loop.py
@@ -108,7 +108,7 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
         # 5 minutes; configurable via HydraFlowConfig.
         return 300
 
-    async def _do_work(self) -> WorkCycleResult:
+    async def _do_work(self) -> WorkCycleResult:  # noqa: PLR0911
         # Canonical operator UI kill-switch (ADR-0049).
         if not self._enabled_cb(self._worker_name):
             return {"status": "disabled"}

--- a/src/diagram_loop.py
+++ b/src/diagram_loop.py
@@ -75,7 +75,10 @@ class DiagramLoop(BaseBackgroundLoop):
         return 14400
 
     async def _do_work(self) -> WorkCycleResult:
-        # Kill-switch (ADR-0049). Belt and suspenders.
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static env-var gate — defense-in-depth (slice #5.0). Belt and suspenders.
         if os.environ.get(_KILL_SWITCH_ENV) == "1":
             return {"skipped": "kill_switch"}
 

--- a/src/edge_proposer_loop.py
+++ b/src/edge_proposer_loop.py
@@ -57,6 +57,10 @@ class EdgeProposerLoop(BaseBackgroundLoop):
         return self._config.edge_proposer_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static config gate — defense-in-depth (slice #5.0).
         if not self._config.edge_proposer_enabled:
             return {"status": "disabled"}
 

--- a/src/pricing_refresh_loop.py
+++ b/src/pricing_refresh_loop.py
@@ -80,7 +80,10 @@ class PricingRefreshLoop(BaseBackgroundLoop):
         return 86400
 
     async def _do_work(self) -> WorkCycleResult:  # noqa: PLR0911 — linear gate checks, each with its own return path
-        # Kill-switch (ADR-0049). Belt and suspenders.
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static env-var gate — defense-in-depth (slice #5.0). Belt and suspenders.
         if os.environ.get(_KILL_SWITCH_ENV) == "1":
             return {"skipped": "kill_switch"}
 

--- a/src/term_proposer_loop.py
+++ b/src/term_proposer_loop.py
@@ -159,6 +159,10 @@ class TermProposerLoop(BaseBackgroundLoop):
         return self._config.term_proposer_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static config gate — defense-in-depth (slice #5.0).
         if not self._config.term_proposer_enabled:
             return {"status": "disabled"}
 

--- a/src/term_pruner_loop.py
+++ b/src/term_pruner_loop.py
@@ -56,6 +56,10 @@ class TermPrunerLoop(BaseBackgroundLoop):
         return self._config.term_pruner_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        # Canonical operator UI kill-switch (ADR-0049).
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
+        # Static config gate — defense-in-depth (slice #5.0).
         if not self._config.term_pruner_enabled:
             return {"status": "disabled"}
 

--- a/tests/regressions/test_canonical_killswitch.py
+++ b/tests/regressions/test_canonical_killswitch.py
@@ -1,0 +1,153 @@
+"""Regression: all 6 non-canonical kill-switch loops now respect _enabled_cb.
+
+Per ADR-0049, every loop's _do_work must check self._enabled_cb(self._worker_name)
+at the top. Before this fix the 6 loops below used raw env-var or static config
+checks instead, so the operator UI toggle could not disable them at runtime.
+
+Each test: instantiate with an enabled_cb that returns False, assert _do_work
+returns {"status": "disabled"} without entering the loop body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from base_background_loop import LoopDeps
+
+
+def _disabled_deps() -> LoopDeps:
+    """Return a LoopDeps whose enabled_cb always returns False."""
+    return LoopDeps(
+        event_bus=MagicMock(),
+        stop_event=asyncio.Event(),
+        status_cb=MagicMock(),
+        enabled_cb=lambda _name: False,
+        sleep_fn=AsyncMock(),
+        interval_cb=MagicMock(return_value=300),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CostBudgetWatcherLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cost_budget_watcher_disabled_by_enabled_cb() -> None:
+    from cost_budget_watcher_loop import CostBudgetWatcherLoop
+
+    loop = CostBudgetWatcherLoop(
+        config=MagicMock(),
+        pr_manager=MagicMock(),
+        state=MagicMock(),
+        deps=_disabled_deps(),
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# DiagramLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_diagram_loop_disabled_by_enabled_cb() -> None:
+    from diagram_loop import DiagramLoop
+
+    loop = DiagramLoop(
+        config=MagicMock(),
+        pr_manager=MagicMock(),
+        deps=_disabled_deps(),
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# PricingRefreshLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pricing_refresh_loop_disabled_by_enabled_cb() -> None:
+    from pricing_refresh_loop import PricingRefreshLoop
+
+    loop = PricingRefreshLoop(
+        config=MagicMock(),
+        pr_manager=MagicMock(),
+        deps=_disabled_deps(),
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# EdgeProposerLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edge_proposer_loop_disabled_by_enabled_cb(tmp_path: Path) -> None:
+    from edge_proposer_loop import EdgeProposerLoop
+
+    config = MagicMock()
+    config.edge_proposer_enabled = True  # static gate is open; cb gate is closed
+    loop = EdgeProposerLoop(
+        config=config,
+        deps=_disabled_deps(),
+        pr_port=MagicMock(),
+        repo_root=tmp_path,
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# TermProposerLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_term_proposer_loop_disabled_by_enabled_cb(tmp_path: Path) -> None:
+    from term_proposer_loop import TermProposerLoop
+
+    config = MagicMock()
+    config.term_proposer_enabled = True  # static gate is open; cb gate is closed
+    config.term_proposer_interval = 86400
+    loop = TermProposerLoop(
+        config=config,
+        deps=_disabled_deps(),
+        llm=MagicMock(),
+        pr_port=MagicMock(),
+        repo_root=tmp_path,
+        dedup_path=tmp_path / "dedup.json",
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# TermPrunerLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_term_pruner_loop_disabled_by_enabled_cb(tmp_path: Path) -> None:
+    from term_pruner_loop import TermPrunerLoop
+
+    config = MagicMock()
+    config.term_pruner_enabled = True  # static gate is open; cb gate is closed
+    config.term_pruner_interval = 86400
+    loop = TermPrunerLoop(
+        config=config,
+        deps=_disabled_deps(),
+        pr_port=MagicMock(),
+        repo_root=tmp_path,
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}


### PR DESCRIPTION
## Summary

Slice #3 found 6 loops using env-var or static-config gates instead of the canonical self._enabled_cb mechanism from ADR-0049. The operator UI toggle could not reach them. This PR adds the canonical in-body gate to each while keeping the existing static gate as defense-in-depth.

## Loops fixed

- CostBudgetWatcherLoop
- DiagramLoop
- PricingRefreshLoop
- EdgeProposerLoop
- TermProposerLoop
- TermPrunerLoop

## Implementation notes

No constructor changes were needed. `_enabled_cb` is already stored in `BaseBackgroundLoop.__init__` via `deps.enabled_cb`, and all 6 loops already received `deps=loop_deps` from `service_registry.py`. The only change per loop is a 3-line guard at the top of `_do_work`.

The existing static gate (env-var or config field) is kept immediately below as defense-in-depth per the slice #5.0 boundary.

## Test plan

- [x] `tests/regressions/test_canonical_killswitch.py` covers all 6 loops (6 new cases).
- [x] `tests/test_loop_wiring_completeness.py` passes (7/7).
- [x] Existing per-loop test suites all pass (41 tests across 6 files).

🤖 Generated with Claude Code