### PR TITLE
feat(pr-manager): wire list_issues_by_label through boundary helper (Phase 8 of #8786)

### DIFF
--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -116,3 +116,20 @@ class GhIssueSummary(BaseModel):
     body: str | None = None
     labels: list[GhLabel] = Field(default_factory=list)
     updated_at: str | None = Field(default=None, alias="updatedAt")
+
+
+class GhIssueListItem(BaseModel):
+    """``gh issue list --json number,title,body,updatedAt`` element shape.
+
+    Narrower than :class:`GhIssueSummary` — list invocations typically
+    omit ``state`` (the filter is already applied by ``--state open|closed``)
+    and ``labels``. A separate shape so the broader summary keeps its
+    drift-detection bite on view invocations.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    number: int
+    title: str
+    body: str | None = None
+    updated_at: str | None = Field(default=None, alias="updatedAt")

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1375,7 +1375,19 @@ class PRManager:
             return "UNKNOWN"
 
     async def list_issues_by_label(self, label: str) -> list[GitHubIssueSummary]:
-        """Return open issues with the given label as a list of dicts."""
+        """Return open issues with the given label as a list of dicts.
+
+        #8786 Phase 8: parses through ``contracts.boundary.parse_list_with_shape``
+        in *lenient* mode — validation failures log WARN but the method's
+        return type and behaviour are unchanged. Existing callers that
+        access ``item["number"]`` etc keep working; shape drift is
+        observable in ``server.log`` and via ``LiveCorpusReplayLoop``.
+        """
+        # Local import keeps the module-load contract identical when
+        # the contracts subsystem isn't imported elsewhere yet.
+        from contracts.boundary import parse_list_with_shape  # noqa: PLC0415
+        from contracts.shapes import GhIssueListItem  # noqa: PLC0415
+
         self._assert_repo()
         output = await self._run_gh(
             "gh",
@@ -1392,15 +1404,31 @@ class PRManager:
             "--limit",
             "100",
         )
-        items = json.loads(output)
+        results = parse_list_with_shape(output, GhIssueListItem)
         return [
             {
-                "number": item.get("number", 0),
-                "title": item.get("title", ""),
-                "body": item.get("body", ""),
-                "updated_at": item.get("updatedAt", ""),
+                "number": (
+                    r.model_instance.number
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("number", 0)
+                ),
+                "title": (
+                    r.model_instance.title
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("title", "")
+                ),
+                "body": (
+                    r.model_instance.body or ""
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("body", "")
+                ),
+                "updated_at": (
+                    r.model_instance.updated_at or ""
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("updatedAt", "")
+                ),
             }
-            for item in items
+            for r in results
         ]
 
     async def list_closed_issues_by_label(

--- a/tests/regressions/test_list_issues_boundary_validation.py
+++ b/tests/regressions/test_list_issues_boundary_validation.py
@@ -1,0 +1,129 @@
+"""Regression: list_issues_by_label is now wired through the contracts boundary
+helper (Phase 8 of #8786) — verify the lenient pattern.
+
+Two invariants:
+1. Behaviour is preserved for well-shaped responses (existing callers see the
+   same dict shape they always did).
+2. Drifted responses still parse to the legacy dict shape via the lenient
+   ``payload`` fallback — a WARN is logged, but the method returns useful data.
+   Strict-mode callers would handle the drift signal differently; that's a
+   per-call-site decision.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+class TestListIssuesByLabelBoundaryWiring:
+    @pytest.mark.asyncio
+    async def test_well_shaped_response_returns_dict_shape_unchanged(
+        self,
+        config,
+        event_bus,
+        caplog,  # noqa: ANN001
+    ) -> None:
+        """Happy path: validation succeeds, dict shape preserved, no WARN."""
+        mgr = make_pr_manager(config, event_bus)
+        issues_json = json.dumps(
+            [
+                {
+                    "number": 7,
+                    "title": "fix bug",
+                    "body": "details",
+                    "updatedAt": "2026-05-13T00:00:00Z",
+                },
+                {
+                    "number": 8,
+                    "title": "add feature",
+                    "body": "",
+                    "updatedAt": "2026-05-14T00:00:00Z",
+                },
+            ]
+        )
+        mock_create = SubprocessMockBuilder().with_stdout(issues_json).build()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+            patch("asyncio.create_subprocess_exec", mock_create),
+        ):
+            result = await mgr.list_issues_by_label("bug")
+
+        assert len(result) == 2
+        assert result[0]["number"] == 7
+        assert result[0]["title"] == "fix bug"
+        assert result[0]["updated_at"] == "2026-05-13T00:00:00Z"
+
+        validation_warns = [
+            r for r in caplog.records if "boundary validation failed" in r.message
+        ]
+        assert validation_warns == [], (
+            "well-shaped responses must not trip the drift signal"
+        )
+
+    @pytest.mark.asyncio
+    async def test_drifted_response_logs_warn_and_falls_back(
+        self,
+        config,
+        event_bus,
+        caplog,  # noqa: ANN001
+    ) -> None:
+        """If gh's response shape changes (e.g. an unexpected type for a
+        required field), the lenient wiring logs WARN but still returns
+        the parsed dict — production behaviour preserved."""
+        mgr = make_pr_manager(config, event_bus)
+        # ``number`` is the wrong type → validation fails. The lenient
+        # wiring falls back to the raw dict.
+        issues_json = json.dumps(
+            [
+                {
+                    "number": "not-an-int",
+                    "title": "x",
+                    "body": "",
+                    "updatedAt": "2026-05-13T00:00:00Z",
+                }
+            ]
+        )
+        mock_create = SubprocessMockBuilder().with_stdout(issues_json).build()
+
+        with (
+            caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+            patch("asyncio.create_subprocess_exec", mock_create),
+        ):
+            result = await mgr.list_issues_by_label("bug")
+
+        # WARN was logged — drift signal fired.
+        warn_msgs = [
+            r.message
+            for r in caplog.records
+            if "boundary validation failed" in r.message
+        ]
+        assert warn_msgs, (
+            f"expected boundary validation WARN, got records: "
+            f"{[r.message for r in caplog.records]}"
+        )
+
+        # Method still returned dicts. The drifted field falls through
+        # to the raw payload value.
+        assert len(result) == 1
+        assert result[0]["title"] == "x"
+        assert result[0]["number"] == "not-an-int"


### PR DESCRIPTION
## Summary

Phase 8 of #8786 — first concrete adoption of the boundary helper at a real call site. Demonstrates the **lenient pattern**: validation failures log WARN but the method's return type and behaviour are unchanged.

## What changed

| File | Change |
|---|---|
| `src/contracts/shapes.py` | New `GhIssueListItem` — narrower than `GhIssueSummary` for `gh issue list` invocations that omit `state` |
| `src/pr_manager.py` | `list_issues_by_label` now routes through `parse_list_with_shape(output, GhIssueListItem)` |

## Why `list_issues_by_label` first

- Read-only; cannot break production state
- Called by many loops (memory_backlog, corpus_learning, auto_agent preflight, stale_issue_gc, …) — WARN signal is well-distributed
- Simple `--json` field set (4 fields), easy to validate
- Existing test coverage in `tests/test_pr_manager_queries.py` (78 tests) keeps the migration honest

The same pattern can be applied to every gh-JSON PRManager method. This PR commits to the *pattern*; the full rollout is small follow-up PRs.

## Test plan

`tests/regressions/test_list_issues_boundary_validation.py` — 2 tests:
- [x] Well-shaped response → typed dict unchanged, no WARN
- [x] Drifted response (wrong type for `number`) → WARN logged, dict still returned with drifted value

`tests/test_pr_manager_queries.py` — 78 existing tests still green.

ruff + pyright clean.

## Lenient vs strict

This wiring uses **lenient** mode (`r.model_instance if not None else r.payload`). A strict caller would check `r.ok` and raise on validation failure. That's a per-method decision — list_issues_by_label is called from caretaker loops where degraded data is safer than a crash, so lenient is right. CI-critical methods (e.g. `get_latest_ci_status`) could go strict in a follow-up.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)