### PR TITLE
feat(contracts): GhReview + get_pr_approvers boundary wiring (Phase 16 of #8786)

### DIFF
--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -151,3 +151,42 @@ class GhPromotionPR(BaseModel):
     merged: bool
     closed_at: str | None = None
     url: str | None = None
+
+
+_GhReviewState = Literal[
+    "APPROVED",
+    "CHANGES_REQUESTED",
+    "COMMENTED",
+    "DISMISSED",
+    "PENDING",
+]
+
+
+class GhReviewAuthor(BaseModel):
+    """Reviewer identity. ``login`` is the GitHub username."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    login: str = ""
+
+
+class GhReview(BaseModel):
+    """One PR review as returned by ``gh pr view N --json reviews`` (each
+    element of the ``reviews`` array) or the underlying GitHub REST
+    ``/pulls/N/reviews`` endpoint."""
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+    state: _GhReviewState
+    author: GhReviewAuthor | None = None
+    submitted_at: str | None = Field(default=None, alias="submittedAt")
+    commit_id: str | None = Field(default=None, alias="commitId")
+
+
+class GhPRReviewsResponse(BaseModel):
+    """Wrapper for ``gh pr view N --json reviews`` — the outer object
+    carries a single ``reviews`` array."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    reviews: list[GhReview] = Field(default_factory=list)

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2129,7 +2129,16 @@ class PRManager:
             return []
 
     async def get_pr_approvers(self, pr_number: int) -> list[str]:
-        """Fetch the list of GitHub usernames that approved *pr_number*."""
+        """Fetch the list of GitHub usernames that approved *pr_number*.
+
+        #8786 Phase 16: routed through the contracts boundary helper in
+        lenient mode against ``GhPRReviewsResponse``. Drift in the
+        review state enum (e.g. a new ``DRAFT`` state) or author shape
+        fires WARN immediately at the call site.
+        """
+        from contracts.boundary import parse_with_shape  # noqa: PLC0415
+        from contracts.shapes import GhPRReviewsResponse  # noqa: PLC0415
+
         try:
             output = await self._run_gh(
                 "gh",
@@ -2141,15 +2150,26 @@ class PRManager:
                 "--json",
                 "reviews",
             )
-            data = json.loads(output)
-            reviews = data.get("reviews", [])
+            result = parse_with_shape(output, GhPRReviewsResponse)
             approvers: list[str] = []
-            for review in reviews:
+            if result.model_instance is not None:
+                for review in result.model_instance.reviews:
+                    if review.state == "APPROVED" and review.author is not None:
+                        login = review.author.login
+                        if login and login not in approvers:
+                            approvers.append(login)
+                return approvers
+            # Lenient fallback — drift logged, dict-access keeps working.
+            data = result.payload if isinstance(result.payload, dict) else {}
+            for review in data.get("reviews", []) or []:
+                if not isinstance(review, dict):
+                    continue
                 if review.get("state") == "APPROVED":
-                    author = review.get("author", {})
-                    login = author.get("login", "")
-                    if login and login not in approvers:
-                        approvers.append(login)
+                    author = review.get("author") or {}
+                    if isinstance(author, dict):
+                        login = author.get("login", "")
+                        if login and login not in approvers:
+                            approvers.append(login)
             return approvers
         except (RuntimeError, ValueError) as exc:
             logger.debug("Could not get approvers for PR #%d: %s", pr_number, exc)

--- a/tests/regressions/test_get_pr_approvers_boundary.py
+++ b/tests/regressions/test_get_pr_approvers_boundary.py
@@ -1,0 +1,114 @@
+"""Regression: get_pr_approvers routes through the boundary helper
+(Phase 16 of #8786). New ``GhPRReviewsResponse`` shape wraps a list of
+``GhReview`` entries."""
+
+from __future__ import annotations
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import SubprocessMockBuilder
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+@pytest.fixture
+def config(tmp_path):  # noqa: ANN001
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def event_bus():  # noqa: ANN201
+    from events import EventBus
+
+    return EventBus()
+
+
+@pytest.mark.asyncio
+async def test_returns_unique_approver_logins(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Multiple reviews from the same author → dedup. Non-approved
+    states filtered out."""
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        {
+            "reviews": [
+                {"state": "COMMENTED", "author": {"login": "alice"}},
+                {"state": "APPROVED", "author": {"login": "alice"}},
+                {"state": "APPROVED", "author": {"login": "bob"}},
+                {"state": "CHANGES_REQUESTED", "author": {"login": "carol"}},
+                {"state": "APPROVED", "author": {"login": "alice"}},  # dup
+            ]
+        }
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.get_pr_approvers(pr_number=42)
+    assert result == ["alice", "bob"]
+    assert not [r for r in caplog.records if "boundary validation failed" in r.message]
+
+
+@pytest.mark.asyncio
+async def test_drifted_state_logs_warn_and_falls_back(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A new state enum value trips validation. The lenient fallback
+    walks the raw dict — APPROVED entries still surface, drifted ones
+    don't get treated as approvals."""
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps(
+        {
+            "reviews": [
+                {"state": "AUTO_APPROVED", "author": {"login": "bot"}},  # drifted
+                {"state": "APPROVED", "author": {"login": "alice"}},
+            ]
+        }
+    )
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.contracts.boundary"),
+        patch("asyncio.create_subprocess_exec", mock_create),
+    ):
+        result = await mgr.get_pr_approvers(pr_number=42)
+    assert any("boundary validation failed" in r.message for r in caplog.records)
+    # The lenient fallback uses dict-access; AUTO_APPROVED ≠ APPROVED so
+    # the bot isn't counted as an approver. Only alice surfaces.
+    assert "alice" in result
+    assert "bot" not in result
+
+
+@pytest.mark.asyncio
+async def test_empty_reviews_returns_empty(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    payload = json.dumps({"reviews": []})
+    mock_create = SubprocessMockBuilder().with_stdout(payload).build()
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.get_pr_approvers(pr_number=42)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_subprocess_failure_returns_empty(
+    config,  # noqa: ANN001
+    event_bus,  # noqa: ANN001
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    mock_create = (
+        SubprocessMockBuilder().with_returncode(1).with_stderr("api error").build()
+    )
+    with patch("asyncio.create_subprocess_exec", mock_create):
+        result = await mgr.get_pr_approvers(pr_number=42)
+    assert result == []


### PR DESCRIPTION
## Summary

Phase 16 of #8786. Adds the gh-PR-review shape surface:

| Shape | Purpose |
|---|---|
| `GhReviewAuthor` | Reviewer identity (`{login}`) |
| `GhReview` | `{state, author?, submittedAt?, commitId?}` — state pinned to Literal |
| `GhPRReviewsResponse` | Wrapper for `gh pr view N --json reviews` |

`get_pr_approvers` now routes through `parse_with_shape` in lenient mode. Drift in the review state enum (a future `AUTO_APPROVED`?) trips WARN immediately; lenient fallback walks the raw dict so APPROVED entries still surface.

## Test plan

`tests/regressions/test_get_pr_approvers_boundary.py` — 4 tests:
- [x] Multiple reviews dedup → unique approver logins, no WARN
- [x] Drifted state enum → WARN logs, lenient fallback still correctly filters by literal `"APPROVED"` (drifted entry NOT counted)
- [x] Empty reviews → empty list
- [x] Subprocess failure → empty (existing semantics)

ruff + pyright clean.

Refs #8786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)