### PR TITLE
feat(contracts): I/O-boundary validation helper (Phase 7 of #8786)

### DIFF
--- a/src/contracts/boundary.py
+++ b/src/contracts/boundary.py
@@ -1,0 +1,163 @@
+"""I/O-boundary validation helper for adapter call sites (Phase 7 of #8786).
+
+The Pydantic shapes in ``contracts.shapes`` catch drift at the call site —
+but only if call sites actually validate. This module provides the small,
+non-intrusive helper that lets ``PRManager``, ``FakeGitHub``, and friends
+opt in without changing their return type or breaking on novel inputs.
+
+Contract:
+
+- ``parse_with_shape(json_str, model)`` returns a typed
+  :class:`BoundaryParseResult`. ``payload`` is always populated when the
+  JSON parsed at all; ``model_instance`` is the validated Pydantic model
+  when validation succeeded, else None; ``validation_error`` carries a
+  compact diagnostic on failure.
+- The helper NEVER raises on validation failure — it logs at WARNING and
+  returns a partial result. Call sites that want strict behaviour check
+  ``model_instance is None`` and raise themselves.
+- JSON parse failures (truly malformed input) DO raise ``ValueError`` so
+  callers don't silently fall back to a stale value.
+
+Why this shape:
+
+- Existing call sites do ``json.loads(stdout)`` → dict and access fields
+  by key. Migrating them to a typed model is a big refactor. This
+  helper lets them log shape drift today without touching their hot
+  path; tightening to ``raise`` on validation failure is a per-call-site
+  decision once the corpus is stable enough.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger("hydraflow.contracts.boundary")
+
+T = TypeVar("T", bound=BaseModel)
+
+
+@dataclass(frozen=True)
+class BoundaryValidationError:
+    """Compact, log-friendly diagnostic for a single failed validation."""
+
+    shape: str
+    failure_count: int
+    sample: list[dict[str, str]]  # up to N errors, one per offending field
+
+
+@dataclass(frozen=True)
+class BoundaryParseResult:
+    """Outcome of a call-site validation."""
+
+    payload: object | None
+    model_instance: BaseModel | None
+    validation_error: BoundaryValidationError | None
+
+    @property
+    def ok(self) -> bool:
+        """True iff JSON parsed AND the shape validated."""
+        return self.model_instance is not None and self.validation_error is None
+
+
+def parse_with_shape(json_str: str, model: type[T]) -> BoundaryParseResult:
+    """Parse *json_str* and validate it against *model*.
+
+    Returns a BoundaryParseResult capturing all three possible outcomes:
+    parse OK + validation OK, parse OK + validation fail, parse fail
+    (raises ValueError so the caller can't silently fall back).
+    """
+    try:
+        payload = json.loads(json_str)
+    except json.JSONDecodeError as exc:
+        msg = f"could not parse JSON at boundary: {exc}"
+        raise ValueError(msg) from exc
+
+    try:
+        instance = model.model_validate(payload)
+    except ValidationError as exc:
+        diag = BoundaryValidationError(
+            shape=model.__name__,
+            failure_count=len(exc.errors()),
+            sample=[
+                {
+                    "loc": ".".join(str(p) for p in e.get("loc", ())),
+                    "type": str(e.get("type", "")),
+                    "msg": str(e.get("msg", ""))[:200],
+                }
+                for e in exc.errors()[:10]
+            ],
+        )
+        logger.warning(
+            "boundary validation failed for %s (count=%d): %s",
+            model.__name__,
+            diag.failure_count,
+            diag.sample[0] if diag.sample else "no detail",
+        )
+        return BoundaryParseResult(
+            payload=payload, model_instance=None, validation_error=diag
+        )
+
+    return BoundaryParseResult(
+        payload=payload, model_instance=instance, validation_error=None
+    )
+
+
+def parse_list_with_shape(json_str: str, model: type[T]) -> list[BoundaryParseResult]:
+    """Parse *json_str* as a list and validate each element against *model*.
+
+    Returns one BoundaryParseResult per list element. Element-level
+    failures don't poison sibling elements — each carries its own
+    validation outcome.
+    """
+    try:
+        payload = json.loads(json_str)
+    except json.JSONDecodeError as exc:
+        msg = f"could not parse JSON list at boundary: {exc}"
+        raise ValueError(msg) from exc
+
+    if not isinstance(payload, list):
+        msg = (
+            f"expected JSON list at boundary, got {type(payload).__name__}: {payload!r}"
+        )
+        raise ValueError(msg)
+
+    out: list[BoundaryParseResult] = []
+    for i, item in enumerate(payload):
+        try:
+            instance = model.model_validate(item)
+        except ValidationError as exc:
+            diag = BoundaryValidationError(
+                shape=model.__name__,
+                failure_count=len(exc.errors()),
+                sample=[
+                    {
+                        "loc": ".".join(str(p) for p in e.get("loc", ())),
+                        "type": str(e.get("type", "")),
+                        "msg": str(e.get("msg", ""))[:200],
+                    }
+                    for e in exc.errors()[:10]
+                ],
+            )
+            logger.warning(
+                "boundary validation failed for %s[%d]: %s",
+                model.__name__,
+                i,
+                diag.sample[0] if diag.sample else "no detail",
+            )
+            out.append(
+                BoundaryParseResult(
+                    payload=item, model_instance=None, validation_error=diag
+                )
+            )
+        else:
+            out.append(
+                BoundaryParseResult(
+                    payload=item, model_instance=instance, validation_error=None
+                )
+            )
+    return out

--- a/tests/test_contracts_boundary.py
+++ b/tests/test_contracts_boundary.py
@@ -1,0 +1,143 @@
+"""Unit tests for the I/O-boundary validation helper (Phase 7 of #8786)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from contracts.boundary import (
+    BoundaryParseResult,
+    parse_list_with_shape,
+    parse_with_shape,
+)
+from contracts.shapes import GhPRDetail, GhPRSummary
+
+# ---------------------------------------------------------------------------
+# parse_with_shape
+# ---------------------------------------------------------------------------
+
+
+def test_parse_with_shape_ok_on_valid_payload() -> None:
+    """Valid JSON + valid shape → ok=True, model_instance populated."""
+    payload = '{"number": 42, "title": "x", "state": "OPEN"}'
+    result = parse_with_shape(payload, GhPRSummary)
+    assert result.ok is True
+    assert result.validation_error is None
+    assert isinstance(result.model_instance, GhPRSummary)
+    assert result.model_instance.number == 42
+
+
+def test_parse_with_shape_logs_and_returns_partial_on_validation_fail(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Validation failure → ok=False, payload still populated, WARN logged.
+    Call sites that don't check ``ok`` keep working with the raw dict."""
+    payload = '{"number": 42, "title": "x", "state": "QUEUED"}'  # bad enum
+    with caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"):
+        result = parse_with_shape(payload, GhPRSummary)
+    assert result.ok is False
+    assert result.model_instance is None
+    assert result.payload == {"number": 42, "title": "x", "state": "QUEUED"}
+    assert result.validation_error is not None
+    assert result.validation_error.shape == "GhPRSummary"
+    assert result.validation_error.failure_count >= 1
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+
+
+def test_parse_with_shape_raises_on_json_parse_error() -> None:
+    """A truly malformed payload is a callable bug — raise so the caller
+    can't silently fall back."""
+    with pytest.raises(ValueError, match="could not parse JSON"):
+        parse_with_shape("not json", GhPRSummary)
+
+
+def test_parse_with_shape_aliases_camelcase() -> None:
+    """gh emits camelCase; the model accepts both via populate_by_name."""
+    payload = (
+        '{"number": 1, "headRefName": "feat/x", "baseRefName": "staging",'
+        ' "mergeable": "MERGEABLE"}'
+    )
+    result = parse_with_shape(payload, GhPRDetail)
+    assert result.ok
+    assert result.model_instance is not None
+    assert result.model_instance.head_ref_name == "feat/x"
+
+
+# ---------------------------------------------------------------------------
+# parse_list_with_shape
+# ---------------------------------------------------------------------------
+
+
+def test_parse_list_with_shape_returns_one_result_per_element() -> None:
+    payload = (
+        '[{"number": 1, "title": "x", "state": "OPEN"},'
+        ' {"number": 2, "title": "y", "state": "MERGED"}]'
+    )
+    results = parse_list_with_shape(payload, GhPRSummary)
+    assert len(results) == 2
+    assert all(r.ok for r in results)
+
+
+def test_parse_list_one_bad_does_not_poison_others(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A drifted element fires its own validation error; siblings remain OK."""
+    payload = (
+        '[{"number": 1, "title": "x", "state": "OPEN"},'
+        ' {"number": 2, "title": "y", "state": "QUEUED"},'  # bad
+        ' {"number": 3, "title": "z", "state": "MERGED"}]'
+    )
+    with caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"):
+        results = parse_list_with_shape(payload, GhPRSummary)
+    assert len(results) == 3
+    assert results[0].ok and results[2].ok
+    assert results[1].ok is False
+    assert results[1].validation_error is not None
+    assert "[1]" in next((r.message for r in caplog.records if "[1]" in r.message), "")
+
+
+def test_parse_list_raises_on_non_list_payload() -> None:
+    with pytest.raises(ValueError, match="expected JSON list"):
+        parse_list_with_shape('{"not": "a list"}', GhPRSummary)
+
+
+def test_parse_list_raises_on_json_error() -> None:
+    with pytest.raises(ValueError, match="could not parse JSON list"):
+        parse_list_with_shape("[oops", GhPRSummary)
+
+
+# ---------------------------------------------------------------------------
+# Call-site usage pattern (demo)
+# ---------------------------------------------------------------------------
+
+
+def test_call_site_pattern_strict_caller() -> None:
+    """A strict caller checks ``ok`` and raises on drift."""
+    payload = '{"number": 1, "title": "x", "state": "QUEUED"}'
+    result = parse_with_shape(payload, GhPRSummary)
+    if not result.ok:
+        # The strict pattern: raise so the caller knows about drift.
+        with pytest.raises(RuntimeError):
+            msg = "gh response shape drift"
+            raise RuntimeError(msg)
+
+
+def test_call_site_pattern_lenient_caller() -> None:
+    """A lenient caller accesses ``payload`` (raw dict) regardless of
+    validation outcome — drift is observed via the WARN log, behavior
+    is preserved."""
+    payload = '{"number": 1, "title": "x", "state": "QUEUED"}'
+    result = parse_with_shape(payload, GhPRSummary)
+    # Lenient path: use the raw payload even when validation failed.
+    assert isinstance(result.payload, dict)
+    assert result.payload["number"] == 1
+
+
+# Type contract: the result dataclass shape is part of the public API.
+
+
+def test_boundary_parse_result_dataclass_fields() -> None:
+    """Compile-time check that the dataclass exposes the documented fields."""
+    fields = BoundaryParseResult.__dataclass_fields__
+    assert set(fields) == {"payload", "model_instance", "validation_error"}


### PR DESCRIPTION
## Summary

Phase 7 of #8786 — ships the small helper that lets adapter call sites (`PRManager`, `FakeGitHub`, …) opt into Pydantic shape validation without changing their return type or breaking on novel inputs.

## Contract

| Function | Behavior |
|---|---|
| `parse_with_shape(json_str, model)` | Parses JSON, validates against Pydantic model. Returns `BoundaryParseResult(payload, model_instance, validation_error)`. |
| `parse_list_with_shape(json_str, model)` | Same, per element of a JSON list. Sibling-isolated (one bad element doesn't poison the rest). |

**Failure semantics:**
- Validation failure → log WARN, return partial result (`payload` populated, `model_instance=None`, `validation_error` diag).
- JSON parse failure → raise `ValueError` (malformed bytes are a callable bug, not a drift signal).

## Why this matters

The trust-arch v2 pattern now has **two independent drift signals**:
1. **Replay-tick** drift via `LiveCorpusReplayLoop` (Phase 2/5) — runs every 15min, diffs sample vs fake.
2. **Call-site** drift via this helper — fires *the moment* real gh returns a drifted shape to production code.

Either one alone is enough to file a `hydraflow-find` issue. Together they bracket the drift surface.

## Out of scope (follow-up)

Wiring the helper into specific `PRManager` methods. Each call site is a small migration but the surface is wide — multiple small PRs are safer than one big rollout. Tracked.

## Test plan

`tests/test_contracts_boundary.py` — 11 tests:
- [x] Success → ok=True, model populated
- [x] Validation fail → log WARN, partial result
- [x] JSON parse → ValueError
- [x] camelCase alias support
- [x] List per-element results + sibling isolation
- [x] Non-list / malformed list → ValueError
- [x] Documented strict + lenient call-site patterns
- [x] Dataclass surface invariant

ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)