### PR TITLE
refactor(ports): AgentPort public method names

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-18T19:03:27.836746+00:00",
-  "commit_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22",
+  "regenerated_at": "2026-05-18T19:04:02.172156+00:00",
+  "commit_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43",
   "artifacts": {
     "loops.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "ports.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "labels.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "modules.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "events.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "adr_xref.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "mockworld.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "changelog.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "coverage_matrix.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "functional_areas.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "ubiquitous-language.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "536d623c2c4d6ed2ae52e8ddab2ba2f8eb9dbc22"
+      "source_sha": "e6dad0c87f9b80e2da0237b6bcb0f3cd775e6a43"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `536d623` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `e6dad0c` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `84b64fd` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `b714ab0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `dc79b3f` — chore(arch): regen arch artifacts from rebased staging tip *(2026-05-18)*
 - `f202e6e` — feat(arch): regenerable coverage_matrix generator for arch-regen (closes advisor-bpl parent bead) *(2026-05-18)*
@@ -305,4 +306,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -6,6 +6,7 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 
 ```mermaid
 graph LR
+    AgentPort --> AgentRunner
     BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
@@ -25,8 +26,9 @@ graph LR
 ### AgentPort
 
 - Module: `src.ports`
-- Methods: `_build_command`, `_execute`, `_verify_result`
-- Adapters: —
+- Methods: `build_command`, `execute`, `verify_result`
+- Adapters:
+  - `AgentRunner` (`src.agent`)
 - Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
 
 ### BotPRPort
@@ -93,4 +95,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `536d623` on 2026-05-18 19:03 UTC. Source last changed at `536d623`. Status: 🟢 fresh._
+_Regenerated from commit `e6dad0c` on 2026-05-18 19:04 UTC. Source last changed at `e6dad0c`. Status: 🟢 fresh._

--- a/src/agent.py
+++ b/src/agent.py
@@ -1346,6 +1346,39 @@ SUMMARY: <one-line summary>
         except (TimeoutError, ValueError, FileNotFoundError):
             return 0
 
+    # AgentPort public interface (hexagonal contract).
+    # The underscore implementations remain for internal BaseRunner use; these
+    # thin forwarders expose the port boundary names used by infrastructure
+    # modules (merge_conflict_resolver, pr_unsticker).
+
+    def build_command(self, _worktree_path: Path | None = None) -> list[str]:
+        """Public AgentPort entry point — delegates to ``_build_command``."""
+        return self._build_command(_worktree_path)
+
+    async def execute(
+        self,
+        cmd: list[str],
+        prompt: str,
+        cwd: Path,
+        event_data: TranscriptEventData,
+        *,
+        on_output: Callable[[str], bool] | None = None,
+        telemetry_stats: Mapping[str, object] | None = None,
+    ) -> str:
+        """Public AgentPort entry point — delegates to ``_execute``."""
+        return await self._execute(
+            cmd,
+            prompt,
+            cwd,
+            event_data,
+            on_output=on_output,
+            telemetry_stats=telemetry_stats,
+        )
+
+    async def verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
+        """Public AgentPort entry point — delegates to ``_verify_result``."""
+        return await self._verify_result(worktree_path, branch)
+
     async def _emit_status(
         self, issue_number: int, worker_id: int, status: WorkerStatus
     ) -> None:

--- a/src/merge_conflict_resolver.py
+++ b/src/merge_conflict_resolver.py
@@ -188,8 +188,8 @@ class MergeConflictResolver:
                         "previous_error_after": error_after,
                     },
                 )
-                cmd = self._agents._build_command(wt_path)
-                transcript = await self._agents._execute(
+                cmd = self._agents.build_command(wt_path)
+                transcript = await self._agents.execute(
                     cmd,
                     prompt,
                     wt_path,
@@ -204,7 +204,7 @@ class MergeConflictResolver:
                 if self._suggest_memory is not None:
                     await self._suggest_memory(transcript, source, f"PR #{pr.number}")
 
-                verify = await self._agents._verify_result(wt_path, pr.branch)
+                verify = await self._agents.verify_result(wt_path, pr.branch)
                 if verify.passed:
                     await self._maybe_summarize_conflict(
                         transcript, issue.id, pr.number
@@ -317,8 +317,8 @@ class MergeConflictResolver:
                     ),
                 },
             )
