### PR TITLE
feat(preflight): specialist-aware playbook bundles (ADR-0063 W1)

### DIFF
--- a/prompts/auto_agent/discover-stuck.md
+++ b/prompts/auto_agent/discover-stuck.md
@@ -1,0 +1,42 @@
+# Auto-Agent — discover-stuck Playbook (ADR-0063 W1)
+
+{{> _envelope.md}}
+
+## Sub-label: discover-stuck
+
+The discover-runner's coherence evaluator rejected the research brief. The
+runner already retried with the original query set; preflight is the second
+chance to expand the queries before a human picks it up.
+
+## Specific guidance
+
+Order of operations:
+
+1. Read the rejected brief and the evaluator's score / reason (in escalation
+   context). The reason will surface as one of: "underspecified scope",
+   "missing cross-reference", "contradicts an Accepted ADR", or
+   "no measurable success criteria".
+2. Apply the "what would 30% more confidence require?" frame. Propose at
+   least three additional research queries that would close the gap — for
+   example:
+   - If the reason is "underspecified scope", queries that bound the scope
+     (which modules, which lifecycle phase, which trust tier).
+   - If the reason is "missing cross-reference", queries that pull adjacent
+     ADRs or wiki entries.
+   - If the reason is "contradicts an Accepted ADR", queries that either
+     locate the supersession (the brief should reference the new ADR) or
+     produce the supersession ADR draft (`hf.adr` slash command).
+3. Re-run the brief with the expanded queries appended. Commit the updated
+   brief on a fresh branch, push, return `resolved` with the new brief
+   pointer.
+4. If the gap is structural (missing source data, no ADR exists to reference,
+   evaluator scoring rubric itself is the blocker), return `needs_human` with
+   the specific blocker. Do not push a brief you know won't pass.
+
+Do NOT:
+- Re-run the original query set unchanged. The discover-runner already did.
+- Lower the coherence threshold to force a pass. Threshold drift is a
+  factory-phase-drift failure mode on its own.
+- Skip the "what would 30% more confidence require?" check. The whole point
+  of W1 routing here is that this prompt produces *different* queries than
+  the runner's first attempt.

