### PR TITLE
fix(sandbox): disable TranscriptSummarizer to unblock rc/* promotion

### DIFF
--- a/docker-compose.sandbox.yml
+++ b/docker-compose.sandbox.yml
@@ -26,6 +26,16 @@ services:
       # adapters take over.
       GH_TOKEN: "unused-by-fake-github"
       ANTHROPIC_API_KEY: "unused-by-fake-llm"
+      # ``TranscriptSummarizer`` shells out to real ``claude -p`` via
+      # ``build_lightweight_command`` after every implementer/planner/
+      # reviewer run.  In this air-gapped network it can't reach the
+      # Anthropic API → infinite retries → scenarios time out (root
+      # cause of the rc/* promotion Sandbox failure on 2026-05-17).
+      # The ``runners=fake_llm`` override in ``mockworld.sandbox_main``
+      # rebinds the four phase runners but NOT the summarizer, so we
+      # disable it explicitly here.  Sandbox scenarios assert lifecycle
+      # outcomes, never summarizer comment text.
+      HYDRAFLOW_TRANSCRIPT_SUMMARIZATION_ENABLED: "false"
     volumes:
       - ./tests/sandbox_scenarios/seeds:/seed:ro
     networks: [sandbox]


### PR DESCRIPTION
## Root cause

The ``Sandbox (rc/* promotion PR full suite)`` job has been red on every rc/* PR for weeks, blocking main promotion.

After every implementer/planner/reviewer run, ``ImplementPhase`` calls ``TranscriptSummarizer.summarize_and_comment(...)``.  The summarizer shells out to real ``claude -p`` via ``build_lightweight_command``.  ``docker-compose.sandbox.yml`` runs the container on an ``internal: true`` network (air-gap, no egress) — Claude can't reach ``api.anthropic.com``, burns its retry budget, and the scenario times out with the implement stage stuck ``in_progress`` awaiting the hung summarizer.

``mockworld.sandbox_main`` rebinds the four phase runners via ``runners=fake_llm`` on ``build_services``, but the summarizer isn't part of that override pathway.

## Fix

``TranscriptSummarizer._generate_summary`` already short-circuits when ``config.transcript_summarization_enabled`` is ``False`` (``transcript_summarizer.py:145``).  Set the matching env var in the sandbox compose file.

Sandbox scenarios assert lifecycle outcomes only — they never inspect summarizer comment text — so disabling is content-neutral.

## Test plan
- [x] Local diff inspection
- [ ] CI ``Sandbox (rc/* promotion PR full suite)`` green on this PR's RC successor

🤖 Generated with [Claude Code](https://claude.com/claude-code)