### PR TITLE
feat(mockworld): FakeAgent (ADR-0047, advisor-ayw5)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T09:11:57.844118+00:00",
-  "commit_sha": "589fcdc124217ae7d70f531803126e04ef784c00",
+  "regenerated_at": "2026-05-19T15:21:51.719873+00:00",
+  "commit_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb",
   "artifacts": {
     "loops.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ports.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "labels.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "modules.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "events.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "adr_xref.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "mockworld.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "changelog.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "coverage_matrix.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "functional_areas.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ubiquitous-language.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "589fcdc124217ae7d70f531803126e04ef784c00"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `3d49c86` — chore(arch): regenerate arch docs after fake-coverage rollup (#8986) (#8986) *(2026-05-19)*
-- `1b3156c` — fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986) (#8986) *(2026-05-19)*
+- `dc49678` — fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986) (#8994) (#8994) *(2026-05-19)*
 - `ce53f28` — fix(adr_touchpoint_auditor): roll up to 1 issue per ADR (#8987) (#8993) (#8993) *(2026-05-19)*
 - `1e70cc0` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8992) (#8992) *(2026-05-19)*
 - `dbe6f17` — feat(loops): remove CodeGroomingLoop (#8984) (#8995) (#8995) *(2026-05-19)*
@@ -340,4 +339,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -60,7 +60,7 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -8,6 +8,7 @@ All Fake adapters under `src/mockworld/fakes/` (classes with ``_is_fake_adapter 
 
 | Fake | Implements | Used in scenarios |
 |---|---|---|
+| **FakeAgent** | `AgentPort` | — |
 | **FakeBeads** | `BeadsPort` | `tests/scenarios/fakes/test_fake_beads.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_bead_workflow.py` |
 | **FakeClock** | `ClockPort` | `tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/fakes/test_fake_clock.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py`<br>`tests/scenarios/test_fidelity.py` |
 | **FakeDocker** | `DockerPort` | `tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_fake_subprocess_runner.py` |
@@ -27,6 +28,7 @@ All Fake adapters under `src/mockworld/fakes/` (classes with ``_is_fake_adapter 
 
 ```mermaid
 graph LR
+    FakeAgent -.-> AgentPort
     FakeBeads -.-> BeadsPort
     tests_scenarios_fakes_test_fake_beads_py([tests/scenarios/fakes/test_fake_beads.py]) --> FakeBeads
     tests_scenarios_fakes_test_mock_world_py([tests/scenarios/fakes/test_mock_world.py]) --> FakeBeads
@@ -66,4 +68,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -33,7 +33,7 @@ graph LR
     src_arch_generators -- "11" --> src_arch
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
-    src_mockworld_fakes -- "25" --> src_mockworld
+    src_mockworld_fakes -- "26" --> src_mockworld
     src_mockworld_fakes -- "1" --> src_telemetry
     src_preflight -- "1" --> src_runners
     src_preflight -- "1" --> src_sentry
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -7,6 +7,7 @@ Hexagonal boundaries. Each `*Port` Protocol with its concrete adapter(s) and fak
 ```mermaid
 graph LR
     AgentPort --> AgentRunner
+    AgentPort -.-> FakeAgent
     BotPRPort --> OpenAutoPRBotPRPort
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
@@ -30,7 +31,7 @@ graph LR
 - Methods: `build_command`, `execute`, `verify_result`
 - Adapters:
   - `AgentRunner` (`src.agent`)
-- Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
+- Fake: `FakeAgent` (`mockworld.fakes.fake_agent`)
 
 ### BotPRPort
 
@@ -96,4 +97,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `589fcdc` on 2026-05-19 09:11 UTC. Source last changed at `589fcdc`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:21 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/src/mockworld/fakes/__init__.py
+++ b/src/mockworld/fakes/__init__.py
@@ -5,6 +5,7 @@ code (server.py, orchestrator.py) does NOT import from this package —
 only the sandbox entrypoint does.
 """
 
+from mockworld.fakes.fake_agent import FakeAgent
 from mockworld.fakes.fake_beads import FakeBeads
 from mockworld.fakes.fake_clock import FakeClock
 from mockworld.fakes.fake_docker import FakeDocker
@@ -21,6 +22,7 @@ from mockworld.fakes.fake_wiki_compiler import FakeWikiCompiler
 from mockworld.fakes.fake_workspace import FakeWorkspace
 
 __all__ = [
+    "FakeAgent",
     "FakeBeads",
     "FakeClock",
     "FakeDocker",

--- a/src/mockworld/fakes/fake_agent.py
+++ b/src/mockworld/fakes/fake_agent.py
@@ -1,0 +1,150 @@
+"""FakeAgent — satisfies AgentPort for scenario testing (ADR-0047).
+
+Provides deterministic, in-memory control over agent subprocess behaviour
+without spawning any real processes.  Designed for:
+
+- ``merge_conflict_resolver`` scenarios that inject an ``AgentPort``
+- Any future infrastructure module that depends on ``AgentPort``
+
+Seeding API
+-----------
+``script_execute(results)``
+    Queue transcript strings to return from ``execute()`` calls in order.
+    When the queue drains the last transcript is repeated (sticky-tail
+    semantics matching ``_ScriptedRunner._pop``).
+
+``script_verify(results)``
+    Queue ``LoopResult`` objects returned by ``verify_result()`` calls.
+
+``script_build_command(cmd)``
+    Override the command returned by ``build_command()``.  Defaults to
+    ``["fake-agent"]``.
+
+Observation API
+---------------
+``execute_calls``
+    List of ``(cmd, prompt, cwd, event_data)`` tuples recorded each time
+    ``execute()`` was called.
+
+``verify_calls``
+    List of ``(worktree_path, branch)`` tuples recorded by
+    ``verify_result()``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from models import LoopResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from models import TranscriptEventData
+
+
+_DEFAULT_TRANSCRIPT = "<FakeAgent: no transcript scripted>"
+_DEFAULT_COMMAND = ["fake-agent"]
+
+
+class FakeAgent:
+    """Deterministic in-memory implementation of ``AgentPort``.
+
+    Satisfies ``ports.AgentPort`` via structural subtyping — every public
+    method matches the port signature exactly so
+    ``isinstance(FakeAgent(), AgentPort)`` returns True.
+    """
+
+    _is_fake_adapter = True  # read by dashboard for MOCKWORLD banner
+
+    def __init__(self) -> None:
+        self._exec_queue: deque[str] = deque()
+        self._exec_last: str | None = None
+        self._verify_queue: deque[LoopResult] = deque()
+        self._verify_last: LoopResult | None = None
+        self._command: list[str] = list(_DEFAULT_COMMAND)
+        # Observation lists — assertions in scenario tests
+        self.execute_calls: list[tuple[list[str], str, Path, Any]] = []
+        self.verify_calls: list[tuple[Path, str]] = []
+
+    # ------------------------------------------------------------------
+    # Seeding / scripting API
+    # ------------------------------------------------------------------
+
+    def script_execute(self, results: list[str]) -> None:
+        """Queue transcript strings returned by successive ``execute()`` calls.
+
+        When the queue drains, the last value is repeated.
+        """
+        self._exec_queue = deque(results)
+        self._exec_last = None
+
+    def script_verify(self, results: list[LoopResult]) -> None:
+        """Queue ``LoopResult`` objects returned by successive ``verify_result()`` calls.
+
+        When the queue drains, the last value is repeated (defaults to
+        ``LoopResult(passed=True, summary="OK")`` if never scripted).
+        """
+        self._verify_queue = deque(results)
+        self._verify_last = None
+
+    def script_build_command(self, cmd: list[str]) -> None:
+        """Override the list returned by ``build_command()``."""
+        self._command = list(cmd)
+
+    # ------------------------------------------------------------------
+    # AgentPort interface
+    # ------------------------------------------------------------------
+
+    def build_command(self, _worktree_path: Path | None = None) -> list[str]:
+        """Return the scripted command (default: ``["fake-agent"]``)."""
+        return list(self._command)
+
+    async def execute(
+        self,
+        cmd: list[str],
+        prompt: str,
+        cwd: Path,
+        event_data: TranscriptEventData,
+        *,
+        on_output: Callable[[str], bool] | None = None,
+        telemetry_stats: Mapping[str, object] | None = None,
+    ) -> str:
+        """Return the next scripted transcript and record the call.
+
+        When ``on_output`` is provided it is called once with the transcript
+        text (mirrors the real ``AgentRunner.execute`` streaming behaviour).
+        """
+        _ = (telemetry_stats,)
+        self.execute_calls.append((list(cmd), prompt, cwd, event_data))
+
+        if self._exec_queue:
+            transcript = self._exec_queue.popleft()
+            self._exec_last = transcript
+        elif self._exec_last is not None:
+            transcript = self._exec_last
+        else:
+            transcript = _DEFAULT_TRANSCRIPT
+
+        if on_output is not None:
+            on_output(transcript)
+
+        return transcript
+
+    async def verify_result(self, worktree_path: Path, branch: str) -> LoopResult:
+        """Return the next scripted ``LoopResult`` and record the call.
+
+        Defaults to ``LoopResult(passed=True, summary="OK")`` when no
+        result has been scripted.
+        """
+        self.verify_calls.append((worktree_path, branch))
+
+        if self._verify_queue:
+            result = self._verify_queue.popleft()
+            self._verify_last = result
+            return result
+        if self._verify_last is not None:
+            return self._verify_last
+        return LoopResult(passed=True, summary="OK")

--- a/tests/test_fake_agent.py
+++ b/tests/test_fake_agent.py
@@ -1,0 +1,231 @@
+"""Tests for FakeAgent — AgentPort conformance + behavioural assertions.
+
+Covers:
+- Protocol conformance (isinstance against AgentPort)
+- Signature parity against the real AgentRunner
+- Default behaviours (no scripting)
+- Scripted execute / verify_result sequences (sticky-tail semantics)
+- Observation lists (execute_calls, verify_calls)
+- build_command override
+- on_output callback forwarding
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from mockworld.fakes.fake_agent import FakeAgent
+from models import LoopResult
+from ports import AgentPort
+
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentConformance:
+    """FakeAgent must satisfy AgentPort via isinstance."""
+
+    def test_isinstance_agent_port(self) -> None:
+        assert isinstance(FakeAgent(), AgentPort), (
+            "FakeAgent does not satisfy AgentPort. "
+            "Ensure all three methods (build_command, execute, verify_result) "
+            "are present with the correct signatures."
+        )
+
+    def test_is_fake_adapter_marker(self) -> None:
+        assert FakeAgent._is_fake_adapter is True
+
+
+# ---------------------------------------------------------------------------
+# Signature parity — FakeAgent must match AgentPort exactly
+# ---------------------------------------------------------------------------
+
+
+def _named_params(cls: type, method: str) -> dict[str, inspect.Parameter]:
+    sig = inspect.signature(getattr(cls, method))
+    return {
+        k: v
+        for k, v in sig.parameters.items()
+        if k != "self"
+        and v.kind
+        not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+
+
+class TestFakeAgentSignatures:
+    """FakeAgent method signatures must be compatible with AgentPort's."""
+
+    @pytest.mark.parametrize("method", ["build_command", "execute", "verify_result"])
+    def test_port_params_present_on_fake(self, method: str) -> None:
+        port_params = _named_params(AgentPort, method)
+        fake_params = _named_params(FakeAgent, method)
+        # All named port params must appear on the fake (no **kwargs absorb here)
+        missing = set(port_params) - set(fake_params)
+        assert not missing, (
+            f"FakeAgent.{method} is missing params declared on AgentPort: {sorted(missing)}"
+        )
+
+    @pytest.mark.parametrize("method", ["build_command", "execute", "verify_result"])
+    def test_required_vs_optional_matches(self, method: str) -> None:
+        port_params = _named_params(AgentPort, method)
+        fake_params = _named_params(FakeAgent, method)
+        for name in set(port_params) & set(fake_params):
+            port_req = port_params[name].default is inspect.Parameter.empty
+            fake_req = fake_params[name].default is inspect.Parameter.empty
+            assert port_req == fake_req, (
+                f"FakeAgent.{method} param '{name}': "
+                f"Port required={port_req}, Fake required={fake_req}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Default behaviour (no scripting)
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentDefaults:
+    def test_build_command_default(self) -> None:
+        agent = FakeAgent()
+        cmd = agent.build_command()
+        assert cmd == ["fake-agent"]
+
+    def test_build_command_with_path(self) -> None:
+        agent = FakeAgent()
+        cmd = agent.build_command(Path("/tmp/wt"))
+        assert cmd == ["fake-agent"]
+
+    @pytest.mark.asyncio
+    async def test_execute_returns_default_transcript(self) -> None:
+        agent = FakeAgent()
+        transcript = await agent.execute(
+            cmd=["fake-agent"],
+            prompt="do the thing",
+            cwd=Path("/tmp/wt"),
+            event_data={"issue": 1},
+        )
+        assert isinstance(transcript, str)
+        assert len(transcript) > 0
+
+    @pytest.mark.asyncio
+    async def test_verify_result_default_passes(self) -> None:
+        agent = FakeAgent()
+        result = await agent.verify_result(Path("/tmp/wt"), "feat/my-branch")
+        assert isinstance(result, LoopResult)
+        assert result.passed is True
+
+    def test_execute_calls_empty_initially(self) -> None:
+        assert FakeAgent().execute_calls == []
+
+    def test_verify_calls_empty_initially(self) -> None:
+        assert FakeAgent().verify_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Scripted execute — queue + sticky-tail
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentScriptedExecute:
+    @pytest.mark.asyncio
+    async def test_scripted_transcript_returned(self) -> None:
+        agent = FakeAgent()
+        agent.script_execute(["transcript A", "transcript B"])
+        assert await agent.execute([], "p", Path("/"), {}) == "transcript A"
+        assert await agent.execute([], "p", Path("/"), {}) == "transcript B"
+
+    @pytest.mark.asyncio
+    async def test_sticky_tail_after_queue_drains(self) -> None:
+        agent = FakeAgent()
+        agent.script_execute(["last transcript"])
+        await agent.execute([], "p", Path("/"), {})  # pops "last transcript"
+        # Queue is empty — sticky tail should repeat
+        result = await agent.execute([], "p", Path("/"), {})
+        assert result == "last transcript"
+
+    @pytest.mark.asyncio
+    async def test_execute_records_call(self) -> None:
+        agent = FakeAgent()
+        cmd = ["fake-agent", "--flag"]
+        prompt = "implement #42"
+        cwd = Path("/tmp/issue-42")
+        event_data = {"issue": 42}
+        await agent.execute(cmd, prompt, cwd, event_data)
+        assert len(agent.execute_calls) == 1
+        recorded_cmd, recorded_prompt, recorded_cwd, recorded_ed = agent.execute_calls[0]
+        assert recorded_cmd == cmd
+        assert recorded_prompt == prompt
+        assert recorded_cwd == cwd
+        assert recorded_ed == event_data
+
+    @pytest.mark.asyncio
+    async def test_on_output_callback_invoked(self) -> None:
+        agent = FakeAgent()
+        agent.script_execute(["hello from fake"])
+        received: list[str] = []
+        await agent.execute([], "", Path("/"), {}, on_output=lambda t: received.append(t) or False)
+        assert received == ["hello from fake"]
+
+
+# ---------------------------------------------------------------------------
+# Scripted verify_result — queue + sticky-tail
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentScriptedVerify:
+    @pytest.mark.asyncio
+    async def test_scripted_results_returned_in_order(self) -> None:
+        agent = FakeAgent()
+        agent.script_verify([
+            LoopResult(passed=False, summary="quality failed", attempts=1),
+            LoopResult(passed=True, summary="OK", attempts=2),
+        ])
+        r1 = await agent.verify_result(Path("/tmp/wt"), "feat/branch")
+        assert r1.passed is False
+        assert r1.summary == "quality failed"
+
+        r2 = await agent.verify_result(Path("/tmp/wt"), "feat/branch")
+        assert r2.passed is True
+
+    @pytest.mark.asyncio
+    async def test_sticky_tail_verify(self) -> None:
+        agent = FakeAgent()
+        scripted = LoopResult(passed=False, summary="persistent failure")
+        agent.script_verify([scripted])
+        await agent.verify_result(Path("/"), "b")
+        second = await agent.verify_result(Path("/"), "b")
+        assert second.passed is False
+        assert second.summary == "persistent failure"
+
+    @pytest.mark.asyncio
+    async def test_verify_records_call(self) -> None:
+        agent = FakeAgent()
+        wt = Path("/tmp/wt-99")
+        branch = "feat/fix-conflict-99"
+        await agent.verify_result(wt, branch)
+        assert agent.verify_calls == [(wt, branch)]
+
+
+# ---------------------------------------------------------------------------
+# build_command override
+# ---------------------------------------------------------------------------
+
+
+class TestFakeAgentBuildCommandOverride:
+    def test_script_build_command(self) -> None:
+        agent = FakeAgent()
+        agent.script_build_command(["claude", "--profile", "prod"])
+        assert agent.build_command() == ["claude", "--profile", "prod"]
+
+    def test_build_command_does_not_mutate_internal_state(self) -> None:
+        agent = FakeAgent()
+        cmd = agent.build_command()
+        cmd.append("--extra")
+        assert agent.build_command() == ["fake-agent"]

--- a/tests/test_mockworld_fakes_conformance.py
+++ b/tests/test_mockworld_fakes_conformance.py
@@ -28,14 +28,17 @@ from typing import Any
 
 import pytest
 
+from mockworld.fakes.fake_agent import FakeAgent
 from mockworld.fakes.fake_github import FakeGitHub
 from mockworld.fakes.fake_workspace import FakeWorkspace
+from ports import AgentPort
 from tests.scenarios.ports import PRPort, WorkspacePort
 
 # Hand-maintained Port↔Fake pair list. Add new pairs as Fakes are
 # introduced. (Auto-discovery via convention ``Fake<PortStem>`` is YAGNI
 # at this scale; ~3 pairs total.)
 _PORT_FAKE_PAIRS: list[tuple[type, type]] = [
+    (AgentPort, FakeAgent),
     (PRPort, FakeGitHub),
     (WorkspacePort, FakeWorkspace),
     # IssueStorePort: no Fake; covered separately by tests/test_ports.py


### PR DESCRIPTION
## Summary

- ADR-0047 mandates a Fake for every Port. `AgentPort` was one of 5 fakeless ports identified by slice #5.2 audit.
- Adds `FakeAgent` under `src/mockworld/fakes/` with scripted `execute`/`verify_result` queues (sticky-tail semantics), observation lists (`execute_calls`, `verify_calls`), and `build_command` override.
- Exports added to `__init__.py`; `AgentPort/FakeAgent` pair added to `test_mockworld_fakes_conformance.py`; `make arch-regen` updates `ports.md` (warning cleared) and `mockworld.md`.

## Test plan
- [x] 23 new tests in `tests/test_fake_agent.py` — Protocol conformance, signature parity, default behaviour, scripted sequences with sticky-tail, observation lists, `on_output` callback, `build_command` override
- [x] `test_mockworld_fakes_conformance.py` — `AgentPort/FakeAgent` pair passes the Port↔Fake signature compatibility check
- [x] `tests/test_ports.py` — all 165 existing port conformance tests still pass
- [x] `make arch-regen` picks up `FakeAgent` in `ports.md` and `mockworld.md` (no more ⚠️ for `AgentPort`)

## Closes
advisor-ayw5

🤖 Generated with [Claude Code](https://claude.com/claude-code)