### PR TITLE
refactor(routes): _epic_routes use public API

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T17:58:15.276352+00:00",
-  "commit_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475",
+  "regenerated_at": "2026-05-18T15:47:26.134129+00:00",
+  "commit_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914",
   "artifacts": {
     "loops.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "ports.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "labels.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "modules.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "events.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "adr_xref.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "mockworld.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "changelog.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     },
     "functional_areas.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "fe1bc3c69e4d531eddfa7cc28d1c75c21af41475"
+      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T15:47:26.134129+00:00",
-  "commit_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914",
+  "regenerated_at": "2026-05-18T17:58:46.346250+00:00",
+  "commit_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e",
   "artifacts": {
     "loops.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "ports.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "labels.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "modules.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "events.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "adr_xref.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "mockworld.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "changelog.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     },
     "functional_areas.md": {
-      "source_sha": "314a5a39dd29fe4de3047d9923622f9d07bf2914"
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "cf1e6136dbe1a505ff22876975e5e6ed9166911e"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,16 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `fe1bc3c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
-- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
-- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
-- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `314a5a3` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -31,7 +22,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -42,7 +32,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
-- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -292,4 +281,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,18 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `314a5a3` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `cf1e613` — fix(format): ruff format *(2026-05-18)*
+- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
+- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
+- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -22,6 +33,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
+- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -32,6 +44,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -281,4 +294,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `fe1bc3c` on 2026-05-18 17:58 UTC. Source last changed at `fe1bc3c`. Status: 🟢 fresh._
+_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `314a5a3` on 2026-05-18 15:47 UTC. Source last changed at `314a5a3`. Status: 🟢 fresh._
+_Regenerated from commit `cf1e613` on 2026-05-18 17:58 UTC. Source last changed at `cf1e613`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_epic_routes.py
+++ b/src/dashboard_routes/_epic_routes.py
@@ -21,7 +21,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         orch = _get_orch()
         if orch is None:
             return JSONResponse([])
-        details = await orch._svc.epic_manager.get_all_detail()
+        details = await orch.epic_manager.get_all_detail()
         return JSONResponse([d.model_dump() for d in details])
 
     @router.get("/api/epics/{epic_number}")
@@ -34,7 +34,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         orch = _get_orch()
         if orch is None:
             return JSONResponse({"error": "orchestrator not running"}, status_code=503)
-        detail = await orch._svc.epic_manager.get_detail(epic_number)
+        detail = await orch.epic_manager.get_detail(epic_number)
         if detail is None:
             return JSONResponse({"error": "epic not found"}, status_code=404)
         return JSONResponse(detail.model_dump())
@@ -53,7 +53,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         orch = _get_orch()
         if orch is None:
             return JSONResponse({"error": "orchestrator not running"}, status_code=503)
-        result = await orch._svc.epic_manager.trigger_release(epic_number)
+        result = await orch.epic_manager.trigger_release(epic_number)
         if "error" in result:
             return JSONResponse(result, status_code=400)
         return JSONResponse(result)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -52,6 +52,7 @@ from subprocess_util import (
 if TYPE_CHECKING:
     from base_background_loop import BaseBackgroundLoop
     from crate_manager import CrateManager
+    from epic import EpicManager
     from github_cache_loop import GitHubDataCache
     from issue_store import IssueStore
     from metrics_manager import MetricsManager
@@ -248,6 +249,11 @@ class HydraFlowOrchestrator:
     def metrics_manager(self) -> MetricsManager:
         """Expose metrics manager for dashboard API."""
         return self._svc.metrics_manager
+
+    @property
+    def epic_manager(self) -> EpicManager:
+        """Expose epic manager for dashboard API."""
+        return self._svc.epic_manager
 
     @property
     def running(self) -> bool:

--- a/tests/test_epic_api.py
+++ b/tests/test_epic_api.py
@@ -324,8 +324,7 @@ class TestEpicEndpoints:
             merged_children=2,
             readiness=EpicReadiness(all_implemented=True),
         )
-        mock_orch._svc = MagicMock()
-        mock_orch._svc.epic_manager.get_all_detail = AsyncMock(
+        mock_orch.epic_manager.get_all_detail = AsyncMock(
             return_value=[mock_detail]
         )
 
@@ -349,8 +348,7 @@ class TestEpicEndpoints:
         from unittest.mock import MagicMock
 
         mock_orch = MagicMock()
-        mock_orch._svc = MagicMock()
-        mock_orch._svc.epic_manager.get_detail = AsyncMock(return_value=None)
+        mock_orch.epic_manager.get_detail = AsyncMock(return_value=None)
 
         router, _pr = make_dashboard_router(
             config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
@@ -378,8 +376,7 @@ class TestEpicEndpoints:
             ],
         )
         mock_orch = MagicMock()
-        mock_orch._svc = MagicMock()
-        mock_orch._svc.epic_manager.get_detail = AsyncMock(return_value=mock_detail)
+        mock_orch.epic_manager.get_detail = AsyncMock(return_value=mock_detail)
 
         router, _pr = make_dashboard_router(
             config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
@@ -418,8 +415,7 @@ class TestEpicEndpoints:
         from unittest.mock import MagicMock
 
         mock_orch = MagicMock()
-        mock_orch._svc = MagicMock()
-        mock_orch._svc.epic_manager.trigger_release = AsyncMock(
+        mock_orch.epic_manager.trigger_release = AsyncMock(
             return_value={"job_id": "release-100-123", "status": "started"}
         )
 
@@ -441,8 +437,7 @@ class TestEpicEndpoints:
         from unittest.mock import MagicMock
 
         mock_orch = MagicMock()
-        mock_orch._svc = MagicMock()
-        mock_orch._svc.epic_manager.trigger_release = AsyncMock(
+        mock_orch.epic_manager.trigger_release = AsyncMock(
             return_value={"error": "epic not found", "status": "failed"}
         )
 

--- a/tests/test_epic_api.py
+++ b/tests/test_epic_api.py
@@ -324,9 +324,7 @@ class TestEpicEndpoints:
             merged_children=2,
             readiness=EpicReadiness(all_implemented=True),
         )
-        mock_orch.epic_manager.get_all_detail = AsyncMock(
-            return_value=[mock_detail]
-        )
+        mock_orch.epic_manager.get_all_detail = AsyncMock(return_value=[mock_detail])
 
         router, _pr = make_dashboard_router(
             config, event_bus, state, tmp_path, get_orch=lambda: mock_orch


### PR DESCRIPTION
## Summary

- Slice 5.8 (PR #8787): `_epic_routes.py` accessed `orch._svc.epic_manager` — a private attribute chain violating the route/service-registry boundary.
- Added `HydraFlowOrchestrator.epic_manager` public property (matches the existing `crate_manager`, `metrics_manager`, `github_cache` pattern).
- Updated all three route handlers to call `orch.epic_manager` and updated test mocks to target the public property.

## Test plan
- [x] `tests/test_epic_api.py` — all 39 tests pass.
- [x] `tests/test_epic.py` + `tests/test_epic_monitor_loop.py` — 150 tests pass total.
- [x] `ruff check` clean on all changed files.
- [x] No behavior change — purely a routing-through-public-API refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)