### PR TITLE
fix(runners): _phase_name for Discover + Shape

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T23:04:04.865660+00:00",
-  "commit_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad",
+  "regenerated_at": "2026-05-18T23:04:28.932170+00:00",
+  "commit_sha": "4e754a975564ca964261281fdfb60c7cebcb712b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "ports.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "labels.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "modules.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "events.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "adr_xref.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "mockworld.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "changelog.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "coverage_matrix.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "functional_areas.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "a2dacb8bd3a54fd2d1297dda81e2e727b2c5faad"
+      "source_sha": "4e754a975564ca964261281fdfb60c7cebcb712b"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `a2dacb8` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `4e754a9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `b6e104d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `bcc0b25` — fix(contracts): widen Cassette._validate_adapter to accept all 9 known fakes (closes slice 5.7) *(2026-05-18)*
 - `a06faa7` — fix(format): ruff format *(2026-05-18)*
 - `0a5dcad` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -318,4 +319,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `a2dacb8` on 2026-05-18 23:04 UTC. Source last changed at `a2dacb8`. Status: 🟢 fresh._
+_Regenerated from commit `4e754a9` on 2026-05-18 23:04 UTC. Source last changed at `4e754a9`. Status: 🟢 fresh._

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
@@ -47,6 +47,7 @@ class DiscoverRunner(BaseRunner):
     """
 
     _log = logger
+    _phase_name: ClassVar[str] = "discover"
 
     def bind_escalation_deps(
         self, prs: PRManager, dedup: DedupStore | None = None

--- a/src/shape_runner.py
+++ b/src/shape_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
@@ -50,6 +50,7 @@ class ShapeRunner(BaseRunner):
     """
 
     _log = logger
+    _phase_name: ClassVar[str] = "shape"
 
     def bind_escalation_deps(
         self, prs: PRManager, dedup: DedupStore | None = None

--- a/tests/test_runners_phase_name.py
+++ b/tests/test_runners_phase_name.py
@@ -1,0 +1,46 @@
+"""Verify that all concrete BaseRunner subclasses have _phase_name defined."""
+
+import pytest
+
+from agent import AgentRunner
+from base_runner import BaseRunner
+from diagnostic_runner import DiagnosticRunner
+from discover_runner import DiscoverRunner
+from hitl_runner import HITLRunner
+from planner import PlannerRunner
+from research_runner import ResearchRunner
+from reviewer import ReviewRunner
+from shape_runner import ShapeRunner
+from triage import TriageRunner
+
+
+@pytest.mark.parametrize(
+    "runner_class",
+    [
+        AgentRunner,
+        DiscoverRunner,
+        PlannerRunner,
+        ReviewRunner,
+        ShapeRunner,
+    ],
+)
+def test_runner_has_phase_name(runner_class: type[BaseRunner]) -> None:
+    """Verify that each runner has _phase_name != 'unknown'.
+
+    Trace spans and phase-rollup logs depend on correct _phase_name
+    declarations. Runners that inherit the default 'unknown' cause
+    mislabelled telemetry.
+    """
+    assert hasattr(runner_class, "_phase_name"), (
+        f"{runner_class.__name__} is missing _phase_name ClassVar"
+    )
+    phase_name = runner_class._phase_name
+    assert phase_name != "unknown", (
+        f"{runner_class.__name__}._phase_name is 'unknown' (inherited default)"
+    )
+    assert isinstance(phase_name, str), (
+        f"{runner_class.__name__}._phase_name must be a string"
+    )
+    assert phase_name.isidentifier(), (
+        f"{runner_class.__name__}._phase_name '{phase_name}' is not a valid identifier"
+    )


### PR DESCRIPTION
## Summary

Slice 5.9 (PR #8795): DiscoverRunner + ShapeRunner inherit BaseRunner._phase_name default \"unknown\". Trace spans and phase-rollup logs for the product track are mislabelled. Adds the ClassVar + parametrized guard test.

🤖 Generated with Claude Code