-            cmd = self._agents._build_command(new_wt)
-            transcript = await self._agents._execute(
+            cmd = self._agents.build_command(new_wt)
+            transcript = await self._agents.execute(
                 cmd,
                 prompt,
                 new_wt,
@@ -333,7 +333,7 @@ class MergeConflictResolver:
             if self._suggest_memory is not None:
                 await self._suggest_memory(transcript, source, f"PR #{pr.number}")
 
-            verify = await self._agents._verify_result(new_wt, pr.branch)
+            verify = await self._agents.verify_result(new_wt, pr.branch)
             if verify.passed:
                 await self._maybe_summarize_conflict(transcript, issue.id, pr.number)
                 expected_title = self._prs.expected_pr_title(issue.id, issue.title)

--- a/src/ports.py
+++ b/src/ports.py
@@ -602,11 +602,11 @@ class AgentPort(Protocol):
     implementations to satisfy structural subtype checks.
     """
 
-    def _build_command(self, _worktree_path: Path | None = None) -> list[str]:
+    def build_command(self, _worktree_path: Path | None = None) -> list[str]:
         """Construct the CLI command for the agent."""
         ...
 
-    async def _execute(
+    async def execute(
         self,
         cmd: list[str],
         prompt: str,
@@ -619,7 +619,7 @@ class AgentPort(Protocol):
         """Run the agent subprocess and return the transcript."""
         ...
 
-    async def _verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
+    async def verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
         """Verify the agent produced valid commits and quality passes."""
         ...
 

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -432,8 +432,8 @@ class PRUnsticker:
         prompt, prompt_stats = self._build_ci_fix_prompt(issue, pr_url, cause_str)
 
         try:
-            cmd = self._agents._build_command(wt_path)
-            transcript = await self._agents._execute(
+            cmd = self._agents.build_command(wt_path)
+            transcript = await self._agents.execute(
                 cmd,
                 prompt,
                 wt_path,
@@ -454,7 +454,7 @@ class PRUnsticker:
                 transcript, "pr_unsticker", f"issue #{issue_number}"
             )
 
-            verify = await self._agents._verify_result(wt_path, branch)
+            verify = await self._agents.verify_result(wt_path, branch)
             if verify.passed:
                 return True
 
@@ -603,8 +603,8 @@ diff — you may catch things `make quality` won't.
             )
 
             try:
-                cmd = self._agents._build_command(wt_path)
-                transcript = await self._agents._execute(
+                cmd = self._agents.build_command(wt_path)
+                transcript = await self._agents.execute(
                     cmd,
                     prompt,
                     wt_path,
@@ -624,7 +624,7 @@ diff — you may catch things `make quality` won't.
                     transcript, "pr_unsticker", f"issue #{issue_number}"
                 )
 
-                verify = await self._agents._verify_result(wt_path, branch)
+                verify = await self._agents.verify_result(wt_path, branch)
                 if verify.passed:
                     # Write path: persist pattern from transcript
                     await self._persist_troubleshooting_pattern(

--- a/tests/test_exception_chaining.py
+++ b/tests/test_exception_chaining.py
@@ -365,7 +365,7 @@ class TestMergeConflictResolverExceptionChaining:
         resolver._publish_review_status = AsyncMock()
 
         # Mock agents._build_command to raise TypeError (a likely bug)
-        resolver._agents._build_command = MagicMock(
+        resolver._agents.build_command = MagicMock(
             side_effect=TypeError("bad merge arg")
         )
 
@@ -384,7 +384,7 @@ class TestMergeConflictResolverExceptionChaining:
         resolver._workspaces.abort_merge = AsyncMock()
 
         # Mock agents._build_command to raise RuntimeError (transient)
-        resolver._agents._build_command = MagicMock(
+        resolver._agents.build_command = MagicMock(
             side_effect=RuntimeError("transient")
         )
 

--- a/tests/test_merge_conflict_resolver.py
+++ b/tests/test_merge_conflict_resolver.py
@@ -107,15 +107,15 @@ class TestMergeConflictResolver:
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
-        mock_agents._execute.assert_not_awaited()
+        mock_agents.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_resolve_runs_agent_on_conflicts(
         self, config: HydraFlowConfig
     ) -> None:
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -129,17 +129,17 @@ class TestMergeConflictResolver:
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
-        mock_agents._build_command.assert_called_once()
-        mock_agents._execute.assert_awaited_once()
-        telemetry = mock_agents._execute.await_args.kwargs["telemetry_stats"]
+        mock_agents.build_command.assert_called_once()
+        mock_agents.execute.assert_awaited_once()
+        telemetry = mock_agents.execute.await_args.kwargs["telemetry_stats"]
         assert "pruned_chars_total" in telemetry
 
     @pytest.mark.asyncio
     async def test_saves_transcript(self, config: HydraFlowConfig) -> None:
         """A transcript file should be saved for each attempt."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript content")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript content")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -163,8 +163,8 @@ class TestSourceParameter:
     ) -> None:
         """Verify that transcripts use the source parameter for filename prefix."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript content")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript content")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -190,8 +190,8 @@ class TestSourceParameter:
     ) -> None:
         """Verify _suggest_memory gets the correct source string."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -220,8 +220,8 @@ class TestWorkerIdNone:
     ) -> None:
         """Verify no REVIEW_UPDATE events when worker_id is None."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -258,8 +258,8 @@ class TestWorkerIdNone:
     ) -> None:
         """Verify REVIEW_UPDATE events are published when worker_id is provided."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -332,9 +332,9 @@ class TestFreshBranchRebuild:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
