### PR TITLE
refactor(phases): DiscoverPhase + ShapePhase use Ports

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T23:39:41.504014+00:00",
-  "commit_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa",
+  "regenerated_at": "2026-05-18T23:39:46.277372+00:00",
+  "commit_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780",
   "artifacts": {
     "loops.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "ports.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "labels.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "modules.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "events.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "adr_xref.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "mockworld.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "changelog.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "coverage_matrix.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "functional_areas.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "ubiquitous-language.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "8cec6db44c4004185c6b3c4e1eb803f697c564aa"
+      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T23:39:46.277372+00:00",
-  "commit_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780",
+  "regenerated_at": "2026-05-19T00:05:34.405368+00:00",
+  "commit_sha": "08be19925c15a6344e23b47eeede3d28b3992b31",
   "artifacts": {
     "loops.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "ports.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "labels.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "modules.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "events.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "adr_xref.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "mockworld.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "changelog.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "coverage_matrix.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "functional_areas.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "ubiquitous-language.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "e4c16cc6ab877cc9548e1c7caf93771261b46780"
+      "source_sha": "08be19925c15a6344e23b47eeede3d28b3992b31"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,9 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `8cec6db` — fix(format): ruff format *(2026-05-18)*
-- `e80d302` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `d67e2b4` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
+- `e4c16cc` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `990441b` — fix(format): ruff format *(2026-05-18)*
 - `47d4138` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `95b28e1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -326,4 +324,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `e4c16cc` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `7ad3209` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6badaf2` — fix(format): ruff format *(2026-05-18)*
+- `e80d302` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `d67e2b4` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
 - `990441b` — fix(format): ruff format *(2026-05-18)*
 - `47d4138` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `95b28e1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -324,4 +327,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._
+_Regenerated from commit `08be199` on 2026-05-19 00:05 UTC. Source last changed at `08be199`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -10,7 +10,6 @@ graph LR
     BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
-    IssueStorePort --> CachingIssueStore
     IssueStorePort --> IssueStore
     IssueStorePort -.-> FakeIssueStore
     ObservabilityPort --> SentryObservabilityAdapter
@@ -52,9 +51,8 @@ graph LR
 ### IssueStorePort
 
 - Module: `src.ports`
-- Methods: `enqueue_transition`, `enrich_with_comments`, `get_implementable`, `get_plannable`, `get_reviewable`, `get_triageable`, `is_active`, `mark_active`, `mark_complete`, `mark_merged`, `release_in_flight`
+- Methods: `enqueue_transition`, `enrich_with_comments`, `get_discoverable`, `get_implementable`, `get_plannable`, `get_reviewable`, `get_shapeable`, `get_triageable`, `is_active`, `mark_active`, `mark_complete`, `mark_merged`, `release_in_flight`
 - Adapters:
-  - `CachingIssueStore` (`src.caching_issue_store`)
   - `IssueStore` (`src.issue_store`)
 - Fake: `FakeIssueStore` (`mockworld.fakes.fake_issue_store`)
 
@@ -98,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `8cec6db` on 2026-05-18 23:39 UTC. Source last changed at `8cec6db`. Status: 🟢 fresh._
+_Regenerated from commit `e4c16cc` on 2026-05-18 23:39 UTC. Source last changed at `e4c16cc`. Status: 🟢 fresh._

--- a/src/discover_phase.py
+++ b/src/discover_phase.py
@@ -4,21 +4,23 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
 from dedup_store import DedupStore
 from discover_runner import DiscoverRunner
 from events import EventBus, EventType, HydraFlowEvent
-from issue_store import IssueStore
 from models import DiscoverResult, Task
 from phase_utils import (
     _sentry_transaction,
     run_refilling_pool,
     store_lifecycle,
 )
-from pr_manager import PRManager
 from state import StateTracker
 from task_source import TaskTransitioner
+
+if TYPE_CHECKING:
+    from ports import IssueStorePort, PRPort
 
 logger = logging.getLogger("hydraflow.discover_phase")
 
@@ -35,8 +37,8 @@ class DiscoverPhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        store: IssueStore,
-        prs: PRManager,
+        store: IssueStorePort,
+        prs: PRPort,
         event_bus: EventBus,
         stop_event: asyncio.Event,
         discover_runner: DiscoverRunner | None = None,

--- a/src/ports.py
+++ b/src/ports.py
@@ -519,6 +519,14 @@ class IssueStorePort(Protocol):
         """Return up to *max_count* issues from the find queue."""
         ...
 
+    def get_discoverable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the discover queue."""
+        ...
+
+    def get_shapeable(self, max_count: int) -> list[Task]:
+        """Return up to *max_count* issues from the shape queue."""
+        ...
+
     def get_plannable(self, max_count: int) -> list[Task]:
         """Return up to *max_count* issues from the plan queue."""
         ...

--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -6,12 +6,12 @@ import asyncio
 import logging
 import re
 from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
 from dedup_store import DedupStore
 from events import EventBus, EventType, HydraFlowEvent
 from expert_council import CouncilResult, ExpertCouncil  # noqa: TCH001
-from issue_store import IssueStore
 from models import (
     ConversationTurn,
     ShapeConversation,
@@ -24,11 +24,13 @@ from phase_utils import (
     run_refilling_pool,
     store_lifecycle,
 )
-from pr_manager import PRManager
 from shape_runner import ShapeRunner  # noqa: TCH001
 from state import StateTracker
 from task_source import TaskTransitioner
 from whatsapp_bridge import WhatsAppBridge  # noqa: TCH001
+
+if TYPE_CHECKING:
+    from ports import IssueStorePort, PRPort
 
 logger = logging.getLogger("hydraflow.shape_phase")
 
@@ -76,8 +78,8 @@ class ShapePhase:
         self,
         config: HydraFlowConfig,
         state: StateTracker,
-        store: IssueStore,
-        prs: PRManager,
+        store: IssueStorePort,
+        prs: PRPort,
         event_bus: EventBus,
         stop_event: asyncio.Event,
         shape_runner: ShapeRunner | None = None,

--- a/tests/test_runners_phase_name.py
+++ b/tests/test_runners_phase_name.py
@@ -4,14 +4,10 @@ import pytest
 
 from agent import AgentRunner
 from base_runner import BaseRunner
-from diagnostic_runner import DiagnosticRunner
 from discover_runner import DiscoverRunner
-from hitl_runner import HITLRunner
 from planner import PlannerRunner
-from research_runner import ResearchRunner
 from reviewer import ReviewRunner
 from shape_runner import ShapeRunner
-from triage import TriageRunner
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Slice 5.9 (PR #8795): DiscoverPhase and ShapePhase accepted concrete `IssueStore` + `PRManager` instead of `IssueStorePort` + `PRPort`. Hexagonal violation; broke fake-adapter testing for these two phases. This switches both to Port deps, matching every other phase coordinator.

Also adds `get_discoverable` and `get_shapeable` to `IssueStorePort` — both methods were called by the phases but missing from the Port definition, making the Port incomplete as a substitution boundary.

## Test plan
- [x] Phase tests pass (18/18).
- [x] Port conformance tests pass (124/124).
- [x] No runtime behavior change — annotation-only tightening with `from __future__ import annotations` in effect.

🤖 Generated with Claude Code