### PR TITLE
fix(audit): P10.2 recognises sharded test files

### DIFF
--- a/scripts/hydraflow_audit/checks/p10_tdd.py
+++ b/scripts/hydraflow_audit/checks/p10_tdd.py
@@ -46,23 +46,38 @@ def _every_module_has_a_test(ctx: CheckContext) -> Finding:
         return finding("P10.2", Status.NA, "no src/")
     if not tests.is_dir():
         return finding("P10.2", Status.FAIL, "tests/ missing")
-    test_stems = {_normalise_test_stem(p.stem) for p in tests.rglob("test_*.py")}
-    orphans: list[str] = []
+
+    src_modules: dict[str, Path] = {}
     for module in src.rglob("*.py"):
-        if _skip_module(module):
+        if _skip_module(module) or module.stem.startswith("_"):
             continue
-        expected = module.stem
-        if expected.startswith("_"):
-            continue
-        if expected not in test_stems:
-            orphans.append(module.relative_to(ctx.root).as_posix())
+        src_modules[module.stem] = module
+    src_stems = set(src_modules)
+
+    # A module is "covered" by any test whose stem matches it exactly OR
+    # starts with ``<module>_`` — pr_manager.py is covered by
+    # test_pr_manager_observability.py, not just test_pr_manager.py.
+    # Longest-prefix wins so that test_state_tracking.py is credited to
+    # state_tracking (when that module exists), not to state.
+    covered: set[str] = set()
+    for tp in tests.rglob("test_*.py"):
+        test_stem = tp.stem.removeprefix("test_")
+        best: str | None = None
+        for src_stem in src_stems:
+            if (test_stem == src_stem or test_stem.startswith(src_stem + "_")) and (
+                best is None or len(src_stem) > len(best)
+            ):
+                best = src_stem
+        if best is not None:
+            covered.add(best)
+
+    orphans = sorted(
+        src_modules[stem].relative_to(ctx.root).as_posix()
+        for stem in src_stems - covered
+    )
+    total = len(src_stems)
     if not orphans:
         return finding("P10.2", Status.PASS)
-    total = sum(
-        1
-        for p in src.rglob("*.py")
-        if not _skip_module(p) and not p.stem.startswith("_")
-    )
     ratio = len(orphans) / total if total else 0
     if ratio < 0.2:
         return finding(
@@ -85,11 +100,6 @@ def _skip_module(path: Path) -> bool:
         or name.endswith("_pb2.py")
         or "/migrations/" in path.as_posix()
     )
-
-
-def _normalise_test_stem(stem: str) -> str:
-    """`test_config` → `config`; `test_config_integration` → `config_integration` (preserve for later)."""
-    return stem.removeprefix("test_")
 
 
 _FIX_COMMIT_RE = re.compile(r"^(fix|bugfix|bug)[\(:]", re.IGNORECASE)

--- a/tests/test_hydraflow_audit_p10_checks.py
+++ b/tests/test_hydraflow_audit_p10_checks.py
@@ -63,6 +63,29 @@ def test_na_without_src(tmp_path: Path) -> None:
     assert _run("P10.2", _ctx(tmp_path)).status is Status.NA
 
 
+def test_sharded_tests_cover_module(tmp_path: Path) -> None:
+    """A module with no ``test_<module>.py`` but with ``test_<module>_<X>.py``
+    shards is considered covered.  pr_manager.py has ~20 sharded test files
+    but no ``test_pr_manager.py`` — the audit must not flag it as orphan."""
+    _write(tmp_path / "src" / "pr_manager.py", "def f(): pass\n")
+    _write(tmp_path / "tests" / "test_pr_manager_observability.py", "def t(): pass\n")
+    _write(tmp_path / "tests" / "test_pr_manager_boundary.py", "def t(): pass\n")
+    assert _run("P10.2", _ctx(tmp_path)).status is Status.PASS
+
+
+def test_longer_module_prefix_wins_over_shorter(tmp_path: Path) -> None:
+    """When both ``state.py`` and ``state_tracking.py`` exist,
+    ``test_state_tracking.py`` is credited to ``state_tracking``, leaving
+    ``state.py`` as an orphan unless it has its own test."""
+    _write(tmp_path / "src" / "state.py", "def f(): pass\n")
+    _write(tmp_path / "src" / "state_tracking.py", "def f(): pass\n")
+    _write(tmp_path / "tests" / "test_state_tracking.py", "def t(): pass\n")
+    result = _run("P10.2", _ctx(tmp_path))
+    assert result.status is Status.WARN
+    assert "src/state.py" in (result.message or "")
+    assert "src/state_tracking.py" not in (result.message or "")
+
+
 # --- P10.3 (git log) ------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

``P10.2`` (every src/ module has a test) was matching only ``test_<module>.py`` exactly.  Modules with sharded tests — ``pr_manager.py`` has ~20 files named ``test_pr_manager_<aspect>.py`` but no ``test_pr_manager.py`` — were counted as orphans, pushing the orphan ratio to ``51/254 = 20.1%`` and flipping the audit to ``WARN`` on every CI run (exit 1 → ``Principles Audit`` red).

A module is now considered covered when any test file's stem either equals it or starts with ``<module>_``.  Longest-prefix wins so that ``test_state_tracking.py`` is credited to ``state_tracking`` (when that module exists) and ``state.py`` correctly remains an orphan unless it has its own test.

After the fix the orphan ratio drops to ``33/254 ≈ 13%`` — solidly under the 20% threshold — and the audit returns exit 0 on CI.

## Test plan
- [x] ``pytest tests/test_hydraflow_audit_p10_checks.py`` — 15/15 green, including two new regression tests (sharded coverage, longest-prefix-wins)
- [x] ``ruff check`` clean; ``pyright`` clean on touched files
- [x] ``python -m scripts.hydraflow_audit . --json`` reports ``P10.2 PASS`` with 33 orphans / 254 modules
- [ ] CI ``Principles Audit`` job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)