### PR TITLE
test(sandbox-failure-fixer): scenario for auto-fix → HITL (closes #8814)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,33 @@
 {
-  "regenerated_at": "2026-05-18T23:30:35.504802+00:00",
-  "commit_sha": "8e528906f00e9453f9bcce265014af7335f65c38",
+  "regenerated_at": "2026-05-18T15:48:10.771881+00:00",
+  "commit_sha": "6e55893ed166b9d685f362495059bb4562b1239d",
   "artifacts": {
     "loops.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "ports.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "labels.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "modules.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "events.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "adr_xref.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "mockworld.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "changelog.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
-    },
-    "coverage_matrix.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     },
     "functional_areas.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
-    },
-    "ubiquitous-language.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
-    },
-    "ubiquitous-language-context-map.md": {
-      "source_sha": "8e528906f00e9453f9bcce265014af7335f65c38"
+      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,33 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T15:48:10.771881+00:00",
-  "commit_sha": "6e55893ed166b9d685f362495059bb4562b1239d",
+  "regenerated_at": "2026-05-18T23:30:59.792301+00:00",
+  "commit_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7",
   "artifacts": {
     "loops.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "ports.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "labels.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "modules.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "events.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "adr_xref.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "mockworld.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "changelog.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
+    },
+    "coverage_matrix.md": {
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     },
     "functional_areas.md": {
-      "source_sha": "6e55893ed166b9d685f362495059bb4562b1239d"
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
+    },
+    "ubiquitous-language.md": {
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
+    },
+    "ubiquitous-language-context-map.md": {
+      "source_sha": "28d5c30fbd7fd67d3d38bd561edca4978e83eaf7"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,47 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `6e55893` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `28d5c30` — fix(format): ruff format *(2026-05-18)*
+- `47d4138` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `95b28e1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `ff38501` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
+- `280478c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `b6e104d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `bcc0b25` — fix(contracts): widen Cassette._validate_adapter to accept all 9 known fakes (closes slice 5.7) *(2026-05-18)*
+- `a06faa7` — fix(format): ruff format *(2026-05-18)*
+- `0a5dcad` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `11b4807` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `899d7aa` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
+- `3d724e9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `bf90023` — fix(format): ruff format *(2026-05-18)*
+- `2ff5ebd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `60c556b` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a0fd1b9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `57291d2` — fix(arch): functional_areas.yml module paths + add CI validation *(2026-05-18)*
+- `0c8243a` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `84b64fd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `b714ab0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `dc79b3f` — chore(arch): regen arch artifacts from rebased staging tip *(2026-05-18)*
+- `f202e6e` — feat(arch): regenerable coverage_matrix generator for arch-regen (closes advisor-bpl parent bead) *(2026-05-18)*
+- `7f7792d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `672680d` — fix(format): ruff format *(2026-05-18)*
+- `ebe1710` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `d0635fe` — fix(format): ruff format *(2026-05-18)*
+- `ea0e084` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `469d933` — fix(format): ruff format *(2026-05-18)*
+- `73a1a7f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6811034` — fix(format): ruff format *(2026-05-18)*
+- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
+- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
+- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
+- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -22,6 +62,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
+- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -32,6 +73,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
+- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -281,4 +323,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,45 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `8e52890` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `ff38501` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
-- `280478c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `b6e104d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `bcc0b25` — fix(contracts): widen Cassette._validate_adapter to accept all 9 known fakes (closes slice 5.7) *(2026-05-18)*
-- `a06faa7` — fix(format): ruff format *(2026-05-18)*
-- `0a5dcad` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `11b4807` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `899d7aa` — fix: ruff auto-fixes (unused imports + import sort) *(2026-05-18)*
-- `3d724e9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `bf90023` — fix(format): ruff format *(2026-05-18)*
-- `2ff5ebd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `60c556b` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a0fd1b9` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `57291d2` — fix(arch): functional_areas.yml module paths + add CI validation *(2026-05-18)*
-- `0c8243a` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `84b64fd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `b714ab0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `dc79b3f` — chore(arch): regen arch artifacts from rebased staging tip *(2026-05-18)*
-- `f202e6e` — feat(arch): regenerable coverage_matrix generator for arch-regen (closes advisor-bpl parent bead) *(2026-05-18)*
-- `7f7792d` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `672680d` — fix(format): ruff format *(2026-05-18)*
-- `ebe1710` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `d0635fe` — fix(format): ruff format *(2026-05-18)*
-- `ea0e084` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `469d933` — fix(format): ruff format *(2026-05-18)*
-- `73a1a7f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `6811034` — fix(format): ruff format *(2026-05-18)*
-- `ea0e457` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `6b7e670` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `f50f9d7` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8f2ece5` — fix(format): ruff format *(2026-05-18)*
-- `77b63eb` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `2997071` — fix(arch): populate Tick + Kill columns in loops.md generator (closes audit gap) *(2026-05-18)*
-- `e3822b1` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `8d259e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
-- `5f913e6` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
-- `a5e7c4a` — fix(adr): reformat ADR-0031 enforcement (commas + bare paths for parser) *(2026-05-18)*
-- `d75c5e3` — Merge branch 'staging' into cleanup/ci-integrity-trio *(2026-05-18)*
+- `6e55893` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `3cf70d6` — fix(adr): add Enforced by line to ADR-0031 (unblocks Tests on staging) *(2026-05-18)*
 - `f9ad184` — Merge pull request #8738 from T-rav/worktree-audit+coverage-matrix-baseline *(2026-05-18)*
 - `c17ffe4` — Merge pull request #8841 from T-rav/docs/wiki-backfill-seven *(2026-05-18)*
@@ -60,7 +22,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ef8979f` — Merge pull request #8787 from T-rav/audit/area-dashboard *(2026-05-18)*
 - `423f2dc` — Merge pull request #8782 from T-rav/audit/area-caretaking *(2026-05-18)*
 - `94a0c81` — Merge pull request #8757 from T-rav/audit/factory-phase-drift *(2026-05-18)*
-- `5d2da98` — chore(arch): regen after rebase onto staging *(2026-05-18)*
 - `ff2e21e` — docs(audit): post-review fixups — bead bodies, header SHA, Ports criteria *(2026-05-18)*
 - `b14d242` — docs(audit): coverage matrix — gap beads filed and cross-linked *(2026-05-18)*
 - `76a89f8` — docs(audit): coverage matrix — parent automation bead advisor-bpl linked *(2026-05-18)*
@@ -71,7 +32,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `826355b` — docs(audit): coverage matrix — Ports section populated (9 rows × 7 cols) *(2026-05-18)*
 - `98872f2` — docs(audit): coverage matrix — Loops section populated (41 rows × 7 cols) *(2026-05-18)*
 - `8b43af9` — docs(audit): coverage matrix baseline skeleton (slice 1 of 5) *(2026-05-18)*
-- `586b727` — cleanup: CI integrity fixes — ubiquitous-language guard + 3 misc (slices 5.5 + 5.10) *(2026-05-18)*
 - `6e74dcf` — Merge branch 'staging' into docs/wiki-backfill-seven *(2026-05-18)*
 - `127d4ae` — Merge branch 'staging' into audit/area-auto-agent *(2026-05-18)*
 - `7ac00f7` — Merge branch 'staging' into audit/area-hexagonal *(2026-05-18)*
@@ -321,4 +281,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -41,7 +41,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
 | `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
 | `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
 | `SecurityPatchLoop` | ✅ [0029] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
 | `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
 | `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -276,4 +276,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._
+_Regenerated from commit `28d5c30` on 2026-05-18 23:30 UTC. Source last changed at `28d5c30`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -95,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `8e52890` on 2026-05-18 23:30 UTC. Source last changed at `8e52890`. Status: 🟢 fresh._
+_Regenerated from commit `6e55893` on 2026-05-18 15:48 UTC. Source last changed at `6e55893`. Status: 🟢 fresh._

--- a/tests/scenarios/test_sandbox_failure_fixer_scenario.py
+++ b/tests/scenarios/test_sandbox_failure_fixer_scenario.py
@@ -178,9 +178,7 @@ class TestSandboxFailureFixerScenario:
         assert _AUTO_FIX_LABEL not in pr.labels, (
             "sandbox-fail-auto-fix should be removed after escalation"
         )
-        assert _HITL_LABEL in pr.labels, (
-            "sandbox-hitl should be added after escalation"
-        )
+        assert _HITL_LABEL in pr.labels, "sandbox-hitl should be added after escalation"
 
     async def test_hitl_queue_reflects_escalated_pr(self, tmp_path) -> None:
         """End-to-end HITL queue integration.

--- a/tests/scenarios/test_sandbox_failure_fixer_scenario.py
+++ b/tests/scenarios/test_sandbox_failure_fixer_scenario.py
@@ -1,0 +1,282 @@
+"""MockWorld scenario for SandboxFailureFixerLoop (bead #8814, slice 5.3).
+
+Four scenarios over the loop's auto-fix → escalation ladder:
+
+* ``test_auto_fix_succeeds_on_first_attempt`` — PR labeled
+  ``sandbox-fail-auto-fix`` is polled; the runner returns a non-crashed
+  outcome on attempt 1. The loop must report ``dispatched=1, escalated=0``.
+
+* ``test_escalates_to_hitl_after_max_attempts`` — PR has already consumed
+  ``auto_agent_max_attempts`` (default 3) attempts. The loop must swap
+  ``sandbox-fail-auto-fix`` → ``sandbox-hitl`` and return
+  ``escalated=1, dispatched=0``.
+
+* ``test_hitl_queue_reflects_escalated_pr`` — end-to-end HITL queue
+  integration: run the loop (PR at cap), then call
+  ``sandbox_hitl_handler`` against the same FakeGitHub and confirm the PR
+  surfaces with the correct shape (number, branch, label, type).
+
+* ``test_opt_out_label_skips_pr`` — PR carrying ``no-auto-fix`` is skipped
+  entirely: no dispatch, no escalation, labels unchanged.
+
+``config.sandbox_failure_fixer_enabled`` defaults to ``False``; scenarios
+pass ``sandbox_failure_fixer_enabled=True`` to ``make_bg_loop_deps`` and
+construct the loop directly (the catalog builder has no config-enable seam,
+matching the direct-construction pattern used in unit tests).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dashboard_routes._hitl_routes import sandbox_hitl_handler
+from tests.scenarios.fakes.mock_world import MockWorld
+
+pytestmark = pytest.mark.scenario_loops
+
+_AUTO_FIX_LABEL = "sandbox-fail-auto-fix"
+_HITL_LABEL = "sandbox-hitl"
+
+
+def _make_state(attempts: dict[int, int] | None = None) -> MagicMock:
+    """Build a state mock mirroring SandboxFailureFixerStateMixin.
+
+    ``get_sandbox_failure_fixer_attempts(pr_number)`` returns the seeded
+    count (0 if absent); ``bump_sandbox_failure_fixer_attempts(pr_number)``
+    increments in-memory and returns the new total.
+    """
+    state = MagicMock()
+    counts: dict[str, int] = {str(k): v for k, v in (attempts or {}).items()}
+
+    def _get(pr_number: int) -> int:
+        return int(counts.get(str(pr_number), 0))
+
+    def _bump(pr_number: int) -> int:
+        new = _get(pr_number) + 1
+        counts[str(pr_number)] = new
+        return new
+
+    state.get_sandbox_failure_fixer_attempts.side_effect = _get
+    state.bump_sandbox_failure_fixer_attempts.side_effect = _bump
+    state._counts = counts
+    return state
+
+
+class TestSandboxFailureFixerScenario:
+    """Slice 5.3 / bead #8814 — auto-fix → HITL escalation path."""
+
+    async def test_auto_fix_succeeds_on_first_attempt(self, tmp_path) -> None:
+        """Sandbox red detected, auto-fix attempt #1 passes.
+
+        The runner returns a non-crashed outcome. The loop must:
+        * Bump attempt counter to 1.
+        * Call runner.run once.
+        * Return dispatched=1, escalated=0.
+        """
+        from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
+        from tests.helpers import make_bg_loop_deps
+
+        world = MockWorld(tmp_path)
+        github = world.github
+
+        github.add_pr(
+            number=42,
+            issue_number=10,
+            branch="rc/2026-05-01-0400",
+        )
+        github.add_pr_label(42, _AUTO_FIX_LABEL)
+
+        state = _make_state()
+        runner = MagicMock()
+        runner.run = AsyncMock(
+            return_value=SimpleNamespace(crashed=False, output_text="fixed")
+        )
+
+        bg = make_bg_loop_deps(
+            tmp_path,
+            sandbox_failure_fixer_enabled=True,
+            auto_agent_max_attempts=3,
+        )
+        loop = SandboxFailureFixerLoop(
+            config=bg.config,
+            state=state,
+            prs=github,
+            runner=runner,
+            deps=bg.loop_deps,
+        )
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["status"] == "ok"
+        assert result["candidates"] == 1
+        assert result["dispatched"] == 1
+        assert result["escalated"] == 0
+        assert result["crashed"] == 0
+
+        runner.run.assert_awaited_once()
+        assert state._counts == {"42": 1}
+
+        # The auto-fix label stays; removal on success is the responsibility
+        # of a downstream watcher, not this loop.
+        pr = github.pr(42)
+        assert _AUTO_FIX_LABEL in pr.labels
+
+    async def test_escalates_to_hitl_after_max_attempts(self, tmp_path) -> None:
+        """Sandbox red, 3 failed attempts → escalate to sandbox-hitl.
+
+        After ``auto_agent_max_attempts`` (3) attempts the loop must:
+        * Skip the runner entirely.
+        * Remove ``sandbox-fail-auto-fix`` from the PR.
+        * Add ``sandbox-hitl`` to the PR.
+        * Return escalated=1, dispatched=0.
+        """
+        from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
+        from tests.helpers import make_bg_loop_deps
+
+        world = MockWorld(tmp_path)
+        github = world.github
+
+        github.add_pr(
+            number=42,
+            issue_number=10,
+            branch="rc/2026-05-01-0400",
+        )
+        github.add_pr_label(42, _AUTO_FIX_LABEL)
+
+        # PR is already at the 3-attempt cap.
+        state = _make_state(attempts={42: 3})
+        runner = MagicMock()
+        runner.run = AsyncMock()
+
+        bg = make_bg_loop_deps(
+            tmp_path,
+            sandbox_failure_fixer_enabled=True,
+            auto_agent_max_attempts=3,
+        )
+        loop = SandboxFailureFixerLoop(
+            config=bg.config,
+            state=state,
+            prs=github,
+            runner=runner,
+            deps=bg.loop_deps,
+        )
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["status"] == "ok"
+        assert result["escalated"] == 1
+        assert result["dispatched"] == 0
+
+        runner.run.assert_not_awaited()
+
+        pr = github.pr(42)
+        assert _AUTO_FIX_LABEL not in pr.labels, (
+            "sandbox-fail-auto-fix should be removed after escalation"
+        )
+        assert _HITL_LABEL in pr.labels, (
+            "sandbox-hitl should be added after escalation"
+        )
+
+    async def test_hitl_queue_reflects_escalated_pr(self, tmp_path) -> None:
+        """End-to-end HITL queue integration.
+
+        After the fixer escalates a PR to ``sandbox-hitl``, the
+        ``sandbox_hitl_handler`` (backing ``/api/sandbox-hitl``) must
+        surface that PR with the correct shape.
+        """
+        from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
+        from tests.helpers import make_bg_loop_deps
+
+        world = MockWorld(tmp_path)
+        github = world.github
+
+        github.add_pr(
+            number=99,
+            issue_number=20,
+            branch="rc/2026-05-02-0800",
+        )
+        github.add_pr_label(99, _AUTO_FIX_LABEL)
+
+        state = _make_state(attempts={99: 3})
+        runner = MagicMock()
+        runner.run = AsyncMock()
+
+        bg = make_bg_loop_deps(
+            tmp_path,
+            sandbox_failure_fixer_enabled=True,
+            auto_agent_max_attempts=3,
+        )
+        loop = SandboxFailureFixerLoop(
+            config=bg.config,
+            state=state,
+            prs=github,
+            runner=runner,
+            deps=bg.loop_deps,
+        )
+
+        # Tick: loop escalates PR #99.
+        result = await loop._do_work()
+        assert result["escalated"] == 1
+
+        # Verify the HITL queue handler surfaces the escalated PR.
+        hitl_payload = await sandbox_hitl_handler(prs=github)
+
+        assert "items" in hitl_payload
+        items = hitl_payload["items"]
+        assert len(items) == 1, f"expected 1 HITL item, got {items!r}"
+
+        item = items[0]
+        assert item["number"] == 99
+        assert item["branch"] == "rc/2026-05-02-0800"
+        assert item["label"] == _HITL_LABEL
+        assert item["type"] == "pr"
+        assert isinstance(item["url"], str)
+
+    async def test_opt_out_label_skips_pr(self, tmp_path) -> None:
+        """PR carrying no-auto-fix is skipped — no dispatch, no escalation."""
+        from sandbox_failure_fixer_loop import SandboxFailureFixerLoop
+        from tests.helpers import make_bg_loop_deps
+
+        world = MockWorld(tmp_path)
+        github = world.github
+
+        github.add_pr(
+            number=77,
+            issue_number=30,
+            branch="rc/2026-05-03-1200",
+        )
+        github.add_pr_label(77, _AUTO_FIX_LABEL)
+        github.add_pr_label(77, "no-auto-fix")
+
+        state = _make_state()
+        runner = MagicMock()
+        runner.run = AsyncMock()
+
+        bg = make_bg_loop_deps(
+            tmp_path,
+            sandbox_failure_fixer_enabled=True,
+            auto_agent_max_attempts=3,
+        )
+        loop = SandboxFailureFixerLoop(
+            config=bg.config,
+            state=state,
+            prs=github,
+            runner=runner,
+            deps=bg.loop_deps,
+        )
+
+        result = await loop._do_work()
+
+        assert result["skipped_opt_out"] == 1
+        assert result["dispatched"] == 0
+        assert result["escalated"] == 0
+        runner.run.assert_not_awaited()
+
+        pr = github.pr(77)
+        assert _AUTO_FIX_LABEL in pr.labels
+        assert _HITL_LABEL not in pr.labels


### PR DESCRIPTION
## Summary

Slice 5.3 bead #8814: SandboxFailureFixerLoop catalog builder existed but no scenario invoked it. This covers the auto-fix-then-HITL escalation path end-to-end.

- First-attempt success: `sandbox-fail-auto-fix` PR dispatched to auto-agent, attempt counter incremented, `dispatched=1`.
- 3-attempt cap exhausted: labels swapped `sandbox-fail-auto-fix` → `sandbox-hitl`, `escalated=1`, runner not called.
- HITL queue integration: after escalation, `sandbox_hitl_handler` (backing `/api/sandbox-hitl`) surfaces the PR with correct shape.
- Opt-out: PR carrying `no-auto-fix` is skipped entirely.

🤖 Generated with Claude Code