### PR TITLE
fix(arch): functional_areas.yml module paths + CI validation

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T19:04:02.172156+00:00",
-  "commit_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43",
+  "regenerated_at": "2026-05-18T21:24:47.528567+00:00",
+  "commit_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167",
   "artifacts": {
     "loops.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "ports.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "labels.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "modules.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "events.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "adr_xref.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "mockworld.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "changelog.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "coverage_matrix.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "functional_areas.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "ubiquitous-language.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
+      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
     }
   }
 }

--- a/docs/arch/functional_areas.yml
+++ b/docs/arch/functional_areas.yml
@@ -106,7 +106,7 @@ areas:
     modules:
       - src/state/**
       - src/events.py
-      - src/session_log.py
+      - src/state/_session.py
     related_adrs: ['0021', '0028']
 
   test_harness:
@@ -183,12 +183,11 @@ areas:
     modules:
       - src/orchestrator.py
       - src/agent.py
-      - src/agent_runner.py
       - src/planner.py
       - src/reviewer.py
       - src/triage_phase.py
       - src/plan_phase.py
       - src/implement_phase.py
-      - src/review_phase.py
+      - src/review_phase/
       - src/hitl_phase.py
     related_adrs: ['0001', '0004', '0011', '0012', '0029']

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `e6dad0c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `316e16c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `57291d2` — fix(arch): functional_areas.yml module paths + add CI validation *(2026-05-18)*
+- `0c8243a` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `84b64fd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `b714ab0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `dc79b3f` — chore(arch): regen arch artifacts from rebased staging tip *(2026-05-18)*
@@ -306,4 +308,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -182,7 +182,7 @@ Crash-recovery state (StateTracker), event bus, session logs, and the on-disk la
 
 - `src/state/**`
 - `src/events.py`
-- `src/session_log.py`
+- `src/state/_session.py`
 
 **Related ADRs:** `ADR-0021`, `ADR-0028`
 
@@ -265,16 +265,15 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 
 - `src/orchestrator.py`
 - `src/agent.py`
-- `src/agent_runner.py`
 - `src/planner.py`
 - `src/reviewer.py`
 - `src/triage_phase.py`
 - `src/plan_phase.py`
 - `src/implement_phase.py`
-- `src/review_phase.py`
+- `src/review_phase/`
 - `src/hitl_phase.py`
 
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._
+_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._

--- a/tests/architecture/test_functional_area_coverage.py
+++ b/tests/architecture/test_functional_area_coverage.py
@@ -77,8 +77,8 @@ def test_functional_areas_modules_paths_exist(real_repo_root: Path):
                 missing.append(path)
 
     assert not missing, (
-        f"Bad modules: paths in docs/arch/functional_areas.yml "
-        f"(paths that don't exist on disk):\n  " + "\n  ".join(sorted(missing))
+        "Bad modules: paths in docs/arch/functional_areas.yml "
+        "(paths that don't exist on disk):\n  " + "\n  ".join(sorted(missing))
     )
 
 

--- a/tests/architecture/test_functional_area_coverage.py
+++ b/tests/architecture/test_functional_area_coverage.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from arch._functional_areas_schema import load_functional_areas
 from arch.extractors.loops import extract_loops
@@ -54,6 +55,31 @@ def test_every_port_is_assigned_to_an_area(real_repo_root: Path):
             + "\n  ".join(sorted(missing))
             + "\n\nFix: edit docs/arch/functional_areas.yml `ports:` lists."
         )
+
+
+def test_functional_areas_modules_paths_exist(real_repo_root: Path):
+    """Every literal (non-glob) path in a modules: list must exist on disk.
+
+    Glob patterns (containing '*') are exempt — they are validated at
+    generation time by the extractor, not here.
+    """
+    yaml_path = real_repo_root / "docs/arch/functional_areas.yml"
+    if not yaml_path.exists():
+        pytest.skip("docs/arch/functional_areas.yml not yet authored")
+
+    data = yaml.safe_load(yaml_path.read_text())
+    missing: list[str] = []
+    for area in data.get("areas", {}).values():
+        for path in area.get("modules", []):
+            if "*" in path:
+                continue  # glob — skip literal-existence check
+            if not (real_repo_root / path).exists():
+                missing.append(path)
+
+    assert not missing, (
+        f"Bad modules: paths in docs/arch/functional_areas.yml "
+        f"(paths that don't exist on disk):\n  " + "\n  ".join(sorted(missing))
+    )
 
 
 def test_no_phantom_assignments(real_repo_root: Path):


### PR DESCRIPTION
## Summary

Slices 5.6 + 5.10 flagged 3 bad module paths in `docs/arch/functional_areas.yml` that CI never validated because the existing tests only check `loops:` and `ports:` keys, not `modules:`.

- `src/session_log.py` → `src/state/_session.py` (session logic moved to state package)
- `src/agent_runner.py` → removed duplicate; entry was an alias for `src/agent.py` which was already listed
- `src/review_phase.py` → `src/review_phase/` (module promoted to a package)

Adds `test_functional_areas_modules_paths_exist` to `tests/architecture/test_functional_area_coverage.py`. The test asserts every literal (non-glob) path in any `modules:` list exists on disk. Glob patterns are skipped since those are validated at generation time.

## Test plan
- [x] New test passes with corrected paths.
- [x] All 4 existing functional-area coverage tests still pass.
- [ ] Full `make quality` on CI.

🤖 Generated with Claude Code