+        mock_agents.execute = AsyncMock(return_value="transcript")
         # First call (merge attempt) fails, second call (rebuild) succeeds
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="quality failed"),
                 LoopResult(passed=True, summary=""),
@@ -372,8 +372,8 @@ class TestFreshBranchRebuild:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="rebuilt transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="rebuilt transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(cfg, agents=mock_agents)
@@ -390,10 +390,10 @@ class TestFreshBranchRebuild:
         assert result is True
         resolver._workspaces.destroy.assert_awaited_once_with(pr.issue_number)
         resolver._workspaces.create.assert_awaited_once_with(pr.issue_number, pr.branch)
-        mock_agents._build_command.assert_called_once_with(new_wt)
-        mock_agents._execute.assert_awaited_once()
-        mock_agents._verify_result.assert_awaited_once()
-        telemetry = mock_agents._execute.await_args.kwargs["telemetry_stats"]
+        mock_agents.build_command.assert_called_once_with(new_wt)
+        mock_agents.execute.assert_awaited_once()
+        mock_agents.verify_result.assert_awaited_once()
+        telemetry = mock_agents.execute.await_args.kwargs["telemetry_stats"]
         assert "pruned_chars_total" in telemetry
 
     @pytest.mark.asyncio
@@ -413,7 +413,7 @@ class TestFreshBranchRebuild:
         result = await resolver.fresh_branch_rebuild(pr, issue, worker_id=0)
 
         assert result is False
-        mock_agents._execute.assert_not_awaited()
+        mock_agents.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fresh_rebuild_skipped_when_no_agents(self, tmp_path: Path) -> None:
@@ -464,9 +464,9 @@ class TestFreshBranchRebuild:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
+        mock_agents.execute = AsyncMock(return_value="transcript")
         # Merge attempt fails, rebuild succeeds
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="failed"),
                 LoopResult(passed=True, summary=""),
@@ -523,8 +523,8 @@ class TestFreshRebuildTitleUpdate:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="rebuilt transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="rebuilt transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(cfg, agents=mock_agents)
@@ -555,8 +555,8 @@ class TestFreshRebuildTitleUpdate:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="failed transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="failed transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="quality check failed")
         )
         resolver = make_conflict_resolver(cfg, agents=mock_agents)
@@ -616,8 +616,8 @@ class TestArchitectureLayering:
     ) -> None:
         """Injected suggest_memory callback should be called on success."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         suggest_fn = AsyncMock()
@@ -641,8 +641,8 @@ class TestArchitectureLayering:
     ) -> None:
         """When suggest_memory is None, resolve should still succeed."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(
