### PR TITLE
fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986)

### DIFF
--- a/docs/adr/0045-trust-architecture-hardening.md
+++ b/docs/adr/0045-trust-architecture-hardening.md
@@ -95,3 +95,18 @@ The following files carry this ADR's decisions and must be kept in sync with any
 - `src/corpus_learning_loop.py`, `src/contract_refresh_loop.py`, `src/staging_bisect_loop.py`, `src/principles_audit_loop.py`, `src/flake_tracker_loop.py`, `src/skill_prompt_eval_loop.py`, `src/fake_coverage_auditor_loop.py`, `src/rc_budget_loop.py`, `src/wiki_rot_detector_loop.py` — the nine watched trust loops.
 - `src/discover_phase.py`, `src/discover_runner.py`, `src/shape_phase.py`, `src/shape_runner.py` — §4.10 product-phase evaluator dispatch (extends ADR-0031 with evaluator skill retry + HITL escalation).
 - `src/report_issue_loop.py` — §4.11 daily-budget sweep hook inside `_do_work` (additive; does not change the screenshot-capture behavior covered by ADR-0018).
+
+## Update Log
+
+- **2026-05-19 (#8986):** `FakeCoverageAuditorLoop` issue shape changed from
+  one-issue-per-`(fake, method)` to a **rollup** issue per `(fake, gap_kind)`
+  with the uncovered-method list in the body. Subsequent ticks update the
+  body via `PRPort.update_issue_body`; 3-strikes escalation moves to the
+  rollup granularity. Background: the per-method shape produced 154 noise
+  issues that were closed en masse on 2026-05-19. The shape change is
+  spec-level (§4.7) and does not affect the ADR's load-bearing decisions
+  (still nine watched trust loops, still weekly cadence, still
+  `hitl-escalation` + `fake-coverage-stuck` on stuck gaps). Migration is
+  self-healing: old per-method dedup keys age out silently when no
+  matching open escalation title is found; the loop's first post-deploy
+  tick produces new rollup issues for any live gaps.

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T07:27:46.943515+00:00",
-  "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
+  "regenerated_at": "2026-05-19T09:11:57.844118+00:00",
+  "commit_sha": "589fcdc124217ae7d70f531803126e04ef784c00",
   "artifacts": {
     "loops.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "ports.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "labels.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "modules.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "events.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "adr_xref.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "mockworld.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "changelog.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "coverage_matrix.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "functional_areas.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "ubiquitous-language.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "7d3fd2b64995a73db203553a6f7a6195e986a94c"
+      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,5 +1,5 @@
 {
-  "regenerated_at": "2026-05-19T07:23:31.330076+00:00",
+  "regenerated_at": "2026-05-19T07:27:46.943515+00:00",
   "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,5 +1,5 @@
 {
-  "regenerated_at": "2026-05-19T07:22:33.990759+00:00",
+  "regenerated_at": "2026-05-19T07:23:31.330076+00:00",
   "commit_sha": "67d29f1ec6c08dbc19b7944f2baec0044b61a47c",
   "artifacts": {
     "loops.md": {

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -333,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,13 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `3d49c86` — chore(arch): regenerate arch docs after fake-coverage rollup (#8986) (#8986) *(2026-05-19)*
+- `1b3156c` — fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986) (#8986) *(2026-05-19)*
+- `ce53f28` — fix(adr_touchpoint_auditor): roll up to 1 issue per ADR (#8987) (#8993) (#8993) *(2026-05-19)*
+- `1e70cc0` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8992) (#8992) *(2026-05-19)*
+- `dbe6f17` — feat(loops): remove CodeGroomingLoop (#8984) (#8995) (#8995) *(2026-05-19)*
+- `6d7319a` — feat(adversarial): earlier-adversarial pipeline — Discovery + Shape + Plan dissent stages (#8953) (#8953) *(2026-05-19)*
+- `35d0308` — test(sandbox): bump scenario timeouts past observed pipeline duration (#8989) (#8989) *(2026-05-19)*
 - `8c85c14` — fix(sandbox): wire FakeSubprocessRunner — the actual claude bypass (#8965) (#8965) *(2026-05-18)*
 - `5f762b0` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
 - `119279f` — chore(arch): regenerate arch docs after rebase *(2026-05-18)*
@@ -333,4 +340,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -333,4 +333,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -65,7 +65,7 @@ per-adapter, not per-port).
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -65,7 +65,7 @@ per-adapter, not per-port).
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:22 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `67d29f1` on 2026-05-19 07:23 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._
+_Regenerated from commit `67d29f1` on 2026-05-19 07:27 UTC. Source last changed at `67d29f1`. Status: 🟢 fresh._

--- a/docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md
@@ -1000,20 +1000,33 @@ compounds rather than stagnating at whatever was cassetted on day one.
    - **Test-facing helpers**: a helper is covered if at least one
      scenario test under `tests/scenarios/` calls it (grep-based
      search against the method name).
-4. For each uncovered method in either set, file a `hydraflow-find`:
-   - Title: `Un-cassetted adapter method: {Fake}.{method}` or
-     `Un-exercised test helper: {Fake}.{method}`.
-   - Body: method signature, which method set, suggested interaction
-     shape for recording (real-adapter) or suggested scenario to
-     invoke it (test-facing).
+4. For each `(fake_class, gap_kind)` with one or more uncovered
+   methods, file (or update) **one rollup** `hydraflow-find` issue —
+   see issue #8986 for the rationale (per-method filing produced
+   O(N) triage cost; 154 noise issues closed manually on 2026-05-19):
+   - Title: `Fake coverage gap: {Fake} adapter surface (N methods)`
+     or `Fake coverage gap: {Fake} test helpers (N methods)`.
+   - Body: bulleted list of every currently-uncovered method, plus a
+     "Recently recovered" strikethrough section for methods that
+     appeared as uncovered last tick but have since gained coverage.
    - Labels: `hydraflow-find`, `fake-coverage-gap`,
      `{adapter-surface|test-helper}`.
+   - Dedup key: `fake_coverage_auditor:{Fake}:{gap_kind}` (no method
+     component). The rollup-issue number is persisted in
+     ``StateData.fake_coverage_rollup_issues`` so subsequent ticks
+     call ``PRPort.update_issue_body`` instead of refiling.
+   - Closed-by-human reset: if state holds a rollup-issue number but
+     no matching open title is found at tick start, the auditor
+     drops the stale state and re-files cleanly.
 5. Factory dispatches implementer; standard repair path records a new
    cassette (real-adapter) or adds a scenario call (test-facing)
-   and commits.
+   and commits. Each merge shrinks the rollup body on the next tick.
 
-**Escalation.** After 3 repair attempts, `hitl-escalation`,
-`fake-coverage-stuck`.
+**Escalation.** After 3 repair attempts at the **rollup** granularity
+(`{Fake}:{gap_kind}`, not `{Fake}.{method}:{gap_kind}`),
+`hitl-escalation`, `fake-coverage-stuck`. Attempt counter keys live in
+``StateData.fake_coverage_attempts`` under the `{Fake}:{gap_kind}`
+shape.
 
 **Five-checkpoint wiring**. Config `fake_coverage_auditor_interval`,
 default `604800`.

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -549,7 +549,9 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             else:
                 # Gap closed — clear attempts + drop the rollup mapping so
                 # the next regression re-files cleanly.
-                self._clear_rollup_state(fake, "adapter-surface", dedup)
+                await self._clear_rollup_state(
+                    fake, "adapter-surface", dedup, recovered=recovered_surface
+                )
 
             # --- test-helper rollup ---
             if uncovered_helpers:
@@ -568,7 +570,9 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 elif action == "updated":
                     updated += 1
             else:
-                self._clear_rollup_state(fake, "test-helper", dedup)
+                await self._clear_rollup_state(
+                    fake, "test-helper", dedup, recovered=recovered_helpers
+                )
 
             all_known[fake] = sorted(covered)
             # Persist this tick's uncovered set under sentinel keys so the
@@ -631,9 +635,12 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 body = self._render_helper_body(fake, uncovered, recovered)
             await self._pr.update_issue_body(tracked_number, body)
             # Bump the attempt counter once per tick the gap remains open
-            # so 3-strikes escalation still fires.
+            # so 3-strikes escalation still fires. Fire escalation exactly
+            # once — when the counter crosses ``_MAX_ATTEMPTS`` — not every
+            # subsequent tick (which would file a fresh HITL issue per
+            # tick until a human acts).
             attempts = self._state.inc_fake_coverage_attempts(key)
-            if attempts >= _MAX_ATTEMPTS:
+            if attempts == _MAX_ATTEMPTS:
                 await self._file_escalation(key, attempts)
                 return ("escalated", False)
             return ("updated", False)
@@ -657,7 +664,11 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             self._dedup.set_all(dedup)
 
         attempts = self._state.inc_fake_coverage_attempts(key)
-        if attempts >= _MAX_ATTEMPTS:
+        if attempts == _MAX_ATTEMPTS:
+            # Fire once when the counter crosses the threshold. Subsequent
+            # ticks fall through to a fresh rollup file via the path below
+            # (or skip if dedup_key was set earlier), which avoids the
+            # tick-per-tick escalation storm.
             await self._file_escalation(key, attempts)
             dedup.add(dedup_key)
             self._dedup.set_all(dedup)
@@ -673,16 +684,32 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         self._dedup.set_all(dedup)
         return ("filed", True)
 
-    def _clear_rollup_state(self, fake: str, kind: str, dedup: set[str]) -> None:
+    async def _clear_rollup_state(
+        self,
+        fake: str,
+        kind: str,
+        dedup: set[str],
+        recovered: list[str] | None = None,
+    ) -> None:
         """Reset rollup tracking when the gap closes (no uncovered methods).
 
         Drops the attempt counter, dedup key, and rollup-issue mapping so
-        a future regression re-files cleanly. The issue itself is left
-        for humans to close (the body will read "(none — auditor should
-        close this issue on next tick)" on the prior tick's update).
+        a future regression re-files cleanly. When the previous tick had
+        an actual gap (``recovered`` is non-empty) AND a rollup issue is
+        tracked, repaint the body with the "all covered" view first so
+        humans looking at the open issue see the resolution rather than
+        a stale list of methods. The issue itself is left open for humans
+        to close.
         """
         key = f"{fake}:{kind}"  # shared key for attempts + rollup mapping
         dedup_key = f"fake_coverage_auditor:{fake}:{kind}"
+        tracked_number = self._state.get_fake_coverage_rollup_issue(key)
+        if tracked_number and recovered:
+            if kind == "adapter-surface":
+                body = self._render_surface_body(fake, [], recovered)
+            else:
+                body = self._render_helper_body(fake, [], recovered)
+            await self._pr.update_issue_body(tracked_number, body)
         self._state.clear_fake_coverage_attempts(key)
         self._state.clear_fake_coverage_rollup_issue(key)
         if dedup_key in dedup:

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -12,10 +12,14 @@ Spec: `docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md`
   scenario test under ``tests/scenarios/`` that calls the helper.
 
 Files ``find_label`` + ``fake_coverage_gap_label`` + one of
-``adapter_surface_label`` | ``test_helper_label`` per uncovered method.
-Escalates after 3 attempts to ``hitl_escalation_label`` +
-``fake_coverage_stuck_label``. All five label fields are registered in
-``HYDRAFLOW_LABELS`` so ``make ensure-labels`` provisions them.
+``adapter_surface_label`` | ``test_helper_label`` per **rollup** —
+one issue per ``(fake_class, gap_kind)`` listing all uncovered methods
+in the body (issue #8986). Subsequent ticks update the body via
+``PRPort.update_issue_body``: append newly-uncovered methods, strike
+through methods that gained coverage. Escalates after 3 attempts at the
+rollup granularity to ``hitl_escalation_label`` + ``fake_coverage_stuck_label``.
+All five label fields are registered in ``HYDRAFLOW_LABELS`` so
+``make ensure-labels`` provisions them.
 """
 
 from __future__ import annotations
@@ -218,17 +222,97 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         # rg exits 0 on match, 1 on no-match, 2+ on error.
         return proc.returncode == 0 and bool(stdout.strip())
 
-    async def _file_surface_gap(self, fake: str, method: str) -> int:
-        title = f"Un-cassetted adapter method: {fake}.{method}"
+    def _render_surface_body(
+        self,
+        fake: str,
+        uncovered: list[str],
+        recovered: list[str],
+    ) -> str:
+        """Build the rollup-issue body for an adapter-surface gap.
+
+        ``uncovered`` is the live list of methods missing cassettes;
+        ``recovered`` is methods that previously appeared in the body but
+        have since gained a cassette — rendered as strikethrough so the
+        history of the rollup is visible to a human triager.
+        """
         subdir = _FAKE_TO_CASSETTE_DIR.get(fake, "?")
-        body = (
-            f"## Fake coverage gap — adapter surface\n\n"
-            f"Fake class `{fake}` exposes a public method `{method}` with no "
-            f"matching cassette under "
-            f"`tests/trust/contracts/cassettes/{subdir}/`.\n\n"
-            f"**Repair:** record a cassette that exercises the real-adapter "
-            f"counterpart and commit. Spec §4.7; filed by `fake_coverage_auditor`."
+        lines = [
+            "## Fake coverage gap — adapter surface",
+            "",
+            f"Fake class `{fake}` exposes public methods with no matching "
+            f"cassette under `tests/trust/contracts/cassettes/{subdir}/`.",
+            "",
+            f"**Uncovered methods ({len(uncovered)}):**",
+            "",
+        ]
+        if uncovered:
+            lines.extend(f"- `{method}`" for method in sorted(uncovered))
+        else:
+            lines.append("_(none — auditor should close this issue on next tick)_")
+        if recovered:
+            lines.extend(
+                [
+                    "",
+                    "**Recently recovered (gained coverage):**",
+                    "",
+                ]
+            )
+            lines.extend(f"- ~~`{method}`~~" for method in sorted(recovered))
+        lines.extend(
+            [
+                "",
+                "**Repair:** record a cassette exercising each real-adapter "
+                "counterpart and commit. Spec §4.7; filed by "
+                "`fake_coverage_auditor` (#8986 rollup).",
+            ]
         )
+        return "\n".join(lines)
+
+    def _render_helper_body(
+        self,
+        fake: str,
+        uncovered: list[str],
+        recovered: list[str],
+    ) -> str:
+        """Build the rollup-issue body for a test-helper gap."""
+        lines = [
+            "## Fake coverage gap — test helper",
+            "",
+            f"Fake class `{fake}` exposes helpers that no scenario under "
+            f"`tests/scenarios/` invokes (grep-based search).",
+            "",
+            f"**Unexercised helpers ({len(uncovered)}):**",
+            "",
+        ]
+        if uncovered:
+            lines.extend(f"- `{method}`" for method in sorted(uncovered))
+        else:
+            lines.append("_(none — auditor should close this issue on next tick)_")
+        if recovered:
+            lines.extend(
+                [
+                    "",
+                    "**Recently recovered (gained a scenario caller):**",
+                    "",
+                ]
+            )
+            lines.extend(f"- ~~`{method}`~~" for method in sorted(recovered))
+        lines.extend(
+            [
+                "",
+                "**Repair:** add a scenario that calls each helper so it is "
+                "part of the working contract. Spec §4.7; filed by "
+                "`fake_coverage_auditor` (#8986 rollup).",
+            ]
+        )
+        return "\n".join(lines)
+
+    async def _file_surface_gap(
+        self, fake: str, uncovered: list[str], recovered: list[str] | None = None
+    ) -> int:
+        """File the adapter-surface rollup issue for ``fake``. (#8986 rollup.)"""
+        title = f"Fake coverage gap: {fake} adapter surface ({len(uncovered)} methods)"
+        body = self._render_surface_body(fake, uncovered, recovered or [])
         return await self._pr.create_issue(
             title,
             body,
@@ -239,15 +323,12 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             ],
         )
 
-    async def _file_helper_gap(self, fake: str, method: str) -> int:
-        title = f"Un-exercised test helper: {fake}.{method}"
-        body = (
-            f"## Fake coverage gap — test helper\n\n"
-            f"Fake class `{fake}` exposes helper `{method}` but no scenario "
-            f"under `tests/scenarios/` invokes it (grep-based search).\n\n"
-            f"**Repair:** add a scenario that calls `{method}` so the helper "
-            f"is part of the working contract. Spec §4.7."
-        )
+    async def _file_helper_gap(
+        self, fake: str, uncovered: list[str], recovered: list[str] | None = None
+    ) -> int:
+        """File the test-helper rollup issue for ``fake``. (#8986 rollup.)"""
+        title = f"Fake coverage gap: {fake} test helpers ({len(uncovered)} methods)"
+        body = self._render_helper_body(fake, uncovered, recovered or [])
         return await self._pr.create_issue(
             title,
             body,
@@ -275,7 +356,14 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         )
 
     async def _reconcile_closed_escalations(self) -> None:
-        """Clear dedup keys for closed fake-coverage-stuck escalations."""
+        """Clear dedup keys for closed fake-coverage-stuck escalations.
+
+        Escalations are now filed at rollup granularity (``{Fake}:{kind}``),
+        so the title-substring match works against the new key shape. Old
+        per-method dedup keys (pre-#8986) carry a ``.method`` segment and
+        will simply not match any open escalation title — they age out
+        silently on the next non-escalated tick.
+        """
         cmd = [
             "gh",
             "issue",
@@ -326,8 +414,62 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         if keep != current:
             self._dedup.set_all(keep)
 
+    async def _list_open_rollup_titles(self) -> set[str]:
+        """Return the set of titles of currently-open rollup issues we filed.
+
+        Used to detect "issue closed-by-human between ticks" so we don't
+        leak a stale rollup-issue-number in state. We look up open issues
+        with ``fake-coverage-gap`` label and snapshot their titles; if the
+        title we expect for ``(fake, kind)`` is missing, treat the rollup
+        as closed and re-file on this tick (zombie-state guard).
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            self._config.repo,
+            "--state",
+            "open",
+            "--author",
+            "@me",
+            "--limit",
+            "200",
+            "--json",
+            "title",
+        ]
+        for label in self._config.fake_coverage_gap_label:
+            cmd.extend(["--label", label])
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            if proc.returncode != 0:
+                return set()
+            data = json.loads(stdout.decode() or "[]")
+        except (OSError, json.JSONDecodeError):
+            return set()
+        return {entry.get("title", "") for entry in data}
+
+    def _rollup_title_prefix(self, fake: str, kind: str) -> str:
+        """Stable prefix for matching an existing rollup title regardless of
+        the trailing ``(N methods)`` count."""
+        if kind == "adapter-surface":
+            return f"Fake coverage gap: {fake} adapter surface"
+        return f"Fake coverage gap: {fake} test helpers"
+
     async def _do_work(self) -> WorkCycleResult:
-        """Scan fakes, compare to cassettes + scenario grep, file gaps."""
+        """Scan fakes, compare to cassettes + scenario grep, file rollup gaps.
+
+        Per #8986 the loop files **one rollup issue per ``(fake, kind)``**
+        instead of one issue per ``(fake, method)`` — drastically reducing
+        triage cost. Subsequent ticks update the rollup body via
+        ``PRPort.update_issue_body``. 3-strikes escalation moves to
+        ``(fake, kind)`` granularity.
+        """
         if not self._enabled_cb(self._worker_name):
             return {"status": "disabled"}
         if not self._config.fake_coverage_auditor_loop_enabled:
@@ -343,7 +485,15 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         if not catalog:
             return {"status": "no_fakes", "filed": 0}
 
+        # Snapshot of open rollup-issue titles — used to detect
+        # closed-by-human rollups and re-file cleanly (zombie-state guard).
+        open_titles = await self._list_open_rollup_titles()
+        # Methods we previously reported but now have coverage — rendered
+        # as strikethrough so the rollup body shows the trajectory.
+        last_known = self._state.get_fake_coverage_last_known()
+
         filed = 0
+        updated = 0
         escalated = 0
         dedup = self._dedup.get()
         all_known: dict[str, list[str]] = {}
@@ -354,49 +504,79 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             cassetted = catalog_cassette_methods(cassette_subdir)
 
             covered: list[str] = []
+            uncovered_surface: list[str] = []
             for method in surface_methods:
                 if method in cassetted:
                     covered.append(method)
-                    continue
-                key = f"fake_coverage_auditor:{fake}.{method}:adapter-surface"
-                if key in dedup:
-                    continue
-                attempts = self._state.inc_fake_coverage_attempts(
-                    f"{fake}.{method}:adapter-surface"
-                )
-                if attempts >= _MAX_ATTEMPTS:
-                    await self._file_escalation(
-                        f"{fake}.{method}:adapter-surface", attempts
-                    )
-                    escalated += 1
                 else:
-                    await self._file_surface_gap(fake, method)
-                    filed += 1
-                dedup.add(key)
-                self._dedup.set_all(dedup)
+                    uncovered_surface.append(method)
 
+            uncovered_helpers: list[str] = []
             for method in helper_methods:
                 if await self._grep_scenario_for_helper(method):
                     covered.append(method)
-                    continue
-                key = f"fake_coverage_auditor:{fake}.{method}:test-helper"
-                if key in dedup:
-                    continue
-                attempts = self._state.inc_fake_coverage_attempts(
-                    f"{fake}.{method}:test-helper"
-                )
-                if attempts >= _MAX_ATTEMPTS:
-                    await self._file_escalation(
-                        f"{fake}.{method}:test-helper", attempts
-                    )
-                    escalated += 1
                 else:
-                    await self._file_helper_gap(fake, method)
+                    uncovered_helpers.append(method)
+
+            # Strikethrough = methods that were uncovered last tick but
+            # are now covered. ``last_known`` persists last tick's
+            # uncovered set under sentinel keys ``__uncovered__:{fake}:{kind}``.
+            prior_uncovered_surface = set(
+                last_known.get(f"__uncovered__:{fake}:adapter-surface", [])
+            )
+            prior_uncovered_helpers = set(
+                last_known.get(f"__uncovered__:{fake}:test-helper", [])
+            )
+            recovered_surface = sorted(prior_uncovered_surface - set(uncovered_surface))
+            recovered_helpers = sorted(prior_uncovered_helpers - set(uncovered_helpers))
+
+            # --- adapter-surface rollup ---
+            if uncovered_surface:
+                action, _did_file = await self._handle_rollup(
+                    fake=fake,
+                    kind="adapter-surface",
+                    uncovered=uncovered_surface,
+                    recovered=recovered_surface,
+                    open_titles=open_titles,
+                    dedup=dedup,
+                )
+                if action == "escalated":
+                    escalated += 1
+                elif action == "filed":
                     filed += 1
-                dedup.add(key)
-                self._dedup.set_all(dedup)
+                elif action == "updated":
+                    updated += 1
+            else:
+                # Gap closed — clear attempts + drop the rollup mapping so
+                # the next regression re-files cleanly.
+                self._clear_rollup_state(fake, "adapter-surface", dedup)
+
+            # --- test-helper rollup ---
+            if uncovered_helpers:
+                action, _did_file = await self._handle_rollup(
+                    fake=fake,
+                    kind="test-helper",
+                    uncovered=uncovered_helpers,
+                    recovered=recovered_helpers,
+                    open_titles=open_titles,
+                    dedup=dedup,
+                )
+                if action == "escalated":
+                    escalated += 1
+                elif action == "filed":
+                    filed += 1
+                elif action == "updated":
+                    updated += 1
+            else:
+                self._clear_rollup_state(fake, "test-helper", dedup)
 
             all_known[fake] = sorted(covered)
+            # Persist this tick's uncovered set under sentinel keys so the
+            # next tick can compute strikethrough.
+            all_known[f"__uncovered__:{fake}:adapter-surface"] = sorted(
+                uncovered_surface
+            )
+            all_known[f"__uncovered__:{fake}:test-helper"] = sorted(uncovered_helpers)
 
         self._state.set_fake_coverage_last_known(all_known)
 
@@ -411,10 +591,103 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         return {
             "status": "ok",
             "filed": filed,
+            "updated": updated,
             "escalated": escalated,
             "fakes_seen": len(catalog),
             "retirement_filed": retirement_filed,
         }
+
+    async def _handle_rollup(
+        self,
+        *,
+        fake: str,
+        kind: str,
+        uncovered: list[str],
+        recovered: list[str],
+        open_titles: set[str],
+        dedup: set[str],
+    ) -> tuple[str, bool]:
+        """Drive the per-``(fake, kind)`` rollup: file/update or escalate.
+
+        Returns ``(action, did_file)`` where ``action`` is one of
+        ``"filed"``, ``"updated"``, ``"escalated"``, or ``"skipped"``.
+        """
+        # Shared ``{fake}:{kind}`` key for the attempt counter and the
+        # rollup-issue-number mapping; the dedup set uses a namespaced
+        # variant. Three independent keys, one logical identity.
+        key = f"{fake}:{kind}"
+        dedup_key = f"fake_coverage_auditor:{fake}:{kind}"
+
+        # If we already have a tracked open rollup, *always* update it —
+        # subsequent ticks must keep the body fresh even though the
+        # dedup key is set.
+        tracked_number = self._state.get_fake_coverage_rollup_issue(key)
+        prefix = self._rollup_title_prefix(fake, kind)
+        still_open = any(title.startswith(prefix) for title in open_titles)
+        if tracked_number and still_open:
+            if kind == "adapter-surface":
+                body = self._render_surface_body(fake, uncovered, recovered)
+            else:
+                body = self._render_helper_body(fake, uncovered, recovered)
+            await self._pr.update_issue_body(tracked_number, body)
+            # Bump the attempt counter once per tick the gap remains open
+            # so 3-strikes escalation still fires.
+            attempts = self._state.inc_fake_coverage_attempts(key)
+            if attempts >= _MAX_ATTEMPTS:
+                await self._file_escalation(key, attempts)
+                return ("escalated", False)
+            return ("updated", False)
+
+        # Closed-by-human zombie: drop the stale state and re-file fresh.
+        if tracked_number and not still_open:
+            self._state.clear_fake_coverage_rollup_issue(key)
+            # Also reset the attempt counter so the human's "close" is
+            # treated as a real reset, not a partial step toward escalation.
+            self._state.clear_fake_coverage_attempts(key)
+            dedup.discard(dedup_key)
+            self._dedup.set_all(dedup)
+
+        # No tracked rollup yet on this tick. Either it's a brand-new gap
+        # or the dedup key is set from a prior tick where we already filed
+        # but lost the number (shouldn't happen post-#8986, but be defensive).
+        if dedup_key in dedup and not tracked_number:
+            # Defensive: dedup key present but no tracked issue number.
+            # Treat as fresh file so the rollup gets re-established.
+            dedup.discard(dedup_key)
+            self._dedup.set_all(dedup)
+
+        attempts = self._state.inc_fake_coverage_attempts(key)
+        if attempts >= _MAX_ATTEMPTS:
+            await self._file_escalation(key, attempts)
+            dedup.add(dedup_key)
+            self._dedup.set_all(dedup)
+            return ("escalated", False)
+
+        if kind == "adapter-surface":
+            number = await self._file_surface_gap(fake, uncovered, recovered)
+        else:
+            number = await self._file_helper_gap(fake, uncovered, recovered)
+        if number:
+            self._state.set_fake_coverage_rollup_issue(key, number)
+        dedup.add(dedup_key)
+        self._dedup.set_all(dedup)
+        return ("filed", True)
+
+    def _clear_rollup_state(self, fake: str, kind: str, dedup: set[str]) -> None:
+        """Reset rollup tracking when the gap closes (no uncovered methods).
+
+        Drops the attempt counter, dedup key, and rollup-issue mapping so
+        a future regression re-files cleanly. The issue itself is left
+        for humans to close (the body will read "(none — auditor should
+        close this issue on next tick)" on the prior tick's update).
+        """
+        key = f"{fake}:{kind}"  # shared key for attempts + rollup mapping
+        dedup_key = f"fake_coverage_auditor:{fake}:{kind}"
+        self._state.clear_fake_coverage_attempts(key)
+        self._state.clear_fake_coverage_rollup_issue(key)
+        if dedup_key in dedup:
+            dedup.discard(dedup_key)
+            self._dedup.set_all(dedup)
 
     async def _audit_retirement(self, cassette_root: Path) -> int:
         """Find baseline_only cassettes covered by live dispatchers; file

--- a/src/models.py
+++ b/src/models.py
@@ -1839,7 +1839,7 @@ class StateData(BaseModel):
     fake_coverage_attempts: dict[str, int] = Field(default_factory=dict)
     # #8986 — rollup issue tracking: maps "{Fake}:{gap_kind}" → open GH issue
     # number. Lets the auditor `update_issue_body` instead of filing N parallel
-    # issues per uncovered method. See `_file_or_update_rollup` in
+    # issues per uncovered method. See `_handle_rollup` in
     # `fake_coverage_auditor_loop.py`.
     fake_coverage_rollup_issues: dict[str, int] = Field(default_factory=dict)
     # AdrTouchpointAuditorLoop (ADR-0056) — cursor is ISO-8601 of last-scanned merged PR.

--- a/src/models.py
+++ b/src/models.py
@@ -1837,6 +1837,11 @@ class StateData(BaseModel):
     skill_prompt_attempts: dict[str, int] = Field(default_factory=dict)
     fake_coverage_last_known: dict[str, list[str]] = Field(default_factory=dict)
     fake_coverage_attempts: dict[str, int] = Field(default_factory=dict)
+    # #8986 — rollup issue tracking: maps "{Fake}:{gap_kind}" → open GH issue
+    # number. Lets the auditor `update_issue_body` instead of filing N parallel
+    # issues per uncovered method. See `_file_or_update_rollup` in
+    # `fake_coverage_auditor_loop.py`.
+    fake_coverage_rollup_issues: dict[str, int] = Field(default_factory=dict)
     # AdrTouchpointAuditorLoop (ADR-0056) — cursor is ISO-8601 of last-scanned merged PR.
     adr_audit_cursor: str = Field(default="")
     adr_audit_attempts: dict[str, int] = Field(default_factory=dict)

--- a/src/state/_fake_coverage.py
+++ b/src/state/_fake_coverage.py
@@ -38,3 +38,26 @@ class FakeCoverageStateMixin:
         attempts.pop(key, None)
         self._data.fake_coverage_attempts = attempts
         self.save()
+
+    # --- #8986 rollup issue tracking ---
+
+    def get_fake_coverage_rollup_issue(self, key: str) -> int | None:
+        """Return the open rollup issue number for ``key`` (``{Fake}:{kind}``),
+        or ``None`` if no rollup is tracked.
+        """
+        value = self._data.fake_coverage_rollup_issues.get(key)
+        return int(value) if value else None
+
+    def set_fake_coverage_rollup_issue(self, key: str, issue_number: int) -> None:
+        """Record the open rollup issue number for ``key`` (``{Fake}:{kind}``)."""
+        mapping = dict(self._data.fake_coverage_rollup_issues)
+        mapping[key] = int(issue_number)
+        self._data.fake_coverage_rollup_issues = mapping
+        self.save()
+
+    def clear_fake_coverage_rollup_issue(self, key: str) -> None:
+        """Forget the rollup issue number for ``key`` (closed-by-human reset)."""
+        mapping = dict(self._data.fake_coverage_rollup_issues)
+        mapping.pop(key, None)
+        self._data.fake_coverage_rollup_issues = mapping
+        self.save()

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -483,6 +483,9 @@ def _build_fake_coverage_auditor(ports: dict[str, Any], config: Any, deps: Any) 
         # Default < _MAX_ATTEMPTS=3 so gap-filing path is taken; escalation
         # tests override explicitly via ``fake_coverage_state``.
         state.inc_fake_coverage_attempts.return_value = 1
+        # #8986 rollup tracking: default to no tracked rollup so the first
+        # tick files a fresh issue (the typical scenario start state).
+        state.get_fake_coverage_rollup_issue.return_value = None
         ports["fake_coverage_state"] = state
 
     dedup = ports.get("fake_coverage_dedup")
@@ -508,6 +511,14 @@ def _build_fake_coverage_auditor(ports: dict[str, Any], config: Any, deps: Any) 
     grep = ports.get("fake_coverage_grep")
     if grep is not None:
         loop._grep_scenario_for_helper = grep  # type: ignore[method-assign]
+    # #8986 — the rollup-existence probe also shells out to ``gh``; default
+    # to "no open rollups" so scenarios don't need to seed it unless they
+    # specifically test the closed-by-human / update-existing paths.
+    list_titles = ports.get("fake_coverage_list_open_titles")
+    if list_titles is None:
+        list_titles = AsyncMock(return_value=set())
+        ports["fake_coverage_list_open_titles"] = list_titles
+    loop._list_open_rollup_titles = list_titles  # type: ignore[method-assign]
 
     return loop
 

--- a/tests/scenarios/test_fake_coverage_auditor_scenario.py
+++ b/tests/scenarios/test_fake_coverage_auditor_scenario.py
@@ -78,9 +78,12 @@ class TestFakeCoverageAuditor:
 
         assert fake_pr.create_issue.await_count == 1
         args = fake_pr.create_issue.await_args.args
-        title, _body, labels = args[0], args[1], args[2]
-        assert "close_issue" in title
+        title, body, labels = args[0], args[1], args[2]
+        # #8986 — rollup shape: title names the (fake, kind) pair; the
+        # uncovered method names live in the body.
         assert "FakeGitHub" in title
+        assert "adapter surface" in title
+        assert "close_issue" in body
         assert "hydraflow-adapter-surface" in labels
         assert "hydraflow-fake-coverage-gap" in labels
         assert "hydraflow-find" in labels
@@ -116,9 +119,12 @@ class TestFakeCoverageAuditor:
 
         assert fake_pr.create_issue.await_count == 1
         args = fake_pr.create_issue.await_args.args
-        title, _body, labels = args[0], args[1], args[2]
-        assert "script_run" in title
+        title, body, labels = args[0], args[1], args[2]
+        # #8986 — rollup shape: title names the (fake, kind) pair; the
+        # uncovered helper names live in the body.
         assert "FakeDocker" in title
+        assert "test helpers" in title
+        assert "script_run" in body
         assert "hydraflow-test-helper" in labels
         assert "hydraflow-fake-coverage-gap" in labels
         assert "hydraflow-find" in labels

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -41,8 +41,11 @@ def loop_env(tmp_path: Path):
     # Default: returns 1 (< _MAX_ATTEMPTS=3) so gap filing path is taken.
     # Escalation tests override this explicitly.
     state.inc_fake_coverage_attempts.return_value = 1
+    # #8986 — rollup-issue tracking: default no tracked rollup.
+    state.get_fake_coverage_rollup_issue.return_value = None
     pr = AsyncMock()
     pr.create_issue = AsyncMock(return_value=42)
+    pr.update_issue_body = AsyncMock(return_value=None)
     dedup = MagicMock()
     dedup.get.return_value = set()
     return cfg, state, pr, dedup
@@ -123,8 +126,9 @@ def test_catalog_cassette_methods_reads_input_command(tmp_path: Path) -> None:
 
 
 async def test_do_work_files_surface_gap(loop_env, monkeypatch, tmp_path) -> None:
-    """Un-cassetted public method → one ``adapter-surface`` issue."""
+    """Un-cassetted public method → one ``adapter-surface`` rollup issue."""
     cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
     fake_dir = tmp_path / "src" / "mockworld" / "fakes"
     fake_dir.mkdir(parents=True)
     (fake_dir / "fake_github.py").write_text(
@@ -149,7 +153,11 @@ async def test_do_work_files_surface_gap(loop_env, monkeypatch, tmp_path) -> Non
     async def fake_reconcile():
         return None
 
+    async def fake_list_titles():
+        return set()
+
     monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
 
     stats = await loop._do_work()
     assert stats["filed"] == 1
@@ -159,8 +167,9 @@ async def test_do_work_files_surface_gap(loop_env, monkeypatch, tmp_path) -> Non
 
 
 async def test_do_work_files_helper_gap(loop_env, monkeypatch, tmp_path) -> None:
-    """Un-exercised ``script_*`` helper → one ``test-helper`` issue."""
+    """Un-exercised ``script_*`` helper → one ``test-helper`` rollup issue."""
     cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
     fake_dir = tmp_path / "src" / "mockworld" / "fakes"
     fake_dir.mkdir(parents=True)
     (fake_dir / "fake_docker.py").write_text(
@@ -180,23 +189,30 @@ async def test_do_work_files_helper_gap(loop_env, monkeypatch, tmp_path) -> None
     async def fake_grep(helper):
         return False  # no scenario calls the helper
 
+    async def fake_list_titles():
+        return set()
+
     monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
     monkeypatch.setattr(loop, "_grep_scenario_for_helper", fake_grep)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
 
     stats = await loop._do_work()
     assert stats["filed"] == 1
     labels = pr.create_issue.await_args.args[2]
     assert "hydraflow-test-helper" in labels
     title = pr.create_issue.await_args.args[0]
-    assert "script_run" in title
+    assert "FakeDocker" in title
+    body = pr.create_issue.await_args.args[1]
+    assert "script_run" in body
 
 
 async def test_escalation_fires_after_three_attempts(
     loop_env, monkeypatch, tmp_path
 ) -> None:
-    """3rd re-file of a stuck gap → ``hitl-escalation`` issue, not another gap."""
+    """3rd attempt at a stuck ``(fake, kind)`` rollup → ``hitl-escalation``."""
     cfg, state, pr, dedup = loop_env
     state.inc_fake_coverage_attempts.return_value = 3
+    state.get_fake_coverage_rollup_issue.return_value = None
     fake_dir = tmp_path / "src" / "mockworld" / "fakes"
     fake_dir.mkdir(parents=True)
     (fake_dir / "fake_github.py").write_text(
@@ -214,13 +230,21 @@ async def test_escalation_fires_after_three_attempts(
     async def fake_reconcile():
         return None
 
+    async def fake_list_titles():
+        return set()
+
     monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
 
     stats = await loop._do_work()
     assert stats["escalated"] == 1
+    # The escalation issue is the only one created (no rollup filed when
+    # attempts >= _MAX_ATTEMPTS).
     labels = pr.create_issue.await_args.args[2]
     assert "hydraflow-hitl-escalation" in labels
     assert "hydraflow-fake-coverage-stuck" in labels
+    # Attempt counter keyed by ``{fake}:{kind}``, not ``{fake}.{method}:{kind}``.
+    state.inc_fake_coverage_attempts.assert_called_with("FakeGitHub:adapter-surface")
 
 
 async def test_close_reconcile_clears_dedup_on_closed_escalation(
@@ -228,8 +252,9 @@ async def test_close_reconcile_clears_dedup_on_closed_escalation(
 ) -> None:
     """Closed ``fake-coverage-stuck`` issues clear their dedup key + attempts."""
     cfg, state, pr, dedup = loop_env
-    stuck_key = "fake_coverage_auditor:FakeGitHub.missing:adapter-surface"
-    current = {stuck_key, "fake_coverage_auditor:FakeGitHub.other:adapter-surface"}
+    # New rollup key shape: ``{fake}:{kind}``.
+    stuck_key = "fake_coverage_auditor:FakeGitHub:adapter-surface"
+    current = {stuck_key, "fake_coverage_auditor:FakeDocker:adapter-surface"}
     dedup.get.return_value = current
 
     stop = asyncio.Event()
@@ -238,7 +263,7 @@ async def test_close_reconcile_clears_dedup_on_closed_escalation(
     )
 
     closed_payload = json.dumps(
-        [{"title": "HITL: fake coverage gap FakeGitHub.missing:adapter-surface ..."}]
+        [{"title": "HITL: fake coverage gap FakeGitHub:adapter-surface ..."}]
     ).encode()
 
     class _FakeProc:
@@ -258,9 +283,9 @@ async def test_close_reconcile_clears_dedup_on_closed_escalation(
     dedup.set_all.assert_called_once()
     remaining = dedup.set_all.call_args.args[0]
     assert stuck_key not in remaining
-    assert "fake_coverage_auditor:FakeGitHub.other:adapter-surface" in remaining
+    assert "fake_coverage_auditor:FakeDocker:adapter-surface" in remaining
     state.clear_fake_coverage_attempts.assert_called_once_with(
-        "FakeGitHub.missing:adapter-surface"
+        "FakeGitHub:adapter-surface"
     )
 
 
@@ -283,9 +308,9 @@ async def test_all_emitted_labels_are_registered_hydraflow_labels(loop_env) -> N
         config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
     )
 
-    await loop._file_surface_gap("FakeGitHub", "create_issue")
-    await loop._file_helper_gap("FakeDocker", "script_run")
-    await loop._file_escalation("FakeGitHub.missing:adapter-surface", 3)
+    await loop._file_surface_gap("FakeGitHub", ["create_issue"])
+    await loop._file_helper_gap("FakeDocker", ["script_run"])
+    await loop._file_escalation("FakeGitHub:adapter-surface", 3)
 
     emitted: set[str] = set()
     for call in pr.create_issue.await_args_list:
@@ -380,3 +405,309 @@ def test_fake_to_cassette_dir_keys_match_real_classes() -> None:
     assert not stale, (
         f"Stale _FAKE_TO_CASSETTE_DIR keys (class no longer exists): {stale}"
     )
+
+
+# =============================================================================
+# #8986 rollup behavior — one issue per (fake, gap_kind), not per method.
+# =============================================================================
+
+
+def _write_fake_with_methods(
+    fake_dir: Path, class_name: str, methods: list[str]
+) -> None:
+    body_lines = "\n".join(
+        f"    async def {m}(self): ..."  # public, non-helper → adapter-surface
+        for m in methods
+    )
+    (fake_dir / f"{class_name.lower().replace('fake', 'fake_')}.py").write_text(
+        f"class {class_name}:\n{body_lines}\n"
+    )
+
+
+async def test_rollup_files_one_issue_for_many_uncovered_methods(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """#8986: 12 uncovered FakeGitHub methods → 1 rollup issue, not 12."""
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
+    state.get_fake_coverage_last_known.return_value = {}
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    methods = [f"op_{i:02d}" for i in range(12)]
+    body_lines = "\n".join(f"    async def {m}(self): ..." for m in methods)
+    (fake_dir / "fake_github.py").write_text(f"class FakeGitHub:\n{body_lines}\n")
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # Exactly ONE issue filed for all 12 uncovered methods.
+    assert pr.create_issue.await_count == 1
+    assert stats["filed"] == 1
+    title = pr.create_issue.await_args.args[0]
+    body = pr.create_issue.await_args.args[1]
+    assert "FakeGitHub" in title
+    assert "12 methods" in title
+    for method in methods:
+        assert method in body
+    # Rollup-issue number was stashed in state.
+    state.set_fake_coverage_rollup_issue.assert_called_once_with(
+        "FakeGitHub:adapter-surface", 42
+    )
+
+
+async def test_rollup_tick_2_updates_body_when_method_gains_coverage(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Tick 2: previously-uncovered method now cassetted → update body, remove it."""
+    cfg, state, pr, dedup = loop_env
+    # State as if tick 1 already filed: rollup-issue tracked + prior uncovered set.
+    state.get_fake_coverage_rollup_issue.return_value = 4242
+    state.get_fake_coverage_last_known.return_value = {
+        "__uncovered__:FakeGitHub:adapter-surface": ["create_issue", "close_issue"],
+        "FakeGitHub": [],
+    }
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def create_issue(self): ...\n"
+        "    async def close_issue(self): ...\n"
+    )
+    cassettes = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassettes.mkdir(parents=True)
+    # create_issue gained coverage between ticks.
+    (cassettes / "create_issue.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "create_issue"}, "output": {}})
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        # Pretend the rollup is still open.
+        return {"Fake coverage gap: FakeGitHub adapter surface (2 methods)"}
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # No new issue created; existing one updated.
+    pr.create_issue.assert_not_awaited()
+    pr.update_issue_body.assert_awaited_once()
+    args = pr.update_issue_body.await_args.args
+    assert args[0] == 4242
+    body = args[1]
+    # The remaining uncovered method is listed; the recovered one is struck.
+    assert "close_issue" in body
+    assert "~~`create_issue`~~" in body
+    assert stats["updated"] == 1
+
+
+async def test_rollup_tick_3_appends_newly_uncovered_method(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Tick 3: a new method becomes uncovered → body updated, method appended."""
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = 4242
+    # Tick 2 reported only [close_issue]; tick 3 sees close_issue + new_method.
+    state.get_fake_coverage_last_known.return_value = {
+        "__uncovered__:FakeGitHub:adapter-surface": ["close_issue"],
+        "FakeGitHub": ["create_issue"],
+    }
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def create_issue(self): ...\n"
+        "    async def close_issue(self): ...\n"
+        "    async def new_method(self): ...\n"
+    )
+    cassettes = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassettes.mkdir(parents=True)
+    (cassettes / "create_issue.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "create_issue"}, "output": {}})
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return {"Fake coverage gap: FakeGitHub adapter surface (1 methods)"}
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    await loop._do_work()
+
+    pr.create_issue.assert_not_awaited()
+    pr.update_issue_body.assert_awaited_once()
+    body = pr.update_issue_body.await_args.args[1]
+    assert "close_issue" in body
+    assert "new_method" in body
+    # create_issue is now covered, not listed (nor strikethrough — it
+    # wasn't in last tick's uncovered set; it was already covered).
+    assert "`create_issue`" not in body or "~~`create_issue`~~" not in body
+
+
+async def test_rollup_escalation_keyed_on_fake_kind_not_method(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """3-strikes counter is per ``(fake, kind)``, never per method."""
+    cfg, state, pr, dedup = loop_env
+    state.inc_fake_coverage_attempts.return_value = 3
+    state.get_fake_coverage_rollup_issue.return_value = None
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def a(self): ...\n"
+        "    async def b(self): ...\n"
+        "    async def c(self): ...\n"
+    )
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # Attempt counter incremented once for the whole (FakeGitHub, adapter-surface)
+    # rollup — NOT once per uncovered method.
+    state.inc_fake_coverage_attempts.assert_called_once_with(
+        "FakeGitHub:adapter-surface"
+    )
+    assert stats["escalated"] == 1
+    # And the escalation issue's title carries the rollup key.
+    title = pr.create_issue.await_args.args[0]
+    assert "FakeGitHub:adapter-surface" in title
+
+
+async def test_rollup_closed_by_human_refiles_cleanly(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Closed-by-human rollup: next tick re-files a fresh issue (zombie guard)."""
+    cfg, state, pr, dedup = loop_env
+    # State thinks rollup #4242 is open, but no matching open title is found.
+    state.get_fake_coverage_rollup_issue.return_value = 4242
+    state.get_fake_coverage_last_known.return_value = {}
+    pr.create_issue = AsyncMock(return_value=5000)
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def missing(self): ...\n"
+    )
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()  # no open rollup → it was closed by a human
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # The stale rollup number was dropped and a fresh issue was filed.
+    state.clear_fake_coverage_rollup_issue.assert_any_call("FakeGitHub:adapter-surface")
+    state.clear_fake_coverage_attempts.assert_any_call("FakeGitHub:adapter-surface")
+    assert pr.create_issue.await_count == 1
+    assert stats["filed"] == 1
+    # New issue number recorded.
+    state.set_fake_coverage_rollup_issue.assert_called_with(
+        "FakeGitHub:adapter-surface", 5000
+    )
+
+
+async def test_helper_rollup_same_shape(loop_env, monkeypatch, tmp_path) -> None:
+    """#8986: test-helper gaps also roll up — 3 uncovered helpers → 1 issue."""
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_docker.py").write_text(
+        "class FakeDocker:\n"
+        "    def script_a(self): ...\n"
+        "    def script_b(self): ...\n"
+        "    def script_c(self): ...\n"
+    )
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "docker").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_grep(_helper):
+        return False
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_grep_scenario_for_helper", fake_grep)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    assert pr.create_issue.await_count == 1
+    assert stats["filed"] == 1
+    title = pr.create_issue.await_args.args[0]
+    body = pr.create_issue.await_args.args[1]
+    assert "FakeDocker" in title
+    assert "3 methods" in title
+    for helper in ("script_a", "script_b", "script_c"):
+        assert helper in body

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -477,7 +477,11 @@ async def test_rollup_tick_2_updates_body_when_method_gains_coverage(
     """Tick 2: previously-uncovered method now cassetted → update body, remove it."""
     cfg, state, pr, dedup = loop_env
     # State as if tick 1 already filed: rollup-issue tracked + prior uncovered set.
-    state.get_fake_coverage_rollup_issue.return_value = 4242
+    # Per-kind tracking — only adapter-surface has a tracked issue; the
+    # test-helper kind is untouched (no helpers in this fake).
+    state.get_fake_coverage_rollup_issue.side_effect = lambda k: (
+        4242 if k == "FakeGitHub:adapter-surface" else None
+    )
     state.get_fake_coverage_last_known.return_value = {
         "__uncovered__:FakeGitHub:adapter-surface": ["create_issue", "close_issue"],
         "FakeGitHub": [],
@@ -665,6 +669,113 @@ async def test_rollup_closed_by_human_refiles_cleanly(
     state.set_fake_coverage_rollup_issue.assert_called_with(
         "FakeGitHub:adapter-surface", 5000
     )
+
+
+async def test_escalation_does_not_storm_after_threshold(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Regression: escalation fires exactly once when attempts crosses
+    ``_MAX_ATTEMPTS`` (==3), not every tick at >=3.
+
+    Without this guard, an open rollup that stays uncovered would file a
+    fresh HITL escalation issue on every subsequent tick until a human
+    closed it — the original bug review caught before merge.
+    """
+    cfg, state, pr, dedup = loop_env
+    # Tracked rollup already open; counter has already crossed threshold.
+    state.get_fake_coverage_rollup_issue.return_value = 4242
+    state.get_fake_coverage_last_known.return_value = {}
+    state.inc_fake_coverage_attempts.return_value = 4  # >MAX, post-threshold tick
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def missing(self): ...\n"
+    )
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return {"Fake coverage gap: FakeGitHub adapter surface (1 method)"}
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    # Body got updated (the rollup is still open and uncovered).
+    assert pr.update_issue_body.await_count == 1
+    # And NO new escalation issue was filed this tick — the
+    # ``attempts == _MAX_ATTEMPTS`` guard only fires once at threshold.
+    assert pr.create_issue.await_count == 0
+    assert stats["escalated"] == 0
+
+
+async def test_rollup_body_updated_when_gap_fully_closes(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """Regression: when all methods become covered, the rollup body is
+    repainted to the "all covered" view BEFORE state is cleared.
+
+    Without this update, the open rollup issue retains the stale list of
+    uncovered methods — humans see "12 methods missing" on an issue where
+    every method is now cassetted.
+    """
+    cfg, state, pr, dedup = loop_env
+    # Tracked rollup #5050 is open ONLY for adapter-surface; prior tick had
+    # ``missing`` uncovered. (Per-kind tracking — test-helper has no issue.)
+    state.get_fake_coverage_rollup_issue.side_effect = lambda k: (
+        5050 if k == "FakeGitHub:adapter-surface" else None
+    )
+    state.get_fake_coverage_last_known.return_value = {
+        "FakeGitHub": ["missing"],
+        "__uncovered__:FakeGitHub:adapter-surface": ["missing"],
+    }
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n    async def missing(self): ...\n"
+    )
+    cassette_dir = tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github"
+    cassette_dir.mkdir(parents=True)
+    # Cassette now exists for the previously-missing method → fully covered.
+    (cassette_dir / "missing.yaml").write_text(
+        yaml.safe_dump({"input": {"command": "missing"}, "output": {}})
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    await loop._do_work()
+
+    # Body was updated with the "all covered" view before state cleared.
+    assert pr.update_issue_body.await_count >= 1
+    update_call = pr.update_issue_body.await_args_list[0]
+    assert update_call.args[0] == 5050
+    body = update_call.args[1]
+    # The recovered method appears (struck through) and no live uncovered.
+    assert "missing" in body
+    # State was cleared after the body update.
+    state.clear_fake_coverage_rollup_issue.assert_any_call("FakeGitHub:adapter-surface")
 
 
 async def test_helper_rollup_same_shape(loop_env, monkeypatch, tmp_path) -> None:

--- a/tests/test_state_fake_coverage.py
+++ b/tests/test_state_fake_coverage.py
@@ -20,8 +20,20 @@ def test_last_known_roundtrip(tmp_path: Path) -> None:
 
 def test_attempt_counter(tmp_path: Path) -> None:
     st = _tracker(tmp_path)
-    key = "FakeGitHub.create_issue:adapter-surface"
+    # #8986: attempt counter is now keyed by {fake}:{kind}, not {fake}.{method}:{kind}.
+    key = "FakeGitHub:adapter-surface"
     assert st.get_fake_coverage_attempts(key) == 0
     assert st.inc_fake_coverage_attempts(key) == 1
     st.clear_fake_coverage_attempts(key)
     assert st.get_fake_coverage_attempts(key) == 0
+
+
+def test_rollup_issue_tracking_roundtrip(tmp_path: Path) -> None:
+    """#8986 — rollup-issue-number state mapping survives save/load."""
+    st = _tracker(tmp_path)
+    key = "FakeGitHub:adapter-surface"
+    assert st.get_fake_coverage_rollup_issue(key) is None
+    st.set_fake_coverage_rollup_issue(key, 9123)
+    assert st.get_fake_coverage_rollup_issue(key) == 9123
+    st.clear_fake_coverage_rollup_issue(key)
+    assert st.get_fake_coverage_rollup_issue(key) is None

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -103,6 +103,7 @@ class TestInitialization:
             "auto_reverts_successful",
             "fake_coverage_attempts",
             "fake_coverage_last_known",
+            "fake_coverage_rollup_issues",
             "flake_attempts",
             "flake_counts",
             "flake_reruns_total",


### PR DESCRIPTION
## Summary

Fixes the noisy filing pattern in `FakeCoverageAuditorLoop` that produced 154 manually-closed issues on 2026-05-19. Per #8986, the loop now files **one rollup issue per `(fake_class, gap_kind)`** with the uncovered-method list in the body, and updates the body via `PRPort.update_issue_body` on subsequent ticks.

- Dedup key: `fake_coverage_auditor:{fake}:adapter-surface` (no method component).
- Attempt counter / 3-strikes escalation moves to `{fake}:{kind}` granularity.
- New state mapping `fake_coverage_rollup_issues` tracks the open rollup issue number per `(fake, kind)`.
- Closed-by-human rollup zombie guard: `_list_open_rollup_titles` lets the loop detect a stale state→issue link and re-file cleanly.

## Migration

Self-healing, no auto-prune. Old per-method dedup keys age out silently because:

1. `_reconcile_closed_escalations` only clears a key when a matching closed-escalation title is found — and the new escalation title shape (`{Fake}:{kind}`) won't match a `{Fake}.{method}:{kind}` key.
2. Old per-method attempt-counter entries in state linger but never match a current key shape — harmless and will be cleaned on the next state reset.

If lingering keys become a problem operationally, a one-time prune-pass behind a config flag can land in a follow-up. Per the issue's "ignored (preferred) or prune with an explicit one-time pass" framing, I picked **ignored** since the keys are passive.

## Test plan

- [x] **Unit: 12 uncovered methods on FakeGitHub → 1 issue** (not 12) with all 12 in body.
- [x] **Unit: tick 2 with one method recovered** → body updated via `update_issue_body`, that method rendered as strikethrough.
- [x] **Unit: tick 3 with a new uncovered method** → body updated, new method appended.
- [x] **Unit: 3-strikes escalation** triggers per `(fake, kind)` — attempt counter called with `"FakeGitHub:adapter-surface"`, not per-method.
- [x] **Unit: closed-by-human rollup** re-files cleanly (zombie state guard) — tracked number cleared, attempt counter reset, new issue filed.
- [x] **Unit: test-helper rollup** same shape — 3 uncovered helpers → 1 issue.
- [x] **State test:** `fake_coverage_rollup_issues` round-trip.
- [x] **MockWorld scenario** (`tests/scenarios/test_fake_coverage_auditor_scenario.py`) updated for the new title/body contract.
- [ ] **Sandbox e2e**: deferred to follow-up. Auditor loops don't have a sandbox harness yet — standing one up exceeds this PR's scope. The MockWorld scenario plus the unit pyramid catch the loop integration + rendering contracts.

## Docs

- Spec `docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md` §4.7 amended with the rollup contract.
- ADR-0045 update-log entry recording the shape change.

## Constraints honored

- Did **not** extract a shared rollup helper to a util module — sibling #8987 (AdrTouchpointAuditorLoop rollup) is being worked in parallel. We can DRY later if a pattern emerges.
- Did **not** touch `src/adr_touchpoint_auditor_loop.py`.
- Did **not** add a new method to `PRPort` — `update_issue_body` already existed and fit the contract (full replace, not append). Body is built fresh from live state each tick, so replace-semantics is correct.

## make quality

Full suite: **1 pre-existing failure unrelated to this PR** (`tests/test_planner.py::test_build_prompt_truncates_long_body` — prompt is 15018 bytes vs 15000 cap; verified the same failure exists on `main` before my changes by stashing locally). All 21 fake-coverage-related tests pass. All other 13,168 tests pass.

Closes #8986