### PR TITLE
fix(adr): add Enforced by line to ADR-0031 (unblocks Tests)

### DIFF
--- a/docs/adr/0031-product-track-architecture.md
+++ b/docs/adr/0031-product-track-architecture.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Accepted on:** 2026-05-12 — promoted after slice #5 audit confirmed live production usage.
 **Date:** 2026-04-04
+**Enforced by:** `tests/test_discover_phase.py`; `tests/test_shape_phase.py`; `tests/test_discover_runner.py`; `tests/test_shape_runner.py`; `tests/scenarios/test_discover_*` and `tests/scenarios/test_shape_*` scenarios; `tests/architecture/test_functional_area_coverage.py` (which asserts discover/shape phases are wired).
 
 ## Context
 


### PR DESCRIPTION
## Summary

PR #8824 promoted ADR-0031 to Accepted without adding the required `**Enforced by:**` line. test_adr_enforcement.py now fails on staging, blocking Tests CI on every open PR.

This adds the enforcement line citing the existing test files that exercise discover + shape phases.

## Test plan
- [ ] test_adr_enforcement.py passes for 0031

🤖 Generated with Claude Code