### PR TITLE
feat(pr-manager): wire find_existing_issue through boundary (Phase 15 of #8786)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1862,6 +1862,11 @@ class PRManager:
         """Search for an open issue with an exact title match.
 
         Returns the issue number of the first match, or 0 if none found.
+
+        #8786 Phase 15: routed through the contracts boundary helper in
+        lenient mode against ``GhIssueListItem``. The ``--json number,title``
+        shape is a strict subset; drift in either field surfaces via WARN
+        without changing the method's return semantics.
         """
         self._assert_repo()
         if self._config.dry_run:
@@ -1885,10 +1890,19 @@ class PRManager:
                 title,
                 cwd=self._config.repo_root,
             )
-            import json as _json  # noqa: PLC0415
+            if not raw.strip():
+                return 0
+            from contracts.boundary import parse_list_with_shape  # noqa: PLC0415
+            from contracts.shapes import GhIssueListItem  # noqa: PLC0415
 
-            results = _json.loads(raw) if raw.strip() else []
-            for item in results:
+            results = parse_list_with_shape(raw, GhIssueListItem)
+            for r in results:
+                if r.model_instance is not None:
+                    if r.model_instance.title == title:
+                        return r.model_instance.number
+                    continue
+                # Lenient fallback preserves the legacy dict-access path.
+                item = r.payload if isinstance(r.payload, dict) else {}
                 if item.get("title") == title:
                     return int(item["number"])
             return 0

--- a/tests/regressions/test_find_existing_issue_boundary.py
+++ b/tests/regressions/test_find_existing_issue_boundary.py
@@ -1,0 +1,94 @@
+"""Regression: find_existing_issue routed through the boundary helper
+(Phase 15 of #8786) — ``--json number,title`` shape vs GhIssueListItem."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+@pytest.mark.asyncio
+async def test_returns_matching_issue_number(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        [
+            {"number": 100, "title": "different bug"},
+            {"number": 101, "title": "exact match"},
+        ]
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.find_existing_issue("exact match")
+    assert result == 101
+    assert not [r for r in caplog.records if "boundary validation failed" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_no_match_returns_zero(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps([{"number": 100, "title": "different bug"}])
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.find_existing_issue("nothing matches")
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_drifted_payload_falls_back_to_dict_access(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A drifted ``number`` field (e.g. as string) trips validation. The
+    lenient fallback uses dict access — when ``int(item["number"])`` then
+    raises, the method's outer except returns 0 cleanly."""
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps([{"number": "not-an-int", "title": "exact match"}])
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.find_existing_issue("exact match")
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+    assert result == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_response_returns_zero(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    mock_create = SubprocessMockBuilder().with_stdout("").build()
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.find_existing_issue("anything")
+    assert result == 0


### PR DESCRIPTION
## Summary

Phase 15 of #8786. `find_existing_issue` now routes through `GhIssueListItem` — the `--json number,title` shape is a strict subset. Drift fires WARN at the call site; return semantics unchanged.

## Test plan

`tests/regressions/test_find_existing_issue_boundary.py` — 4 tests:
- [x] Match found → correct issue number, no WARN
- [x] No match → 0
- [x] Drifted `number` field → WARN logged, lenient fallback's `int()` raises, method returns 0 cleanly
- [x] Empty response → 0

ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)