### PR TITLE
feat(pr-manager): wire list_closed_issues_by_label through boundary (Phase 10 of #8786)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1434,7 +1434,14 @@ class PRManager:
     async def list_closed_issues_by_label(
         self, label: str, limit: int = 100
     ) -> list[GitHubIssueSummary]:
-        """Return closed issues with the given label as a list of dicts."""
+        """Return closed issues with the given label as a list of dicts.
+
+        #8786 Phase 10: routed through the contracts boundary helper in
+        lenient mode — same pattern as ``list_issues_by_label``.
+        """
+        from contracts.boundary import parse_list_with_shape  # noqa: PLC0415
+        from contracts.shapes import GhIssueListItem  # noqa: PLC0415
+
         self._assert_repo()
         output = await self._run_gh(
             "gh",
@@ -1451,15 +1458,31 @@ class PRManager:
             "--limit",
             str(limit),
         )
-        items = json.loads(output)
+        results = parse_list_with_shape(output, GhIssueListItem)
         return [
             {
-                "number": item.get("number", 0),
-                "title": item.get("title", ""),
-                "body": item.get("body", ""),
-                "updated_at": item.get("updatedAt", ""),
+                "number": (
+                    r.model_instance.number
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("number", 0)
+                ),
+                "title": (
+                    r.model_instance.title
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("title", "")
+                ),
+                "body": (
+                    r.model_instance.body or ""
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("body", "")
+                ),
+                "updated_at": (
+                    r.model_instance.updated_at or ""
+                    if r.model_instance is not None
+                    else (r.payload or {}).get("updatedAt", "")
+                ),
             }
-            for item in items
+            for r in results
         ]
 
     async def list_prs_by_label(self, label: str) -> list[PRInfo]:

--- a/tests/regressions/test_list_closed_issues_boundary_validation.py
+++ b/tests/regressions/test_list_closed_issues_boundary_validation.py
@@ -1,0 +1,89 @@
+"""Regression: list_closed_issues_by_label routed through the contracts
+boundary helper (Phase 10 of #8786). Mirrors the Phase 8 wiring for
+list_issues_by_label."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+@pytest.mark.asyncio
+async def test_well_shaped_response_returns_dict_unchanged(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    issues_json = json.dumps(
+        [
+            {
+                "number": 100,
+                "title": "ancient bug",
+                "body": "resolved",
+                "updatedAt": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(issues_json).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.list_closed_issues_by_label("bug")
+
+    assert len(result) == 1
+    assert result[0]["number"] == 100
+    assert result[0]["title"] == "ancient bug"
+    assert result[0]["updated_at"] == "2026-04-01T00:00:00Z"
+    assert not [r for r in caplog.records if "boundary validation failed" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_drifted_response_logs_warn_and_falls_back(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    # ``number`` is the wrong type — validation fails, lenient fallback used.
+    issues_json = json.dumps(
+        [
+            {
+                "number": None,
+                "title": "x",
+                "body": "",
+                "updatedAt": "2026-04-01T00:00:00Z",
+            }
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(issues_json).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.list_closed_issues_by_label("bug")
+
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+    assert len(result) == 1
+    assert result[0]["title"] == "x"


### PR DESCRIPTION
## Summary

Phase 10 of #8786 — mirrors Phase 8 (#8846) for `list_closed_issues_by_label`. Same `GhIssueListItem` shape, same lenient pattern.

## Why batched separately

Each call-site migration is independently reviewable + revertable. A single sprawling PR touching every PRManager method would couple unrelated risks. The closed-issues path is exercised by `auto_agent_preflight_loop` reconciliation — drift signal here surfaces a separate segment of production traffic than the open-issues path.

## Test plan

`tests/regressions/test_list_closed_issues_boundary_validation.py` — 2 tests:
- [x] Well-shaped response → typed dict unchanged, no WARN
- [x] Drifted response → WARN logged, dict returned

78 existing PRManager queries tests still green. ruff + pyright clean.

## Out of scope

Other read-only PRManager methods (`find_open_pr_for_branch`, `get_latest_ci_status`, `list_recent_promotion_prs`, etc.) use different `--json` field sets and need their own Pydantic models. Each is a small follow-up.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)