### PR TITLE
fix(security): WhatsApp webhook HMAC signature verification (closes #6651)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T15:47:01.418972+00:00",
-  "commit_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19",
+  "regenerated_at": "2026-05-18T18:26:21.543800+00:00",
+  "commit_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "ports.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "labels.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "modules.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "events.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "adr_xref.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "mockworld.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "changelog.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     },
     "functional_areas.md": {
-      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "73d99b2a223d4333885e66bac7b1a366faf22c80"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T17:58:46.346250+00:00",
-  "commit_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e",
+  "regenerated_at": "2026-05-18T15:47:01.418972+00:00",
+  "commit_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19",
   "artifacts": {
     "loops.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "ports.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "labels.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "modules.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "events.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "adr_xref.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "mockworld.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "changelog.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     },
     "functional_areas.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+      "source_sha": "d1c2a5e9e1a94e0e65e421db9814ebdd9df80a19"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,20 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `d1c2a5e` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `73d99b2` — fix(format): ruff format *(2026-05-18)*
+- `73a1a7f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6811034` — fix(format): ruff format *(2026-05-18)*
+- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
+- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
+- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -22,6 +35,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
+- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -32,6 +46,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -281,4 +296,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,18 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `cf1e613` — fix(format): ruff format *(2026-05-18)*
-- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
-- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
-- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
-- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `d1c2a5e` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -33,7 +22,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -44,7 +32,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
-- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -294,4 +281,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._
+_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `d1c2a5e` on 2026-05-18 15:47 UTC. Source last changed at `d1c2a5e`. Status: 🟢 fresh._
+_Regenerated from commit `73d99b2` on 2026-05-18 18:26 UTC. Source last changed at `73d99b2`. Status: 🟢 fresh._

--- a/src/config.py
+++ b/src/config.py
@@ -59,6 +59,10 @@ class Credentials(BaseModel):
         default="",
         description="WhatsApp webhook verification token",
     )
+    whatsapp_app_secret: str = Field(
+        default="",
+        description="WhatsApp app secret used to verify X-Hub-Signature-256 webhook signatures",
+    )
 
 
 class ManagedRepo(BaseModel):
@@ -2651,6 +2655,7 @@ def build_credentials(config: HydraFlowConfig) -> Credentials:
         whatsapp_phone_id=os.environ.get("HYDRAFLOW_WHATSAPP_PHONE_ID", ""),
         whatsapp_recipient=os.environ.get("HYDRAFLOW_WHATSAPP_RECIPIENT", ""),
         whatsapp_verify_token=os.environ.get("HYDRAFLOW_WHATSAPP_VERIFY_TOKEN", ""),
+        whatsapp_app_secret=os.environ.get("HYDRAFLOW_WHATSAPP_APP_SECRET", ""),
     )
 
 

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import copy
+import hashlib
+import hmac
 import json
 import logging
 import math
