### PR TITLE
fix(adr_touchpoint_auditor): roll up to 1 issue per ADR (#8987)

### DIFF
--- a/docs/adr/0056-adr-touchpoint-gate-to-caretaker-loop.md
+++ b/docs/adr/0056-adr-touchpoint-gate-to-caretaker-loop.md
@@ -27,9 +27,10 @@ The loop runs on a configurable interval (default: 4 hours). On each tick it:
 
 1. Walks merged PRs since the last cursor (`state.adr_audit_cursor`, ISO-8601 of the most-recently-scanned merge).
 2. For each merged PR, computes the file-diff and intersects it with the citation table from `ADRIndex` (Accepted ADRs whose `Related:` line names a `src/...` module).
-3. For each ADR whose cited module changed *without* the ADR file being in the same diff, files a `hydraflow-find` issue with title `ADR drift: ADR-NNNN cited modules changed in PR #NNNN`. Labels: `find_label`, `adr_drift_label` (`hydraflow-adr-drift`).
-4. Dedup key `adr_touchpoint_auditor:{pr}:{adr}` prevents re-filing the same drift across re-scans (e.g. cursor rewind during incident response).
-5. After 3 unresolved attempts on the same key, escalates to `hitl_escalation_label` + `adr_drift_stuck_label` (`hydraflow-adr-drift-stuck`). Closing the escalation issue clears the dedup key and attempt counter (same reconcile pattern as `FakeCoverageAuditorLoop`).
+3. For each ADR whose cited module changed *without* the ADR file being in the same diff, files **one rollup `hydraflow-find` issue per ADR** with title `ADR drift: ADR-NNNN cited modules drifted across N PRs` and a body listing every contributing PR (#NNNN, mergedAt, changed cited paths). Labels: `find_label`, `adr_drift_label` (`hydraflow-adr-drift`). (Amended 2026-05-19 by #8987 — was previously one issue per `(PR, ADR)` tuple; the per-tuple shape produced 57 noise issues in a single grooming sweep.)
+4. Dedup key `adr_touchpoint_auditor:ADR-NNNN` (per ADR, no PR component) prevents re-filing the same rollup across re-scans (e.g. cursor rewind during incident response). On subsequent ticks, an open rollup for the same ADR is **updated in place** via `PRPort.update_issue_body` — new drifting PRs are appended, PRs that have gained ADR coverage are dropped.
+5. When any PR diff this tick includes the ADR's own markdown file, the rollup is **closed automatically** — drift is considered resolved by that PR.
+6. After 3 unresolved attempts on the same per-ADR rollup, escalates to `hitl_escalation_label` + `adr_drift_stuck_label` (`hydraflow-adr-drift-stuck`). Closing the escalation issue clears the dedup key, the per-ADR attempt counter, and the rollup state (same reconcile pattern as `FakeCoverageAuditorLoop`).
 
 The loop honors the [ADR-0049](0049-trust-loop-kill-switch-convention.md) in-body kill-switch:
 
@@ -63,6 +64,7 @@ async def _do_work(self) -> dict[str, Any] | None:
 **Migration:**
 - The gate workflow + script are deleted in PR #8484.
 - The first deploy after this ADR lands seeds `adr_audit_cursor` to "now"; pre-existing merged PRs are *not* retroactively scanned. Operators who want a backfill can manually rewind the cursor in `.hydraflow/.../state.json`.
+- **#8987 rollup migration:** Existing per-tuple dedup keys (`adr_touchpoint_auditor:PR-N:ADR-N`) and per-tuple attempt counters are **silently ignored** by the new code path — they become dead weight in the dedup store but are harmless. The 57 noise issues filed under the old shape were closed on 2026-05-19 and need no further action. A future cleanup pass may prune the dead keys; until then, they cost a few KB of state and are not re-filed.
 
 ## Notes for future ADRs
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,6 +1,6 @@
 {
-  "regenerated_at": "2026-05-19T08:04:27.326152+00:00",
-  "commit_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c",
+  "regenerated_at": "2026-05-19T07:16:55.974746+00:00",
+  "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {
       "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,5 +1,5 @@
 {
-  "regenerated_at": "2026-05-19T07:16:55.974746+00:00",
+  "regenerated_at": "2026-05-19T07:22:33.990759+00:00",
   "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -333,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,10 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `7d3fd2b` — chore(arch): regenerate timestamps after dedup commit *(2026-05-19)*
-- `090a2a1` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8988) *(2026-05-19)*
-- `6d7319a` — feat(adversarial): earlier-adversarial pipeline — Discovery + Shape + Plan dissent stages (#8953) (#8953) *(2026-05-19)*
-- `35d0308` — test(sandbox): bump scenario timeouts past observed pipeline duration (#8989) (#8989) *(2026-05-19)*
 - `8c85c14` — fix(sandbox): wire FakeSubprocessRunner — the actual claude bypass (#8965) (#8965) *(2026-05-18)*
 - `5f762b0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `119279f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -337,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -65,7 +65,7 @@ per-adapter, not per-port).
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0052] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `7d3fd2b` on 2026-05-19 08:04 UTC. Source last changed at `7d3fd2b`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:16 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/src/adr_drift.py
+++ b/src/adr_drift.py
@@ -4,6 +4,10 @@ Given an ADR index and a PR's file diff, returns a list of `DriftFinding`s
 — one per Accepted/Proposed ADR whose cited `src/` modules changed without
 the ADR's own markdown file being part of the same diff.
 
+For per-ADR rollups (#8987) ``compute_drift_by_adr`` aggregates per-PR
+findings across a batch of merged PRs, producing one entry per drifted
+ADR with the union of contributing PRs.
+
 Kept pure (no I/O, no `gh` calls) so the loop can drive it from real
 state and tests can drive it from stubbed inputs.
 """
@@ -72,3 +76,49 @@ def compute_drift(
             )
         )
     return findings
+
+
+@dataclass(frozen=True)
+class AdrRollupEntry:
+    """All PRs that drifted a given ADR in one scan batch (#8987).
+
+    Used by ``AdrTouchpointAuditorLoop`` to file/update one rollup issue
+    per ADR instead of one issue per ``(PR, ADR)`` tuple.
+    """
+
+    adr: ADR
+    contributors: tuple[DriftFinding, ...]
+
+    @property
+    def pr_numbers(self) -> tuple[int, ...]:
+        return tuple(sorted({f.pr_number for f in self.contributors}))
+
+
+def compute_drift_by_adr(
+    adr_index: ADRIndex,
+    pr_diffs: Iterable[tuple[int, Iterable[str]]],
+) -> list[AdrRollupEntry]:
+    """Group per-PR drift findings into one rollup entry per drifted ADR.
+
+    ``pr_diffs`` is an iterable of ``(pr_number, changed_files)`` tuples
+    — typically the PRs returned by one ``gh pr list`` page. Output is
+    sorted by ADR number for deterministic processing.
+
+    A PR whose diff includes the ADR's own file is silently skipped for
+    that ADR — drift on that pair is considered resolved by the same PR
+    (matches ``compute_drift``'s per-PR semantics).
+    """
+    pr_diffs = list(pr_diffs)
+    if not pr_diffs:
+        return []
+
+    per_adr: dict[int, tuple[ADR, list[DriftFinding]]] = {}
+    for pr_number, changed_files in pr_diffs:
+        for finding in compute_drift(adr_index, pr_number, changed_files):
+            slot = per_adr.setdefault(finding.adr.number, (finding.adr, []))
+            slot[1].append(finding)
+
+    return [
+        AdrRollupEntry(adr=adr, contributors=tuple(findings))
+        for _, (adr, findings) in sorted(per_adr.items())
+    ]

--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -431,7 +431,10 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
                 updated += 1
                 # Attempt-counter ticks per ADR; escalate at 3 strikes.
                 attempts = self._state.inc_adr_audit_attempts(rollup_key)
-                if attempts >= _MAX_ATTEMPTS:
+                # Fire escalation exactly once at the threshold — using
+                # ``==`` not ``>=`` so subsequent ticks for a still-open
+                # rollup don't file a fresh HITL issue every tick.
+                if attempts == _MAX_ATTEMPTS:
                     await self._file_drift_escalation(rollup_key, attempts)
                     escalated += 1
                 continue
@@ -442,7 +445,10 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
                 continue
 
             attempts = self._state.inc_adr_audit_attempts(rollup_key)
-            if attempts >= _MAX_ATTEMPTS:
+            # Same once-at-threshold guard as the existing-rollup branch
+            # above. ``_reconcile_closed_escalations`` resets attempts on
+            # human close so a recurrence after close can re-escalate.
+            if attempts == _MAX_ATTEMPTS:
                 await self._file_drift_escalation(rollup_key, attempts)
                 escalated += 1
             else:

--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -8,6 +8,16 @@ follows the `FakeCoverageAuditorLoop` pattern.
 Cursor is `state.adr_audit_cursor` (ISO-8601 of the most-recently-scanned
 merged-PR mergedAt). First run after deploy seeds it to "now" — pre-existing
 merge history is frozen and not retroactively scanned.
+
+Per-ADR rollup (#8987): findings are aggregated into **one issue per ADR**
+listing all PRs that drifted it. Subsequent ticks update the body via
+``PRPort.update_issue_body``. When an ADR's own file appears in a PR diff
+the rollup is closed — drift is resolved by the same PR.
+
+Migration: old per-tuple dedup keys (``adr_touchpoint_auditor:PR-N:ADR-N``)
+and per-tuple attempt counters are silently ignored. They are not pruned —
+the keys become dead weight in the dedup store until a future cleanup. New
+keys are ``adr_touchpoint_auditor:ADR-NNNN`` (no PR component).
 """
 
 from __future__ import annotations
@@ -36,8 +46,20 @@ _MAX_ATTEMPTS = 3
 _DEFAULT_PR_LIMIT = 50  # gh pr list page size per tick
 
 
+def _rollup_key(adr_number: int) -> str:
+    return f"ADR-{adr_number:04d}"
+
+
+def _dedup_key(adr_number: int) -> str:
+    return f"adr_touchpoint_auditor:{_rollup_key(adr_number)}"
+
+
 class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
-    """ADR drift auditor (ADR-0056). Replaces the deleted touchpoint gate."""
+    """ADR drift auditor (ADR-0056). Replaces the deleted touchpoint gate.
+
+    Files **one rollup issue per ADR** (#8987) listing all PRs that drifted
+    its cited modules.
+    """
 
     def __init__(
         self,
@@ -107,30 +129,78 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
     def _changed_paths(pr: dict) -> list[str]:
         return [f.get("path", "") for f in pr.get("files", []) if f.get("path")]
 
-    async def _file_drift_finding(self, finding: DriftFinding) -> int:
-        adr = finding.adr
-        title = (
-            f"ADR drift: ADR-{adr.number:04d} cited modules changed in "
-            f"PR #{finding.pr_number}"
+    def _rollup_body(
+        self,
+        adr,
+        pr_entries: list[dict],
+    ) -> str:
+        """Render the rollup issue body.
+
+        ``pr_entries`` is a list of ``{number, mergedAt, changed_cited_files}``
+        dicts, one per PR currently included in the rollup.
+        """
+        pr_entries = sorted(pr_entries, key=lambda e: int(e.get("number", 0)))
+        repo = self._config.repo
+        lines = [
+            "## ADR drift rollup",
+            "",
+            f"PRs whose diff changed `src/` modules cited by "
+            f"**ADR-{adr.number:04d}: {adr.title}** (status: {adr.status}) "
+            f"without the ADR file being in the same diff:",
+            "",
+        ]
+        for entry in pr_entries:
+            pr_number = int(entry.get("number", 0))
+            merged_at = entry.get("mergedAt") or "?"
+            files = entry.get("changed_cited_files") or []
+            files_str = ", ".join(f"`{p}`" for p in files) or "(no paths recorded)"
+            lines.append(
+                f"- PR [#{pr_number}](https://github.com/{repo}/pull/{pr_number}) "
+                f"(merged {merged_at}): {files_str}"
+            )
+        lines.extend(
+            [
+                "",
+                "**Repair options:**",
+                f"1. Update `docs/adr/{adr.number:04d}-*.md` to reflect the new "
+                "behavior (closes this rollup automatically on the next tick), OR",
+                "2. Confirm the changes are consistent with the existing ADR — close "
+                "this issue with a one-line explanation (the close comment is the "
+                "audit trail).",
+                "",
+                "_Filed by `adr_touchpoint_auditor` per ADR-0056 (per-ADR rollup, #8987)._",
+            ]
         )
-        files_block = "\n".join(f"- `{p}`" for p in finding.changed_cited_files)
-        body = (
-            f"## ADR drift\n\n"
-            f"PR [#{finding.pr_number}](https://github.com/{self._config.repo}/pull/{finding.pr_number}) "
-            f"changed `src/` modules cited by **ADR-{adr.number:04d}: {adr.title}** "
-            f"(status: {adr.status}) without the ADR file being in the same diff:\n\n"
-            f"{files_block}\n\n"
-            f"**Repair options:**\n"
-            f"1. Update `docs/adr/{adr.number:04d}-*.md` to reflect the new behavior, OR\n"
-            f"2. Confirm the change is consistent with the existing ADR — close this "
-            f"issue with a one-line explanation (the close comment is the audit trail).\n\n"
-            f"_Filed by `adr_touchpoint_auditor` per ADR-0056._"
+        return "\n".join(lines)
+
+    def _rollup_title(self, adr, pr_count: int) -> str:
+        plural = "PR" if pr_count == 1 else "PRs"
+        return (
+            f"ADR drift: ADR-{adr.number:04d} cited modules drifted "
+            f"across {pr_count} {plural}"
         )
+
+    async def _file_drift_rollup(
+        self,
+        adr,
+        pr_entries: list[dict],
+    ) -> int:
+        title = self._rollup_title(adr, len(pr_entries))
+        body = self._rollup_body(adr, pr_entries)
         return await self._pr.create_issue(
             title,
             body,
             [*self._config.find_label, *self._config.adr_drift_label],
         )
+
+    async def _update_drift_rollup(
+        self,
+        issue_number: int,
+        adr,
+        pr_entries: list[dict],
+    ) -> None:
+        body = self._rollup_body(adr, pr_entries)
+        await self._pr.update_issue_body(issue_number, body)
 
     async def _file_drift_escalation(self, key: str, attempts: int) -> int:
         title = f"HITL: ADR drift {key} unresolved after {attempts}"
@@ -196,12 +266,39 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
                     and key.split(":", 1)[1] in title
                 ):
                     keep.discard(key)
-                    self._state.clear_adr_audit_attempts(key.split(":", 1)[1])
+                    attempt_id = key.split(":", 1)[1]
+                    self._state.clear_adr_audit_attempts(attempt_id)
+                    self._state.clear_adr_rollup(attempt_id)
         if keep != current:
             self._dedup.set_all(keep)
 
-    async def _do_work(self) -> WorkCycleResult:
-        """Scan recently-merged PRs vs ADR citations, file drift findings."""
+    def _adrs_updated_in_diff(self, changed_files: list[str]) -> set[int]:
+        """Return ADR numbers whose own markdown file appears in *changed_files*."""
+        updated: set[int] = set()
+        for adr in self._adr_index.adrs():
+            prefix = f"docs/adr/{adr.number:04d}-"
+            if any(f.startswith(prefix) for f in changed_files):
+                updated.add(adr.number)
+        return updated
+
+    @staticmethod
+    def _contribs_to_pr_entries(
+        contribs: tuple[DriftFinding, ...], pr_meta: dict[int, dict]
+    ) -> list[dict]:
+        entries: list[dict] = []
+        for f in contribs:
+            meta = pr_meta.get(f.pr_number, {})
+            entries.append(
+                {
+                    "number": f.pr_number,
+                    "mergedAt": meta.get("mergedAt", ""),
+                    "changed_cited_files": list(f.changed_cited_files),
+                }
+            )
+        return entries
+
+    async def _do_work(self) -> WorkCycleResult:  # noqa: PLR0915
+        """Scan recently-merged PRs vs ADR citations, file per-ADR drift rollups."""
         if not self._enabled_cb(self._worker_name):
             return {"status": "disabled"}
         if not self._config.adr_touchpoint_auditor_loop_enabled:
@@ -218,38 +315,147 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
         prs = await self._list_recent_merged_prs(cursor)
         if not prs:
             self._emit_trace(t0, scanned=0, filed=0)
-            return {"status": "ok", "scanned": 0, "filed": 0, "escalated": 0}
+            return {
+                "status": "ok",
+                "scanned": 0,
+                "filed": 0,
+                "escalated": 0,
+                "closed": 0,
+                "updated": 0,
+            }
 
-        from adr_drift import compute_drift  # noqa: PLC0415
+        from adr_drift import compute_drift_by_adr  # noqa: PLC0415
 
-        filed = 0
-        escalated = 0
-        dedup = self._dedup.get()
+        # Build (pr_number, changed_files) batch + per-PR metadata.
+        pr_meta: dict[int, dict] = {}
+        pr_diffs: list[tuple[int, list[str]]] = []
+        adrs_resolved_this_tick: set[int] = set()
         new_cursor = cursor
         for pr in prs:
             pr_number = int(pr.get("number", 0))
             if not pr_number:
                 continue
             changed = self._changed_paths(pr)
-            for finding in compute_drift(self._adr_index, pr_number, changed):
-                key = (
-                    f"adr_touchpoint_auditor:PR-{pr_number}:"
-                    f"ADR-{finding.adr.number:04d}"
-                )
-                if key in dedup:
-                    continue
-                attempt_id = key.split(":", 1)[1]
-                attempts = self._state.inc_adr_audit_attempts(attempt_id)
-                if attempts >= _MAX_ATTEMPTS:
-                    await self._file_drift_escalation(attempt_id, attempts)
-                    escalated += 1
-                else:
-                    await self._file_drift_finding(finding)
-                    filed += 1
-                dedup.add(key)
-                self._dedup.set_all(dedup)
+            pr_meta[pr_number] = {
+                "mergedAt": pr.get("mergedAt") or "",
+                "changed_files": changed,
+            }
+            pr_diffs.append((pr_number, changed))
+            adrs_resolved_this_tick |= self._adrs_updated_in_diff(changed)
             merged_at = pr.get("mergedAt") or ""
             new_cursor = max(new_cursor, merged_at)
+
+        rollups = compute_drift_by_adr(self._adr_index, pr_diffs)
+
+        # Resolve rollups for ADRs that were updated in any PR diff this tick.
+        closed = 0
+        for adr_num in adrs_resolved_this_tick:
+            rollup_key = _rollup_key(adr_num)
+            existing = self._state.get_adr_rollup(rollup_key)
+            if not existing:
+                continue
+            try:
+                await self._pr.close_issue(int(existing["issue_number"]))
+            except (
+                RuntimeError,
+                AttributeError,
+            ) as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "Could not close ADR rollup issue #%s: %s",
+                    existing.get("issue_number"),
+                    exc,
+                )
+            self._state.clear_adr_rollup(rollup_key)
+            self._state.clear_adr_audit_attempts(rollup_key)
+            current = self._dedup.get()
+            if _dedup_key(adr_num) in current:
+                self._dedup.set_all(current - {_dedup_key(adr_num)})
+            closed += 1
+
+        filed = 0
+        updated = 0
+        escalated = 0
+        dedup = self._dedup.get()
+        for entry in rollups:
+            adr_num = entry.adr.number
+            # Skip ADRs whose own file was in this tick's diffs — they were just
+            # resolved above; their rollup (if any) was closed.
+            if adr_num in adrs_resolved_this_tick:
+                continue
+
+            rollup_key = _rollup_key(adr_num)
+            dedup_key = _dedup_key(adr_num)
+            existing = self._state.get_adr_rollup(rollup_key)
+            new_pr_entries = self._contribs_to_pr_entries(entry.contributors, pr_meta)
+            new_pr_numbers = {int(e["number"]) for e in new_pr_entries}
+
+            if existing:
+                # Compute the set of PRs that this tick observed touching the
+                # ADR's own file (and therefore "gained ADR coverage"). Any
+                # tracked PR appearing in such a diff is dropped from the rollup.
+                # (Rollup-wide close is handled above when *any* PR diff touches
+                # the ADR file; this branch only runs for ADRs not in
+                # ``adrs_resolved_this_tick``, so dropping here is a no-op in
+                # practice — but kept as defense for partial-state cases.)
+                gained_coverage: set[int] = set()
+                for pr_num, meta in pr_meta.items():
+                    if entry.adr.number in self._adrs_updated_in_diff(
+                        meta["changed_files"]
+                    ):
+                        gained_coverage.add(pr_num)
+
+                kept_existing = [
+                    n for n in existing["pr_numbers"] if n not in gained_coverage
+                ]
+                merged_pr_numbers = sorted({*kept_existing, *new_pr_numbers})
+                merged_entries: list[dict] = list(new_pr_entries)
+                new_present = new_pr_numbers
+                for n in merged_pr_numbers:
+                    if n in new_present:
+                        continue
+                    merged_entries.append(
+                        {
+                            "number": n,
+                            "mergedAt": "",
+                            "changed_cited_files": [],
+                        }
+                    )
+                await self._update_drift_rollup(
+                    int(existing["issue_number"]), entry.adr, merged_entries
+                )
+                self._state.set_adr_rollup(
+                    rollup_key,
+                    issue_number=int(existing["issue_number"]),
+                    pr_numbers=merged_pr_numbers,
+                )
+                updated += 1
+                # Attempt-counter ticks per ADR; escalate at 3 strikes.
+                attempts = self._state.inc_adr_audit_attempts(rollup_key)
+                if attempts >= _MAX_ATTEMPTS:
+                    await self._file_drift_escalation(rollup_key, attempts)
+                    escalated += 1
+                continue
+
+            if dedup_key in dedup:
+                # Rollup state was cleared (e.g. external close) but dedup not
+                # yet reconciled — skip until reconcile catches up.
+                continue
+
+            attempts = self._state.inc_adr_audit_attempts(rollup_key)
+            if attempts >= _MAX_ATTEMPTS:
+                await self._file_drift_escalation(rollup_key, attempts)
+                escalated += 1
+            else:
+                issue_number = await self._file_drift_rollup(entry.adr, new_pr_entries)
+                if issue_number:
+                    self._state.set_adr_rollup(
+                        rollup_key,
+                        issue_number=issue_number,
+                        pr_numbers=sorted(new_pr_numbers),
+                    )
+                filed += 1
+            dedup.add(dedup_key)
+            self._dedup.set_all(dedup)
 
         if new_cursor != cursor:
             self._state.set_adr_audit_cursor(new_cursor)
@@ -259,6 +465,8 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
             "status": "ok",
             "scanned": len(prs),
             "filed": filed,
+            "updated": updated,
+            "closed": closed,
             "escalated": escalated,
         }
 

--- a/src/models.py
+++ b/src/models.py
@@ -1840,6 +1840,10 @@ class StateData(BaseModel):
     # AdrTouchpointAuditorLoop (ADR-0056) — cursor is ISO-8601 of last-scanned merged PR.
     adr_audit_cursor: str = Field(default="")
     adr_audit_attempts: dict[str, int] = Field(default_factory=dict)
+    # Per-ADR rollup tracking (#8987). Keyed by "ADR-NNNN"; value carries the
+    # rollup issue number + the set of PR numbers currently listed in the body.
+    # Used so subsequent ticks update the body in-place rather than re-filing.
+    adr_rollup_issues: dict[str, dict] = Field(default_factory=dict)
     memory_backlog_attempts: dict[str, int] = Field(default_factory=dict)
     # LiveCorpusReplayLoop (#8786 Phase 3) — per-drift-signature attempt
     # counters for the 3-attempt escalation chain.

--- a/src/state/_adr_audit.py
+++ b/src/state/_adr_audit.py
@@ -38,3 +38,32 @@ class AdrAuditStateMixin:
         attempts.pop(key, None)
         self._data.adr_audit_attempts = attempts
         self.save()
+
+    # Per-ADR rollup tracking (#8987) — see ADR-0056 amendment.
+
+    def get_adr_rollup(self, adr_key: str) -> dict | None:
+        """Return ``{'issue_number': int, 'pr_numbers': list[int]}`` or ``None``."""
+        entry = self._data.adr_rollup_issues.get(adr_key)
+        if not entry:
+            return None
+        return {
+            "issue_number": int(entry.get("issue_number", 0)),
+            "pr_numbers": list(entry.get("pr_numbers", [])),
+        }
+
+    def set_adr_rollup(
+        self, adr_key: str, *, issue_number: int, pr_numbers: list[int]
+    ) -> None:
+        rollups = dict(self._data.adr_rollup_issues)
+        rollups[adr_key] = {
+            "issue_number": int(issue_number),
+            "pr_numbers": sorted({int(n) for n in pr_numbers}),
+        }
+        self._data.adr_rollup_issues = rollups
+        self.save()
+
+    def clear_adr_rollup(self, adr_key: str) -> None:
+        rollups = dict(self._data.adr_rollup_issues)
+        rollups.pop(adr_key, None)
+        self._data.adr_rollup_issues = rollups
+        self.save()

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -310,6 +310,7 @@ class MockWorld:
             "create_task",
             "close_task",
             "close_issue",
+            "update_issue_body",
             "find_existing_issue",
             "push_branch",
             "create_pr",

--- a/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
+++ b/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
@@ -38,15 +38,17 @@ def _write_adr(adr_dir, *, number: int, title: str, related: list[str]) -> None:
 
 
 class TestAdrTouchpointAuditor:
-    """ADR-0056 — drift detection MockWorld scenarios."""
+    """ADR-0056 — drift detection MockWorld scenarios (per-ADR rollup #8987)."""
 
-    async def test_drift_files_one_finding(self, tmp_path) -> None:
-        """Merged PR touches an ADR-cited src/ file → one drift issue filed."""
+    async def test_drift_files_one_rollup(self, tmp_path) -> None:
+        """Merged PR touches an ADR-cited src/ file → one rollup issue filed."""
         from adr_index import ADRIndex  # noqa: PLC0415
 
         world = MockWorld(tmp_path)
         fake_pr = AsyncMock()
         fake_pr.create_issue = AsyncMock(return_value=2001)
+        fake_pr.update_issue_body = AsyncMock(return_value=None)
+        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -71,6 +73,7 @@ class TestAdrTouchpointAuditor:
         state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00Z"
         state.get_adr_audit_attempts.return_value = 0
         state.inc_adr_audit_attempts.return_value = 1
+        state.get_adr_rollup.return_value = None
 
         _seed_ports(
             world,
@@ -84,11 +87,71 @@ class TestAdrTouchpointAuditor:
         await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
 
         assert fake_pr.create_issue.await_count == 1
-        title, _body, labels = fake_pr.create_issue.await_args.args
+        title, body, labels = fake_pr.create_issue.await_args.args
         assert "ADR-0024" in title
-        assert "PR #8473" in title
+        assert "1 PR" in title
+        assert "#8473" in body
         assert "hydraflow-find" in labels
         assert "hydraflow-adr-drift" in labels
+
+    async def test_three_prs_drifting_same_adr_one_rollup(self, tmp_path) -> None:
+        """3 PRs drifting the same ADR file ONE rollup with all PRs in body."""
+        from adr_index import ADRIndex  # noqa: PLC0415
+
+        world = MockWorld(tmp_path)
+        fake_pr = AsyncMock()
+        fake_pr.create_issue = AsyncMock(return_value=2010)
+        fake_pr.update_issue_body = AsyncMock(return_value=None)
+        fake_pr.close_issue = AsyncMock(return_value=None)
+
+        repo = tmp_path / "repo"
+        adr_dir = repo / "docs" / "adr"
+        adr_dir.mkdir(parents=True)
+        _write_adr(adr_dir, number=24, title="alpha", related=["src/agent.py"])
+        adr_index = ADRIndex(adr_dir)
+
+        async def list_merged_prs(_cursor):
+            return [
+                {
+                    "number": 8501,
+                    "mergedAt": "2026-05-07T10:00:00Z",
+                    "files": [{"path": "src/agent.py"}],
+                },
+                {
+                    "number": 8502,
+                    "mergedAt": "2026-05-07T11:00:00Z",
+                    "files": [{"path": "src/agent.py"}],
+                },
+                {
+                    "number": 8503,
+                    "mergedAt": "2026-05-07T12:00:00Z",
+                    "files": [{"path": "src/agent.py"}],
+                },
+            ]
+
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        state = MagicMock()
+        state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00Z"
+        state.get_adr_audit_attempts.return_value = 0
+        state.inc_adr_audit_attempts.return_value = 1
+        state.get_adr_rollup.return_value = None
+
+        _seed_ports(
+            world,
+            pr_manager=fake_pr,
+            adr_touchpoint_state=state,
+            adr_touchpoint_index=adr_index,
+            adr_touchpoint_list_merged_prs=list_merged_prs,
+            adr_touchpoint_reconcile_closed=AsyncMock(return_value=None),
+        )
+
+        await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
+
+        assert fake_pr.create_issue.await_count == 1
+        body = fake_pr.create_issue.await_args.args[1]
+        for n in (8501, 8502, 8503):
+            assert f"#{n}" in body
 
     async def test_no_drift_when_adr_in_diff(self, tmp_path) -> None:
         """ADR file in the diff → no issue filed."""
@@ -97,6 +160,8 @@ class TestAdrTouchpointAuditor:
         world = MockWorld(tmp_path)
         fake_pr = AsyncMock()
         fake_pr.create_issue = AsyncMock(return_value=2002)
+        fake_pr.update_issue_body = AsyncMock(return_value=None)
+        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -122,6 +187,7 @@ class TestAdrTouchpointAuditor:
         state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00Z"
         state.get_adr_audit_attempts.return_value = 0
         state.inc_adr_audit_attempts.return_value = 1
+        state.get_adr_rollup.return_value = None
 
         _seed_ports(
             world,

--- a/tests/test_adr_drift.py
+++ b/tests/test_adr_drift.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from adr_drift import DriftFinding, _adr_file_in_diff, compute_drift
+from adr_drift import (
+    AdrRollupEntry,
+    DriftFinding,
+    _adr_file_in_diff,
+    compute_drift,
+    compute_drift_by_adr,
+)
 from adr_index import ADR, ADRIndex
 
 
@@ -142,3 +148,60 @@ def test_drift_finding_is_immutable() -> None:
     )
     with pytest.raises(AttributeError):  # frozen dataclass
         f.pr_number = 2  # type: ignore[misc]
+
+
+def test_compute_drift_by_adr_groups_multiple_prs(adr_index: ADRIndex) -> None:
+    """#8987 — 3 PRs drifting the same ADR collapse into one rollup entry."""
+    rollups = compute_drift_by_adr(
+        adr_index,
+        [
+            (10, ["src/alpha.py"]),
+            (11, ["src/alpha.py", "tests/x.py"]),
+            (12, ["src/alpha.py"]),
+        ],
+    )
+    assert len(rollups) == 1
+    entry = rollups[0]
+    assert entry.adr.number == 1
+    assert entry.pr_numbers == (10, 11, 12)
+    assert len(entry.contributors) == 3
+
+
+def test_compute_drift_by_adr_one_pr_n_adrs(adr_index: ADRIndex) -> None:
+    """#8987 — one PR drifting two ADRs yields two rollup entries."""
+    rollups = compute_drift_by_adr(
+        adr_index,
+        [(99, ["src/alpha.py", "src/beta.py"])],
+    )
+    assert [e.adr.number for e in rollups] == [1, 2]
+    for entry in rollups:
+        assert entry.pr_numbers == (99,)
+
+
+def test_compute_drift_by_adr_skips_prs_with_adr_in_diff(adr_index: ADRIndex) -> None:
+    """A PR whose diff includes the ADR file is silently skipped for that ADR."""
+    rollups = compute_drift_by_adr(
+        adr_index,
+        [
+            (10, ["src/alpha.py"]),
+            (11, ["src/alpha.py", "docs/adr/0001-alpha.md"]),
+        ],
+    )
+    assert len(rollups) == 1
+    assert rollups[0].pr_numbers == (10,)
+
+
+def test_compute_drift_by_adr_empty_input(adr_index: ADRIndex) -> None:
+    assert compute_drift_by_adr(adr_index, []) == []
+
+
+def test_adr_rollup_entry_is_immutable(adr_index: ADRIndex) -> None:
+    adr = next(a for a in adr_index.adrs() if a.number == 1)
+    entry = AdrRollupEntry(
+        adr=adr,
+        contributors=(
+            DriftFinding(adr=adr, pr_number=1, changed_cited_files=("src/alpha.py",)),
+        ),
+    )
+    with pytest.raises(AttributeError):  # frozen dataclass
+        entry.adr = adr  # type: ignore[misc]

--- a/tests/test_adr_touchpoint_auditor_loop.py
+++ b/tests/test_adr_touchpoint_auditor_loop.py
@@ -1,4 +1,9 @@
-"""Unit tests for AdrTouchpointAuditorLoop (ADR-0056)."""
+"""Unit tests for AdrTouchpointAuditorLoop (ADR-0056 + #8987 rollup).
+
+Per-ADR rollup behavior (#8987): one issue per ADR listing all PRs that
+drifted it. Subsequent ticks update the body. Dedup key is
+``adr_touchpoint_auditor:ADR-NNNN`` (no PR component).
+"""
 
 from __future__ import annotations
 
@@ -36,6 +41,16 @@ def _write_adr(adr_dir: Path, *, number: int, title: str, related: list[str]) ->
     (adr_dir / f"{number:04d}-{title.lower()}.md").write_text(body)
 
 
+def _state_mock() -> MagicMock:
+    """Build a MagicMock state with rollup-aware defaults."""
+    state = MagicMock()
+    state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00+00:00"
+    state.get_adr_audit_attempts.return_value = 0
+    state.inc_adr_audit_attempts.return_value = 1
+    state.get_adr_rollup.return_value = None
+    return state
+
+
 @pytest.fixture
 def loop_env(tmp_path: Path):
     adr_dir = tmp_path / "docs" / "adr"
@@ -48,12 +63,11 @@ def loop_env(tmp_path: Path):
         repo="hydra/hydraflow",
         repo_root=tmp_path,
     )
-    state = MagicMock()
-    state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00+00:00"
-    state.get_adr_audit_attempts.return_value = 0
-    state.inc_adr_audit_attempts.return_value = 1
+    state = _state_mock()
     pr = AsyncMock()
     pr.create_issue = AsyncMock(return_value=42)
+    pr.update_issue_body = AsyncMock(return_value=None)
+    pr.close_issue = AsyncMock(return_value=None)
     dedup = MagicMock()
     dedup.get.return_value = set()
 
@@ -97,8 +111,8 @@ async def test_first_run_seeds_cursor_and_returns(loop_env) -> None:
     pr.create_issue.assert_not_awaited()
 
 
-async def test_drift_files_one_issue_per_drifted_adr(loop_env, monkeypatch) -> None:
-    """A merged PR touching an ADR-cited src/ file (without the ADR in the diff) → 1 issue."""
+async def test_drift_files_one_rollup_per_adr(loop_env, monkeypatch) -> None:
+    """A merged PR touching an ADR-cited src/ file → 1 rollup issue."""
     cfg, state, pr, dedup, idx = loop_env
     stop = asyncio.Event()
     loop = AdrTouchpointAuditorLoop(
@@ -132,15 +146,215 @@ async def test_drift_files_one_issue_per_drifted_adr(loop_env, monkeypatch) -> N
     stats = await loop._do_work()
     assert stats["scanned"] == 1
     assert stats["filed"] == 1
+    assert stats["updated"] == 0
     assert stats["escalated"] == 0
     title = pr.create_issue.await_args.args[0]
+    body = pr.create_issue.await_args.args[1]
     assert "ADR-0024" in title
-    assert "PR #8473" in title
+    assert "1 PR" in title  # rollup count
+    assert "PR #8473" in title or "#8473" in body
+    # Rollup state was recorded so the next tick can update in-place.
+    state.set_adr_rollup.assert_called_once()
+    call_kwargs = state.set_adr_rollup.call_args.kwargs
+    assert call_kwargs["pr_numbers"] == [8473]
+    assert call_kwargs["issue_number"] == 42
 
 
-async def test_no_drift_when_adr_in_diff(loop_env, monkeypatch) -> None:
-    """ADR file in same diff → no drift, no issue filed."""
+async def test_one_pr_drifting_8_adrs_files_8_issues(loop_env, monkeypatch) -> None:
+    """A single PR drifting 8 ADRs files 8 issues (one per ADR)."""
     cfg, state, pr, dedup, idx = loop_env
+    # Add 8 ADRs each citing a distinct file the PR will touch.
+    adr_dir = cfg.repo_root / "docs" / "adr"
+    for i in range(8):
+        _write_adr(
+            adr_dir,
+            number=100 + i,
+            title=f"big{i}",
+            related=[f"src/big{i}.py"],
+        )
+    from adr_index import ADRIndex  # noqa: PLC0415
+
+    idx = ADRIndex(adr_dir)
+
+    pr.create_issue = AsyncMock(side_effect=list(range(200, 208)))
+
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8500,
+                "mergedAt": "2026-05-07T20:00:00Z",
+                "files": [{"path": f"src/big{i}.py"} for i in range(8)],
+            }
+        ]
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
+
+    stats = await loop._do_work()
+    assert stats["filed"] == 8
+    assert pr.create_issue.await_count == 8
+
+
+async def test_three_prs_drifting_same_adr_file_one_rollup(
+    loop_env, monkeypatch
+) -> None:
+    """3 PRs drifting the same ADR file ONE issue with all 3 PRs in body."""
+    cfg, state, pr, dedup, idx = loop_env
+    pr.create_issue = AsyncMock(return_value=555)
+
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8501,
+                "mergedAt": "2026-05-07T10:00:00Z",
+                "files": [{"path": "src/agent.py"}],
+            },
+            {
+                "number": 8502,
+                "mergedAt": "2026-05-07T11:00:00Z",
+                "files": [{"path": "src/agent.py"}],
+            },
+            {
+                "number": 8503,
+                "mergedAt": "2026-05-07T12:00:00Z",
+                "files": [{"path": "src/agent.py"}],
+            },
+        ]
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
+
+    stats = await loop._do_work()
+    assert stats["filed"] == 1
+    assert pr.create_issue.await_count == 1
+    body = pr.create_issue.await_args.args[1]
+    assert "#8501" in body
+    assert "#8502" in body
+    assert "#8503" in body
+    # Rollup pr_numbers persisted to state.
+    pr_numbers = state.set_adr_rollup.call_args.kwargs["pr_numbers"]
+    assert sorted(pr_numbers) == [8501, 8502, 8503]
+
+
+async def test_subsequent_tick_updates_body_with_new_prs(loop_env, monkeypatch) -> None:
+    """Tick N+1 with a new PR drifting same ADR → update_issue_body, no new issue."""
+    cfg, state, pr, dedup, idx = loop_env
+    # Existing rollup state from a previous tick.
+    state.get_adr_rollup.return_value = {
+        "issue_number": 999,
+        "pr_numbers": [8501],
+    }
+
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8502,
+                "mergedAt": "2026-05-07T22:00:00Z",
+                "files": [{"path": "src/agent.py"}],
+            }
+        ]
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
+
+    stats = await loop._do_work()
+    assert stats["filed"] == 0
+    assert stats["updated"] == 1
+    pr.create_issue.assert_not_awaited()
+    pr.update_issue_body.assert_awaited_once()
+    issue_number_arg, body_arg = pr.update_issue_body.await_args.args
+    assert issue_number_arg == 999
+    assert "#8501" in body_arg
+    assert "#8502" in body_arg
+    # State persists the merged PR set.
+    merged = state.set_adr_rollup.call_args.kwargs["pr_numbers"]
+    assert merged == [8501, 8502]
+
+
+async def test_pr_gaining_adr_coverage_removed_from_rollup(
+    loop_env, monkeypatch
+) -> None:
+    """A PR added in tick N, then ADR file updated in tick N+1 → rollup closed."""
+    cfg, state, pr, dedup, idx = loop_env
+    state.get_adr_rollup.return_value = {
+        "issue_number": 999,
+        "pr_numbers": [8501],
+    }
+    dedup.get.return_value = {"adr_touchpoint_auditor:ADR-0024"}
+
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8502,
+                "mergedAt": "2026-05-07T22:00:00Z",
+                "files": [
+                    {"path": "src/agent.py"},
+                    {"path": "docs/adr/0024-alpha.md"},
+                ],
+            }
+        ]
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
+
+    stats = await loop._do_work()
+    assert stats["closed"] == 1
+    assert stats["filed"] == 0
+    pr.close_issue.assert_awaited_once_with(999)
+    state.clear_adr_rollup.assert_called_with("ADR-0024")
+    state.clear_adr_audit_attempts.assert_called_with("ADR-0024")
+    # Dedup key cleaned up.
+    dedup.set_all.assert_called()
+    last_set = dedup.set_all.call_args.args[0]
+    assert "adr_touchpoint_auditor:ADR-0024" not in last_set
+
+
+async def test_adr_file_in_diff_closes_rollup_no_new_issue(
+    loop_env, monkeypatch
+) -> None:
+    """ADR's own file in diff and no open rollup → no issue filed, no close."""
+    cfg, state, pr, dedup, idx = loop_env
+
     stop = asyncio.Event()
     loop = AdrTouchpointAuditorLoop(
         config=cfg,
@@ -163,54 +377,17 @@ async def test_no_drift_when_adr_in_diff(loop_env, monkeypatch) -> None:
             }
         ]
 
