### PR TITLE
fix(mockworld): export FakeObservability from package __init__

### DIFF
--- a/src/mockworld/fakes/__init__.py
+++ b/src/mockworld/fakes/__init__.py
@@ -18,7 +18,7 @@ from mockworld.fakes.fake_issue_fetcher import FakeIssueFetcher
 from mockworld.fakes.fake_issue_store import FakeIssueStore
 from mockworld.fakes.fake_llm import FakeLLM
 from mockworld.fakes.fake_review_insight_store import FakeReviewInsightStore
-from mockworld.fakes.fake_sentry import FakeSentry
+from mockworld.fakes.fake_sentry import FakeObservability, FakeSentry
 from mockworld.fakes.fake_subprocess_runner import FakeSubprocessRunner
 from mockworld.fakes.fake_wiki_compiler import FakeWikiCompiler
 from mockworld.fakes.fake_workspace import FakeWorkspace
@@ -36,6 +36,7 @@ __all__ = [
     "FakeIssueFetcher",
     "FakeIssueStore",
     "FakeLLM",
+    "FakeObservability",
     "FakeReviewInsightStore",
     "FakeSentry",
     "FakeSubprocessRunner",


### PR DESCRIPTION
## Summary

staging Tests step fails on ImportError: cannot import name FakeObservability from mockworld.fakes. PR #9001 added the FakeObservability=FakeSentry alias in fake_sentry.py but the package __init__.py export was missed. This adds the export.

🤖 Generated with Claude Code