### PR TITLE
fix(loops): observability cascade — audit-json stdout + ADR H1 titles + ci_monitor #0 guard

### DIFF
--- a/scripts/hydraflow_audit/__main__.py
+++ b/scripts/hydraflow_audit/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -65,9 +66,12 @@ def main(argv: list[str] | None = None) -> int:
         findings = run_checks(specs, ctx)
 
         out_path = args.out or (target_root / ".hydraflow" / "audit-report.json")
-        write_json(findings, out_path)
+        payload = write_json(findings, out_path)
 
-        if not args.json:
+        if args.json:
+            json.dump(payload, sys.stdout, indent=2)
+            sys.stdout.write("\n")
+        else:
             print(format_terminal(findings))
             print(f"\nJSON report: {out_path}")
 

--- a/scripts/hydraflow_audit/report.py
+++ b/scripts/hydraflow_audit/report.py
@@ -17,14 +17,19 @@ _STATUS_GLYPH = {
 }
 
 
-def write_json(findings: list[Finding], out_path: Path) -> None:
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+def build_payload(findings: list[Finding]) -> dict:
+    return {
         "version": 1,
         "summary": _summarise(findings),
         "findings": [f.to_dict() for f in findings],
     }
+
+
+def write_json(findings: list[Finding], out_path: Path) -> dict:
+    payload = build_payload(findings)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return payload
 
 
 def format_terminal(findings: list[Finding]) -> str:

--- a/src/adr_reviewer.py
+++ b/src/adr_reviewer.py
@@ -25,6 +25,19 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.adr_reviewer")
 
+_ADR_H1_RE = re.compile(r"^#\s+ADR-\d+\s*:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _title_from_h1(content: str) -> str:
+    """Return the title text from an ADR's H1 (``# ADR-NNNN: Title``) or '' if absent."""
+    match = _ADR_H1_RE.search(content)
+    return match.group(1).strip() if match else ""
+
+
+def _title_from_slug(stem: str) -> str:
+    """Derive a fallback title from the ADR filename stem (``NNNN-some-slug`` → ``some slug``)."""
+    return stem.split("-", 1)[-1].replace("-", " ") if "-" in stem else stem
+
 
 def _write_adr_decision(
     config: HydraFlowConfig, title: str, body: str, decision_type: str
@@ -181,23 +194,25 @@ class ADRCouncilReviewer:
         return results
 
     def _load_all_adrs(self, adr_dir: Path) -> list[tuple[int, str, str, str]]:
-        """Load all ADR files as (number, title, content, filename)."""
+        """Load all ADR files as (number, title, content, filename).
+
+        The title is taken from the H1 line (``# ADR-NNNN: Title``) so that
+        cross-reference validators compare citations against the canonical
+        heading rather than the slugified filename.  Falls back to the
+        filename slug when no H1 is present.
+        """
         results: list[tuple[int, str, str, str]] = []
         for path in sorted(adr_dir.glob("*.md")):
             match = ADR_FILE_RE.match(path.name)
             if not match:
                 continue
             adr_number = int(match.group(1))
-            title = (
-                path.stem.split("-", 1)[-1].replace("-", " ")
-                if "-" in path.stem
-                else path.stem
-            )
             try:
                 content = path.read_text(encoding="utf-8")
             except (OSError, UnicodeDecodeError):
                 logger.warning("Skipping unreadable ADR file: %s", path)
                 continue
+            title = _title_from_h1(content) or _title_from_slug(path.stem)
             results.append((adr_number, title, content, path.name))
         return results
 

--- a/src/ci_monitor_loop.py
+++ b/src/ci_monitor_loop.py
@@ -121,6 +121,12 @@ class CIMonitorLoop(BaseBackgroundLoop):
             issue_number = await self._prs.create_issue(
                 title, body, labels=["hydraflow-ci-failure"]
             )
+            if issue_number == 0:
+                logger.error(
+                    "CI monitor: create_issue returned 0 (failure sentinel) — "
+                    "not tracking phantom issue; will retry on next cycle"
+                )
+                return {"status": "red", "error": True}
             self._open_issue = issue_number
             logger.info(
                 "CI monitor: filed issue #%d for CI failure (%s)",

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1878,7 +1878,14 @@ class PRManager:
         body: str,
         labels: list[str] | None = None,
     ) -> int:
-        """Create a new GitHub issue. Returns the issue number (0 on failure)."""
+        """Create a new GitHub issue. Returns the issue number (0 on failure).
+
+        Callers MUST check for ``0`` before storing or referencing the
+        returned value.  Treating ``0`` as a real issue number causes
+        downstream ``gh issue comment 0`` / ``gh issue close 0`` calls
+        to fail with "Could not resolve to an issue or pull request with
+        the number of 0" every cycle.
+        """
         self._assert_repo()
         if self._config.dry_run:
             logger.info("[dry-run] Would create issue: %s", title)

--- a/tests/test_adr_reviewer.py
+++ b/tests/test_adr_reviewer.py
@@ -201,12 +201,39 @@ class TestLoadAllADRs:
         assert len(result) == 1
         assert result[0][0] == 1
 
-    def test_extracts_title_from_filename(self, tmp_path: Path) -> None:
+    def test_extracts_title_from_h1(self, tmp_path: Path) -> None:
         adr_dir = tmp_path / "docs" / "adr"
         _write_adr(adr_dir, 5, "Use Docker Containers", "Accepted")
         reviewer = _make_reviewer(tmp_path)
         result = reviewer._load_all_adrs(adr_dir)
-        assert result[0][1] == "use docker containers"
+        assert result[0][1] == "Use Docker Containers"
+
+    def test_h1_title_wins_over_filename_slug(self, tmp_path: Path) -> None:
+        """When H1 differs from the filename slug (real-world ADR-0023 pattern),
+        the H1 is the canonical title — citations must validate against it."""
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0023-dead-class-artifacts-in-mock-based-tests.md").write_text(
+            "# ADR-0023: Require Instantiation Verification for Test-Local Classes\n"
+            "\n**Status:** Accepted\n",
+            encoding="utf-8",
+        )
+        reviewer = _make_reviewer(tmp_path)
+        result = reviewer._load_all_adrs(adr_dir)
+        assert (
+            result[0][1] == "Require Instantiation Verification for Test-Local Classes"
+        )
+
+    def test_falls_back_to_filename_slug_when_no_h1(self, tmp_path: Path) -> None:
+        adr_dir = tmp_path / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "0099-legacy-no-heading.md").write_text(
+            "**Status:** Accepted\n\nSome body without an H1.\n",
+            encoding="utf-8",
+        )
+        reviewer = _make_reviewer(tmp_path)
+        result = reviewer._load_all_adrs(adr_dir)
+        assert result[0][1] == "legacy no heading"
 
     def test_includes_filename_in_tuple(self, tmp_path: Path) -> None:
         adr_dir = tmp_path / "docs" / "adr"