@@ -664,8 +664,8 @@ class TestArchitectureLayering:
     ) -> None:
         """_publish_review_status should emit events via EventBus without phase_utils."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(config, agents=mock_agents)
@@ -705,8 +705,8 @@ class TestArchitectureLayering:
             state_file=tmp_path / "state.json",
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="rebuilt transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="rebuilt transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         resolver = make_conflict_resolver(cfg, agents=mock_agents)

--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -511,9 +511,9 @@ class TestAgentPortMethods:
     """All methods declared in AgentPort exist on AgentRunner."""
 
     _REQUIRED_METHODS = [
-        "_build_command",
-        "_execute",
-        "_verify_result",
+        "build_command",
+        "execute",
+        "verify_result",
     ]
 
     @pytest.mark.parametrize("method", _REQUIRED_METHODS)
@@ -529,8 +529,9 @@ class TestAgentPortSignatures:
     """AgentPort method signatures must match AgentRunner's implementations."""
 
     _SIGNED_METHODS = [
-        "_build_command",
-        "_execute",
+        "build_command",
+        "execute",
+        "verify_result",
     ]
 
     @pytest.mark.parametrize("method", _SIGNED_METHODS)

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -422,9 +422,9 @@ class TestCIFailureResolution:
             captured_prompt = prompt
             return await original_execute(cmd, prompt, wt_arg, issue_number, **kwargs)
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = capture_execute
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = capture_execute
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
 
@@ -816,9 +816,9 @@ class TestPromptTelemetry:
         h.state.set_hitl_cause(42, "x" * 6000)
 
         h.wt.start_merge_main = AsyncMock(return_value=True)
-        h.agents._build_command = MagicMock(return_value=["cmd"])
-        h.agents._execute = AsyncMock(return_value="done")
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["cmd"])
+        h.agents.execute = AsyncMock(return_value="done")
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
 
@@ -830,7 +830,7 @@ class TestPromptTelemetry:
             "https://example.com/pull/1",
         )
         assert ok is True
-        telemetry = h.agents._execute.await_args.kwargs["telemetry_stats"]
+        telemetry = h.agents.execute.await_args.kwargs["telemetry_stats"]
         assert telemetry["pruned_chars_total"] > 0
 
 
@@ -1066,9 +1066,9 @@ def _setup_ci_fix_memory_test(
     h.wt.start_merge_main = AsyncMock(return_value=True)  # Clean rebase
     h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
-    h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-    h.agents._execute = AsyncMock(return_value=transcript)
-    h.agents._verify_result = AsyncMock(
+    h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+    h.agents.execute = AsyncMock(return_value=transcript)
+    h.agents.verify_result = AsyncMock(
         return_value=LoopResult(passed=True, summary="OK")
     )
 
@@ -1128,9 +1128,9 @@ class TestCITimeoutResolution:
             captured_prompt = prompt
             return await original_execute(cmd, prompt, wt_arg, issue_meta, **kwargs)
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = capture_execute
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = capture_execute
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
 
@@ -1211,9 +1211,9 @@ class TestCITimeoutResolution:
             captured_prompt = prompt
             return "transcript"
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = capture_execute
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = capture_execute
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1257,10 +1257,10 @@ class TestCITimeoutResolution:
         h.agents._runner = MagicMock()
         h.agents._runner.run_simple = AsyncMock(side_effect=TimeoutError("timed out"))
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value="transcript")
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value="transcript")
         # Verification always fails
-        h.agents._verify_result = AsyncMock(
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="tests still hang")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1276,7 +1276,7 @@ class TestCITimeoutResolution:
         assert stats["failed"] == 1
         assert stats["resolved"] == 0
         # Agent should have been called max_ci_timeout_fix_attempts times
-        assert h.agents._execute.await_count == 2
+        assert h.agents.execute.await_count == 2
 
     def test_ci_timeout_priority_ordering(self) -> None:
         """CI_TIMEOUT should sort before CI_FAILURE in priority."""
