### PR TITLE
docs(adr): promote 0031 and 0047 to Accepted

### DIFF
--- a/docs/adr/0031-product-track-architecture.md
+++ b/docs/adr/0031-product-track-architecture.md
@@ -1,6 +1,7 @@
 # ADR-0031: Product Track Architecture — Discover and Shape Phases
 
-**Status:** Proposed
+**Status:** Accepted
+**Accepted on:** 2026-05-12 — promoted after slice #5 audit confirmed live production usage.
 **Date:** 2026-04-04
 
 ## Context

--- a/docs/adr/0047-fake-adapter-contract-testing-cassettes.md
+++ b/docs/adr/0047-fake-adapter-contract-testing-cassettes.md
@@ -1,6 +1,7 @@
 # ADR-0047: Fake-adapter contract testing via cassette record/replay
 
-- **Status:** Proposed
+- **Status:** Accepted
+- **Accepted on:** 2026-05-12 — promoted after slice #5 audit confirmed live production usage.
 - **Date:** 2026-04-23
 - **Supersedes:** none
 - **Superseded by:** none


### PR DESCRIPTION
## Summary

Slice 5.7 + 5.9 audits found ADR-0031 and ADR-0047 still tagged Proposed despite full production implementations. This promotes both to Accepted with a dated note.

## Test plan
- [ ] adr-validator (if any) still passes.

🤖 Generated with Claude Code