-    async def fake_reconcile():
-        return None
-
     monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
-    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
-
-    stats = await loop._do_work()
-    assert stats["scanned"] == 1
-    assert stats["filed"] == 0
-    pr.create_issue.assert_not_awaited()
-
-
-async def test_dedup_prevents_refile_within_same_tick(loop_env, monkeypatch) -> None:
-    """A finding already in dedup is skipped."""
-    cfg, state, pr, dedup, idx = loop_env
-    dedup.get.return_value = {"adr_touchpoint_auditor:PR-8473:ADR-0024"}
-
-    stop = asyncio.Event()
-    loop = AdrTouchpointAuditorLoop(
-        config=cfg,
-        state=state,
-        pr_manager=pr,
-        dedup=dedup,
-        adr_index=idx,
-        deps=_deps(stop),
-    )
-
-    async def fake_list(_cursor):
-        return [
-            {
-                "number": 8473,
-                "mergedAt": "2026-05-06T20:00:00Z",
-                "files": [{"path": "src/agent.py"}],
-            }
-        ]
-
-    async def fake_reconcile():
-        return None
-
-    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
-    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
 
     stats = await loop._do_work()
     assert stats["filed"] == 0
     pr.create_issue.assert_not_awaited()
+    pr.close_issue.assert_not_awaited()
 
 
 async def test_escalation_after_three_attempts(loop_env, monkeypatch) -> None:
