### PR TITLE
cleanup: remove 2 dead methods (slice 5.1 findings)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T18:45:07.322005+00:00",
-  "commit_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b",
+  "regenerated_at": "2026-05-18T15:47:32.150421+00:00",
+  "commit_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "ports.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "labels.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "modules.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "events.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "adr_xref.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "mockworld.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "changelog.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     },
     "functional_areas.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "a864c462ab946c125fcf8b27cc3745ed8485c58b"
+      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T15:47:32.150421+00:00",
-  "commit_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d",
+  "regenerated_at": "2026-05-18T18:45:42.986620+00:00",
+  "commit_sha": "9ca35c75d112e50a520f76456481e7d597a66b77",
   "artifacts": {
     "loops.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "ports.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "labels.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "modules.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "events.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "adr_xref.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "mockworld.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "changelog.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     },
     "functional_areas.md": {
-      "source_sha": "19767018012dae7b1448c725ab79f3f15dda1d6d"
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,24 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `1976701` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `9ca35c7` — fix(format): ruff format *(2026-05-18)*
+- `ebe1710` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `d0635fe` — fix(format): ruff format *(2026-05-18)*
+- `ea0e084` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `469d933` — fix(format): ruff format *(2026-05-18)*
+- `73a1a7f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6811034` — fix(format): ruff format *(2026-05-18)*
+- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
+- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
+- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -22,6 +39,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
+- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -32,6 +50,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -281,4 +300,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,22 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `a864c46` — fix(format): ruff format *(2026-05-18)*
-- `ea0e084` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `469d933` — fix(format): ruff format *(2026-05-18)*
-- `73a1a7f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `6811034` — fix(format): ruff format *(2026-05-18)*
-- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
-- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
-- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
-- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `1976701` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -37,7 +22,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -48,7 +32,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
-- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -298,4 +281,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `a864c46` on 2026-05-18 18:45 UTC. Source last changed at `a864c46`. Status: 🟢 fresh._
+_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `1976701` on 2026-05-18 15:47 UTC. Source last changed at `1976701`. Status: 🟢 fresh._
+_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -216,12 +216,6 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         out.write_text(json.dumps(report, indent=2))
         return out
 
-    async def _audit_hydraflow_self(self) -> dict[str, str]:
-        """Audit the HydraFlow working tree and persist the dated snapshot."""
-        report = await self._run_audit(_HYDRAFLOW_SELF, self._config.repo_root)
-        self._save_snapshot(_HYDRAFLOW_SELF, report)
-        return self._snapshot_from_report(report)
-
     async def _run_git(self, *args: str, cwd: Path | None = None) -> tuple[int, str]:
         """Run a git subcommand; returns ``(exit_code, combined_output)``."""
         cmd = ["git", *args]

--- a/src/staging_bisect_loop.py
+++ b/src/staging_bisect_loop.py
@@ -901,25 +901,6 @@ class StagingBisectLoop(BaseBackgroundLoop):
             title, body, ["hydraflow-find", "rc-red-retry"]
         )
 
-    @staticmethod
-    def _compute_lineage_id(culprit_pr_title: str, failing_tests: str) -> str:
-        """Stable hash of culprit-PR title + failing-test set.
-
-        Two retries of the same defect (same PR title family + same
-        tests fail) collapse to the same lineage; a different defect
-        on the same PR title gets a different lineage because its
-        failing-test set differs. 12-char hex prefix is enough — collisions
-        across the lifetime of a single repo are vanishingly unlikely.
-        """
-        import hashlib  # noqa: PLC0415
-
-        # Normalize tests: strip + sort + dedup so order doesn't matter.
-        tests_set = sorted(
-            set(filter(None, (s.strip() for s in failing_tests.split(","))))
-        )
-        material = f"{culprit_pr_title.strip()}|{','.join(tests_set)}"
-        return hashlib.blake2s(material.encode(), digest_size=6).hexdigest()
-
     async def _check_pending_watchdog(self) -> dict[str, Any] | None:
         """Resolve any pending watchdog to green / still-red / timeout.
 

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -50,46 +50,6 @@ def test_skeleton_worker_name_and_interval(loop_env):
     assert loop._get_default_interval() == 604800  # spec §4.4
 
 
-async def test_audit_hydraflow_self_saves_snapshot(loop_env, tmp_path, monkeypatch):
-    cfg, state, pr = loop_env
-    stop = asyncio.Event()
-    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
-
-    fake_findings = [
-        {
-            "check_id": "P1.1",
-            "status": "PASS",
-            "severity": "STRUCTURAL",
-            "principle": "P1",
-            "source": "docs/adr",
-            "what": "doc exists",
-            "remediation": "write docs",
-            "message": "",
-        },
-        {
-            "check_id": "P2.4",
-            "status": "PASS",
-            "severity": "BEHAVIORAL",
-            "principle": "P2",
-            "source": "Makefile",
-            "what": "target runs",
-            "remediation": "fix target",
-            "message": "",
-        },
-    ]
-
-    async def fake_run_audit(slug, repo_root):
-        return {"summary": {}, "findings": fake_findings}
-
-    monkeypatch.setattr(loop, "_run_audit", fake_run_audit)
-
-    snapshot = await loop._audit_hydraflow_self()
-    assert snapshot == {"P1.1": "PASS", "P2.4": "PASS"}
-    snap_dir = cfg.data_root / "hydraflow-self" / "audit"
-    saved = list(snap_dir.glob("*.json"))
-    assert len(saved) == 1
-
-
 async def test_audit_managed_repo_clones_or_fetches(loop_env, tmp_path, monkeypatch):
     cfg, state, pr = loop_env
     stop = asyncio.Event()

--- a/tests/test_staging_bisect_loop.py
+++ b/tests/test_staging_bisect_loop.py
@@ -848,4 +848,3 @@ class TestG10RetryLineageWiring:
         # past cap.
         all_labels = [c.args[2] for c in prs.create_issue.await_args_list]
         assert all("hitl-escalation" not in lbls for lbls in all_labels)
-

--- a/tests/test_staging_bisect_loop.py
+++ b/tests/test_staging_bisect_loop.py
@@ -849,11 +849,3 @@ class TestG10RetryLineageWiring:
         all_labels = [c.args[2] for c in prs.create_issue.await_args_list]
         assert all("hitl-escalation" not in lbls for lbls in all_labels)
 
-    def test_compute_lineage_id_is_deterministic(self) -> None:
-        from staging_bisect_loop import StagingBisectLoop
-
-        a = StagingBisectLoop._compute_lineage_id("Title X", "test_a, test_b")
-        b = StagingBisectLoop._compute_lineage_id("Title X", "test_b, test_a")
-        c = StagingBisectLoop._compute_lineage_id("Title X", "test_a, test_c")
-        assert a == b  # order-independent
-        assert a != c  # different test sets diverge


### PR DESCRIPTION
## Summary

Slice 5.1 (PR #8793) identified 2 dead methods that are defined + unit-tested in isolation but never called in production. Removes them and their isolated tests.

- `StagingBisectLoop._compute_lineage_id` (bead advisor-isag) — static hash helper, no production caller
- `PrinciplesAuditLoop._audit_hydraflow_self` (bead advisor-90yv) — audit convenience wrapper, no production caller

## Test plan
- [x] Grep confirms no callers in `src/` beyond the definitions themselves.
- [x] 59 remaining tests in both suites pass (`pytest tests/test_staging_bisect_loop.py tests/test_principles_audit_loop.py -x`).

🤖 Generated with Claude Code