### PR TITLE
feat(cassettes): baseline_only marker + retirement plan (Phase 4 of #8786)

### DIFF
--- a/src/contracts/_schema.py
+++ b/src/contracts/_schema.py
@@ -43,6 +43,12 @@ class Cassette(BaseModel):
     input: CassetteInput
     output: CassetteOutput
     normalizers: list[str] = Field(default_factory=list)
+    # Phase 4 of #8786 — marks cassettes that are hand-authored baselines
+    # rather than recorded live. The eventual retirement signal: once a
+    # ``LiveCorpusReplayLoop`` dispatcher covers the same (adapter, command,
+    # args) shape, the baseline cassette is redundant and can be removed.
+    # ``FakeCoverageAuditorLoop`` will surface such overlaps (follow-up).
+    baseline_only: bool = Field(default=False)
 
     @field_validator("recorded_at", mode="before")
     @classmethod

--- a/tests/test_cassette_baseline_only.py
+++ b/tests/test_cassette_baseline_only.py
@@ -1,0 +1,76 @@
+"""Regression: github cassettes carry ``baseline_only: true`` (Phase 4 of #8786).
+
+The marker is the machine-checkable retirement signal — when a
+``LiveCorpusReplayLoop`` dispatcher covers the same shape, the
+baseline cassette is redundant and a future audit can flag it. Until
+then the marker just documents the corpus as hand-authored.
+
+This test guards against:
+- New github cassettes landing without the marker.
+- A future PR accidentally flipping all markers off in bulk.
+- The schema field disappearing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from contracts._schema import Cassette
+
+_GH_CASSETTES = Path(__file__).parent / "trust" / "contracts" / "cassettes" / "github"
+
+
+def test_every_github_cassette_is_baseline_only() -> None:
+    """Every YAML cassette under cassettes/github/ must carry
+    ``baseline_only: true``. New cassettes without it suggest the author
+    is recording live (which github currently does NOT do — see the
+    cassette dir README)."""
+    yamls = list(_GH_CASSETTES.glob("*.yaml"))
+    assert yamls, "expected at least one github cassette"
+    missing: list[str] = []
+    for path in yamls:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        if raw.get("baseline_only") is not True:
+            missing.append(path.name)
+    assert not missing, (
+        "the following github cassettes are missing `baseline_only: true`: "
+        f"{missing}. See cassettes/github/README.md for the retirement plan."
+    )
+
+
+def test_cassette_schema_round_trips_baseline_only() -> None:
+    """The Cassette pydantic model preserves baseline_only on dump."""
+    raw = {
+        "adapter": "github",
+        "interaction": "merge_pr",
+        "recorded_at": "2026-05-13T00:00:00Z",
+        "recorder_sha": "00000000",
+        "fixture_repo": "x/y",
+        "input": {"command": "merge_pr", "args": ["42"], "stdin": None, "env": {}},
+        "output": {"exit_code": 0, "stdout": "", "stderr": ""},
+        "normalizers": [],
+        "baseline_only": True,
+    }
+    cassette = Cassette.model_validate(raw)
+    assert cassette.baseline_only is True
+    dumped = cassette.model_dump()
+    assert dumped["baseline_only"] is True
+
+
+def test_cassette_schema_defaults_baseline_only_false() -> None:
+    """Default is False so existing live-recorded cassettes (git, docker,
+    claude) don't suddenly claim to be baselines."""
+    raw = {
+        "adapter": "git",
+        "interaction": "commit",
+        "recorded_at": "2026-05-13T00:00:00Z",
+        "recorder_sha": "abc1234",
+        "fixture_repo": "x/y",
+        "input": {"command": "commit", "args": ["initial"], "stdin": None, "env": {}},
+        "output": {"exit_code": 0, "stdout": "[main abc1234] initial\n", "stderr": ""},
+        "normalizers": ["sha:short"],
+    }
+    cassette = Cassette.model_validate(raw)
+    assert cassette.baseline_only is False

--- a/tests/trust/contracts/cassettes/github/README.md
+++ b/tests/trust/contracts/cassettes/github/README.md
@@ -2,7 +2,31 @@
 
 Every cassette in this directory is a **hand-authored baseline** — they are
 not refreshed by `ContractRefreshLoop` against a live `gh` CLI. Identifiable
-by `recorder_sha: "00000000"` in the YAML header.
+by both:
+
+- `recorder_sha: "00000000"` (historical convention)
+- `baseline_only: true` in the YAML body (Phase 4 of #8786 — the machine-
+  checkable retirement marker)
+
+## Retirement plan (Phase 4 of #8786)
+
+A baseline cassette is **redundant** (and eligible for removal) once the
+same `(adapter, command, args)` shape is covered by a `LiveCorpusReplayLoop`
+dispatcher in `src/live_corpus_replay_loop.py`'s registry. At that point:
+
+- The shadow corpus captures the *real* gh output continuously.
+- The Pydantic shape models in `src/contracts/shapes.py` catch shape drift
+  at the call site.
+- The replay loop diffs sample vs fake output every 15 minutes.
+
+The hand-authored baseline becomes a duplicate of stronger signals.
+
+A future `FakeCoverageAuditorLoop` check (filed as follow-up) will warn
+when `baseline_only=true` AND a live dispatcher exists for the same shape
+— that's the retirement signal. Removal then happens in a one-PR cleanup.
+
+Until then, baselines stay because they're the only contract test for the
+respective FakeGitHub methods.
 
 ## Why hand-authored?
 

--- a/tests/trust/contracts/cassettes/github/add_labels.yaml
+++ b/tests/trust/contracts/cassettes/github/add_labels.yaml
@@ -16,3 +16,4 @@ output:
   stdout: ""
   stderr: ""
 normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/close_issue.yaml
+++ b/tests/trust/contracts/cassettes/github/close_issue.yaml
@@ -14,3 +14,4 @@ output:
   stdout: ""
   stderr: ""
 normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/close_task.yaml
+++ b/tests/trust/contracts/cassettes/github/close_task.yaml
@@ -14,3 +14,4 @@ output:
   stdout: ""
   stderr: "✓ Closed issue #42\n"
 normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/create_task.yaml
+++ b/tests/trust/contracts/cassettes/github/create_task.yaml
@@ -16,3 +16,4 @@ output:
   stderr: ""
 normalizers:
   - pr_number
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/ensure_labels_exist.yaml
+++ b/tests/trust/contracts/cassettes/github/ensure_labels_exist.yaml
@@ -13,3 +13,4 @@ output:
   stdout: ""
   stderr: ""
 normalizers: []
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/merge_pr.yaml
+++ b/tests/trust/contracts/cassettes/github/merge_pr.yaml
@@ -15,3 +15,4 @@ output:
   stderr: ""
 normalizers:
   - pr_number
+baseline_only: true

--- a/tests/trust/contracts/cassettes/github/pr_create.yaml
+++ b/tests/trust/contracts/cassettes/github/pr_create.yaml
@@ -16,3 +16,4 @@ output:
   stderr: ""
 normalizers:
   - pr_number
+baseline_only: true


### PR DESCRIPTION
## Summary

Phase 4 of #8786 — closes acceptance criterion **#6**: "hand-authored github cassette dependency reduced to zero **or explicit baseline-only marker**". Ships the **marker** option (the second clause), because removing the cassettes now would leave a coverage gap until dispatchers land.

## What's here

- **`Cassette.baseline_only: bool = False`** new optional schema field.
- **All 7 github cassettes** now carry `baseline_only: true`.
- **README** at `cassettes/github/README.md` documents the retirement criterion: a baseline is eligible for removal once a `LiveCorpusReplayLoop` dispatcher covers the same `(adapter, command, args)` shape (machine-checkable by a future audit).

## Why not just delete?

- `LiveCorpusReplayLoop`'s dispatcher registry is intentionally empty in Phase 2 (wired but inert).
- Hand-authored cassettes are still the only contract test for FakeGitHub's mutating-op surface.
- Removing them now = coverage gap until dispatchers + Pydantic shape validators reach parity.

The marker is the *graduation signal*: once a live dispatcher exists for the same shape, `FakeCoverageAuditorLoop` (future extension) flags the cassette as redundant, and a one-PR cleanup removes it.

## Test plan

- [x] `tests/test_cassette_baseline_only.py` — 3 tests: every github cassette has the marker, schema round-trips, default is False.
- [x] `tests/trust/contracts/` — 21 existing contract tests still green (no behaviour change).
- [x] ruff + pyright clean.

## Combined #8786 trail

| Phase | PR | Status |
|---|---|---|
| 0.1 — `ShadowCorpus` storage | #8822 | ✅ Merged |
| 0.2 — `set_shadow_sampler` hook | #8823 | ✅ Merged |
| 0.3 — Startup registration | #8829 | ✅ Auto-merge engaged |
| 1 — Pydantic shapes | #8832 | ✅ Auto-merge engaged |
| 2 — Replay loop skeleton | #8833 | ✅ Auto-merge engaged |
| 3 — 3-attempt escalation | #8835 | ✅ Auto-merge engaged |
| 4 — Baseline marker | this PR | open |

Acceptance criteria 1, 2, 3, 4, 5, 6 of #8786 all addressed in this trail.

## Follow-ups (each small, parallelizable)

- Populate `LiveCorpusReplayLoop` dispatcher registry with concrete gh/git/docker/claude shapes.
- `FakeCoverageAuditorLoop` check: warn when `baseline_only=true` AND a dispatcher exists for the same shape.
- Wire `PRManager` + `FakeGitHub` through Pydantic shape validators at every call site.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)