### PR TITLE
fix(shape-runner): preserve 'PRManager not bound' log text

### DIFF
--- a/src/shape_runner.py
+++ b/src/shape_runner.py
@@ -251,7 +251,7 @@ class ShapeRunner(BaseRunner):
             return
         if prs is None:
             logger.warning(
-                "shape-stuck for #%d but PRPort not bound; logging only. "
+                "shape-stuck for #%d but PRManager not bound; logging only. "
                 "attempts=%d summary=%s",
                 task.id,
                 attempts,


### PR DESCRIPTION
PR #8966's replace_all rewrote the user-facing log text in shape_runner.py (line 254) from "PRManager not bound" to "PRPort not bound" while widening the type param. tests/test_shape_runner_evaluator.py::test_unbound_escalation_logs_only greps the literal string and broke RC #8967's Tests check.

Reverting just the log message; parameter type stays PRPort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)