### PR TITLE
fix(sandbox): disable transcript summarization — claude subprocess hangs in air-gapped container

### DIFF
--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -49,6 +49,20 @@ def _load_seed() -> MockWorldSeed:
 
 async def main() -> None:
     config = load_runtime_config()
+    # Sandbox-specific config override — disable transcript summarization.
+    # TranscriptSummarizer spawns a real `claude` subprocess via
+    # `subprocess_util.run_simple` after each agent phase to summarize the
+    # transcript. The sandbox is `internal: true` per
+    # docker-compose.sandbox.yml, so that subprocess hangs for ~30s of
+    # api_retry exponential backoff before failing with "unknown" network
+    # errors. With multiple parallel issues (s02_batch_three_issues) the
+    # cumulative hang exceeds the per-scenario 60s test timeout and the
+    # implement phase reports `in_progress` past deadline.
+    #
+    # The four primary LLM-backed runners (triage/plan/agent/review) are
+    # already overridden via `runners=fake_llm` below; this turns off the
+    # remaining secondary `claude` caller on the post-phase hook path.
+    config.transcript_summarization_enabled = False  # type: ignore[misc]
     seed = _load_seed()
     event_bus = EventBus()
     state = build_state_tracker(config)


### PR DESCRIPTION
## Summary

Fixes #8951 (sandbox rc/* full suite has been failing on 5+ scenarios since 2026-05-08).

## Root cause

The sandbox is \`internal: true\` per \`docker-compose.sandbox.yml\` (no external egress). Four primary LLM-backed runners (triage/plan/agent/review) are overridden via \`runners=fake_llm\` in \`sandbox_main.py\`, but **TranscriptSummarizer is constructed unconditionally** and spawns a real \`claude\` subprocess after each agent phase to summarize the transcript.

In the air-gapped sandbox the subprocess hangs with \`api_retry\` events (exponential backoff: 4s, 9s, 16s, ...) before failing with \`error: "unknown"\`. With multiple parallel issues (s02_batch_three_issues = 3 issues), cumulative ~30s hang per issue exceeds the 60s per-scenario test timeout and \`/api/timeline/issue/N\` reports \`current_stage: implement, status: in_progress\` past deadline.

## Fix

One-line config override in \`sandbox_main.py\`:

\`\`\`python
config.transcript_summarization_enabled = False
\`\`\`

Short-circuits TranscriptSummarizer at its config gate before any subprocess spawns. The four primary runners still work via the FakeLLM override.

## Test plan
- [ ] Next RC PR exercises Sandbox (rc/* full suite) and runs s02, s03, s04, s05, s06 against this fix
- [ ] If AC also bites (post-merge claude spawn), follow-up override needed; surfaces only if scenarios reach \`merged\` stage

## Follow-up scope

- AcceptanceCriteriaGenerator (post-merge) — same problem, same shape, fix similar
- Caretaker loops (ReportIssue, Sentry, etc.) — emit their own claude subprocesses on intervals; haven't bitten yet but could

🤖 Generated with [Claude Code](https://claude.com/claude-code)