+    """3-strikes escalation triggers per-ADR rollup."""
     cfg, state, pr, dedup, idx = loop_env
     state.inc_adr_audit_attempts.return_value = 3
 
@@ -233,11 +410,8 @@ async def test_escalation_after_three_attempts(loop_env, monkeypatch) -> None:
             }
         ]
 
-    async def fake_reconcile():
-        return None
-
     monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
-    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
 
     stats = await loop._do_work()
     assert stats["escalated"] == 1
@@ -245,6 +419,8 @@ async def test_escalation_after_three_attempts(loop_env, monkeypatch) -> None:
     labels = pr.create_issue.await_args.args[2]
     assert "hydraflow-hitl-escalation" in labels
     assert "hydraflow-adr-drift-stuck" in labels
+    # The 3-strike attempt counter key is per ADR, not per (PR, ADR).
+    state.inc_adr_audit_attempts.assert_called_with("ADR-0024")
 
 
 async def test_cursor_advances_to_most_recent_merged_at(loop_env, monkeypatch) -> None:
@@ -274,11 +450,8 @@ async def test_cursor_advances_to_most_recent_merged_at(loop_env, monkeypatch) -
             },
         ]
 
-    async def fake_reconcile():
-        return None
-
     monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
-    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
 
     await loop._do_work()
     state.set_adr_audit_cursor.assert_called_with("2026-05-06T22:00:00Z")
