### PR TITLE
feat(discover): discover-expander subagent (ADR-0063 W3a)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -117,6 +117,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("max_test_adequacy_attempts", "HYDRAFLOW_MAX_TEST_ADEQUACY_ATTEMPTS", 1),
     ("max_plan_compliance_attempts", "HYDRAFLOW_MAX_PLAN_COMPLIANCE_ATTEMPTS", 1),
     ("max_discover_attempts", "HYDRAFLOW_MAX_DISCOVER_ATTEMPTS", 3),
+    ("max_discover_expansions", "HYDRAFLOW_MAX_DISCOVER_EXPANSIONS", 1),
     ("max_shape_attempts", "HYDRAFLOW_MAX_SHAPE_ATTEMPTS", 3),
     ("max_review_fix_attempts", "HYDRAFLOW_MAX_REVIEW_FIX_ATTEMPTS", 2),
     ("min_review_findings", "HYDRAFLOW_MIN_REVIEW_FINDINGS", 3),
@@ -719,6 +720,15 @@ class HydraFlowConfig(BaseModel):
         ge=0,
         le=5,
         description="Max Discover-brief evaluator retries before HITL escalation (0 = disabled)",
+    )
+    max_discover_expansions: int = Field(
+        default=1,
+        ge=0,
+        le=3,
+        description=(
+            "Max discover-expander subagent dispatches per issue before "
+            "falling through to HITL escalation (ADR-0063 W3a; 0 = disabled)"
+        ),
     )
     max_shape_attempts: int = Field(
         default=3,

--- a/src/discover_expander.py
+++ b/src/discover_expander.py
@@ -1,0 +1,267 @@
+"""Discover expander — autonomous context recovery for coherence failures.
+
+ADR-0063 W3a. When the ``discover-completeness`` evaluator rejects a
+research brief, the current behavior is to retry the same prompt up to
+``max_discover_attempts`` and then escalate via ``hitl-escalation`` /
+``discover-stuck``. Per ADR-0063 §"Decision" (`discover` row, CTX
+mitigation), the autonomous recovery step inserted BEFORE escalation is
+a subagent dispatch that proposes new research queries based on the
+coherence-failure reason; the expanded brief is then re-fed to the
+discover step.
+
+This module is pure: it takes an async ``executor`` callable (matching
+the ``BaseRunner._execute`` signature) so the runner stays the only
+component that owns subprocess wiring. Tests pass a mock executor and
+assert on the parsed expansion query list.
+
+Output contract — the subagent emits structured markers:
+
+    EXPANSION_QUERIES_START
+    - <one new research query per bullet>
+    - <...>
+    EXPANSION_QUERIES_END
+
+A missing marker block falls open with an empty list (the runner then
+proceeds to its next regular retry attempt; expansion was tried, did
+not produce queries, no harm done). The expander never raises on the
+agent transcript — only on ``CreditExhaustedError`` propagated by the
+executor (via ``reraise_on_credit_or_bug`` upstream).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models import Task
+
+logger = logging.getLogger("hydraflow.discover_expander")
+
+
+_QUERIES_BLOCK_RE = re.compile(
+    r"EXPANSION_QUERIES_START\s*\n(.*?)\n\s*EXPANSION_QUERIES_END",
+    re.DOTALL,
+)
+_BULLET_RE = re.compile(r"^\s*[-*]\s+(.+)$")
+
+
+# Type alias for the executor callable. Matches ``BaseRunner._execute``'s
+# subset of arguments the expander needs.
+Executor = Callable[..., Awaitable[str]]
+
+
+def build_expander_prompt(
+    *,
+    issue_number: int,
+    issue_title: str,
+    issue_body: str,
+    original_brief: str,
+    coherence_failure_reason: str,
+    failure_findings: list[str] | None = None,
+) -> str:
+    """Build the prompt that asks an agent to propose new research queries.
+
+    The prompt frames the task as "what would 30% more confidence
+    require?" per ADR-0063, then asks for ≥3 specific new queries
+    grounded in the coherence-failure reason.
+    """
+    findings_section = ""
+    if failure_findings:
+        bullet_lines = "\n".join(f"- {f}" for f in failure_findings[:10])
+        findings_section = (
+            f"\n## Specific Findings From The Coherence Evaluator\n\n{bullet_lines}\n"
+        )
+
+    return f"""You are the discover-expander subagent for HydraFlow's Discover
+phase (ADR-0063 W3a). The discover-completeness evaluator just rejected
+a research brief for issue #{issue_number}. Before escalating to a
+human, the factory dispatches you to propose new research queries that,
+if answered, would lift the brief past the rubric on the next attempt.
+
+## Issue #{issue_number}: {issue_title}
+
+```
+{issue_body or "(No description provided)"}
+```
+
+## Research Brief That Was Rejected
+
+```
+{original_brief or "(empty brief)"}
+```
+
+## Coherence Failure Reason
+
+{coherence_failure_reason or "(no summary provided)"}
+{findings_section}
+## Your Mission
+
+Ask: "what would 30% more confidence require?" The original discover
+agent produced the brief above and the rubric judged it insufficient.
+Your job is NOT to rewrite the brief — it is to propose research
+queries the next discovery attempt should answer.
+
+Propose at least three (3) new research queries. Each query must:
+
+- Be specific enough that a researcher could go investigate it
+  (no "do better"). Name a competitor, a persona, a metric, an ADR,
+  a file path, a market segment.
+- Address the SPECIFIC failure mode named in the coherence summary.
+  - `missing-section:*` → name what evidence the missing section would
+    need to ground (e.g. "research three competing dark-mode toggles
+    and quote the accessibility commitments each makes").
+  - `shallow-section:*` → name the depth gap (e.g. "find at least
+    five user reports of friction with current per-device theme
+    persistence on G2 or Reddit").
+  - `paraphrase-only` → propose queries that would add NEW information
+    not in the issue body (competitors, constraints, code paths,
+    measurable targets).
+  - `vague-criterion` → propose queries that would yield observable
+    outcomes (metrics, exit codes, UI states).
+  - `hid-ambiguity` → propose open questions the brief failed to name.
+- Be answerable in one research pass — do not propose multi-month
+  studies.
+
+## Required Output
+
+EXPANSION_QUERIES_START
+- <query 1, specific and answerable>
+- <query 2, addresses the failure mode>
+- <query 3, adds new information>
+- <optional further queries>
+EXPANSION_QUERIES_END
+
+Do NOT modify files. Do NOT write a new brief. Only emit the bullet
+list inside the markers above.
+"""
+
+
+def parse_expansion_queries(transcript: str) -> list[str]:
+    """Parse new research queries from an expander transcript.
+
+    Returns the bulleted queries between ``EXPANSION_QUERIES_START`` and
+    ``EXPANSION_QUERIES_END``. Returns an empty list when markers are
+    missing or no bullets are present — callers should treat that as
+    "expansion produced nothing useful" rather than an error.
+    """
+    match = _QUERIES_BLOCK_RE.search(transcript)
+    if not match:
+        return []
+    block = match.group(1)
+    queries: list[str] = []
+    for line in block.splitlines():
+        m = _BULLET_RE.match(line)
+        if m:
+            text = m.group(1).strip()
+            if text:
+                queries.append(text)
+    return queries
+
+
+def format_queries_for_prompt(queries: list[str]) -> str:
+    """Format expansion queries as a prompt-injection block for retry.
+
+    The runner appends this block to the next discovery prompt so the
+    next attempt explicitly answers each query. Empty list → empty
+    string (no injection).
+    """
+    if not queries:
+        return ""
+    lines = [
+        "## Expanded Research Queries (from discover-expander, ADR-0063 W3a)",
+        "",
+        (
+            "The previous discovery brief was rejected by the coherence "
+            "evaluator. The discover-expander subagent proposed the "
+            "following new research queries; your next brief MUST answer "
+            "each of them, citing evidence."
+        ),
+        "",
+    ]
+    for q in queries:
+        lines.append(f"- {q}")
+    return "\n".join(lines)
+
+
+async def expand_research_brief(
+    *,
+    task: Task,
+    original_brief: str,
+    coherence_failure_reason: str,
+    failure_findings: list[str] | None,
+    executor: Executor,
+    cmd: list[str],
+    cwd: Path,
+) -> list[str]:
+    """Dispatch a subagent to propose new research queries.
+
+    Parameters
+    ----------
+    task:
+        The discover-phase ``Task`` whose brief was rejected.
+    original_brief:
+        The rejected brief text.
+    coherence_failure_reason:
+        The ``SUMMARY`` line from the discover-completeness evaluator
+        (e.g. ``"paraphrase-only — brief restates issue body"``).
+    failure_findings:
+        Optional ``FINDINGS`` bullets from the evaluator transcript.
+    executor:
+        An async callable matching ``BaseRunner._execute``'s signature:
+        ``(cmd, prompt, cwd, event_data, *, on_output=None) -> str``.
+        Injected so the discover runner stays the only owner of
+        subprocess wiring.
+    cmd:
+        The agent CLI invocation list (the runner builds this once).
+    cwd:
+        The working directory for the agent subprocess.
+
+    Returns
+    -------
+    list[str]
+        Parsed expansion queries. May be empty when the subagent
+        produced no usable output — the caller should treat that as
+        "expansion attempted, no signal" and fall through to the
+        existing escalation path.
+    """
+    prompt = build_expander_prompt(
+        issue_number=task.id,
+        issue_title=task.title,
+        issue_body=task.body or "",
+        original_brief=original_brief,
+        coherence_failure_reason=coherence_failure_reason,
+        failure_findings=failure_findings,
+    )
+    try:
+        transcript = await executor(
+            cmd,
+            prompt,
+            cwd,
+            {"issue": task.id, "source": "discover:expander"},
+        )
+    except Exception as exc:  # noqa: BLE001 — log and fall through
+        # Do not call ``reraise_on_credit_or_bug`` here — the executor
+        # (``BaseRunner._execute``) already classifies credit / programmer
+        # bugs and re-raises them through ``stream_claude_process``. Any
+        # exception that reaches here is a transient agent failure; log
+        # it and return no queries so the runner continues to escalation.
+        logger.warning(
+            "discover-expander dispatch failed for #%d: %s — returning no queries",
+            task.id,
+            exc,
+        )
+        return []
+    queries = parse_expansion_queries(transcript)
+    if not queries:
+        logger.info("discover-expander for #%d produced no parseable queries", task.id)
+    else:
+        logger.info(
+            "discover-expander for #%d produced %d new research queries",
+            task.id,
+            len(queries),
+        )
+    return queries

--- a/src/discover_runner.py
+++ b/src/discover_runner.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
+from discover_expander import expand_research_brief, format_queries_for_prompt
 from exception_classify import reraise_on_credit_or_bug
 from models import DiscoverResult
 from plugin_skill_registry import (
@@ -69,6 +70,15 @@ class DiscoverRunner(BaseRunner):
         RETRY it re-runs discovery up to the budget, then escalates via
         ``hitl-escalation`` / ``discover-stuck`` and returns the last
         (best-available) brief so the phase can still post a comment.
+
+        ADR-0063 W3a — discover-expander. On the FIRST coherence-failure
+        within the bounded retry loop the runner dispatches the
+        ``discover-expander`` subagent (capped by
+        ``config.max_discover_expansions``, default 1) to propose new
+        research queries; those queries are injected into the next
+        attempt's prompt before re-running discovery. One expansion per
+        issue by default — further coherence failures fall through to
+        normal retry + escalation.
         """
         result = DiscoverResult(issue_number=task.id)
         if self._config.dry_run:
@@ -78,10 +88,15 @@ class DiscoverRunner(BaseRunner):
 
         max_attempts = max(1, self._config.max_discover_attempts or 1)
         evaluator_enabled = self._config.max_discover_attempts > 0
+        max_expansions = max(0, int(self._config.max_discover_expansions or 0))
+        expansions_used = 0
+        expanded_queries: list[str] = []
         last_summary = ""
         last_findings: list[str] = []
         for attempt in range(1, max_attempts + 1):
-            result = await self._run_discovery_once(task, attempt)
+            result = await self._run_discovery_once(
+                task, attempt, expanded_queries=expanded_queries
+            )
             if not evaluator_enabled:
                 return result
             passed, summary, findings = await self._evaluate_brief(
@@ -97,14 +112,80 @@ class DiscoverRunner(BaseRunner):
                 max_attempts,
                 summary,
             )
+            # ADR-0063 W3a — on the first coherence failure, dispatch
+            # the discover-expander before the next attempt. Bounded by
+            # ``max_discover_expansions`` (default 1). When the
+            # expander returns no queries we still proceed to the next
+            # attempt (no harm), but we do not consume another expansion
+            # slot — there was nothing to inject.
+            should_expand = expansions_used < max_expansions and attempt < max_attempts
+            if should_expand:
+                new_queries = await self._dispatch_expander(
+                    task=task,
+                    original_brief=result.research_brief,
+                    coherence_failure_reason=summary,
+                    failure_findings=findings,
+                )
+                if new_queries:
+                    expansions_used += 1
+                    # Accumulate: queries from successive expansions all
+                    # feed forward so the next attempt sees the union.
+                    expanded_queries = expanded_queries + new_queries
+                    logger.info(
+                        "discover-expander injected %d new queries for #%d "
+                        "(expansion %d/%d)",
+                        len(new_queries),
+                        task.id,
+                        expansions_used,
+                        max_expansions,
+                    )
         await self._escalate_stuck(task, last_summary, last_findings, max_attempts)
         return result
 
-    async def _run_discovery_once(self, task: Task, attempt: int) -> DiscoverResult:
+    async def _dispatch_expander(
+        self,
+        *,
+        task: Task,
+        original_brief: str,
+        coherence_failure_reason: str,
+        failure_findings: list[str],
+    ) -> list[str]:
+        """Dispatch the discover-expander subagent (ADR-0063 W3a).
+
+        Thin wrapper that supplies the runner's CLI command, working
+        directory, and ``_execute`` callable to the pure expander helper.
+        Returns the parsed expansion queries (possibly empty).
+        """
+        try:
+            return await expand_research_brief(
+                task=task,
+                original_brief=original_brief,
+                coherence_failure_reason=coherence_failure_reason,
+                failure_findings=failure_findings,
+                executor=self._execute,
+                cmd=self._build_command(),
+                cwd=self._config.repo_root,
+            )
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
+            logger.warning("discover-expander wrapper failed for #%d: %s", task.id, exc)
+            return []
+
+    async def _run_discovery_once(
+        self,
+        task: Task,
+        attempt: int,
+        *,
+        expanded_queries: list[str] | None = None,
+    ) -> DiscoverResult:
         """Run a single discovery pass — produces one :class:`DiscoverResult`.
 
         Factored from the original single-shot ``discover`` body so the
-        outer loop can invoke it once per attempt.
+        outer loop can invoke it once per attempt. ``expanded_queries``
+        (ADR-0063 W3a) carries research queries the discover-expander
+        subagent produced after a prior coherence failure; when present
+        they are appended to the prompt so the next brief explicitly
+        addresses each one.
         """
         result = DiscoverResult(issue_number=task.id)
         transcript = ""
@@ -125,6 +206,13 @@ class DiscoverRunner(BaseRunner):
                     f"in what the team already knows."
                     f"{memory_section}"
                 )
+
+            # ADR-0063 W3a — inject any expanded research queries from a
+            # prior discover-expander dispatch so this attempt's brief
+            # answers them explicitly.
+            expansion_section = format_queries_for_prompt(expanded_queries or [])
+            if expansion_section:
+                prompt = f"{prompt}\n\n{expansion_section}"
 
             def _check_complete(accumulated: str) -> bool:
                 if _DISCOVER_END in accumulated:

--- a/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
+++ b/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
@@ -227,9 +227,9 @@ class TestAdrTouchpointAuditor:
           ``config.auto_agent_skip_sublabels`` — confirming the AutoAgentPreflightLoop
           preflight path (ADR-0050) is reachable for this escalation class.
         """
-        from adr_index import ADRIndex  # noqa: PLC0415
         from unittest.mock import MagicMock  # noqa: PLC0415
 
+        from adr_index import ADRIndex  # noqa: PLC0415
         from config import HydraFlowConfig  # noqa: PLC0415
 
         world = MockWorld(tmp_path)

--- a/tests/scenarios/test_product_phase_trust_scenario.py
+++ b/tests/scenarios/test_product_phase_trust_scenario.py
@@ -91,6 +91,16 @@ _OK_DISCOVER_EVAL = (
 
 _OK_SHAPE_EVAL = "SHAPE_COHERENCE_RESULT: OK\nSUMMARY: All rubric criteria pass\n"
 
+# ADR-0063 W3a — the discover-expander emits a marker-bracketed bullet
+# list of new research queries to inject into the next discovery prompt.
+_EXPANDER_QUERIES = (
+    "EXPANSION_QUERIES_START\n"
+    "- Investigate per-device vs per-account theme persistence trade-offs.\n"
+    "- Survey accessibility commitments for dark-mode in 3 competitors.\n"
+    "- Identify whether OS-prefers-color-scheme is honored by current code.\n"
+    "EXPANSION_QUERIES_END"
+)
+
 
 def _build_execute_stub(
     script: dict[str, list[str]],
@@ -224,13 +234,18 @@ class TestProductPhaseTrustScenario:
 
         call_log: list[str] = []
 
-        # Discover scripts: two attempts on the runner, two evaluator calls.
+        # Discover scripts: two attempts on the runner, two evaluator
+        # calls, plus one discover-expander dispatch inserted between
+        # the first coherence failure and the second attempt
+        # (ADR-0063 W3a — the autonomous recovery step before
+        # HITL escalation).
         discover_script = {
             "discover:attempt": [_BAD_BRIEF_JSON, _GOOD_BRIEF_JSON],
             "discover:evaluator": [
                 _retry_eval_transcript(),
                 _OK_DISCOVER_EVAL,
             ],
+            "discover:expander": [_EXPANDER_QUERIES],
         }
         shape_script = {
             "shape:attempt": [_SHAPE_FINAL_PROPOSAL],
@@ -255,14 +270,20 @@ class TestProductPhaseTrustScenario:
         assert did_discover, "DiscoverPhase should process the seeded issue"
 
         # Discover retry path exercised: two _run_discovery_once calls,
-        # plus two evaluator dispatches (first RETRY, second OK).
+        # plus two evaluator dispatches (first RETRY, second OK), plus
+        # one discover-expander dispatch between them (ADR-0063 W3a).
         discover_attempts = [c for c in call_log if c.startswith("discover:attempt")]
         discover_evals = [c for c in call_log if c == "discover:evaluator"]
+        discover_expansions = [c for c in call_log if c == "discover:expander"]
         assert len(discover_attempts) == 2, (
             f"expected 2 discover attempts (RETRY→OK), got {discover_attempts}"
         )
         assert len(discover_evals) == 2, (
             f"expected 2 evaluator dispatches, got {discover_evals}"
+        )
+        assert len(discover_expansions) == 1, (
+            f"expected 1 discover-expander dispatch after first coherence "
+            f"failure (ADR-0063 W3a), got {discover_expansions}"
         )
 
         # FakeGitHub's transition advanced the issue into shape.
@@ -313,12 +334,17 @@ class TestProductPhaseTrustScenario:
         call_log: list[str] = []
 
         # Two bad briefs, two RETRY evaluations — exhausts the budget.
+        # The discover-expander runs once between the failures
+        # (ADR-0063 W3a, default ``max_discover_expansions=1``) but
+        # cannot help here — both briefs still fail the rubric and
+        # escalation fires after attempt 2.
         discover_script = {
             "discover:attempt": [_BAD_BRIEF_JSON, _BAD_BRIEF_JSON],
             "discover:evaluator": [
                 _retry_eval_transcript("missing-section:acceptance-criteria"),
                 _retry_eval_transcript("paraphrase-only"),
             ],
+            "discover:expander": [_EXPANDER_QUERIES],
         }
 
         discover_phase = _wire_discover_phase(
@@ -343,4 +369,73 @@ class TestProductPhaseTrustScenario:
         assert "#502" in escalations[0].title
 
         # Asyncio bookkeeping: let the bus drain any queued events cleanly.
+        await asyncio.sleep(0)
+
+    async def test_w3a_expander_recovery_prevents_escalation(self, tmp_path) -> None:
+        """ADR-0063 W3a — coherence failure recovers via discover-expander.
+
+        Sets ``max_discover_attempts=2`` (one fewer than the happy-path
+        scenario) and ``max_discover_expansions=1``. Attempt 1 produces
+        a bad brief that fails coherence; the discover-expander
+        dispatches between attempts; attempt 2 (now seeing expanded
+        queries injected into its prompt) produces a good brief.
+        Escalation is NOT filed, even though without the expander the
+        2-attempt budget would have exhausted on a second bad brief.
+        """
+        world = MockWorld(tmp_path)
+
+        world.add_issue(
+            601,
+            "Maybe a dark mode?",
+            _AMBIGUOUS_BODY,
+            labels=["hydraflow-discover"],
+        )
+        task = Task(
+            id=601,
+            title="Maybe a dark mode?",
+            body=_AMBIGUOUS_BODY,
+            tags=["hydraflow-discover"],
+        )
+        world.harness.seed_issue(task, stage="discover")
+
+        call_log: list[str] = []
+
+        # Tight budget: only 2 attempts. The expander is the load-bearing
+        # step — without it, attempt 2 would have nothing new to work
+        # with and the brief would fail again.
+        discover_script = {
+            "discover:attempt": [_BAD_BRIEF_JSON, _GOOD_BRIEF_JSON],
+            "discover:evaluator": [
+                _retry_eval_transcript("paraphrase-only"),
+                _OK_DISCOVER_EVAL,
+            ],
+            "discover:expander": [_EXPANDER_QUERIES],
+        }
+
+        discover_phase = _wire_discover_phase(
+            world,
+            max_attempts=2,
+            call_log=call_log,
+            discover_script=discover_script,
+        )
+
+        await discover_phase.discover_issues()
+
+        # Expander dispatched exactly once (between attempt 1 and attempt 2).
+        assert call_log.count("discover:expander") == 1, call_log
+        # Both discover attempts ran.
+        assert sum(1 for c in call_log if c.startswith("discover:attempt")) == 2
+
+        # Issue transitioned to shape — no escalation filed.
+        labels_after = world.github.issue(601).labels
+        assert "hydraflow-shape" in labels_after, labels_after
+        escalations = [
+            i for i in world.github._issues.values() if "hitl-escalation" in i.labels
+        ]
+        assert not escalations, (
+            f"discover-expander recovery should have prevented escalation; "
+            f"got {[(i.number, i.title, i.labels) for i in escalations]}"
+        )
+
+        # Asyncio bookkeeping.
         await asyncio.sleep(0)

--- a/tests/test_discover_expander.py
+++ b/tests/test_discover_expander.py
@@ -1,0 +1,285 @@
+"""Unit tests for ``discover_expander`` (ADR-0063 W3a).
+
+The expander is pure: it builds a prompt, dispatches a subagent through
+an injected ``executor`` callable, and parses the structured marker
+block. Tests assert on the prompt content (failure reason + findings
+threaded in), the parser's bullet extraction (with malformed markers
+falling open to ``[]``), and the dispatch surface (executor invoked
+with the ``discover:expander`` source tag).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from discover_expander import (
+    build_expander_prompt,
+    expand_research_brief,
+    format_queries_for_prompt,
+    parse_expansion_queries,
+)
+from models import Task
+
+
+def _task(issue_id: int = 7) -> Task:
+    return Task(
+        id=issue_id,
+        title="Maybe a dark mode?",
+        body="It depends on per-device vs per-account.",
+        tags=[],
+        comments=[],
+        source_url="",
+        links=[],
+        complexity_score=0,
+        created_at="",
+        metadata={},
+    )
+
+
+class TestBuildExpanderPrompt:
+    def test_includes_issue_metadata(self) -> None:
+        prompt = build_expander_prompt(
+            issue_number=42,
+            issue_title="vague thing",
+            issue_body="Maybe X?",
+            original_brief="Brief that paraphrased the body.",
+            coherence_failure_reason="paraphrase-only — no new info",
+        )
+        assert "Issue #42: vague thing" in prompt
+        assert "Maybe X?" in prompt
+        assert "Brief that paraphrased the body." in prompt
+        assert "paraphrase-only — no new info" in prompt
+
+    def test_findings_section_renders_when_present(self) -> None:
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            original_brief="brief",
+            coherence_failure_reason="missing-section:open-questions",
+            failure_findings=[
+                "missing-section:open-questions — no questions listed",
+                "missing-section:open-questions — body has 'maybe'",
+            ],
+        )
+        assert "Specific Findings From The Coherence Evaluator" in prompt
+        assert "no questions listed" in prompt
+        assert "body has 'maybe'" in prompt
+
+    def test_findings_section_absent_when_none(self) -> None:
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            original_brief="brief",
+            coherence_failure_reason="vague-criterion",
+            failure_findings=None,
+        )
+        assert "Specific Findings From The Coherence Evaluator" not in prompt
+
+    def test_findings_truncated_to_ten(self) -> None:
+        # 12 findings → only the first 10 rendered (defensive cap to keep
+        # the expander prompt under any LLM context budget).
+        many = [f"finding-{i}" for i in range(12)]
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            original_brief="brief",
+            coherence_failure_reason="shallow-section:intent",
+            failure_findings=many,
+        )
+        for i in range(10):
+            assert f"finding-{i}" in prompt
+        assert "finding-10" not in prompt
+        assert "finding-11" not in prompt
+
+    def test_empty_body_renders_placeholder(self) -> None:
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="",
+            original_brief="brief",
+            coherence_failure_reason="vague-criterion",
+        )
+        assert "(No description provided)" in prompt
+
+    def test_empty_brief_renders_placeholder(self) -> None:
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            original_brief="",
+            coherence_failure_reason="vague-criterion",
+        )
+        assert "(empty brief)" in prompt
+
+    def test_output_marker_contract_documented(self) -> None:
+        # The prompt MUST instruct the agent to emit the canonical
+        # markers the parser keys off; otherwise the dispatch silently
+        # returns no queries every time.
+        prompt = build_expander_prompt(
+            issue_number=1,
+            issue_title="t",
+            issue_body="b",
+            original_brief="brief",
+            coherence_failure_reason="vague-criterion",
+        )
+        assert "EXPANSION_QUERIES_START" in prompt
+        assert "EXPANSION_QUERIES_END" in prompt
+
+
+class TestParseExpansionQueries:
+    def test_extracts_bullets(self) -> None:
+        transcript = (
+            "Some reasoning text.\n"
+            "EXPANSION_QUERIES_START\n"
+            "- First specific query about competitor X.\n"
+            "- Second query about persona Y's friction points.\n"
+            "- Third query about ADR-0042 trade-offs.\n"
+            "EXPANSION_QUERIES_END\n"
+            "trailing noise"
+        )
+        out = parse_expansion_queries(transcript)
+        assert out == [
+            "First specific query about competitor X.",
+            "Second query about persona Y's friction points.",
+            "Third query about ADR-0042 trade-offs.",
+        ]
+
+    def test_accepts_asterisk_bullets(self) -> None:
+        transcript = (
+            "EXPANSION_QUERIES_START\n"
+            "* asterisk style query\n"
+            "* another asterisk one\n"
+            "EXPANSION_QUERIES_END"
+        )
+        out = parse_expansion_queries(transcript)
+        assert out == ["asterisk style query", "another asterisk one"]
+
+    def test_ignores_non_bullet_lines_inside_block(self) -> None:
+        transcript = (
+            "EXPANSION_QUERIES_START\n"
+            "Some preamble text inside the block.\n"
+            "- real query one\n"
+            "More prose.\n"
+            "- real query two\n"
+            "EXPANSION_QUERIES_END"
+        )
+        out = parse_expansion_queries(transcript)
+        assert out == ["real query one", "real query two"]
+
+    def test_missing_markers_returns_empty(self) -> None:
+        assert parse_expansion_queries("nothing structured here") == []
+
+    def test_only_start_marker_returns_empty(self) -> None:
+        assert parse_expansion_queries("EXPANSION_QUERIES_START\n- q1\nno end") == []
+
+    def test_empty_block_returns_empty(self) -> None:
+        transcript = "EXPANSION_QUERIES_START\n\nEXPANSION_QUERIES_END"
+        assert parse_expansion_queries(transcript) == []
+
+    def test_whitespace_only_bullet_filtered(self) -> None:
+        transcript = "EXPANSION_QUERIES_START\n- \n- real one\nEXPANSION_QUERIES_END"
+        assert parse_expansion_queries(transcript) == ["real one"]
+
+
+class TestFormatQueriesForPrompt:
+    def test_renders_bulleted_section(self) -> None:
+        out = format_queries_for_prompt(["alpha", "beta"])
+        assert "Expanded Research Queries" in out
+        assert "- alpha" in out
+        assert "- beta" in out
+        assert "ADR-0063 W3a" in out
+
+    def test_empty_list_returns_empty_string(self) -> None:
+        # Empty input → no injection. The runner appends unconditionally;
+        # the empty-string contract keeps that call site simple.
+        assert format_queries_for_prompt([]) == ""
+
+
+class TestExpandResearchBrief:
+    async def test_invokes_executor_with_expander_source_tag(self) -> None:
+        captured_event: dict[str, object] = {}
+
+        async def _exec(_cmd, _prompt, _cwd, event_data, **_kw):
+            captured_event.update(event_data)
+            return (
+                "EXPANSION_QUERIES_START\n"
+                "- query 1\n"
+                "- query 2\n"
+                "- query 3\n"
+                "EXPANSION_QUERIES_END"
+            )
+
+        queries = await expand_research_brief(
+            task=_task(7),
+            original_brief="paraphrased brief",
+            coherence_failure_reason="paraphrase-only — no new info",
+            failure_findings=["paraphrase-only — no competitor named"],
+            executor=_exec,
+            cmd=["claude"],
+            cwd=Path("/tmp"),
+        )
+        assert queries == ["query 1", "query 2", "query 3"]
+        assert captured_event["issue"] == 7
+        assert captured_event["source"] == "discover:expander"
+
+    async def test_executor_exception_returns_empty_list(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        async def _exec(*_a, **_k):
+            raise RuntimeError("transient agent failure")
+
+        with caplog.at_level("WARNING", logger="hydraflow.discover_expander"):
+            queries = await expand_research_brief(
+                task=_task(9),
+                original_brief="brief",
+                coherence_failure_reason="vague-criterion",
+                failure_findings=[],
+                executor=_exec,
+                cmd=["claude"],
+                cwd=Path("/tmp"),
+            )
+        assert queries == []
+        assert any(
+            "discover-expander dispatch failed for #9" in r.message
+            for r in caplog.records
+        )
+
+    async def test_empty_transcript_returns_empty_list(self) -> None:
+        exec_mock = AsyncMock(return_value="agent produced no markers")
+        queries = await expand_research_brief(
+            task=_task(11),
+            original_brief="brief",
+            coherence_failure_reason="hid-ambiguity",
+            failure_findings=None,
+            executor=exec_mock,
+            cmd=["claude"],
+            cwd=Path("/tmp"),
+        )
+        assert queries == []
+        exec_mock.assert_awaited_once()
+
+    async def test_prompt_threads_failure_reason_to_executor(self) -> None:
+        captured_prompt = {"text": ""}
+
+        async def _exec(_cmd, prompt, _cwd, _event, **_kw):
+            captured_prompt["text"] = prompt
+            return "EXPANSION_QUERIES_START\n- q\nEXPANSION_QUERIES_END"
+
+        await expand_research_brief(
+            task=_task(13),
+            original_brief="brief body here",
+            coherence_failure_reason="missing-section:acceptance-criteria",
+            failure_findings=["acceptance-criteria absent from brief"],
+            executor=_exec,
+            cmd=["claude"],
+            cwd=Path("/tmp"),
+        )
+        assert "missing-section:acceptance-criteria" in captured_prompt["text"]
+        assert "acceptance-criteria absent from brief" in captured_prompt["text"]
+        assert "brief body here" in captured_prompt["text"]

--- a/tests/test_discover_runner_evaluator.py
+++ b/tests/test_discover_runner_evaluator.py
@@ -48,6 +48,11 @@ def _make_runner(
 ):
     """Build a DiscoverRunner with ``_execute`` scripted [discover, eval, ...]."""
     config.max_discover_attempts = max_attempts
+    # These tests pre-date the discover-expander (ADR-0063 W3a) and
+    # script ``_execute`` strictly as [discover, eval, ...]. Disable the
+    # expander here so the dispatch sequence stays as designed; the
+    # expander itself is covered by ``test_discover_runner_expander.py``.
+    config.max_discover_expansions = 0
     config.repo_root = Path("/tmp")
     config.dry_run = False
     runner = DiscoverRunner(config=config, event_bus=MagicMock(spec=EventBus))

--- a/tests/test_discover_runner_evaluator_dispatch.py
+++ b/tests/test_discover_runner_evaluator_dispatch.py
@@ -40,3 +40,20 @@ def test_discover_runner_class_constructs_callable() -> None:
         "DiscoverRunner missing or not a class — evaluator dispatch has "
         "nowhere to plug into the runner"
     )
