### PR TITLE
fix(loops): CorpusLearningLoop returns accurate status

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,42 @@
 {
-  "regenerated_at": "2026-05-13T04:55:23.757269+00:00",
-  "commit_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff",
+  "regenerated_at": "2026-05-18T22:37:41.204767+00:00",
+  "commit_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4",
   "artifacts": {
     "loops.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "ports.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "labels.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "modules.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "events.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "adr_xref.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "mockworld.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "changelog.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
+    },
+    "coverage_matrix.md": {
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     },
     "functional_areas.md": {
-      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "c7c9c3dab1c43c3cac0c08275402a8b84b11f5e4"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T22:37:16.550192+00:00",
-  "commit_sha": "5489df25154f4ba1aa10854437b58ed364441961",
+  "regenerated_at": "2026-05-13T04:55:23.757269+00:00",
+  "commit_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "ports.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "labels.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "modules.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "events.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "adr_xref.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "mockworld.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "changelog.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
-    },
-    "coverage_matrix.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     },
     "functional_areas.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "5489df25154f4ba1aa10854437b58ed364441961"
+      "source_sha": "629efbc545d0a6502ab6c256e18dd5b981810fff"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `5489df2` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `c7c9c3d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `899d7aa` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
+- `3d724e9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `bf90023` — fix(format): ruff format *(2026-05-18)*
 - `2ff5ebd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `60c556b` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -81,6 +83,11 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W20
 
+- `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
+- `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
+- `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
+- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
+- `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
 - `1f954c2` — docs(audit): per-area review — Hexagonal Boundaries (slice 5.2 of 5) *(2026-05-12)*
@@ -307,4 +314,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -81,11 +81,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W20
 
-- `0c98560` — merge: reconcile main into staging (33 commits ahead) *(2026-05-16)*
-- `b1eafc5` — fix(staging): wire LiveCorpusReplayLoop + audit fixes — unblock RC promotion (#8939) (#8939) *(2026-05-16)*
-- `ef3b5f5` — chore(arch): regen arch + wiki artifacts from staging tip (#8926) (#8926) *(2026-05-16)*
-- `9bfce88` — docs(wiki): backfill 7 undocumented topics (closes slice 5.0 + 5.3 doc gaps) *(2026-05-12)*
-- `4ba1202` — docs(adr): promote 0031 + 0047 to Accepted (status drift fix from slice 5 audits) *(2026-05-12)*
 - `01ae95c` — fix(bg-loops): YAML resilience + auto-ensure PR labels (#8753) (#8753) *(2026-05-12)*
 - `92601fd` — audit: per-area review — Auto-Agent (slice 5.3) *(2026-05-12)*
 - `1f954c2` — docs(audit): per-area review — Hexagonal Boundaries (slice 5.2 of 5) *(2026-05-12)*
@@ -312,4 +307,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -21,7 +21,7 @@ graph LR
     src_state["src.state"]
     src_telemetry["src.telemetry"]
     src -- "4" --> src_arch
-    src -- "3" --> src_contracts
+    src -- "25" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -21,7 +21,7 @@ graph LR
     src_state["src.state"]
     src_telemetry["src.telemetry"]
     src -- "4" --> src_arch
-    src -- "25" --> src_contracts
+    src -- "3" --> src_contracts
     src -- "4" --> src_dashboard_routes
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._
+_Regenerated from commit `c7c9c3d` on 2026-05-18 22:37 UTC. Source last changed at `c7c9c3d`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `5489df2` on 2026-05-18 22:37 UTC. Source last changed at `5489df2`. Status: 🟢 fresh._
+_Regenerated from commit `629efbc` on 2026-05-13 04:55 UTC. Source last changed at `629efbc`. Status: 🟢 fresh._

--- a/src/corpus_learning_loop.py
+++ b/src/corpus_learning_loop.py
@@ -902,7 +902,7 @@ class CorpusLearningLoop(BaseBackgroundLoop):
             )
 
         return {
-            "status": "noop",
+            "status": "ok" if cases_filed > 0 else "noop",
             "escape_issues_seen": len(signals),
             "cases_synthesized": cases_synthesized,
             "cases_validated": cases_validated,

--- a/tests/regressions/test_corpus_learning_status_telemetry.py
+++ b/tests/regressions/test_corpus_learning_status_telemetry.py
@@ -1,0 +1,160 @@
+"""Regression test for bead advisor-uyzu (slice #5.1, PR #8793).
+
+Bug: ``CorpusLearningLoop._do_work`` always returned ``status="noop"``
+regardless of how many cases were filed. The hardcoded return misled
+``TrustFleetSanityLoop`` telemetry into treating every productive tick
+as idle work.
+
+Expected behaviour after fix:
+  - When ``cases_filed > 0``, ``status`` is ``"ok"``.
+  - When ``cases_filed == 0`` (no signals, or all deduped), ``status``
+    is ``"noop"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+from base_background_loop import LoopDeps  # noqa: E402
+from config import HydraFlowConfig  # noqa: E402
+from corpus_learning_loop import (  # noqa: E402
+    CorpusLearningLoop,
+    SynthesizedCase,
+    ValidationResult,
+)
+from events import EventBus  # noqa: E402
+
+
+def _iso_offset(days: int) -> str:
+    return (datetime.now(UTC) + timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _deps(stop: asyncio.Event, *, enabled: bool = True) -> LoopDeps:
+    return LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: enabled,
+    )
+
+
+def _loop(
+    tmp_path: Path,
+    *,
+    enabled: bool = True,
+    prs: object | None = None,
+    dedup: object | None = None,
+    **config_overrides: object,
+) -> CorpusLearningLoop:
+    config_overrides.setdefault("repo_root", tmp_path)
+    cfg = HydraFlowConfig(
+        data_root=tmp_path,
+        repo="hydra/hydraflow",
+        **config_overrides,
+    )
+    return CorpusLearningLoop(
+        config=cfg,
+        prs=prs if prs is not None else AsyncMock(),
+        dedup=dedup if dedup is not None else MagicMock(),
+        deps=_deps(asyncio.Event(), enabled=enabled),
+    )
+
+
+class _InMemoryDedup:
+    def __init__(self) -> None:
+        self._values: set[str] = set()
+
+    def get(self) -> set[str]:
+        return set(self._values)
+
+    def add(self, value: str) -> None:
+        self._values.add(value)
+
+
+class _AutoPrResultStub:
+    def __init__(self, *, status: str, pr_url: str | None = None) -> None:
+        self.status = status
+        self.pr_url = pr_url
+        self.branch = "test-branch"
+        self.error = None
+
+
+def test_do_work_returns_ok_status_when_cases_are_filed(
+    monkeypatch: object,
+    tmp_path: Path,
+) -> None:
+    """_do_work must return status='ok' when at least one case is filed.
+
+    Before the fix this always returned status='noop', producing misleading
+    telemetry in TrustFleetSanityLoop's event log.
+    """
+    prs = AsyncMock()
+    prs.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 501,
+                "title": "escape signal one",
+                "body": "",
+                "updated_at": _iso_offset(-1),
+            },
+        ]
+    )
+
+    dedup = _InMemoryDedup()
+    loop = _loop(tmp_path, prs=prs, dedup=dedup)
+
+    # Shortcut synthesis and validation so the test exercises only the
+    # status-return path, not the full pipeline.
+    loop._synthesize_case = lambda sig: SynthesizedCase(  # type: ignore[method-assign]
+        issue_number=sig.issue_number,
+        slug=f"case-{sig.issue_number}",
+        expected_catcher="diff-sanity",
+        keyword="renamed",
+        before_files={"src/x.py": "before\n"},
+        after_files={"src/x.py": "after\n"},
+        readme="Repro.",
+    )
+    loop._validate_case = lambda c: ValidationResult(ok=True)  # type: ignore[method-assign]
+    loop._materialize_case_on_disk = lambda c, r: []  # type: ignore[method-assign]
+
+    async def fake_open(**kwargs: object) -> object:  # noqa: ARG001
+        return _AutoPrResultStub(
+            status="opened",
+            pr_url="https://github.com/hydra/hydraflow/pull/999",
+        )
+
+    import corpus_learning_loop as mod
+
+    monkeypatch.setattr(mod, "open_automated_pr_async", fake_open)  # type: ignore[attr-defined]
+
+    result = asyncio.run(loop._do_work())
+
+    assert result is not None
+    assert result["cases_filed"] == 1
+    # Before the fix this would be "noop" even with cases_filed=1.
+    assert result["status"] == "ok", (
+        f"Expected status='ok' when cases_filed=1, got {result['status']!r}"
+    )
+
+
+def test_do_work_returns_noop_status_when_no_cases_filed(tmp_path: Path) -> None:
+    """_do_work must return status='noop' when no signals produce filed cases.
+
+    Verifies the zero-work path still correctly reports 'noop' so the
+    fix did not break the no-op signal.
+    """
+    prs = AsyncMock()
+    prs.list_issues_by_label = AsyncMock(return_value=[])
+    loop = _loop(tmp_path, prs=prs)
+
+    result = asyncio.run(loop._do_work())
+
+    assert result is not None
+    assert result["cases_filed"] == 0
+    assert result["status"] == "noop"


### PR DESCRIPTION
## Summary

Slice 5.1 (PR #8793, bead advisor-uyzu): `_do_work` hardcoded `status="noop"` regardless of `cases_filed`. Telemetry was lying to `TrustFleetSanityLoop`.

- Single-line fix: `"ok" if cases_filed > 0 else "noop"`, matching the convention in `principles_audit_loop` and `wiki_rot_detector_loop`.
- Regression test in `tests/regressions/test_corpus_learning_status_telemetry.py` asserts `status="ok"` when 1+ cases are filed and `status="noop"` when zero.

## Test plan
- [x] Regression test `test_do_work_returns_ok_status_when_cases_are_filed` asserts status reflects `cases_filed > 0`.
- [x] Regression test `test_do_work_returns_noop_status_when_no_cases_filed` asserts no-op path still correct.
- [x] All 41 existing `test_corpus_learning_loop.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)