### PR TITLE
fix(loops): bulk reraise_on_credit_or_bug fix (slice #3 + #5.0 findings)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T17:42:55.024918+00:00",
-  "commit_sha": "a85a539f66652419beab96b00d0d8daf96422b59",
+  "regenerated_at": "2026-05-18T17:44:57.176183+00:00",
+  "commit_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "ports.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "labels.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "modules.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "events.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "adr_xref.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "mockworld.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "changelog.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "functional_areas.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "ubiquitous-language.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+      "source_sha": "0f40720a9b024ce66bb8f830892969cf8b9336dc"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `a85a539` — fix(format): ruff format *(2026-05-18)*
+- `0f40720` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
 - `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
 - `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -290,4 +291,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._
+_Regenerated from commit `0f40720` on 2026-05-18 17:44 UTC. Source last changed at `0f40720`. Status: 🟢 fresh._

--- a/src/code_grooming_loop.py
+++ b/src/code_grooming_loop.py
@@ -11,6 +11,7 @@ from agent_cli import build_agent_command
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
 from dedup_store import DedupStore
+from exception_classify import reraise_on_credit_or_bug
 from runner_utils import StreamConfig, stream_claude_process
 
 if TYPE_CHECKING:
@@ -127,7 +128,8 @@ class CodeGroomingLoop(BaseBackgroundLoop):
 
         try:
             findings = await self._run_audit()
-        except Exception:
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
             logger.warning("Code grooming audit failed", exc_info=True)
             return {"filed": 0, "error": True}
 

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -63,6 +63,7 @@ from typing import TYPE_CHECKING
 
 from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult  # noqa: TCH001
 from skill_registry import BUILTIN_SKILLS, AgentSkill
 
@@ -532,7 +533,8 @@ class CorpusLearningLoop(BaseBackgroundLoop):
                 body,
                 ["hitl-escalation", "corpus-learning-stuck"],
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.warning(
                 "corpus-learning: failed to file `corpus-learning-stuck` "
                 "escalation for #%d",
@@ -756,7 +758,8 @@ class CorpusLearningLoop(BaseBackgroundLoop):
             if proc.returncode != 0:
                 return
             issues = json.loads(out or b"[]")
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("corpus-learning reconcile: skipped", exc_info=True)
             return
         for issue in issues:
@@ -812,7 +815,8 @@ class CorpusLearningLoop(BaseBackgroundLoop):
                         continue
                     seen_issues.add(sig.issue_number)
                     signals.append(sig)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.warning(
                 "corpus-learning: escape-signal query failed — skipping tick",
                 exc_info=True,

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 import trace_collector
 from base_background_loop import BaseBackgroundLoop, LoopDeps
+from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
 
 if TYPE_CHECKING:
@@ -95,7 +96,8 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         # running.
         try:
             self_report = await self._run_audit(_HYDRAFLOW_SELF, self._config.repo_root)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.warning(
                 "Skipping self-audit this tick — audit-json unavailable",
                 exc_info=True,
@@ -135,7 +137,8 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
                     stats["escalations_filed"] += fire["escalated"]
                 else:
                     self._state.set_last_green_audit(mr.slug, snapshot)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                reraise_on_credit_or_bug(exc)
                 logger.warning(
                     "PrinciplesAuditLoop: skipping %s — audit failed",
                     mr.slug,
@@ -382,7 +385,8 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
                 logger.debug("reconcile: gh issue list failed")
                 return
             issues = json.loads(out or b"[]")
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("reconcile: skipped", exc_info=True)
             return
         for issue in issues:

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -14,8 +14,8 @@ from typing import TYPE_CHECKING, Any
 from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
-from exception_classify import reraise_on_credit_or_bug
 from events import EventType, HydraFlowEvent
+from exception_classify import reraise_on_credit_or_bug
 from knowledge_metrics import metrics as _metrics
 from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
 from staleness import evaluate as evaluate_staleness

--- a/src/repo_wiki_loop.py
+++ b/src/repo_wiki_loop.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 from auto_pr import open_automated_pr_async
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import Credentials, HydraFlowConfig
+from exception_classify import reraise_on_credit_or_bug
 from events import EventType, HydraFlowEvent
 from knowledge_metrics import metrics as _metrics
 from repo_wiki import DEFAULT_TOPICS, RepoWikiStore, WikiEntry, active_lint_tracked
@@ -126,7 +127,8 @@ async def run_generalization_pass(
                     )
                     try:
                         await event_bus.publish(event)
-                    except Exception:  # noqa: BLE001
+                    except Exception as exc:  # noqa: BLE001
+                        reraise_on_credit_or_bug(exc)
                         logger.debug("tribal promotion event publish failed")
     return result
 
@@ -273,7 +275,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
                             )
                             if after < len(entries):
                                 total_compiled += len(entries) - after
-                        except Exception:  # noqa: BLE001
+                        except Exception as exc:  # noqa: BLE001
+                            reraise_on_credit_or_bug(exc)
                             logger.warning(
                                 "Wiki compile failed for %s/%s",
                                 slug,
@@ -310,7 +313,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
                             # collapses many entries into one or two.
                             if synthesized:
                                 total_compiled += synthesized
-                        except Exception:  # noqa: BLE001
+                        except Exception as exc:  # noqa: BLE001
+                            reraise_on_credit_or_bug(exc)
                             logger.warning(
                                 "Wiki compile_tracked failed for %s/%s",
                                 slug,
@@ -365,7 +369,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
                         repo_root=Path(self._config.repo_root),
                         repo_slug=slug,
                     )
-                except Exception:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
+                    reraise_on_credit_or_bug(exc)
                     logger.warning(
                         "wiki drift detection failed for %s", slug, exc_info=True
                     )
@@ -414,7 +419,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
                             self._config.semantic_drift_max_entries_per_tick
                         ),
                     )
-                except Exception:  # noqa: BLE001
+                except Exception as exc:  # noqa: BLE001
+                    reraise_on_credit_or_bug(exc)
                     logger.warning(
                         "semantic drift scan failed for %s", slug, exc_info=True
                     )
@@ -443,7 +449,8 @@ class RepoWikiLoop(BaseBackgroundLoop):
                     compiler=self._wiki_compiler,
                     event_bus=self._bus,
                 )
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                reraise_on_credit_or_bug(exc)
                 logger.warning("generalization pass failed", exc_info=True)
 
         return stats

--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -25,6 +25,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
+from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
 
 if TYPE_CHECKING:
@@ -84,14 +85,19 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                 self._config.skill_prompt_eval_max_corpus_cases
             ),
         }
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=self._config.repo_root,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=env,
-        )
-        stdout, stderr = await proc.communicate()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=self._config.repo_root,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            stdout, stderr = await proc.communicate()
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
+            logger.warning("trust-adversarial subprocess failed: %s", exc)
+            return []
         if proc.returncode not in (0, 1):  # 1 = failures present; still valid output
             logger.warning(
                 "trust-adversarial exit=%d: %s",

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
+from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
 from trust_fleet_anomaly_detectors import (
     TRUST_LOOP_WORKERS,
@@ -388,7 +389,8 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout, _ = await proc.communicate()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("gh issue list failed", exc_info=True)
             return
         if proc.returncode != 0:
@@ -429,7 +431,8 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                 duration_ms=duration_ms,
                 stderr_excerpt=f"anomalies={anomalies}",
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("trace emission failed", exc_info=True)
 
     # ------------------------------------------------------------------
@@ -503,7 +506,8 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
         """
         try:
             loaded = await self._source_bus.load_events_since(since)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("load_events_since failed", exc_info=True)
             return []
         return loaded or []

--- a/src/wiki_rot_detector_loop.py
+++ b/src/wiki_rot_detector_loop.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
+from exception_classify import reraise_on_credit_or_bug
 from models import WorkCycleResult
 from wiki_rot_citations import (
     Cite,
@@ -110,7 +111,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         for slug in repos:
             try:
                 result = await self._tick_repo(slug, self_slug)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                reraise_on_credit_or_bug(exc)
                 logger.exception("wiki_rot_detector: slug=%s failed", slug)
                 continue
             scanned += 1
@@ -160,7 +162,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
                     f"scanned={scanned} filed={filed} escalated={escalated}"
                 ),
             )
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("trace emission failed", exc_info=True)
 
     async def _tick_repo(
@@ -235,7 +238,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         """
         try:
             repo_dir = self._wiki.repo_dir(slug)
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("wiki.repo_dir(%s) failed", slug, exc_info=True)
             return []
         if not repo_dir.is_dir():
@@ -364,7 +368,8 @@ class WikiRotDetectorLoop(BaseBackgroundLoop):
         """
         try:
             closed = await self._gh_closed_escalations()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             logger.debug("reconcile: gh list failed", exc_info=True)
             return
 

--- a/tests/regressions/test_credit_exhausted_reraise.py
+++ b/tests/regressions/test_credit_exhausted_reraise.py
@@ -1,0 +1,136 @@
+"""Regression: broad except Exception blocks in caretaker loops must NOT swallow
+CreditExhaustedError (dark-factory.md §2.2).
+
+Slice #3 + #5.0 audit found 7 loops with broad except blocks that would eat
+CreditExhaustedError, causing the loop to burn attempt budget against an
+exhausted billing signal. This file guards two representative loops; the
+same reraise_on_credit_or_bug pattern covers all 7.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from subprocess_util import CreditExhaustedError
+from tests.helpers import make_bg_loop_deps
+
+
+# ---------------------------------------------------------------------------
+# CodeGroomingLoop — wraps stream_claude_process via _run_audit
+# ---------------------------------------------------------------------------
+
+
+class TestCodeGroomingCreditExhaustedReraise:
+    """CreditExhaustedError raised by _run_audit must propagate out of _do_work."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_run_audit(
+        self, tmp_path: Path
+    ) -> None:
+        """When _run_audit raises CreditExhaustedError the loop MUST re-raise it,
+        not swallow it and return {"filed": 0, "error": True}."""
+        from unittest.mock import patch
+
+        from code_grooming_loop import CodeGroomingLoop
+
+        deps = make_bg_loop_deps(tmp_path, code_grooming_enabled=True)
+        loop = CodeGroomingLoop(
+            config=deps.config,
+            pr_manager=AsyncMock(),
+            deps=deps.loop_deps,
+        )
+
+        with patch.object(
+            loop,
+            "_run_audit",
+            new_callable=AsyncMock,
+            side_effect=CreditExhaustedError("billing limit reached"),
+        ):
+            with pytest.raises(CreditExhaustedError, match="billing limit reached"):
+                await loop._do_work()
+
+
+# ---------------------------------------------------------------------------
+# CorpusLearningLoop — wraps gh issue list subprocess + escape-signal query
+# ---------------------------------------------------------------------------
+
+
+class TestCorpusLearningCreditExhaustedReraise:
+    """CreditExhaustedError raised inside corpus learning broad-except paths must
+    propagate, not be swallowed."""
+
+    def _make_loop(self, tmp_path: Path):
+        from corpus_learning_loop import CorpusLearningLoop
+        from dedup_store import DedupStore
+
+        deps = make_bg_loop_deps(tmp_path)
+        pr_manager = AsyncMock()
+        pr_manager.list_issues_by_label = AsyncMock(return_value=[])
+        dedup = DedupStore(
+            "corpus_learning",
+            deps.config.data_root / "memory" / "corpus_learning_dedup.json",
+        )
+        state = MagicMock()
+        state.increment_corpus_validation_attempts = MagicMock(return_value=3)
+        state.reset_corpus_validation_attempts = MagicMock()
+
+        loop = CorpusLearningLoop(
+            config=deps.config,
+            prs=pr_manager,
+            dedup=dedup,
+            state=state,
+            deps=deps.loop_deps,
+        )
+        return loop, pr_manager
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_escape_signal_query(
+        self, tmp_path: Path
+    ) -> None:
+        """CreditExhaustedError raised by _list_escape_signals must not be swallowed
+        by the broad except in _do_work."""
+        from unittest.mock import patch
+
+        loop, _ = self._make_loop(tmp_path)
+
+        with patch.object(
+            loop,
+            "_list_escape_signals",
+            new_callable=AsyncMock,
+            side_effect=CreditExhaustedError("credits exhausted"),
+        ):
+            with pytest.raises(CreditExhaustedError, match="credits exhausted"):
+                await loop._do_work()
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_create_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """CreditExhaustedError raised by create_issue in _record_validation_failure
+        must propagate out of the broad except that guards it."""
+        from corpus_learning_loop import EscapeSignal, ValidationResult
+
+        loop, pr_manager = self._make_loop(tmp_path)
+        pr_manager.create_issue = AsyncMock(
+            side_effect=CreditExhaustedError("credits exhausted during issue creation")
+        )
+
+        signal = EscapeSignal(
+            issue_number=99,
+            title="test: escape",
+            body="",
+            updated_at="2026-01-01T00:00:00Z",
+            label="skill-escape",
+        )
+        result = ValidationResult(ok=False, failing_gate="harness", reason="diff empty")
+
+        with pytest.raises(
+            CreditExhaustedError, match="credits exhausted during issue creation"
+        ):
+            await loop._record_validation_failure(signal, result)


### PR DESCRIPTION
## Summary

- Slice #3 + slice #5.0 audits found 7 caretaker loops swallowing `CreditExhaustedError` in broad `except Exception` blocks. Per `docs/wiki/dark-factory.md §2.2`, every subprocess-spawning runner must call `reraise_on_credit_or_bug(exc)` as the first statement in such blocks.
- Added `from exception_classify import reraise_on_credit_or_bug` and the reraise call to 15 call sites across all 7 files. Each `except Exception:` was also updated to `except Exception as exc:` to bind the variable.
- Added regression tests in `tests/regressions/test_credit_exhausted_reraise.py` asserting `CreditExhaustedError` propagates through `CodeGroomingLoop._do_work` and `CorpusLearningLoop._do_work` / `_record_validation_failure`.

## Loops fixed

- `CorpusLearningLoop` — 3 except blocks (create_issue escalation, gh reconcile subprocess, escape-signal query)
- `PrinciplesAuditLoop` — 3 except blocks (self-audit, per-repo audit, gh reconcile subprocess)
- `TrustFleetSanityLoop` — 3 except blocks (gh subprocess, trace emission, load_events_since)
- `WikiRotDetectorLoop` — 4 except blocks (tick_repo, trace emission, wiki.repo_dir, gh reconcile)
- `CodeGroomingLoop` — 1 except block (wraps stream_claude_process via _run_audit)
- `RepoWikiLoop` — 6 except blocks (event publish, compile_topic, compile_topic_tracked, drift detection, semantic drift scan, generalization pass)
- `SkillPromptEvalLoop` — added guarding try/except around asyncio.create_subprocess_exec in _run_corpus

## Test plan

- [x] Regression tests in `tests/regressions/test_credit_exhausted_reraise.py` assert `CreditExhaustedError` propagates (3 tests, all green).
- [x] All 7 existing loop test suites pass (112 tests).

## Closes

The dark-factory-gap beads tagged `kind=safety` for these 7 loops (slice #3 + #5.0 audit findings).

🤖 Generated with Claude Code