### PR TITLE
feat(subprocess): opt-in shadow sampling hook (Phase 0.2 of #8786)

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -22,6 +22,62 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hydraflow.subprocess")
 
 # ---------------------------------------------------------------------------
+# Shadow sampling hook (#8786 Phase 0.2)
+#
+# When a sampler is installed via :func:`set_shadow_sampler`, every
+# completed ``gh`` / ``git`` / ``docker`` / ``claude`` call feeds it the
+# (adapter, command, args, stdout, stderr, exit_code) tuple. Sampler
+# failures are caught and logged — they MUST NOT break the production
+# call path. Default is None (no sampling).
+# ---------------------------------------------------------------------------
+_ShadowSampler = Callable[..., object]
+_shadow_sampler: _ShadowSampler | None = None
+
+_ADAPTER_BY_COMMAND: dict[str, str] = {
+    "gh": "github",
+    "git": "git",
+    "docker": "docker",
+    "claude": "claude",
+}
+
+
+def set_shadow_sampler(sampler: _ShadowSampler | None) -> None:
+    """Install (or clear with None) the shadow-corpus sampling hook.
+
+    The sampler is invoked with keyword args
+    ``adapter, command, args, stdout, stderr, exit_code`` after every
+    completed call to ``gh``/``git``/``docker``/``claude``. Non-adapter
+    binaries (npm, ruff, …) are skipped. The sampler runs synchronously
+    inside ``run_subprocess`` but exceptions are swallowed — observability
+    must never break the production call path.
+    """
+    global _shadow_sampler  # noqa: PLW0603
+    _shadow_sampler = sampler
+
+
+def _maybe_sample_shadow(
+    cmd: tuple[str, ...], exit_code: int, stdout: str, stderr: str
+) -> None:
+    """Fire the shadow sampler (if installed) for known adapter commands."""
+    if _shadow_sampler is None or not cmd:
+        return
+    adapter = _ADAPTER_BY_COMMAND.get(cmd[0])
+    if adapter is None:
+        return
+    try:
+        _shadow_sampler(
+            adapter=adapter,
+            command=cmd[0],
+            args=list(cmd[1:]),
+            stdout=stdout,
+            stderr=stderr,
+            exit_code=exit_code,
+        )
+    except Exception:  # noqa: BLE001 — observability must never break the call path
+        logger.warning("shadow sampler raised; ignoring", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
 # Pluggable time source — allows tests to inject FakeClock without patching
 # stdlib. Production code always uses time.time. Only the rate-limit cooldown
 # logic calls _time_source(); all other timing calls are left untouched.
@@ -479,6 +535,10 @@ async def run_subprocess(
                 f"Command {cmd!r} timed out after {timeout}s"
             ) from exc
         if result.returncode != 0:
+            # Sample the failure shape too — a loop that branches on a
+            # specific stderr (404, "not found", auth errors) needs that
+            # shape protected against drift just as much as success.
+            _maybe_sample_shadow(cmd, result.returncode, result.stdout, result.stderr)
             msg = f"Command {cmd!r} failed (rc={result.returncode}): {result.stderr}"
             cause = subprocess.CalledProcessError(
                 result.returncode,
@@ -492,6 +552,7 @@ async def run_subprocess(
                 _trigger_rate_limit_cooldown()
             raise RuntimeError(msg) from cause
         _reset_rate_limit_backoff()
+        _maybe_sample_shadow(cmd, result.returncode, result.stdout, result.stderr)
         return result.stdout
 
     if use_semaphore:

--- a/tests/test_subprocess_util_shadow_sampling.py
+++ b/tests/test_subprocess_util_shadow_sampling.py
@@ -1,0 +1,198 @@
+"""Tests for the shadow-sampling hook in subprocess_util (Phase 0.2 of #8786).
+
+The hook is opt-in: when ``set_shadow_sampler(None)`` (the default), nothing
+changes. When a sampler is installed, every ``gh``/``git``/``docker``/``claude``
+call feeds it the (adapter, command, args, stdout, stderr, exit_code) tuple
+after the subprocess returns — successes AND failures, because the failure
+shape itself is part of the contract.
+
+Critically: a sampler that raises must NEVER fail the subprocess call.
+That's the whole point of "non-blocking observability".
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from execution import SimpleResult
+
+
+class _StubRunner:
+    """Minimal SubprocessRunner stub: returns a canned SimpleResult."""
+
+    def __init__(
+        self, *, stdout: str = "", stderr: str = "", returncode: int = 0
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self._returncode = returncode
+
+    async def run_simple(
+        self,
+        cmd: Sequence[str],
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout: float = 120.0,
+        input: bytes | None = None,  # noqa: A002
+    ) -> SimpleResult:
+        del cmd, cwd, env, timeout, input
+        return SimpleResult(
+            stdout=self._stdout,
+            stderr=self._stderr,
+            returncode=self._returncode,
+        )
+
+    async def create_streaming_process(
+        self, *_a: Any, **_k: Any
+    ) -> Any:  # pragma: no cover
+        raise NotImplementedError
+
+    async def cleanup(self) -> None:  # pragma: no cover
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _reset_sampler() -> Any:
+    """Ensure each test starts/ends with no sampler installed."""
+    from subprocess_util import set_shadow_sampler
+
+    set_shadow_sampler(None)
+    yield
+    set_shadow_sampler(None)
+
+
+class _RecordingSampler:
+    """Captures every sample call without persisting anything."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self,
+        *,
+        adapter: str,
+        command: str,
+        args: list[str],
+        stdout: str,
+        stderr: str,
+        exit_code: int,
+    ) -> Path | None:
+        self.calls.append(
+            {
+                "adapter": adapter,
+                "command": command,
+                "args": args,
+                "stdout": stdout,
+                "stderr": stderr,
+                "exit_code": exit_code,
+            }
+        )
+        return None
+
+
+@pytest.mark.asyncio
+async def test_no_sampling_when_sampler_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default (no sampler installed) — run_subprocess is a no-op for shadow."""
+    from subprocess_util import run_subprocess
+
+    runner = _StubRunner(stdout="ok\n")
+    result = await run_subprocess("gh", "pr", "view", "1", runner=runner)
+    assert result == "ok\n"
+    # The sampler is None; nothing to assert beyond "the call succeeded".
+
+
+@pytest.mark.asyncio
+async def test_sampler_called_on_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When installed, the sampler sees the adapter, args, stdout, exit_code=0."""
+    from subprocess_util import run_subprocess, set_shadow_sampler
+
+    sampler = _RecordingSampler()
+    set_shadow_sampler(sampler)
+    runner = _StubRunner(stdout='{"state":"OPEN"}\n')
+
+    await run_subprocess("gh", "pr", "view", "42", "--json", "state", runner=runner)
+
+    assert len(sampler.calls) == 1
+    call = sampler.calls[0]
+    assert call["adapter"] == "github"
+    assert call["command"] == "gh"
+    assert call["args"] == ["pr", "view", "42", "--json", "state"]
+    assert call["stdout"] == '{"state":"OPEN"}\n'
+    assert call["exit_code"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sampler_called_on_failure() -> None:
+    """Failures are sampled too — the failure shape IS part of the contract.
+    A loop that depends on a specific stderr for a 404 path needs that
+    shape protected against drift just as much as the success path."""
+    from subprocess_util import run_subprocess, set_shadow_sampler
+
+    sampler = _RecordingSampler()
+    set_shadow_sampler(sampler)
+    runner = _StubRunner(stdout="", stderr="not found\n", returncode=1)
+
+    with pytest.raises(RuntimeError):
+        await run_subprocess("gh", "pr", "view", "99999", runner=runner)
+
+    assert len(sampler.calls) == 1
+    assert sampler.calls[0]["exit_code"] == 1
+    assert sampler.calls[0]["stderr"] == "not found\n"
+
+
+@pytest.mark.asyncio
+async def test_sampler_failure_does_not_break_subprocess() -> None:
+    """A sampler that raises must not propagate — observability never breaks
+    the production call path."""
+    from subprocess_util import run_subprocess, set_shadow_sampler
+
+    def angry_sampler(**_kw: Any) -> Path | None:
+        raise RuntimeError("disk full")
+
+    set_shadow_sampler(angry_sampler)
+    runner = _StubRunner(stdout="ok\n")
+    # Must succeed despite the sampler raising.
+    result = await run_subprocess("git", "status", runner=runner)
+    assert result == "ok\n"
+
+
+@pytest.mark.asyncio
+async def test_unknown_command_not_sampled() -> None:
+    """Only known adapters (gh/git/docker/claude) feed the corpus; other
+    binaries (npm, ruff, …) are skipped — they're not contract surfaces."""
+    from subprocess_util import run_subprocess, set_shadow_sampler
+
+    sampler = _RecordingSampler()
+    set_shadow_sampler(sampler)
+    runner = _StubRunner(stdout="")
+
+    await run_subprocess("npm", "install", runner=runner)
+    await run_subprocess("ruff", "check", runner=runner)
+
+    assert sampler.calls == [], "non-adapter commands must not feed the shadow corpus"
+
+
+@pytest.mark.asyncio
+async def test_adapter_inferred_per_command() -> None:
+    """gh→github, git→git, docker→docker, claude→claude."""
+    from subprocess_util import run_subprocess, set_shadow_sampler
+
+    sampler = _RecordingSampler()
+    set_shadow_sampler(sampler)
+    runner = _StubRunner(stdout="")
+
+    for cmd0, _expected in (
+        ("gh", "github"),
+        ("git", "git"),
+        ("docker", "docker"),
+        ("claude", "claude"),
+    ):
+        await run_subprocess(cmd0, "version", runner=runner)
+
+    adapters = [c["adapter"] for c in sampler.calls]
+    assert adapters == ["github", "git", "docker", "claude"]


### PR DESCRIPTION
## Summary

Phase 0.2 of #8786. Wires a single observability hook into `run_subprocess` so production `gh`/`git`/`docker`/`claude` calls feed a shadow corpus when one is installed. Combined with #8822 (storage layer), this completes the data-capture half of the live shadow contract pattern.

Stacked on top of #8822 logically (uses `ShadowCorpus.record`-shaped callable) but mechanically independent — no import dependency.

## What's here

- **`set_shadow_sampler(sampler | None)`** — module-level install/clear. Default `None` (off).
- **`_maybe_sample_shadow(...)`** — fired inside `_exec` for both success and failure paths. Adapter inferred from `cmd[0]`; non-adapter binaries (npm, ruff, pyright) skipped.
- Sampler raising is **swallowed + logged**, never propagated. Observability must not break the call path.

## Why both success + failure paths get sampled

A loop that branches on a specific stderr (404, auth errors, rate-limit messages) needs that failure shape protected against drift just as much as the happy path. The current cassette pattern under-covers failure shapes; this hook fixes that for free.

## Test plan

`tests/test_subprocess_util_shadow_sampling.py` — 6 tests:
- [x] No sampling when sampler unset (default behavior preserved)
- [x] Sampler called on success with full call shape
- [x] Sampler called on failure (RuntimeError raised AND sample captured)
- [x] Sampler raising does NOT break the subprocess call
- [x] Non-adapter binaries (npm, ruff) skipped
- [x] Adapter inference for gh / git / docker / claude

Existing `tests/test_subprocess_util.py` — 97 tests still green. Total 103 / 103.

ruff + pyright clean on touched files.

## Out of scope (next PRs against #8786)

- Register the corpus + sampler at orchestrator startup (`service_registry`)
- `LiveCorpusReplayLoop` skeleton + scenario test
- Pydantic-typed I/O boundary shapes
- Auto-repair chain
- Retire hand-authored github cassettes

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)