### PR TITLE
fix(state): lock StateData + typed trace_runs (slice 5.6)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,39 +1,39 @@
 {
-  "regenerated_at": "2026-05-18T18:45:42.986620+00:00",
-  "commit_sha": "9ca35c75d112e50a520f76456481e7d597a66b77",
+  "regenerated_at": "2026-05-18T18:46:30.639258+00:00",
+  "commit_sha": "50817aa991bc1a406049e056ff3663e061e38e57",
   "artifacts": {
     "loops.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "ports.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "labels.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "modules.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "events.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "adr_xref.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "mockworld.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "changelog.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "functional_areas.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "ubiquitous-language.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "9ca35c75d112e50a520f76456481e7d597a66b77"
+      "source_sha": "50817aa991bc1a406049e056ff3663e061e38e57"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -189,4 +189,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `9ca35c7` — fix(format): ruff format *(2026-05-18)*
+- `50817aa` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
+- `672680d` — fix(format): ruff format *(2026-05-18)*
 - `ebe1710` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `d0635fe` — fix(format): ruff format *(2026-05-18)*
 - `ea0e084` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -300,4 +301,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -39,4 +39,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -93,4 +93,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `9ca35c7` on 2026-05-18 18:45 UTC. Source last changed at `9ca35c7`. Status: 🟢 fresh._
+_Regenerated from commit `50817aa` on 2026-05-18 18:46 UTC. Source last changed at `50817aa`. Status: 🟢 fresh._

--- a/src/models.py
+++ b/src/models.py
@@ -1725,8 +1725,30 @@ class CodeGroomingSettings(BaseModel):
     dry_run: bool = False
 
 
+class ActiveTraceRun(BaseModel):
+    """A single in-progress trace run stored in ``trace_runs["active"]``."""
+
+    run_id: int
+    started_at: str
+
+
+class TraceRunsContainer(BaseModel):
+    """Typed container for the ``trace_runs`` field of StateData.
+
+    Structure (from _trace_runs.py):
+    - ``active``: keyed by ``"<issue>:<phase>"``, value is an ActiveTraceRun.
+    - ``next_run_id``: keyed by ``"<issue>:<phase>"``, value is the next int
+      run_id to allocate.
+    """
+
+    active: dict[str, ActiveTraceRun] = Field(default_factory=dict)
+    next_run_id: dict[str, int] = Field(default_factory=dict)
+
+
 class StateData(BaseModel):
     """Typed schema for the JSON-backed crash-recovery state."""
+
+    model_config = ConfigDict(extra="ignore")
 
     schema_version: int = 1
     processed_issues: dict[str, str] = Field(default_factory=dict)
@@ -1841,9 +1863,7 @@ class StateData(BaseModel):
     )
     diagnosis_severities: dict[str, str] = Field(default_factory=dict)
     sentry_creation_attempts: dict[str, int] = Field(default_factory=dict)
-    trace_runs: dict[str, dict[str, object]] = Field(
-        default_factory=lambda: {"active": {}, "next_run_id": {}}
-    )
+    trace_runs: TraceRunsContainer = Field(default_factory=TraceRunsContainer)
     # StagingBisectLoop state (spec §4.3 + §8). Written by StagingPromotionLoop
     # on each promotion outcome; polled + mutated by StagingBisectLoop.
     last_green_rc_sha: str = ""

--- a/src/state/_trace_runs.py
+++ b/src/state/_trace_runs.py
@@ -29,26 +29,25 @@ class TraceRunsMixin:
 
     def begin_trace_run(self, issue_number: int, phase: str) -> int:
         """Allocate a new run_id and mark the run active. Returns the new run_id."""
+        from models import ActiveTraceRun
+
         key = self._trace_run_key(issue_number, phase)
-        next_ids = self._data.trace_runs.setdefault("next_run_id", {})
-        active = self._data.trace_runs.setdefault("active", {})
+        next_ids = self._data.trace_runs.next_run_id
+        active = self._data.trace_runs.active
 
-        current = int(
-            next_ids.get(key, 0)  # type: ignore[arg-type]
-        )
+        current = next_ids.get(key, 0)
         new_id = current + 1
-        next_ids[key] = new_id  # type: ignore[index]
+        next_ids[key] = new_id
 
-        active[key] = {  # type: ignore[index]
-            "run_id": new_id,
-            "started_at": datetime.now(UTC).isoformat(),
-        }
+        active[key] = ActiveTraceRun(
+            run_id=new_id,
+            started_at=datetime.now(UTC).isoformat(),
+        )
         self.save()
         return new_id
 
     def end_trace_run(self, issue_number: int, phase: str) -> None:
         """Mark the run finalized — removes from active set."""
         key = self._trace_run_key(issue_number, phase)
-        active = self._data.trace_runs.setdefault("active", {})
-        active.pop(key, None)
+        self._data.trace_runs.active.pop(key, None)
         self.save()

--- a/tests/regressions/test_statedata_extra_fields.py
+++ b/tests/regressions/test_statedata_extra_fields.py
@@ -1,0 +1,74 @@
+"""Regression test: StateData must silently ignore unknown fields on load.
+
+Rationale: state.json is written by one version of HydraFlow and read by
+another. Older state files may contain fields that have since been removed,
+and newer state files may contain fields not yet known to an older build
+running from a checkpoint. The ``extra='ignore'`` config on StateData is the
+load-bearing guard. If it is ever changed to ``extra='forbid'``, every
+restart from a state file containing an unknown field would raise a
+``ValidationError`` and crash the pipeline.
+
+This test loads a state dict containing an unknown field and asserts that
+StateData parses it without raising an exception.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "src"))
+
+from models import StateData  # noqa: E402
+
+
+class TestStateDataExtraFields:
+    """StateData must not raise on extra fields in the persisted dict."""
+
+    def test_unknown_top_level_field_is_ignored(self) -> None:
+        """A field that does not exist on StateData must be silently dropped."""
+        payload = {
+            "schema_version": 1,
+            "unknown_field_from_the_future": "some_value",
+        }
+        # Must not raise ValidationError or any other exception.
+        data = StateData.model_validate(payload)
+        assert data.schema_version == 1
+        assert not hasattr(data, "unknown_field_from_the_future")
+
+    def test_multiple_unknown_fields_are_all_ignored(self) -> None:
+        """Multiple unknown fields are all silently dropped."""
+        payload = {
+            "schema_version": 1,
+            "ghost_field_alpha": 42,
+            "ghost_field_beta": {"nested": True},
+            "ghost_field_gamma": [1, 2, 3],
+        }
+        data = StateData.model_validate(payload)
+        assert data.schema_version == 1
+
+    def test_extra_ignore_is_explicitly_configured(self) -> None:
+        """model_config must declare extra='ignore' — not rely on Pydantic default.
+
+        This test guards against a silent regression where someone sets
+        extra='forbid' or removes the explicit declaration, relying on the
+        Pydantic v2 default (which *happens* to be 'ignore' today but is not
+        guaranteed to stay that way and may be overridden by a base class).
+        """
+        config = StateData.model_config
+        assert config.get("extra") == "ignore", (
+            "StateData.model_config must set extra='ignore' explicitly. "
+            "Without it, a future Pydantic upgrade or base-class change could "
+            "flip the behaviour and break restarts from older state files."
+        )
+
+    def test_round_trip_with_extra_field_in_json(self) -> None:
+        """model_validate_json must also tolerate unknown fields in JSON."""
+        json_str = (
+            '{"schema_version": 1, "retired_old_field": "whatever", '
+            '"another_removed_field": 99}'
+        )
+        data = StateData.model_validate_json(json_str)
+        assert data.schema_version == 1

--- a/tests/test_models_state_data_trace_runs.py
+++ b/tests/test_models_state_data_trace_runs.py
@@ -7,23 +7,25 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
-from models import StateData  # noqa: E402
+from models import ActiveTraceRun, StateData, TraceRunsContainer  # noqa: E402
 
 
 class TestStateDataTraceRuns:
     def test_trace_runs_default_empty(self):
         data = StateData()
-        assert data.trace_runs == {"active": {}, "next_run_id": {}}
+        assert data.trace_runs == TraceRunsContainer()
+        assert data.trace_runs.active == {}
+        assert data.trace_runs.next_run_id == {}
 
     def test_trace_runs_round_trip(self):
         data = StateData()
-        data.trace_runs["active"]["42:implement"] = {
-            "run_id": 2,
-            "started_at": "2026-04-06T12:00:00Z",
-        }
-        data.trace_runs["next_run_id"]["42:implement"] = 3
+        data.trace_runs.active["42:implement"] = ActiveTraceRun(
+            run_id=2,
+            started_at="2026-04-06T12:00:00Z",
+        )
+        data.trace_runs.next_run_id["42:implement"] = 3
 
         as_json = data.model_dump_json()
         rebuilt = StateData.model_validate_json(as_json)
-        assert rebuilt.trace_runs["active"]["42:implement"]["run_id"] == 2
-        assert rebuilt.trace_runs["next_run_id"]["42:implement"] == 3
+        assert rebuilt.trace_runs.active["42:implement"].run_id == 2
+        assert rebuilt.trace_runs.next_run_id["42:implement"] == 3

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from models import LifetimeStats, StateData
+from models import LifetimeStats, StateData, TraceRunsContainer
 from state import StateTracker
 from tests.helpers import make_tracker
 
@@ -222,7 +222,7 @@ class TestStateDataModel:
         assert data.issue_attempts == {}
         assert data.active_issue_numbers == []
         assert data.lifetime_stats == LifetimeStats()
-        assert data.trace_runs == {"active": {}, "next_run_id": {}}
+        assert data.trace_runs == TraceRunsContainer()
         assert data.last_updated is None
 
     def test_validates_correct_data(self) -> None:


### PR DESCRIPTION
## Summary

Slice 5.6 findings 4 + 5. Explicit extra=ignore lock on StateData prevents accidental schema-tightening regressions. TraceRun typed model replaces dict[str, Any] on the trace_runs field; the other 3 weakly-typed fields (rc_budget_duration_history, escalation_contexts, diagnostic_attempts) are filed as separate follow-up beads.

## Test plan
- [ ] tests/regressions/test_statedata_extra_fields.py passes
- [ ] trace_runs roundtrip preserved

🤖 Generated with Claude Code