@@ -311,9 +484,9 @@ async def test_kill_switch_short_circuits(loop_env) -> None:
 async def test_close_reconcile_clears_dedup(loop_env, monkeypatch) -> None:
     """Closed adr-drift-stuck escalations clear their dedup key + attempt counter."""
     cfg, state, pr, dedup, idx = loop_env
-    stuck_attempt_key = "PR-8473:ADR-0024"
+    stuck_attempt_key = "ADR-0024"
     full_dedup_key = f"adr_touchpoint_auditor:{stuck_attempt_key}"
-    current = {full_dedup_key, "adr_touchpoint_auditor:PR-9000:ADR-0042"}
+    current = {full_dedup_key, "adr_touchpoint_auditor:ADR-0042"}
     dedup.get.return_value = current
 
     stop = asyncio.Event()
@@ -346,5 +519,6 @@ async def test_close_reconcile_clears_dedup(loop_env, monkeypatch) -> None:
     dedup.set_all.assert_called_once()
     remaining = dedup.set_all.call_args.args[0]
     assert full_dedup_key not in remaining
-    assert "adr_touchpoint_auditor:PR-9000:ADR-0042" in remaining
-    state.clear_adr_audit_attempts.assert_called_once_with(stuck_attempt_key)
+    assert "adr_touchpoint_auditor:ADR-0042" in remaining
+    state.clear_adr_audit_attempts.assert_called_with(stuck_attempt_key)
+    state.clear_adr_rollup.assert_called_with(stuck_attempt_key)