--- a/prompts/auto_agent/implement-stuck.md
+++ b/prompts/auto_agent/implement-stuck.md
@@ -1,0 +1,38 @@
+# Auto-Agent — implement-stuck Playbook (ADR-0063 W1)
+
+{{> _envelope.md}}
+
+## Sub-label: implement-stuck
+
+ImplementPhase hit the attempt cap or produced a zero-diff branch. The
+implementation runner already tried the plain "implement this spec" loop.
+Don't retry the same shape — apply the two-stage review pattern.
+
+## Specific guidance
+
+Order of operations:
+
+1. Read the spec (issue body / escalation context) and any prior attempts'
+   diagnoses (in prior attempts block).
+2. Dispatch a spec-compliance subagent (mental model — even if you do this
+   in-process): "given this spec and this current branch state, list every
+   spec requirement not yet satisfied by the diff." If the diff is empty,
+   list every requirement from scratch.
+3. For each unmet requirement, write the failing test first (TDD per
+   `docs/wiki/testing.md`). If a requirement can't be tested with the
+   existing fixture set, that's the diagnosis — escalate with the specific
+   testing gap.
+4. Implement the smallest change that makes the test pass. Then run
+   `make quality` (per CLAUDE.md quick-rules) before pushing.
+5. Either push and open a PR (`resolved`) or return `needs_human` with the
+   precise spec-vs-code gap (e.g. "spec requires Port X; the existing
+   adapter registry has no slot for X, blocked on ADR amendment").
+
+Do NOT:
+- Force-push the existing branch over the prior implementation. Start fresh
+  on `agent/auto-agent-<issue>` or whatever branch the loop already created.
+- Mark the spec as "ambiguous, escalating" without first trying the
+  spec-compliance walk. Most "ambiguous" specs are precise but contradicted
+  by an unspoken convention; the wiki entries surface those.
+- Skip `make quality`. Cleanup PRs over-pruning defensive guards has
+  bitten this project before (PR #8460 → #8463).

--- a/prompts/auto_agent/plan-stuck.md
+++ b/prompts/auto_agent/plan-stuck.md
@@ -1,0 +1,36 @@
+# Auto-Agent — plan-stuck Playbook (ADR-0063 W1)
+
+{{> _envelope.md}}
+
+## Sub-label: plan-stuck
+
+PlanReviewer rejected the plan. The pipeline already retried once with the
+same shape. Don't re-run the planner; expand the touchpoint set and re-plan.
+
+## Specific guidance
+
+Order of operations:
+
+1. Read the prior plan and the PlanReviewer's rejection (in escalation context
+   and prior attempts).
+2. Pull the touchpoints the original plan likely missed:
+   - `grep`-walk the ADR set for any ADR cross-referenced by an ADR the plan
+     already touches. Stop after one hop unless a touched ADR explicitly
+     points at a third.
+   - `git log --since=30.days -- <touched-file>` for each file the plan names,
+     to surface recent PR conflicts on the same surface area.
+   - Pull wiki entries (`docs/wiki/`) for affected modules — wiki entries
+     encode the "load-bearing conventions" the planner needs to honor.
+3. Re-shape the plan with `superpowers:writing-plans` discipline: explicit
+   success criteria, file-by-file change list, test layer at each step.
+4. Either commit a `plan.md` update on a fresh branch and open a PR
+   (`resolved`), or return `needs_human` with the specific touchpoint conflict
+   you found (e.g. "ADR-0029 caretaker-loop pattern conflicts with this
+   plan's eager-evaluation step").
+
+Do NOT:
+- Re-run the same plan-shape the original planner produced.
+- Skip the touchpoint walk — the failure mode is missing context, not missing
+  attempts.
+- Expand scope beyond what the touchpoints reveal. If the touchpoints suggest
+  the plan needs to grow by >2x, escalate.

--- a/prompts/auto_agent/review-stuck.md
+++ b/prompts/auto_agent/review-stuck.md
@@ -1,0 +1,42 @@
+# Auto-Agent — review-stuck Playbook (ADR-0063 W1)
+
+{{> _envelope.md}}
+
+## Sub-label: review-stuck
+
+ReviewPhase escalated. Most commonly this is a sandbox/CI red — but the
+SandboxFailureFixerLoop already runs for those, so by the time the issue
+reaches you, the failure-fixer either gave up or wasn't applicable.
+
+## Specific guidance
+
+Order of operations:
+
+1. Identify the failure class from the escalation context:
+   - **CI / sandbox red** — read the test transcript (in escalation context).
+     Then `git log -3 --stat` on the branch to see the last three commits.
+     Pair the failing test name(s) to the commit that touched the closest
+     surface. Fix the test or the production code, push, return `resolved`.
+   - **Visual-validation failure** — HITL-by-design (ADR-0063 §Decision).
+     Return `needs_human` with the failing screenshot path; do not attempt
+     a fix.
+   - **Merge conflict with main** — also HITL-by-design when the conflict
+     touches files outside the PR's stated scope. Otherwise, rebase, run
+     `make quality`, and push.
+
+2. If the failure class is ambiguous, the diagnosis goes in the audit and
+   the issue gets `needs_human` — don't guess.
+
+Tools you should reach for:
+- `git log --oneline -10` and `git log -3 --stat` (recent commit shape)
+- `git diff HEAD~3` (what changed)
+- The test transcript text in `escalation_context_block`
+- The wiki entries in `wiki_excerpts_block` (often encode the regression
+  pattern explicitly)
+
+Do NOT:
+- Modify visual-validation baselines without a human signing off.
+- Force-push to resolve merge conflicts.
+- "Fix" failures by deleting tests. If a test is genuinely wrong, the fix
+  is to change the assertion (with a code comment explaining why) — not to
+  delete the test.

--- a/prompts/auto_agent/triage-stuck.md
+++ b/prompts/auto_agent/triage-stuck.md
@@ -1,0 +1,39 @@
+# Auto-Agent — triage-stuck Playbook (ADR-0063 W1)
+
+{{> _envelope.md}}
+
+## Sub-label: triage-stuck
+
+The triage runner parked this issue with a `parking_reason` (visible in the
+escalation context). No loop currently re-attempts triage on parked issues
+(that gap is W2 of ADR-0063); preflight is the first re-entry point.
+
+## Specific guidance
+
+Order of operations:
+
+1. Read the `parking_reason` (in escalation context). It will be one of:
+   - `under_specified` — issue body doesn't include enough to triage.
+   - `unknown_domain` — issue references a system the triage runner has no
+     prior label for.
+   - `dependency_conflict` — issue depends on another issue not yet closed.
+2. For `under_specified` issues: scan the issue body + comments for any
+   recoverable signal (referenced file, error message, sentry event). If
+   you find one, post a one-line clarification comment ("auto-triaged as
+   `<labels>` based on referenced file `<path>`") and apply the label
+   set yourself. Return `resolved`.
+3. For `unknown_domain` issues: read the wiki (`docs/wiki/`) for any module
+   matching keywords in the issue body. If a match exists, apply
+   `area:<module>` plus the most-likely lifecycle label. Return `resolved`.
+4. For `dependency_conflict` issues: confirm the blocking issue is still
+   open. If closed, re-trigger triage with the dependency-cleared signal
+   (post a comment). If still open, return `needs_human` with the explicit
+   dependency chain — don't unblock prematurely.
+
+Do NOT:
+- Apply broad catchall labels like `bug` or `enhancement` without a specific
+  scope signal. The triage runner already rejected the issue once for being
+  under-specified; the auto-agent should be no looser.
+- Re-open closed issues.
+- Modify the triage runner itself — that's covered by the deny-list and
+  recursion guard.

--- a/src/preflight/agent.py
+++ b/src/preflight/agent.py
@@ -14,6 +14,7 @@ from typing import Any
 from exception_classify import reraise_on_credit_or_bug
 from preflight.context import PreflightContext
 from preflight.decision import PreflightResult
+from preflight.playbooks import DEFAULT_PERSONA, get_playbook
 from preflight.runner import parse_agent_response, render_blocks, render_prompt
 
 logger = logging.getLogger("hydraflow.preflight.agent")
@@ -57,13 +58,23 @@ async def run_preflight(
         recent_commits=context.recent_commits,
         prior_attempts=context.prior_attempts,
     )
+
+    # ADR-0063 W1: route by sub-label to a specialist playbook. When the
+    # registry has no specialist (unrecognised sub-label, or a sub-label like
+    # `flaky-test-stuck` whose existing prompt file is enough), the default
+    # playbook returns `_default` persona + `_default` template — and we keep
+    # the operator-configured `deps.persona` so deployments that customised
+    # the persona via config still see their value.
+    playbook = get_playbook(context.sub_label)
+    persona = playbook.persona if playbook.persona != DEFAULT_PERSONA else deps.persona
     prompt = render_prompt(
         sub_label=context.sub_label,
-        persona=deps.persona,
+        persona=persona,
         issue_number=context.issue_number,
         repo_slug=repo_slug,
         worktree_path=worktree_path,
         issue_body=context.issue_body,
+        prompt_template=playbook.prompt_template,
         **blocks,
     )
 

--- a/src/preflight/playbooks/__init__.py
+++ b/src/preflight/playbooks/__init__.py
@@ -1,0 +1,193 @@
+"""Specialist-aware preflight playbooks (ADR-0063 W1).
+
+Each `PreflightPlaybook` bundles a phase-specific persona, a prompt-template
+selector, and optional context-gathering hints. The registry maps
+sub-labels (e.g. ``plan-stuck``) to playbooks; unknown sub-labels fall back
+to ``_default`` so behavior is backwards-compatible with pre-W1 preflight.
+
+Why a per-phase bundle (not a generic lead-engineer prompt):
+
+- ADR-0063 §Context: ``hitl-escalation`` for five phases is a model-competence
+  failure, not a raging fire. The current generic preflight retries against
+  the same prompt; the matrix shows that doesn't shift the resolution rate.
+  Specialist routing changes the *content* of the retry — persona, context,
+  prompt anchor — so the next attempt has a chance to do something the first
+  couldn't.
+
+- Why frozen dataclasses: the registry is loaded once at import and consulted
+  by every preflight tick. Frozen entries make accidental mutation in a hot
+  path a TypeError instead of a silent bug.
+
+- Why bundle the prompt template + persona together (not just a persona): the
+  prompt file owns the "order of operations" the specialist follows. Pairing
+  them keeps the persona claim ("plan-touchpoint specialist") consistent with
+  the actions the prompt asks for. Splitting them invites drift.
+
+- Why no behavior coupling to ``PreflightAgent``: the registry returns data,
+  not callables. ``PreflightAgent`` reads ``playbook.persona`` and passes
+  ``playbook.prompt_template`` to the runner. This keeps the playbook layer
+  testable in isolation and lets W2-W5 add specialists without touching
+  ``PreflightAgent`` itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# The generic lead-engineer persona used by ``_default`` and any sub-label
+# the registry doesn't specialise. Mirrors the pre-W1 ``auto_agent_persona``
+# config default so existing deployments see no behavior change for
+# unspecialised sub-labels.
+DEFAULT_PERSONA = (
+    "the lead engineer for this project — pragmatic, prefers small fixes, "
+    "leaves regression tests, doesn't over-engineer. When in doubt about "
+    "scope, do less."
+)
+
+
+@dataclass(frozen=True)
+class PreflightPlaybook:
+    """Per-sub-label specialist bundle.
+
+    Attributes:
+        name: Sub-label this playbook handles (e.g. ``plan-stuck``).
+            ``_default`` is reserved for the fallback.
+        persona: Persona string substituted into the shared prompt envelope
+            ``{persona}`` slot. Overrides ``config.auto_agent_persona`` for
+            this sub-label when not equal to ``DEFAULT_PERSONA``.
+        prompt_template: Filename stem under ``prompts/auto_agent/`` (e.g.
+            ``plan-stuck`` resolves to ``prompts/auto_agent/plan-stuck.md``).
+            Use ``"_default"`` to force the generic playbook prompt; ``None``
+            means "use the runner's sub-label-derived lookup" (preserves the
+            pre-W1 behavior where sub-label X loads ``X.md`` when present).
+    """
+
+    name: str
+    persona: str
+    prompt_template: str | None
+
+
+_DEFAULT_PLAYBOOK = PreflightPlaybook(
+    name="_default",
+    persona=DEFAULT_PERSONA,
+    # `None` preserves the pre-W1 lookup: render_prompt falls back from
+    # `<sub_label>.md` to `_default.md` based on file existence. This keeps
+    # the existing prompt files (flaky-test-stuck.md, wiki-rot-stuck.md, ...)
+    # active for sub-labels without a specialist registry entry.
+    prompt_template=None,
+)
+
+
+# Specialist personas — each is tied to the per-phase remediation pattern in
+# ADR-0063 §Decision. Keep these in sync with the prompt files in
+# prompts/auto_agent/<name>.md and with ADR-0063 W1's specialist list.
+_PLAN_STUCK = PreflightPlaybook(
+    name="plan-stuck",
+    persona=(
+        "a planning specialist for this project. Plans escalated to you have "
+        "already failed PlanReviewer at least once. Your job is to pull the "
+        "touchpoint set the original planner missed (cross-referenced ADRs, "
+        "recent PR conflicts on touched files, current wiki entries for "
+        "affected modules) and re-plan with explicit success criteria "
+        "(superpowers:writing-plans discipline). Do not re-run the same plan "
+        "shape — the planner already tried that."
+    ),
+    prompt_template="plan-stuck",
+)
+
+_IMPLEMENT_STUCK = PreflightPlaybook(
+    name="implement-stuck",
+    persona=(
+        "an implementation specialist for this project. Implementations "
+        "escalated to you have hit the attempt cap or produced a zero-diff "
+        "branch. The original spec is in the issue body / escalation context. "
+        "Your job is to apply the superpowers:subagent-driven-development "
+        "two-stage review (spec compliance, then code quality) and either "
+        "produce a diff that satisfies the spec-compliance check or return "
+        "needs_human with the specific spec-vs-code gap you found."
+    ),
+    prompt_template="implement-stuck",
+)
+
+_REVIEW_STUCK = PreflightPlaybook(
+    name="review-stuck",
+    persona=(
+        "a review-recovery specialist for this project. Reviews escalated to "
+        "you failed the sandbox/CI tier. Your job is to read the test "
+        "transcript and the last 3 commits' diffs (not just the failure log) "
+        "and either fix the regression or return needs_human with a precise "
+        "diagnosis of which commit introduced the failure. Visual-validation "
+        "and merge-conflict failures are HITL-by-design — escalate cleanly."
+    ),
+    prompt_template="review-stuck",
+)
+
+_TRIAGE_STUCK = PreflightPlaybook(
+    name="triage-stuck",
+    persona=(
+        "a triage specialist for this project. Issues escalated to you were "
+        "parked by the triage runner with a parking_reason (visible in the "
+        "escalation context). Your job is to re-classify the issue with the "
+        "parking_reason as additional context — most parked issues are "
+        "under-specified, not impossible; ask the smallest clarifying "
+        "question or assign the smallest reasonable label set and unblock."
+    ),
+    prompt_template="triage-stuck",
+)
+
+_DISCOVER_STUCK = PreflightPlaybook(
+    name="discover-stuck",
+    persona=(
+        "a discovery / research specialist for this project. Discover-phase "
+        "escalations land here when the coherence evaluator rejected the "
+        "research brief. Your job is to ask 'what would 30% more confidence "
+        "require?' — propose at least three additional research queries that "
+        "would close the coherence gap, expand the brief, and re-run the "
+        "evaluator. If the gap is structural (missing source, dead ADR "
+        "reference), return needs_human with the specific blocker."
+    ),
+    prompt_template="discover-stuck",
+)
+
+
+# Registry. Sub-labels mapped to their specialist. Anything not in this dict
+# resolves to ``_DEFAULT_PLAYBOOK`` via ``get_playbook``. Adding a specialist
+# is a single-line append plus a matching prompt file.
+_REGISTRY: dict[str, PreflightPlaybook] = {
+    pb.name: pb
+    for pb in (
+        _PLAN_STUCK,
+        _IMPLEMENT_STUCK,
+        _REVIEW_STUCK,
+        _TRIAGE_STUCK,
+        _DISCOVER_STUCK,
+    )
+}
+
+
+def get_playbook(sub_label: str) -> PreflightPlaybook:
+    """Return the playbook for ``sub_label`` (falls back to ``_default``).
+
+    Backwards-compatible: any sub-label the registry doesn't specialise gets
+    the generic lead-engineer playbook, which renders the existing
+    ``prompts/auto_agent/_default.md`` (or a sub-label-specific prompt file
+    if one exists, via the runner's existing lookup) with the default persona.
+    """
+    return _REGISTRY.get(sub_label, _DEFAULT_PLAYBOOK)
+
+
+def iter_playbooks() -> tuple[PreflightPlaybook, ...]:
+    """Return the specialist registry (excluding the ``_default`` fallback).
+
+    Useful for diagnostics, dashboards, and tests that need to verify every
+    specialist ships a prompt file.
+    """
+    return tuple(_REGISTRY.values())
+
+
+__all__ = [
+    "DEFAULT_PERSONA",
+    "PreflightPlaybook",
+    "get_playbook",
+    "iter_playbooks",
+]

--- a/src/preflight/runner.py
+++ b/src/preflight/runner.py
@@ -27,9 +27,20 @@ def render_prompt(
     sentry_events_block: str,
     recent_commits_block: str,
     prior_attempts_block: str,
+    prompt_template: str | None = None,
 ) -> str:
-    """Load the sub-label prompt file (or _default.md) + envelope, render."""
-    prompt_path = _PROMPT_DIR / f"{sub_label}.md"
+    """Load the sub-label prompt file (or _default.md) + envelope, render.
+
+    Args:
+        prompt_template: When provided, overrides the sub-label-derived file
+            lookup. The W1 playbook registry (ADR-0063) uses this to drive
+            prompt selection from the playbook bundle rather than the raw
+            sub-label string — letting a sub-label without its own prompt
+            file route to a specialist persona + the ``_default`` template,
+            or vice versa.
+    """
+    template_stem = prompt_template if prompt_template is not None else sub_label
+    prompt_path = _PROMPT_DIR / f"{template_stem}.md"
     if not prompt_path.exists():
         prompt_path = _PROMPT_DIR / "_default.md"
 

--- a/tests/scenarios/test_auto_agent_playbook_routing.py
+++ b/tests/scenarios/test_auto_agent_playbook_routing.py
@@ -1,0 +1,191 @@
+"""Scenario tests: per-sub-label playbook routing (ADR-0063 W1).
+
+For each W1 specialist sub-label, an end-to-end `_do_work` tick must:
+  1. select the matching playbook (asserted via the prompt that reaches spawn),
+  2. substitute the playbook's specialist persona (not the deps default),
+  3. render the playbook's prompt template (not _default.md).
+
+These are MockWorld-style scenario tests — the spawn function is stubbed but
+every other layer (loop, context-gather, decision, audit) runs for real.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auto_agent_preflight_loop import AutoAgentPreflightLoop
+from preflight.agent import PreflightSpawn
+from preflight.playbooks import DEFAULT_PERSONA, get_playbook
+from tests.helpers import make_bg_loop_deps
+
+
+def _make_loop(tmp_path: Path, **overrides):
+    deps = make_bg_loop_deps(tmp_path, **overrides)
+    state = MagicMock()
+    state.get_auto_agent_attempts = MagicMock(return_value=0)
+    state.bump_auto_agent_attempts = MagicMock(return_value=1)
+    state.clear_auto_agent_attempts = MagicMock()
+    state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
+    state.add_auto_agent_daily_spend = MagicMock(return_value=0.0)
+    state.get_escalation_context = MagicMock(return_value=None)
+    pr = AsyncMock()
+    pr.list_closed_issues_by_label = AsyncMock(return_value=[])
+    audit = MagicMock()
+    audit.append = MagicMock()
+    audit.entries_for_issue = MagicMock(return_value=[])
+    loop = AutoAgentPreflightLoop(
+        config=deps.config,
+        state=state,
+        pr_manager=pr,
+        wiki_store=None,
+        audit_store=audit,
+        deps=deps.loop_deps,
+    )
+    return loop, state, pr, audit
+
+
+def _capture_spawn(loop) -> list[str]:
+    """Replace `_build_spawn_fn` so the rendered prompt is captured.
+
+    Returns a list the test inspects after `_do_work` completes.
+    """
+    captured: list[str] = []
+
+    async def _spawn(prompt: str, worktree_path: str) -> PreflightSpawn:
+        captured.append(prompt)
+        return PreflightSpawn(
+            process=None,
+            output_text="<status>needs_human</status><diagnosis>x</diagnosis>",
+            cost_usd=0.0,
+            tokens=0,
+            crashed=False,
+        )
+
+    loop._build_spawn_fn = lambda issue: _spawn
+    return captured
+
+
+def _issue(sub_label: str, number: int = 1) -> dict:
+    return {
+        "number": number,
+        "body": "x",
+        "labels": [
+            {"name": "hitl-escalation"},
+            {"name": sub_label},
+        ],
+    }
+
+
+# Each tuple: (sub_label, expected persona-marker substring, expected prompt-file
+# header substring). The persona marker is a substring of the playbook persona
+# that won't appear in the generic envelope/default copy; the header substring
+# proves render_prompt picked the playbook's prompt_template.
+_W1_ROUTING_CASES = [
+    ("plan-stuck", "planning specialist", "plan-stuck Playbook"),
+    ("implement-stuck", "implementation specialist", "implement-stuck Playbook"),
+    ("review-stuck", "review-recovery specialist", "review-stuck Playbook"),
+    ("triage-stuck", "triage specialist", "triage-stuck Playbook"),
+    (
+        "discover-stuck",
+        "discovery / research specialist",
+        "discover-stuck Playbook",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("sub_label", "persona_marker", "prompt_header"), _W1_ROUTING_CASES
+)
+@pytest.mark.asyncio
+async def test_specialist_playbook_fires_for_sublabel(
+    tmp_path: Path,
+    sub_label: str,
+    persona_marker: str,
+    prompt_header: str,
+) -> None:
+    loop, _state, pr, _audit = _make_loop(tmp_path)
+    pr.list_issues_by_label = AsyncMock(return_value=[_issue(sub_label)])
+    prompts = _capture_spawn(loop)
+
+    await loop._do_work()
+
+    assert len(prompts) == 1, f"expected exactly one spawn for {sub_label}"
+    prompt = prompts[0]
+    assert persona_marker in prompt, (
+        f"{sub_label}: specialist persona '{persona_marker}' missing from "
+        f"rendered prompt — playbook routing did not fire"
+    )
+    assert prompt_header in prompt, (
+        f"{sub_label}: prompt header '{prompt_header}' missing — "
+        f"render_prompt picked the wrong template"
+    )
+
+
+@pytest.mark.asyncio
+async def test_unspecialised_sublabel_uses_default_persona(tmp_path: Path) -> None:
+    """A sub-label with no W1 specialist (e.g. `flaky-test-stuck`, which ships
+    its own prompt file but no specialist persona) still uses the operator-
+    configured `auto_agent_persona` from config — backwards-compat."""
+    loop, _state, pr, _audit = _make_loop(
+        tmp_path, auto_agent_persona="CUSTOM_OPERATOR_PERSONA"
+    )
+    pr.list_issues_by_label = AsyncMock(return_value=[_issue("flaky-test-stuck")])
+    prompts = _capture_spawn(loop)
+
+    await loop._do_work()
+
+    assert len(prompts) == 1
+    prompt = prompts[0]
+    assert "CUSTOM_OPERATOR_PERSONA" in prompt
+    # And the flaky-test-stuck prompt file is still rendered (not _default.md).
+    assert "flaky-test-stuck Playbook" in prompt
+
+
+@pytest.mark.asyncio
+async def test_unknown_sublabel_falls_back_to_default_prompt(tmp_path: Path) -> None:
+    """A completely unknown sub-label uses the operator persona AND the
+    generic _default.md prompt (the runner's existing fallback path)."""
+    loop, _state, pr, _audit = _make_loop(tmp_path, auto_agent_persona="OPERATOR_X")
+    pr.list_issues_by_label = AsyncMock(return_value=[_issue("totally-novel-stuck")])
+    prompts = _capture_spawn(loop)
+
+    await loop._do_work()
+
+    prompt = prompts[0]
+    assert "OPERATOR_X" in prompt
+    assert "Default Playbook" in prompt
+
+
+def test_w1_routing_table_matches_registry() -> None:
+    """Guard: the parametrised W1 routing table must cover every specialist
+    in the registry (and no others). Catches drift between the registry
+    and these scenario tests when W2-W5 add specialists without test
+    updates."""
+    from preflight.playbooks import iter_playbooks
+
+    table_names = {sub for sub, _, _ in _W1_ROUTING_CASES}
+    registry_names = {pb.name for pb in iter_playbooks()}
+    assert table_names == registry_names, (
+        f"W1 routing-table specialists {table_names} do not match registry "
+        f"specialists {registry_names}. Update _W1_ROUTING_CASES (or the "
+        f"registry) to match."
+    )
+
+
+def test_w1_persona_assertions_come_from_registry() -> None:
+    """Guard: each row's `persona_marker` must be present in the playbook's
+    actual persona string — protects against typos drifting between this
+    parametrise table and the registry definitions."""
+    for sub_label, persona_marker, _ in _W1_ROUTING_CASES:
+        pb = get_playbook(sub_label)
+        assert pb.persona != DEFAULT_PERSONA, (
+            f"{sub_label} is not in the specialist registry"
+        )
+        assert persona_marker.lower() in pb.persona.lower(), (
+            f"{sub_label} routing table expects persona marker "
+            f"'{persona_marker}' which is missing from the playbook persona "
+            f"in src/preflight/playbooks/__init__.py"
+        )

--- a/tests/test_preflight_agent.py
+++ b/tests/test_preflight_agent.py
@@ -154,6 +154,80 @@ def test_hash_prompt_stable() -> None:
 
 
 @pytest.mark.asyncio
+async def test_playbook_persona_overrides_deps_persona() -> None:
+    """ADR-0063 W1: when the sub-label resolves to a specialist playbook,
+    the playbook's persona is substituted into the prompt — not the generic
+    ``deps.persona``. The deps persona remains the default for unspecialised
+    sub-labels (backwards-compat)."""
+    captured_prompts: list[str] = []
+
+    async def _spawn(*, prompt: str, worktree_path: str) -> PreflightSpawn:
+        captured_prompts.append(prompt)
+        return PreflightSpawn(
+            process=None,
+            output_text="<status>needs_human</status><diagnosis>x</diagnosis>",
+            cost_usd=0.0,
+            tokens=0,
+            crashed=False,
+        )
+
+    deps = PreflightAgentDeps(
+        persona="GENERIC_DEFAULT",
+        cost_cap_usd=None,
+        wall_clock_cap_s=None,
+        spawn_fn=_spawn,
+    )
+    # plan-stuck is a specialist sub-label in the W1 registry.
+    await run_preflight(
+        context=_ctx(sub_label="plan-stuck"),
+        repo_slug="x/y",
+        worktree_path="/tmp",
+        deps=deps,
+    )
+    assert len(captured_prompts) == 1
+    prompt = captured_prompts[0]
+    # The specialist persona for plan-stuck mentions "planning specialist"
+    # and uses the plan-stuck prompt file.
+    assert "planning specialist" in prompt
+    assert "GENERIC_DEFAULT" not in prompt
+    assert "plan-stuck Playbook" in prompt
+
+
+@pytest.mark.asyncio
+async def test_unspecialised_sublabel_uses_deps_persona() -> None:
+    """Backwards-compat: a sub-label not in the W1 registry still receives the
+    operator-configured ``deps.persona`` (generic lead-engineer)."""
+    captured_prompts: list[str] = []
+
+    async def _spawn(*, prompt: str, worktree_path: str) -> PreflightSpawn:
+        captured_prompts.append(prompt)
+        return PreflightSpawn(
+            process=None,
+            output_text="<status>needs_human</status><diagnosis>x</diagnosis>",
+            cost_usd=0.0,
+            tokens=0,
+            crashed=False,
+        )
+
+    deps = PreflightAgentDeps(
+        persona="OPERATOR_CONFIGURED",
+        cost_cap_usd=None,
+        wall_clock_cap_s=None,
+        spawn_fn=_spawn,
+    )
+    # flaky-test-stuck has a prompt file but no specialist persona — should
+    # still use the deps.persona verbatim.
+    await run_preflight(
+        context=_ctx(sub_label="flaky-test-stuck"),
+        repo_slug="x/y",
+        worktree_path="/tmp",
+        deps=deps,
+    )
+    prompt = captured_prompts[0]
+    assert "OPERATOR_CONFIGURED" in prompt
+
+
+@pytest.mark.asyncio
 async def test_unparseable_response_falls_back_to_needs_human() -> None:
     spawn_fn = AsyncMock(
         return_value=PreflightSpawn(

--- a/tests/test_preflight_playbooks.py
+++ b/tests/test_preflight_playbooks.py
@@ -1,0 +1,128 @@
+"""PreflightPlaybook + registry tests (ADR-0063 W1).
+
+Each phase-failure sub-label routes to a specialist-aware playbook bundle.
+The registry maps sub-label -> Playbook; unknown sub-labels fall back to a
+generic lead-engineer playbook (the pre-W1 behavior).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from preflight.playbooks import (
+    DEFAULT_PERSONA,
+    PreflightPlaybook,
+    get_playbook,
+    iter_playbooks,
+)
+
+
+def test_default_playbook_returned_for_unknown_sublabel() -> None:
+    pb = get_playbook("totally-made-up")
+    assert isinstance(pb, PreflightPlaybook)
+    assert pb.name == "_default"
+    # `None` template -> runner falls back to `<sub_label>.md` then
+    # `_default.md`, preserving pre-W1 lookup behavior.
+    assert pb.prompt_template is None
+    # Default persona is the generic lead-engineer text from config (pre-W1
+    # behavior). Tests assert the marker substring so a copy edit on the full
+    # text doesn't churn tests.
+    assert "lead engineer" in pb.persona
+
+
+def test_plan_stuck_playbook_specialises() -> None:
+    pb = get_playbook("plan-stuck")
+    assert pb.name == "plan-stuck"
+    # Persona-specific: PlanReviewer failures need writing-plans discipline.
+    assert pb.persona != DEFAULT_PERSONA
+    assert "plan" in pb.persona.lower()
+    # ADR-0063 W1 calls this out as the touchpoint-expander prompt anchor.
+    assert "touchpoint" in pb.persona.lower() or "adr" in pb.persona.lower()
+
+
+def test_implement_stuck_playbook_specialises() -> None:
+    pb = get_playbook("implement-stuck")
+    assert pb.name == "implement-stuck"
+    assert pb.persona != DEFAULT_PERSONA
+    assert "implement" in pb.persona.lower() or "code" in pb.persona.lower()
+
+
+def test_review_stuck_playbook_specialises() -> None:
+    pb = get_playbook("review-stuck")
+    assert pb.name == "review-stuck"
+    assert pb.persona != DEFAULT_PERSONA
+    # Review failures want test-transcript + recent-diff context per ADR-0063.
+    assert "review" in pb.persona.lower() or "test" in pb.persona.lower()
+
+
+def test_triage_stuck_playbook_specialises() -> None:
+    pb = get_playbook("triage-stuck")
+    assert pb.name == "triage-stuck"
+    assert pb.persona != DEFAULT_PERSONA
+    assert "triage" in pb.persona.lower() or "classif" in pb.persona.lower()
+
+
+def test_discover_stuck_playbook_specialises() -> None:
+    """`discover-stuck` is the only phase-stuck label currently in production.
+
+    The playbook exists so when the discover-runner escalates a coherence-
+    evaluator failure, preflight already routes to a discover-shaped retry.
+    """
+    pb = get_playbook("discover-stuck")
+    assert pb.name == "discover-stuck"
+    assert pb.persona != DEFAULT_PERSONA
+    assert "discover" in pb.persona.lower() or "research" in pb.persona.lower()
+
+
+def test_existing_sublabel_falls_back_to_default_when_unspecialised() -> None:
+    """Backwards-compat: sub-labels with no specialist entry still resolve.
+
+    `flaky-test-stuck` already ships with a prompt file but no phase-specialist
+    persona; the registry should return the default playbook (so the existing
+    prompt file is used by the runner, and the generic persona applies).
+    """
+    pb = get_playbook("flaky-test-stuck")
+    assert pb.name == "_default"
+    assert pb.prompt_template is None
+
+
+def test_iter_playbooks_returns_all_specialists_in_registry() -> None:
+    """`iter_playbooks()` exposes the W1 specialist set for diagnostics."""
+    names = {pb.name for pb in iter_playbooks()}
+    # Per ADR-0063 W1: specialists for the four most common phase failures plus
+    # discover (the only label currently in prod). _default is excluded — it's
+    # the fallback, not a specialist.
+    assert {
+        "plan-stuck",
+        "implement-stuck",
+        "review-stuck",
+        "triage-stuck",
+        "discover-stuck",
+    }.issubset(names)
+    assert "_default" not in names
+
+
+def test_playbook_prompt_template_resolves_when_file_exists() -> None:
+    """A playbook's `prompt_template` is the filename stem under prompts/auto_agent/.
+
+    For every specialist that ships a custom prompt file, the file must exist
+    so the runner doesn't silently fall back to _default at render time.
+    """
+    from pathlib import Path
+
+    prompt_dir = Path(__file__).parent.parent / "prompts" / "auto_agent"
+    for pb in iter_playbooks():
+        if pb.prompt_template in (None, "_default"):
+            continue
+        prompt_path = prompt_dir / f"{pb.prompt_template}.md"
+        assert prompt_path.exists(), (
+            f"playbook {pb.name} references prompt_template "
+            f"{pb.prompt_template!r} but {prompt_path} is missing"
+        )
+
+
+def test_playbook_is_immutable_dataclass() -> None:
+    """Frozen so callers can't mutate the registry entries by accident."""
+    pb = get_playbook("plan-stuck")
+    with pytest.raises((AttributeError, TypeError)):
+        pb.persona = "mutated"  # type: ignore[misc]

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -47,6 +47,51 @@ def test_default_fallback_for_unknown_sub_label() -> None:
     assert "Default Playbook" in out
 
 
+def test_explicit_prompt_template_overrides_sub_label_lookup() -> None:
+    """ADR-0063 W1: PreflightPlaybook.prompt_template lets the registry pick
+    a prompt file independent of the sub-label string. Sub-label
+    ``my-custom-stuck`` with template ``plan-stuck`` must render plan-stuck.md.
+    """
+    out = render_prompt(
+        sub_label="my-custom-stuck",
+        persona="x",
+        issue_number=1,
+        repo_slug="r/s",
+        worktree_path="/tmp",
+        issue_body="b",
+        issue_comments_block="x",
+        escalation_context_block="x",
+        wiki_excerpts_block="x",
+        sentry_events_block="x",
+        recent_commits_block="x",
+        prior_attempts_block="x",
+        prompt_template="plan-stuck",
+    )
+    assert "plan-stuck Playbook" in out
+
+
+def test_explicit_default_template_renders_default_even_for_known_sub_label() -> None:
+    """A playbook that points at ``_default`` renders the generic prompt even
+    when a same-named prompt file exists (e.g. for sub-labels whose specialist
+    persona is enough and no custom file is justified)."""
+    out = render_prompt(
+        sub_label="flaky-test-stuck",  # has its own .md file
+        persona="x",
+        issue_number=1,
+        repo_slug="r/s",
+        worktree_path="/tmp",
+        issue_body="b",
+        issue_comments_block="x",
+        escalation_context_block="x",
+        wiki_excerpts_block="x",
+        sentry_events_block="x",
+        recent_commits_block="x",
+        prior_attempts_block="x",
+        prompt_template="_default",
+    )
+    assert "Default Playbook" in out
+
+
 def test_parse_agent_response_resolved() -> None:
     out = parse_agent_response(
         "<status>resolved</status><pr_url>https://x</pr_url><diagnosis>did it</diagnosis>"


### PR DESCRIPTION
## Summary
Closes advisor-5nxu (ADR-0063 W1). Routes AutoAgentPreflightLoop by sub-label to a per-phase playbook bundle (persona + prompt template) instead of the generic lead-engineer persona.

- `src/preflight/playbooks/__init__.py` — frozen-dataclass registry; unknown sub-labels fall back to default playbook (backwards-compatible).
- `src/preflight/runner.py` — `render_prompt` accepts `prompt_template` override.
- `src/preflight/agent.py` — wires playbook lookup, preserves operator-customised persona when registry would have used DEFAULT_PERSONA.
- Five new specialist prompts: discover-stuck, plan-stuck, implement-stuck, review-stuck, triage-stuck.

## Test plan
- [x] `pytest tests/test_preflight_playbooks.py tests/test_preflight_agent.py tests/test_preflight_runner.py tests/scenarios/test_auto_agent_playbook_routing.py -o "addopts="` — 34 passed
- [x] `pyright src/preflight/` — clean