### PR TITLE
fix(observability): unblock staging Type Check on sentry_adapter

### DIFF
--- a/src/observability/sentry_adapter.py
+++ b/src/observability/sentry_adapter.py
@@ -50,7 +50,7 @@ class SentryObservabilityAdapter:
             # ``LogLevelStr | None`` (a Literal). Our public API accepts
             # an open ``str`` so callers don't have to import sentry-sdk
             # types; narrow at this seam via cast.
-            sentry_sdk.capture_message(message, level=cast(Any, level))
+            sentry_sdk.capture_message(message, level=cast(Any, level))  # type: ignore[arg-type]
         except ImportError:
             pass
         except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary

Staging Type Check fails on src/observability/sentry_adapter.py with newer pyright. Adds type: ignore[arg-type] to the cast call (the cast was intended to narrow but pyright still rejects).

Unblocks the last 2 open audit PRs (#8851, #8856).

🤖 Generated with Claude Code