--- a/tests/test_adr_touchpoint_auditor_loop.py
+++ b/tests/test_adr_touchpoint_auditor_loop.py
@@ -423,6 +423,56 @@ async def test_escalation_after_three_attempts(loop_env, monkeypatch) -> None:
     state.inc_adr_audit_attempts.assert_called_with("ADR-0024")
 
 
+async def test_escalation_does_not_storm_after_threshold(loop_env, monkeypatch) -> None:
+    """Regression for the #8993 review finding: escalation fires exactly
+    once when the per-ADR attempt counter crosses ``_MAX_ATTEMPTS`` (==3),
+    not on every subsequent tick.
+
+    Setup: an existing rollup (issue #4242) is open for ADR-0024, the
+    attempt counter is now 4 (one tick after threshold). The loop should
+    update the body and persist the new PR set, but it should NOT file a
+    fresh HITL escalation issue.
+    """
+    cfg, state, pr, dedup, idx = loop_env
+    # Tracked rollup exists with one prior PR; counter is past the threshold.
+    state.get_adr_rollup.return_value = {
+        "issue_number": 4242,
+        "pr_numbers": [8473],
+    }
+    state.inc_adr_audit_attempts.return_value = 4
+
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8473,
+                "mergedAt": "2026-05-06T20:00:00Z",
+                "files": [{"path": "src/agent.py"}],
+            }
+        ]
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", AsyncMock())
+
+    stats = await loop._do_work()
+
+    # Existing rollup body was refreshed.
+    assert pr.update_issue_body.await_count >= 1
+    # And NO new escalation issue was filed — ``==`` not ``>=`` is the
+    # whole point of this regression test.
+    assert pr.create_issue.await_count == 0
+    assert stats["escalated"] == 0
+
+
 async def test_cursor_advances_to_most_recent_merged_at(loop_env, monkeypatch) -> None:
     cfg, state, pr, dedup, idx = loop_env
 

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -135,8 +135,8 @@ class TestInitialization:
             # AdrTouchpointAuditorLoop (ADR-0056)
             "adr_audit_cursor",
             "adr_audit_attempts",
