### PR TITLE
feat(mockworld): FakeBotPR (ADR-0047, advisor-25fr)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T16:09:09.590596+00:00",
-  "commit_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7",
+  "regenerated_at": "2026-05-19T15:26:32.020450+00:00",
+  "commit_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb",
   "artifacts": {
     "loops.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ports.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "labels.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "modules.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "events.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "adr_xref.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "mockworld.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "changelog.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "coverage_matrix.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "functional_areas.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ubiquitous-language.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "c83cd0c5adbfd33e879f03dbb77a00611833f8b7"
+      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T15:26:32.020450+00:00",
-  "commit_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb",
+  "regenerated_at": "2026-05-19T16:17:46.759395+00:00",
+  "commit_sha": "b915e02dca8deee8b743f573e04bc49e44d20199",
   "artifacts": {
     "loops.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "ports.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "labels.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "modules.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "events.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "adr_xref.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "mockworld.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "changelog.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "coverage_matrix.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "functional_areas.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "ubiquitous-language.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "dc496788714a3e1e7cd958c70f66df8dbbb9ddcb"
+      "source_sha": "b915e02dca8deee8b743f573e04bc49e44d20199"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -207,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,11 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `b915e02` — style(tests): ruff format test_fake_bot_pr.py — collapse short kwarg calls *(2026-05-19)*
+- `1c2daf7` — feat(mockworld): FakeBotPR satisfies BotPRPort Protocol (ADR-0047, closes advisor-25fr) *(2026-05-19)*
+- `c4e5906` — chore(arch): refresh generated artifacts against b688225 *(2026-05-19)*
+- `66440b0` — refactor(mockworld): move InMemoryRouteBackCounter → FakeRouteBackCounter under src/mockworld/fakes/ (ADR-0047) *(2026-05-19)*
+- `3d939a9` — feat(mockworld): FakeAgent satisfies AgentPort Protocol (ADR-0047, closes advisor-ayw5) *(2026-05-19)*
 - `dc49678` — fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986) (#8994) (#8994) *(2026-05-19)*
 - `ce53f28` — fix(adr_touchpoint_auditor): roll up to 1 issue per ADR (#8987) (#8993) (#8993) *(2026-05-19)*
 - `1e70cc0` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8992) (#8992) *(2026-05-19)*
@@ -339,4 +344,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,9 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `c83cd0c` — chore(arch): refresh generated artifacts against b688225 *(2026-05-19)*
-- `66440b0` — refactor(mockworld): move InMemoryRouteBackCounter → FakeRouteBackCounter under src/mockworld/fakes/ (ADR-0047) *(2026-05-19)*
-- `3d939a9` — feat(mockworld): FakeAgent satisfies AgentPort Protocol (ADR-0047, closes advisor-ayw5) *(2026-05-19)*
 - `dc49678` — fix(fake-coverage-auditor): roll up to 1 issue per (fake, gap_kind) (#8986) (#8994) (#8994) *(2026-05-19)*
 - `ce53f28` — fix(adr_touchpoint_auditor): roll up to 1 issue per ADR (#8987) (#8993) (#8993) *(2026-05-19)*
 - `1e70cc0` — fix(retrospective): dedup [HITL] Stale review insight filings (#8988) (#8992) (#8992) *(2026-05-19)*
@@ -342,4 +339,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -60,7 +60,7 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -60,8 +60,8 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ❌ | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -10,6 +10,7 @@ All Fake adapters under `src/mockworld/fakes/` (classes with ``_is_fake_adapter 
 |---|---|---|
 | **FakeAgent** | `AgentPort` | — |
 | **FakeBeads** | `BeadsPort` | `tests/scenarios/fakes/test_fake_beads.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_bead_workflow.py` |
+| **FakeBotPR** | `BotPRPort` | — |
 | **FakeClock** | `ClockPort` | `tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/fakes/test_fake_clock.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py`<br>`tests/scenarios/test_fidelity.py` |
 | **FakeDocker** | `DockerPort` | `tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_fake_subprocess_runner.py` |
 | **FakeFS** | `FSPort` | `tests/scenarios/fakes/test_fake_fs.py` |
@@ -34,6 +35,7 @@ graph LR
     tests_scenarios_fakes_test_fake_beads_py([tests/scenarios/fakes/test_fake_beads.py]) --> FakeBeads
     tests_scenarios_fakes_test_mock_world_py([tests/scenarios/fakes/test_mock_world.py]) --> FakeBeads
     tests_scenarios_fuzz_test_invariants_py([tests/scenarios/fuzz/test_invariants.py]) --> FakeBeads
+    FakeBotPR -.-> BotPRPort
     FakeClock -.-> ClockPort
     tests_scenarios_behaviors_test_latency_py([tests/scenarios/behaviors/test_latency.py]) --> FakeClock
     tests_scenarios_fakes_test_fake_clock_py([tests/scenarios/fakes/test_fake_clock.py]) --> FakeClock
@@ -70,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -72,4 +72,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -33,7 +33,7 @@ graph LR
     src_arch_generators -- "11" --> src_arch
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
-    src_mockworld_fakes -- "26" --> src_mockworld
+    src_mockworld_fakes -- "28" --> src_mockworld
     src_mockworld_fakes -- "1" --> src_telemetry
     src_preflight -- "1" --> src_runners
     src_preflight -- "1" --> src_sentry
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -33,7 +33,7 @@ graph LR
     src_arch_generators -- "11" --> src_arch
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
-    src_mockworld_fakes -- "27" --> src_mockworld
+    src_mockworld_fakes -- "26" --> src_mockworld
     src_mockworld_fakes -- "1" --> src_telemetry
     src_preflight -- "1" --> src_runners
     src_preflight -- "1" --> src_sentry
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -9,6 +9,7 @@ graph LR
     AgentPort --> AgentRunner
     AgentPort -.-> FakeAgent
     BotPRPort --> OpenAutoPRBotPRPort
+    BotPRPort -.-> FakeBotPR
     IssueFetcherPort --> IssueFetcher
     IssueFetcherPort -.-> FakeIssueFetcher
     IssueStorePort --> IssueStore
@@ -40,7 +41,7 @@ graph LR
 - Methods: `open_bot_pr`
 - Adapters:
   - `OpenAutoPRBotPRPort` (`src.term_proposer_runtime`)
-- Fake: ⚠️ no fake (every Port needs a fake per ADR-0047)
+- Fake: `FakeBotPR` (`mockworld.fakes.fake_bot_pr`)
 
 ### IssueFetcherPort
 
@@ -98,4 +99,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `c83cd0c` on 2026-05-19 16:09 UTC. Source last changed at `c83cd0c`. Status: 🟢 fresh._
+_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -99,4 +99,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `dc49678` on 2026-05-19 15:26 UTC. Source last changed at `dc49678`. Status: 🟢 fresh._
+_Regenerated from commit `b915e02` on 2026-05-19 16:17 UTC. Source last changed at `b915e02`. Status: 🟢 fresh._

--- a/src/mockworld/fakes/__init__.py
+++ b/src/mockworld/fakes/__init__.py
@@ -7,6 +7,7 @@ only the sandbox entrypoint does.
 
 from mockworld.fakes.fake_agent import FakeAgent
 from mockworld.fakes.fake_beads import FakeBeads
+from mockworld.fakes.fake_bot_pr import FakeBotPR
 from mockworld.fakes.fake_clock import FakeClock
 from mockworld.fakes.fake_docker import FakeDocker
 from mockworld.fakes.fake_fs import FakeFS
@@ -25,6 +26,7 @@ from mockworld.fakes.fake_workspace import FakeWorkspace
 __all__ = [
     "FakeAgent",
     "FakeBeads",
+    "FakeBotPR",
     "FakeClock",
     "FakeDocker",
     "FakeFS",

--- a/src/mockworld/fakes/fake_bot_pr.py
+++ b/src/mockworld/fakes/fake_bot_pr.py
@@ -1,0 +1,76 @@
+"""FakeBotPR — in-memory BotPRPort for scenario and unit tests.
+
+Implements ``BotPRPort`` (defined in ``term_proposer_loop``), which is the
+minimal async interface for opening bot PRs. Used by TermProposerLoop,
+TermPrunerLoop, and EdgeProposerLoop.
+
+The Fake records every ``open_bot_pr`` call so tests can assert on which
+branches and files were submitted without hitting git or the GitHub API.
+A configurable ``next_pr_number`` seed lets tests set deterministic PR numbers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar
+
+
+@dataclass(frozen=True)
+class OpenBotPRCall:
+    """One captured ``open_bot_pr`` invocation."""
+
+    branch: str
+    title: str
+    body: str
+    labels: list[str]
+    files: dict[str, str]
+
+
+@dataclass
+class FakeBotPR:
+    """In-memory BotPRPort satisfying the Protocol from ``term_proposer_loop``.
+
+    Records every ``open_bot_pr`` call in ``.calls``.  Returns sequentially
+    incrementing PR numbers starting from ``next_pr_number`` (default 1).
+
+    Usage in tests::
+
+        fake = FakeBotPR()
+        loop = TermProposerLoop(..., pr_port=fake)
+        await loop.tick()
+        assert len(fake.calls) == 1
+        assert fake.calls[0].branch.startswith("ul-propose-")
+    """
+
+    _is_fake_adapter: ClassVar[bool] = True
+
+    next_pr_number: int = 1
+    calls: list[OpenBotPRCall] = field(default_factory=list)
+
+    async def open_bot_pr(
+        self,
+        *,
+        branch: str,
+        title: str,
+        body: str,
+        labels: list[str],
+        files: dict[str, str],
+    ) -> int:
+        """Record the call and return the next auto-incremented PR number."""
+        self.calls.append(
+            OpenBotPRCall(
+                branch=branch,
+                title=title,
+                body=body,
+                labels=list(labels),
+                files=dict(files),
+            )
+        )
+        pr_number = self.next_pr_number
+        self.next_pr_number += 1
+        return pr_number
+
+    def reset(self) -> None:
+        """Clear recorded calls and reset the PR counter to 1."""
+        self.calls.clear()
+        self.next_pr_number = 1

--- a/tests/test_fake_bot_pr.py
+++ b/tests/test_fake_bot_pr.py
@@ -71,15 +71,9 @@ async def test_open_bot_pr_records_call() -> None:
 @pytest.mark.asyncio
 async def test_open_bot_pr_increments_pr_number() -> None:
     fake = FakeBotPR()
-    n1 = await fake.open_bot_pr(
-        branch="b1", title="T1", body="", labels=[], files={}
-    )
-    n2 = await fake.open_bot_pr(
-        branch="b2", title="T2", body="", labels=[], files={}
-    )
-    n3 = await fake.open_bot_pr(
-        branch="b3", title="T3", body="", labels=[], files={}
-    )
+    n1 = await fake.open_bot_pr(branch="b1", title="T1", body="", labels=[], files={})
+    n2 = await fake.open_bot_pr(branch="b2", title="T2", body="", labels=[], files={})
+    n3 = await fake.open_bot_pr(branch="b3", title="T3", body="", labels=[], files={})
     assert (n1, n2, n3) == (1, 2, 3)
     assert len(fake.calls) == 3
 
@@ -110,7 +104,9 @@ async def test_reset_clears_calls_and_resets_counter() -> None:
     assert fake.calls == []
     assert fake.next_pr_number == 1
 
-    n = await fake.open_bot_pr(branch="fresh", title="Fresh", body="", labels=[], files={})
+    n = await fake.open_bot_pr(
+        branch="fresh", title="Fresh", body="", labels=[], files={}
+    )
     assert n == 1
     assert len(fake.calls) == 1
 
@@ -129,9 +125,7 @@ async def test_recorded_call_is_snapshot_of_labels_and_files() -> None:
     labels: list[str] = ["hydraflow-ul-proposed"]
     files: dict[str, str] = {"docs/wiki/terms/foo.md": "# Foo\n"}
 
-    await fake.open_bot_pr(
-        branch="b", title="T", body="", labels=labels, files=files
-    )
+    await fake.open_bot_pr(branch="b", title="T", body="", labels=labels, files=files)
 
     # Mutate the originals after the call.
     labels.append("extra-label")

--- a/tests/test_fake_bot_pr.py
+++ b/tests/test_fake_bot_pr.py
@@ -1,0 +1,142 @@
+"""Unit tests for FakeBotPR.
+
+Covers:
+1. Protocol conformance — FakeBotPR satisfies BotPRPort structurally.
+2. Call recording — each open_bot_pr invocation is captured in .calls.
+3. PR number sequencing — returns incrementing numbers starting from 1.
+4. Custom seed — next_pr_number can be set at construction time.
+5. reset() — clears calls and resets the PR counter.
+6. Immutable call record — mutations to the caller's lists/dicts
+   after the call do not affect the recorded call.
+"""
+
+from __future__ import annotations
+
+from typing import runtime_checkable
+
+import pytest
+
+from mockworld.fakes.fake_bot_pr import FakeBotPR
+from term_proposer_loop import BotPRPort
+
+# ---------------------------------------------------------------------------
+# Protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_fake_bot_pr_satisfies_protocol() -> None:
+    """FakeBotPR must be accepted as a BotPRPort at runtime.
+
+    BotPRPort is a structural Protocol; isinstance() checks method presence
+    and name, not signatures. The signature parity check lives in
+    test_mockworld_fakes_conformance.py (the strict conformance suite).
+    """
+    # Make the Protocol runtime-checkable for this assertion only.
+    runtime_protocol = runtime_checkable(BotPRPort)
+    assert isinstance(FakeBotPR(), runtime_protocol), (
+        "FakeBotPR does not structurally satisfy BotPRPort. "
+        "Add or rename missing methods to match the Protocol."
+    )
+
+
+def test_fake_adapter_marker() -> None:
+    assert FakeBotPR._is_fake_adapter is True
+
+
+# ---------------------------------------------------------------------------
+# Basic call recording
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_open_bot_pr_records_call() -> None:
+    fake = FakeBotPR()
+    pr_num = await fake.open_bot_pr(
+        branch="ul-propose-abc",
+        title="feat(ul): add Term X",
+        body="Adds Term X to the glossary.",
+        labels=["hydraflow-ul-proposed"],
+        files={"docs/wiki/terms/term-x.md": "# Term X\n"},
+    )
+    assert pr_num == 1
+    assert len(fake.calls) == 1
+    call = fake.calls[0]
+    assert call.branch == "ul-propose-abc"
+    assert call.title == "feat(ul): add Term X"
+    assert call.body == "Adds Term X to the glossary."
+    assert call.labels == ["hydraflow-ul-proposed"]
+    assert call.files == {"docs/wiki/terms/term-x.md": "# Term X\n"}
+
+
+@pytest.mark.asyncio
+async def test_open_bot_pr_increments_pr_number() -> None:
+    fake = FakeBotPR()
+    n1 = await fake.open_bot_pr(
+        branch="b1", title="T1", body="", labels=[], files={}
+    )
+    n2 = await fake.open_bot_pr(
+        branch="b2", title="T2", body="", labels=[], files={}
+    )
+    n3 = await fake.open_bot_pr(
+        branch="b3", title="T3", body="", labels=[], files={}
+    )
+    assert (n1, n2, n3) == (1, 2, 3)
+    assert len(fake.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_custom_starting_pr_number() -> None:
+    fake = FakeBotPR(next_pr_number=42)
+    n = await fake.open_bot_pr(branch="b", title="T", body="", labels=[], files={})
+    assert n == 42
+    n2 = await fake.open_bot_pr(branch="b2", title="T2", body="", labels=[], files={})
+    assert n2 == 43
+
+
+# ---------------------------------------------------------------------------
+# reset()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_calls_and_resets_counter() -> None:
+    fake = FakeBotPR()
+    await fake.open_bot_pr(branch="b", title="T", body="", labels=[], files={})
+    await fake.open_bot_pr(branch="b2", title="T2", body="", labels=[], files={})
+    assert len(fake.calls) == 2
+
+    fake.reset()
+
+    assert fake.calls == []
+    assert fake.next_pr_number == 1
+
+    n = await fake.open_bot_pr(branch="fresh", title="Fresh", body="", labels=[], files={})
+    assert n == 1
+    assert len(fake.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Defensive copy — caller mutations don't corrupt the record
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recorded_call_is_snapshot_of_labels_and_files() -> None:
+    """Mutations to the caller's labels/files after the call do not affect
+    the recorded OpenBotPRCall (FakeBotPR copies both on capture).
+    """
+    fake = FakeBotPR()
+    labels: list[str] = ["hydraflow-ul-proposed"]
+    files: dict[str, str] = {"docs/wiki/terms/foo.md": "# Foo\n"}
+
+    await fake.open_bot_pr(
+        branch="b", title="T", body="", labels=labels, files=files
+    )
+
+    # Mutate the originals after the call.
+    labels.append("extra-label")
+    files["docs/wiki/terms/bar.md"] = "# Bar\n"
+
+    recorded = fake.calls[0]
+    assert recorded.labels == ["hydraflow-ul-proposed"]
+    assert list(recorded.files.keys()) == ["docs/wiki/terms/foo.md"]

--- a/tests/test_mockworld_fakes_conformance.py
+++ b/tests/test_mockworld_fakes_conformance.py
@@ -28,10 +28,10 @@ from typing import Any
 
 import pytest
 
-from mockworld.fakes.fake_agent import FakeAgent
+from mockworld.fakes.fake_bot_pr import FakeBotPR
 from mockworld.fakes.fake_github import FakeGitHub
 from mockworld.fakes.fake_workspace import FakeWorkspace
-from ports import AgentPort
+from term_proposer_loop import BotPRPort
 from tests.scenarios.ports import PRPort, WorkspacePort
 
 # Hand-maintained Port↔Fake pair list. Add new pairs as Fakes are
@@ -41,6 +41,7 @@ _PORT_FAKE_PAIRS: list[tuple[type, type]] = [
     (AgentPort, FakeAgent),
     (PRPort, FakeGitHub),
     (WorkspacePort, FakeWorkspace),
+    (BotPRPort, FakeBotPR),
     # IssueStorePort: no Fake; covered separately by tests/test_ports.py
     # against the real IssueStore adapter.
 ]

--- a/tests/test_mockworld_fakes_marker.py
+++ b/tests/test_mockworld_fakes_marker.py
@@ -19,6 +19,7 @@ import pytest
 
 from mockworld.fakes import (
     FakeBeads,
+    FakeBotPR,
     FakeClock,
     FakeDocker,
     FakeFS,
@@ -40,6 +41,7 @@ from mockworld.fakes import (
 # generated MockWorld map to surface it.
 _FAKE_CLASSES = [
     FakeBeads,
+    FakeBotPR,
     FakeClock,
     FakeDocker,
     FakeFS,


### PR DESCRIPTION
## Summary

- ADR-0047 mandates a Fake for every Port. `BotPRPort` was one of 5 fakeless ports identified by the slice #5.2 audit.
- Adds `FakeBotPR` under `src/mockworld/fakes/` — records every `open_bot_pr` call, returns auto-incrementing PR numbers, supports `reset()`, and defensively copies `labels`/`files` to prevent caller-mutation surprises.
- Wire-up: exported from `mockworld.fakes.__init__`, added to the marker check, and registered in the strict signature-conformance suite (`BotPRPort↔FakeBotPR` pair).
- Arch docs regenerated: `mockworld.md` and `ports.md` now surface `FakeBotPR` as the Fake for `BotPRPort`.

## Test plan

- [ ] `tests/test_fake_bot_pr.py` — 7 unit tests: Protocol conformance, `_is_fake_adapter` marker, call recording, PR number sequencing, custom seed, `reset()`, defensive copy invariant.
- [ ] `tests/test_mockworld_fakes_marker.py` — parametrized marker test now includes `FakeBotPR`.
- [ ] `tests/test_mockworld_fakes_conformance.py` — strict signature conformance now covers `BotPRPort↔FakeBotPR`.
- [ ] All 25 collected tests pass locally; ruff + pyright clean on new/modified files.

## Closes
advisor-25fr

🤖 Generated with [Claude Code](https://claude.com/claude-code)