### PR TITLE
fix(contracts): widen Cassette validator to allow all 9 audited fakes

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,42 @@
 {
-  "regenerated_at": "2026-05-13T04:20:46.983251+00:00",
-  "commit_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74",
+  "regenerated_at": "2026-05-18T23:04:04.865660+00:00",
+  "commit_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad",
   "artifacts": {
     "loops.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "ports.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "labels.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "modules.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "events.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "adr_xref.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "mockworld.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "changelog.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+    },
+    "coverage_matrix.md": {
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     },
     "functional_areas.md": {
-      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T22:38:07.042630+00:00",
-  "commit_sha": "b65be003749f488145e29c557929b544e7a84163",
+  "regenerated_at": "2026-05-13T04:20:46.983251+00:00",
+  "commit_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "ports.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "labels.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "modules.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "events.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "adr_xref.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "mockworld.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "changelog.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
-    },
-    "coverage_matrix.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     },
     "functional_areas.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "b65be003749f488145e29c557929b544e7a84163"
+      "source_sha": "7ab9e33d6c8113a9fb726c369946b4f885028b74"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -69,11 +69,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0057 | `src.term_pruner_loop`, `src.ubiquitous_language` |
 | ADR-0058 | `src.edge_proposer_loop`, `src.ubiquitous_language` |
 | ADR-0059 | `src.mockworld.fakes.fake_llm`, `src.review_advisor`, `src.review_phase`, `src.reviewer` |
-| ADR-0059 | `src.dashboard_routes._atlas_routes`, `src.ubiquitous_language` |
-| ADR-0060 | `src.dashboard_routes._atlas_routes` |
-| ADR-0061 | `src.repo_wiki` |
-| ADR-0062 | `src.entry_evidence_loop`, `src.term_proposer_llm` |
-| ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 
 ## Module → ADRs
 
@@ -98,7 +93,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
 | `src.dashboard_routes` | ADR-0007, ADR-0008, ADR-0013, ADR-0019, ADR-0038 |
-| `src.dashboard_routes._atlas_routes` | ADR-0059, ADR-0060 |
 | `src.dashboard_routes._cost_rollups` | ADR-0045 |
 | `src.dashboard_routes._diagnostics_routes` | ADR-0050 |
 | `src.dashboard_routes._routes` | ADR-0030 |
@@ -106,7 +100,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.discover_runner` | ADR-0031, ADR-0045, ADR-0063 |
 | `src.docker_runner` | ADR-0010, ADR-0043 |
 | `src.edge_proposer_loop` | ADR-0058 |
-| `src.entry_evidence_loop` | ADR-0062 |
 | `src.epic` | ADR-0011, ADR-0012, ADR-0019 |
 | `src.epic_monitor_loop` | ADR-0012 |
 | `src.escalation_gate` | ADR-0015 |
@@ -151,7 +144,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.prompt_template` | ADR-0043 |
 | `src.rc_budget_loop` | ADR-0045 |
 | `src.repo_runtime` | ADR-0038 |
-| `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
+| `src.repo_wiki` | ADR-0032, ADR-0053 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
 | `src.review_advisor` | ADR-0059 |
@@ -176,17 +169,16 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.telemetry.slugs` | ADR-0055 |
 | `src.telemetry.spans` | ADR-0055 |
 | `src.telemetry.subprocess_bridge` | ADR-0055 |
-| `src.term_proposer_llm` | ADR-0062 |
 | `src.term_proposer_loop` | ADR-0054 |
 | `src.term_pruner_loop` | ADR-0057 |
 | `src.trace_collector` | ADR-0055 |
 | `src.triage_phase` | ADR-0014, ADR-0017, ADR-0031, ADR-0039, ADR-0063 |
 | `src.trust_fleet_sanity_loop` | ADR-0045, ADR-0046 |
-| `src.ubiquitous_language` | ADR-0054, ADR-0057, ADR-0058, ADR-0059 |
+| `src.ubiquitous_language` | ADR-0054, ADR-0057, ADR-0058 |
 | `src.visual_validation` | ADR-0015 |
 | `src.wiki_compiler` | ADR-0032 |
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -69,6 +69,11 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0057 | `src.term_pruner_loop`, `src.ubiquitous_language` |
 | ADR-0058 | `src.edge_proposer_loop`, `src.ubiquitous_language` |
 | ADR-0059 | `src.mockworld.fakes.fake_llm`, `src.review_advisor`, `src.review_phase`, `src.reviewer` |
+| ADR-0059 | `src.dashboard_routes._atlas_routes`, `src.ubiquitous_language` |
+| ADR-0060 | `src.dashboard_routes._atlas_routes` |
+| ADR-0061 | `src.repo_wiki` |
+| ADR-0062 | `src.entry_evidence_loop`, `src.term_proposer_llm` |
+| ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 
 ## Module → ADRs
 
@@ -93,6 +98,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.corpus_learning_loop` | ADR-0045 |
 | `src.dashboard` | ADR-0007, ADR-0008, ADR-0038 |
 | `src.dashboard_routes` | ADR-0007, ADR-0008, ADR-0013, ADR-0019, ADR-0038 |
+| `src.dashboard_routes._atlas_routes` | ADR-0059, ADR-0060 |
 | `src.dashboard_routes._cost_rollups` | ADR-0045 |
 | `src.dashboard_routes._diagnostics_routes` | ADR-0050 |
 | `src.dashboard_routes._routes` | ADR-0030 |
@@ -100,6 +106,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.discover_runner` | ADR-0031, ADR-0045, ADR-0063 |
 | `src.docker_runner` | ADR-0010, ADR-0043 |
 | `src.edge_proposer_loop` | ADR-0058 |
+| `src.entry_evidence_loop` | ADR-0062 |
 | `src.epic` | ADR-0011, ADR-0012, ADR-0019 |
 | `src.epic_monitor_loop` | ADR-0012 |
 | `src.escalation_gate` | ADR-0015 |
@@ -144,7 +151,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.prompt_template` | ADR-0043 |
 | `src.rc_budget_loop` | ADR-0045 |
 | `src.repo_runtime` | ADR-0038 |
-| `src.repo_wiki` | ADR-0032, ADR-0053 |
+| `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
 | `src.review_advisor` | ADR-0059 |
@@ -169,16 +176,17 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.telemetry.slugs` | ADR-0055 |
 | `src.telemetry.spans` | ADR-0055 |
 | `src.telemetry.subprocess_bridge` | ADR-0055 |
+| `src.term_proposer_llm` | ADR-0062 |
 | `src.term_proposer_loop` | ADR-0054 |
 | `src.term_pruner_loop` | ADR-0057 |
 | `src.trace_collector` | ADR-0055 |
 | `src.triage_phase` | ADR-0014, ADR-0017, ADR-0031, ADR-0039, ADR-0063 |
 | `src.trust_fleet_sanity_loop` | ADR-0045, ADR-0046 |
-| `src.ubiquitous_language` | ADR-0054, ADR-0057, ADR-0058 |
+| `src.ubiquitous_language` | ADR-0054, ADR-0057, ADR-0058, ADR-0059 |
 | `src.visual_validation` | ADR-0015 |
 | `src.wiki_compiler` | ADR-0032 |
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `b65be00` — fix(format): ruff format *(2026-05-18)*
+- `a2dacb8` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `bcc0b25` — fix(contracts): widen Cassette._validate_adapter to accept all 9 known fakes (closes slice 5.7) *(2026-05-18)*
+- `a06faa7` — fix(format): ruff format *(2026-05-18)*
 - `0a5dcad` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `11b4807` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `899d7aa` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
@@ -85,6 +87,11 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W20
 
+- `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
+- `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
+- `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
+- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
+- `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
 - `1f954c2` — docs(audit): per-area review — Hexagonal Boundaries (slice 5.2 of 5) *(2026-05-12)*
@@ -311,4 +318,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -85,11 +85,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W20
 
-- `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
-- `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
-- `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
-- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
-- `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
 - `1f954c2` — docs(audit): per-area review — Hexagonal Boundaries (slice 5.2 of 5) *(2026-05-12)*
@@ -316,4 +311,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -13,6 +13,7 @@ flowchart LR
         caretaking_DependabotMergeLoop([DependabotMergeLoop])
         caretaking_DiagnosticLoop([DiagnosticLoop])
         caretaking_EdgeProposerLoop([EdgeProposerLoop])
+        caretaking_EntryEvidenceLoop([EntryEvidenceLoop])
         caretaking_EpicMonitorLoop([EpicMonitorLoop])
         caretaking_EpicSweeperLoop([EpicSweeperLoop])
         caretaking_GitHubCacheLoop([GitHubCacheLoop])
@@ -46,6 +47,7 @@ flowchart LR
         trust_fleet_CorpusLearningLoop([CorpusLearningLoop])
         trust_fleet_FakeCoverageAuditorLoop([FakeCoverageAuditorLoop])
         trust_fleet_FlakeTrackerLoop([FlakeTrackerLoop])
+        trust_fleet_LiveCorpusReplayLoop([LiveCorpusReplayLoop])
         trust_fleet_PrinciplesAuditLoop([PrinciplesAuditLoop])
         trust_fleet_RCBudgetLoop([RCBudgetLoop])
         trust_fleet_StagingBisectLoop([StagingBisectLoop])
@@ -94,6 +96,7 @@ Autonomous background loops that maintain the system without human input — wik
 - `DependabotMergeLoop` — `src.dependabot_merge_loop`
 - `DiagnosticLoop` — `src.diagnostic_loop`
 - `EdgeProposerLoop` — `src.edge_proposer_loop`
+- `EntryEvidenceLoop` — `src.entry_evidence_loop`
 - `EpicMonitorLoop` — `src.epic_monitor_loop`
 - `EpicSweeperLoop` — `src.epic_sweeper_loop`
 - `GitHubCacheLoop` — `src.github_cache_loop`
@@ -143,6 +146,7 @@ The trust-architecture hardening fleet (ADR-0045) — RC promotion gate, staging
 - `CorpusLearningLoop` — `src.corpus_learning_loop`
 - `FakeCoverageAuditorLoop` — `src.fake_coverage_auditor_loop`
 - `FlakeTrackerLoop` — `src.flake_tracker_loop`
+- `LiveCorpusReplayLoop` — `src.live_corpus_replay_loop`
 - `PrinciplesAuditLoop` — `src.principles_audit_loop`
 - `RCBudgetLoop` — `src.rc_budget_loop`
 - `StagingBisectLoop` — `src.staging_bisect_loop`
@@ -272,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -13,7 +13,6 @@ flowchart LR
         caretaking_DependabotMergeLoop([DependabotMergeLoop])
         caretaking_DiagnosticLoop([DiagnosticLoop])
         caretaking_EdgeProposerLoop([EdgeProposerLoop])
-        caretaking_EntryEvidenceLoop([EntryEvidenceLoop])
         caretaking_EpicMonitorLoop([EpicMonitorLoop])
         caretaking_EpicSweeperLoop([EpicSweeperLoop])
         caretaking_GitHubCacheLoop([GitHubCacheLoop])
@@ -47,7 +46,6 @@ flowchart LR
         trust_fleet_CorpusLearningLoop([CorpusLearningLoop])
         trust_fleet_FakeCoverageAuditorLoop([FakeCoverageAuditorLoop])
         trust_fleet_FlakeTrackerLoop([FlakeTrackerLoop])
-        trust_fleet_LiveCorpusReplayLoop([LiveCorpusReplayLoop])
         trust_fleet_PrinciplesAuditLoop([PrinciplesAuditLoop])
         trust_fleet_RCBudgetLoop([RCBudgetLoop])
         trust_fleet_StagingBisectLoop([StagingBisectLoop])
@@ -96,7 +94,6 @@ Autonomous background loops that maintain the system without human input — wik
 - `DependabotMergeLoop` — `src.dependabot_merge_loop`
 - `DiagnosticLoop` — `src.diagnostic_loop`
 - `EdgeProposerLoop` — `src.edge_proposer_loop`
-- `EntryEvidenceLoop` — `src.entry_evidence_loop`
 - `EpicMonitorLoop` — `src.epic_monitor_loop`
 - `EpicSweeperLoop` — `src.epic_sweeper_loop`
 - `GitHubCacheLoop` — `src.github_cache_loop`
@@ -146,7 +143,6 @@ The trust-architecture hardening fleet (ADR-0045) — RC promotion gate, staging
 - `CorpusLearningLoop` — `src.corpus_learning_loop`
 - `FakeCoverageAuditorLoop` — `src.fake_coverage_auditor_loop`
 - `FlakeTrackerLoop` — `src.flake_tracker_loop`
-- `LiveCorpusReplayLoop` — `src.live_corpus_replay_loop`
 - `PrinciplesAuditLoop` — `src.principles_audit_loop`
 - `RCBudgetLoop` — `src.rc_budget_loop`
 - `StagingBisectLoop` — `src.staging_bisect_loop`
@@ -276,4 +272,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -6,47 +6,49 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 
 | Loop | Module | Tick (s) | Kill Switch | Events | ADRs |
 |---|---|---|---|---|---|
-| **ADRReviewerLoop** | `src.adr_reviewer_loop` | — | — | — | — |
-| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | — | — | — | ADR-0056 |
-| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | — | — | — | — |
-| **CIMonitorLoop** | `src.ci_monitor_loop` | — | — | — | — |
-| **CodeGroomingLoop** | `src.code_grooming_loop` | — | — | — | — |
-| **ContractRefreshLoop** | `src.contract_refresh_loop` | — | — | — | — |
-| **CorpusLearningLoop** | `src.corpus_learning_loop` | — | — | — | — |
-| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | — | — | — | — |
-| **DependabotMergeLoop** | `src.dependabot_merge_loop` | — | — | — | — |
-| **DiagnosticLoop** | `src.diagnostic_loop` | — | — | DIAGNOSTIC_UPDATE | — |
-| **DiagramLoop** | `src.diagram_loop` | — | — | — | ADR-0029, ADR-0049 |
-| **EdgeProposerLoop** | `src.edge_proposer_loop` | — | — | — | — |
-| **EpicMonitorLoop** | `src.epic_monitor_loop` | — | — | — | — |
-| **EpicSweeperLoop** | `src.epic_sweeper_loop` | — | — | — | — |
-| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | — | — | — | — |
-| **FlakeTrackerLoop** | `src.flake_tracker_loop` | — | — | — | — |
-| **GitHubCacheLoop** | `src.github_cache_loop` | — | — | — | — |
-| **HealthMonitorLoop** | `src.health_monitor_loop` | — | — | — | — |
-| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | — | — | — | — |
-| **MemoryBacklogLoop** | `src.memory_backlog_loop` | — | — | — | — |
-| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | — | — | — | — |
-| **PRUnstickerLoop** | `src.pr_unsticker_loop` | — | — | — | — |
-| **PricingRefreshLoop** | `src.pricing_refresh_loop` | — | — | — | — |
-| **PrinciplesAuditLoop** | `src.principles_audit_loop` | — | — | — | ADR-0044 |
-| **RCBudgetLoop** | `src.rc_budget_loop` | — | — | — | — |
-| **RepoWikiLoop** | `src.repo_wiki_loop` | — | — | — | — |
-| **ReportIssueLoop** | `src.report_issue_loop` | — | — | REPORT_UPDATE | — |
-| **RetrospectiveLoop** | `src.retrospective_loop` | — | — | RETROSPECTIVE_UPDATE | — |
-| **RunsGCLoop** | `src.runs_gc_loop` | — | — | — | — |
-| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | — | — | — | ADR-0049 |
-| **SecurityPatchLoop** | `src.security_patch_loop` | — | — | — | — |
-| **SentryLoop** | `src.sentry_loop` | — | — | — | — |
-| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | — | — | — | — |
-| **StagingBisectLoop** | `src.staging_bisect_loop` | — | — | — | ADR-0042 |
-| **StagingPromotionLoop** | `src.staging_promotion_loop` | — | — | — | ADR-0042 |
-| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | — | — | — | — |
-| **StaleIssueLoop** | `src.stale_issue_loop` | — | — | — | — |
-| **TermProposerLoop** | `src.term_proposer_loop` | — | — | — | ADR-0054 |
-| **TermPrunerLoop** | `src.term_pruner_loop` | — | — | — | — |
-| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | — | — | BACKGROUND_WORKER_STATUS | — |
-| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
-| **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
+| **ADRReviewerLoop** | `src.adr_reviewer_loop` | 86400 | — | — | — |
+| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | 14400 | — | — | ADR-0056 |
+| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | 120 | — | — | — |
+| **CIMonitorLoop** | `src.ci_monitor_loop` | 300 | — | — | — |
+| **CodeGroomingLoop** | `src.code_grooming_loop` | 86400 | — | — | — |
+| **ContractRefreshLoop** | `src.contract_refresh_loop` | 604800 | — | — | — |
+| **CorpusLearningLoop** | `src.corpus_learning_loop` | 3600 | — | — | — |
+| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | 300 | `HYDRAFLOW_DISABLE_COST_BUDGET_WATCHER` | — | — |
+| **DependabotMergeLoop** | `src.dependabot_merge_loop` | 3600 | — | — | — |
+| **DiagnosticLoop** | `src.diagnostic_loop` | 30 | — | DIAGNOSTIC_UPDATE | — |
+| **DiagramLoop** | `src.diagram_loop` | 14400 | `HYDRAFLOW_DISABLE_DIAGRAM_LOOP` | — | ADR-0029, ADR-0049 |
+| **EdgeProposerLoop** | `src.edge_proposer_loop` | 86400 | — | — | — |
+| **EntryEvidenceLoop** | `src.entry_evidence_loop` | 86400 | — | — | ADR-0062 |
+| **EpicMonitorLoop** | `src.epic_monitor_loop` | 1800 | — | — | — |
+| **EpicSweeperLoop** | `src.epic_sweeper_loop` | 3600 | — | — | — |
+| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | 604800 | — | — | — |
+| **FlakeTrackerLoop** | `src.flake_tracker_loop` | 14400 | — | — | — |
+| **GitHubCacheLoop** | `src.github_cache_loop` | 300 | — | — | — |
+| **HealthMonitorLoop** | `src.health_monitor_loop` | 7200 | — | — | — |
+| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | 600 | — | — | — |
+| **LiveCorpusReplayLoop** | `src.live_corpus_replay_loop` | 900 | — | — | — |
+| **MemoryBacklogLoop** | `src.memory_backlog_loop` | 86400 | — | — | — |
+| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | 600 | — | — | — |
+| **PRUnstickerLoop** | `src.pr_unsticker_loop` | 3600 | — | — | — |
+| **PricingRefreshLoop** | `src.pricing_refresh_loop` | 86400 | `HYDRAFLOW_DISABLE_PRICING_REFRESH` | — | — |
+| **PrinciplesAuditLoop** | `src.principles_audit_loop` | 604800 | — | — | ADR-0044 |
+| **RCBudgetLoop** | `src.rc_budget_loop` | 14400 | — | — | — |
+| **RepoWikiLoop** | `src.repo_wiki_loop` | 3600 | — | — | — |
+| **ReportIssueLoop** | `src.report_issue_loop` | 30 | — | REPORT_UPDATE | — |
+| **RetrospectiveLoop** | `src.retrospective_loop` | 1800 | — | RETROSPECTIVE_UPDATE | — |
+| **RunsGCLoop** | `src.runs_gc_loop` | 3600 | — | — | — |
+| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | 3600 | — | — | ADR-0049 |
+| **SecurityPatchLoop** | `src.security_patch_loop` | 3600 | — | — | — |
+| **SentryLoop** | `src.sentry_loop` | 600 | — | — | — |
+| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | 604800 | — | — | — |
+| **StagingBisectLoop** | `src.staging_bisect_loop` | 600 | — | — | ADR-0042 |
+| **StagingPromotionLoop** | `src.staging_promotion_loop` | 300 | — | — | ADR-0042 |
+| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | 3600 | — | — | — |
+| **StaleIssueLoop** | `src.stale_issue_loop` | 86400 | — | — | — |
+| **TermProposerLoop** | `src.term_proposer_loop` | 14400 | — | — | ADR-0054 |
+| **TermPrunerLoop** | `src.term_pruner_loop` | 86400 | — | — | — |
+| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | 600 | — | BACKGROUND_WORKER_STATUS | — |
+| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
+| **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -6,49 +6,47 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 
 | Loop | Module | Tick (s) | Kill Switch | Events | ADRs |
 |---|---|---|---|---|---|
-| **ADRReviewerLoop** | `src.adr_reviewer_loop` | 86400 | — | — | — |
-| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | 14400 | — | — | ADR-0056 |
-| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | 120 | — | — | — |
-| **CIMonitorLoop** | `src.ci_monitor_loop` | 300 | — | — | — |
-| **CodeGroomingLoop** | `src.code_grooming_loop` | 86400 | — | — | — |
-| **ContractRefreshLoop** | `src.contract_refresh_loop` | 604800 | — | — | — |
-| **CorpusLearningLoop** | `src.corpus_learning_loop` | 3600 | — | — | — |
-| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | 300 | `HYDRAFLOW_DISABLE_COST_BUDGET_WATCHER` | — | — |
-| **DependabotMergeLoop** | `src.dependabot_merge_loop` | 3600 | — | — | — |
-| **DiagnosticLoop** | `src.diagnostic_loop` | 30 | — | DIAGNOSTIC_UPDATE | — |
-| **DiagramLoop** | `src.diagram_loop` | 14400 | `HYDRAFLOW_DISABLE_DIAGRAM_LOOP` | — | ADR-0029, ADR-0049 |
-| **EdgeProposerLoop** | `src.edge_proposer_loop` | 86400 | — | — | — |
-| **EntryEvidenceLoop** | `src.entry_evidence_loop` | 86400 | — | — | ADR-0062 |
-| **EpicMonitorLoop** | `src.epic_monitor_loop` | 1800 | — | — | — |
-| **EpicSweeperLoop** | `src.epic_sweeper_loop` | 3600 | — | — | — |
-| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | 604800 | — | — | — |
-| **FlakeTrackerLoop** | `src.flake_tracker_loop` | 14400 | — | — | — |
-| **GitHubCacheLoop** | `src.github_cache_loop` | 300 | — | — | — |
-| **HealthMonitorLoop** | `src.health_monitor_loop` | 7200 | — | — | — |
-| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | 600 | — | — | — |
-| **LiveCorpusReplayLoop** | `src.live_corpus_replay_loop` | 900 | — | — | — |
-| **MemoryBacklogLoop** | `src.memory_backlog_loop` | 86400 | — | — | — |
-| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | 600 | — | — | — |
-| **PRUnstickerLoop** | `src.pr_unsticker_loop` | 3600 | — | — | — |
-| **PricingRefreshLoop** | `src.pricing_refresh_loop` | 86400 | `HYDRAFLOW_DISABLE_PRICING_REFRESH` | — | — |
-| **PrinciplesAuditLoop** | `src.principles_audit_loop` | 604800 | — | — | ADR-0044 |
-| **RCBudgetLoop** | `src.rc_budget_loop` | 14400 | — | — | — |
-| **RepoWikiLoop** | `src.repo_wiki_loop` | 3600 | — | — | — |
-| **ReportIssueLoop** | `src.report_issue_loop` | 30 | — | REPORT_UPDATE | — |
-| **RetrospectiveLoop** | `src.retrospective_loop` | 1800 | — | RETROSPECTIVE_UPDATE | — |
-| **RunsGCLoop** | `src.runs_gc_loop` | 3600 | — | — | — |
-| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | 3600 | — | — | ADR-0049 |
-| **SecurityPatchLoop** | `src.security_patch_loop` | 3600 | — | — | — |
-| **SentryLoop** | `src.sentry_loop` | 600 | — | — | — |
-| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | 604800 | — | — | — |
-| **StagingBisectLoop** | `src.staging_bisect_loop` | 600 | — | — | ADR-0042 |
-| **StagingPromotionLoop** | `src.staging_promotion_loop` | 300 | — | — | ADR-0042 |
-| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | 3600 | — | — | — |
-| **StaleIssueLoop** | `src.stale_issue_loop` | 86400 | — | — | — |
-| **TermProposerLoop** | `src.term_proposer_loop` | 14400 | — | — | ADR-0054 |
-| **TermPrunerLoop** | `src.term_pruner_loop` | 86400 | — | — | — |
-| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | 600 | — | BACKGROUND_WORKER_STATUS | — |
-| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
-| **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
+| **ADRReviewerLoop** | `src.adr_reviewer_loop` | — | — | — | — |
+| **AdrTouchpointAuditorLoop** | `src.adr_touchpoint_auditor_loop` | — | — | — | ADR-0056 |
+| **AutoAgentPreflightLoop** | `src.auto_agent_preflight_loop` | — | — | — | — |
+| **CIMonitorLoop** | `src.ci_monitor_loop` | — | — | — | — |
+| **CodeGroomingLoop** | `src.code_grooming_loop` | — | — | — | — |
+| **ContractRefreshLoop** | `src.contract_refresh_loop` | — | — | — | — |
+| **CorpusLearningLoop** | `src.corpus_learning_loop` | — | — | — | — |
+| **CostBudgetWatcherLoop** | `src.cost_budget_watcher_loop` | — | — | — | — |
+| **DependabotMergeLoop** | `src.dependabot_merge_loop` | — | — | — | — |
+| **DiagnosticLoop** | `src.diagnostic_loop` | — | — | DIAGNOSTIC_UPDATE | — |
+| **DiagramLoop** | `src.diagram_loop` | — | — | — | ADR-0029, ADR-0049 |
+| **EdgeProposerLoop** | `src.edge_proposer_loop` | — | — | — | — |
+| **EpicMonitorLoop** | `src.epic_monitor_loop` | — | — | — | — |
+| **EpicSweeperLoop** | `src.epic_sweeper_loop` | — | — | — | — |
+| **FakeCoverageAuditorLoop** | `src.fake_coverage_auditor_loop` | — | — | — | — |
+| **FlakeTrackerLoop** | `src.flake_tracker_loop` | — | — | — | — |
+| **GitHubCacheLoop** | `src.github_cache_loop` | — | — | — | — |
+| **HealthMonitorLoop** | `src.health_monitor_loop` | — | — | — | — |
+| **LabelDriftWatcherLoop** | `src.label_drift_watcher_loop` | — | — | — | — |
+| **MemoryBacklogLoop** | `src.memory_backlog_loop` | — | — | — | — |
+| **MergeStateWatcherLoop** | `src.merge_state_watcher_loop` | — | — | — | — |
+| **PRUnstickerLoop** | `src.pr_unsticker_loop` | — | — | — | — |
+| **PricingRefreshLoop** | `src.pricing_refresh_loop` | — | — | — | — |
+| **PrinciplesAuditLoop** | `src.principles_audit_loop` | — | — | — | ADR-0044 |
+| **RCBudgetLoop** | `src.rc_budget_loop` | — | — | — | — |
+| **RepoWikiLoop** | `src.repo_wiki_loop` | — | — | — | — |
+| **ReportIssueLoop** | `src.report_issue_loop` | — | — | REPORT_UPDATE | — |
+| **RetrospectiveLoop** | `src.retrospective_loop` | — | — | RETROSPECTIVE_UPDATE | — |
+| **RunsGCLoop** | `src.runs_gc_loop` | — | — | — | — |
+| **SandboxFailureFixerLoop** | `src.sandbox_failure_fixer_loop` | — | — | — | ADR-0049 |
+| **SecurityPatchLoop** | `src.security_patch_loop` | — | — | — | — |
+| **SentryLoop** | `src.sentry_loop` | — | — | — | — |
+| **SkillPromptEvalLoop** | `src.skill_prompt_eval_loop` | — | — | — | — |
+| **StagingBisectLoop** | `src.staging_bisect_loop` | — | — | — | ADR-0042 |
+| **StagingPromotionLoop** | `src.staging_promotion_loop` | — | — | — | ADR-0042 |
+| **StaleIssueGCLoop** | `src.stale_issue_gc_loop` | — | — | — | — |
+| **StaleIssueLoop** | `src.stale_issue_loop` | — | — | — | — |
+| **TermProposerLoop** | `src.term_proposer_loop` | — | — | — | ADR-0054 |
+| **TermPrunerLoop** | `src.term_pruner_loop` | — | — | — | — |
+| **TrustFleetSanityLoop** | `src.trust_fleet_sanity_loop` | — | — | BACKGROUND_WORKER_STATUS | — |
+| **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | — | — | — | — |
+| **WorkspaceGCLoop** | `src.workspace_gc_loop` | — | — | — | — |
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -21,11 +21,11 @@ graph LR
     src_state["src.state"]
     src_telemetry["src.telemetry"]
     src -- "4" --> src_arch
-    src -- "25" --> src_contracts
+    src -- "1" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
-    src -- "46" --> src_state
+    src -- "45" --> src_state
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -21,11 +21,11 @@ graph LR
     src_state["src.state"]
     src_telemetry["src.telemetry"]
     src -- "4" --> src_arch
-    src -- "1" --> src_contracts
+    src -- "25" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
-    src -- "45" --> src_state
+    src -- "46" --> src_state
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._
+_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `b65be00` on 2026-05-18 22:38 UTC. Source last changed at `b65be00`. Status: 🟢 fresh._
+_Regenerated from commit `7ab9e33` on 2026-05-13 04:20 UTC. Source last changed at `7ab9e33`. Status: 🟢 fresh._

--- a/src/contracts/_schema.py
+++ b/src/contracts/_schema.py
@@ -14,6 +14,23 @@ from pathlib import Path
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
+# Canonical set of known adapter names. Derived from
+# ``FakeCoverageAuditorLoop._FAKE_TO_CASSETTE_DIR`` — the two must stay in
+# sync. When a new fake is added to that map, add its cassette-dir name here.
+KNOWN_ADAPTERS: frozenset[str] = frozenset(
+    {
+        "github",
+        "docker",
+        "git",
+        "beads",
+        "sentry",
+        "http",
+        "subprocess",
+        "fs",
+        "llm",
+    }
+)
+
 
 class CassetteInput(BaseModel):
     """One-interaction input block."""
@@ -61,8 +78,9 @@ class Cassette(BaseModel):
     @field_validator("adapter")
     @classmethod
     def _validate_adapter(cls, v: str) -> str:
-        if v not in {"github", "git", "docker"}:
-            msg = f"adapter must be one of github|git|docker, got {v!r}"
+        if v not in KNOWN_ADAPTERS:
+            known = "|".join(sorted(KNOWN_ADAPTERS))
+            msg = f"adapter must be one of {known}, got {v!r}"
             raise ValueError(msg)
         return v
 

--- a/tests/test_contract_cassette_schema.py
+++ b/tests/test_contract_cassette_schema.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from contracts._schema import KNOWN_ADAPTERS
 from tests.trust.contracts._schema import (
     NORMALIZERS,
     Cassette,
@@ -51,6 +52,17 @@ class TestLoadCassette:
         path.write_text(_MINIMAL_YAML.replace("adapter: github", "adapter: slack"))
         with pytest.raises(ValueError, match="adapter must be one of"):
             load_cassette(path)
+
+    @pytest.mark.parametrize(
+        "adapter",
+        sorted(KNOWN_ADAPTERS),
+    )
+    def test_all_known_adapters_validate(self, tmp_path: Path, adapter: str) -> None:
+        """Every adapter name in KNOWN_ADAPTERS must pass Pydantic validation."""
+        path = tmp_path / f"{adapter}.yaml"
+        path.write_text(_MINIMAL_YAML.replace("adapter: github", f"adapter: {adapter}"))
+        cas = load_cassette(path)
+        assert cas.adapter == adapter
 
     def test_rejects_unknown_normalizer(self, tmp_path: Path) -> None:
         path = tmp_path / "c.yaml"

--- a/tests/trust/contracts/_schema.py
+++ b/tests/trust/contracts/_schema.py
@@ -11,6 +11,7 @@ Existing test-side call sites continue to work via this re-export.
 from __future__ import annotations
 
 from contracts._schema import (  # noqa: F401
+    KNOWN_ADAPTERS,
     NORMALIZERS,
     Cassette,
     CassetteInput,


### PR DESCRIPTION
## Summary

- Slice 5.7 (PR #8803) flagged: `Cassette._validate_adapter` only allowed `github|git|docker` but `FakeCoverageAuditorLoop._FAKE_TO_CASSETTE_DIR` maps 9 fakes — `beads`, `sentry`, `http`, `subprocess`, and `fs` would fail Pydantic validation at load time.
- Introduces `KNOWN_ADAPTERS: frozenset[str]` in `src/contracts/_schema.py` as the single source of truth, derived from the same 9 names in `_FAKE_TO_CASSETTE_DIR`.
- Updates `_validate_adapter` to check against `KNOWN_ADAPTERS` and includes the full sorted list in the error message.
- Exports `KNOWN_ADAPTERS` from the `tests/trust/contracts/_schema.py` shim for test-side import.

## Test plan

- [x] 9 new parametrized tests (`test_all_known_adapters_validate`) — one per adapter — all pass.
- [x] Existing cassettes for `github`, `git`, `docker` still validate.
- [x] `test_rejects_unknown_adapter` (with `adapter: slack`) still raises `ValueError`.
- [x] Full `make quality` run: 12515 passed, 1 pre-existing failure in `test_planner.py::test_build_prompt_truncates_long_body` (prompt-length threshold broken by CLAUDE.md growth, present on `staging` before this branch).

🤖 Generated with Claude Code