### PR TITLE
feat(live-corpus-replay): 3-attempt escalation chain (Phase 3 of #8786)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1287,6 +1287,17 @@ class HydraFlowConfig(BaseModel):
             "adapter output via registered dispatchers."
         ),
     )
+    live_corpus_max_drift_attempts: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description=(
+            "Per-drift-signature attempt cap before LiveCorpusReplayLoop "
+            "escalates to hitl-escalation (auto-agent preflight). Each "
+            "tick that re-detects the same drift signature counts as "
+            "one attempt; a clean tick clears all counters."
+        ),
+    )
 
     # Code grooming
     code_grooming_enabled: bool = Field(

--- a/src/live_corpus_replay_loop.py
+++ b/src/live_corpus_replay_loop.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
 from models import WorkCycleResult  # noqa: TCH001
+from state import StateTracker  # noqa: TCH001
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -68,6 +69,7 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
         pr_manager: PRManager,
         dedup: DedupStore,
         deps: LoopDeps,
+        state: StateTracker | None = None,
         dispatchers: dict[DispatcherKey, Dispatcher] | None = None,
     ) -> None:
         super().__init__(
@@ -79,6 +81,7 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
         self._corpus = corpus
         self._pr = pr_manager
         self._dedup = dedup
+        self._state = state
         self._dispatchers: dict[DispatcherKey, Dispatcher] = dict(dispatchers or {})
 
     def _get_default_interval(self) -> int:
@@ -136,13 +139,38 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
                 drifted.append((path, signature))
 
         filed_issue: int | None = None
+        escalated_issue: int | None = None
+        escalated_signatures: list[str] = []
+
         if drifted:
+            # Increment per-signature attempt counters and identify any
+            # that have hit the escalation threshold.
+            if self._state is not None:
+                threshold = self._config.live_corpus_max_drift_attempts
+                for _path, sig in drifted:
+                    attempts = self._state.inc_live_corpus_drift_attempts(sig)
+                    if attempts >= threshold and sig not in escalated_signatures:
+                        escalated_signatures.append(sig)
+
             dedup_key = _fleet_dedup_key(drifted)
             seen = self._dedup.get()
             if dedup_key not in seen:
                 filed_issue = await self._file_drift_issue(drifted)
                 seen.add(dedup_key)
                 self._dedup.set_all(seen)
+
+            # If any signature reached the threshold, file an escalation
+            # issue routed to the auto-agent preflight loop via the
+            # ``hitl-escalation`` label.
+            if escalated_signatures:
+                escalated_issue = await self._file_escalation_issue(
+                    escalated_signatures
+                )
+        # Clean tick: clear all attempt counters so a future
+        # re-occurrence of the same drift starts fresh.
+        elif self._state is not None:
+            self._state.clear_live_corpus_drift_attempts()
+
         return {
             "status": "ok",
             "compared": compared,
@@ -150,7 +178,45 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
             "drifted": len(drifted),
             "errors": errors,
             "filed_issue": filed_issue,
+            "escalated_issue": escalated_issue,
+            "escalated_signatures": len(escalated_signatures),
         }
+
+    async def _file_escalation_issue(self, signatures: list[str]) -> int:
+        """File a ``hitl-escalation`` issue when drift signatures exhaust
+        the loop's own retry budget.
+
+        Routed via the existing ``hitl-escalation`` label to the
+        ``AutoAgentPreflightLoop`` — that loop runs its OWN 3-attempt
+        cycle (auto-agent IMPL pipeline) before labeling
+        ``human-required``. The combined autonomous-attempt budget is
+        ``live_corpus_max_drift_attempts × auto_agent_max_attempts``.
+        """
+        labels = ["hitl-escalation", "shadow-drift-stuck"]
+        title = (
+            f"Shadow drift stuck: {len(signatures)} signature(s) survived "
+            f"{self._config.live_corpus_max_drift_attempts} tick(s) without repair"
+        )
+        sig_lines = "\n".join(f"- `{s[:12]}`" for s in signatures[:50])
+        body = (
+            f"## Drift survived the LiveCorpusReplayLoop retry budget\n\n"
+            f"After {self._config.live_corpus_max_drift_attempts} consecutive "
+            f"ticks of detecting the same drift signature(s) without the "
+            f"earlier `hydraflow-find` repair PR landing, the loop escalates "
+            f"to `hitl-escalation` so `AutoAgentPreflightLoop` runs its own "
+            f"attempts.\n\n"
+            f"### Stuck signatures\n\n{sig_lines}\n\n"
+            f"### Repair path\n\n"
+            f"The auto-agent preflight loop will pick this up and run "
+            f"`auto_agent_max_attempts` IMPL attempts before adding "
+            f"`human-required`. Closing this issue clears all per-signature "
+            f"counters on the next clean tick."
+        )
+        return await self._pr.create_issue(
+            title=title,
+            body=body,
+            labels=labels,
+        )
 
     async def _file_drift_issue(self, drifted: list[tuple[Path, str]]) -> int:
         """File a single hydraflow-find issue covering all drift this tick."""

--- a/src/models.py
+++ b/src/models.py
@@ -1832,6 +1832,9 @@ class StateData(BaseModel):
     adr_audit_cursor: str = Field(default="")
     adr_audit_attempts: dict[str, int] = Field(default_factory=dict)
     memory_backlog_attempts: dict[str, int] = Field(default_factory=dict)
+    # LiveCorpusReplayLoop (#8786 Phase 3) — per-drift-signature attempt
+    # counters for the 3-attempt escalation chain.
+    live_corpus_drift_attempts: dict[str, int] = Field(default_factory=dict)
     escalation_contexts: dict[str, dict[str, object]] = Field(default_factory=dict)
     diagnostic_attempts: dict[str, list[dict[str, object]]] = Field(
         default_factory=dict

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1060,6 +1060,7 @@ def build_services(
             corpus=shadow_corpus,
             pr_manager=prs,
             dedup=_live_corpus_replay_dedup,
+            state=state,
             deps=loop_deps,
         )
 

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -36,6 +36,7 @@ from ._flake_tracker import FlakeTrackerStateMixin
 from ._hitl import HITLStateMixin
 from ._issue import IssueStateMixin
 from ._lifetime import LifetimeStatsMixin
+from ._live_corpus_replay import LiveCorpusReplayStateMixin
 from ._memory_backlog import MemoryBacklogStateMixin
 from ._principles_audit import PrinciplesAuditStateMixin
 from ._rc_budget import RCBudgetStateMixin
@@ -89,6 +90,7 @@ class StateTracker(
     FlakeTrackerStateMixin,
     SkillPromptEvalStateMixin,
     FakeCoverageStateMixin,
+    LiveCorpusReplayStateMixin,
     MemoryBacklogStateMixin,
     RCBudgetStateMixin,
     WikiRotDetectorStateMixin,

--- a/src/state/_live_corpus_replay.py
+++ b/src/state/_live_corpus_replay.py
@@ -1,0 +1,42 @@
+"""State accessors for LiveCorpusReplayLoop (#8786 Phase 3).
+
+Per-signature attempt counters for the 3-attempt escalation chain. A drift
+signature persists across loop ticks until either:
+
+- The fake catches up (clean tick clears all counters).
+- The counter hits the threshold and an escalation issue is filed via
+  the ``hitl-escalation`` label — the auto-agent preflight loop picks
+  that up and runs its own 3-attempt cycle before human-required fires.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models import StateData
+
+
+class LiveCorpusReplayStateMixin:
+    """Per-drift-signature attempt counters."""
+
+    _data: StateData
+
+    def save(self) -> None: ...  # provided by CoreMixin
+
+    def get_live_corpus_drift_attempts(self, signature: str) -> int:
+        return int(self._data.live_corpus_drift_attempts.get(signature, 0))
+
+    def inc_live_corpus_drift_attempts(self, signature: str) -> int:
+        current = int(self._data.live_corpus_drift_attempts.get(signature, 0)) + 1
+        attempts = dict(self._data.live_corpus_drift_attempts)
+        attempts[signature] = current
+        self._data.live_corpus_drift_attempts = attempts
+        self.save()
+        return current
+
+    def clear_live_corpus_drift_attempts(self) -> None:
+        """Clear ALL counters — called on a clean tick (no drift detected)."""
+        if self._data.live_corpus_drift_attempts:
+            self._data.live_corpus_drift_attempts = {}
+            self.save()

--- a/tests/test_live_corpus_replay_loop.py
+++ b/tests/test_live_corpus_replay_loop.py
@@ -29,15 +29,35 @@ from events import EventBus
 from live_corpus_replay_loop import LiveCorpusReplayLoop
 
 
+class _FakeState:
+    """Minimal StateTracker stub for the per-signature attempt counters."""
+
+    def __init__(self) -> None:
+        self._attempts: dict[str, int] = {}
+
+    def get_live_corpus_drift_attempts(self, sig: str) -> int:
+        return self._attempts.get(sig, 0)
+
+    def inc_live_corpus_drift_attempts(self, sig: str) -> int:
+        self._attempts[sig] = self._attempts.get(sig, 0) + 1
+        return self._attempts[sig]
+
+    def clear_live_corpus_drift_attempts(self) -> None:
+        self._attempts.clear()
+
+
 def _build_loop(
     tmp_path: Path,
     *,
     pr_manager: Any | None = None,
-) -> tuple[LiveCorpusReplayLoop, ShadowCorpus, Any]:
+    state: Any | None = None,
+    max_drift_attempts: int = 3,
+) -> tuple[LiveCorpusReplayLoop, ShadowCorpus, Any, Any]:
     config = HydraFlowConfig(
         data_root=tmp_path / "data",
         repo_root=tmp_path / "repo",
         repo="hydra/hydraflow",
+        live_corpus_max_drift_attempts=max_drift_attempts,
     )
     (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
     corpus = ShadowCorpus(config.data_root / "contract_shadow")
@@ -49,6 +69,7 @@ def _build_loop(
         "live_corpus_replay",
         config.data_root / "dedup" / "live_corpus_replay.json",
     )
+    state_obj = state if state is not None else _FakeState()
     stop = asyncio.Event()
     deps = LoopDeps(
         event_bus=EventBus(),
@@ -63,13 +84,14 @@ def _build_loop(
         pr_manager=pr,
         dedup=dedup,
         deps=deps,
+        state=state_obj,
     )
-    return loop, corpus, pr
+    return loop, corpus, pr, state_obj
 
 
 @pytest.mark.asyncio
 async def test_empty_corpus_returns_ok_with_zero_compared(tmp_path: Path) -> None:
-    loop, _, pr = _build_loop(tmp_path)
+    loop, _, pr, _state = _build_loop(tmp_path)
     result = await loop._do_work()
     assert result == {
         "status": "ok",
@@ -78,13 +100,15 @@ async def test_empty_corpus_returns_ok_with_zero_compared(tmp_path: Path) -> Non
         "drifted": 0,
         "errors": 0,
         "filed_issue": None,
+        "escalated_issue": None,
+        "escalated_signatures": 0,
     }
     pr.create_issue.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_sample_with_no_dispatcher_is_skipped(tmp_path: Path) -> None:
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     corpus.record(
         adapter="github",
         command="gh",
@@ -103,7 +127,7 @@ async def test_sample_with_no_dispatcher_is_skipped(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_dispatcher_match_no_drift(tmp_path: Path) -> None:
     """Fake output equal to sample → compared=1, no drift, no issue."""
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     payload = {"state": "OPEN", "mergeable": "MERGEABLE"}
     corpus.record(
         adapter="github",
@@ -127,7 +151,7 @@ async def test_dispatcher_match_no_drift(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_dispatcher_match_with_drift_files_issue(tmp_path: Path) -> None:
     """Fake output diverges → single hydraflow-find issue filed."""
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     corpus.record(
         adapter="github",
         command="gh",
@@ -153,7 +177,7 @@ async def test_dispatcher_match_with_drift_files_issue(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_identical_drift_dedups_across_ticks(tmp_path: Path) -> None:
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     corpus.record(
         adapter="github",
         command="gh",
@@ -180,7 +204,7 @@ async def test_identical_drift_dedups_across_ticks(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_dispatcher_raising_is_caught(tmp_path: Path) -> None:
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     corpus.record(
         adapter="github",
         command="gh",
@@ -202,7 +226,7 @@ async def test_dispatcher_raising_is_caught(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_disabled_kill_switch_short_circuits(tmp_path: Path) -> None:
-    loop, corpus, pr = _build_loop(tmp_path)
+    loop, corpus, pr, _state = _build_loop(tmp_path)
     loop._enabled_cb = lambda _name: False
     corpus.record(
         adapter="github",
@@ -215,3 +239,90 @@ async def test_disabled_kill_switch_short_circuits(tmp_path: Path) -> None:
     result = await loop._do_work()
     assert result == {"status": "disabled"}
     pr.create_issue.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: 3-attempt escalation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_escalation_fires_after_threshold_attempts(tmp_path: Path) -> None:
+    """When the same drift signature survives ``live_corpus_max_drift_attempts``
+    consecutive ticks, the loop files a ``hitl-escalation`` issue routed to
+    the auto-agent preflight pipeline."""
+    pr = MagicMock()
+    # Two awaited calls in this test: one drift issue (tick 1), one
+    # escalation issue (tick 3 hits the threshold). Ticks 2/3 dedup-skip
+    # the drift issue.
+    pr.create_issue = AsyncMock(side_effect=[4242, 5555])
+    loop, corpus, _pr, _state = _build_loop(
+        tmp_path, pr_manager=pr, max_drift_attempts=3
+    )
+    corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "42"],
+        stdout='{"state":"MERGED"}\n',
+        stderr="",
+        exit_code=0,
+    )
+
+    async def stale_fake(_sample):  # noqa: ANN001
+        return {"state": "OPEN"}
+
+    loop.register("github", "gh", stale_fake)
+
+    # Three ticks with identical drift. The third one hits the threshold.
+    results = []
+    for _ in range(3):
+        results.append(await loop._do_work())
+
+    assert results[0]["escalated_signatures"] == 0
+    assert results[1]["escalated_signatures"] == 0
+    assert results[2]["escalated_signatures"] == 1
+    assert results[2]["escalated_issue"] == 5555
+
+    # The escalation issue carries the hitl-escalation label so the
+    # AutoAgentPreflightLoop picks it up.
+    escalation_call = pr.create_issue.await_args_list[-1]
+    labels = escalation_call.kwargs.get("labels") or escalation_call.args[2]
+    assert "hitl-escalation" in labels
+    assert "shadow-drift-stuck" in labels
+
+
+@pytest.mark.asyncio
+async def test_clean_tick_clears_attempt_counters(tmp_path: Path) -> None:
+    """When drift resolves (clean tick), all attempt counters reset so a
+    future re-occurrence of the same signature starts fresh."""
+    loop, corpus, _pr, state = _build_loop(tmp_path, max_drift_attempts=3)
+    sample_path = corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "1"],
+        stdout='{"state":"MERGED"}\n',
+        stderr="",
+        exit_code=0,
+    )
+    assert sample_path is not None
+
+    async def stale_fake(_sample):  # noqa: ANN001
+        return {"state": "OPEN"}
+
+    loop.register("github", "gh", stale_fake)
+    await loop._do_work()
+    await loop._do_work()
+    # After two ticks of drift, the per-signature counter is 2.
+    assert len(state._attempts) == 1
+    counter = next(iter(state._attempts.values()))
+    assert counter == 2
+
+    # Now the fake catches up — clean tick.
+    async def fixed_fake(_sample):  # noqa: ANN001
+        return {"state": "MERGED"}
+
+    loop.register("github", "gh", fixed_fake)
+    clean = await loop._do_work()
+
+    assert clean["drifted"] == 0
+    assert state._attempts == {}, "clean tick must clear all counters"


### PR DESCRIPTION
## Summary

Phase 3 of #8786. Closes the **auto-repair routing** half of the v2 trust pattern. When the same drift signature survives `live_corpus_max_drift_attempts` consecutive ticks without the earlier `hydraflow-find` repair landing, the loop escalates to `hitl-escalation` so `AutoAgentPreflightLoop` runs its own 3-attempt IMPL cycle before any `human-required` label fires.

Closes acceptance criterion **#5** (3-attempt escalation chain) and **#4** (drift signal reaches autonomous queue without human routing) of #8786.

## The escalation chain — end-to-end

```
tick 1:  drift detected → hydraflow-find issue → IMPL pipeline picks up → repair PR
tick 2:  same drift → counter=2 → dedup-skip find-issue → no escalation yet
tick 3:  same drift → counter=3 (threshold) → hitl-escalation issue →
         AutoAgentPreflightLoop picks up → auto-agent runs N IMPL attempts
         → if exhausted, label human-required (existing path)
clean:   drift resolved → counters cleared → future re-occurrence starts fresh
```

**Combined autonomous-attempt budget**: `live_corpus_max_drift_attempts × auto_agent_max_attempts` before *any* human is asked. Dark factory.

## What's here

- **`LiveCorpusReplayStateMixin`** (`src/state/_live_corpus_replay.py`) — per-drift-signature attempt counters on `StateData.live_corpus_drift_attempts`. Mirrors `MemoryBacklogStateMixin`.
- **`LiveCorpusReplayLoop`** now takes `state: StateTracker` (optional — Phase 2 behaviour preserved when state is None). Each drifted signature increments; threshold hits fire `_file_escalation_issue`. Clean tick clears ALL counters.
- **`live_corpus_max_drift_attempts`** config field (default 3, range 1..20).
- **service_registry** threads `state=state` into the loop construction.

## Test plan

- [x] 2 new escalation tests: threshold-fires-escalation, clean-tick-clears-counters
- [x] All 7 prior tests updated for the new result dict (`escalated_issue`, `escalated_signatures`)
- [x] Scenario test still asserts `hydraflow-find` routing (Phase 2 #4) — Phase 3 adds `hitl-escalation` as the second-tier signal, not a replacement
- [x] 47 #8786-related tests green; existing `test_service_registry.py` green
- [x] ruff + pyright clean

## What this PR does NOT do (Phase 4 follow-up)

- Retire hand-authored github cassettes — should happen once concrete dispatchers cover the same surface. Tracked separately.
- Populate the dispatcher registry with real production call shapes. Each dispatcher is a small isolated PR.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)