+
+
+def test_discover_runner_exposes_expansion_cap_config() -> None:
+    """ADR-0063 W3a: the runner caps discover-expander dispatches via
+    ``max_discover_expansions``. Without the field the W3a wiring
+    cannot resolve the cap and would loop unbounded."""
+    from config import HydraFlowConfig
+
+    field = HydraFlowConfig.model_fields.get("max_discover_expansions")
+    assert field is not None, (
+        "max_discover_expansions missing from HydraFlowConfig — "
+        "DiscoverRunner cannot bound discover-expander dispatches"
+    )
+    assert field.default == 1, (
+        f"max_discover_expansions default changed to {field.default}; "
+        "ADR-0063 W3a specifies one expansion per issue by default"
+    )

--- a/tests/test_discover_runner_expander.py
+++ b/tests/test_discover_runner_expander.py
@@ -1,0 +1,248 @@
+"""Unit tests for DiscoverRunner ↔ discover-expander wiring (ADR-0063 W3a).
+
+Asserts on the runner-level orchestration: the expander is dispatched
+between attempts after the FIRST coherence failure, the bounded
+``max_discover_expansions`` cap is respected (default 1), and the
+queries the expander returned are threaded into the next discovery
+prompt so the next attempt sees them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from discover_runner import DiscoverRunner
+from events import EventBus
+from models import DiscoverResult
+
+
+def _make_task(issue_id: int = 42):
+    from models import Task as _Task
+
+    return _Task(
+        id=issue_id,
+        title="Vague thing",
+        body="Maybe do something?",
+        tags=[],
+        comments=[],
+        source_url="",
+        links=[],
+        complexity_score=0,
+        created_at="",
+        metadata={},
+    )
+
+
+_D_START = "DISCOVER_START\nbrief\nDISCOVER_END"
+_OK_EVAL = "DISCOVER_COMPLETENESS_RESULT: OK\nSUMMARY: pass\n"
+_EXPANDER_OUT = (
+    "EXPANSION_QUERIES_START\n"
+    "- Concrete query 1 grounded in failure reason.\n"
+    "- Concrete query 2 about an unexplored persona.\n"
+    "- Concrete query 3 about a measurable target.\n"
+    "EXPANSION_QUERIES_END"
+)
+
+
+def _retry_eval(keyword: str = "paraphrase-only") -> str:
+    return (
+        f"DISCOVER_COMPLETENESS_RESULT: RETRY\n"
+        f"SUMMARY: {keyword} — brief restates body\n"
+        f"FINDINGS:\n- {keyword} — no new info present\n"
+    )
+
+
+def _make_runner(
+    config,
+    *,
+    max_attempts: int,
+    max_expansions: int,
+    queue: list[tuple[str, str]],
+) -> tuple[DiscoverRunner, list[str], list[str]]:
+    """Build a runner whose ``_execute`` returns scripted transcripts.
+
+    ``queue`` is consumed in order; each entry is ``(expected_kind,
+    transcript)`` where ``expected_kind`` is one of ``"discover"``,
+    ``"evaluator"``, ``"expander"``. The stub asserts each call matches
+    the next expected kind so the test fails loudly on order drift.
+
+    Returns the runner, the source-tag call log, and the list of
+    prompts the discovery agent saw (for asserting that expanded
+    queries were threaded in).
+    """
+    config.max_discover_attempts = max_attempts
+    config.max_discover_expansions = max_expansions
+    config.repo_root = Path("/tmp")
+    config.dry_run = False
+    runner = DiscoverRunner(config=config, event_bus=MagicMock(spec=EventBus))
+    call_log: list[str] = []
+    discover_prompts: list[str] = []
+    _queue = list(queue)
+
+    async def _fake_execute(_cmd, prompt, _cwd, event_data, **_kw):
+        source = str(event_data.get("source", ""))
+        call_log.append(source)
+        expected_kind, content = _queue.pop(0)
+        if expected_kind == "discover":
+            assert source.startswith("discover:attempt"), source
+            discover_prompts.append(prompt)
+        elif expected_kind == "evaluator":
+            assert source == "discover:evaluator", source
+        elif expected_kind == "expander":
+            assert source == "discover:expander", source
+        else:
+            raise AssertionError(f"unknown expected_kind={expected_kind!r}")
+        return content
+
+    runner._execute = AsyncMock(side_effect=_fake_execute)  # type: ignore[assignment]
+    runner._build_command = lambda _w=None: ["claude"]  # type: ignore[assignment]
+    runner._build_prompt = lambda t: f"BASE PROMPT for #{t.id}"  # type: ignore[assignment]
+    runner._save_transcript = lambda *a, **k: None  # type: ignore[assignment]
+    runner._inject_memory = AsyncMock(return_value="")  # type: ignore[assignment]
+    runner._extract_result = lambda tx, n: DiscoverResult(  # type: ignore[assignment]
+        issue_number=n, research_brief=tx
+    )
+    runner._extract_raw_brief = lambda tx: tx  # type: ignore[assignment]
+    return runner, call_log, discover_prompts
+
+
+class TestDiscoverRunnerExpander:
+    """ADR-0063 W3a — the expander is the autonomous step inserted
+    between coherence failure and HITL escalation."""
+
+    async def test_first_coherence_failure_triggers_expander(self, config) -> None:
+        """RETRY on attempt 1 → expander dispatches → OK on attempt 2."""
+        runner, calls, prompts = _make_runner(
+            config,
+            max_attempts=3,
+            max_expansions=1,
+            queue=[
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("paraphrase-only")),
+                ("expander", _EXPANDER_OUT),
+                ("discover", _D_START),
+                ("evaluator", _OK_EVAL),
+            ],
+        )
+        await runner.discover(_make_task(101))
+        # Expander invoked exactly once.
+        assert calls.count("discover:expander") == 1
+        # Both discover attempts ran (initial + post-expansion).
+        assert sum(1 for c in calls if c.startswith("discover:attempt")) == 2
+        # The post-expansion prompt MUST carry the expanded queries.
+        assert "Expanded Research Queries" in prompts[1]
+        assert "Concrete query 1 grounded in failure reason." in prompts[1]
+        # The first prompt did NOT carry expanded queries (nothing to inject yet).
+        assert "Expanded Research Queries" not in prompts[0]
+
+    async def test_max_expansions_cap_respected(self, config) -> None:
+        """With max_expansions=1, a second coherence failure does NOT
+        dispatch the expander again — the runner falls through to its
+        normal retry → escalation path."""
+        runner, calls, _ = _make_runner(
+            config,
+            max_attempts=3,
+            max_expansions=1,
+            queue=[
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("paraphrase-only")),
+                ("expander", _EXPANDER_OUT),
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("hid-ambiguity")),
+                # No expander here — cap exhausted; goes straight to next attempt.
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("vague-criterion")),
+            ],
+        )
+        prs = MagicMock()
+        prs.create_issue = AsyncMock(return_value=999)
+        dedup = MagicMock()
+        dedup.get = MagicMock(return_value=set())
+        dedup.add = MagicMock()
+        runner.bind_escalation_deps(prs, dedup)
+
+        await runner.discover(_make_task(202))
+        # Exactly one expansion across the whole retry budget.
+        assert calls.count("discover:expander") == 1
+        # All three discover attempts consumed → escalation filed.
+        assert sum(1 for c in calls if c.startswith("discover:attempt")) == 3
+        prs.create_issue.assert_awaited_once()
+
+    async def test_max_expansions_zero_disables_expander(self, config) -> None:
+        """With max_expansions=0, the expander never dispatches — the
+        runner reverts to the pre-W3a behavior (retry → escalate)."""
+        runner, calls, prompts = _make_runner(
+            config,
+            max_attempts=2,
+            max_expansions=0,
+            queue=[
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("paraphrase-only")),
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("hid-ambiguity")),
+            ],
+        )
+        prs = MagicMock()
+        prs.create_issue = AsyncMock(return_value=1)
+        dedup = MagicMock()
+        dedup.get = MagicMock(return_value=set())
+        dedup.add = MagicMock()
+        runner.bind_escalation_deps(prs, dedup)
+
+        await runner.discover(_make_task(303))
+        assert "discover:expander" not in calls
+        assert all("Expanded Research Queries" not in p for p in prompts)
+        prs.create_issue.assert_awaited_once()
+
+    async def test_expander_empty_output_does_not_consume_slot(self, config) -> None:
+        """When the expander returns no queries, the slot is preserved —
+        the next coherence failure may try expansion again."""
+        empty_expander = "agent rambled but produced no marker block"
+        runner, calls, prompts = _make_runner(
+            config,
+            max_attempts=3,
+            max_expansions=1,
+            queue=[
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("paraphrase-only")),
+                ("expander", empty_expander),  # produces no queries
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("vague-criterion")),
+                ("expander", _EXPANDER_OUT),  # second attempt succeeds
+                ("discover", _D_START),
+                ("evaluator", _OK_EVAL),
+            ],
+        )
+        await runner.discover(_make_task(404))
+        # Two expander dispatches — first produced nothing (slot
+        # preserved), second produced queries (slot consumed).
+        assert calls.count("discover:expander") == 2
+        # The final discover prompt carries the second expander's queries.
+        assert "Concrete query 1 grounded in failure reason." in prompts[-1]
+
+    async def test_no_expansion_when_attempt_is_last(self, config) -> None:
+        """The runner does not waste a dispatch when no further attempt
+        will use it — expansion runs only between attempts, not after
+        the final one."""
+        runner, calls, _ = _make_runner(
+            config,
+            max_attempts=1,
+            max_expansions=1,
+            queue=[
+                ("discover", _D_START),
+                ("evaluator", _retry_eval("paraphrase-only")),
+                # No expander here — attempt 1 was the last; runner
+                # escalates instead.
+            ],
+        )
+        prs = MagicMock()
+        prs.create_issue = AsyncMock(return_value=1)
+        dedup = MagicMock()
+        dedup.get = MagicMock(return_value=set())
+        dedup.add = MagicMock()
+        runner.bind_escalation_deps(prs, dedup)
+
+        await runner.discover(_make_task(505))
+        assert "discover:expander" not in calls
+        prs.create_issue.assert_awaited_once()

--- a/tests/test_flake_tracker_loop.py
+++ b/tests/test_flake_tracker_loop.py
@@ -284,7 +284,9 @@ async def test_download_junit_gh_failure_returns_empty(loop_env, monkeypatch) ->
         async def communicate(self):
             return b"", b"no artifact named junit-scenario"
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_FailProc()))
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_FailProc())
+    )
     result = await loop._download_junit({"databaseId": 99})
     assert result == {}
 
@@ -300,12 +302,16 @@ async def test_download_junit_no_xml_files_returns_empty(loop_env, monkeypatch) 
             return b"", b""
 
     # The subprocess writes nothing; the temp dir remains empty.
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_OkProc()))
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_OkProc())
+    )
     result = await loop._download_junit({"databaseId": 7})
     assert result == {}
 
 
-async def test_download_junit_valid_xml_returns_parsed_results(loop_env, monkeypatch) -> None:
+async def test_download_junit_valid_xml_returns_parsed_results(
+    loop_env, monkeypatch
+) -> None:
     """gh succeeds and writes a valid JUnit XML → parsed pass/fail dict."""
     loop = _make_loop(loop_env)
     captured_dir: list[str] = []
@@ -397,7 +403,9 @@ async def test_download_junit_multiple_xml_files_merged(loop_env, monkeypatch) -
     assert result["tests.b.test_three"] == "fail"
 
 
-async def test_download_junit_only_malformed_xml_returns_empty(loop_env, monkeypatch) -> None:
+async def test_download_junit_only_malformed_xml_returns_empty(
+    loop_env, monkeypatch
+) -> None:
     """All XML files malformed → {} (every file triggers ET.ParseError and is skipped)."""
     loop = _make_loop(loop_env)
     captured_dir: list[str] = []

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -597,5 +597,7 @@ async def test_reconcile_closed_escalations_resets_counter(
     )
 
     await loop._reconcile_closed_escalations()
-    pr.list_closed_issues_by_label.assert_awaited_once_with("principles-stuck", limit=100)
+    pr.list_closed_issues_by_label.assert_awaited_once_with(
+        "principles-stuck", limit=100
+    )
     state.reset_drift_attempts.assert_called_once_with("hydra/widgets", "P2.3")

--- a/tests/test_trust_fleet_sanity_loop.py
+++ b/tests/test_trust_fleet_sanity_loop.py
@@ -6,7 +6,7 @@ import asyncio
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -15,8 +15,8 @@ from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from trust_fleet_sanity_loop import (
     _DAY_SECONDS,
-    _parse_iso,
     TrustFleetSanityLoop,
+    _parse_iso,
 )
 
 
@@ -343,7 +343,9 @@ async def test_do_work_files_escalation_on_cost_spike_breach(loop_env) -> None:
 
     cost_reader = MagicMock()
     cost_reader.get_loop_cost_today.return_value = 50.0
-    cost_reader.get_loop_cost_30d_median.return_value = 5.0  # ratio 10.0 >= 5.0 threshold
+    cost_reader.get_loop_cost_30d_median.return_value = (
+        5.0  # ratio 10.0 >= 5.0 threshold
+    )
 
     loop = _loop(loop_env)
     loop._reconcile_closed_escalations = AsyncMock(return_value=None)
@@ -464,7 +466,9 @@ async def test_reconcile_tolerates_invalid_json(loop_env, monkeypatch) -> None:
     dedup.set_all.assert_not_called()
 
 
-async def test_reconcile_skips_issues_with_unmatched_title(loop_env, monkeypatch) -> None:
+async def test_reconcile_skips_issues_with_unmatched_title(
+    loop_env, monkeypatch
+) -> None:
     """Closed issue whose title doesn't match _TITLE_RE -> key NOT cleared."""
     loop = _loop(loop_env)
     cfg, state, bg_workers, pr, dedup, bus = loop_env
