### PR TITLE
fix(retrospective): dedup [HITL] Stale review insight filings (#8988)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,5 +1,5 @@
 {
-  "regenerated_at": "2026-05-19T07:16:27.277601+00:00",
+  "regenerated_at": "2026-05-19T07:21:10.081717+00:00",
   "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,5 +1,5 @@
 {
-  "regenerated_at": "2026-05-19T07:41:11.970315+00:00",
+  "regenerated_at": "2026-05-19T07:16:27.277601+00:00",
   "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T07:21:10.081717+00:00",
-  "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
+  "regenerated_at": "2026-05-19T08:04:27.326152+00:00",
+  "commit_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c",
   "artifacts": {
     "loops.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "ports.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "labels.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "modules.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "events.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "adr_xref.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "mockworld.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "changelog.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "coverage_matrix.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "functional_areas.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "ubiquitous-language.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c"
+      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,9 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `4667a12` — feat(loops): remove CodeGroomingLoop (#8984) (#8984) *(2026-05-19)*
-- `6d7319a` — feat(adversarial): earlier-adversarial pipeline — Discovery + Shape + Plan dissent stages (#8953) (#8953) *(2026-05-19)*
-- `35d0308` — test(sandbox): bump scenario timeouts past observed pipeline duration (#8989) (#8989) *(2026-05-19)*
 - `8c85c14` — fix(sandbox): wire FakeSubprocessRunner — the actual claude bypass (#8965) (#8965) *(2026-05-18)*
 - `5f762b0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `119279f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -336,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `7d3fd2b` — chore(arch): regenerate timestamps after dedup commit *(2026-05-19)*
+- `090a2a1` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8988) *(2026-05-19)*
+- `6d7319a` — feat(adversarial): earlier-adversarial pipeline — Discovery + Shape + Plan dissent stages (#8953) (#8953) *(2026-05-19)*
+- `35d0308` — test(sandbox): bump scenario timeouts past observed pipeline duration (#8989) (#8989) *(2026-05-19)*
 - `8c85c14` — fix(sandbox): wire FakeSubprocessRunner — the actual claude bypass (#8965) (#8965) *(2026-05-18)*
 - `5f762b0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `119279f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -333,4 +337,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -333,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `4667a12` on 2026-05-19 07:49 UTC. Source last changed at `4667a12`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:21 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._

--- a/src/retrospective_loop.py
+++ b/src/retrospective_loop.py
@@ -223,7 +223,12 @@ class RetrospectiveLoop(BaseBackgroundLoop):
                 self._hitl_filed_at[category] = now
                 continue
 
-            # 3. File a fresh HITL issue.
+            # 3. File a fresh HITL issue. Set the window-tracker BEFORE
+            #    the await so a crash between issue creation and the
+            #    assignment doesn't strand the freshly-filed issue with
+            #    no in-memory guard — protects against the cross-tick
+            #    race where ``find_existing_issue`` may not yet see the
+            #    just-filed issue via GitHub's search index.
             body = (
                 f"## Stale Improvement Proposal\n\n"
                 f"The improvement proposal for **{category}** ({desc}) "
@@ -233,8 +238,14 @@ class RetrospectiveLoop(BaseBackgroundLoop):
                 f"---\n*Auto-escalated by HydraFlow review insight verification.*"
             )
             hitl_labels = list(self._config.hitl_label)
-            await self._prs.create_issue(title, body, hitl_labels)
             self._hitl_filed_at[category] = now
+            try:
+                await self._prs.create_issue(title, body, hitl_labels)
+            except Exception:
+                # Filing failed — clear the optimistic guard so the next
+                # tick can retry. Re-raise to preserve normal error flow.
+                self._hitl_filed_at.pop(category, None)
+                raise
 
         return {"stale_proposals": len(stale)}
 

--- a/src/retrospective_loop.py
+++ b/src/retrospective_loop.py
@@ -9,6 +9,7 @@ Unacknowledged items survive crashes for replay.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
@@ -23,6 +24,19 @@ if TYPE_CHECKING:
     from review_insights import ReviewInsightStore
 
 logger = logging.getLogger("hydraflow.retrospective_loop")
+
+# Window (#8988): once a HITL stale-insight issue is filed for a category,
+# do not refile (or recomment) within this window even if the open-issue
+# GitHub lookup races and returns 0.  An hour is much shorter than the
+# 30-minute retrospective_interval default cadence, but long enough to
+# survive back-to-back ticks that hit GitHub before its search index
+# catches up to a freshly-created issue.
+_HITL_DEDUP_WINDOW = timedelta(hours=1)
+
+
+def _now_utc() -> datetime:
+    """Indirection seam so tests can pin the clock."""
+    return datetime.now(UTC)
 
 
 class RetrospectiveLoop(BaseBackgroundLoop):
@@ -47,6 +61,10 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         self._insights = insights
         self._queue = queue
         self._prs = prs
+        # Per-category last-filed timestamps for HITL stale-insight dedup
+        # (#8988).  Lives in-memory; the open-issue GitHub lookup is the
+        # cross-restart authority.  This dict is the race-safety net.
+        self._hitl_filed_at: dict[str, datetime] = {}
 
     def _get_default_interval(self) -> int:
         return self._config.retrospective_interval
@@ -140,7 +158,21 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         return {"patterns_filed": filed}
 
     async def _handle_verify_proposals(self) -> dict[str, int]:
-        """Verify improvement proposal outcomes and escalate stale ones."""
+        """Verify improvement proposal outcomes and escalate stale ones.
+
+        Dedup rules (issue #8988):
+
+        - **Open issue exists** for the same category → post a comment
+          carrying the new tick's evidence instead of opening a duplicate.
+        - **Closed issue exists** for the same category → treat the human
+          close as a re-arm signal: clear the in-memory window-tracker so
+          the next stale signal files fresh.  Mirrors
+          ``FakeCoverageAuditorLoop._reconcile_closed_escalations``.
+        - **In-memory window guard** (:data:`_HITL_DEDUP_WINDOW`): if this
+          category was filed within the window, skip entirely.  Catches
+          races where GitHub's search index has not caught up to a
+          freshly-created issue.
+        """
         from review_insights import (  # noqa: PLC0415
             _PROPOSAL_STALE_DAYS,
             CATEGORY_DESCRIPTIONS,
@@ -150,12 +182,48 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         records = self._insights.load_recent(50)
         stale = verify_proposals(self._insights, records)
 
+        if not stale:
+            return {"stale_proposals": 0}
+
+        if self._prs is None:
+            logger.warning("Retrospective: cannot file HITL issue — no PRPort")
+            return {"stale_proposals": len(stale)}
+
+        # Re-arm: any closed HITL stale-insight issue clears its category
+        # from the in-memory window-tracker so the next stale tick files
+        # fresh.  Cheap; runs once per verify-proposals tick.
+        await self._reconcile_closed_hitl_issues()
+
+        now = _now_utc()
         for category in stale:
-            if self._prs is None:
-                logger.warning("Retrospective: cannot file HITL issue — no PRPort")
-                break
             desc = CATEGORY_DESCRIPTIONS.get(category, category)
             title = f"[HITL] Stale review insight: {desc}"
+
+            # 1. Window guard — protects against races where GitHub's
+            #    search index has not surfaced our just-filed issue yet.
+            last = self._hitl_filed_at.get(category)
+            if last is not None and (now - last) < _HITL_DEDUP_WINDOW:
+                logger.debug(
+                    "Retrospective: skipping HITL stale-insight refile for "
+                    "category=%s — within %s dedup window",
+                    category,
+                    _HITL_DEDUP_WINDOW,
+                )
+                continue
+
+            # 2. Open-issue lookup — if one is open, comment instead of
+            #    filing a duplicate.
+            existing = await self._prs.find_existing_issue(title)
+            if existing:
+                tick_evidence = self._build_stale_tick_comment(
+                    category, desc, _PROPOSAL_STALE_DAYS
+                )
+                await self._prs.post_comment(existing, tick_evidence)
+                # Touch the window-tracker so we don't immediately re-comment.
+                self._hitl_filed_at[category] = now
+                continue
+
+            # 3. File a fresh HITL issue.
             body = (
                 f"## Stale Improvement Proposal\n\n"
                 f"The improvement proposal for **{category}** ({desc}) "
@@ -166,8 +234,81 @@ class RetrospectiveLoop(BaseBackgroundLoop):
             )
             hitl_labels = list(self._config.hitl_label)
             await self._prs.create_issue(title, body, hitl_labels)
+            self._hitl_filed_at[category] = now
 
         return {"stale_proposals": len(stale)}
+
+    @staticmethod
+    def _build_stale_tick_comment(category: str, desc: str, stale_days: int) -> str:
+        """Comment body posted to an existing open HITL stale-insight issue.
+
+        Carries the tick context so a human grooming the issue can see the
+        signal is still recurring rather than letting duplicates pile up.
+        """
+        return (
+            f"Still stale — pattern frequency for **{category}** ({desc}) "
+            f"has not decreased after {stale_days}+ days.  This is a "
+            f"recurring tick from `RetrospectiveLoop`; the underlying "
+            f"escalation remains open.\n\n"
+            f"_Auto-comment by HydraFlow review insight verification._"
+        )
+
+    async def _reconcile_closed_hitl_issues(self) -> None:
+        """Clear the in-memory window-tracker for closed HITL stale-insight issues.
+
+        Mirrors :meth:`FakeCoverageAuditorLoop._reconcile_closed_escalations`:
+        a human-closed HITL issue is the re-arm signal — the next stale
+        tick should be free to file fresh.
+
+        Only inspects closed issues carrying the configured ``hitl_label``;
+        matches by title prefix ``[HITL] Stale review insight:`` to scope
+        the clear to this loop's own escalations.
+        """
+        if self._prs is None:
+            return
+        if not self._hitl_filed_at:
+            return  # Nothing to re-arm.
+
+        hitl_labels = list(self._config.hitl_label)
+        if not hitl_labels:
+            return
+
+        try:
+            closed = await self._prs.list_closed_issues_by_label(hitl_labels[0])
+        except Exception:  # noqa: BLE001
+            # The lookup is best-effort; reraising would block the entire
+            # verify-proposals tick on a transient GitHub fault.
+            logger.debug(
+                "Retrospective: could not list closed HITL issues for re-arm",
+                exc_info=True,
+            )
+            return
+
+        from review_insights import CATEGORY_DESCRIPTIONS  # noqa: PLC0415
+
+        prefix = "[HITL] Stale review insight: "
+        # Build desc → category reverse lookup once.
+        desc_to_category = {
+            CATEGORY_DESCRIPTIONS.get(cat, cat): cat
+            for cat in list(self._hitl_filed_at.keys())
+        }
+
+        cleared: list[str] = []
+        for entry in closed:
+            title = entry.get("title", "") if isinstance(entry, dict) else ""
+            if not title.startswith(prefix):
+                continue
+            desc = title[len(prefix) :]
+            category = desc_to_category.get(desc) or desc
+            if category in self._hitl_filed_at:
+                del self._hitl_filed_at[category]
+                cleared.append(category)
+
+        if cleared:
+            logger.info(
+                "Retrospective: re-armed HITL stale-insight tracker for %s",
+                cleared,
+            )
 
     async def _publish_update(self, item: QueueItem, status: str) -> None:
         await self._bus.publish(

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -3221,9 +3221,31 @@ class ReviewPhase:
                     self._insights.record_proposal(category, pre_count=count)
 
                 stale = verify_proposals(self._insights, recent)
+                # Dedup mirror of RetrospectiveLoop._handle_verify_proposals
+                # (#8988). This fallback branch fires only when no
+                # retrospective_queue is wired, but it MUST avoid filing a
+                # duplicate `[HITL] Stale review insight: <category>` when
+                # one is already open — same anti-pattern as the loop site.
                 for category in stale:
                     desc = CATEGORY_DESCRIPTIONS.get(category, category)
                     title = f"[HITL] Stale review insight: {desc}"
+                    hitl_labels = list(self._config.hitl_label)
+                    existing = await self._prs.find_existing_issue(title)
+                    if existing:
+                        await self._prs.post_comment(
+                            existing,
+                            (
+                                f"Still stale — pattern frequency for "
+                                f"**{category}** ({desc}) has not decreased "
+                                f"after {_PROPOSAL_STALE_DAYS}+ days. "
+                                f"Recurring tick from `ReviewPhase` fallback "
+                                f"(retrospective queue not wired); the "
+                                f"underlying escalation remains open.\n\n"
+                                f"_Auto-comment by HydraFlow review insight "
+                                f"verification._"
+                            ),
+                        )
+                        continue
                     body = (
                         f"## Stale Improvement Proposal\n\n"
                         f"The improvement proposal for **{category}** ({desc}) "
@@ -3232,7 +3254,6 @@ class ReviewPhase:
                         f"required to resolve this recurring feedback loop.\n\n"
                         f"---\n*Auto-escalated by HydraFlow review insight verification.*"
                     )
-                    hitl_labels = list(self._config.hitl_label)
                     await self._transitioner.create_task(title, body, hitl_labels)
         except (RuntimeError, OSError):
             status = "error"

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -16,7 +16,7 @@ import logging
 import re
 import time
 from collections.abc import Callable, Coroutine
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -120,6 +120,14 @@ from review_insights import (
 )
 from reviewer import ReviewRunner
 from state import StateTracker
+
+# Mirrors ``retrospective_loop._HITL_DEDUP_WINDOW``. Two PR reviews
+# completing back-to-back for the same stale category could otherwise
+# both call ``find_existing_issue`` before either write is indexed by
+# GitHub search, and both file. The window is intentionally identical
+# between sites so behavior is uniform whether the loop or the fallback
+# fires (#8988).
+_HITL_DEDUP_WINDOW = timedelta(hours=1)
 from task_source import TaskTransitioner
 from transcript_summarizer import TranscriptSummarizer
 
@@ -189,6 +197,12 @@ class ReviewPhase:
             self._insights = ReviewInsightStore(config.memory_dir)
         self._active_issues_cb = active_issues_cb
         self._active_issues: set[int] = set()
+        # In-memory window guard for the stale-HITL fallback branch
+        # (mirror of ``RetrospectiveLoop._hitl_filed_at``). Two PR
+        # reviews completing back-to-back for the same stale category
+        # could otherwise both call ``find_existing_issue`` before
+        # either write is indexed by GitHub search, and both file.
+        self._hitl_filed_at: dict[str, datetime] = {}
         self._active_issues_lock = asyncio.Lock()
         self._conflict_resolver = conflict_resolver
         self._post_merge = post_merge
@@ -3226,10 +3240,17 @@ class ReviewPhase:
                 # retrospective_queue is wired, but it MUST avoid filing a
                 # duplicate `[HITL] Stale review insight: <category>` when
                 # one is already open — same anti-pattern as the loop site.
+                now_hitl = datetime.now(UTC)
                 for category in stale:
                     desc = CATEGORY_DESCRIPTIONS.get(category, category)
                     title = f"[HITL] Stale review insight: {desc}"
                     hitl_labels = list(self._config.hitl_label)
+                    # Window guard — protects against back-to-back PR
+                    # reviews racing the GitHub search index, same shape
+                    # as ``RetrospectiveLoop._handle_verify_proposals``.
+                    last = self._hitl_filed_at.get(category)
+                    if last is not None and (now_hitl - last) < _HITL_DEDUP_WINDOW:
+                        continue
                     existing = await self._prs.find_existing_issue(title)
                     if existing:
                         await self._prs.post_comment(
@@ -3245,6 +3266,7 @@ class ReviewPhase:
                                 f"verification._"
                             ),
                         )
+                        self._hitl_filed_at[category] = now_hitl
                         continue
                     body = (
                         f"## Stale Improvement Proposal\n\n"
@@ -3254,7 +3276,14 @@ class ReviewPhase:
                         f"required to resolve this recurring feedback loop.\n\n"
                         f"---\n*Auto-escalated by HydraFlow review insight verification.*"
                     )
-                    await self._transitioner.create_task(title, body, hitl_labels)
+                    self._hitl_filed_at[category] = now_hitl
+                    try:
+                        await self._transitioner.create_task(
+                            title, body, hitl_labels
+                        )
+                    except Exception:
+                        self._hitl_filed_at.pop(category, None)
+                        raise
         except (RuntimeError, OSError):
             status = "error"
             details["error"] = "review insight recording failed"

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -120,14 +120,6 @@ from review_insights import (
 )
 from reviewer import ReviewRunner
 from state import StateTracker
-
-# Mirrors ``retrospective_loop._HITL_DEDUP_WINDOW``. Two PR reviews
-# completing back-to-back for the same stale category could otherwise
-# both call ``find_existing_issue`` before either write is indexed by
-# GitHub search, and both file. The window is intentionally identical
-# between sites so behavior is uniform whether the loop or the fallback
-# fires (#8988).
-_HITL_DEDUP_WINDOW = timedelta(hours=1)
 from task_source import TaskTransitioner
 from transcript_summarizer import TranscriptSummarizer
 
@@ -145,6 +137,14 @@ from ._common import (
 )
 
 logger = logging.getLogger("hydraflow.review_phase")
+
+# Mirrors ``retrospective_loop._HITL_DEDUP_WINDOW``. Two PR reviews
+# completing back-to-back for the same stale category could otherwise
+# both call ``find_existing_issue`` before either write is indexed by
+# GitHub search, and both file. The window is intentionally identical
+# between sites so behavior is uniform whether the loop or the fallback
+# fires (#8988).
+_HITL_DEDUP_WINDOW = timedelta(hours=1)
 
 
 class ReviewPhase:
@@ -3278,9 +3278,7 @@ class ReviewPhase:
                     )
                     self._hitl_filed_at[category] = now_hitl
                     try:
-                        await self._transitioner.create_task(
-                            title, body, hitl_labels
-                        )
+                        await self._transitioner.create_task(title, body, hitl_labels)
                     except Exception:
                         self._hitl_filed_at.pop(category, None)
                         raise

--- a/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
+++ b/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
@@ -200,3 +200,93 @@ class TestReviewPhaseFallbackDedup:
         phase._prs.post_comment.assert_awaited_once()
         assert phase._prs.post_comment.await_args.args[0] == 7777
         phase._prs.create_task.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fallback_window_guard_skips_back_to_back_filings(self) -> None:
+        """Review #8992 S2 fix: two PR reviews completing back-to-back for
+        the same stale category must not both file — the in-memory
+        ``_hitl_filed_at`` window guard short-circuits the second call
+        before it can race ``find_existing_issue``.
+        """
+        from models import ReviewVerdict
+        from tests.conftest import ConfigFactory, ReviewResultFactory
+        from tests.helpers import make_review_phase
+
+        config = ConfigFactory.create()
+        phase = make_review_phase(config, default_mocks=True)
+        phase._retrospective_queue = None
+
+        # First call: no open issue → would file. Second call: same
+        # category, no open issue *yet* (GH search hasn't indexed) →
+        # must be short-circuited by the window guard.
+        phase._prs.find_existing_issue = AsyncMock(return_value=None)
+        phase._prs.post_comment = AsyncMock()
+        phase._prs.create_task = AsyncMock()
+
+        result = ReviewResultFactory.create(verdict=ReviewVerdict.REQUEST_CHANGES)
+
+        mock_insights = MagicMock()
+        mock_insights.load_recent.return_value = []
+        mock_insights.get_proposed_categories.return_value = set()
+        phase._insights = mock_insights
+
+        with (
+            patch("review_phase.analyze_patterns", return_value=[]),
+            patch(
+                "review_phase._phase.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_phase._phase.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_phase._phase._PROPOSAL_STALE_DAYS", 30),
+        ):
+            # First tick: fires through to create_task.
+            await phase._record_review_insight(result)
+            # Second tick (back-to-back, same category): blocked by guard.
+            await phase._record_review_insight(result)
+
+        # Only one task created — window guard skipped the second tick.
+        assert phase._prs.create_task.await_count == 1
+
+
+class TestRetrospectiveLoopGuardCrashWindow:
+    """Review #8992 S1 fix: the in-memory ``_hitl_filed_at`` guard must
+    be populated BEFORE the ``await create_issue``, not after — otherwise
+    a crash between the GitHub write and the assignment leaves the
+    just-filed issue with no in-memory guard on restart.
+    """
+
+    @pytest.mark.asyncio
+    async def test_guard_is_set_before_create_issue_await(
+        self, tmp_path: Path
+    ) -> None:
+        from retrospective_loop import RetrospectiveLoop  # noqa: PLC0415
+
+        loop, insights, _queue, prs = _make_loop_with_prs(tmp_path)
+        prs.find_existing_issue = AsyncMock(return_value=None)
+        prs.post_comment = AsyncMock()
+
+        # Sentinel that captures the guard value at the moment of the await.
+        captured: dict[str, datetime | None] = {"value_at_await": None}
+
+        async def capture_create_issue(_title, _body, _labels):
+            captured["value_at_await"] = loop._hitl_filed_at.get(
+                "missing_tests"
+            )
+            return 9999
+
+        prs.create_issue = AsyncMock(side_effect=capture_create_issue)
+
+        insights.load_recent.return_value = []
+
+        with patch(
+            "review_insights.verify_proposals",
+            return_value=["missing_tests"],
+        ):
+            await loop._handle_verify_proposals()
+
+        # The guard was set *before* the await completed — fixing
+        # the crash-window race.
+        assert captured["value_at_await"] is not None

--- a/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
+++ b/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
@@ -1,0 +1,202 @@
+"""Regression for issue #8988 — RetrospectiveLoop must not file duplicate
+``[HITL] Stale review insight: <category>`` issues every tick.
+
+Before the fix, ``RetrospectiveLoop._handle_verify_proposals`` filed a fresh
+issue on **every** tick a category was stale, with no open-issue check.  Four
+duplicates were closed manually on 2026-05-19 (``Missing or insufficient test
+coverage`` was filed multiple times for the same recurring pattern).
+
+The contract guarded here:
+
+1. Same category stale across N ticks → 1 ``create_issue`` + N-1 ``post_comment``.
+2. ``[HITL] Stale review insight:`` fallback at
+   ``src/review_phase/_phase.py:3216`` follows the same dedup contract.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from retrospective_loop import RetrospectiveLoop
+from retrospective_queue import QueueItem, QueueKind
+from tests.helpers import make_bg_loop_deps
+
+
+def _make_loop_with_prs(
+    tmp_path: Path,
+) -> tuple[RetrospectiveLoop, MagicMock, MagicMock, MagicMock]:
+    """Return (loop, insights, queue, prs) with PRPort mocks wired."""
+    deps = make_bg_loop_deps(tmp_path, enabled=True)
+
+    retro = MagicMock()
+    retro._load_recent = MagicMock(return_value=[])
+    retro._detect_patterns = AsyncMock()
+
+    insights = MagicMock()
+    insights.load_recent = MagicMock(return_value=[])
+    insights.get_proposed_categories = MagicMock(return_value=set())
+
+    queue = MagicMock()
+    queue.load = MagicMock(return_value=[])
+    queue.acknowledge = MagicMock()
+
+    prs = MagicMock()
+    prs.create_issue = AsyncMock(return_value=4242)
+    prs.find_existing_issue = AsyncMock(return_value=0)
+    prs.list_closed_issues_by_label = AsyncMock(return_value=[])
+    prs.post_comment = AsyncMock()
+
+    loop = RetrospectiveLoop(
+        config=deps.config,
+        deps=deps.loop_deps,
+        retrospective=retro,
+        insights=insights,
+        queue=queue,
+        prs=prs,
+    )
+    return loop, insights, queue, prs
+
+
+class TestStaleHITLDedupRegression:
+    """Issue #8988 regression — guards the dedup contract end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_five_ticks_one_issue_four_comments(self, tmp_path: Path) -> None:
+        loop, insights, queue, prs = _make_loop_with_prs(tmp_path)
+        insights.load_recent.return_value = []
+
+        # After the first create, GitHub returns the open issue number.
+        def find_side_effect(_title: str) -> int:
+            return 4242 if prs.create_issue.await_count > 0 else 0
+
+        prs.find_existing_issue.side_effect = find_side_effect
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            from datetime import timedelta
+
+            base = datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
+            for tick_idx in range(5):
+                fake_now = base + timedelta(hours=2 * tick_idx)
+                queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+                with patch("retrospective_loop._now_utc", return_value=fake_now):
+                    await loop._do_work()
+
+        assert prs.create_issue.await_count == 1
+        assert prs.post_comment.await_count == 4
+        for call in prs.post_comment.await_args_list:
+            assert call.args[0] == 4242
+
+    @pytest.mark.asyncio
+    async def test_closed_then_re_armed(self, tmp_path: Path) -> None:
+        """Human close → next stale tick files fresh."""
+        from datetime import timedelta
+
+        loop, insights, queue, prs = _make_loop_with_prs(tmp_path)
+        insights.load_recent.return_value = []
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            # Tick 1 — file new issue
+            prs.find_existing_issue.return_value = 0
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 1
+            # Tick 2 — human closes #4242, next stale tick must re-arm
+            prs.list_closed_issues_by_label.return_value = [
+                {
+                    "number": 4242,
+                    "title": "[HITL] Stale review insight: Missing test coverage",
+                    "body": "",
+                    "updated_at": "2026-05-19T01:00:00Z",
+                }
+            ]
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
+                + timedelta(days=1),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 2
+
+
+class TestReviewPhaseFallbackDedup:
+    """Mirror site — ``src/review_phase/_phase.py:3216`` (fallback branch)
+    must also dedup when a HITL stale-insight issue is already open.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fallback_branch_dedups_via_find_existing_issue(self) -> None:
+        """The fallback path (no retrospective_queue wired) must comment on
+        an existing open HITL issue rather than file a duplicate."""
+        from models import ReviewVerdict
+        from tests.conftest import ConfigFactory, ReviewResultFactory
+        from tests.helpers import make_review_phase
+
+        config = ConfigFactory.create()
+        phase = make_review_phase(config, default_mocks=True)
+        # Disable the queue so we go down the fallback branch.
+        phase._retrospective_queue = None
+
+        # Wire up dedup-aware port mocks.
+        phase._prs.find_existing_issue = AsyncMock(return_value=7777)
+        phase._prs.post_comment = AsyncMock()
+        phase._prs.create_task = AsyncMock()
+
+        result = ReviewResultFactory.create(verdict=ReviewVerdict.REQUEST_CHANGES)
+
+        mock_insights = MagicMock()
+        mock_insights.load_recent.return_value = []
+        mock_insights.get_proposed_categories.return_value = set()
+        phase._insights = mock_insights
+
+        with (
+            patch("review_phase.analyze_patterns", return_value=[]),
+            patch(
+                "review_phase._phase.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_phase._phase.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_phase._phase._PROPOSAL_STALE_DAYS", 30),
+        ):
+            await phase._record_review_insight(result)
+
+        # Existing open issue → comment, do NOT create a new task.
+        phase._prs.post_comment.assert_awaited_once()
+        assert phase._prs.post_comment.await_args.args[0] == 7777
+        phase._prs.create_task.assert_not_awaited()

--- a/tests/scenarios/test_caretaker_loops.py
+++ b/tests/scenarios/test_caretaker_loops.py
@@ -136,6 +136,81 @@ class TestL11RetrospectiveLoop:
         fake_queue.acknowledge.assert_called_once_with([item.id])
         fake_retro._load_recent.assert_called_once()
 
+    async def test_stale_hitl_dedup_across_ticks(self, tmp_path) -> None:
+        """Issue #8988: ``RetrospectiveLoop`` must not file duplicate
+        ``[HITL] Stale review insight:`` issues on repeated stale ticks.
+
+        Drives the real loop against FakeGitHub for three ticks of the
+        same stale category and asserts the FakeGitHub issue count caps
+        at 1 with follow-up comments on the existing issue.
+        """
+        from datetime import UTC, datetime, timedelta
+        from unittest.mock import patch  # noqa: PLC0415
+
+        from retrospective_queue import QueueItem, QueueKind  # noqa: PLC0415
+
+        world = MockWorld(tmp_path)
+
+        fake_queue = MagicMock()
+        fake_queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+        fake_queue.acknowledge = MagicMock()
+
+        fake_insights = MagicMock()
+        fake_insights.load_recent.return_value = []
+        fake_insights.get_proposed_categories.return_value = set()
+
+        _seed_ports(
+            world,
+            retrospective_queue=fake_queue,
+            insights=fake_insights,
+        )
+
+        # Snapshot FakeGitHub HITL title count.
+        hitl_title = "[HITL] Stale review insight: Missing test coverage"
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            base = datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
+            # Tick 1: file
+            with patch("retrospective_loop._now_utc", return_value=base):
+                await world.run_with_loops(["retrospective"], cycles=1)
+            # Tick 2: comment
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=base + timedelta(hours=2),
+            ):
+                await world.run_with_loops(["retrospective"], cycles=1)
+            # Tick 3: comment
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=base + timedelta(hours=4),
+            ):
+                await world.run_with_loops(["retrospective"], cycles=1)
+
+        hitl_issues = [
+            issue
+            for issue in world._github._issues.values()
+            if issue.title == hitl_title
+        ]
+        assert len(hitl_issues) == 1, (
+            f"expected 1 HITL issue, got {len(hitl_issues)}: "
+            f"{[i.number for i in hitl_issues]}"
+        )
+        # And the loop should have posted 2 follow-up comments on the
+        # one open HITL issue.
+        assert len(hitl_issues[0].comments) == 2, (
+            f"expected 2 follow-up comments, got {len(hitl_issues[0].comments)}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # L12: Epic Sweeper verifies done-epic children closed

--- a/tests/test_retrospective_loop.py
+++ b/tests/test_retrospective_loop.py
@@ -64,7 +64,10 @@ def _make_loop(
     prs: MagicMock | None = None
     if with_prs:
         prs = MagicMock()
-        prs.create_issue = AsyncMock()
+        prs.create_issue = AsyncMock(return_value=0)
+        prs.find_existing_issue = AsyncMock(return_value=0)
+        prs.list_closed_issues_by_label = AsyncMock(return_value=[])
+        prs.post_comment = AsyncMock()
 
     loop = RetrospectiveLoop(
         config=deps.config,
@@ -295,3 +298,191 @@ class TestMultipleItemBatch:
         assert result["processed"] == 2
         assert retro._detect_patterns.await_count == 2
         queue.acknowledge.assert_called_once_with([items[0].id, items[1].id])
+
+
+class TestStaleHITLDedup:
+    """Issue #8988 — dedup [HITL] Stale review insight: <category> filings.
+
+    Behaviors guarded:
+      1. Same category stale across N ticks → 1 open issue + N-1 comments.
+      2. Closed-and-re-armed: stale → file → human closes → stale again → new file.
+      3. In-memory `_hitl_filed_at` window guard prevents same-tick double-file
+         even when the open-issue lookup races.
+    """
+
+    @pytest.mark.asyncio
+    async def test_five_stale_ticks_one_issue_four_comments(
+        self, tmp_path: Path
+    ) -> None:
+        """5 ticks of the same stale category → create_issue called once,
+        post_comment called 4 times (ticks 2..5 comment on the open one)."""
+        from unittest.mock import patch
+
+        loop, _, insights, queue, prs = _make_loop(tmp_path, with_prs=True)
+        assert prs is not None
+        item = QueueItem(kind=QueueKind.VERIFY_PROPOSALS)
+        insights.load_recent.return_value = []
+
+        # First call creates issue #4242. Subsequent find_existing_issue
+        # calls discover it as open.
+        prs.create_issue.return_value = 4242
+
+        def find_existing_side_effect(title: str) -> int:
+            # Mimics gh: returns 0 before create, 4242 after.
+            return 4242 if prs.create_issue.await_count > 0 else 0
+
+        prs.find_existing_issue.side_effect = find_existing_side_effect
+
+        # Each tick must re-load the queue (load is sync).  We reset queue
+        # state between ticks because acknowledge() clears nothing in the
+        # mock — but we need queue.load() to return the same item every tick.
+        queue.load.return_value = [item]
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            # Advance simulated time per tick so the window-guard does not
+            # block the 5 ticks (default window is 1 hour).
+            from datetime import UTC, datetime, timedelta
+
+            base = datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
+            for tick_idx in range(5):
+                fake_now = base + timedelta(hours=2 * tick_idx)
+                with patch(
+                    "retrospective_loop._now_utc",
+                    return_value=fake_now,
+                ):
+                    # New item id per tick so acknowledge tracking is clean
+                    item2 = QueueItem(kind=QueueKind.VERIFY_PROPOSALS)
+                    queue.load.return_value = [item2]
+                    await loop._do_work()
+
+        assert prs.create_issue.await_count == 1, (
+            f"expected exactly 1 create_issue, got {prs.create_issue.await_count}"
+        )
+        assert prs.post_comment.await_count == 4, (
+            f"expected 4 follow-up comments, got {prs.post_comment.await_count}"
+        )
+        # The four comments must target the open issue #4242
+        for call in prs.post_comment.await_args_list:
+            assert call.args[0] == 4242
+
+    @pytest.mark.asyncio
+    async def test_closed_then_re_armed_files_new_issue(self, tmp_path: Path) -> None:
+        """Closed HITL issue → category stale again → 1 NEW issue filed.
+
+        Mirrors FakeCoverageAuditorLoop._reconcile_closed_escalations:
+        a closed escalation resets dedup so the category re-arms.
+        """
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+
+        loop, _, insights, queue, prs = _make_loop(tmp_path, with_prs=True)
+        assert prs is not None
+        insights.load_recent.return_value = []
+
+        prs.create_issue.return_value = 5000
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            # ---- Tick 1: file new issue ----
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            prs.find_existing_issue.return_value = 0  # nothing open
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 1
+            assert prs.post_comment.await_count == 0
+
+            # ---- Tick 2: human has closed #5000 ----
+            # find_existing_issue now returns 0 (no OPEN one), but the loop
+            # also checks list_closed_issues_by_label to re-arm the in-memory
+            # window-tracker.
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            prs.find_existing_issue.return_value = 0
+            prs.list_closed_issues_by_label.return_value = [
+                {
+                    "number": 5000,
+                    "title": "[HITL] Stale review insight: Missing test coverage",
+                    "body": "",
+                    "updated_at": "2026-05-19T01:00:00Z",
+                }
+            ]
+            # Ensure we are outside the window guard (default 1h)
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 20, 0, 0, 0, tzinfo=UTC),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 2, (
+                f"expected re-armed file, got {prs.create_issue.await_count}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_window_guard_blocks_double_file_within_window(
+        self, tmp_path: Path
+    ) -> None:
+        """Two ticks within the dedup window must not double-file even if
+        find_existing_issue races and returns 0 both times."""
+        from datetime import UTC, datetime
+        from unittest.mock import patch
+
+        loop, _, insights, queue, prs = _make_loop(tmp_path, with_prs=True)
+        assert prs is not None
+        insights.load_recent.return_value = []
+
+        prs.create_issue.return_value = 9001
+        prs.find_existing_issue.return_value = 0  # always race-lose
+
+        with (
+            patch(
+                "review_insights.verify_proposals",
+                return_value=["missing_tests"],
+            ),
+            patch(
+                "review_insights.CATEGORY_DESCRIPTIONS",
+                {"missing_tests": "Missing test coverage"},
+            ),
+            patch("review_insights._PROPOSAL_STALE_DAYS", 30),
+        ):
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 1
+
+            # Five minutes later — still well inside default window.
+            queue.load.return_value = [QueueItem(kind=QueueKind.VERIFY_PROPOSALS)]
+            with patch(
+                "retrospective_loop._now_utc",
+                return_value=datetime(2026, 5, 19, 0, 5, 0, tzinfo=UTC),
+            ):
+                await loop._do_work()
+
+            assert prs.create_issue.await_count == 1, (
+                "Window guard must prevent second file inside the cooldown"
+            )


### PR DESCRIPTION
## Summary

Closes #8988 — `RetrospectiveLoop._handle_verify_proposals` filed a fresh `[HITL] Stale review insight: <category>` issue on **every** tick a category was stale. No open-issue check, no comment fallback. Four duplicates were closed manually on 2026-05-19 (`Missing or insufficient test coverage` was filed multiple times for the same recurring pattern).

The fix introduces the same dedup pattern used by `FakeCoverageAuditorLoop`:

- **Open issue exists** → post a comment with the new tick's evidence via `PRPort.post_comment`, do **not** open a duplicate.
- **Closed issue exists** → human-close is the re-arm signal; clear the in-memory window-tracker so the next stale tick files fresh (mirrors `FakeCoverageAuditorLoop._reconcile_closed_escalations`).
- **In-memory `_hitl_filed_at: dict[category, datetime]`** window guard (default 1h) blocks double-file from same-tick races where GitHub's search index has not yet surfaced a just-filed issue.

The mirror site at `src/review_phase/_phase.py:3216` (fallback branch when the retrospective queue is not wired) is fixed with the same pattern.

## Files changed

- `src/retrospective_loop.py` — dedup logic, `_now_utc()` seam, `_reconcile_closed_hitl_issues()`.
- `src/review_phase/_phase.py` — fallback-branch dedup via `find_existing_issue` + `post_comment`.
- `tests/test_retrospective_loop.py` — `TestStaleHITLDedup` (3 cases).
- `tests/scenarios/test_caretaker_loops.py` — `test_stale_hitl_dedup_across_ticks` MockWorld scenario.
- `tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py` — regression for both sites.

## Test plan

- [x] Unit: same category stale across 5 ticks → 1 `create_issue` + 4 `post_comment` (`TestStaleHITLDedup::test_five_stale_ticks_one_issue_four_comments`)
- [x] Unit: category stale → file → human closes → stale again → 1 NEW issue filed (`test_closed_then_re_armed_files_new_issue`)
- [x] Unit: window-guard blocks double-file when GitHub search index races (`test_window_guard_blocks_double_file_within_window`)
- [x] MockWorld scenario: 3 ticks against FakeGitHub → 1 HITL issue + 2 follow-up comments (`TestL11RetrospectiveLoop::test_stale_hitl_dedup_across_ticks`)
- [x] Regression: `tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py` guards both the loop and the `ReviewPhase` fallback branch
- [x] `make quality` — 13167 tests pass; the single failure (`tests/test_planner.py::test_build_prompt_truncates_long_body`) is pre-existing on `main` (prompt grew past a hard-coded 15000-char budget after a skill-description update) and unrelated to this change

## Sandbox e2e

Skipped for this PR — the retrospective loop is a queue-driven background worker with no UI/docker surface. Filing a follow-up if the dark-factory rotation surfaces dedup edge cases in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)