### PR TITLE
feat(plan): plan-touchpoint-expander subagent (ADR-0063 W3b)

### DIFF
--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -12,7 +12,14 @@ from analysis import PlanAnalyzer
 from config import HydraFlowConfig
 from events import EventBus
 from harness_insights import FailureCategory, HarnessInsightStore
-from models import EpicGapReview, IssueOutcomeType, PipelineStage, PlanResult, Task
+from models import (
+    EpicGapReview,
+    IssueOutcomeType,
+    PipelineStage,
+    PlanResult,
+    PlanReview,
+    Task,
+)
 from phase_utils import (
     MemorySuggester,
     PipelineEscalator,
@@ -46,6 +53,7 @@ if TYPE_CHECKING:
     from epic import EpicManager
     from issue_cache import IssueCache
     from plan_reviewer import PlanReviewer
+    from plan_touchpoint_expander import PlanTouchpointExpander
     from ports import IssueStorePort, PRPort
     from wiki_compiler import CorroborationDecision, WikiCompiler  # noqa: TCH004
 
@@ -106,6 +114,7 @@ class PlanPhase:
         wiki_compiler: WikiCompiler | None = None,
         issue_cache: IssueCache | None = None,
         plan_reviewer: PlanReviewer | None = None,
+        touchpoint_expander: PlanTouchpointExpander | None = None,
     ) -> None:
         self._config = config
         self._state = state
@@ -124,6 +133,13 @@ class PlanPhase:
         self._wiki_compiler = wiki_compiler
         self._issue_cache = issue_cache
         self._plan_reviewer = plan_reviewer
+        # Touchpoint expander (ADR-0063 W3b). Dispatched on the FIRST
+        # PlanReviewer blocking-finding failure to enrich the next
+        # review pass with cross-referenced ADRs, recent PR conflict
+        # history, and current wiki entries for the touched modules.
+        # Optional — when None, the existing route-back path runs
+        # unchanged (backward-compat).
+        self._touchpoint_expander = touchpoint_expander
         # Earlier-adversarial pipeline agents (ADR-pending). Optional —
         # the factory wires them in when feature-enabled; legacy paths
         # leave them None and the adversarial stages are skipped. See
@@ -614,6 +630,15 @@ class PlanPhase:
             review = await self._plan_reviewer.review(
                 issue, result, plan_version=plan_version
             )
+            # ADR-0063 W3b: on the FIRST blocking review, dispatch the
+            # touchpoint-expander (if wired) and re-run the reviewer
+            # against an enriched plan. Bounded to one expansion attempt
+            # — if the second pass still flags blocking findings, the
+            # existing READY-stage gate routes the issue back to plan
+            # (or escalates after the per-issue route-back cap).
+            review = await self._maybe_expand_touchpoints(
+                issue, result, review, plan_version
+            )
             if review.success:
                 self._issue_cache.record_review_stored(
                     issue.id,
@@ -644,6 +669,86 @@ class PlanPhase:
             )
 
         return plan_version
+
+    async def _maybe_expand_touchpoints(
+        self,
+        issue: Task,
+        result: PlanResult,
+        first_review: PlanReview,
+        plan_version: int,
+    ) -> PlanReview:
+        """Run the touchpoint-expander + re-review on FIRST blocking failure.
+
+        Returns the review that should be cached. When no expander is
+        wired, the first review has no blocking findings, the expander
+        surfaces no touchpoints, or the reviewer is missing, returns
+        ``first_review`` unchanged so the existing route-back path runs.
+
+        Bounded to one expansion attempt per ADR-0063 W3b — the second
+        review's verdict (clean or still-blocking) is what the cache
+        records. A still-blocking second review routes back via the
+        existing READY-stage gate.
+        """
+        if (
+            self._touchpoint_expander is None
+            or self._plan_reviewer is None
+            or not first_review.success
+            or not first_review.has_blocking_findings
+        ):
+            return first_review
+
+        try:
+            expansion = await self._touchpoint_expander.expand_touchpoints(
+                original_plan=result.plan,
+                reviewer_failure=first_review,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Touchpoint expander raised for issue #%d — falling back "
+                "to existing route-back path",
+                issue.id,
+                exc_info=True,
+            )
+            return first_review
+
+        context_block = expansion.render_context_block()
+        if not context_block:
+            logger.info(
+                "Touchpoint expander surfaced no touchpoints for issue #%d "
+                "— skipping re-review",
+                issue.id,
+            )
+            return first_review
+
+        # Build an enriched plan_result for the second review pass. We
+        # do NOT mutate the original result — the cached plan_stored
+        # record (already written above) reflects the planner's output,
+        # not the enrichment. The expansion is a reviewer-side aid.
+        enriched_plan = f"{result.plan}\n\n{context_block}"
+        enriched_result = result.model_copy(update={"plan": enriched_plan})
+
+        try:
+            second_review = await self._plan_reviewer.review(
+                issue, enriched_result, plan_version=plan_version
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Re-review with expanded touchpoints raised for issue #%d "
+                "— falling back to original review",
+                issue.id,
+                exc_info=True,
+            )
+            return first_review
+
+        logger.info(
+            "Touchpoint-expander re-review for issue #%d: %d touchpoints "
+            "surfaced, blocking=%s → %s",
+            issue.id,
+            len(expansion.touchpoints),
+            first_review.has_blocking_findings,
+            second_review.has_blocking_findings,
+        )
+        return second_review
 
     _WIKI_INGEST_MAX_CHARS = 40_000
 

