### PR TITLE
test(ci-monitor): cover _rehydrate_open_issue restart-recovery

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T21:24:47.528567+00:00",
-  "commit_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167",
+  "regenerated_at": "2026-05-18T21:25:13.543601+00:00",
+  "commit_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11",
   "artifacts": {
     "loops.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "ports.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "labels.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "modules.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "events.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "adr_xref.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "mockworld.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "changelog.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "coverage_matrix.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "functional_areas.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "ubiquitous-language.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "316e16ce1721a2ff6c5ad9b4154638abcc7ca167"
+      "source_sha": "40248bfa5feda3b78c6c6e09062ddfda2cb33a11"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `316e16c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `40248bf` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a0fd1b9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `57291d2` — fix(arch): functional_areas.yml module paths + add CI validation *(2026-05-18)*
 - `0c8243a` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `84b64fd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -308,4 +309,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `316e16c` on 2026-05-18 21:24 UTC. Source last changed at `316e16c`. Status: 🟢 fresh._
+_Regenerated from commit `40248bf` on 2026-05-18 21:25 UTC. Source last changed at `40248bf`. Status: 🟢 fresh._

--- a/tests/test_ci_monitor_loop.py
+++ b/tests/test_ci_monitor_loop.py
@@ -165,3 +165,94 @@ class TestCIMonitorLoop:
         assert result.get("error") is True
         assert "issue_created" not in result
         assert loop._open_issue is None
+
+
+class TestRehydrateOpenIssue:
+    """Tests for _rehydrate_open_issue — the restart-recovery path (ADR-0029)."""
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_open_issue_when_existing_issue_found(
+        self, tmp_path: Path
+    ) -> None:
+        """When an open CI-failure issue already exists, loop rehydrates state from it."""
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.list_issues_by_label = AsyncMock(return_value=[{"number": 42}])
+
+        await loop._rehydrate_open_issue()
+
+        assert loop._open_issue == 42
+        pr.list_issues_by_label.assert_awaited_once_with("hydraflow-ci-failure")
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_open_issue_when_no_existing_issue(
+        self, tmp_path: Path
+    ) -> None:
+        """When no open CI-failure issue exists, _open_issue stays None (fresh start)."""
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.list_issues_by_label = AsyncMock(return_value=[])
+
+        await loop._rehydrate_open_issue()
+
+        assert loop._open_issue is None
+        pr.list_issues_by_label.assert_awaited_once_with("hydraflow-ci-failure")
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_open_issue_api_failure_is_handled_gracefully(
+        self, tmp_path: Path
+    ) -> None:
+        """When the API call to list issues fails, the loop logs and skips — no crash."""
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.list_issues_by_label = AsyncMock(side_effect=RuntimeError("API down"))
+
+        # Must not raise; _open_issue must remain None (safe default)
+        await loop._rehydrate_open_issue()
+
+        assert loop._open_issue is None
+        assert loop._startup_check_done is True
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_open_issue_is_idempotent(self, tmp_path: Path) -> None:
+        """Calling _rehydrate_open_issue twice in succession produces the same state.
+
+        The guard flag (_startup_check_done) must prevent a second API call so that
+        a concurrent or repeated invocation cannot overwrite rehydrated state.
+        """
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.list_issues_by_label = AsyncMock(return_value=[{"number": 77}])
+
+        await loop._rehydrate_open_issue()
+        assert loop._open_issue == 77
+
+        # Mutate the mock to return a different result for a second API call
+        pr.list_issues_by_label.return_value = [{"number": 99}]
+
+        await loop._rehydrate_open_issue()
+
+        # State must be unchanged; the second call must have been a no-op
+        assert loop._open_issue == 77
+        pr.list_issues_by_label.assert_awaited_once()  # called exactly once total
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_does_not_duplicate_issue_on_restart(
+        self, tmp_path: Path
+    ) -> None:
+        """After restart rehydration, a red CI poll must NOT create a second issue.
+
+        This is the primary regression ADR-0029 guards against: without rehydration
+        every process restart would call create_issue even though one already exists.
+        """
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.list_issues_by_label = AsyncMock(return_value=[{"number": 55}])
+        pr.get_latest_ci_status.return_value = (
+            "failure",
+            "https://github.com/runs/456",
+        )
+
+        # Simulate the first _do_work call after a process restart
+        result = await loop._do_work()
+
+        # Rehydration should have set _open_issue; create_issue must NOT be called
+        assert loop._open_issue == 55
+        pr.create_issue.assert_not_awaited()
+        assert result is not None
+        assert result["status"] == "red"


### PR DESCRIPTION
## Summary

Slice 5.4 (PR #8805) QG-H3: `_rehydrate_open_issue` had zero test coverage despite ADR-0029 calling it load-bearing for restart recovery. A regression here would silently duplicate the CI-failure issue on every process restart.

Adds 5 tests in a dedicated `TestRehydrateOpenIssue` class:

- **existing issue found** — loop sets `_open_issue` from API result, does not create a duplicate
- **no existing issue** — `_open_issue` stays `None`, fresh start proceeds normally
- **API failure is handled gracefully** — `RuntimeError` from `list_issues_by_label` is caught; loop logs and continues, does not crash
- **idempotency** — calling `_rehydrate_open_issue` twice produces the same state; `_startup_check_done` prevents a second API call from overwriting rehydrated state
- **end-to-end restart guard** — after rehydration, a red CI `_do_work` cycle does NOT call `create_issue` for the already-tracked issue

## Test plan
- [x] 5 new tests covering all branches of `_rehydrate_open_issue`
- [x] All 13 tests in `test_ci_monitor_loop.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)