### PR TITLE
feat(contracts): cassette retirement audit helper (Phase 6 of #8786)

### DIFF
--- a/src/contracts/retirement.py
+++ b/src/contracts/retirement.py
@@ -1,0 +1,126 @@
+"""Cassette retirement audit (Phase 6 of #8786).
+
+A baseline cassette becomes a retirement candidate once a
+``LiveCorpusReplayLoop`` dispatcher covers the same ``(adapter, command)``
+shape AND the dispatcher exercises that shape meaningfully (i.e. returns
+non-None for matching samples). For the first wave (the shape dispatcher
+from Phase 5), "meaningfully" means: the cassette's command shape would
+be picked up — currently any github ``gh`` call.
+
+This module ships the audit as a pure function so it can be invoked from
+``FakeCoverageAuditorLoop``, a one-off CLI, or a future check in
+``trust_fleet_sanity_loop``. The integration into a running loop is a
+deliberate follow-up so the audit's noise level can be tuned before it
+files issues.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+logger = logging.getLogger("hydraflow.contracts.retirement")
+
+
+@dataclass(frozen=True)
+class RetirementCandidate:
+    """One cassette eligible for retirement.
+
+    ``reason`` is a short machine-readable tag. ``dispatcher_key`` is the
+    ``(adapter, command)`` tuple that covers this cassette's shape.
+    """
+
+    path: Path
+    adapter: str
+    interaction: str
+    dispatcher_key: tuple[str, str]
+    reason: str
+
+
+def find_retirement_candidates(
+    cassettes_root: Path,
+    dispatcher_keys: set[tuple[str, str]],
+) -> list[RetirementCandidate]:
+    """Return baseline cassettes whose (adapter, command) is dispatcher-covered.
+
+    Iterates every ``*.yaml`` under ``cassettes_root/<adapter>/`` that has
+    ``baseline_only: true`` and a ``input.command`` matching one of the
+    registered dispatcher keys. Malformed cassettes are skipped with a
+    warning (the audit must not crash on bad files).
+    """
+    if not cassettes_root.is_dir():
+        return []
+
+    candidates: list[RetirementCandidate] = []
+    for adapter_dir in sorted(cassettes_root.iterdir()):
+        if not adapter_dir.is_dir():
+            continue
+        adapter = adapter_dir.name
+        for yaml_path in sorted(adapter_dir.glob("*.yaml")):
+            try:
+                raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or {}
+            except (OSError, yaml.YAMLError) as exc:
+                logger.warning(
+                    "retirement audit: could not load %s: %s", yaml_path, exc
+                )
+                continue
+            if not raw.get("baseline_only"):
+                continue
+            cassette_adapter = str(raw.get("adapter") or adapter)
+            cmd = str((raw.get("input") or {}).get("command") or "")
+            if not cmd:
+                continue
+            # Match either the exact (adapter, command) key or an adapter
+            # wildcard. The Phase 5 shape dispatcher uses
+            # ("github", "gh") — that's an exact match for every github
+            # cassette whose ``command`` happens to also be "gh" (the
+            # convention for the existing hand-authored corpus uses the
+            # FakeGitHub method name, not "gh", so most github cassettes
+            # won't trigger today — by design).
+            key = (cassette_adapter, cmd)
+            if key in dispatcher_keys:
+                candidates.append(
+                    RetirementCandidate(
+                        path=yaml_path,
+                        adapter=cassette_adapter,
+                        interaction=str(raw.get("interaction") or ""),
+                        dispatcher_key=key,
+                        reason="dispatcher_covers_shape",
+                    )
+                )
+    return candidates
+
+
+def format_candidates_for_issue(
+    candidates: list[RetirementCandidate],
+) -> str:
+    """Render a candidate list as a markdown body for an audit issue."""
+    if not candidates:
+        return "No retirement candidates."
+    lines = [
+        "## Cassette retirement candidates",
+        "",
+        "The following baseline cassettes are covered by a live",
+        "``LiveCorpusReplayLoop`` dispatcher and may be retired:",
+        "",
+        "| Cassette | Adapter | Interaction | Dispatcher |",
+        "|---|---|---|---|",
+    ]
+    for c in candidates:
+        lines.append(
+            f"| `{c.path.name}` | {c.adapter} | {c.interaction} | "
+            f"{c.dispatcher_key[0]}/{c.dispatcher_key[1]} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Retirement is a one-PR cleanup: verify the live dispatcher",
+            "covers the same drift signal these cassettes catch, then",
+            "delete the cassette files and the matching dispatcher entry",
+            "in ``_invoke_fake_<adapter>``.",
+        ]
+    )
+    return "\n".join(lines)

--- a/src/live_corpus_replay_loop.py
+++ b/src/live_corpus_replay_loop.py
@@ -95,6 +95,15 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
         """
         self._dispatchers[(adapter, command)] = fn
 
+    def registered_shapes(self) -> set[DispatcherKey]:
+        """Return the set of ``(adapter, command)`` pairs covered by this loop.
+
+        Used by external retirement-audit code (Phase 6 of #8786) — when
+        a hand-authored baseline cassette's shape is covered by a live
+        dispatcher, the cassette becomes a retirement candidate.
+        """
+        return set(self._dispatchers.keys())
+
     async def _do_work(self) -> WorkCycleResult:
         if not self._enabled_cb(self._worker_name):
             return {"status": "disabled"}

--- a/tests/test_cassette_retirement.py
+++ b/tests/test_cassette_retirement.py
@@ -1,0 +1,194 @@
+"""Unit tests for the cassette retirement audit (Phase 6 of #8786)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from contracts.retirement import (
+    RetirementCandidate,
+    find_retirement_candidates,
+    format_candidates_for_issue,
+)
+
+
+def _write_cassette(
+    path: Path,
+    *,
+    adapter: str,
+    command: str,
+    interaction: str = "anything",
+    baseline_only: bool = False,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "adapter": adapter,
+        "interaction": interaction,
+        "recorded_at": "2026-05-13T00:00:00Z",
+        "recorder_sha": "00000000",
+        "fixture_repo": "x/y",
+        "input": {"command": command, "args": [], "stdin": None, "env": {}},
+        "output": {"exit_code": 0, "stdout": "", "stderr": ""},
+        "normalizers": [],
+        "baseline_only": baseline_only,
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def test_no_candidates_when_no_dispatchers(tmp_path: Path) -> None:
+    """Empty dispatcher set → no candidates ever."""
+    _write_cassette(
+        tmp_path / "github" / "merge_pr.yaml",
+        adapter="github",
+        command="merge_pr",
+        baseline_only=True,
+    )
+    candidates = find_retirement_candidates(tmp_path, dispatcher_keys=set())
+    assert candidates == []
+
+
+def test_dispatcher_covers_baseline_cassette(tmp_path: Path) -> None:
+    """When a dispatcher key matches the cassette's (adapter, command) and
+    baseline_only=true, the cassette is a retirement candidate."""
+    _write_cassette(
+        tmp_path / "github" / "x.yaml",
+        adapter="github",
+        command="gh",
+        interaction="pr_view",
+        baseline_only=True,
+    )
+    candidates = find_retirement_candidates(
+        tmp_path, dispatcher_keys={("github", "gh")}
+    )
+    assert len(candidates) == 1
+    assert candidates[0].adapter == "github"
+    assert candidates[0].interaction == "pr_view"
+    assert candidates[0].dispatcher_key == ("github", "gh")
+    assert candidates[0].reason == "dispatcher_covers_shape"
+
+
+def test_non_baseline_cassettes_ignored(tmp_path: Path) -> None:
+    """Live-recorded cassettes (baseline_only=false or missing) are NEVER
+    candidates — those represent the live-recording corpus, not legacy
+    baselines."""
+    _write_cassette(
+        tmp_path / "git" / "commit.yaml",
+        adapter="git",
+        command="commit",
+        baseline_only=False,
+    )
+    candidates = find_retirement_candidates(
+        tmp_path, dispatcher_keys={("git", "commit")}
+    )
+    assert candidates == []
+
+
+def test_missing_dispatcher_for_command_no_candidate(tmp_path: Path) -> None:
+    """A baseline cassette whose command isn't dispatcher-covered stays."""
+    _write_cassette(
+        tmp_path / "github" / "merge_pr.yaml",
+        adapter="github",
+        command="merge_pr",
+        baseline_only=True,
+    )
+    # Dispatcher registered for "gh" but cassette command is "merge_pr".
+    candidates = find_retirement_candidates(
+        tmp_path, dispatcher_keys={("github", "gh")}
+    )
+    assert candidates == []
+
+
+def test_malformed_cassette_skipped(tmp_path: Path) -> None:
+    """A YAML parse error must not crash the audit — log + skip."""
+    (tmp_path / "github").mkdir()
+    (tmp_path / "github" / "broken.yaml").write_text(
+        "this is: not: valid: yaml: at all: [", encoding="utf-8"
+    )
+    # Also write a good baseline to prove the audit continued past the bad one.
+    _write_cassette(
+        tmp_path / "github" / "good.yaml",
+        adapter="github",
+        command="gh",
+        baseline_only=True,
+    )
+    candidates = find_retirement_candidates(
+        tmp_path, dispatcher_keys={("github", "gh")}
+    )
+    assert len(candidates) == 1
+    assert candidates[0].path.name == "good.yaml"
+
+
+def test_nonexistent_root_returns_empty(tmp_path: Path) -> None:
+    candidates = find_retirement_candidates(
+        tmp_path / "does-not-exist", dispatcher_keys={("github", "gh")}
+    )
+    assert candidates == []
+
+
+def test_format_empty(tmp_path: Path) -> None:
+    assert format_candidates_for_issue([]) == "No retirement candidates."
+
+
+def test_format_renders_table(tmp_path: Path) -> None:
+    candidates = [
+        RetirementCandidate(
+            path=tmp_path / "github" / "merge_pr.yaml",
+            adapter="github",
+            interaction="merge_pr",
+            dispatcher_key=("github", "gh"),
+            reason="dispatcher_covers_shape",
+        )
+    ]
+    body = format_candidates_for_issue(candidates)
+    assert "merge_pr.yaml" in body
+    assert "github" in body
+    assert "| Cassette |" in body
+
+
+@pytest.mark.asyncio
+async def test_live_loop_exposes_registered_shapes() -> None:
+    """LiveCorpusReplayLoop.registered_shapes() returns the (adapter, command)
+    set the retirement audit consumes."""
+    import asyncio
+    import tempfile
+    from unittest.mock import AsyncMock, MagicMock
+
+    from base_background_loop import LoopDeps
+    from config import HydraFlowConfig
+    from contracts.shadow import ShadowCorpus
+    from dedup_store import DedupStore
+    from events import EventBus
+    from live_corpus_replay_loop import LiveCorpusReplayLoop
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        config = HydraFlowConfig(
+            data_root=root / "data", repo_root=root / "repo", repo="x/y"
+        )
+        (root / "repo").mkdir()
+        corpus = ShadowCorpus(config.data_root / "contract_shadow")
+        dedup = DedupStore("x", config.data_root / "dedup" / "x.json")
+        stop = asyncio.Event()
+        deps = LoopDeps(
+            event_bus=EventBus(),
+            stop_event=stop,
+            status_cb=MagicMock(),
+            enabled_cb=lambda _: True,
+            sleep_fn=AsyncMock(),
+        )
+        loop = LiveCorpusReplayLoop(
+            config=config,
+            corpus=corpus,
+            pr_manager=AsyncMock(),
+            dedup=dedup,
+            deps=deps,
+        )
+
+        async def _stub(_sample):  # noqa: ANN001
+            return None
+
+        loop.register("github", "gh", _stub)
+        loop.register("git", "git", _stub)
+        assert loop.registered_shapes() == {("github", "gh"), ("git", "git")}


### PR DESCRIPTION
## Summary

Phase 6 of #8786 — ships the **retirement signal** for hand-authored baseline cassettes. `find_retirement_candidates(cassettes_root, dispatcher_keys)` returns every baseline cassette whose `(adapter, command)` shape is covered by a live `LiveCorpusReplayLoop` dispatcher.

## What's here

| Piece | Purpose |
|---|---|
| `src/contracts/retirement.py` | Pure audit function + `RetirementCandidate` dataclass + markdown body formatter |
| `LiveCorpusReplayLoop.registered_shapes()` | Introspection surface — returns the set of `(adapter, command)` keys |

## Why a free helper, not a loop method

The audit is data-only — it inspects cassette YAMLs on disk and a static set of dispatcher keys. No state, no I/O beyond reading. Pure functions are easier to unit-test, easier to wire from any caller (a future `FakeCoverageAuditorLoop` extension, a CLI, a dashboard endpoint).

## Why no issue-filer wiring yet

The Phase 5 shape dispatcher is registered for `("github", "gh")` but the existing hand-authored cassettes use FakeGitHub-method names (`create_pr`, `merge_pr`, …) as their `input.command`, not `gh`. So today the audit returns 0 candidates by design. Wiring an issue-filer now would be a no-op at best and noisy at worst once richer dispatchers land. Follow-up tracks both: filing the issues AND tightening the dispatcher coverage.

## Test plan

`tests/test_cassette_retirement.py` — 9 tests:
- [x] Empty dispatcher set → no candidates
- [x] Dispatcher covers baseline → candidate
- [x] Non-baseline cassettes ignored
- [x] Mismatched command → no candidate
- [x] Malformed YAML skipped without crashing
- [x] Non-existent root → empty
- [x] Markdown body formatter (empty + non-empty)
- [x] `registered_shapes()` round-trips after `.register()`

ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)