--- a/src/plan_touchpoint_expander.py
+++ b/src/plan_touchpoint_expander.py
@@ -1,0 +1,307 @@
+"""Plan touchpoint-expander (ADR-0063 W3b).
+
+Dispatched on the FIRST ``PlanReviewer`` blocking-finding failure before
+the issue is routed back to plan or escalated. The expander walks
+cross-referenced ADRs, recent PR conflict signals, and current wiki
+entries for the modules the plan touches, then returns an enriched
+``ExpandedTouchpoints`` block. The block is folded into the next
+review pass as additional context so the reviewer can re-evaluate the
+plan against the proper architectural surface.
+
+Failure mode: this is a read-only subagent call. Any failure (agent
+down, malformed JSON, missing fields) returns an empty
+``ExpandedTouchpoints`` so the caller falls through to the existing
+route-back / HITL escalation path — the expander never blocks
+escalation.
+
+See also:
+- ``src/assumption_surfacer.py`` — sibling subagent dispatcher (same
+  ``AgentLike`` contract, same JSON-parse soft-fail policy).
+- ``src/plan_reviewer.py`` — produces the ``PlanReview`` consumed here.
+- ADR-0063 §"Implementation strategy — W3" — design rationale.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+
+from exception_classify import reraise_on_credit_or_bug
+from models import PlanFindingSeverity, PlanReview
+from src.adversarial_agents import AgentLike
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Marker contract
+# ---------------------------------------------------------------------------
+
+# The expander agent brackets its structured output with these markers so
+# the parser can extract the touchpoints block deterministically. Mirrors
+# the ``PLAN_REVIEW_START`` / ``PLAN_REVIEW_END`` shape used by
+# ``PlanReviewer`` so the agent operator sees a consistent contract.
+TOUCHPOINTS_START = "TOUCHPOINTS_START"
+TOUCHPOINTS_END = "TOUCHPOINTS_END"
+
+
+# Touchpoint kinds we recognize. Anything else collapses to ``other`` so
+# malformed agent output doesn't poison the downstream reviewer prompt.
+_KNOWN_KINDS: frozenset[str] = frozenset({"adr", "pr", "wiki"})
+
+
+@dataclass
+class Touchpoint:
+    """A single architectural touchpoint the expander surfaced.
+
+    ``kind`` is normalized to lowercase at construction; unknown values
+    collapse to ``other`` so the reviewer's next-pass prompt stays
+    well-formed even on malformed agent output.
+    """
+
+    kind: str
+    ref: str
+    title: str = ""
+    why: str = ""
+
+    def __post_init__(self) -> None:
+        normalized = self.kind.lower().strip()
+        self.kind = normalized if normalized in _KNOWN_KINDS else "other"
+
+
+@dataclass
+class ExpandedTouchpoints:
+    """Output of the touchpoint-expander.
+
+    ``touchpoints`` is the parsed list (possibly empty). ``error`` is set
+    when the agent or parser soft-failed — callers can log it but should
+    still treat the result as a no-op (no touchpoints surfaced means the
+    next pass runs without enrichment, same as if the expander never ran).
+    """
+
+    touchpoints: list[Touchpoint] = field(default_factory=list)
+    duration_seconds: float = 0.0
+    error: str | None = None
+
+    def render_context_block(self) -> str:
+        """Render the touchpoints as a markdown block for the next reviewer pass.
+
+        Returns an empty string when no touchpoints are present so the
+        caller can unconditionally concatenate the block into the next
+        review prompt without a guard. The block is wrapped in
+        ``EXPANDED_TOUCHPOINTS`` markers so the reviewer agent can find
+        the inserted context regardless of surrounding prose.
+        """
+        if not self.touchpoints:
+            return ""
+        lines = ["## EXPANDED_TOUCHPOINTS", ""]
+        for t in self.touchpoints:
+            title = f" — {t.title}" if t.title else ""
+            why = f" ({t.why})" if t.why else ""
+            lines.append(f"- [{t.kind}] {t.ref}{title}{why}")
+        lines.append("")
+        lines.append("## END_EXPANDED_TOUCHPOINTS")
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+_SYSTEM_PROMPT = """\
+You are the Plan Touchpoint Expander. The HydraFlow plan reviewer
+returned blocking findings against a plan. Your job is to surface the
+architectural touchpoints the plan should have considered: ADR
+cross-references, recent merged PRs that touched the same files (a
+conflict-history signal), and current per-repo wiki entries for the
+affected modules.
+
+You are a read-only research agent. Do not propose a new plan. Do not
+critique the reviewer. Return ONLY the touchpoints the next planner
+attempt needs in front of it to satisfy `writing-plans`-shaped success
+criteria: concrete, observable, testable.
+
+Output strict JSON between the TOUCHPOINTS_START and TOUCHPOINTS_END
+markers, with this shape:
+TOUCHPOINTS_START
+{
+  "touchpoints": [
+    {"kind": "adr|pr|wiki",
+     "ref": "ADR-NNNN | #PR | path/to/wiki/entry.md",
+     "title": "human-readable title",
+     "why": "one sentence — why this touchpoint matters for the failed findings"}
+  ]
+}
+TOUCHPOINTS_END
+
+If no relevant touchpoints exist, return an empty "touchpoints" list.
+Bound your output to the touchpoints with the highest blast radius —
+typically 3-8 entries. Do not pad.
+"""
+
+
+class PlanTouchpointExpander:
+    """Read-only subagent that expands ADR/PR/wiki touchpoints for a failed plan review.
+
+    Instantiated with an ``AgentLike`` adapter — same shape as the
+    earlier-adversarial pipeline agents (``AssumptionSurfacer``,
+    ``SpecJudge``, etc.). The factory wires a real Claude-CLI-backed
+    adapter; tests use a JSON-returning stub.
+    """
+
+    def __init__(self, agent: AgentLike) -> None:
+        self._agent = agent
+
+    async def expand_touchpoints(
+        self,
+        *,
+        original_plan: str,
+        reviewer_failure: PlanReview,
+    ) -> ExpandedTouchpoints:
+        """Run the expander against a failed plan review.
+
+        Returns an ``ExpandedTouchpoints`` carrying the parsed
+        touchpoints (possibly empty). Never raises into the caller —
+        agent failures soft-fail with ``error`` populated and an empty
+        touchpoint list so the existing route-back path remains intact.
+
+        Defensive: if the caller invokes the expander on a review with
+        no blocking findings, we return an empty result without burning
+        an agent call.
+        """
+        start = time.monotonic()
+
+        blocking = [
+            f
+            for f in reviewer_failure.findings
+            if f.severity in (PlanFindingSeverity.CRITICAL, PlanFindingSeverity.HIGH)
+        ]
+        if not blocking:
+            logger.debug(
+                "plan_touchpoint_expander invoked with no blocking findings — "
+                "skipping agent call"
+            )
+            return ExpandedTouchpoints(duration_seconds=time.monotonic() - start)
+
+        prompt = self._build_prompt(plan=original_plan, findings=blocking)
+
+        try:
+            raw = await self._agent.run(_SYSTEM_PROMPT, prompt)
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
+            logger.warning(
+                "plan_touchpoint_expander agent raised — soft-failing: %s", exc
+            )
+            return ExpandedTouchpoints(
+                duration_seconds=time.monotonic() - start,
+                error=f"agent failure: {exc}",
+            )
+
+        touchpoints = self._parse_touchpoints(raw)
+        return ExpandedTouchpoints(
+            touchpoints=touchpoints,
+            duration_seconds=time.monotonic() - start,
+        )
+
+    # ------------------------------------------------------------------
+    # Pure helpers (testable in isolation)
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _build_prompt(
+        cls,
+        *,
+        plan: str,
+        findings: list,  # type: ignore[type-arg]
+    ) -> str:
+        """Build the user-message prompt for the expander agent.
+
+        Filters to blocking severities (critical/high) so the agent's
+        context window is spent on the failures that actually drove the
+        route-back. Pure function — no I/O.
+        """
+        blocking = [
+            f
+            for f in findings
+            if f.severity in (PlanFindingSeverity.CRITICAL, PlanFindingSeverity.HIGH)
+        ]
+        findings_block = (
+            "\n".join(
+                f"- [{f.severity}] {f.dimension}: {f.description}" for f in blocking
+            )
+            or "(no blocking findings)"
+        )
+
+        return (
+            f"## Plan that failed review\n\n"
+            f"{plan}\n\n"
+            f"## Blocking review findings\n\n"
+            f"{findings_block}\n\n"
+            f"## Task\n\n"
+            f"Identify the architectural touchpoints (ADRs, recent PRs on "
+            f"the same files, current wiki entries) the next plan attempt "
+            f"must consider to satisfy `writing-plans`-shaped success "
+            f"criteria: concrete, observable, testable.\n\n"
+            f"Emit your structured output between {TOUCHPOINTS_START} and "
+            f"{TOUCHPOINTS_END} markers as specified."
+        )
+
+    @classmethod
+    def _parse_touchpoints(cls, raw: str) -> list[Touchpoint]:
+        """Extract structured touchpoints from the agent's raw output.
+
+        Tolerates the agent emitting a raw JSON object or wrapping the
+        JSON in TOUCHPOINTS_START/END markers. Missing required fields
+        cause that entry to be skipped; malformed JSON returns an empty
+        list (soft-fail).
+        """
+        # Permit the agent to emit either raw JSON or a marker-wrapped block.
+        json_text = raw
+        start_idx = raw.find(TOUCHPOINTS_START)
+        end_idx = raw.find(TOUCHPOINTS_END)
+        if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
+            json_text = raw[start_idx + len(TOUCHPOINTS_START) : end_idx].strip()
+
+        try:
+            data = json.loads(json_text)
+        except json.JSONDecodeError:
+            logger.warning(
+                "plan_touchpoint_expander: agent output not parseable as JSON"
+            )
+            return []
+
+        if not isinstance(data, dict):
+            return []
+        entries = data.get("touchpoints")
+        if not isinstance(entries, list):
+            return []
+
+        touchpoints: list[Touchpoint] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            kind = entry.get("kind")
+            ref = entry.get("ref")
+            if not kind or not ref:
+                continue
+            touchpoints.append(
+                Touchpoint(
+                    kind=str(kind),
+                    ref=str(ref),
+                    title=str(entry.get("title", "")),
+                    why=str(entry.get("why", "")),
+                )
+            )
+        return touchpoints
+
+
+__all__ = [
+    "ExpandedTouchpoints",
+    "PlanTouchpointExpander",
+    "Touchpoint",
+    "TOUCHPOINTS_END",
+    "TOUCHPOINTS_START",
+]

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -62,6 +62,7 @@ from models import StatusCallback
 from observability.sentry_adapter import SentryObservabilityAdapter
 from plan_phase import PlanPhase
 from plan_reviewer import PlanReviewer
+from plan_touchpoint_expander import PlanTouchpointExpander
 from planner import PlannerRunner
 from ports import (
     IssueFetcherPort,
@@ -708,6 +709,13 @@ def build_services(
             },
             spec_ac_agent=adversarial_agent,
             spec_judge_agent=adversarial_agent,
+        )
+        # ADR-0063 W3b: the plan touchpoint-expander shares the same
+        # AgentLike contract and the same enablement gate. Wired post-
+        # construction (mirrors ``attach_adversarial_agents``) so the
+        # field default stays ``None`` for legacy code paths and tests.
+        planner_phase._touchpoint_expander = PlanTouchpointExpander(
+            agent=adversarial_agent,
         )
         discover_phase.attach_adversarial_agents(
             surfacer_agent=adversarial_agent,

--- a/tests/scenarios/test_plan_touchpoint_expander_scenario.py
+++ b/tests/scenarios/test_plan_touchpoint_expander_scenario.py
@@ -1,0 +1,322 @@
+"""MockWorld scenarios for the plan touchpoint-expander (ADR-0063 W3b).
+
+Drives ``PlanPhase`` end-to-end against the harness fakes to assert the
+load-bearing transitions:
+
+* First PlanReviewer review returns blocking findings → expander
+  dispatched → second review against the enriched plan reaches READY.
+* Expander surfaces zero touchpoints → no second review fires;
+  existing route-back path runs unchanged.
+* Second review still blocking → expander runs once only; the cache
+  records the still-blocking verdict so the READY-stage gate routes
+  back to plan (dark-factory contract: never deadlock on expansion).
+
+Pattern mirrors ``test_adversarial_pipeline.py`` — attach stubs to
+``world.harness.plan_phase`` before invoking ``plan_issues``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from models import (
+    PlanFinding,
+    PlanFindingSeverity,
+    PlanResult,
+    PlanReview,
+    Task,
+)
+from plan_touchpoint_expander import (
+    ExpandedTouchpoints,
+    Touchpoint,
+)
+from tests.conftest import PlanResultFactory, TaskFactory
+from tests.helpers import supply_once
+
+pytestmark = pytest.mark.scenario
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _ScriptedReviewer:
+    """Returns a scripted sequence of ``PlanReview`` objects per call."""
+
+    def __init__(self, reviews: list[PlanReview]) -> None:
+        self._reviews = list(reviews)
+        self.calls: list[tuple[Task, PlanResult]] = []
+
+    async def review(
+        self, task: Task, plan_result: PlanResult, *, plan_version: int = 1
+    ) -> PlanReview:
+        self.calls.append((task, plan_result))
+        if not self._reviews:
+            raise AssertionError("ran out of scripted reviews")
+        return self._reviews.pop(0)
+
+
+class _ScriptedExpander:
+    """Returns a scripted ``ExpandedTouchpoints`` and records calls."""
+
+    def __init__(self, output: ExpandedTouchpoints) -> None:
+        self.output = output
+        self.calls: list[tuple[str, PlanReview]] = []
+
+    async def expand_touchpoints(
+        self,
+        *,
+        original_plan: str,
+        reviewer_failure: PlanReview,
+    ) -> ExpandedTouchpoints:
+        self.calls.append((original_plan, reviewer_failure))
+        return self.output
+
+
+def _blocking(
+    issue_id: int, *, description: str = "missed ADR cross-ref"
+) -> PlanReview:
+    return PlanReview(
+        issue_number=issue_id,
+        plan_version=1,
+        success=True,
+        findings=[
+            PlanFinding(
+                severity=PlanFindingSeverity.HIGH,
+                dimension="correctness",
+                description=description,
+            ),
+        ],
+        summary="1 high finding",
+    )
+
+
+def _clean(issue_id: int) -> PlanReview:
+    return PlanReview(
+        issue_number=issue_id,
+        plan_version=1,
+        success=True,
+        findings=[],
+        summary="clean",
+    )
+
+
+def _setup_planner(harness: Any, issue_id: int) -> None:
+    """Wire a planner that returns a successful, simple plan."""
+
+    async def _planner_plan(*_args: Any, **_kwargs: Any) -> PlanResult:
+        return PlanResultFactory.create(
+            issue_number=issue_id,
+            success=True,
+            plan="Step 1: change schema\nStep 2: update tests",
+            summary="Done",
+            use_defaults=True,
+        )
+
+    harness.planners.plan = _planner_plan
+
+
+def _wire_issue_cache(plan_phase: Any) -> dict[str, Any]:
+    """Replace plan_phase._issue_cache with a record-capturing stub.
+
+    Returns the dict that captures the final ``review_stored`` payload
+    so scenarios can assert against the cached verdict.
+    """
+    captured: dict[str, Any] = {}
+
+    class _Cache:
+        def record_plan_stored(self, _issue_id: int, **_kw: Any) -> int:
+            return 1
+
+        def record_review_stored(
+            self,
+            issue_id: int,
+            *,
+            review_text: str,
+            has_blocking: bool,
+            findings: list[dict],
+        ) -> None:
+            captured["issue_id"] = issue_id
+            captured["review_text"] = review_text
+            captured["has_blocking"] = has_blocking
+            captured["findings"] = findings
+
+    plan_phase._issue_cache = _Cache()
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: blocking → expander → re-review clean → READY.
+# ---------------------------------------------------------------------------
+
+
+class TestS1ExpanderUnblocksReview:
+    """First review blocks; expander surfaces touchpoints; re-review clean."""
+
+    async def test_blocking_then_expander_then_clean(self, mock_world) -> None:
+        world = mock_world
+        world.add_issue(
+            301,
+            "Touch ADR-0021 schema",
+            "Plan touches StateData and requires schema migration.",
+            labels=["hydraflow-plan"],
+        )
+        harness = world.harness
+        phase = harness.plan_phase
+
+        reviewer = _ScriptedReviewer([_blocking(301), _clean(301)])
+        expander = _ScriptedExpander(
+            ExpandedTouchpoints(
+                touchpoints=[
+                    Touchpoint(
+                        kind="adr",
+                        ref="ADR-0021",
+                        title="Persistence architecture",
+                        why="Plan changes StateData schema",
+                    ),
+                    Touchpoint(
+                        kind="wiki",
+                        ref="architecture-state-persistence.md",
+                        title="Pydantic schema evolution",
+                        why="Plan touches Pydantic models",
+                    ),
+                ]
+            )
+        )
+        phase._plan_reviewer = reviewer
+        phase._touchpoint_expander = expander
+        captured = _wire_issue_cache(phase)
+
+        _setup_planner(harness, 301)
+        issue = TaskFactory.create(id=301, tags=["hydraflow-plan"])
+        harness.store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        # Expander dispatched once; reviewer ran twice (initial + re-review).
+        assert len(expander.calls) == 1
+        assert len(reviewer.calls) == 2
+
+        # Re-review saw the enriched plan with the touchpoints block.
+        second_plan = reviewer.calls[1][1].plan
+        assert "ADR-0021" in second_plan
+        assert "EXPANDED_TOUCHPOINTS" in second_plan
+
+        # Cache reflects the SECOND review's verdict.
+        assert captured["has_blocking"] is False
+        assert captured["findings"] == []
+
+        # READY-stage transition fired (label flipped on the FakeGitHub side).
+        labels = world.github.issue(301).labels
+        assert "hydraflow-ready" in labels, (
+            f"expected ready label after expanded re-review; got {labels}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: blocking → expander → no touchpoints → fall through.
+# ---------------------------------------------------------------------------
+
+
+class TestS2EmptyExpansionFallsThrough:
+    """Expander surfaces zero touchpoints → no re-review; route-back path runs."""
+
+    async def test_empty_expansion_records_first_review(self, mock_world) -> None:
+        world = mock_world
+        world.add_issue(
+            302,
+            "Touch nothing important",
+            "Plan body.",
+            labels=["hydraflow-plan"],
+        )
+        harness = world.harness
+        phase = harness.plan_phase
+
+        reviewer = _ScriptedReviewer([_blocking(302)])
+        expander = _ScriptedExpander(ExpandedTouchpoints(touchpoints=[]))
+        phase._plan_reviewer = reviewer
+        phase._touchpoint_expander = expander
+        captured = _wire_issue_cache(phase)
+
+        _setup_planner(harness, 302)
+        issue = TaskFactory.create(id=302, tags=["hydraflow-plan"])
+        harness.store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        # Expander ran but no re-review fired.
+        assert len(expander.calls) == 1
+        assert len(reviewer.calls) == 1
+
+        # The cached record reflects the original blocking verdict so the
+        # READY-stage gate will route back via the existing path.
+        assert captured["has_blocking"] is True
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: blocking → expander → still blocking → no third try.
+# ---------------------------------------------------------------------------
+
+
+class TestS3StillBlockingAfterExpansion:
+    """Re-review still blocking → expander runs once only; cache the second verdict.
+
+    Per ADR-0063 W3b: bounded to one expansion attempt. A still-blocking
+    second review means the issue routes back via the existing READY-stage
+    gate (dark-factory contract: never deadlock on expansion).
+    """
+
+    async def test_still_blocking_routes_back_via_gate(self, mock_world) -> None:
+        world = mock_world
+        world.add_issue(
+            303,
+            "Stubborn plan",
+            "Plan body.",
+            labels=["hydraflow-plan"],
+        )
+        harness = world.harness
+        phase = harness.plan_phase
+
+        reviewer = _ScriptedReviewer(
+            [
+                _blocking(303, description="first failure"),
+                _blocking(303, description="still failing after enrichment"),
+            ]
+        )
+        expander = _ScriptedExpander(
+            ExpandedTouchpoints(
+                touchpoints=[
+                    Touchpoint(
+                        kind="adr",
+                        ref="ADR-0001",
+                        title="Async loops",
+                        why="touched module",
+                    ),
+                ]
+            )
+        )
+        phase._plan_reviewer = reviewer
+        phase._touchpoint_expander = expander
+        captured = _wire_issue_cache(phase)
+
+        _setup_planner(harness, 303)
+        issue = TaskFactory.create(id=303, tags=["hydraflow-plan"])
+        harness.store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        # Expander runs exactly once even though the re-review still blocks.
+        assert len(expander.calls) == 1
+        assert len(reviewer.calls) == 2
+
+        # Cache reflects the second (still-blocking) verdict so the
+        # existing READY-stage gate routes the issue back to plan.
+        assert captured["has_blocking"] is True
+        # Description from the second blocking review wins.
+        assert any(
+            f["description"] == "still failing after enrichment"
+            for f in captured["findings"]
+        )

--- a/tests/test_plan_phase_touchpoint_expander_wiring.py
+++ b/tests/test_plan_phase_touchpoint_expander_wiring.py
@@ -1,0 +1,280 @@
+"""Tests for PlanPhase ↔ PlanTouchpointExpander wiring (ADR-0063 W3b).
+
+The expander is invoked at one specific seam: inside
+``PlanPhase._write_plan_records`` immediately after the FIRST
+``PlanReviewer.review`` call returns blocking findings. The expander's
+output is rendered into a context block, appended to the plan text, and
+a SECOND ``PlanReviewer.review`` call runs against the enriched plan.
+The cache record reflects the second review's verdict.
+
+Pattern: ``make_plan_phase`` builds the phase with mocks; we inject a
+stub ``PlanReviewer`` and a stub expander and drive
+``_write_plan_records`` directly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from models import (
+    PlanFinding,
+    PlanFindingSeverity,
+    PlanResult,
+    PlanReview,
+    Task,
+)
+from plan_touchpoint_expander import (
+    ExpandedTouchpoints,
+    Touchpoint,
+)
+from tests.helpers import make_plan_phase
+
+# ---------------------------------------------------------------------------
+# Stub PlanReviewer and PlanTouchpointExpander
+# ---------------------------------------------------------------------------
+
+
+class _StubReviewer:
+    """Returns a scripted sequence of ``PlanReview`` objects per call."""
+
+    def __init__(self, reviews: list[PlanReview]) -> None:
+        self._reviews = list(reviews)
+        self.calls: list[tuple[Task, PlanResult]] = []
+
+    async def review(
+        self, task: Task, plan_result: PlanResult, *, plan_version: int = 1
+    ) -> PlanReview:
+        self.calls.append((task, plan_result))
+        if not self._reviews:
+            raise AssertionError("ran out of scripted reviews")
+        return self._reviews.pop(0)
+
+
+class _StubExpander:
+    """Returns a scripted ``ExpandedTouchpoints`` and records calls."""
+
+    def __init__(self, output: ExpandedTouchpoints) -> None:
+        self.output = output
+        self.calls: list[tuple[str, PlanReview]] = []
+
+    async def expand_touchpoints(
+        self,
+        *,
+        original_plan: str,
+        reviewer_failure: PlanReview,
+    ) -> ExpandedTouchpoints:
+        self.calls.append((original_plan, reviewer_failure))
+        return self.output
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _blocking_review(issue_id: int = 42) -> PlanReview:
+    return PlanReview(
+        issue_number=issue_id,
+        plan_version=1,
+        success=True,
+        findings=[
+            PlanFinding(
+                severity=PlanFindingSeverity.HIGH,
+                dimension="correctness",
+                description="missed ADR-0021 state schema rule",
+            ),
+        ],
+        summary="1 high finding",
+    )
+
+
+def _clean_review(issue_id: int = 42) -> PlanReview:
+    return PlanReview(
+        issue_number=issue_id,
+        plan_version=1,
+        success=True,
+        findings=[],
+        summary="clean",
+    )
+
+
+def _result() -> PlanResult:
+    return PlanResult(
+        issue_number=42,
+        success=True,
+        plan="step 1: do it",
+        summary="done",
+    )
+
+
+def _task() -> Task:
+    return Task(id=42, title="t", body="b")
+
+
+# ---------------------------------------------------------------------------
+# Wiring tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestExpanderWiring:
+    async def test_expander_invoked_on_first_blocking_review(self, config) -> None:
+        """First review returns blocking findings → expander dispatched once."""
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_blocking_review(), _clean_review()])
+        expander = _StubExpander(
+            ExpandedTouchpoints(
+                touchpoints=[
+                    Touchpoint(
+                        kind="adr",
+                        ref="ADR-0021",
+                        title="Persistence",
+                        why="state schema",
+                    ),
+                ]
+            )
+        )
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        phase._touchpoint_expander = expander  # type: ignore[attr-defined]
+
+        # Wire a minimal issue cache stub so _write_plan_records exercises
+        # the review path.
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = lambda *_a, **_kw: None
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        assert len(expander.calls) == 1, "expander should run on first failure"
+        # Second review's plan_result.plan must include the expanded
+        # touchpoints block so the reviewer has the enriched context.
+        assert len(reviewer.calls) == 2
+        first_plan = reviewer.calls[0][1].plan
+        second_plan = reviewer.calls[1][1].plan
+        assert "ADR-0021" not in first_plan
+        assert "ADR-0021" in second_plan
+        assert "EXPANDED_TOUCHPOINTS" in second_plan
+
+    async def test_expander_not_invoked_on_clean_first_review(self, config) -> None:
+        """Clean first review → expander never called, single review run."""
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_clean_review()])
+        expander = _StubExpander(ExpandedTouchpoints())
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        phase._touchpoint_expander = expander  # type: ignore[attr-defined]
+
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = lambda *_a, **_kw: None
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        assert expander.calls == []
+        assert len(reviewer.calls) == 1
+
+    async def test_expander_not_invoked_when_not_wired(self, config) -> None:
+        """Backward-compat: no expander wired → single review, no error."""
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_blocking_review()])
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        # No touchpoint_expander assigned — should default to None.
+
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = lambda *_a, **_kw: None
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        assert len(reviewer.calls) == 1
+
+    async def test_expander_skipped_on_second_failure(self, config) -> None:
+        """Second review also blocking → no third try.
+
+        Per ADR-0063 W3b: the expander runs on FIRST failure only. If the
+        enriched re-review still fails, the issue routes back to plan via
+        the existing READY-stage gate — we don't loop on expansion.
+        """
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_blocking_review(), _blocking_review()])
+        expander = _StubExpander(
+            ExpandedTouchpoints(
+                touchpoints=[Touchpoint(kind="adr", ref="ADR-0001", title="t", why="w")]
+            )
+        )
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        phase._touchpoint_expander = expander  # type: ignore[attr-defined]
+
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = lambda *_a, **_kw: None
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        # The expander runs exactly once, the reviewer exactly twice.
+        assert len(expander.calls) == 1
+        assert len(reviewer.calls) == 2
+
+    async def test_empty_touchpoints_skips_second_review(self, config) -> None:
+        """Expander returned no touchpoints → no re-review (nothing to enrich)."""
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_blocking_review()])
+        expander = _StubExpander(ExpandedTouchpoints(touchpoints=[]))
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        phase._touchpoint_expander = expander  # type: ignore[attr-defined]
+
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = lambda *_a, **_kw: None
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        # Expander ran but no second review happened.
+        assert len(expander.calls) == 1
+        assert len(reviewer.calls) == 1
+
+    async def test_cache_records_second_review_findings(self, config) -> None:
+        """The review_stored record reflects the SECOND review's findings."""
+        phase, _state, _planners, _prs, _store, _stop = make_plan_phase(config)
+
+        reviewer = _StubReviewer([_blocking_review(), _clean_review()])
+        expander = _StubExpander(
+            ExpandedTouchpoints(
+                touchpoints=[Touchpoint(kind="adr", ref="ADR-0001", title="t", why="w")]
+            )
+        )
+        phase._plan_reviewer = reviewer  # type: ignore[assignment]
+        phase._touchpoint_expander = expander  # type: ignore[attr-defined]
+
+        recorded: dict = {}
+
+        def _record(issue_id, *, review_text, has_blocking, findings):
+            recorded["issue_id"] = issue_id
+            recorded["has_blocking"] = has_blocking
+            recorded["findings"] = findings
+            recorded["review_text"] = review_text
+
+        cache = AsyncMock()
+        cache.record_plan_stored = lambda *_a, **_kw: 1
+        cache.record_review_stored = _record
+        phase._issue_cache = cache  # type: ignore[assignment]
+
+        await phase._write_plan_records(_task(), _result())
+
+        assert recorded["has_blocking"] is False
+        assert recorded["findings"] == []

--- a/tests/test_plan_touchpoint_expander.py
+++ b/tests/test_plan_touchpoint_expander.py
@@ -1,0 +1,346 @@
+"""Tests for plan_touchpoint_expander (ADR-0063 W3b).
+
+The expander is a read-only subagent dispatched on the FIRST PlanReviewer
+blocking-finding failure. It walks ADR cross-references, recent PR
+conflict signals, and related wiki entries for the modules the plan
+touches, then returns an enriched touchpoint list that is folded back
+into the next review pass as context.
+
+These are pure-helper tests:
+
+  1. ``_build_prompt`` includes the original plan, the blocking findings,
+     and the success-criteria framing.
+  2. ``_parse_touchpoints`` extracts a structured ``ExpandedTouchpoints``
+     payload from the agent JSON, with soft-fail behavior on malformed
+     output.
+  3. ``expand_touchpoints`` orchestrates the agent call and returns an
+     ``ExpandedTouchpoints`` carrying the parsed payload + duration.
+
+Pattern mirrors ``test_assumption_surfacer.py`` /
+``test_spec_judge.py`` — a stub ``AgentLike`` captures the prompt and
+returns a canned JSON payload.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from models import PlanFinding, PlanFindingSeverity, PlanReview
+from plan_touchpoint_expander import (
+    ExpandedTouchpoints,
+    PlanTouchpointExpander,
+    Touchpoint,
+)
+
+# ---------------------------------------------------------------------------
+# Stub fixtures
+# ---------------------------------------------------------------------------
+
+
+class _StubAgent:
+    """Captures the prompts and returns a canned JSON payload."""
+
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+        self.last_system_prompt: str | None = None
+        self.last_user_message: str | None = None
+        self.calls = 0
+
+    async def run(self, system_prompt: str, user_message: str) -> str:
+        self.calls += 1
+        self.last_system_prompt = system_prompt
+        self.last_user_message = user_message
+        return self.payload
+
+
+def _finding(
+    severity: PlanFindingSeverity = PlanFindingSeverity.HIGH,
+    dimension: str = "correctness",
+    description: str = "missed ADR-0021 cross-ref",
+    suggestion: str = "",
+) -> PlanFinding:
+    return PlanFinding(
+        severity=severity,
+        dimension=dimension,
+        description=description,
+        suggestion=suggestion,
+    )
+
+
+def _review(findings: list[PlanFinding]) -> PlanReview:
+    return PlanReview(
+        issue_number=42,
+        plan_version=1,
+        success=True,
+        findings=findings,
+        summary="some blocking findings",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPrompt:
+    def test_includes_plan_text(self) -> None:
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="step 1: load config\nstep 2: edit foo.py",
+            findings=[_finding()],
+        )
+        assert "step 1: load config" in prompt
+        assert "step 2: edit foo.py" in prompt
+
+    def test_includes_blocking_findings(self) -> None:
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="plan body",
+            findings=[
+                _finding(
+                    severity=PlanFindingSeverity.CRITICAL,
+                    dimension="convention",
+                    description="ignored ADR-0042 base branch rule",
+                ),
+                _finding(
+                    severity=PlanFindingSeverity.HIGH,
+                    dimension="test_strategy",
+                    description="no MockWorld scenario",
+                ),
+            ],
+        )
+        assert "critical" in prompt.lower()
+        assert "ADR-0042" in prompt
+        assert "MockWorld" in prompt
+
+    def test_filters_to_blocking_severities(self) -> None:
+        """The expander should not waste tokens on low/info findings."""
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="plan",
+            findings=[
+                _finding(severity=PlanFindingSeverity.LOW, description="cosmetic nit"),
+                _finding(
+                    severity=PlanFindingSeverity.HIGH,
+                    description="serious gap",
+                ),
+            ],
+        )
+        assert "serious gap" in prompt
+        assert "cosmetic nit" not in prompt
+
+    def test_includes_writing_plans_success_criteria(self) -> None:
+        """Per ADR-0063 W3b: the prompt frames success criteria via
+        the writing-plans discipline (concrete, observable, testable)."""
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="plan",
+            findings=[_finding()],
+        )
+        assert "writing-plans" in prompt.lower() or "success criteria" in prompt.lower()
+
+    def test_asks_for_adr_pr_wiki_touchpoints(self) -> None:
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="plan",
+            findings=[_finding()],
+        )
+        # The three categories ADR-0063 W3b enumerates.
+        assert "ADR" in prompt
+        assert "PR" in prompt or "pull request" in prompt.lower()
+        assert "wiki" in prompt.lower()
+
+    def test_emits_marker_contract(self) -> None:
+        prompt = PlanTouchpointExpander._build_prompt(
+            plan="plan", findings=[_finding()]
+        )
+        assert "TOUCHPOINTS_START" in prompt
+        assert "TOUCHPOINTS_END" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _parse_touchpoints
+# ---------------------------------------------------------------------------
+
+
+class TestParseTouchpoints:
+    def test_parses_well_formed_payload(self) -> None:
+        payload = json.dumps(
+            {
+                "touchpoints": [
+                    {
+                        "kind": "adr",
+                        "ref": "ADR-0021",
+                        "title": "Persistence architecture",
+                        "why": "plan changes state schema",
+                    },
+                    {
+                        "kind": "pr",
+                        "ref": "#8700",
+                        "title": "Recent state migration",
+                        "why": "merge-conflict signal on state/_route_back.py",
+                    },
+                    {
+                        "kind": "wiki",
+                        "ref": "architecture-state-persistence.md",
+                        "title": "Pydantic schema evolution",
+                        "why": "plan touches StateData",
+                    },
+                ]
+            }
+        )
+        out = PlanTouchpointExpander._parse_touchpoints(payload)
+        assert isinstance(out, list)
+        assert len(out) == 3
+        assert out[0].kind == "adr"
+        assert out[0].ref == "ADR-0021"
+        assert out[1].kind == "pr"
+        assert out[2].kind == "wiki"
+
+    def test_malformed_json_returns_empty(self) -> None:
+        out = PlanTouchpointExpander._parse_touchpoints("not json at all")
+        assert out == []
+
+    def test_missing_touchpoints_key_returns_empty(self) -> None:
+        out = PlanTouchpointExpander._parse_touchpoints(json.dumps({"foo": "bar"}))
+        assert out == []
+
+    def test_skips_entries_missing_required_fields(self) -> None:
+        payload = json.dumps(
+            {
+                "touchpoints": [
+                    {"kind": "adr"},  # missing ref
+                    {
+                        "kind": "wiki",
+                        "ref": "patterns.md",
+                        "title": "OK",
+                        "why": "fine",
+                    },
+                    {"ref": "ADR-0001"},  # missing kind
+                ]
+            }
+        )
+        out = PlanTouchpointExpander._parse_touchpoints(payload)
+        assert len(out) == 1
+        assert out[0].ref == "patterns.md"
+
+    def test_unknown_kind_normalized_to_other(self) -> None:
+        payload = json.dumps(
+            {
+                "touchpoints": [
+                    {"kind": "weird", "ref": "X", "title": "T", "why": "w"},
+                ]
+            }
+        )
+        out = PlanTouchpointExpander._parse_touchpoints(payload)
+        assert len(out) == 1
+        assert out[0].kind == "other"
+
+
+# ---------------------------------------------------------------------------
+# expand_touchpoints (orchestration)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestExpandTouchpoints:
+    async def test_returns_parsed_touchpoints(self) -> None:
+        payload = json.dumps(
+            {
+                "touchpoints": [
+                    {
+                        "kind": "adr",
+                        "ref": "ADR-0042",
+                        "title": "Two-tier branch",
+                        "why": "PR base branch",
+                    },
+                ]
+            }
+        )
+        agent = _StubAgent(payload)
+        expander = PlanTouchpointExpander(agent=agent)
+
+        out = await expander.expand_touchpoints(
+            original_plan="some plan",
+            reviewer_failure=_review([_finding()]),
+        )
+
+        assert isinstance(out, ExpandedTouchpoints)
+        assert len(out.touchpoints) == 1
+        assert out.touchpoints[0].ref == "ADR-0042"
+        assert agent.calls == 1
+
+    async def test_no_blocking_findings_returns_empty(self) -> None:
+        """If the caller invokes the expander on a clean review (defensive),
+        we don't burn an agent call — return empty."""
+        agent = _StubAgent(payload=json.dumps({"touchpoints": []}))
+        expander = PlanTouchpointExpander(agent=agent)
+
+        out = await expander.expand_touchpoints(
+            original_plan="plan",
+            reviewer_failure=_review([_finding(severity=PlanFindingSeverity.LOW)]),
+        )
+
+        assert out.touchpoints == []
+        assert agent.calls == 0
+
+    async def test_agent_failure_returns_empty_soft_fail(self) -> None:
+        """Agent raising should not crash the caller — soft-fail."""
+
+        class _RaisingAgent:
+            async def run(self, system_prompt: str, user_message: str) -> str:
+                raise RuntimeError("agent down")
+
+        expander = PlanTouchpointExpander(agent=_RaisingAgent())
+
+        out = await expander.expand_touchpoints(
+            original_plan="plan",
+            reviewer_failure=_review([_finding()]),
+        )
+
+        assert isinstance(out, ExpandedTouchpoints)
+        assert out.touchpoints == []
+        assert out.error is not None
+
+    async def test_renders_context_block(self) -> None:
+        """The result should expose a rendered context block usable by
+        the next reviewer pass."""
+        payload = json.dumps(
+            {
+                "touchpoints": [
+                    {
+                        "kind": "adr",
+                        "ref": "ADR-0001",
+                        "title": "Async loops",
+                        "why": "concurrency model",
+                    },
+                    {
+                        "kind": "wiki",
+                        "ref": "gotchas.md",
+                        "title": "Worktree rules",
+                        "why": "plan creates branches",
+                    },
+                ]
+            }
+        )
+        expander = PlanTouchpointExpander(agent=_StubAgent(payload))
+
+        out = await expander.expand_touchpoints(
+            original_plan="plan",
+            reviewer_failure=_review([_finding()]),
+        )
+
+        block = out.render_context_block()
+        assert "ADR-0001" in block
+        assert "gotchas.md" in block
+        # Marker shape so the reviewer can recognize the inserted block.
+        assert "EXPANDED_TOUCHPOINTS" in block
+
+
+class TestTouchpoint:
+    def test_normalizes_kind_case(self) -> None:
+        t = Touchpoint(kind="ADR", ref="ADR-0001", title="t", why="w")
+        assert t.kind == "adr"
+
+
+class TestExpandedTouchpoints:
+    def test_empty_render_returns_empty_string(self) -> None:
+        out = ExpandedTouchpoints()
+        assert out.render_context_block() == ""


### PR DESCRIPTION
## Summary
Closes advisor-mba6 (ADR-0063 W3b). Dispatches `plan-touchpoint-expander` on the first PlanReviewer blocking-finding failure to enrich the next review pass with cross-referenced ADRs, recent PR conflict history, and current wiki entries for affected modules. Bounded to one expansion attempt; second-pass blocking findings continue to route back via the existing READY-stage gate.

- New: `src/plan_touchpoint_expander.py`
- `src/plan_phase.py` — first-failure expansion hook (optional dependency; None → backward-compat)
- `src/service_registry.py` — wires expander post-construction with the adversarial-agent gate

## Test plan
- [x] `pytest tests/test_plan_touchpoint_expander.py tests/test_plan_phase_touchpoint_expander_wiring.py -o "addopts="` — 23 passed
- [x] `pytest tests/test_plan_phase.py tests/test_service_registry.py -o "addopts="` — 67 passed (regression)
- [x] `pytest tests/scenarios/test_plan_touchpoint_expander_scenario.py -o "addopts="` — 3 passed
- [x] `pyright src/plan_phase.py src/plan_touchpoint_expander.py src/service_registry.py` — clean