-            # Earlier-adversarial pipeline (ADR-0064)
-            "adversarial_states",
+            # Per-ADR rollup tracking (#8987) — see ADR-0056 amendment.
+            "adr_rollup_issues",
             # MemoryBacklogLoop (ADR-0057)
             "memory_backlog_attempts",
         }

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -139,6 +139,10 @@ class TestInitialization:
             "adr_rollup_issues",
             # MemoryBacklogLoop (ADR-0057)
             "memory_backlog_attempts",
+            # Earlier-adversarial pipeline (#8953) — pulled in by the
+            # rebase; the enumeration needs the entry so set-equality
+            # holds against the live StateData.
+            "adversarial_states",
         }
         assert set(d.keys()) == expected_keys
 


### PR DESCRIPTION
Closes #8987.

## Summary

`AdrTouchpointAuditorLoop` previously filed one `hydraflow-find` issue per `(PR, ADR)` tuple. A PR touching modules cited by 8 ADRs filed 8 issues; 3 PRs drifting the same ADR filed 3. The 2026-05-19 grooming sweep closed **57** of these as auto-noise.

This PR collapses findings into **one rollup issue per ADR** listing all PRs that drifted it.

## Behavioral changes

- Issue title shape: `ADR drift: ADR-NNNN cited modules drifted across N PRs`.
- Dedup key: `adr_touchpoint_auditor:ADR-NNNN` (no PR component).
- Subsequent ticks update the rollup body via existing `PRPort.update_issue_body` rather than file a new issue. New drifting PRs appended; PRs that have gained ADR coverage are dropped.
- When a PR diff includes the ADR's own markdown file, the rollup issue is closed automatically (drift resolved by that PR).
- 3-strikes escalation now ticks per ADR (key = `ADR-NNNN`).

