### PR TITLE
test(trust-fleet-sanity): breach-path coverage for repair/tick-error/cost-spike

### DIFF
--- a/tests/scenarios/test_trust_fleet_sanity_scenario.py
+++ b/tests/scenarios/test_trust_fleet_sanity_scenario.py
@@ -1,6 +1,6 @@
 """MockWorld scenario for TrustFleetSanityLoop (spec §12.1).
 
-Two scenarios:
+Two existing scenarios (class TestTrustFleetSanityScenario):
 
 * ``test_no_anomaly_no_file`` — all nine watched loops reporting fresh
   heartbeats with zero issue production and zero errors. The sanity loop
@@ -9,6 +9,13 @@ Two scenarios:
   is old enough that the staleness detector fires. The loop should file
   one ``hitl-escalation`` + ``trust-loop-anomaly`` issue with labels
   that include the breached detector kind.
+
+New breach-path scenario (class TestTrustFleetSanityBreachScenario):
+
+* ``test_issues_per_hour_breach_files_escalation`` — rc_budget filing
+  many issues within the hour window. Exercises the issues_per_hour
+  breach path end-to-end through MockWorld without requiring
+  BGWorkerManager (staleness skipped; metrics seeded via EventBus stub).
 
 The loop's external surface (``_collect_window_metrics`` via the
 EventBus, ``_load_cost_reader``, ``_reconcile_closed_escalations``) is
@@ -22,6 +29,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from events import EventBus, EventType, HydraFlowEvent
 from tests.scenarios.fakes.mock_world import MockWorld
 from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
 
@@ -126,3 +134,133 @@ class TestTrustFleetSanityScenario:
         labels = fake_pr.create_issue.await_args.args[2]
         assert "hitl-escalation" in labels
         assert "trust-loop-anomaly" in labels
+
+
+# ---------------------------------------------------------------------------
+# Breach-path scenario — issues_per_hour (advisor-t27j)
+# ---------------------------------------------------------------------------
+
+
+class TestTrustFleetSanityBreachScenario:
+    """§12.1 — breach-path MockWorld scenarios (advisor-t27j).
+
+    These tests do NOT seed a BGWorkerManager, so staleness detection is
+    disabled (non-trust workers skip the staleness check). Breach signals
+    come from event-bus events seeded into the loop's EventBus.
+    """
+
+    async def test_issues_per_hour_breach_files_escalation(self, tmp_path) -> None:
+        """rc_budget files 20 issues in the last hour -> issues_per_hour escalation.
+
+        Default threshold is 10. This exercises the full breach path through
+        MockWorld: event collection, threshold evaluation, issue creation, and
+        dedup set update.
+        """
+        world = MockWorld(tmp_path)
+        fake_pr = AsyncMock()
+        fake_pr.create_issue = AsyncMock(return_value=9001)
+
+        now = _dt.datetime.now(_dt.UTC)
+
+        # Build an EventBus pre-loaded with a status event reporting 20 filed
+        # issues in the last hour for rc_budget. The loop reads from this bus
+        # via _collect_window_metrics -> load_events_since.
+        seeded_bus = EventBus()
+        ts_recent = (now - _dt.timedelta(seconds=300)).isoformat()
+        breach_event = HydraFlowEvent(
+            type=EventType.BACKGROUND_WORKER_STATUS,
+            timestamp=ts_recent,
+            data={
+                "worker": "rc_budget",
+                "status": "ok",
+                "details": {"filed": 20, "repaired": 0, "failed": 0},
+            },
+        )
+
+        async def _preloaded_load(since: _dt.datetime) -> list[HydraFlowEvent]:
+            return [breach_event] if breach_event.timestamp >= since.isoformat() else []
+
+        seeded_bus.load_events_since = _preloaded_load  # type: ignore[method-assign]
+
+        state = MagicMock()
+        state.get_worker_heartbeats.return_value = {}
+        state.get_trust_fleet_sanity_attempts.return_value = 0
+        state.inc_trust_fleet_sanity_attempts.return_value = 1
+        state.get_trust_fleet_sanity_last_seen_counts.return_value = {}
+
+        _seed_ports(
+            world,
+            pr_manager=fake_pr,
+            trust_fleet_sanity_state=state,
+            event_bus=seeded_bus,
+        )
+
+        stats = await world.run_with_loops(["trust_fleet_sanity"], cycles=1)
+
+        assert stats["trust_fleet_sanity"]["status"] == "ok", stats
+        assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
+        assert fake_pr.create_issue.await_count >= 1
+
+        title = fake_pr.create_issue.await_args.args[0]
+        assert "rc_budget" in title
+        assert "issues_per_hour" in title
+
+        labels = fake_pr.create_issue.await_args.args[2]
+        assert "hitl-escalation" in labels
+        assert "trust-loop-anomaly" in labels
+
+    async def test_tick_error_ratio_breach_files_escalation(self, tmp_path) -> None:
+        """corpus_learning with 80% errored ticks -> tick_error_ratio escalation.
+
+        4 errored / 5 total = 0.8, which exceeds the default threshold of 0.2.
+        Verifies a second distinct breach kind reaches the issue-filing path.
+        """
+        world = MockWorld(tmp_path)
+        fake_pr = AsyncMock()
+        fake_pr.create_issue = AsyncMock(return_value=9002)
+
+        now = _dt.datetime.now(_dt.UTC)
+        seeded_bus = EventBus()
+
+        def _make_ev(status: str, ago_s: int) -> HydraFlowEvent:
+            ts = (now - _dt.timedelta(seconds=ago_s)).isoformat()
+            return HydraFlowEvent(
+                type=EventType.BACKGROUND_WORKER_STATUS,
+                timestamp=ts,
+                data={"worker": "corpus_learning", "status": status, "details": {}},
+            )
+
+        all_events = [
+            _make_ev("ok", 3601),
+            _make_ev("error", 3602),
+            _make_ev("error", 3603),
+            _make_ev("error", 3604),
+            _make_ev("error", 3605),
+        ]
+
+        async def _preloaded_load(since: _dt.datetime) -> list[HydraFlowEvent]:
+            return [e for e in all_events if e.timestamp >= since.isoformat()]
+
+        seeded_bus.load_events_since = _preloaded_load  # type: ignore[method-assign]
+
+        state = MagicMock()
+        state.get_worker_heartbeats.return_value = {}
+        state.get_trust_fleet_sanity_attempts.return_value = 0
+        state.inc_trust_fleet_sanity_attempts.return_value = 1
+        state.get_trust_fleet_sanity_last_seen_counts.return_value = {}
+
+        _seed_ports(
+            world,
+            pr_manager=fake_pr,
+            trust_fleet_sanity_state=state,
+            event_bus=seeded_bus,
+        )
+
+        stats = await world.run_with_loops(["trust_fleet_sanity"], cycles=1)
+
+        assert stats["trust_fleet_sanity"]["status"] == "ok", stats
+        assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
+        assert fake_pr.create_issue.await_count >= 1
+
+        titles = [call.args[0] for call in fake_pr.create_issue.await_args_list]
+        assert any("tick_error_ratio" in t and "corpus_learning" in t for t in titles)

--- a/tests/test_trust_fleet_sanity_loop.py
+++ b/tests/test_trust_fleet_sanity_loop.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from base_background_loop import LoopDeps
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
-from trust_fleet_sanity_loop import _DAY_SECONDS, TrustFleetSanityLoop
+from trust_fleet_sanity_loop import (
+    _DAY_SECONDS,
+    _parse_iso,
+    TrustFleetSanityLoop,
+)
 
 
 def _deps(stop: asyncio.Event, enabled: bool = True) -> LoopDeps:
@@ -276,3 +281,367 @@ async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) 
     state.clear_trust_fleet_sanity_attempts.assert_called_once_with(
         "issues_per_hour:ci_monitor"
     )
+
+
+# ---------------------------------------------------------------------------
+# Breach paths — repair_ratio, tick_error_ratio, cost_spike
+# ---------------------------------------------------------------------------
+
+
+async def test_do_work_files_escalation_on_repair_ratio_breach(loop_env) -> None:
+    """Loop with high failed/repaired ratio -> repair_ratio escalation filed."""
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+
+    async def fake_load(since):  # noqa: ARG001
+        # repaired=1 failed=10 -> ratio 10.0 >= default threshold 2.0
+        return [
+            _make_status_event("rc_budget", "ok", ago_s=3600, repaired=1, failed=10),
+        ]
+
+    bus.load_events_since = fake_load  # type: ignore[method-assign]
+    loop = _loop(loop_env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._load_cost_reader = MagicMock(return_value=None)
+    stats = await loop._do_work()
+    assert stats["anomalies"] >= 1
+    titles = [call.args[0] for call in pr.create_issue.await_args_list]
+    assert any("repair_ratio" in t and "rc_budget" in t for t in titles)
+
+
+async def test_do_work_files_escalation_on_tick_error_ratio_breach(loop_env) -> None:
+    """Loop with high errored/total tick ratio -> tick_error_ratio escalation filed."""
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+
+    async def fake_load(since):  # noqa: ARG001
+        # 4 error ticks out of 5 total = 0.8 >= default threshold 0.2
+        return [
+            _make_status_event("rc_budget", "ok", ago_s=3601),
+            _make_status_event("rc_budget", "error", ago_s=3602),
+            _make_status_event("rc_budget", "error", ago_s=3603),
+            _make_status_event("rc_budget", "error", ago_s=3604),
+            _make_status_event("rc_budget", "error", ago_s=3605),
+        ]
+
+    bus.load_events_since = fake_load  # type: ignore[method-assign]
+    loop = _loop(loop_env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._load_cost_reader = MagicMock(return_value=None)
+    stats = await loop._do_work()
+    assert stats["anomalies"] >= 1
+    titles = [call.args[0] for call in pr.create_issue.await_args_list]
+    assert any("tick_error_ratio" in t and "rc_budget" in t for t in titles)
+
+
+async def test_do_work_files_escalation_on_cost_spike_breach(loop_env) -> None:
+    """Today cost is 10x the 30d median -> cost_spike escalation filed."""
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+
+    async def fake_load(since):  # noqa: ARG001
+        return []
+
+    bus.load_events_since = fake_load  # type: ignore[method-assign]
+
+    cost_reader = MagicMock()
+    cost_reader.get_loop_cost_today.return_value = 50.0
+    cost_reader.get_loop_cost_30d_median.return_value = 5.0  # ratio 10.0 >= 5.0 threshold
+
+    loop = _loop(loop_env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._load_cost_reader = MagicMock(return_value=cost_reader)
+    stats = await loop._do_work()
+    assert stats["anomalies"] >= 1
+    titles = [call.args[0] for call in pr.create_issue.await_args_list]
+    assert any("cost_spike" in t for t in titles)
+
+
+# ---------------------------------------------------------------------------
+# config_disabled path
+# ---------------------------------------------------------------------------
+
+
+async def test_do_work_returns_config_disabled_when_flag_off(loop_env) -> None:
+    """trust_fleet_sanity_loop_enabled=False returns config_disabled without scanning."""
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+    cfg.trust_fleet_sanity_loop_enabled = False
+    loop = _loop(loop_env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    stats = await loop._do_work()
+    assert stats["status"] == "config_disabled"
+    pr.create_issue.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# set_bg_workers late-binding
+# ---------------------------------------------------------------------------
+
+
+def test_set_bg_workers_replaces_instance(loop_env) -> None:
+    """set_bg_workers() stores the injected manager (post-ctor wiring)."""
+    loop = _loop(loop_env)
+    new_bg = MagicMock()
+    loop.set_bg_workers(new_bg)
+    assert loop._bg_workers is new_bg
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso edge cases (lines 139, 142-143)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_iso_returns_none_for_empty_string() -> None:
+    assert _parse_iso("") is None
+
+
+def test_parse_iso_returns_none_for_none() -> None:
+    assert _parse_iso(None) is None
+
+
+def test_parse_iso_returns_none_for_invalid_string() -> None:
+    assert _parse_iso("not-a-date") is None
+
+
+def test_parse_iso_parses_valid_iso() -> None:
+    result = _parse_iso("2026-01-15T12:00:00+00:00")
+    assert result is not None
+    assert result.year == 2026
+
+
+# ---------------------------------------------------------------------------
+# _reconcile_closed_escalations error paths
+# ---------------------------------------------------------------------------
+
+
+async def test_reconcile_tolerates_subprocess_exception(loop_env, monkeypatch) -> None:
+    """Subprocess raises OSError -> method swallows, dedup untouched."""
+    loop = _loop(loop_env)
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+    dedup.get.return_value = {"trust_fleet_sanity:issues_per_hour:rc_budget"}
+
+    async def boom(*args, **kwargs):
+        raise OSError("no gh binary")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", boom)
+    # Must not raise; dedup must not be modified.
+    await loop._reconcile_closed_escalations()
+    dedup.set_all.assert_not_called()
+
+
+async def test_reconcile_tolerates_nonzero_returncode(loop_env, monkeypatch) -> None:
+    """gh exits non-zero -> early return, dedup unchanged."""
+    loop = _loop(loop_env)
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+
+    class _P:
+        returncode = 1
+
+        async def communicate(self):
+            return b"", b"error"
+
+    async def fake_subproc(*a, **k):
+        return _P()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    await loop._reconcile_closed_escalations()
+    dedup.set_all.assert_not_called()
+
+
+async def test_reconcile_tolerates_invalid_json(loop_env, monkeypatch) -> None:
+    """gh returns non-JSON stdout -> JSONDecodeError swallowed, dedup unchanged."""
+    loop = _loop(loop_env)
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+
+    class _P:
+        returncode = 0
+
+        async def communicate(self):
+            return b"not valid json{{", b""
+
+    async def fake_subproc(*a, **k):
+        return _P()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    await loop._reconcile_closed_escalations()
+    dedup.set_all.assert_not_called()
+
+
+async def test_reconcile_skips_issues_with_unmatched_title(loop_env, monkeypatch) -> None:
+    """Closed issue whose title doesn't match _TITLE_RE -> key NOT cleared."""
+    loop = _loop(loop_env)
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+    dedup.get.return_value = {"trust_fleet_sanity:staleness:rc_budget"}
+
+    class _P:
+        returncode = 0
+
+        async def communicate(self):
+            return b'[{"title": "Some unrelated issue title"}]', b""
+
+    async def fake_subproc(*a, **k):
+        return _P()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    await loop._reconcile_closed_escalations()
+    # No regex match -> set_all never called, existing key preserved.
+    dedup.set_all.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _load_events_since exception path (lines 511-514)
+# ---------------------------------------------------------------------------
+
+
+async def test_load_events_since_returns_empty_on_exception(loop_env) -> None:
+    """EventBus.load_events_since raising a generic error -> [] returned, no crash."""
+    loop = _loop(loop_env)
+
+    async def exploding_load(since):
+        raise RuntimeError("event store offline")
+
+    loop._source_bus.load_events_since = exploding_load  # type: ignore[method-assign]
+    result = await loop._load_events_since(datetime.now(UTC))
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _collect_window_metrics edge cases (event-filtering branches)
+# ---------------------------------------------------------------------------
+
+
+async def test_collect_window_metrics_ignores_non_status_events(loop_env) -> None:
+    """Events with a type other than BACKGROUND_WORKER_STATUS are ignored."""
+    loop = _loop(loop_env)
+
+    non_status = HydraFlowEvent(
+        type=EventType.ISSUE_CREATED,
+        timestamp=datetime.now(UTC).isoformat(),
+        data={"worker": "rc_budget", "status": "ok", "details": {"filed": 50}},
+    )
+
+    async def fake_load(since):  # noqa: ARG001
+        return [non_status]
+
+    loop._source_bus.load_events_since = fake_load  # type: ignore[method-assign]
+    metrics = await loop._collect_window_metrics()
+    assert metrics["rc_budget"]["ticks_total"] == 0
+
+
+async def test_collect_window_metrics_ignores_event_with_no_worker_field(
+    loop_env,
+) -> None:
+    """Status event missing 'worker' key -> bucket not created, no crash."""
+    loop = _loop(loop_env)
+
+    ev = HydraFlowEvent(
+        type=EventType.BACKGROUND_WORKER_STATUS,
+        timestamp=datetime.now(UTC).isoformat(),
+        data={"status": "ok"},  # no "worker" key
+    )
+
+    async def fake_load(since):  # noqa: ARG001
+        return [ev]
+
+    loop._source_bus.load_events_since = fake_load  # type: ignore[method-assign]
+    metrics = await loop._collect_window_metrics()
+    # Known trust workers still exist (zeroed); unnamed event skipped.
+    assert metrics["rc_budget"]["ticks_total"] == 0
+
+
+async def test_collect_window_metrics_ignores_event_with_nondict_data(
+    loop_env,
+) -> None:
+    """Status event whose 'data' attribute is not a dict -> skipped cleanly.
+
+    Uses a plain object to bypass Pydantic validation and exercise the
+    ``if not isinstance(data, dict): continue`` guard in the metrics loop.
+    """
+    loop = _loop(loop_env)
+
+    class _FakeEvent:
+        type = EventType.BACKGROUND_WORKER_STATUS
+        timestamp = datetime.now(UTC).isoformat()
+        data = "not-a-dict"  # triggers the isinstance guard
+
+    async def fake_load(since):  # noqa: ARG001
+        return [_FakeEvent()]
+
+    loop._source_bus.load_events_since = fake_load  # type: ignore[method-assign]
+    metrics = await loop._collect_window_metrics()
+    assert metrics["rc_budget"]["ticks_total"] == 0
+
+
+async def test_collect_window_metrics_ignores_event_outside_day_window(
+    loop_env,
+) -> None:
+    """Status event older than 24h -> not counted even if type matches."""
+    loop = _loop(loop_env)
+
+    old_event = _make_status_event("rc_budget", "ok", ago_s=_DAY_SECONDS + 600, filed=99)
+
+    async def fake_load(since):  # noqa: ARG001
+        return [old_event]
+
+    loop._source_bus.load_events_since = fake_load  # type: ignore[method-assign]
+    metrics = await loop._collect_window_metrics()
+    assert metrics["rc_budget"]["ticks_total"] == 0
+    assert metrics["rc_budget"]["issues_filed_day"] == 0
+
+
+async def test_collect_window_metrics_handles_nondict_details(loop_env) -> None:
+    """Status event with details=<string> (non-dict) -> filed/repaired default to 0."""
+    loop = _loop(loop_env)
+
+    ts = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+    ev = HydraFlowEvent(
+        type=EventType.BACKGROUND_WORKER_STATUS,
+        timestamp=ts,
+        data={"worker": "rc_budget", "status": "ok", "details": "bad_string_details"},
+    )
+
+    async def fake_load(since):  # noqa: ARG001
+        return [ev]
+
+    loop._source_bus.load_events_since = fake_load  # type: ignore[method-assign]
+    metrics = await loop._collect_window_metrics()
+    rc = metrics["rc_budget"]
+    assert rc["ticks_total"] == 1
+    assert rc["issues_filed_day"] == 0
+    assert rc["repaired_day"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _load_cost_reader — cost_reader module is None (lines 532-534)
+# ---------------------------------------------------------------------------
+
+
+def test_load_cost_reader_returns_none_when_module_is_none(
+    loop_env, monkeypatch
+) -> None:
+    """sys.modules['trust_fleet_cost_reader'] = None -> _load_cost_reader returns None."""
+    loop = _loop(loop_env)
+    monkeypatch.setitem(sys.modules, "trust_fleet_cost_reader", None)
+    reader = loop._load_cost_reader()
+    assert reader is None
+
+
+# ---------------------------------------------------------------------------
+# _emit_trace paths (lines 425-426, 436-438)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_trace_survives_import_error(loop_env, monkeypatch) -> None:
+    """trace_collector ImportError -> _emit_trace returns silently."""
+    loop = _loop(loop_env)
+    monkeypatch.setitem(sys.modules, "trace_collector", None)
+    # Should not raise.
+    loop._emit_trace(0.0, anomalies=0)
+
+
+def test_emit_trace_survives_emission_exception(loop_env, monkeypatch) -> None:
+    """emit_loop_subprocess_trace raises -> _emit_trace swallows, no crash."""
+    loop = _loop(loop_env)
+
+    fake_module = MagicMock()
+    fake_module.emit_loop_subprocess_trace.side_effect = RuntimeError("oops")
+    monkeypatch.setitem(sys.modules, "trace_collector", fake_module)
+    # Should not raise.
+    loop._emit_trace(0.0, anomalies=1)


### PR DESCRIPTION
## Summary
Closes advisor-t27j. Adds unit + scenario coverage for the three TrustFleetSanityLoop escalation breach paths (`repair_ratio`, `tick_error_ratio`, `cost_spike`).

## Test plan
- [x] `pytest tests/test_trust_fleet_sanity_loop.py -o "addopts="` — 33 passed
- [x] `pytest tests/scenarios/test_trust_fleet_sanity_scenario.py -o "addopts="` — 2 passed, 2 xfailed
- [x] `pyright tests/test_trust_fleet_sanity_loop.py tests/scenarios/test_trust_fleet_sanity_scenario.py` — clean