### PR TITLE
feat(contracts): pydantic shapes for gh JSON I/O boundary (Phase 1 of #8786)

### DIFF
--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -1,0 +1,118 @@
+"""Pydantic shapes for the gh-CLI JSON I/O boundary (Phase 1 of #8786).
+
+Each model corresponds to a real ``gh ... --json FIELDS`` invocation used by
+HydraFlow's production code. Validating both the real-adapter response AND
+the fake-adapter return at the same model catches shape drift at the call
+site — without needing a cassette recorder or replay tick. Loop A (#8786)
+detects *value-level* drift via the shadow corpus; these models catch
+*shape-level* drift (fields appearing, disappearing, or changing type).
+
+Design notes:
+
+- ``Pydantic v2`` with ``ConfigDict(extra="ignore")``. New optional fields
+  from gh upgrades are silently dropped; missing required fields or
+  type-mismatched fields raise ``ValidationError``. That's the signal we
+  want — shape drift breaks loudly at the call site.
+
+- Where gh returns a string-typed enum (``state``, ``mergeable``,
+  ``conclusion``), we use ``Literal`` to pin the known values. A new
+  state value from gh trips validation immediately rather than flowing
+  through to call sites that branch on the old set.
+
+- Optional fields are typed ``X | None = None``. Some gh commands return
+  the field, some omit it depending on ``--json FIELDS``. The model is
+  a superset; callers select which fields they need.
+
+- ``GhLabel`` and ``GhCheckRun`` are nested types reused across the
+  parent shapes — they're contracts in their own right.
+
+The matching contract-test live in ``tests/test_contracts_shapes.py``.
+Wiring the real ``PRManager`` and ``FakeGitHub`` to validate through
+these models is the *next* PR — this one ships the shapes + validation
+contract, the wiring is parallelizable.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+_GhIssueState = Literal["OPEN", "CLOSED"]
+_GhPRState = Literal["OPEN", "CLOSED", "MERGED"]
+_GhMergeable = Literal["MERGEABLE", "CONFLICTING", "UNKNOWN"]
+_GhCheckState = Literal["QUEUED", "IN_PROGRESS", "COMPLETED", "PENDING", "WAITING"]
+_GhCheckConclusion = Literal[
+    "SUCCESS",
+    "FAILURE",
+    "NEUTRAL",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STALE",
+    "SKIPPED",
+    "STARTUP_FAILURE",
+]
+
+
+class GhLabel(BaseModel):
+    """One label as returned by ``gh ... --json labels``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    color: str | None = None
+    description: str | None = None
+
+
+class GhCheckRun(BaseModel):
+    """One CI check as returned by ``gh pr checks --json``."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    name: str
+    state: _GhCheckState | None = None
+    conclusion: _GhCheckConclusion | None = None
+    details_url: str | None = Field(default=None, alias="detailsUrl")
+
+
+class GhPRSummary(BaseModel):
+    """List-shape: ``gh pr list --json number,title,state[,labels,updatedAt]``."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    number: int
+    title: str
+    state: _GhPRState
+    body: str | None = None
+    labels: list[GhLabel] = Field(default_factory=list)
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+
+
+class GhPRDetail(BaseModel):
+    """Detail-shape: ``gh pr view N --json number,headRefName,baseRefName,labels,mergeable,isDraft,url[,headRefOid]``."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    number: int
+    url: str | None = None
+    head_ref_name: str | None = Field(default=None, alias="headRefName")
+    base_ref_name: str | None = Field(default=None, alias="baseRefName")
+    head_ref_oid: str | None = Field(default=None, alias="headRefOid")
+    labels: list[GhLabel] = Field(default_factory=list)
+    mergeable: _GhMergeable | None = None
+    is_draft: bool | None = Field(default=None, alias="isDraft")
+
+
+class GhIssueSummary(BaseModel):
+    """``gh issue view N --json number,state[,title,body,labels,updatedAt,stateReason]``."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    number: int
+    state: _GhIssueState
+    state_reason: str | None = Field(default=None, alias="stateReason")
+    title: str | None = None
+    body: str | None = None
+    labels: list[GhLabel] = Field(default_factory=list)
+    updated_at: str | None = Field(default=None, alias="updatedAt")

--- a/tests/test_contracts_shapes.py
+++ b/tests/test_contracts_shapes.py
@@ -1,0 +1,207 @@
+"""Unit tests for ``contracts.shapes`` — gh JSON I/O boundary models (#8786 Phase 1).
+
+Each test parses a representative ``gh --json`` payload through the model
+and asserts the round-trip + enum pinning + alias handling. Drift tests
+prove that a removed/renamed/typed-wrong field actually trips
+``ValidationError`` — the whole point of the shape-typed boundary.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from contracts.shapes import (
+    GhCheckRun,
+    GhIssueSummary,
+    GhLabel,
+    GhPRDetail,
+    GhPRSummary,
+)
+
+# ---------------------------------------------------------------------------
+# GhLabel
+# ---------------------------------------------------------------------------
+
+
+def test_label_parses_full_shape() -> None:
+    raw = {"name": "in-progress", "color": "ededed", "description": "active"}
+    label = GhLabel.model_validate(raw)
+    assert label.name == "in-progress"
+    assert label.color == "ededed"
+
+
+def test_label_tolerates_missing_optional_fields() -> None:
+    """gh --json name without color/description is a common minimal payload."""
+    label = GhLabel.model_validate({"name": "bug"})
+    assert label.color is None
+    assert label.description is None
+
+
+def test_label_rejects_missing_name() -> None:
+    """name is the contract — a label without a name is a shape drift."""
+    with pytest.raises(ValidationError):
+        GhLabel.model_validate({"color": "ededed"})
+
+
+# ---------------------------------------------------------------------------
+# GhCheckRun
+# ---------------------------------------------------------------------------
+
+
+def test_check_run_parses_alias_detailsUrl() -> None:
+    """gh emits camelCase; the model accepts camelCase via alias."""
+    raw = {
+        "name": "Lint & Format",
+        "state": "COMPLETED",
+        "conclusion": "SUCCESS",
+        "detailsUrl": "https://github.com/x/y/actions/runs/1",
+    }
+    cr = GhCheckRun.model_validate(raw)
+    assert cr.details_url == "https://github.com/x/y/actions/runs/1"
+
+
+def test_check_run_rejects_unknown_state() -> None:
+    """A new state value from a gh upgrade trips the model — that's the
+    shape-drift signal we want."""
+    with pytest.raises(ValidationError):
+        GhCheckRun.model_validate({"name": "x", "state": "WARP_DRIVE"})
+
+
+def test_check_run_rejects_unknown_conclusion() -> None:
+    with pytest.raises(ValidationError):
+        GhCheckRun.model_validate(
+            {"name": "x", "state": "COMPLETED", "conclusion": "MAYBE"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# GhPRSummary
+# ---------------------------------------------------------------------------
+
+
+def test_pr_summary_parses_typical_list_payload() -> None:
+    raw = {
+        "number": 42,
+        "title": "feat: x",
+        "state": "OPEN",
+        "labels": [{"name": "in-progress"}],
+        "updatedAt": "2026-05-13T01:00:00Z",
+    }
+    s = GhPRSummary.model_validate(raw)
+    assert s.number == 42
+    assert s.state == "OPEN"
+    assert s.updated_at == "2026-05-13T01:00:00Z"
+    assert len(s.labels) == 1
+    assert s.labels[0].name == "in-progress"
+
+
+def test_pr_summary_pins_state_enum() -> None:
+    """A drifted state ('MERGE_QUEUED' etc) trips validation."""
+    raw = {"number": 1, "title": "x", "state": "MERGE_QUEUED"}
+    with pytest.raises(ValidationError):
+        GhPRSummary.model_validate(raw)
+
+
+def test_pr_summary_ignores_unknown_fields() -> None:
+    """Unknown fields (new gh output) are silently ignored — they don't
+    break shape compatibility for existing fields."""
+    raw = {
+        "number": 1,
+        "title": "x",
+        "state": "OPEN",
+        "futureUnknownField": "ignored",
+    }
+    s = GhPRSummary.model_validate(raw)
+    assert s.number == 1
+
+
+# ---------------------------------------------------------------------------
+# GhPRDetail
+# ---------------------------------------------------------------------------
+
+
+def test_pr_detail_parses_full_shape() -> None:
+    raw = {
+        "number": 42,
+        "url": "https://github.com/x/y/pull/42",
+        "headRefName": "feat/x",
+        "baseRefName": "staging",
+        "headRefOid": "1a2b3c4d5e6f7g8h",
+        "labels": [{"name": "in-progress"}, {"name": "hydraflow-ready"}],
+        "mergeable": "MERGEABLE",
+        "isDraft": False,
+    }
+    d = GhPRDetail.model_validate(raw)
+    assert d.head_ref_name == "feat/x"
+    assert d.base_ref_name == "staging"
+    assert d.head_ref_oid == "1a2b3c4d5e6f7g8h"
+    assert d.mergeable == "MERGEABLE"
+    assert d.is_draft is False
+    assert len(d.labels) == 2
+
+
+def test_pr_detail_pins_mergeable_enum() -> None:
+    raw = {"number": 1, "mergeable": "PROBABLY"}
+    with pytest.raises(ValidationError):
+        GhPRDetail.model_validate(raw)
+
+
+def test_pr_detail_round_trips_json_dump() -> None:
+    """``model_dump_json`` produces output that's reparseable — important
+    for the eventual replay loop persisting these via the shadow corpus."""
+    raw = {"number": 1, "headRefName": "b", "mergeable": "CONFLICTING"}
+    d = GhPRDetail.model_validate(raw)
+    payload = json.loads(d.model_dump_json(by_alias=True))
+    again = GhPRDetail.model_validate(payload)
+    assert again == d
+
+
+# ---------------------------------------------------------------------------
+# GhIssueSummary
+# ---------------------------------------------------------------------------
+
+
+def test_issue_summary_parses_typical_payload() -> None:
+    raw = {
+        "number": 7,
+        "state": "OPEN",
+        "title": "Find: cassette drift",
+        "body": "details…",
+        "labels": [{"name": "hydraflow-find"}],
+        "updatedAt": "2026-05-13T01:00:00Z",
+    }
+    i = GhIssueSummary.model_validate(raw)
+    assert i.number == 7
+    assert i.state == "OPEN"
+    assert i.title == "Find: cassette drift"
+    assert i.labels[0].name == "hydraflow-find"
+
+
+def test_issue_summary_includes_state_reason() -> None:
+    """gh reports stateReason='completed'|'not_planned' for closed issues."""
+    raw = {"number": 7, "state": "CLOSED", "stateReason": "completed"}
+    i = GhIssueSummary.model_validate(raw)
+    assert i.state == "CLOSED"
+    assert i.state_reason == "completed"
+
+
+def test_issue_summary_pins_state_enum() -> None:
+    raw = {"number": 1, "state": "REOPENED"}
+    with pytest.raises(ValidationError):
+        GhIssueSummary.model_validate(raw)
+
+
+# ---------------------------------------------------------------------------
+# Validator helper — the call-site contract
+# ---------------------------------------------------------------------------
+
+
+def test_models_validate_real_json_strings() -> None:
+    """The most common call pattern: gh returns a JSON string; the call
+    site validates it through the model. ``model_validate_json`` covers it."""
+    raw = '{"number":1,"title":"x","state":"OPEN"}'
+    s = GhPRSummary.model_validate_json(raw)
+    assert s.number == 1


### PR DESCRIPTION
## Summary

Phase 1 of #8786. Defines the schema layer that catches **shape drift at the call site** — faster and cheaper signal than the value-level drift Loop A catches via the shadow corpus.

`src/contracts/shapes.py` ships 5 Pydantic models matching real `gh ... --json` payloads used in `PRManager`:

| Model | Real source |
|---|---|
| `GhLabel` | every `labels` field |
| `GhCheckRun` | `gh pr checks --json name,state,detailsUrl,conclusion` |
| `GhPRSummary` | `gh pr list --json number,title,state[,labels,updatedAt,body]` |
| `GhPRDetail` | `gh pr view N --json number,headRefName,baseRefName,labels,mergeable,isDraft,url[,headRefOid]` |
| `GhIssueSummary` | `gh issue view N --json number,state[,stateReason,title,body,labels,updatedAt]` |

## Design choices

- **`ConfigDict(extra="ignore")`** — unknown fields from gh upgrades pass silently. Missing/renamed/typed-wrong fields raise `ValidationError`. Drift is loud where it breaks code, silent where it doesn't.
- **`Literal` enums** for `state`, `mergeable`, `conclusion`, check state — a new upstream value trips validation immediately rather than flowing through to branching code with stale assumptions.
- **`populate_by_name`** + camelCase aliases (`updatedAt`, `headRefName`, `isDraft`, `detailsUrl`, `stateReason`) so call sites can use either form.

## Test plan

`tests/test_contracts_shapes.py` — 16 tests:
- [x] Full-shape parse for each model
- [x] Optional-field tolerance
- [x] Required-field rejection
- [x] Literal-enum pinning (mergeable, state, conclusion, check state)
- [x] Unknown-field ignore (forward compatibility)
- [x] JSON round-trip via `model_dump_json`
- [x] `model_validate_json` for the typical call-site usage

ruff + pyright clean.

## Next PR

Wire `PRManager` (real adapter) and `FakeGitHub` (fake) to validate their outputs through these models at the call site. That's many small edits across PRManager — parallelizable but bigger blast radius, so it's its own PR.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)