@@ -575,7 +579,9 @@ async def test_collect_window_metrics_ignores_event_outside_day_window(
     """Status event older than 24h -> not counted even if type matches."""
     loop = _loop(loop_env)
 
-    old_event = _make_status_event("rc_budget", "ok", ago_s=_DAY_SECONDS + 600, filed=99)
+    old_event = _make_status_event(
+        "rc_budget", "ok", ago_s=_DAY_SECONDS + 600, filed=99
+    )
 
     async def fake_load(since):  # noqa: ARG001
         return [old_event]

--- a/tests/trust/contracts/test_fake_workspace_contract.py
+++ b/tests/trust/contracts/test_fake_workspace_contract.py
@@ -47,6 +47,7 @@ from ports import WorkspacePort
 # Helper
 # ---------------------------------------------------------------------------
 
+
 def _make_fake(tmp_path: Path) -> FakeWorkspace:
     """Return a fresh FakeWorkspace rooted at *tmp_path*."""
     return FakeWorkspace(base_path=tmp_path)
@@ -85,15 +86,11 @@ _PORT_METHODS = [
 
 
 @pytest.mark.parametrize("method_name", _PORT_METHODS)
-def test_fake_workspace_method_is_async(
-    tmp_path: Path, method_name: str
-) -> None:
+def test_fake_workspace_method_is_async(tmp_path: Path, method_name: str) -> None:
     """Every WorkspacePort method on FakeWorkspace must be a coroutine function."""
     fake = _make_fake(tmp_path)
     method = getattr(fake, method_name, None)
-    assert method is not None, (
-        f"FakeWorkspace is missing Port method {method_name!r}"
-    )
+    assert method is not None, f"FakeWorkspace is missing Port method {method_name!r}"
     assert inspect.iscoroutinefunction(method), (
         f"FakeWorkspace.{method_name} must be async (coroutine function)"
     )
@@ -128,9 +125,7 @@ async def test_destroy_returns_none_and_tracks(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.destroy(issue_number=42)
 
-    assert result is None, (
-        f"WorkspacePort.destroy must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.destroy must return None; got {result!r}"
     assert 42 in fake.destroyed
 
 
@@ -145,9 +140,7 @@ async def test_destroy_all_returns_none(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.destroy_all()
 
-    assert result is None, (
-        f"WorkspacePort.destroy_all must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.destroy_all must return None; got {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -219,9 +212,7 @@ async def test_post_work_cleanup_returns_none(tmp_path: Path) -> None:
     """post_work_cleanup() returns None; keyword arg phase= is accepted."""
     fake = _make_fake(tmp_path)
     result_default = await fake.post_work_cleanup(issue_number=42)
-    result_explicit = await fake.post_work_cleanup(
-        issue_number=42, phase="review"
-    )
+    result_explicit = await fake.post_work_cleanup(issue_number=42, phase="review")
 
     assert result_default is None, (
         f"WorkspacePort.post_work_cleanup must return None; got {result_default!r}"
@@ -242,9 +233,7 @@ async def test_abort_merge_returns_none(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.abort_merge(worktree_path=tmp_path / "issue-1")
 
-    assert result is None, (
-        f"WorkspacePort.abort_merge must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.abort_merge must return None; got {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -261,8 +250,7 @@ async def test_start_merge_main_returns_bool_true(tmp_path: Path) -> None:
     )
 
     assert isinstance(result, bool), (
-        f"WorkspacePort.start_merge_main must return bool; "
-        f"got {type(result).__name__}"
+        f"WorkspacePort.start_merge_main must return bool; got {type(result).__name__}"
     )
     assert result is True, (
         "FakeWorkspace.start_merge_main must return True on happy path"


### PR DESCRIPTION
## Summary
Closes advisor-98eh (ADR-0063 W3a). DiscoverRunner now dispatches the `discover-expander` subagent on the first coherence-evaluator failure within its bounded retry loop, injecting new research queries into the next attempt's prompt.

- New: `src/discover_expander.py` — dispatch + parse/format helpers.
- `src/discover_runner.py` — first-failure expansion hook; successive expansions accumulate queries.
- `src/config.py` — `max_discover_expansions: int = 1` (env: `HYDRAFLOW_MAX_DISCOVER_EXPANSIONS`).

## Test plan
- [x] `pytest tests/test_discover_expander.py tests/test_discover_runner_expander.py tests/test_discover_runner_evaluator.py tests/test_discover_runner_evaluator_dispatch.py -o "addopts="` — 35 passed
- [x] `pytest tests/scenarios/test_product_phase_trust_scenario.py -o "addopts="` — 3 passed
- [x] `pyright src/discover_expander.py src/discover_runner.py src/config.py` — clean