## Test pyramid

- **Unit (`tests/test_adr_drift.py`):** 5 new cases for `compute_drift_by_adr` — multi-PR grouping, one-PR-N-ADRs, skip PRs with ADR file in diff, empty input, immutability.
- **Unit (`tests/test_adr_touchpoint_auditor_loop.py`):** new cases covering all acceptance criteria from #8987:
  - 1 PR drifting 8 ADRs → 8 issues (one per ADR)
  - 3 PRs drifting same ADR → 1 rollup with all 3 PRs in body
  - Tick N+1 with new PR drifting same ADR → `update_issue_body` (no new issue)
  - PR diff includes ADR's own markdown file → rollup closed, dedup key cleared
  - 3-strikes escalation triggers per ADR
  - Reconcile-closed clears per-ADR rollup state
- **MockWorld scenario (`tests/scenarios/test_adr_touchpoint_auditor_scenario.py`):** Tier B coverage updated for the rollup shape (3 cases).
- **Sandbox e2e:** Skipped — the auditor loop has no docker/UI surface and the existing sandbox harness does not exercise drift-noise scenarios. Flagged as a follow-up if the sandbox tier grows a noise-control coverage axis.

## Migration

Existing per-tuple dedup keys (`adr_touchpoint_auditor:PR-N:ADR-N`) and per-tuple attempt counters are **silently ignored** by the new code path. They become dead weight in the dedup store (a few KB) until a future cleanup. Documented in ADR-0056's amended Migration block.

