### PR TITLE
test(contracts): FakeGitHub cassettes for CIMonitor methods

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T21:25:43.963462+00:00",
-  "commit_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50",
+  "regenerated_at": "2026-05-18T22:37:16.550192+00:00",
+  "commit_sha": "5489df25154f4ba1aa10854437b58ed364441961",
   "artifacts": {
     "loops.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "ports.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "labels.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "modules.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "events.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "adr_xref.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "mockworld.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "changelog.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "coverage_matrix.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "functional_areas.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "ubiquitous-language.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "9a44abbf176f14828b017ad1d14fbcb4eeeeca50"
+      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `9a44abb` — fix(format): ruff format *(2026-05-18)*
+- `5489df2` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `bf90023` — fix(format): ruff format *(2026-05-18)*
 - `2ff5ebd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `60c556b` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `a0fd1b9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -311,4 +312,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `9a44abb` on 2026-05-18 21:25 UTC. Source last changed at `9a44abb`. Status: 🟢 fresh._
+_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._

--- a/tests/trust/contracts/cassettes/github/create_issue.yaml
+++ b/tests/trust/contracts/cassettes/github/create_issue.yaml
@@ -1,0 +1,23 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# create_issue returns the new issue number. When the fake's _issues store is
+# empty, max(keys, default=9000) + 1 = 9001. stdout follows the same URL
+# convention as create_task so the contract is checkable and consistent with
+# `gh issue create --json url` output shape.
+adapter: github
+interaction: create_issue
+recorded_at: "2026-05-12T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: create_issue
+  args:
+    - "[CI] Main branch CI is failing (failure)"
+    - "CI failure body."
+    - "hydraflow-ci-failure"
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: "https://github.com/test-org/test-repo/issues/9001\n"
+  stderr: ""
+normalizers: []

--- a/tests/trust/contracts/cassettes/github/get_latest_ci_status.yaml
+++ b/tests/trust/contracts/cassettes/github/get_latest_ci_status.yaml
@@ -1,0 +1,20 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# get_latest_ci_status returns the (conclusion, url) tuple for main-branch CI.
+# The default FakeGitHub._ci_main_status is ("success", "") — no prior
+# set_ci_main_status call. stdout encodes "conclusion\nurl\n" so that
+# the dispatcher can be verified against the real `gh run list` shape.
+adapter: github
+interaction: get_latest_ci_status
+recorded_at: "2026-05-12T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: get_latest_ci_status
+  args: []
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: "success\n\n"
+  stderr: ""
+normalizers: []

--- a/tests/trust/contracts/cassettes/github/list_issues_by_label.yaml
+++ b/tests/trust/contracts/cassettes/github/list_issues_by_label.yaml
@@ -1,0 +1,24 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# list_issues_by_label returns a list of open-issue dicts for issues carrying
+# the requested label. The dispatcher seeds one issue (#42, title "CI failure
+# detected") with the label "hydraflow-ci-failure" and asserts the JSON list
+# back as stdout. The updated_at field is normalised with timestamps.ISO8601
+# so replay is stable across time zones.
+adapter: github
+interaction: list_issues_by_label
+recorded_at: "2026-05-12T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: list_issues_by_label
+  args:
+    - "hydraflow-ci-failure"
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: "[{\"number\": 42, \"title\": \"CI failure detected\", \"body\": \"main is red\",
+    \"updated_at\": \"2026-01-01T00:00:00Z\"}]\n"
+  stderr: ""
+normalizers:
+  - timestamps.ISO8601

--- a/tests/trust/contracts/cassettes/github/post_comment.yaml
+++ b/tests/trust/contracts/cassettes/github/post_comment.yaml
@@ -1,0 +1,22 @@
+# Hand-authored baseline (recorder_sha: "00000000").
+# post_comment appends a comment to an issue; it returns None and produces no
+# stdout/stderr (mirrors `gh issue comment` with --body-file which exits 0
+# silently on success). The dispatcher seeds issue #42 and verifies the
+# comment landed via side-effect inspection, not stdout.
+adapter: github
+interaction: post_comment
+recorded_at: "2026-05-12T00:00:00Z"
+recorder_sha: "00000000"
+fixture_repo: T-rav-Hydra-Ops/hydraflow-contracts-sandbox
+input:
+  command: post_comment
+  args:
+    - "42"
+    - "CI has recovered — auto-closing this issue."
+  stdin: null
+  env: {}
+output:
+  exit_code: 0
+  stdout: ""
+  stderr: ""
+normalizers: []

--- a/tests/trust/contracts/test_fake_github_contract.py
+++ b/tests/trust/contracts/test_fake_github_contract.py
@@ -81,6 +81,47 @@ async def _invoke_fake_github(cassette: Cassette) -> FakeOutput:  # noqa: PLR091
         await fake.ensure_labels_exist()
         return FakeOutput(exit_code=0, stdout="", stderr="")
 
+    if method == "get_latest_ci_status":
+        # Default FakeGitHub._ci_main_status is ("success", "").
+        conclusion, url = await fake.get_latest_ci_status()
+        stdout = f"{conclusion}\n{url}\n"
+        return FakeOutput(exit_code=0, stdout=stdout, stderr="")
+
+    if method == "list_issues_by_label":
+        import json as _json
+
+        label = str(args[0])
+        # Seed one issue carrying the label so the list is non-empty and
+        # the contract covers the dict shape, not just the empty-list path.
+        fake.add_issue(42, "CI failure detected", "main is red", labels=[label])
+        issues = await fake.list_issues_by_label(label)
+        stdout = _json.dumps(issues) + "\n"
+        return FakeOutput(exit_code=0, stdout=stdout, stderr="")
+
+    if method == "create_issue":
+        title = str(args[0])
+        body = str(args[1]) if len(args) > 1 else ""
+        labels = [str(a) for a in args[2:]] if len(args) > 2 else None
+        # Empty store: max(keys, default=9000)+1 = 9001; cassette hard-codes
+        # that value so the contract is deterministic.
+        new_number = await fake.create_issue(title, body, labels=labels)
+        return FakeOutput(
+            exit_code=0,
+            stdout=f"https://github.com/test-org/test-repo/issues/{new_number}\n",
+            stderr="",
+        )
+
+    if method == "post_comment":
+        issue_number = int(args[0])
+        body = str(args[1]) if len(args) > 1 else ""
+        fake.add_issue(issue_number, "Seed issue", "")
+        await fake.post_comment(issue_number, body)
+        # Side-effect: comment must be recorded on the issue.
+        assert body in fake._issues[issue_number].comments, (
+            f"post_comment did not record comment on issue #{issue_number}"
+        )
+        return FakeOutput(exit_code=0, stdout="", stderr="")
+
     msg = f"FakeGitHub has no contract-tested method {method!r}"
     raise NotImplementedError(msg)
 


### PR DESCRIPTION
## Summary

Slice 5.4 (PR #8805) flagged QG-H2: FakeGitHub trust contracts cover 0/4 of the methods CIMonitorLoop calls. Real gh CLI drift on these methods is invisible until RC promotion. This adds cassettes for `get_latest_ci_status`, `list_issues_by_label`, `create_issue`, `post_comment`.

All 4 cassettes are hand-authored baselines (recorder_sha: 00000000) following the pattern documented in `tests/trust/contracts/cassettes/github/README.md` — appropriate because these are mutating or state-query operations that cannot be replayed live without polluting the sandbox repo.

## Test plan
- [x] 4 new cassettes added under `tests/trust/contracts/cassettes/github/`.
- [x] Dispatcher entries wired in `_invoke_fake_github` for all 4 methods.
- [x] `pytest tests/trust/contracts/test_fake_github_contract.py -v` — 12/12 passed (was 8).
- [x] `make trust-contracts` — 24/24 passed.

🤖 Generated with Claude Code