### PR TITLE
feat(pr-manager): wire find_open_pr_for_branch through boundary (Phase 12 of #8786)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -955,9 +955,18 @@ class PRManager:
     async def find_open_pr_for_branch(
         self, branch: str, *, issue_number: int = 0
     ) -> PRInfo | None:
-        """Return the open PR for *branch*, or ``None`` when absent/unreadable."""
+        """Return the open PR for *branch*, or ``None`` when absent/unreadable.
+
+        #8786 Phase 12: routed through the contracts boundary helper in
+        lenient mode against ``GhPRDetail`` (only ``number`` is required;
+        ``url``/``isDraft`` are optional, matching the narrow ``--jq``
+        projection used here).
+        """
         if self._config.dry_run:
             return None
+        from contracts.boundary import parse_list_with_shape  # noqa: PLC0415
+        from contracts.shapes import GhPRDetail  # noqa: PLC0415
+
         head_filter = f"{self._repo_owner}:{branch}" if self._repo_owner else branch
         try:
             raw = await self._run_gh(
@@ -975,10 +984,22 @@ class PRManager:
                 "--jq",
                 "[.[] | {number, url: .html_url, isDraft: .draft}]",
             )
-            prs = json.loads(raw)
-            if not prs:
+            results = parse_list_with_shape(raw, GhPRDetail)
+            if not results:
                 return None
-            pr_data = prs[0]
+            r = results[0]
+            if r.model_instance is not None:
+                m = r.model_instance
+                return PRInfo(
+                    number=m.number,
+                    issue_number=issue_number,
+                    branch=branch,
+                    url=m.url or "",
+                    draft=bool(m.is_draft),
+                )
+            # Lenient fallback to raw dict — preserves existing behaviour
+            # if a future gh shape change trips validation.
+            pr_data = r.payload if isinstance(r.payload, dict) else {}
             return PRInfo(
                 number=int(pr_data["number"]),
                 issue_number=issue_number,

--- a/tests/regressions/test_find_open_pr_boundary.py
+++ b/tests/regressions/test_find_open_pr_boundary.py
@@ -1,0 +1,108 @@
+"""Regression: find_open_pr_for_branch routes through the boundary
+helper (Phase 12 of #8786). Lenient mode against ``GhPRDetail`` —
+``number`` required, ``url`` / ``isDraft`` optional matching the
+``--jq`` projection ``[.[] | {number, url: .html_url, isDraft: .draft}]``."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+@pytest.mark.asyncio
+async def test_well_shaped_response_returns_pr_info(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        [
+            {
+                "number": 99,
+                "url": "https://github.com/x/y/pull/99",
+                "isDraft": False,
+            }
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.find_open_pr_for_branch("feat/x", issue_number=42)
+
+    assert result is not None
+    assert result.number == 99
+    assert result.issue_number == 42
+    assert result.branch == "feat/x"
+    assert str(result.url) == "https://github.com/x/y/pull/99"
+    assert result.draft is False
+    assert not [r for r in caplog.records if "boundary validation failed" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_empty_response_returns_none(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    """No matching PR → None (existing semantics preserved)."""
+    mgr = make_pr_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout("[]").build()
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.find_open_pr_for_branch("feat/missing")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_drifted_response_falls_back_to_raw_dict(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If the shape drifts (e.g. number arrives as string), lenient
+    fallback still extracts the PR info — production keeps working."""
+    mgr = make_pr_manager(config, event_bus)
+    # ``number`` arrives as something Pydantic can't coerce cleanly.
+    payload = json.dumps(
+        [
+            {
+                "number": "ninety-nine",  # bad
+                "url": "https://github.com/x/y/pull/99",
+                "isDraft": True,
+            }
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        # Validation fails → lenient fallback path → ``int(pr_data["number"])``
+        # raises ValueError → method's try/except returns None.
+        result = await mgr.find_open_pr_for_branch("feat/x")
+
+    # Behaviour is preserved (None on parse failure) + drift signal
+    # surfaced via WARN.
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+    assert result is None


### PR DESCRIPTION
## Summary

Phase 12 of #8786. Routes `find_open_pr_for_branch` through the contracts boundary helper. **Reuses `GhPRDetail`** — the `--jq` projection `{number, url: .html_url, isDraft: .draft}` is a strict subset (number required, rest optional).

## Test plan

`tests/regressions/test_find_open_pr_boundary.py` — 3 tests:
- [x] Well-shaped response → PRInfo populated, no WARN
- [x] Empty `[]` response → None (existing semantics)
- [x] Drifted response (number as string) → WARN logged, fallback hits the existing `int(pr_data["number"])` ValueError path → method returns None gracefully

All 78 existing PRManager queries tests green. ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)