### PR TITLE
fix(contract-refresh): target configured base_branch so auto-merge can fire

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -368,6 +368,12 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             pr_title=title,
             pr_body=body,
             commit_message=title,
+            # Target the configured base branch (staging when ADR-0042's
+            # two-tier model is active) so GitHub's native auto-merge can
+            # actually fire. Defaulting to ``main`` blocked merges under
+            # branch protection and broke the closed-loop chain:
+            # drift → PR → auto-merge → clean tick.
+            base=self._config.base_branch(),
             auto_merge=True,
             raise_on_failure=False,
             labels=["contract-refresh", "auto-merge"],

--- a/tests/regressions/test_contract_refresh_pr_targets_staging.py
+++ b/tests/regressions/test_contract_refresh_pr_targets_staging.py
@@ -1,0 +1,137 @@
+"""Regression: ContractRefreshLoop PRs must target the configured base branch.
+
+Per CLAUDE.md (ADR-0042 two-tier branch model): "PRs target staging, not main.
+Only RC promotion PRs use --base main." ``ContractRefreshLoop._open_refresh_pr``
+defaulted to ``main`` (the ``open_automated_pr_async`` parameter default),
+which meant every contract-refresh PR was opened against a protected branch
+that requires an RC promotion to merge into. The "auto-merge" label and
+``auto_merge=True`` flag both became no-ops because the merge gate at GitHub
+was unreachable — the closed-loop "drift → PR → auto-merge → clean tick"
+chain was broken at step 3.
+
+The fix is the same pattern repo_wiki_loop already uses:
+``base=self._config.base_branch()``. The helper returns ``staging_branch``
+when ``staging_enabled`` is true (the dark-factory norm) and ``main_branch``
+otherwise — so refresh PRs land where the auto-merge gate can actually fire.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import contract_refresh_loop as crl_module
+from auto_pr import AutoPrResult
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from contract_refresh_loop import ContractRefreshLoop
+from events import EventBus
+
+
+class _CaptureAutoPR:
+    """Captures ``open_automated_pr_async`` kwargs for assertion."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(self, **kwargs: Any) -> AutoPrResult:
+        self.calls.append(kwargs)
+        return AutoPrResult(
+            status="opened",
+            pr_url="https://github.com/x/y/pull/1",
+            branch=kwargs.get("branch", ""),
+        )
+
+
+def _loop(tmp_path: Path, **config_overrides: Any) -> ContractRefreshLoop:
+    cfg = HydraFlowConfig(
+        data_root=tmp_path / "data",
+        repo_root=tmp_path / "repo",
+        repo="hydra/hydraflow",
+        **config_overrides,
+    )
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    stop = asyncio.Event()
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=MagicMock(),
+        enabled_cb=lambda _: True,
+        sleep_fn=AsyncMock(),
+    )
+    return ContractRefreshLoop(
+        config=cfg, prs=AsyncMock(), state=MagicMock(), deps=deps
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_pr_targets_staging_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With ``staging_enabled=True``, the refresh PR must target staging,
+    not main — otherwise auto-merge can never fire against the protected
+    main branch and the closed-loop chain is broken."""
+    capture = _CaptureAutoPR()
+    monkeypatch.setattr(crl_module, "open_automated_pr_async", capture)
+
+    loop = _loop(tmp_path, staging_enabled=True)
+    drifted = tmp_path / "drift.yaml"
+    drifted.write_text("x")
+    fleet = crl_module.FleetDriftReport(
+        reports=[
+            crl_module.AdapterDriftReport(
+                adapter="git",
+                drifted_cassettes=[drifted],
+                new_cassettes=[],
+                deleted_cassettes=[],
+            )
+        ],
+        has_drift=True,
+    )
+
+    pr_url = await loop._open_refresh_pr([drifted], fleet)
+
+    assert pr_url == "https://github.com/x/y/pull/1"
+    assert len(capture.calls) == 1
+    base = capture.calls[0].get("base")
+    expected = loop._config.base_branch()
+    assert base == expected, (
+        f"refresh PR opened against {base!r}; expected {expected!r} (the "
+        f"configured base_branch) — refresh PRs targeting main can't auto-merge "
+        f"under ADR-0042 branch protection"
+    )
+    assert capture.calls[0].get("auto_merge") is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_pr_targets_main_when_staging_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When staging is disabled, base_branch() returns main_branch — the
+    fix must respect that, not hardcode staging."""
+    capture = _CaptureAutoPR()
+    monkeypatch.setattr(crl_module, "open_automated_pr_async", capture)
+
+    loop = _loop(tmp_path, staging_enabled=False)
+    drifted = tmp_path / "drift.yaml"
+    drifted.write_text("x")
+    fleet = crl_module.FleetDriftReport(
+        reports=[
+            crl_module.AdapterDriftReport(
+                adapter="git",
+                drifted_cassettes=[drifted],
+                new_cassettes=[],
+                deleted_cassettes=[],
+            )
+        ],
+        has_drift=True,
+    )
+
+    await loop._open_refresh_pr([drifted], fleet)
+
+    assert len(capture.calls) == 1
+    assert capture.calls[0].get("base") == loop._config.main_branch


### PR DESCRIPTION
## Summary

`ContractRefreshLoop._open_refresh_pr` defaulted to `base="main"` (the `open_automated_pr_async` parameter default). Under ADR-0042's two-tier branch model, `main` is protected — RC promotion is the only path. Result: every contract-refresh PR was opened against a branch where GitHub native auto-merge can **never fire**. Both `auto_merge=True` and the `auto-merge` label were no-ops.

That broke step 3 of the closed-loop chain:

```
drift detected → refresh PR opened → ❌ auto-merge blocked → next tick sees same drift
```

## Fix

Pass `base=self._config.base_branch()` (matching `repo_wiki_loop` already does). The helper returns `staging_branch` when `staging_enabled=True` (the dark-factory norm) and `main_branch` otherwise.

## Why this unblocks dark-factory mode

The "remove the human, catch drift and auto-correct" loop relies on:
1. Continuous drift detection — already in place (`ContractRefreshLoop._do_work`).
2. PR opens with native auto-merge — already in place (`auto_merge=True` → `gh pr merge --auto`).
3. **Merge actually fires when CI is green** — *this was broken*. Now fixed.
4. Fake-drift issues route to autonomous loops:
   - First-line: `hydraflow-find` + `fake-drift` → IMPL pipeline picks it up.
   - 3-attempt escalation: `hitl-escalation` + `fake-repair-stuck` → auto-agent preflight picks it up. If auto-agent's attempts exhaust, *then* a human label fires.

Step 3 was the gating bug — everything else was already wired.

## Test plan

- [x] `tests/regressions/test_contract_refresh_pr_targets_staging.py` — two tests covering both branches of `base_branch()` (staging on / off); both RED before fix.
- [x] Existing `tests/test_contract_refresh_loop.py` + `test_contract_refresh_integration.py` — 21 tests green (was 21, still 21).
- [x] ruff + pyright clean.

## Out of scope

- The bigger trust-architecture v2 redesign (shadow corpus + Pydantic shapes) — filed separately as a `hydraflow-find` issue.
- `diagram_loop.py` + `term_proposer_runtime.py` also hardcode `base="main"` — same fix pattern, but those loops have different auto-merge semantics. Tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)