@@ -2040,10 +2042,25 @@ def create_router(
         """
         from whatsapp_bridge import WhatsAppBridge  # noqa: PLC0415
 
-        # Signature verification: reject unsigned or forged requests
         _cfg, _st, _bus, _get_orch = _resolve_runtime(None)
         if not _cfg.whatsapp_enabled:
             return JSONResponse({"status": "disabled"}, status_code=403)
+
+        # Signature verification: reject unsigned or forged requests.
+        # Meta sends X-Hub-Signature-256: sha256=<hex> computed over the raw
+        # request body using the app secret.  We must verify before processing.
+        raw_body = await request.body()
+        sig_header = request.headers.get("x-hub-signature-256")
+        if sig_header is None:
+            return JSONResponse({"status": "missing_signature"}, status_code=403)
+
+        app_secret = ctx.credentials.whatsapp_app_secret
+        expected_mac = hmac.new(
+            app_secret.encode(), raw_body, hashlib.sha256
+        ).hexdigest()
+        expected_header = f"sha256={expected_mac}"
+        if not hmac.compare_digest(sig_header, expected_header):
+            return JSONResponse({"status": "invalid_signature"}, status_code=403)
 
         request_body = await request.json()
         text, issue_number = WhatsAppBridge.parse_webhook(request_body)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -660,6 +660,7 @@ class CredentialsFactory:
         whatsapp_phone_id: str = "",
         whatsapp_recipient: str = "",
         whatsapp_verify_token: str = "",
+        whatsapp_app_secret: str = "",
     ) -> Credentials:
         """Create a Credentials with test-friendly defaults."""
         return Credentials(
@@ -671,6 +672,7 @@ class CredentialsFactory:
             whatsapp_phone_id=whatsapp_phone_id,
             whatsapp_recipient=whatsapp_recipient,
             whatsapp_verify_token=whatsapp_verify_token,
+            whatsapp_app_secret=whatsapp_app_secret,
         )
 
 

--- a/tests/regressions/test_issue_6651.py
+++ b/tests/regressions/test_issue_6651.py
@@ -84,7 +84,6 @@ class TestWhatsAppWebhookSignatureVerification:
     """Issue #6651: POST /api/webhooks/whatsapp must verify X-Hub-Signature-256."""
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6651 — fix not yet landed", strict=False)
     async def test_missing_signature_header_returns_403(
         self,
         config,
@@ -125,7 +124,6 @@ class TestWhatsAppWebhookSignatureVerification:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6651 — fix not yet landed", strict=False)
     async def test_invalid_signature_returns_403(
         self,
         config,
@@ -167,7 +165,6 @@ class TestWhatsAppWebhookSignatureVerification:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6651 — fix not yet landed", strict=False)
     async def test_unsigned_request_stores_spoofed_response(
         self,
         config,

--- a/tests/test_dashboard_routes_whatsapp_hmac.py
+++ b/tests/test_dashboard_routes_whatsapp_hmac.py
@@ -31,11 +31,7 @@ _VALID_PAYLOAD = {
     "entry": [
         {
             "changes": [
-                {
-                    "value": {
-                        "messages": [{"text": {"body": "LGTM, ship it #99"}}]
-                    }
-                }
+                {"value": {"messages": [{"text": {"body": "LGTM, ship it #99"}}]}}
             ]
         }
     ]
@@ -210,7 +206,10 @@ class TestWhatsAppWebhookHMAC:
 
         request = _make_request(_VALID_PAYLOAD, signature_header=valid_sig)
 
-        with patch("whatsapp_bridge.WhatsAppBridge.parse_webhook", return_value=("LGTM, ship it #99", 99)):
+        with patch(
+            "whatsapp_bridge.WhatsAppBridge.parse_webhook",
+            return_value=("LGTM, ship it #99", 99),
+        ):
             response = await handler(request)
 
         assert response.status_code == 200

--- a/tests/test_dashboard_routes_whatsapp_hmac.py
+++ b/tests/test_dashboard_routes_whatsapp_hmac.py
@@ -1,0 +1,216 @@
+"""Unit tests for WhatsApp webhook HMAC-SHA256 signature verification.
+
+Covers the X-Hub-Signature-256 verification introduced to fix issue #6651.
+These tests are distinct from tests/regressions/test_issue_6651.py, which
+anchors the original bug report.  These tests validate the full behaviour of
+the fixed endpoint including the valid-signature happy path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.helpers import (
+    CredentialsFactory,
+    find_endpoint,
+    make_dashboard_router,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_APP_SECRET = "unit-test-app-secret"
+
+_VALID_PAYLOAD = {
+    "entry": [
+        {
+            "changes": [
+                {
+                    "value": {
+                        "messages": [{"text": {"body": "LGTM, ship it #99"}}]
+                    }
+                }
+            ]
+        }
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_sig(body: bytes, secret: str) -> str:
+    """Compute the X-Hub-Signature-256 header value Meta would send."""
+    mac = hmac.new(secret.encode(), body, hashlib.sha256)
+    return f"sha256={mac.hexdigest()}"
+
+
+def _make_request(
+    payload: dict,
+    *,
+    signature_header: str | None,
+) -> MagicMock:
+    """Build a mock Request with an optional X-Hub-Signature-256 header."""
+    body_bytes = json.dumps(payload).encode()
+    request = MagicMock()
+    request.body = AsyncMock(return_value=body_bytes)
+    request.json = AsyncMock(return_value=payload)
+
+    headers: dict[str, str] = {"content-type": "application/json"}
+    if signature_header is not None:
+        headers["x-hub-signature-256"] = signature_header
+    request.headers = headers
+    return request
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestWhatsAppWebhookHMAC:
+    """Unit tests for HMAC-SHA256 verification on POST /api/webhooks/whatsapp."""
+
+    @pytest.mark.asyncio
+    async def test_missing_header_returns_403(
+        self,
+        config,
+        event_bus,
+        state,
+        tmp_path,
+    ) -> None:
+        """No X-Hub-Signature-256 header → 403 Forbidden."""
+        config.whatsapp_enabled = True
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            credentials=CredentialsFactory.create(
+                whatsapp_token="tok",
+                whatsapp_app_secret=_APP_SECRET,
+            ),
+        )
+
+        handler = find_endpoint(router, "/api/webhooks/whatsapp", "POST")
+        assert handler is not None
+
+        request = _make_request(_VALID_PAYLOAD, signature_header=None)
+        response = await handler(request)
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_forged_body_returns_403(
+        self,
+        config,
+        event_bus,
+        state,
+        tmp_path,
+    ) -> None:
+        """Signature computed over a *different* body → 403 Forbidden.
+
+        Simulates a MITM attacker that sends a valid signature header from a
+        prior request but swaps the body for a forged payload.
+        """
+        config.whatsapp_enabled = True
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            credentials=CredentialsFactory.create(
+                whatsapp_token="tok",
+                whatsapp_app_secret=_APP_SECRET,
+            ),
+        )
+
+        handler = find_endpoint(router, "/api/webhooks/whatsapp", "POST")
+        assert handler is not None
+
+        # Signature covers the *original* legitimate body, not _VALID_PAYLOAD.
+        legitimate_body = b'{"entry": []}'
+        forged_sig = _make_sig(legitimate_body, _APP_SECRET)
+
+        request = _make_request(_VALID_PAYLOAD, signature_header=forged_sig)
+        response = await handler(request)
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_wrong_secret_returns_403(
+        self,
+        config,
+        event_bus,
+        state,
+        tmp_path,
+    ) -> None:
+        """Signature computed with the wrong secret → 403 Forbidden."""
+        config.whatsapp_enabled = True
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            credentials=CredentialsFactory.create(
+                whatsapp_token="tok",
+                whatsapp_app_secret=_APP_SECRET,
+            ),
+        )
+
+        handler = find_endpoint(router, "/api/webhooks/whatsapp", "POST")
+        assert handler is not None
+
+        body_bytes = json.dumps(_VALID_PAYLOAD).encode()
+        bad_sig = _make_sig(body_bytes, "wrong-secret")
+
+        request = _make_request(_VALID_PAYLOAD, signature_header=bad_sig)
+        response = await handler(request)
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_valid_signature_returns_200(
+        self,
+        config,
+        event_bus,
+        state,
+        tmp_path,
+    ) -> None:
+        """Request with a correct X-Hub-Signature-256 → 200 OK.
+
+        Requires WhatsApp bridge to successfully parse the payload.
+        """
+        config.whatsapp_enabled = True
+        router, pr_mgr = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            credentials=CredentialsFactory.create(
+                whatsapp_token="tok",
+                whatsapp_app_secret=_APP_SECRET,
+            ),
+        )
+        pr_mgr.post_comment = AsyncMock()
+
+        handler = find_endpoint(router, "/api/webhooks/whatsapp", "POST")
+        assert handler is not None
+
+        body_bytes = json.dumps(_VALID_PAYLOAD).encode()
+        valid_sig = _make_sig(body_bytes, _APP_SECRET)
+
+        request = _make_request(_VALID_PAYLOAD, signature_header=valid_sig)
+
+        with patch("whatsapp_bridge.WhatsAppBridge.parse_webhook", return_value=("LGTM, ship it #99", 99)):
+            response = await handler(request)
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Issue #6651 (surfaced again by slice 5.8 PR #8787): `POST /api/webhooks/whatsapp` claimed HMAC verification in its docstring but performed zero signature checks — any caller could inject forged WhatsApp messages into active Shape conversations.
- Implements `X-Hub-Signature-256` HMAC-SHA256 verification using `hmac.compare_digest` (constant-time) against the raw request body and a new `whatsapp_app_secret` credential (`HYDRAFLOW_WHATSAPP_APP_SECRET` env var). Requests missing the header or carrying an invalid signature are rejected with 403 before the payload is parsed or stored.
- Adds `whatsapp_app_secret` field to `Credentials`, `build_credentials()`, and `CredentialsFactory.create()`.

## Test plan

- [x] `tests/regressions/test_issue_6651.py` — 3 xfail markers removed, all 3 pass.
- [x] `tests/test_dashboard_routes_whatsapp_hmac.py` — 4 new unit tests: missing header → 403, forged body → 403, wrong secret → 403, valid signature → 200.
- [x] `make quality` passes (all checks passed, 0 errors).

## Closes
#6651

🤖 Generated with [Claude Code](https://claude.com/claude-code)