@@ -1339,9 +1339,9 @@ class TestCITimeoutResolution:
             captured_prompt = prompt
             return "transcript"
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = capture_execute
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = capture_execute
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1403,9 +1403,9 @@ Done."""
         h.agents._runner = MagicMock()
         h.agents._runner.run_simple = AsyncMock(side_effect=TimeoutError("timed out"))
 
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value=transcript_with_pattern)
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value=transcript_with_pattern)
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1454,9 +1454,9 @@ Done."""
 
         h.agents._runner = MagicMock()
         h.agents._runner.run_simple = AsyncMock(side_effect=TimeoutError("timed out"))
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value="transcript")
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value="transcript")
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1523,9 +1523,9 @@ Done."""
 
         h.agents._runner = MagicMock()
         h.agents._runner.run_simple = AsyncMock(side_effect=TimeoutError("timed out"))
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value=transcript_no_block)
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value=transcript_no_block)
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1597,9 +1597,9 @@ TROUBLESHOOTING_PATTERN_END
         h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
         h.agents._runner = MagicMock()
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value="Fixed by setting return_value.")
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value="Fixed by setting return_value.")
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1659,9 +1659,9 @@ TROUBLESHOOTING_PATTERN_END
         h.wt.create = AsyncMock(return_value=tmp_path / "worktrees" / "issue-42")
 
         h.agents._runner = MagicMock()
-        h.agents._build_command = MagicMock(return_value=["claude", "-p"])
-        h.agents._execute = AsyncMock(return_value="Fixed it.")
-        h.agents._verify_result = AsyncMock(
+        h.agents.build_command = MagicMock(return_value=["claude", "-p"])
+        h.agents.execute = AsyncMock(return_value="Fixed it.")
+        h.agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="OK")
         )
         h.prs.push_branch = AsyncMock(return_value=True)
@@ -1758,8 +1758,8 @@ class TestNarrowedExceptionHandling:
         h.state.set_hitl_cause(42, "ci_failure")
 
         h.wt.start_merge_main = AsyncMock(return_value=True)
-        h.agents._build_command = MagicMock(return_value=["cmd"])
-        h.agents._execute = AsyncMock(side_effect=AttributeError("bad attr"))
+        h.agents.build_command = MagicMock(return_value=["cmd"])
+        h.agents.execute = AsyncMock(side_effect=AttributeError("bad attr"))
 
         with pytest.raises(AttributeError, match="bad attr"):
             await h.unsticker._resolve_ci_or_quality(
@@ -1777,8 +1777,8 @@ class TestNarrowedExceptionHandling:
         h.state.set_hitl_cause(42, "ci_failure")
 
         h.wt.start_merge_main = AsyncMock(return_value=True)
-        h.agents._build_command = MagicMock(return_value=["cmd"])
-        h.agents._execute = AsyncMock(side_effect=RuntimeError("agent crashed"))
+        h.agents.build_command = MagicMock(return_value=["cmd"])
+        h.agents.execute = AsyncMock(side_effect=RuntimeError("agent crashed"))
 
         result = await h.unsticker._resolve_ci_or_quality(
             42, issue, tmp_path / "h.wt", "branch", "url"
@@ -1892,8 +1892,8 @@ class TestNarrowedExceptionHandling:
         h.state.set_hitl_cause(42, "ci_timeout")
 
         h.wt.start_merge_main = AsyncMock(return_value=True)
-        h.agents._build_command = MagicMock(return_value=["cmd"])
-        h.agents._execute = AsyncMock(side_effect=AttributeError("bad attr"))
+        h.agents.build_command = MagicMock(return_value=["cmd"])
+        h.agents.execute = AsyncMock(side_effect=AttributeError("bad attr"))
 
         with pytest.raises(AttributeError, match="bad attr"):
             await h.unsticker._resolve_ci_timeout(

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -264,11 +264,11 @@ class TestPostMergeConflictFix:
     ) -> None:
         """When merge fails and agent can't resolve, should escalate to HITL."""
         mock_agents = AsyncMock()
-        mock_agents._build_command = MagicMock(return_value=["claude"])
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.build_command = MagicMock(return_value=["claude"])
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
-        mock_agents._execute = AsyncMock(return_value="conflict resolution transcript")
+        mock_agents.execute = AsyncMock(return_value="conflict resolution transcript")
         phase = make_review_phase(config, agents=mock_agents)
         issue = TaskFactory.create()
         pr = PRInfoFactory.create()
@@ -296,9 +296,9 @@ class TestPostMergeConflictFix:
     ) -> None:
         """Merge conflict escalation should record review_label as HITL origin."""
         mock_agents = AsyncMock()
-        mock_agents._build_command = MagicMock(return_value=["claude"])
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.build_command = MagicMock(return_value=["claude"])
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
         phase = make_review_phase(config, agents=mock_agents)
@@ -322,9 +322,9 @@ class TestPostMergeConflictFix:
     ) -> None:
         """Merge conflict escalation should record cause in state."""
         mock_agents = AsyncMock()