## ADR action

Amended **ADR-0056** (`docs/adr/0056-adr-touchpoint-gate-to-caretaker-loop.md`) in-place to record the rollup shape and migration choice. No new ADR — this is a refinement of the same caretaker-loop design, not a superseding decision.

## Files changed

- `src/adr_drift.py` — added `compute_drift_by_adr()` + `AdrRollupEntry` (pure aggregation).
- `src/adr_touchpoint_auditor_loop.py` — rewrote `_do_work` for per-ADR rollup; new `_file_drift_rollup`, `_update_drift_rollup`, `_adrs_updated_in_diff`, `_contribs_to_pr_entries` helpers.
- `src/models.py` — added `adr_rollup_issues: dict[str, dict]` to `StateData`.
- `src/state/_adr_audit.py` — added `get_adr_rollup`, `set_adr_rollup`, `clear_adr_rollup`.
- `docs/adr/0056-*.md` — amendment.
- `tests/test_adr_drift.py`, `tests/test_adr_touchpoint_auditor_loop.py`, `tests/scenarios/test_adr_touchpoint_auditor_scenario.py`, `tests/test_state_tracking.py` — coverage + state-keys update.
- `docs/arch/generated/*` — auto-regenerated by `make quality`.

## Test plan

- [x] `pytest tests/test_adr_drift.py` — 12 pass
- [x] `pytest tests/test_adr_touchpoint_auditor_loop.py` — 13 pass
- [x] `pytest tests/scenarios/test_adr_touchpoint_auditor_scenario.py -m scenario_loops` — 3 pass
- [x] `make quality` — 13167 passed (1 unrelated pre-existing failure in `test_planner.py::test_build_prompt_truncates_long_body`, reproduced on clean `main`)
- [ ] After merge: confirm the auditor loop stops filing per-tuple issues in the live fleet

## Constraints honored

- Did not extract a shared rollup helper (sibling #8986 is a parallel agent). Rollup logic kept inside `adr_touchpoint_auditor_loop.py`; DRY pass after both PRs land.
- Did not touch `src/fake_coverage_auditor_loop.py` (parallel agent's territory).
- Did not add new `PRPort` methods — `update_issue_body` + `close_issue` already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)