### PR TITLE
fix(mockworld): catalog completeness + CI guard

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T19:02:46.092508+00:00",
-  "commit_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0",
+  "regenerated_at": "2026-05-18T19:03:27.836746+00:00",
+  "commit_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "ports.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "labels.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "modules.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "events.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "adr_xref.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "mockworld.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "changelog.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "coverage_matrix.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "functional_areas.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "ubiquitous-language.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "f6933e01e8af70677f3dc547f2d02006ed3290f0"
+      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `f6933e0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `536d623` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `b714ab0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `dc79b3f` — chore(arch): regen arch artifacts from rebased staging tip *(2026-05-18)*
 - `f202e6e` — feat(arch): regenerable coverage_matrix generator for arch-regen (closes advisor-bpl parent bead) *(2026-05-18)*
 - `7f7792d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -304,4 +305,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -21,7 +21,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
 | `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
 | `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ❌ | ❌ |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
 | `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
 | `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
 | `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
@@ -29,7 +29,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
 | `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ❌ | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
 | `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
 | `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
@@ -43,14 +43,14 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
 | `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `SecurityPatchLoop` | ✅ [0029] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
-| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ✅ in catalog | ❌ |
+| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
 | `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
 | `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
-| `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ❌ | ✅ `s13_rc_rebase_recovery.py` |
+| `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
 | `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
 | `StaleIssueLoop` | ❌ | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ (caretaker loop) | ✅ `test_term_proposer_loop.py` | ❌ | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_term_pruner_loop.py` | ❌ | ❌ |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ (caretaker loop) | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ❌ | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
 | `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `f6933e0` on 2026-05-18 19:02 UTC. Source last changed at `f6933e0`. Status: 🟢 fresh._
+_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -154,7 +154,7 @@ def _build_repo_wiki(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     return RepoWikiLoop(config=config, wiki_store=wiki_store, deps=deps)
 
 
-def _build_sentry(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+def _build_sentry_ingest(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from sentry_loop import SentryLoop  # noqa: PLC0415
 
     return SentryLoop(config=config, prs=ports["github"], deps=deps)
@@ -978,6 +978,140 @@ def _build_contract_refresh(ports: dict[str, Any], config: Any, deps: Any) -> An
     return loop
 
 
+def _build_edge_proposer(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build EdgeProposerLoop for scenarios (ADR-0058).
+
+    The loop's external surface — ``_do_work`` shells to ``gh pr create`` /
+    ``git`` via ``OpenAutoPRBotPRPort`` — cannot run inside a unit scenario.
+    Tests seed a fake BotPRPort via ``edge_proposer_pr_port``, and a repo root
+    via ``edge_proposer_repo_root`` (defaults to ``config.repo_root``).
+    """
+    from edge_proposer_loop import EdgeProposerLoop  # noqa: PLC0415
+
+    pr_port = ports.get("edge_proposer_pr_port")
+    if pr_port is None:
+        pr_port = MagicMock()
+        pr_port.open_bot_pr = AsyncMock(return_value=0)
+        ports["edge_proposer_pr_port"] = pr_port
+
+    repo_root = ports.get("edge_proposer_repo_root") or config.repo_root
+    return EdgeProposerLoop(
+        config=config,
+        deps=deps,
+        pr_port=pr_port,
+        repo_root=repo_root,
+    )
+
+
+def _build_label_drift_watcher(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build LabelDriftWatcherLoop for scenarios (ADR-0056).
+
+    Minimal builder: the loop takes only ``pr_manager``; no state or dedup.
+    The ``pr_manager`` port falls back to ``ports['github']`` so the standard
+    FakeGitHub fixture is sufficient for smoke scenarios.
+    """
+    from label_drift_watcher_loop import LabelDriftWatcherLoop  # noqa: PLC0415
+
+    pr_manager = ports.get("pr_manager") or ports["github"]
+    return LabelDriftWatcherLoop(config=config, pr_manager=pr_manager, deps=deps)
+
+
+def _build_staging_promotion(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build StagingPromotionLoop for scenarios (ADR-0042).
+
+    The loop's external surface — ``gh pr create`` / ``gh pr merge`` /
+    ``gh api`` calls made through ``PRPort`` — cannot run live inside a
+    scenario. Tests seed a FakeGitHub via ``ports['github']`` and may
+    pre-seed ``staging_promotion_state`` to inspect cadence tracking.
+
+    ``staging_enabled`` is forced ``True`` so the loop's internal guard
+    doesn't short-circuit every tick in the scenario sandbox (mirrors
+    the ``_build_staging_bisect`` pattern).
+    """
+    from staging_promotion_loop import StagingPromotionLoop  # noqa: PLC0415
+
+    state = ports.get("staging_promotion_state") or MagicMock()
+    ports.setdefault("staging_promotion_state", state)
+
+    prs = ports.get("pr_manager") or ports["github"]
+
+    if not getattr(config, "staging_enabled", False):
+        object.__setattr__(config, "staging_enabled", True)
+
+    return StagingPromotionLoop(config=config, prs=prs, deps=deps, state=state)
+
+
+def _build_term_proposer(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build TermProposerLoop for scenarios (ADR-0054).
+
+    The loop calls an LLM (``TermProposerLLM``) and opens bot PRs via
+    ``BotPRPort``; neither can run live inside a scenario. Tests seed:
+
+    * ``term_proposer_llm`` — a ``TermProposerLLM`` instance (or duck-typed
+      substitute with a ``draft`` async method); defaults to a MagicMock.
+    * ``term_proposer_pr_port`` — a ``BotPRPort`` duck-type; defaults to a
+      MagicMock whose ``open_bot_pr`` resolves to ``0``.
+    * ``term_proposer_repo_root`` — ``Path``; defaults to ``config.repo_root``.
+    * ``term_proposer_dedup_path`` — ``Path``; defaults to a ``dedup.json``
+      under ``config.repo_root``.
+    """
+    from term_proposer_loop import TermProposerLoop  # noqa: PLC0415
+
+    llm = ports.get("term_proposer_llm")
+    if llm is None:
+        llm = MagicMock()
+        llm.draft = AsyncMock(return_value=[])
+        ports["term_proposer_llm"] = llm
+
+    pr_port = ports.get("term_proposer_pr_port")
+    if pr_port is None:
+        pr_port = MagicMock()
+        pr_port.open_bot_pr = AsyncMock(return_value=0)
+        ports["term_proposer_pr_port"] = pr_port
+
+    repo_root = ports.get("term_proposer_repo_root") or config.repo_root
+    dedup_path = ports.get("term_proposer_dedup_path") or (
+        config.repo_root / ".term_proposer_dedup.json"
+    )
+
+    return TermProposerLoop(
+        config=config,
+        deps=deps,
+        llm=llm,
+        pr_port=pr_port,
+        repo_root=repo_root,
+        dedup_path=dedup_path,
+    )
+
+
+def _build_term_pruner(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build TermPrunerLoop for scenarios (ADR-0057).
+
+    The loop opens bot PRs via ``BotPRPort``; this cannot run live inside a
+    scenario. Tests seed:
+
+    * ``term_pruner_pr_port`` — a ``BotPRPort`` duck-type; defaults to a
+      MagicMock whose ``open_bot_pr`` resolves to ``0``.
+    * ``term_pruner_repo_root`` — ``Path``; defaults to ``config.repo_root``.
+    """
+    from term_pruner_loop import TermPrunerLoop  # noqa: PLC0415
+
+    pr_port = ports.get("term_pruner_pr_port")
+    if pr_port is None:
+        pr_port = MagicMock()
+        pr_port.open_bot_pr = AsyncMock(return_value=0)
+        ports["term_pruner_pr_port"] = pr_port
+
+    repo_root = ports.get("term_pruner_repo_root") or config.repo_root
+
+    return TermPrunerLoop(
+        config=config,
+        deps=deps,
+        pr_port=pr_port,
+        repo_root=repo_root,
+    )
+
+
 def _build_diagram_loop(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from diagram_loop import DiagramLoop  # noqa: PLC0415
 
@@ -1034,7 +1168,7 @@ _BUILDERS: dict[str, Any] = {
     "adr_reviewer": _build_adr_reviewer,
     "github_cache": _build_github_cache,
     "repo_wiki": _build_repo_wiki,
-    "sentry": _build_sentry,
+    "sentry_ingest": _build_sentry_ingest,
     "diagnostic": _build_diagnostic,
     "code_grooming": _build_code_grooming,
     "report_issue": _build_report_issue,
@@ -1068,6 +1202,14 @@ _BUILDERS: dict[str, Any] = {
     # auto-agent (spec §1–§11; ADR-0050)
     "auto_agent_preflight": _build_auto_agent_preflight,
     "sandbox_failure_fixer": _build_sandbox_failure_fixer,
+    # ubiquitous-language (ADR-0054 + ADR-0057 + ADR-0058)
+    "edge_proposer": _build_edge_proposer,
+    "term_proposer": _build_term_proposer,
+    "term_pruner": _build_term_pruner,
+    # label drift (ADR-0056)
+    "label_drift_watcher": _build_label_drift_watcher,
+    # staging promotion (ADR-0042)
+    "staging_promotion": _build_staging_promotion,
 }
 
 

--- a/tests/scenarios/catalog/test_catalog_completeness.py
+++ b/tests/scenarios/catalog/test_catalog_completeness.py
@@ -1,0 +1,90 @@
+"""CI guard: MockWorld catalog must cover every loop in bg_loop_registry.
+
+Any loop added to ``orchestrator.py``'s ``bg_loop_registry`` without a
+corresponding builder in ``loop_registrations._BUILDERS`` will be caught here
+before it reaches code review.
+
+Loops intentionally excluded from the catalog (e.g. ``github_cache``, which
+is started separately and has no scenario coverage) are listed in
+``_CATALOG_SKIP``. Add to the skip list only with a comment explaining why.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.scenarios.catalog.loop_registrations import _BUILDERS
+
+SRC = Path(__file__).resolve().parents[3] / "src"
+
+# ---------------------------------------------------------------------------
+# Loops that exist in bg_loop_registry but intentionally lack catalog builders.
+# These are loops started outside the standard BGWorkerManager lifecycle.
+# ---------------------------------------------------------------------------
+_CATALOG_SKIP: set[str] = {
+    "github_cache",  # started separately via GitHubCacheLoop; no scenario needed
+}
+
+
+def _parse_bg_loop_registry() -> set[str]:
+    """Extract worker_name keys from orchestrator.py's bg_loop_registry dict."""
+    text = (SRC / "orchestrator.py").read_text()
+    # Match lines like:  "memory_sync": svc.memory_sync_bg,
+    return set(re.findall(r'"(\w+)"\s*:\s*svc\.', text))
+
+
+def test_catalog_covers_bg_loop_registry() -> None:
+    """Every loop in bg_loop_registry must have a catalog builder.
+
+    When this test fails, add the missing loop to
+    ``tests/scenarios/catalog/loop_registrations.py`` following the builder
+    pattern documented there. Only add to ``_CATALOG_SKIP`` if the loop is
+    genuinely not exercised via MockWorld scenarios.
+    """
+    registry_keys = _parse_bg_loop_registry()
+    catalog_keys = set(_BUILDERS.keys())
+    missing = (registry_keys - catalog_keys) - _CATALOG_SKIP
+    assert not missing, (
+        f"Loops in bg_loop_registry but missing from MockWorld catalog: "
+        f"{sorted(missing)}\n\n"
+        f"Add a builder to tests/scenarios/catalog/loop_registrations.py, "
+        f"or add to _CATALOG_SKIP with a justification comment."
+    )
+
+
+def test_catalog_skip_entries_are_real_loops() -> None:
+    """Catch stale entries in _CATALOG_SKIP that are neither in the registry
+    nor in the catalog itself.
+
+    An entry is valid if it appears in either the orchestrator ``bg_loop_registry``
+    or the catalog ``_BUILDERS`` (``github_cache`` is in the catalog but started
+    outside the registry lifecycle). An entry that appears in neither is a typo.
+    """
+    registry_keys = _parse_bg_loop_registry()
+    catalog_keys = set(_BUILDERS.keys())
+    known = registry_keys | catalog_keys
+    stale = _CATALOG_SKIP - known
+    assert not stale, (
+        f"_CATALOG_SKIP entries not found in bg_loop_registry or catalog (stale?): "
+        f"{sorted(stale)}"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_BUILDERS.keys()))
+def test_builder_key_matches_registry(name: str) -> None:
+    """Each catalog key must match a key in bg_loop_registry (or the skip list).
+
+    This catches typos where the catalog registers a builder under the wrong
+    name (e.g. ``sentry`` vs the canonical ``sentry_ingest``).
+    """
+    registry_keys = _parse_bg_loop_registry()
+    # github_cache is in the catalog for historical reasons but not in the
+    # orchestrator registry; allow it via the same skip mechanism.
+    allowed = registry_keys | _CATALOG_SKIP
+    assert name in allowed, (
+        f"Catalog key {name!r} is not present in bg_loop_registry. "
+        f"Either fix the key to match the registry, or add it to _CATALOG_SKIP."
+    )

--- a/tests/scenarios/catalog/test_loop_instantiation.py
+++ b/tests/scenarios/catalog/test_loop_instantiation.py
@@ -9,45 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from tests.scenarios.catalog import LoopCatalog
-from tests.scenarios.catalog.loop_registrations import ensure_registered
-
-ALL_LOOPS = (
-    "ci_monitor",
-    "stale_issue_gc",
-    "dependabot_merge",
-    "pr_unsticker",
-    "health_monitor",
-    "workspace_gc",
-    "runs_gc",
-    "retrospective",
-    "adr_reviewer",
-    "github_cache",
-    "repo_wiki",
-    "sentry",
-    "diagnostic",
-    "code_grooming",
-    "report_issue",
-    "epic_sweeper",
-    "security_patch",
-    "stale_issue",
-    "epic_monitor",
-    "wiki_rot_detector",
-    # trust-arch caretaker fleet (§4.4–§4.8)
-    "principles_audit",
-    "flake_tracker",
-    "skill_prompt_eval",
-    "fake_coverage_auditor",
-    "rc_budget",
-    # trust-arch meta + attribution (§4.3 + §12.1)
-    "staging_bisect",
-    "trust_fleet_sanity",
-    # trust-arch contract refresh (§4.2)
-    "contract_refresh",
-    # trust-arch corpus learning (§4.1 v2)
-    "corpus_learning",
-    # auto-agent HITL pre-flight (ADR-0050)
-    "auto_agent_preflight",
-)
+from tests.scenarios.catalog.loop_registrations import _BUILDERS, ensure_registered
 
 
 @pytest.fixture(autouse=True)
@@ -56,7 +18,7 @@ def _ensure_registered() -> Iterator[None]:
     yield
 
 
-@pytest.mark.parametrize("name", ALL_LOOPS)
+@pytest.mark.parametrize("name", sorted(_BUILDERS.keys()))
 def test_loop_instantiates(tmp_path: Path, name: str) -> None:
     """Every loop builder returns an instance — no TypeError from signature drift.
 
@@ -84,6 +46,7 @@ def test_loop_instantiates(tmp_path: Path, name: str) -> None:
         "hindsight": MagicMock(),
         "sentry": MagicMock(),
         "clock": MagicMock(),
+        "state": MagicMock(),
     }
 
     try:

--- a/tests/scenarios/catalog/test_loop_registrations.py
+++ b/tests/scenarios/catalog/test_loop_registrations.py
@@ -1,4 +1,10 @@
-"""Verify all 20 phase-1+3b loops register via the catalog."""
+"""Verify every catalog builder registers successfully via the catalog.
+
+The loop list is derived from ``_BUILDERS`` so it stays in sync automatically
+when new builders are added. The CI completeness guard lives in
+``test_catalog_completeness.py``; this file only checks that each registered
+builder is retrievable from ``LoopCatalog`` after ``ensure_registered()``.
+"""
 
 from __future__ import annotations
 
@@ -7,47 +13,7 @@ from collections.abc import Iterator
 import pytest
 
 from tests.scenarios.catalog import LoopCatalog
-from tests.scenarios.catalog.loop_registrations import ensure_registered
-
-ALL_LOOPS = (
-    # phase 1 (6)
-    "ci_monitor",
-    "stale_issue_gc",
-    "dependabot_merge",
-    "pr_unsticker",
-    "health_monitor",
-    "workspace_gc",
-    # phase 3b (14)
-    "runs_gc",
-    "retrospective",
-    "adr_reviewer",
-    "github_cache",
-    "repo_wiki",
-    "sentry",
-    "diagnostic",
-    "code_grooming",
-    "report_issue",
-    "epic_sweeper",
-    "security_patch",
-    "stale_issue",
-    "epic_monitor",
-    "wiki_rot_detector",
-    # trust-arch caretaker fleet (§4.4–§4.8)
-    "principles_audit",
-    "flake_tracker",
-    "skill_prompt_eval",
-    "fake_coverage_auditor",
-    "rc_budget",
-    # trust-arch meta + attribution (§4.3 + §12.1)
-    "staging_bisect",
-    "trust_fleet_sanity",
-    # trust-arch contract refresh (§4.2)
-    "contract_refresh",
-    # trust-arch corpus learning (§4.1 v2)
-    "corpus_learning",
-    # auto-agent HITL pre-flight (ADR-0050)
-    "auto_agent_preflight",
-)
+from tests.scenarios.catalog.loop_registrations import _BUILDERS, ensure_registered
 
 
 @pytest.fixture(autouse=True)
@@ -56,6 +22,6 @@ def _ensure_registered() -> Iterator[None]:
     yield
 
 
-@pytest.mark.parametrize("name", ALL_LOOPS)
+@pytest.mark.parametrize("name", sorted(_BUILDERS.keys()))
 def test_loop_registered(name: str) -> None:
     assert LoopCatalog.is_registered(name), f"{name!r} not registered"


### PR DESCRIPTION
## Summary

Slice 5.10 (PR #8789) flagged that 6 post-trust-fleet loops lack catalog builders, plus the ALL_LOOPS hardcoded list is stale (30 vs registry 41+). Adds the missing builders and a CI test that fails when registry/catalog diverge.

Refiled as advisor-cbp3 after a prior attempt was interrupted by usage cap.

**6 builders added:**
- `edge_proposer` (EdgeProposerLoop, ADR-0058)
- `label_drift_watcher` (LabelDriftWatcherLoop, ADR-0056)
- `staging_promotion` (StagingPromotionLoop, ADR-0042)
- `term_proposer` (TermProposerLoop, ADR-0054)
- `term_pruner` (TermPrunerLoop, ADR-0057)
- `sentry_ingest` (SentryLoop renamed from stale key `sentry`)

**Test changes:**
- `test_loop_registrations.py` and `test_loop_instantiation.py`: replaced hardcoded 30-entry `ALL_LOOPS` tuple with `sorted(_BUILDERS.keys())` so parametrized list auto-updates
- New `tests/scenarios/catalog/test_catalog_completeness.py`: three tests that assert `bg_loop_registry` and `_BUILDERS` stay in sync

## Test plan
- [x] Completeness test passes after fixes (44 tests, all green)
- [x] All 132 catalog tests pass
- [x] `make quality` run — 7 pre-existing failures on `staging` (all `live_corpus_replay` wiring + 2 unrelated), none introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)