-        mock_agents._build_command = MagicMock(return_value=["claude"])
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.build_command = MagicMock(return_value=["claude"])
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
         phase = make_review_phase(config, agents=mock_agents)
@@ -348,9 +348,9 @@ class TestPostMergeConflictFix:
     ) -> None:
         """When merge fails but agent resolves conflicts, review should proceed."""
         mock_agents = AsyncMock()
-        mock_agents._build_command = MagicMock(return_value=["claude"])
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.build_command = MagicMock(return_value=["claude"])
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(config, default_mocks=True, agents=mock_agents)

--- a/tests/test_review_phase_hitl.py
+++ b/tests/test_review_phase_hitl.py
@@ -65,8 +65,8 @@ class TestHITLEscalationEvents:
     ) -> None:
         """Merge conflict escalation should emit HITL_ESCALATION with cause merge_conflict."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
         phase = make_review_phase(config, agents=mock_agents, event_bus=event_bus)

--- a/tests/test_review_phase_merge.py
+++ b/tests/test_review_phase_merge.py
@@ -60,15 +60,15 @@ class TestResolveMergeConflicts:
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
         # Agent should NOT have been invoked
-        mock_agents._execute.assert_not_awaited()
+        mock_agents.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_runs_agent_and_verifies_on_conflicts(
         self, config: HydraFlowConfig
     ) -> None:
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(config)
@@ -83,9 +83,9 @@ class TestResolveMergeConflicts:
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
-        mock_agents._build_command.assert_called_once()
-        mock_agents._execute.assert_awaited_once()
-        mock_agents._verify_result.assert_awaited_once()
+        mock_agents.build_command.assert_called_once()
+        mock_agents.execute.assert_awaited_once()
+        mock_agents.verify_result.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_aborts_merge_on_agent_exception(
@@ -93,7 +93,7 @@ class TestResolveMergeConflicts:
     ) -> None:
         """On agent exception on all attempts, should abort merge and return False."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(side_effect=RuntimeError("agent crashed"))
+        mock_agents.execute = AsyncMock(side_effect=RuntimeError("agent crashed"))
         phase = make_review_phase(config)
         phase._conflict_resolver._agents = mock_agents
         pr = PRInfoFactory.create()
@@ -113,8 +113,8 @@ class TestResolveMergeConflicts:
     @pytest.mark.asyncio
     async def test_retries_on_verify_failure(self, config: HydraFlowConfig) -> None:
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="quality failed"),
                 LoopResult(passed=True, summary=""),
@@ -133,8 +133,8 @@ class TestResolveMergeConflicts:
         )
 
         assert result == ConflictResolutionResult(success=True, used_rebuild=False)
-        assert mock_agents._execute.await_count == 2
-        assert mock_agents._verify_result.await_count == 2
+        assert mock_agents.execute.await_count == 2
+        assert mock_agents.verify_result.await_count == 2
 
     @pytest.mark.asyncio
     async def test_exhausts_all_attempts_then_returns_false(
@@ -150,8 +150,8 @@ class TestResolveMergeConflicts:
             state_file=config.state_file,
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="quality failed")
         )
         phase = make_review_phase(cfg)
@@ -168,15 +168,15 @@ class TestResolveMergeConflicts:
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
         # Default is 3 attempts
-        assert mock_agents._execute.await_count == 3
-        assert mock_agents._verify_result.await_count == 3
+        assert mock_agents.execute.await_count == 3
+        assert mock_agents.verify_result.await_count == 3
 
     @pytest.mark.asyncio
     async def test_feeds_error_to_retry_prompt(self, config: HydraFlowConfig) -> None:
         """On retry, the prompt should include the previous error."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="ruff check failed"),
                 LoopResult(passed=True, summary=""),
@@ -195,7 +195,7 @@ class TestResolveMergeConflicts:
         )
 
         # Second call to _execute should have received a prompt with the error
-        second_call_args = mock_agents._execute.call_args_list[1]
+        second_call_args = mock_agents.execute.call_args_list[1]
         prompt_arg = second_call_args.args[1]
         assert "ruff check failed" in prompt_arg
         assert "Previous Attempt Failed" in prompt_arg
@@ -204,8 +204,8 @@ class TestResolveMergeConflicts:
     async def test_aborts_merge_between_retries(self, config: HydraFlowConfig) -> None:
         """abort_merge should be called before attempt 2+."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="failed"),
                 LoopResult(passed=True, summary=""),
