### PR TITLE
feat(contracts): shadow corpus storage (Phase 0 of #8786)

### DIFF
--- a/src/contracts/shadow.py
+++ b/src/contracts/shadow.py
@@ -1,0 +1,220 @@
+"""Live shadow corpus — Phase 0 of #8786.
+
+Captures real subprocess interactions (gh/git/docker/claude) so a follow-up
+``LiveCorpusReplayLoop`` can diff them against fake-adapter outputs without
+needing a shared sandbox repo. This module owns *storage*; wiring into
+``subprocess_util.run_subprocess`` lives in a separate PR so the surface
+area stays small.
+
+Design constraints from #8786:
+
+- **Bounded**: ``max_per_adapter`` caps the corpus by per-adapter LRU on
+  file mtime. One sample per (adapter, command, args) shape — repeated
+  invocations overwrite the same file (most recent wins).
+- **Normalized**: every persisted ``stdout`` / ``stderr`` passes through
+  the existing cassette normalizers (``pr_number``, ``sha:short``,
+  ``sha:long``, ``timestamps.ISO8601``) so volatile fields collapse to
+  stable tokens before persistence.
+- **PII-scrubbed**: defence in depth above normalizers — emails, GitHub
+  PAT tokens, and basic-auth credentials in URLs are redacted before the
+  bytes hit disk. Other tokens (Slack, SSH keys, etc.) can be added as
+  the corpus grows; the test suite documents the supported scrubs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+import yaml
+
+from contracts._schema import apply_normalizers
+
+logger = logging.getLogger("hydraflow.contracts.shadow")
+
+# Adapters the shadow corpus knows how to label. Keep aligned with the
+# cassette schema's ``_KNOWN_ADAPTERS`` plus ``claude`` (whose contract
+# fixtures are JSONL streams; this module handles command-shaped calls).
+Adapter = Literal["github", "git", "docker", "claude"]
+_KNOWN_ADAPTERS: frozenset[str] = frozenset({"github", "git", "docker", "claude"})
+
+# Normalizers applied to every persisted stdout/stderr. Order matches
+# ``contracts._schema.NORMALIZERS`` — sha:long before sha:short so the
+# 40-char hashes aren't half-consumed by the 7-12 char rule.
+_DEFAULT_NORMALIZERS: tuple[str, ...] = (
+    "pr_number",
+    "timestamps.ISO8601",
+    "sha:long",
+    "sha:short",
+)
+
+# PII scrub regexes. Applied after normalizers, before write. Each rule is
+# (compiled regex, replacement token). Patterns are deliberately
+# conservative to avoid over-redacting legitimate output.
+_EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
+_GH_TOKEN_RE = re.compile(r"\bgh[psoru]_[A-Za-z0-9]{20,}\b")
+_BASIC_AUTH_RE = re.compile(r"://[^/\s@]+:[^/\s@]+@")
+_PII_RULES: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Basic-auth in URLs must scrub first — the email regex would otherwise
+    # grab ``user:secrettoken@host`` and mask the credential as ``<EMAIL>``,
+    # losing the "this was a credential" signal in the persisted sample.
+    (_BASIC_AUTH_RE, "://<CREDS>@"),
+    (_GH_TOKEN_RE, "<GH_TOKEN>"),
+    (_EMAIL_RE, "<EMAIL>"),
+)
+
+
+@dataclass(frozen=True)
+class ShadowSample:
+    """One live-recorded subprocess interaction (in-memory view)."""
+
+    adapter: str
+    command: str
+    args: list[str]
+    exit_code: int
+    stdout: str
+    stderr: str
+    sampled_at: str
+    call_hash: str
+
+
+def _scrub(text: str) -> str:
+    """Apply normalizers then PII rules. Idempotent."""
+    text = apply_normalizers(text, list(_DEFAULT_NORMALIZERS))
+    for pattern, token in _PII_RULES:
+        text = pattern.sub(token, text)
+    return text
+
+
+def _call_hash(adapter: str, command: str, args: list[str]) -> str:
+    """Stable 12-hex-char digest of the call shape.
+
+    Deterministic on (adapter, command, args) so repeated invocations of
+    the same shape land at the same path. Truncated to 12 chars — the
+    corpus is small enough that collision odds are negligible at that
+    width (~1 in 2^48).
+    """
+    raw = "\n".join([adapter, command, *args]).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:12]
+
+
+class ShadowCorpus:
+    """Bounded, normalized, PII-scrubbed storage for live subprocess samples."""
+
+    def __init__(self, root: Path, *, max_per_adapter: int = 100) -> None:
+        if max_per_adapter < 1:
+            msg = f"max_per_adapter must be >= 1, got {max_per_adapter}"
+            raise ValueError(msg)
+        self._root = root
+        self._max_per_adapter = max_per_adapter
+
+    def record(
+        self,
+        *,
+        adapter: str,
+        command: str,
+        args: list[str],
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+    ) -> Path | None:
+        """Persist one sample and return its path.
+
+        Returns ``None`` if persistence is skipped for any reason — the
+        caller treats that as "no observation this tick" rather than an
+        error. Unknown adapters are a programming bug, not a runtime
+        condition, so they raise.
+        """
+        if adapter not in _KNOWN_ADAPTERS:
+            msg = (
+                f"unknown adapter {adapter!r}; expected one of "
+                f"{sorted(_KNOWN_ADAPTERS)}"
+            )
+            raise ValueError(msg)
+
+        adapter_dir = self._root / adapter
+        adapter_dir.mkdir(parents=True, exist_ok=True)
+
+        call_hash = _call_hash(adapter, command, args)
+        path = adapter_dir / f"{call_hash}.yaml"
+
+        payload = {
+            "adapter": adapter,
+            "command": command,
+            "args": list(args),
+            "sampled_at": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "call_hash": call_hash,
+            "output": {
+                "exit_code": exit_code,
+                "stdout": _scrub(stdout),
+                "stderr": _scrub(stderr),
+            },
+        }
+        try:
+            with path.open("w", encoding="utf-8") as fh:
+                yaml.safe_dump(payload, fh, sort_keys=False, default_flow_style=False)
+        except OSError as exc:
+            logger.warning("shadow corpus: failed to persist %s: %s", path, exc)
+            return None
+
+        self._prune(adapter)
+        return path
+
+    def list(self, *, adapter: str | None = None) -> list[Path]:
+        """Enumerate samples; if ``adapter`` is None, return every adapter's."""
+        if adapter is not None:
+            if adapter not in _KNOWN_ADAPTERS:
+                msg = f"unknown adapter {adapter!r}"
+                raise ValueError(msg)
+            adapter_dir = self._root / adapter
+            if not adapter_dir.is_dir():
+                return []
+            return sorted(adapter_dir.glob("*.yaml"))
+        out: list[Path] = []
+        for name in sorted(_KNOWN_ADAPTERS):
+            adapter_dir = self._root / name
+            if adapter_dir.is_dir():
+                out.extend(sorted(adapter_dir.glob("*.yaml")))
+        return out
+
+    def load(self, path: Path) -> ShadowSample:
+        """Parse a persisted YAML back into a typed ShadowSample."""
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        output = raw.get("output") or {}
+        return ShadowSample(
+            adapter=str(raw["adapter"]),
+            command=str(raw["command"]),
+            args=list(raw.get("args") or []),
+            exit_code=int(output.get("exit_code", 0)),
+            stdout=str(output.get("stdout", "")),
+            stderr=str(output.get("stderr", "")),
+            sampled_at=str(raw.get("sampled_at", "")),
+            call_hash=str(raw.get("call_hash", "")),
+        )
+
+    def _prune(self, adapter: str) -> int:
+        """LRU-evict oldest samples in ``adapter`` until count <= cap.
+
+        Returns the number of files evicted (0 if under cap). Uses mtime
+        as the LRU signal — the most-recently-recorded shape wins.
+        """
+        adapter_dir = self._root / adapter
+        if not adapter_dir.is_dir():
+            return 0
+        samples = sorted(adapter_dir.glob("*.yaml"), key=lambda p: p.stat().st_mtime)
+        excess = len(samples) - self._max_per_adapter
+        if excess <= 0:
+            return 0
+        evicted = 0
+        for victim in samples[:excess]:
+            try:
+                victim.unlink()
+                evicted += 1
+            except OSError as exc:
+                logger.warning("shadow corpus: failed to evict %s: %s", victim, exc)
+        return evicted

--- a/tests/test_contract_shadow.py
+++ b/tests/test_contract_shadow.py
@@ -1,0 +1,371 @@
+"""Unit tests for the live-shadow corpus (Phase 0 of #8786).
+
+The shadow corpus captures real subprocess interactions (gh/git/docker/claude)
+so a follow-up ``LiveCorpusReplayLoop`` can diff them against fake-adapter
+outputs without needing a sandbox repo. This file pins the storage shape,
+normalizer + PII contracts, and LRU behaviour — wiring into
+``subprocess_util.run_subprocess`` lives in a separate PR.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Storage shape
+# ---------------------------------------------------------------------------
+
+
+def test_record_creates_yaml_at_adapter_subdir(tmp_path: Path) -> None:
+    """One sample per (adapter, command, args) lives at
+    ``<root>/<adapter>/<call_hash>.yaml`` so the corpus is easy to enumerate."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "42", "--json", "state,mergeable"],
+        stdout='{"state":"OPEN","mergeable":"MERGEABLE"}\n',
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    assert path.parent == tmp_path / "github"
+    assert path.suffix == ".yaml"
+    assert path.exists()
+
+
+def test_record_round_trips_via_yaml(tmp_path: Path) -> None:
+    """The persisted YAML matches the documented schema (adapter/command/args/
+    output blocks) so a future replay loop can load and dispatch."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="git",
+        command="git",
+        args=["commit", "-m", "test"],
+        stdout="[main abc1234] test\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert loaded["adapter"] == "git"
+    assert loaded["command"] == "git"
+    assert loaded["args"] == ["commit", "-m", "test"]
+    assert loaded["output"]["exit_code"] == 0
+    assert "stdout" in loaded["output"]
+
+
+def test_record_rejects_unknown_adapter(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    with pytest.raises(ValueError, match="adapter"):
+        corpus.record(
+            adapter="bigquery",  # not one of github|git|docker|claude
+            command="bq",
+            args=["query"],
+            stdout="",
+            stderr="",
+            exit_code=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic hashing — same call shape overwrites same file
+# ---------------------------------------------------------------------------
+
+
+def test_same_call_shape_overwrites_same_file(tmp_path: Path) -> None:
+    """The call_hash is deterministic on (adapter, command, args). Two
+    invocations of the same shape write to the same path — most recent
+    wins. This is what makes the corpus bounded by call-shape variety
+    rather than call frequency."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    first = corpus.record(
+        adapter="git",
+        command="git",
+        args=["status", "--porcelain"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    second = corpus.record(
+        adapter="git",
+        command="git",
+        args=["status", "--porcelain"],
+        stdout=" M file.py\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert first == second
+    loaded = yaml.safe_load(second.read_text(encoding="utf-8"))
+    assert loaded["output"]["stdout"] == " M file.py\n"
+
+
+def test_distinct_args_produce_distinct_files(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    a = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "1"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    b = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "2"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    assert a != b
+
+
+# ---------------------------------------------------------------------------
+# Normalizers — collapse volatile fields before persisting
+# ---------------------------------------------------------------------------
+
+
+def test_record_applies_pr_number_normalizer(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "42"],
+        stdout="https://github.com/org/repo/pull/42\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "<PR_NUMBER>" in loaded["output"]["stdout"]
+    assert "/pull/42" not in loaded["output"]["stdout"]
+
+
+def test_record_applies_iso8601_normalizer(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["issue", "view", "1"],
+        stdout='{"updatedAt": "2026-05-13T01:23:45Z"}\n',
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "<ISO8601>" in loaded["output"]["stdout"]
+
+
+def test_record_applies_sha_short_normalizer(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="git",
+        command="git",
+        args=["commit", "-m", "x"],
+        stdout="[main 1a2b3c4] x\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "<SHORT_SHA>" in loaded["output"]["stdout"]
+
+
+# ---------------------------------------------------------------------------
+# PII scrub — defence in depth above normalizers
+# ---------------------------------------------------------------------------
+
+
+def test_record_scrubs_email_pii(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="git",
+        command="git",
+        args=["log", "-1"],
+        stdout="Author: Jane Doe <jane.doe@example.com>\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    stdout = loaded["output"]["stdout"]
+    assert "jane.doe@example.com" not in stdout
+    assert "<EMAIL>" in stdout
+
+
+def test_record_scrubs_github_token(tmp_path: Path) -> None:
+    """A leaked PAT in stdout must be redacted before persistence."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["auth", "status"],
+        stdout="Token: ghp_AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPp1234\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    stdout = loaded["output"]["stdout"]
+    assert "ghp_AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPp1234" not in stdout
+    assert "<GH_TOKEN>" in stdout
+
+
+def test_record_scrubs_basic_auth_in_url(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="git",
+        command="git",
+        args=["remote", "-v"],
+        stdout="origin\thttps://user:secrettoken@github.com/x/y.git (fetch)\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    stdout = loaded["output"]["stdout"]
+    assert "secrettoken" not in stdout
+    assert "<CREDS>" in stdout
+
+
+# ---------------------------------------------------------------------------
+# LRU bounding
+# ---------------------------------------------------------------------------
+
+
+def test_lru_evicts_oldest_when_over_limit(tmp_path: Path) -> None:
+    """``max_per_adapter`` bounds total samples per adapter. Once the cap is
+    hit, the next record evicts the least-recently-written sample."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path, max_per_adapter=3)
+    paths: list[Path] = []
+    for i in range(5):
+        p = corpus.record(
+            adapter="git",
+            command="git",
+            args=["log", "--oneline", "-n", str(i)],
+            stdout="",
+            stderr="",
+            exit_code=0,
+        )
+        assert p is not None
+        paths.append(p)
+
+    # 5 distinct call shapes → 5 distinct files attempted. Only the most
+    # recent 3 survive.
+    surviving = list((tmp_path / "git").glob("*.yaml"))
+    assert len(surviving) == 3, (
+        f"expected 3 surviving samples after LRU eviction, got {len(surviving)}"
+    )
+    # The first two should be gone.
+    assert paths[0] not in surviving
+    assert paths[1] not in surviving
+    # The last three should be present.
+    for p in paths[2:]:
+        assert p in surviving
+
+
+def test_lru_is_per_adapter(tmp_path: Path) -> None:
+    """One adapter hitting its cap must not evict samples from another."""
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path, max_per_adapter=2)
+    git_p = corpus.record(
+        adapter="git",
+        command="git",
+        args=["status"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    for i in range(3):
+        corpus.record(
+            adapter="github",
+            command="gh",
+            args=["pr", "view", str(i)],
+            stdout="",
+            stderr="",
+            exit_code=0,
+        )
+    assert git_p is not None and git_p.exists()
+    assert len(list((tmp_path / "github").glob("*.yaml"))) == 2
+
+
+# ---------------------------------------------------------------------------
+# Enumeration / loading
+# ---------------------------------------------------------------------------
+
+
+def test_list_filters_by_adapter(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    corpus.record(
+        adapter="git",
+        command="git",
+        args=["status"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "1"],
+        stdout="",
+        stderr="",
+        exit_code=0,
+    )
+    git_paths = corpus.list(adapter="git")
+    assert len(git_paths) == 1
+    assert git_paths[0].parent.name == "git"
+    all_paths = corpus.list()
+    assert len(all_paths) == 2
+
+
+def test_load_round_trips_a_sample(tmp_path: Path) -> None:
+    from contracts.shadow import ShadowCorpus
+
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter="git",
+        command="git",
+        args=["status", "--porcelain"],
+        stdout=" M src/x.py\n",
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    sample = corpus.load(path)
+    assert sample.adapter == "git"
+    assert sample.command == "git"
+    assert sample.args == ["status", "--porcelain"]
+    assert sample.exit_code == 0
+    assert sample.stdout == " M src/x.py\n"


### PR DESCRIPTION
## Summary

Foundation for the **live-shadow contract pattern** that will replace hand-authored github cassettes with continuous production sampling. Closes acceptance criterion #2 of #8786 (shadow corpus storage bounded, normalized, PII-scrubbed); other phases follow up against the same issue.

## Scope

This PR ships **storage only**. The surface area is deliberately small so the wiring into `subprocess_util.run_subprocess` (one entry point in prod code) and the `LiveCorpusReplayLoop` (one new background loop) land as follow-ups, each independently reviewable.

## What's here

`src/contracts/shadow.py`:
- **`ShadowCorpus`** — bounded, normalized, PII-scrubbed YAML storage.
- **`ShadowSample`** — typed in-memory view for the eventual replay loop.
- Deterministic `call_hash(adapter, command, args)` — same call shape overwrites the same file; corpus is bounded by call-shape variety, not call frequency.
- LRU eviction per-adapter on mtime; default cap 100 / adapter.
- **Normalizers** applied via existing `contracts._schema.apply_normalizers`: `pr_number`, `timestamps.ISO8601`, `sha:long`, `sha:short`.
- **PII scrub** applied after normalizers: basic-auth URLs (`user:token@host`), GitHub PATs (`gh[psoru]_…`), emails. Order matters — basic-auth scrubs first so `user:token@host` keeps the credential signal instead of being miscategorised as an email.

`tests/test_contract_shadow.py` — **15 unit tests** covering:
- Storage shape + YAML round-trip
- Deterministic hashing (same shape → same file, distinct args → distinct files)
- Each normalizer (pr_number, ISO8601, sha:short)
- Each PII rule (email, GH PAT, basic-auth)
- Per-adapter LRU eviction + isolation between adapters
- `list()` + `load()` round-trip

## Out of scope (separate PRs against #8786)

- **Phase 0 part 2**: wire the sampler into `subprocess_util.run_subprocess` (one call site)
- **Phase 1**: Pydantic-typed I/O boundary shapes (`src/contracts/shapes.py`)
- **Phase 2**: `LiveCorpusReplayLoop` skeleton (registered loop, scenario-tested)
- **Phase 3**: auto-repair chain (regen-stub PR → auto-agent → escalation)
- **Phase 4**: retire hand-authored github cassettes

## Test plan

- [x] `tests/test_contract_shadow.py` — 15 tests, all green
- [x] ruff + pyright clean on touched files
- [x] No existing tests touched; no behaviour change in any currently-running code path

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)