### PR TITLE
feat(pr-manager): wire list_recent_promotion_prs through boundary (Phase 11 of #8786)

### DIFF
--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -133,3 +133,21 @@ class GhIssueListItem(BaseModel):
     title: str
     body: str | None = None
     updated_at: str | None = Field(default=None, alias="updatedAt")
+
+
+class GhPromotionPR(BaseModel):
+    """``gh api repos/.../pulls`` element after the custom ``--jq`` filter
+    used by :meth:`PRManager.list_recent_promotion_prs`.
+
+    Shape: ``{number, branch, merged, closed_at, url}``. Not directly
+    produced by any ``gh ... --json FIELDS`` invocation — this is the
+    HydraFlow-defined projection over the GitHub REST PR payload.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    number: int
+    branch: str
+    merged: bool
+    closed_at: str | None = None
+    url: str | None = None

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -687,9 +687,18 @@ class PRManager:
         Each entry: ``{number, branch, merged, closed_at, url}``. Used for
         RC lifecycle dashboard metrics (throughput + failure rate). Only
         PRs whose ``updated_at`` is within *days* of now are returned.
+
+        #8786 Phase 11: routed through the contracts boundary helper in
+        lenient mode against ``GhPromotionPR``. The HydraFlow-defined
+        projection (a custom ``--jq``) is part of our public contract
+        with downstream callers and benefits from the same drift signal
+        as direct ``--json`` invocations.
         """
         if self._config.dry_run:
             return []
+        from contracts.boundary import parse_list_with_shape  # noqa: PLC0415
+        from contracts.shapes import GhPromotionPR  # noqa: PLC0415
+
         prefix = self._config.rc_branch_prefix
         cutoff = (datetime.now(UTC) - timedelta(days=days)).isoformat()
         try:
@@ -720,7 +729,15 @@ class PRManager:
             text = raw.strip()
             if not text:
                 return []
-            return json.loads(text)
+            results = parse_list_with_shape(text, GhPromotionPR)
+            return [
+                (
+                    r.model_instance.model_dump(by_alias=False)
+                    if r.model_instance is not None
+                    else (r.payload if isinstance(r.payload, dict) else {})
+                )
+                for r in results
+            ]
         except (RuntimeError, ValueError, json.JSONDecodeError):
             logger.debug("Could not list recent promotion PRs", exc_info=True)
             return []

--- a/tests/regressions/test_list_recent_promotion_prs_boundary.py
+++ b/tests/regressions/test_list_recent_promotion_prs_boundary.py
@@ -1,0 +1,129 @@
+"""Regression: list_recent_promotion_prs routes through the contracts boundary
+helper (Phase 11 of #8786). New shape ``GhPromotionPR`` covers the custom
+``--jq`` projection used by this method."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+@pytest.mark.asyncio
+async def test_well_shaped_response_parses_cleanly(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        [
+            {
+                "number": 42,
+                "branch": "rc/2026-05-14-1000",
+                "merged": True,
+                "closed_at": "2026-05-14T11:00:00Z",
+                "url": "https://github.com/x/y/pull/42",
+            },
+            {
+                "number": 43,
+                "branch": "rc/2026-05-14-1400",
+                "merged": False,
+                "closed_at": "2026-05-14T15:00:00Z",
+                "url": "https://github.com/x/y/pull/43",
+            },
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.list_recent_promotion_prs(days=7)
+
+    assert len(result) == 2
+    assert result[0]["number"] == 42
+    assert result[0]["merged"] is True
+    assert result[1]["merged"] is False
+    assert not [r for r in caplog.records if "boundary validation failed" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_drifted_response_logs_warn_and_falls_back(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If gh's payload changes shape (e.g., ``merged`` becomes a string),
+    the lenient wiring logs WARN but still returns the raw dict so the
+    dashboard keeps working."""
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        [
+            {
+                # ``number`` missing — required field. Pydantic raises.
+                "branch": "rc/x",
+                "merged": True,
+                "closed_at": "2026-05-14T15:00:00Z",
+                "url": "https://github.com/x/y/pull/99",
+            }
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.list_recent_promotion_prs(days=7)
+
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+    assert len(result) == 1
+    # Lenient fallback returns the raw dict; the missing-required-field
+    # is observable to the caller AND surfaced via WARN — both signals fire.
+    assert result[0].get("branch") == "rc/x"
+
+
+@pytest.mark.asyncio
+async def test_empty_response_returns_empty_list(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout("").build()
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.list_recent_promotion_prs(days=7)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_subprocess_failure_returns_empty(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    """Existing behaviour: gh failure → empty list, no exception."""
+    mgr = make_pr_manager(config, event_bus)
+    mock_create = (
+        SubprocessMockBuilder().with_returncode(1).with_stderr("api error").build()
+    )
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.list_recent_promotion_prs(days=7)
+    assert result == []


### PR DESCRIPTION
## Summary

Phase 11 of #8786 — addresses the queued ask: `list_recent_promotion_prs` uses a custom `--jq` projection, so it needs its own Pydantic shape. Ships `GhPromotionPR` + wires the method through the boundary helper.

## What's here

| File | Change |
|---|---|
| `src/contracts/shapes.py` | New `GhPromotionPR` — `{number, branch, merged, closed_at?, url?}` |
| `src/pr_manager.py` | `list_recent_promotion_prs` routed through `parse_list_with_shape` (lenient) |

## Why it matters

This is the first shape covering a HydraFlow-defined projection rather than a stock `gh ... --json` output. The dashboard depends on `list_recent_promotion_prs` for RC throughput/failure metrics. Schema drift in GitHub's REST `pulls` endpoint OR a regression in the `--jq` filter now surfaces immediately via WARN — and degrades gracefully (raw dict returned, dashboard keeps working).

## Test plan

`tests/regressions/test_list_recent_promotion_prs_boundary.py` — 4 tests:
- [x] Well-shaped response → typed, no WARN
- [x] Missing required field → WARN logged, dict still returned
- [x] Empty stdout → empty list (existing semantics preserved)
- [x] Subprocess failure → empty list (existing semantics preserved)

All 80 existing PRManager queries tests still green. ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)