@@ -230,8 +230,8 @@ class TestResolveMergeConflicts:
     async def test_saves_transcript_per_attempt(self, config: HydraFlowConfig) -> None:
         """A transcript file should be saved for each attempt."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript content")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript content")
+        mock_agents.verify_result = AsyncMock(
             side_effect=[
                 LoopResult(passed=False, summary="failed"),
                 LoopResult(passed=True, summary=""),
@@ -265,8 +265,8 @@ class TestResolveMergeConflicts:
             state_file=config.state_file,
         )
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="quality failed")
         )
         phase = make_review_phase(cfg)
@@ -282,7 +282,7 @@ class TestResolveMergeConflicts:
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
-        assert mock_agents._execute.await_count == 1
+        assert mock_agents.execute.await_count == 1
 
     @pytest.mark.asyncio
     async def test_zero_attempts_returns_false(self, config: HydraFlowConfig) -> None:
@@ -310,7 +310,7 @@ class TestResolveMergeConflicts:
         )
 
         assert result == ConflictResolutionResult(success=False, used_rebuild=False)
-        mock_agents._execute.assert_not_awaited()
+        mock_agents.execute.assert_not_awaited()
         # Final abort_merge should still be called
         phase._workspaces.abort_merge.assert_awaited_once()
 
@@ -320,8 +320,8 @@ class TestResolveMergeConflicts:
     ) -> None:
         """MemorySuggester should be called with the conflict transcript."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript with suggestion")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript with suggestion")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(config)
@@ -350,8 +350,8 @@ class TestResolveMergeConflicts:
     ) -> None:
         """Exceptions from file_memory_suggestion must not break conflict resolution."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(config)
@@ -399,8 +399,8 @@ class TestMergeWithMain:
     ) -> None:
         """When merge fails but conflict resolution succeeds, should return True."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(config, agents=mock_agents)

--- a/tests/test_review_phase_metrics.py
+++ b/tests/test_review_phase_metrics.py
@@ -131,8 +131,8 @@ class TestLifecycleMetricRecording:
     ) -> None:
         """Merge conflict HITL escalation should increment the hitl counter."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
         phase = make_review_phase(config, agents=mock_agents, default_mocks=True)
@@ -489,8 +489,8 @@ class TestGranularReviewStatusEvents:
     ) -> None:
         """A 'merge_fix' event should be published when resolving conflicts."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=True, summary="")
         )
         phase = make_review_phase(
@@ -520,8 +520,8 @@ class TestGranularReviewStatusEvents:
     ) -> None:
         """An 'escalating' event should be published when conflicts can't be resolved."""
         mock_agents = AsyncMock()
-        mock_agents._execute = AsyncMock(return_value="transcript")
-        mock_agents._verify_result = AsyncMock(
+        mock_agents.execute = AsyncMock(return_value="transcript")
+        mock_agents.verify_result = AsyncMock(
             return_value=LoopResult(passed=False, summary="")
         )
         phase = make_review_phase(


### PR DESCRIPTION
## Summary

- Slice 5.2 (PR #8811): `AgentPort` exposed three underscore-prefixed methods as its hexagonal contract, which is semantically confusing since underscore conventionally means private to the class.
- Rename `_build_command` → `build_command`, `_execute` → `execute`, `_verify_result` → `verify_result` in `AgentPort`.
- Add thin public forwarders on `AgentRunner` that delegate to the existing `BaseRunner` implementations, preserving the full `BaseRunner`/subclass hierarchy untouched (no blast radius on subclasses).
- Update callsites in `merge_conflict_resolver` and `pr_unsticker` to use the new names.
- Update all test mocks across 8 test files. Add `verify_result` to `TestAgentPortSignatures` (it was previously missing from the signature-checked set).

## Test plan

- [x] `TestAgentPortConformance`, `TestAgentPortMethods`, `TestAgentPortSignatures` all pass (7 tests)
- [x] `test_merge_conflict_resolver.py` passes (full suite)
- [x] `test_pr_unsticker.py` passes (full suite)
- [x] `test_review_phase_core/merge/hitl/metrics.py` pass
- [x] `test_exception_chaining.py` passes
- [x] Total: 405 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)