--- a/tests/test_ci_monitor_loop.py
+++ b/tests/test_ci_monitor_loop.py
@@ -144,3 +144,24 @@ class TestCIMonitorLoop:
         """_get_default_interval reads from config."""
         loop, _stop, _pr = _make_loop(tmp_path)
         assert loop._get_default_interval() == loop._config.ci_monitor_interval
+
+    @pytest.mark.asyncio
+    async def test_failed_issue_creation_does_not_track_phantom_zero(
+        self, tmp_path: Path
+    ) -> None:
+        """When create_issue returns 0 (failure sentinel — e.g. missing label),
+        the loop must not store 0 as ``_open_issue``.  Otherwise every later cycle
+        emits ``gh issue comment 0`` / ``gh issue close 0`` calls that GitHub
+        rejects with "Could not resolve to an issue or pull request with the
+        number of 0"."""
+        loop, _stop, pr = _make_loop(tmp_path)
+        pr.get_latest_ci_status.return_value = ("failure", "https://github.com/runs/1")
+        pr.create_issue = AsyncMock(return_value=0)
+
+        result = await loop._do_work()
+
+        assert result is not None
+        assert result["status"] == "red"
+        assert result.get("error") is True
+        assert "issue_created" not in result
+        assert loop._open_issue is None

--- a/tests/test_hydraflow_audit_cli.py
+++ b/tests/test_hydraflow_audit_cli.py
@@ -1,0 +1,68 @@
+"""CLI behaviour tests for ``python -m scripts.hydraflow_audit``.
+
+Guards the contract that ``--json`` emits a JSON payload on **stdout**.
+``principles_audit_loop`` parses subprocess stdout; an earlier regression
+shipped ``--json`` that only wrote the report file and printed nothing,
+causing the loop to fail every cycle with ``JSONDecodeError``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+from scripts.hydraflow_audit.__main__ import main
+
+
+def _seed_target(target: Path) -> None:
+    """Create a minimal ADR-0044 file so the audit can run."""
+    adr_dir = target / "docs" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "0044-hydraflow-principles.md").write_text(
+        "# ADR-0044: HydraFlow Principles\n\n"
+        "**Status:** Accepted\n\n"
+        "### P1. Documentation Contract\n\n"
+        "| check_id | type | source | what | remediation |\n"
+        "|---|---|---|---|---|\n"
+        "| P1.1 | STRUCTURAL | CLAUDE.md | CLAUDE.md exists | touch CLAUDE.md |\n",
+        encoding="utf-8",
+    )
+
+
+def test_json_flag_writes_payload_to_stdout(tmp_path: Path) -> None:
+    _seed_target(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main([str(tmp_path), "--json"])
+
+    payload = json.loads(buf.getvalue())
+    assert payload["version"] == 1
+    assert "summary" in payload
+    assert "findings" in payload
+    assert isinstance(payload["findings"], list)
+
+
+def test_json_flag_also_writes_report_file(tmp_path: Path) -> None:
+    _seed_target(tmp_path)
+    with redirect_stdout(io.StringIO()):
+        main([str(tmp_path), "--json"])
+
+    report = tmp_path / ".hydraflow" / "audit-report.json"
+    assert report.exists()
+    on_disk = json.loads(report.read_text())
+    assert on_disk["version"] == 1
+
+
+def test_terminal_mode_does_not_emit_json_on_stdout(tmp_path: Path) -> None:
+    _seed_target(tmp_path)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        main([str(tmp_path)])
+
+    out = buf.getvalue()
+    assert "HydraFlow Conformance Audit" in out
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(out)


### PR DESCRIPTION
## Summary

Three independent fixes that together stop the loop observability cascade that was thrashing the running factory.  Each is a small, self-contained commit with regression coverage.

### 1. ``fix(audit): hydraflow_audit --json emits payload to stdout``
``PrinciplesAuditLoop`` parses ``make audit-json`` stdout as JSON, but ``--json`` only wrote the report file and printed nothing — the loop crashed every cycle with ``JSONDecodeError: Expecting value: line 1 column 1``.  Refactor ``write_json`` to return its payload and have ``__main__`` emit it to stdout under ``--json``.

### 2. ``fix(adr-reviewer): take ADR title from H1, not filename slug``
``ADRReviewer._load_all_adrs`` derived the title from the filename stem.  When the H1 drifts from the slug (e.g. ADR-0023's filename ``dead-class-artifacts-in-mock-based-tests.md`` vs its H1 ``Require Instantiation Verification for Test-Local Classes``), every cross-reference was flagged as a title mismatch.  Extract from the H1 regex; fall back to the slug only when there is no H1.

### 3. ``fix(ci-monitor): refuse to track issue #0 when create_issue fails``
``PRManager.create_issue`` returns ``0`` on failure (e.g. missing label).  ``CIMonitorLoop`` was blindly storing that ``0`` as ``_open_issue``, so every later cycle ran ``gh issue comment 0`` / ``gh issue close 0``.  Short-circuit the ``== 0`` case in the loop and document the sentinel contract on ``create_issue``.

A wider refactor (raise on failure, or change the return to ``Optional[int]``) is tracked separately — ~30 callers across the loop fleet need migration and the surgical fix unblocks the factory now.

## Production state cleanup done out-of-band
- Created missing GitHub labels: ``hydraflow-ci-failure``, ``contract-refresh``, ``hydraflow-ul-edges``, ``arch-knowledge`` (loops were crashing on ``gh issue/pr create --label <missing>``).
- Switched ``T-rav/harvestd`` local clone to SSH origin so the repo runtime can authenticate to the private repo.
- Deleted three stuck ``contract-refresh/2026-05-*`` branches on the remote that were causing non-fast-forward push retries every minute.

## Test plan
- [x] ``pytest tests/test_hydraflow_audit_cli.py tests/test_adr_reviewer.py tests/test_adr_pre_validator.py tests/test_ci_monitor_loop.py tests/test_state_principles_audit.py`` — 243 green locally
- [x] ``ruff check`` + ``pyright`` on touched files
- [x] ``python -m scripts.hydraflow_audit . --json`` now emits a parseable JSON document on stdout
- [ ] CI green
- [ ] After merge, watch ``PrinciplesAuditLoop`` and ``CIMonitorLoop`` for the next two cycles — issue-#0 spam and ``JSONDecodeError`` warnings should both stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)