### PR TITLE
fix(preflight): reraise CreditExhaustedError in run_preflight (closes #8812)

### DIFF
--- a/src/preflight/agent.py
+++ b/src/preflight/agent.py
@@ -11,6 +11,7 @@ import time
 from dataclasses import dataclass
 from typing import Any
 
+from exception_classify import reraise_on_credit_or_bug
 from preflight.context import PreflightContext
 from preflight.decision import PreflightResult
 from preflight.runner import parse_agent_response, render_blocks, render_prompt
@@ -71,6 +72,7 @@ async def run_preflight(
     try:
         spawn = await deps.spawn_fn(prompt=prompt, worktree_path=worktree_path)
     except Exception as exc:
+        reraise_on_credit_or_bug(exc)
         logger.exception("PreflightAgent spawn failed: %s", exc)
         return PreflightResult(
             status="fatal",

--- a/tests/regressions/test_preflight_credit_exhausted.py
+++ b/tests/regressions/test_preflight_credit_exhausted.py
@@ -1,0 +1,77 @@
+"""Regression test for issue #8812.
+
+Bug: ``run_preflight`` had a bare ``except Exception`` block that swallowed
+``CreditExhaustedError`` even though ``BaseSubprocessRunner`` correctly
+reraises it.  ``AutoAgentPreflightLoop`` then loops indefinitely burning budget
+unless ``auto_agent_daily_budget_usd`` is configured (defaults to unlimited).
+
+Fix: call ``reraise_on_credit_or_bug(exc)`` as the first line of the except
+body so that fatal billing signals propagate to the caller.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from preflight.agent import PreflightAgentDeps, run_preflight
+from preflight.context import PreflightContext
+from subprocess_util import CreditExhaustedError
+
+
+def _ctx() -> PreflightContext:
+    return PreflightContext(
+        issue_number=42,
+        issue_body="body",
+        issue_comments=[],
+        sub_label="flaky-test-stuck",
+        escalation_context=None,
+        wiki_excerpts="",
+        sentry_events=[],
+        recent_commits=[],
+    )
+
+
+class TestRunPreflightDoesNotSwallowCreditExhausted:
+    """Issue #8812: run_preflight must not swallow CreditExhaustedError."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_from_spawn_fn(self) -> None:
+        """CreditExhaustedError raised by spawn_fn must propagate, not be swallowed."""
+        spawn_fn = AsyncMock(side_effect=CreditExhaustedError("credits exhausted"))
+        deps = PreflightAgentDeps(
+            persona="test",
+            cost_cap_usd=None,
+            wall_clock_cap_s=None,
+            spawn_fn=spawn_fn,
+        )
+
+        with pytest.raises(CreditExhaustedError):
+            await run_preflight(
+                context=_ctx(),
+                repo_slug="x/y",
+                worktree_path="/tmp",
+                deps=deps,
+            )
+
+    @pytest.mark.asyncio
+    async def test_generic_runtime_error_still_returns_fatal(self) -> None:
+        """Non-fatal errors (RuntimeError etc.) must still be caught and return fatal."""
+        spawn_fn = AsyncMock(side_effect=RuntimeError("oom"))
+        deps = PreflightAgentDeps(
+            persona="test",
+            cost_cap_usd=None,
+            wall_clock_cap_s=None,
+            spawn_fn=spawn_fn,
+        )
+
+        result = await run_preflight(
+            context=_ctx(),
+            repo_slug="x/y",
+            worktree_path="/tmp",
+            deps=deps,
+        )
+
+        assert result.status == "fatal"
+        assert "spawn failed" in result.diagnosis


### PR DESCRIPTION
## Summary

Slice #5.3 audit (PR #8817) flagged this as a critical billing-safety bug: `run_preflight` has a bare `except Exception` that swallows `CreditExhaustedError` even though `BaseSubprocessRunner` correctly reraises it. `AutoAgentPreflightLoop` then loops indefinitely burning budget when credits are exhausted.

- Added `reraise_on_credit_or_bug(exc)` as the first line of the `except Exception` block in `run_preflight` (one-line fix per the dark-factory convention).
- Added import of `reraise_on_credit_or_bug` from `exception_classify`.
- Generic non-fatal errors (RuntimeError, etc.) continue to be caught and returned as `status="fatal"` as before.

## Test plan

- [x] Regression test asserts `CreditExhaustedError` propagates from `spawn_fn` through `run_preflight`.
- [x] Regression test confirms generic `RuntimeError` is still caught and returns `status="fatal"`.
- [x] All 7 existing `test_preflight_agent.py` tests still pass.
- [x] All 14 existing `test_auto_agent_preflight_loop.py` tests still pass.

## Closes

#8812

🤖 Generated with Claude Code