### PR TITLE
fix(principles-audit): route close-reconcile via PRPort.list_closed_issues_by_label

### DIFF
--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -357,30 +357,15 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
         (slug, check_id) pair from the title, and calls
         ``reset_drift_attempts``. Close-to-clear latency is bounded by the
         loop interval.
+
+        Routes through ``self._pr.list_closed_issues_by_label`` so
+        MockWorld scenarios can stub this call without spawning real
+        subprocesses (advisor-0dmd).
         """
         try:
-            proc = await asyncio.create_subprocess_exec(
-                "gh",
-                "issue",
-                "list",
-                "--repo",
-                self._config.repo,
-                "--state",
-                "closed",
-                "--label",
-                "principles-stuck",
-                "--json",
-                "title",
-                "--limit",
-                "100",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            issues = await self._pr.list_closed_issues_by_label(
+                "principles-stuck", limit=100
             )
-            out, _ = await proc.communicate()
-            if proc.returncode != 0:
-                logger.debug("reconcile: gh issue list failed")
-                return
-            issues = json.loads(out or b"[]")
         except Exception as exc:  # noqa: BLE001
             reraise_on_credit_or_bug(exc)
             logger.debug("reconcile: skipped", exc_info=True)

--- a/tests/scenarios/test_principles_audit_scenario.py
+++ b/tests/scenarios/test_principles_audit_scenario.py
@@ -194,3 +194,49 @@ class TestPrinciplesAuditScenario:
         assert "hydraflow-find" in labels
         assert "principles-drift" in labels
         assert "check-P1.1" in labels
+
+    async def test_reconcile_closed_escalations_via_pr_port(self, tmp_path) -> None:
+        """Closing a principles-stuck issue clears the attempt counter via PRPort.
+
+        Verifies the advisor-0dmd fix: _reconcile_closed_escalations now routes
+        through PRPort.list_closed_issues_by_label instead of spawning a raw
+        ``gh`` subprocess. MockWorld can stub the port; no real process needed.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_pr = AsyncMock()
+        fake_pr.create_issue = AsyncMock(return_value=0)
+        # One closed principles-stuck issue whose title encodes (slug, check_id).
+        fake_pr.list_closed_issues_by_label = AsyncMock(
+            return_value=[
+                {"title": "Principles drift stuck: P3.2 in acme/widget"},
+            ]
+        )
+
+        state = _stateful_onboarding_mock()
+        # Simulate that the escalation counter was previously incremented.
+        state.reset_drift_attempts = MagicMock()
+
+        # All-green audit so no regressions are filed — keeps scenario focused
+        # on the reconcile path alone.
+        all_green_report = {
+            "findings": [_finding(check_id="P3.2", status="PASS", principle="P3")]
+        }
+        run_audit = AsyncMock(return_value=all_green_report)
+
+        _seed_ports(
+            world,
+            pr_manager=fake_pr,
+            principles_audit_state=state,
+            principles_audit_run_audit=run_audit,
+            principles_audit_managed_repos=[],
+        )
+
+        await world.run_with_loops(["principles_audit"], cycles=1)
+
+        # Port was called with the correct label — no subprocess spawned.
+        fake_pr.list_closed_issues_by_label.assert_awaited_once_with(
+            "principles-stuck", limit=100
+        )
+        # Counter reset for the parsed (slug, check_id) pair.
+        state.reset_drift_attempts.assert_called_once_with("acme/widget", "P3.2")

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -574,10 +574,14 @@ async def test_maybe_escalate_fires_once_at_threshold(loop_env) -> None:
 
 @pytest.mark.asyncio
 async def test_reconcile_closed_escalations_resets_counter(
-    loop_env, monkeypatch
+    loop_env,
 ) -> None:
     """Closing a `principles-stuck` issue triggers reset_drift_attempts
-    with the (slug, check_id) parsed from the title."""
+    with the (slug, check_id) parsed from the title.
+
+    Routes through PRPort.list_closed_issues_by_label (advisor-0dmd fix)
+    so no real subprocess is spawned.
+    """
     cfg, state, pr = loop_env
     stop = asyncio.Event()
     deps = LoopDeps(
@@ -588,19 +592,10 @@ async def test_reconcile_closed_escalations_resets_counter(
     )
     loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=deps)
 
-    class FakeProc:
-        returncode = 0
-
-        async def communicate(self):
-            return (
-                b'[{"title": "Principles drift stuck: P2.3 in hydra/widgets"}]',
-                b"",
-            )
-
-    async def fake_subproc(*args, **kwargs):
-        return FakeProc()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+    pr.list_closed_issues_by_label = AsyncMock(
+        return_value=[{"title": "Principles drift stuck: P2.3 in hydra/widgets"}]
+    )
 
     await loop._reconcile_closed_escalations()
+    pr.list_closed_issues_by_label.assert_awaited_once_with("principles-stuck", limit=100)
     state.reset_drift_attempts.assert_called_once_with("hydra/widgets", "P2.3")


### PR DESCRIPTION
## Summary
Closes advisor-0dmd. `_reconcile_closed_escalations` previously shelled out to `gh issue list` via `asyncio.create_subprocess_exec`, which prevented MockWorld scenarios from stubbing the call.

Routes the call through the existing `PRPort.list_closed_issues_by_label("principles-stuck", limit=100)` instead.

## Test plan
- [x] `pytest tests/test_principles_audit_loop.py tests/scenarios/test_principles_audit_scenario.py -o "addopts="` — 23 passed
- [x] `pyright src/principles_audit_loop.py` — clean