### PR TITLE
fix(arch): loops.md generator populates Tick + Kill (closes 82 audit beads)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T14:53:34.811669+00:00",
-  "commit_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd",
+  "regenerated_at": "2026-05-18T15:46:35.634260+00:00",
+  "commit_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4",
   "artifacts": {
     "loops.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "ports.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "labels.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "modules.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "events.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "adr_xref.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "mockworld.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "changelog.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     },
     "functional_areas.md": {
-      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
+      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T17:23:22.453754+00:00",
-  "commit_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038",
+  "regenerated_at": "2026-05-18T14:53:34.811669+00:00",
+  "commit_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "ports.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "labels.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "modules.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "events.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "adr_xref.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "mockworld.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "changelog.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     },
     "functional_areas.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "5a74449aa55c8f96c74ca1cb793b4540e9c4b038"
+      "source_sha": "fbbc1a36dbbbf23f91be7d74d63e72ab6aa03edd"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T15:46:35.634260+00:00",
-  "commit_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4",
+  "regenerated_at": "2026-05-18T17:42:55.024918+00:00",
+  "commit_sha": "a85a539f66652419beab96b00d0d8daf96422b59",
   "artifacts": {
     "loops.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "ports.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "labels.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "modules.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "events.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "adr_xref.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "mockworld.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "changelog.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     },
     "functional_areas.md": {
-      "source_sha": "998ea93e7b06fde512de639044c40d3cbd689ce4"
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "a85a539f66652419beab96b00d0d8daf96422b59"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,48 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `fbbc1a3` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `998ea93` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f0f114` — Merge branch 'staging' into fix/loops-registry-tick-kill *(2026-05-18)*
+- `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
+- `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
+- `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
+- `1bc107e` — Merge pull request #8817 from T-rav/audit/area-auto-agent *(2026-05-18)*
+- `0550ced` — Merge pull request #8811 from T-rav/audit/area-hexagonal *(2026-05-18)*
+- `6a38b76` — Merge pull request #8805 from T-rav/audit/area-quality-gates *(2026-05-18)*
+- `e9480be` — Merge pull request #8803 from T-rav/audit/area-mockworld *(2026-05-18)*
+- `7d69454` — Merge pull request #8801 from T-rav/audit/area-state-persistence *(2026-05-18)*
+- `8ad91b1` — Merge pull request #8795 from T-rav/audit/area-goal-driven *(2026-05-18)*
+- `e07431b` — Merge pull request #8794 from T-rav/audit/area-arch-knowledge *(2026-05-18)*
+- `4b44c0f` — Merge pull request #8793 from T-rav/audit/area-trust-fleet *(2026-05-18)*
+- `08994cf` — Merge pull request #8789 from T-rav/audit/area-orchestration *(2026-05-18)*
+- `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
+- `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
+- `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
+- `90464fd` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
+- `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
+- `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
+- `8581fca` — docs(audit): coverage matrix — sampling + counts reconciliation *(2026-05-18)*
+- `cfea975` — docs(audit): coverage matrix — aliases + excluded_refs lists *(2026-05-18)*
+- `bec174c` — docs(audit): coverage matrix — Phases section populated (8 rows × 6 cols) *(2026-05-18)*
+- `10122ba` — docs(audit): coverage matrix — fix Ports section fake/cassette/contract logic *(2026-05-18)*
+- `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
+- `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
+- `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
+- `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
+- `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
+- `86f5c3a` — Merge branch 'staging' into audit/area-quality-gates *(2026-05-18)*
+- `55bb1f3` — Merge branch 'staging' into audit/area-mockworld *(2026-05-18)*
+- `507446a` — Merge branch 'staging' into audit/area-state-persistence *(2026-05-18)*
+- `d5e9f09` — Merge branch 'staging' into audit/area-goal-driven *(2026-05-18)*
+- `0428ce8` — Merge branch 'staging' into audit/area-arch-knowledge *(2026-05-18)*
+- `ed9e629` — Merge branch 'staging' into audit/area-trust-fleet *(2026-05-18)*
+- `9486027` — Merge branch 'staging' into audit/area-orchestration *(2026-05-18)*
+- `e638d27` — Merge branch 'staging' into audit/area-dashboard *(2026-05-18)*
+- `69a3235` — Merge branch 'staging' into audit/area-caretaking *(2026-05-18)*
+- `d8257f4` — Merge branch 'staging' into audit/factory-phase-drift *(2026-05-18)*
+- `e8aff97` — Merge branch 'staging' into audit/dark-factory-compat *(2026-05-18)*
 - `c0c7aab` — Merge pull request #8824 from T-rav/docs/promote-adrs-31-47 *(2026-05-18)*
 
 ## 2026-W20
@@ -14,6 +55,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
 - `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
 - `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
+- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
 - `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
@@ -241,4 +283,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,14 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `998ea93` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8f0f114` — Merge branch 'staging' into fix/loops-registry-tick-kill *(2026-05-18)*
+- `a85a539` — fix(format): ruff format *(2026-05-18)*
+- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
+- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -23,7 +29,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `90464fd` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -34,6 +40,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -283,4 +290,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,52 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `5a74449` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
-- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
-- `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
-- `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
-- `1bc107e` — Merge pull request #8817 from T-rav/audit/area-auto-agent *(2026-05-18)*
-- `0550ced` — Merge pull request #8811 from T-rav/audit/area-hexagonal *(2026-05-18)*
-- `6a38b76` — Merge pull request #8805 from T-rav/audit/area-quality-gates *(2026-05-18)*
-- `e9480be` — Merge pull request #8803 from T-rav/audit/area-mockworld *(2026-05-18)*
-- `7d69454` — Merge pull request #8801 from T-rav/audit/area-state-persistence *(2026-05-18)*
-- `8ad91b1` — Merge pull request #8795 from T-rav/audit/area-goal-driven *(2026-05-18)*
-- `e07431b` — Merge pull request #8794 from T-rav/audit/area-arch-knowledge *(2026-05-18)*
-- `4b44c0f` — Merge pull request #8793 from T-rav/audit/area-trust-fleet *(2026-05-18)*
-- `08994cf` — Merge pull request #8789 from T-rav/audit/area-orchestration *(2026-05-18)*
-- `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
-- `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
-- `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
-- `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
-- `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
-- `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
-- `8581fca` — docs(audit): coverage matrix — sampling + counts reconciliation *(2026-05-18)*
-- `cfea975` — docs(audit): coverage matrix — aliases + excluded_refs lists *(2026-05-18)*
-- `bec174c` — docs(audit): coverage matrix — Phases section populated (8 rows × 6 cols) *(2026-05-18)*
-- `10122ba` — docs(audit): coverage matrix — fix Ports section fake/cassette/contract logic *(2026-05-18)*
-- `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
-- `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
-- `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
-- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
-- `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
-- `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
-- `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
-- `86f5c3a` — Merge branch 'staging' into audit/area-quality-gates *(2026-05-18)*
-- `55bb1f3` — Merge branch 'staging' into audit/area-mockworld *(2026-05-18)*
-- `507446a` — Merge branch 'staging' into audit/area-state-persistence *(2026-05-18)*
-- `d5e9f09` — Merge branch 'staging' into audit/area-goal-driven *(2026-05-18)*
-- `0428ce8` — Merge branch 'staging' into audit/area-arch-knowledge *(2026-05-18)*
-- `ed9e629` — Merge branch 'staging' into audit/area-trust-fleet *(2026-05-18)*
-- `9486027` — Merge branch 'staging' into audit/area-orchestration *(2026-05-18)*
-- `e638d27` — Merge branch 'staging' into audit/area-dashboard *(2026-05-18)*
-- `69a3235` — Merge branch 'staging' into audit/area-caretaking *(2026-05-18)*
-- `d8257f4` — Merge branch 'staging' into audit/factory-phase-drift *(2026-05-18)*
-- `e8aff97` — Merge branch 'staging' into audit/dark-factory-compat *(2026-05-18)*
+- `fbbc1a3` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
 - `c0c7aab` — Merge pull request #8824 from T-rav/docs/promote-adrs-31-47 *(2026-05-18)*
 
 ## 2026-W20
@@ -59,7 +14,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
 - `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
 - `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
-- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
 - `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
@@ -287,4 +241,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -6,49 +6,49 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 
 | Loop | Module | Tick (s) | Kill Switch | Events | ADRs |
 |---|---|---|---|---|---|
-| **ADRReviewerLoop** | `src.adr_reviewer_loop` | — | — | — | — |
-| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | — | — | — | ADR-0056 |
-| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | — | — | — | — |
-| **CIMonitorLoop** | `src.ci_monitor_loop` | — | — | — | — |
-| **CodeGroomingLoop** | `src.code_grooming_loop` | — | — | — | — |
-| **ContractRefreshLoop** | `src.contract_refresh_loop` | — | — | — | — |
-| **CorpusLearningLoop** | `src.corpus_learning_loop` | — | — | — | — |
-| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | — | — | — | — |
-| **DependabotMergeLoop** | `src.dependabot_merge_loop` | — | — | — | — |
-| **DiagnosticLoop** | `src.diagnostic_loop` | — | — | DIAGNOSTIC_UPDATE | — |
-| **DiagramLoop** | `src.diagram_loop` | — | — | — | ADR-0029, ADR-0049 |
-| **EdgeProposerLoop** | `src.edge_proposer_loop` | — | — | — | — |
-| **EntryEvidenceLoop** | `src.entry_evidence_loop` | — | — | — | ADR-0062 |
-| **EpicMonitorLoop** | `src.epic_monitor_loop` | — | — | — | — |
-| **EpicSweeperLoop** | `src.epic_sweeper_loop` | — | — | — | — |
-| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | — | — | — | — |
-| **FlakeTrackerLoop** | `src.flake_tracker_loop` | — | — | — | — |
-| **GitHubCacheLoop** | `src.github_cache_loop` | — | — | — | — |
-| **HealthMonitorLoop** | `src.health_monitor_loop` | — | — | — | — |
-| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | — | — | — | — |
-| **LiveCorpusReplayLoop** | `src.live_corpus_replay_loop` | — | — | — | — |
-| **MemoryBacklogLoop** | `src.memory_backlog_loop` | — | — | — | — |
-| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | — | — | — | — |
-| **PRUnstickerLoop** | `src.pr_unsticker_loop` | — | — | — | — |
-| **PricingRefreshLoop** | `src.pricing_refresh_loop` | — | — | — | — |
-| **PrinciplesAuditLoop** | `src.principles_audit_loop` | — | — | — | ADR-0044 |
-| **RCBudgetLoop** | `src.rc_budget_loop` | — | — | — | — |
-| **RepoWikiLoop** | `src.repo_wiki_loop` | — | — | — | — |
-| **ReportIssueLoop** | `src.report_issue_loop` | — | — | REPORT_UPDATE | — |
-| **RetrospectiveLoop** | `src.retrospective_loop` | — | — | RETROSPECTIVE_UPDATE | — |
-| **RunsGCLoop** | `src.runs_gc_loop` | — | — | — | — |
-| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | — | — | — | ADR-0049 |
-| **SecurityPatchLoop** | `src.security_patch_loop` | — | — | — | — |
-| **SentryLoop** | `src.sentry_loop` | — | — | — | — |
-| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | — | — | — | — |
-| **StagingBisectLoop** | `src.staging_bisect_loop` | — | — | — | ADR-0042 |
-| **StagingPromotionLoop** | `src.staging_promotion_loop` | — | — | — | ADR-0042 |
-| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | — | — | — | — |
-| **StaleIssueLoop** | `src.stale_issue_loop` | — | — | — | — |
-| **TermProposerLoop** | `src.term_proposer_loop` | — | — | — | ADR-0054 |
-| **TermPrunerLoop** | `src.term_pruner_loop` | — | — | — | — |
-| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | — | — | BACKGROUND_WORKER_STATUS | — |
-| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
-| **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
+| **ADRReviewerLoop** | `src.adr_reviewer_loop` | 86400 | — | — | — |
+| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | 14400 | — | — | ADR-0056 |
+| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | 120 | — | — | — |
+| **CIMonitorLoop** | `src.ci_monitor_loop` | 300 | — | — | — |
+| **CodeGroomingLoop** | `src.code_grooming_loop` | 86400 | — | — | — |
+| **ContractRefreshLoop** | `src.contract_refresh_loop` | 604800 | — | — | — |
+| **CorpusLearningLoop** | `src.corpus_learning_loop` | 3600 | — | — | — |
+| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | 300 | `HYDRAFLOW_DISABLE_COST_BUDGET_WATCHER` | — | — |
+| **DependabotMergeLoop** | `src.dependabot_merge_loop` | 3600 | — | — | — |
+| **DiagnosticLoop** | `src.diagnostic_loop` | 30 | — | DIAGNOSTIC_UPDATE | — |
+| **DiagramLoop** | `src.diagram_loop` | 14400 | `HYDRAFLOW_DISABLE_DIAGRAM_LOOP` | — | ADR-0029, ADR-0049 |
+| **EdgeProposerLoop** | `src.edge_proposer_loop` | 86400 | — | — | — |
+| **EntryEvidenceLoop** | `src.entry_evidence_loop` | 86400 | — | — | ADR-0062 |
+| **EpicMonitorLoop** | `src.epic_monitor_loop` | 1800 | — | — | — |
+| **EpicSweeperLoop** | `src.epic_sweeper_loop` | 3600 | — | — | — |
+| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | 604800 | — | — | — |
+| **FlakeTrackerLoop** | `src.flake_tracker_loop` | 14400 | — | — | — |
+| **GitHubCacheLoop** | `src.github_cache_loop` | 300 | — | — | — |
+| **HealthMonitorLoop** | `src.health_monitor_loop` | 7200 | — | — | — |
+| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | 600 | — | — | — |
+| **LiveCorpusReplayLoop** | `src.live_corpus_replay_loop` | 900 | — | — | — |
+| **MemoryBacklogLoop** | `src.memory_backlog_loop` | 86400 | — | — | — |
+| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | 600 | — | — | — |
+| **PRUnstickerLoop** | `src.pr_unsticker_loop` | 3600 | — | — | — |
+| **PricingRefreshLoop** | `src.pricing_refresh_loop` | 86400 | `HYDRAFLOW_DISABLE_PRICING_REFRESH` | — | — |
+| **PrinciplesAuditLoop** | `src.principles_audit_loop` | 604800 | — | — | ADR-0044 |
+| **RCBudgetLoop** | `src.rc_budget_loop` | 14400 | — | — | — |
+| **RepoWikiLoop** | `src.repo_wiki_loop` | 3600 | — | — | — |
+| **ReportIssueLoop** | `src.report_issue_loop` | 30 | — | REPORT_UPDATE | — |
+| **RetrospectiveLoop** | `src.retrospective_loop` | 1800 | — | RETROSPECTIVE_UPDATE | — |
+| **RunsGCLoop** | `src.runs_gc_loop` | 3600 | — | — | — |
+| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | 3600 | — | — | ADR-0049 |
+| **SecurityPatchLoop** | `src.security_patch_loop` | 3600 | — | — | — |
+| **SentryLoop** | `src.sentry_loop` | 600 | — | — | — |
+| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | 604800 | — | — | — |
+| **StagingBisectLoop** | `src.staging_bisect_loop` | 600 | — | — | ADR-0042 |
+| **StagingPromotionLoop** | `src.staging_promotion_loop` | 300 | — | — | ADR-0042 |
+| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | 3600 | — | — | — |
+| **StaleIssueLoop** | `src.stale_issue_loop` | 86400 | — | — | — |
+| **TermProposerLoop** | `src.term_proposer_loop` | 14400 | — | — | ADR-0054 |
+| **TermPrunerLoop** | `src.term_pruner_loop` | 86400 | — | — | — |
+| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | 600 | — | BACKGROUND_WORKER_STATUS | — |
+| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
+| **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `5a74449` on 2026-05-18 17:23 UTC. Source last changed at `5a74449`. Status: 🟢 fresh._
+_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._
+_Regenerated from commit `a85a539` on 2026-05-18 17:42 UTC. Source last changed at `a85a539`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `fbbc1a3` on 2026-05-18 14:53 UTC. Source last changed at `fbbc1a3`. Status: 🟢 fresh._
+_Regenerated from commit `998ea93` on 2026-05-18 15:46 UTC. Source last changed at `998ea93`. Status: 🟢 fresh._

--- a/src/arch/extractors/loops.py
+++ b/src/arch/extractors/loops.py
@@ -47,7 +47,9 @@ def _module_int_constants(tree: ast.Module) -> dict[str, int]:
     for node in tree.body:
         if not isinstance(node, ast.Assign):
             continue
-        if not (isinstance(node.value, ast.Constant) and isinstance(node.value.value, int)):
+        if not (
+            isinstance(node.value, ast.Constant) and isinstance(node.value.value, int)
+        ):
             continue
         for tgt in node.targets:
             if isinstance(tgt, ast.Name):
@@ -80,7 +82,11 @@ def _load_config_defaults(src_dir: Path) -> dict[str, int]:
         if not isinstance(node.value, ast.Call):
             continue
         for kw in node.value.keywords:
-            if kw.arg == "default" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+            if (
+                kw.arg == "default"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, int)
+            ):
                 result[node.target.id] = kw.value.value
                 break
     return result
@@ -207,7 +213,9 @@ def extract_loops(src_dir: Path) -> list[LoopInfo]:
                     name=node.name,
                     module=_module_for(py, src_dir),
                     source_path=str(py.relative_to(src_dir.parent)),
-                    tick_interval_seconds=_tick_interval(node, module_constants, config_defaults),
+                    tick_interval_seconds=_tick_interval(
+                        node, module_constants, config_defaults
+                    ),
                     event_subscriptions=_event_subs(node),
                     kill_switch_var=_kill_switch(node, source),
                     adr_refs=_adr_refs(node, tree),

--- a/src/arch/extractors/loops.py
+++ b/src/arch/extractors/loops.py
@@ -33,7 +33,77 @@ def _is_basebackgroundloop_subclass(cls: ast.ClassDef) -> bool:
     return False
 
 
-def _tick_interval(cls: ast.ClassDef) -> int | None:
+def _module_int_constants(tree: ast.Module) -> dict[str, int]:
+    """Return module-level ``NAME = <int>`` assignments as a name→value dict.
+
+    Used to resolve module-level constants referenced inside
+    ``_get_default_interval``, e.g.::
+
+        _DEFAULT_INTERVAL_SECONDS = 600  # module level
+        def _get_default_interval(self) -> int:
+            return _DEFAULT_INTERVAL_SECONDS
+    """
+    result: dict[str, int] = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not (isinstance(node.value, ast.Constant) and isinstance(node.value.value, int)):
+            continue
+        for tgt in node.targets:
+            if isinstance(tgt, ast.Name):
+                result[tgt.id] = node.value.value
+    return result
+
+
+def _load_config_defaults(src_dir: Path) -> dict[str, int]:
+    """Parse ``src/config.py`` and return a map of field_name → default int value.
+
+    The map is used to resolve ``return self._config.<field>`` in
+    ``_get_default_interval`` methods.  Only ``Field(default=<int>)`` entries
+    are captured; computed defaults or non-integer defaults are ignored.
+    """
+    config_path = src_dir / "config.py"
+    if not config_path.exists():
+        return {}
+    try:
+        tree = ast.parse(config_path.read_text(), filename=str(config_path))
+    except SyntaxError:
+        return {}
+
+    result: dict[str, int] = {}
+    for node in ast.walk(tree):
+        # AnnAssign: field_name: int = Field(default=<int>, ...)
+        if not isinstance(node, ast.AnnAssign):
+            continue
+        if not isinstance(node.target, ast.Name):
+            continue
+        if not isinstance(node.value, ast.Call):
+            continue
+        for kw in node.value.keywords:
+            if kw.arg == "default" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+                result[node.target.id] = kw.value.value
+                break
+    return result
+
+
+def _tick_interval(
+    cls: ast.ClassDef,
+    module_constants: dict[str, int],
+    config_defaults: dict[str, int],
+) -> int | None:
+    """Resolve the default tick interval for a loop class.
+
+    Resolution order (first match wins):
+
+    1. Class-body attribute assignment ``tick_interval_seconds = <int>``
+       (legacy/test fixture convention).
+    2. ``_get_default_interval`` method that returns an int literal.
+    3. ``_get_default_interval`` method that returns a module-level constant
+       (e.g. ``return _DEFAULT_INTERVAL_SECONDS``).
+    4. ``_get_default_interval`` method that returns ``self._config.<field>``
+       where ``<field>`` has a known default in ``config_defaults``.
+    """
+    # (1) Legacy class attribute used in tests / older loops
     for node in cls.body:
         if not isinstance(node, ast.Assign):
             continue
@@ -45,12 +115,50 @@ def _tick_interval(cls: ast.ClassDef) -> int | None:
                 and isinstance(node.value.value, int)
             ):
                 return node.value.value
+
+    # (2–4) Look inside _get_default_interval
+    for node in cls.body:
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != "_get_default_interval":
+            continue
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Return) or stmt.value is None:
+                continue
+            val = stmt.value
+            # (2) Direct literal: return 14400
+            if isinstance(val, ast.Constant) and isinstance(val.value, int):
+                return val.value
+            # (3) Module-level Name: return _DEFAULT_INTERVAL_SECONDS
+            if isinstance(val, ast.Name) and val.id in module_constants:
+                return module_constants[val.id]
+            # (4) Config attribute: return self._config.field_name
+            if (
+                isinstance(val, ast.Attribute)
+                and isinstance(val.value, ast.Attribute)
+                and isinstance(val.value.value, ast.Name)
+                and val.value.value.id == "self"
+                and val.value.attr == "_config"
+                and val.attr in config_defaults
+            ):
+                return config_defaults[val.attr]
+
     return None
 
 
-def _kill_switch(cls: ast.ClassDef) -> str | None:
-    src = ast.unparse(cls)
-    m = _KILL_RE.search(src)
+def _kill_switch(cls: ast.ClassDef, module_src: str) -> str | None:
+    """Find the HYDRAFLOW_DISABLE_… env-var name for this loop.
+
+    The env-var string can appear in two places:
+
+    * Inline in the class body (e.g. ``os.environ.get("HYDRAFLOW_DISABLE_FOO")``).
+    * A module-level constant ``_KILL_SWITCH_ENV = "HYDRAFLOW_DISABLE_FOO"``
+      that the class body references by name.
+
+    Searching only the class body (``ast.unparse(cls)``) misses the second
+    case.  We search the full module source text instead, which covers both.
+    """
+    m = _KILL_RE.search(module_src)
     return m.group(0) if m else None
 
 
@@ -76,14 +184,17 @@ def extract_loops(src_dir: Path) -> list[LoopInfo]:
     `BaseBackgroundLoop` base class itself is skipped.
     """
     src_dir = Path(src_dir).resolve()
+    config_defaults = _load_config_defaults(src_dir)
     out: list[LoopInfo] = []
     for py in sorted(src_dir.rglob("*.py")):
         if py.name.startswith("_"):
             continue
         try:
-            tree = ast.parse(py.read_text(), filename=str(py))
+            source = py.read_text()
+            tree = ast.parse(source, filename=str(py))
         except SyntaxError:
             continue
+        module_constants = _module_int_constants(tree)
         for node in tree.body:
             if not isinstance(node, ast.ClassDef):
                 continue
@@ -96,9 +207,9 @@ def extract_loops(src_dir: Path) -> list[LoopInfo]:
                     name=node.name,
                     module=_module_for(py, src_dir),
                     source_path=str(py.relative_to(src_dir.parent)),
-                    tick_interval_seconds=_tick_interval(node),
+                    tick_interval_seconds=_tick_interval(node, module_constants, config_defaults),
                     event_subscriptions=_event_subs(node),
-                    kill_switch_var=_kill_switch(node),
+                    kill_switch_var=_kill_switch(node, source),
                     adr_refs=_adr_refs(node, tree),
                 )
             )

--- a/tests/architecture/test_extractor_loops.py
+++ b/tests/architecture/test_extractor_loops.py
@@ -67,3 +67,90 @@ def test_output_is_sorted_by_name(fixture_src_tree):
     )
     names = [loop.name for loop in extract_loops(root / "src")]
     assert names == ["AlphaLoop", "ZebraLoop"]
+
+
+def test_tick_from_get_default_interval_literal(fixture_src_tree):
+    """Tick is extracted from _get_default_interval returning a literal int."""
+    root = fixture_src_tree(
+        {
+            "src/diagram_loop.py": """
+            from base_background_loop import BaseBackgroundLoop
+
+            class DiagramLoop(BaseBackgroundLoop):
+                def _get_default_interval(self) -> int:
+                    # 4 hours
+                    return 14400
+            """,
+        }
+    )
+    loops = extract_loops(root / "src")
+    assert len(loops) == 1
+    assert loops[0].tick_interval_seconds == 14400
+
+
+def test_tick_from_get_default_interval_module_constant(fixture_src_tree):
+    """Tick is extracted from _get_default_interval returning a module-level constant."""
+    root = fixture_src_tree(
+        {
+            "src/merge_loop.py": """
+            from base_background_loop import BaseBackgroundLoop
+
+            _DEFAULT_INTERVAL_SECONDS = 600
+
+            class MergeLoop(BaseBackgroundLoop):
+                def _get_default_interval(self) -> int:
+                    return _DEFAULT_INTERVAL_SECONDS
+            """,
+        }
+    )
+    loops = extract_loops(root / "src")
+    assert len(loops) == 1
+    assert loops[0].tick_interval_seconds == 600
+
+
+def test_tick_from_get_default_interval_config_field(fixture_src_tree):
+    """Tick is extracted from _get_default_interval returning self._config.<field>
+    where the field default is declared in config.py as Field(default=<int>)."""
+    root = fixture_src_tree(
+        {
+            "src/ci_monitor_loop.py": """
+            from base_background_loop import BaseBackgroundLoop
+
+            class CIMonitorLoop(BaseBackgroundLoop):
+                def _get_default_interval(self) -> int:
+                    return self._config.ci_monitor_interval
+            """,
+            "src/config.py": """
+            from pydantic import Field
+
+            class HydraFlowConfig:
+                ci_monitor_interval: int = Field(default=300)
+            """,
+        }
+    )
+    loops = extract_loops(root / "src")
+    assert len(loops) == 1
+    assert loops[0].tick_interval_seconds == 300
+
+
+def test_kill_switch_from_module_level_constant(fixture_src_tree):
+    """Kill switch env var is found even when defined as a module-level constant
+    referenced by name inside the class body (not inlined as a string literal)."""
+    root = fixture_src_tree(
+        {
+            "src/diagram_loop.py": """
+            import os
+            from base_background_loop import BaseBackgroundLoop
+
+            _KILL_SWITCH_ENV = "HYDRAFLOW_DISABLE_DIAGRAM_LOOP"
+
+            class DiagramLoop(BaseBackgroundLoop):
+                def _do_work(self):
+                    if os.environ.get(_KILL_SWITCH_ENV) == "1":
+                        return {"skipped": "kill_switch"}
+            """,
+        }
+    )
+    loops = extract_loops(root / "src")
+    assert len(loops) == 1
+    assert loops[0].kill_switch_var == "HYDRAFLOW_DISABLE_DIAGRAM_LOOP"


### PR DESCRIPTION
## Summary

- Slice #1 audit flagged Tick and Kill Switch columns as `—` on all 41 loops in `docs/arch/generated/loops.md`. Root cause: the AST extractor predicate only matched a `tick_interval_seconds` class attribute that no real loop uses, and searched only the class body for `HYDRAFLOW_DISABLE_` strings while the env var names live at module level.
- Extended `_tick_interval` to resolve all three conventions used in production loops: literal int returns in `_get_default_interval`, module-level constant returns, and `self._config.<field>` returns resolved via a one-time AST scan of `config.py`.
- Extended `_kill_switch` to search the full module source text instead of just the class body unparsed text.

## Result

All 42 loops in `docs/arch/generated/loops.md` now show real Tick values (0 `—` remaining in that column). 3 loops show Kill Switch env vars (`HYDRAFLOW_DISABLE_DIAGRAM_LOOP`, `HYDRAFLOW_DISABLE_COST_BUDGET_WATCHER`, `HYDRAFLOW_DISABLE_PRICING_REFRESH`). The remaining loops use `enabled_cb(worker_name)` for kill-switch control — no env var string, so `—` is correct there.

## Closes

All coverage-gap beads with title containing `missing Generated` (41 loops × 2 cells = 82 beads).

## Test plan

- [x] `make arch-regen` produces non-`—` Tick + Kill cells for loops that expose those.
- [x] `tests/architecture/test_curated_drift.py` passes.
- [x] `tests/architecture/` — 89 passed, 1 skipped, 1 xfailed.
- [x] Four new tests cover all three tick-resolution paths and module-level kill-switch pattern.
- [x] Sample verified: `CIMonitorLoop` Tick=300, `DiagramLoop` Tick=14400 Kill=`HYDRAFLOW_DISABLE_DIAGRAM_LOOP`, `MergeStateWatcherLoop` Tick=600 (from module constant).
- [x] Pre-existing failure `test_build_prompt_truncates_long_body` confirmed present on staging baseline — not introduced by this PR.

🤖 Generated with Claude Code