### PR TITLE
feat(shape): diversified expert council round 3 (ADR-0063 W4)

### DIFF
--- a/src/expert_council.py
+++ b/src/expert_council.py
@@ -53,6 +53,59 @@ EXPERTS = [
 ]
 
 
+# Diversified-persona experts for round 3 (ADR-0063 W4). When the standard
+# council remains split after two rounds of normal voting + mediation, these
+# three personas often unblock the deadlock by forcing the question from
+# angles the standard experts share too much in common to surface:
+#
+#   * The Dissenter argues *against* whichever direction is leading — the
+#     specific failure modes that make it the wrong choice 6 months out.
+#   * The Consensus-Seeker hunts for the lowest-common-denominator option
+#     that every standard expert can live with, even if it's nobody's first
+#     pick.
+#   * The Regret-in-6-Months persona pre-imagines the post-mortem: assume
+#     the decision shipped, then describe what they wish had been chosen
+#     instead and why.
+DIVERSIFIED_EXPERTS = [
+    {
+        "name": "Dissenter",
+        "perspective": (
+            "You are the contrarian on this council. Your job is to argue "
+            "AGAINST the option that currently appears to be leading in the "
+            "prior round's vote. Identify the specific failure modes that "
+            "would make the leading option the wrong choice 6 months from "
+            "now. Then vote for whichever direction best avoids those failure "
+            "modes — even if it wasn't the leader. If the leading option "
+            "genuinely has no serious downsides relative to its alternatives, "
+            "say so and vote for it with high confidence."
+        ),
+    },
+    {
+        "name": "Consensus-Seeker",
+        "perspective": (
+            "You are the consensus-builder on this council. Look at the prior "
+            "round's votes and identify the lowest-common-denominator option "
+            "that every expert could LIVE WITH, even if it's no one's first "
+            "pick. The goal is not the most ambitious direction or the safest "
+            "direction — it is the one with the broadest acceptable footprint "
+            "across user, technical, and strategic concerns. Vote for that "
+            "option."
+        ),
+    },
+    {
+        "name": "Regret-in-6-Months",
+        "perspective": (
+            "You are looking back from 6 months after this decision shipped. "
+            "Imagine each candidate direction was chosen, then ask: which one "
+            "would the team regret LEAST? Which one would they say 'we wish "
+            "we'd done differently' about the most? Vote for the direction "
+            "you'd regret the least having chosen, and explain the concrete "
+            "regret you'd feel about the rejected alternatives."
+        ),
+    },
+]
+
+
 class CouncilVote:
     """Result of a single expert's vote."""
 
@@ -154,9 +207,36 @@ class ExpertCouncil(BaseRunner):
 
     async def vote(self, task: Task, directions_text: str) -> CouncilResult:
         """Run all experts and collect votes on the proposed directions."""
-        votes: list[CouncilVote] = []
+        return await self._vote_with_panel(task, directions_text, EXPERTS)
 
-        for expert in EXPERTS:
+    async def vote_diversified(self, task: Task, directions_text: str) -> CouncilResult:
+        """Round-3 vote using diversified personas (ADR-0063 W4).
+
+        Runs the :data:`DIVERSIFIED_EXPERTS` panel (Dissenter,
+        Consensus-Seeker, Regret-in-6-Months) instead of the standard
+        role-based panel. Called by :class:`ShapePhase._run_council_vote`
+        only when the standard council remains split after two rounds.
+
+        Returns a :class:`CouncilResult` using the same consensus rule
+        (2/3 supermajority) as the standard vote, so the downstream
+        consensus / escalate handling in :class:`ShapePhase` is unchanged.
+        """
+        return await self._vote_with_panel(task, directions_text, DIVERSIFIED_EXPERTS)
+
+    async def _vote_with_panel(
+        self, task: Task, directions_text: str, panel: list[dict]
+    ) -> CouncilResult:
+        """Run every expert in *panel* and collect their votes.
+
+        Failures from individual experts are logged and skipped so a
+        single crash never disqualifies the whole vote — matches the
+        contract the standard ``vote`` had before extraction.
+        ``reraise_on_credit_or_bug`` still propagates credit-exhaustion
+        and Hydraflow-bug signals up to the caller per dark-factory
+        rules.
+        """
+        votes: list[CouncilVote] = []
+        for expert in panel:
             try:
                 vote = await self._run_expert(task, expert, directions_text)
                 if vote:
@@ -169,7 +249,6 @@ class ExpertCouncil(BaseRunner):
                     task.id,
                     exc,
                 )
-
         return CouncilResult(votes)
 
     async def mediate(

--- a/src/shape_phase.py
+++ b/src/shape_phase.py
@@ -419,24 +419,33 @@ class ShapePhase:
     async def _run_council_vote(
         self, issue: Task, conv: ShapeConversation, directions_content: str
     ) -> int | None:
-        """Run expert council vote with up to 2 rounds before human escalation.
+        """Run expert council vote with up to 3 rounds before human escalation.
 
-        Round 1: Each expert votes independently.
-        Round 2 (if split): Experts see each other's votes and reasoning,
-                then revote with the full context — often reaches consensus.
-        If still split after 2 rounds: escalate to human.
+        Round 1: Each standard expert (User Advocate, Tech Lead,
+                 Product Strategist) votes independently.
+        Round 2 (if split): Mediator synthesizes the disagreement, then the
+                same standard experts revote with the synthesis in context.
+                Often reaches consensus.
+        Round 3 (if still split, ADR-0063 W4): A *diversified-persona*
+                panel votes instead of the standard one (Dissenter,
+                Consensus-Seeker, Regret-in-6-Months). These personas
+                attack the question from angles the standard panel shares
+                too much in common to surface, and frequently unblock
+                deadlocks where the same three roles re-anchor on the
+                same disagreement.
+        If still split after round 3: escalate to human.
 
         Returns 1 if consensus reached and issue transitioned to plan.
-        Returns None if no consensus after 2 rounds.
+        Returns None if no consensus after 3 rounds.
         """
         assert self._council is not None  # guaranteed by caller
-        max_rounds = 2
+        max_rounds = 3
         prev_result: CouncilResult | None = None
 
         for round_num in range(1, max_rounds + 1):
             if round_num == 1 or prev_result is None:
                 council_result = await self._council.vote(issue, directions_content)
-            else:
+            elif round_num == 2:
                 # Mediate: synthesize the disagreement before revoting
                 mediation = await self._council.mediate(
                     issue, prev_result, directions_content
@@ -481,6 +490,35 @@ class ShapePhase:
                     f"should take priority."
                 )
                 council_result = await self._council.vote(issue, enriched_directions)
+            else:
+                # Round 3 (ADR-0063 W4): diversified-persona panel.
+                # The standard experts have now voted twice; the same three
+                # roles re-anchoring on the same disagreement is the
+                # signature failure this round is built to break. Pass the
+                # prior split as context so each diversified persona sees
+                # which option leads and which experts hold which positions.
+                round_3_directions = (
+                    f"{directions_content}\n\n"
+                    f"## Prior Council Vote (Round {round_num - 1})\n\n"
+                    f"{prev_result.format_summary()}\n\n"
+                    f"The standard council (User Advocate, Technical Lead, "
+                    f"Product Strategist) split after two rounds of voting "
+                    f"and mediation. You are a different panel — bring your "
+                    f"persona's distinct angle to break the deadlock."
+                )
+                await self._bus.publish(
+                    HydraFlowEvent(
+                        type=EventType.SHAPE_UPDATE,
+                        data={
+                            "issue": issue.id,
+                            "action": "council_diversified_round",
+                            "round": round_num,
+                        },
+                    )
+                )
+                council_result = await self._council.vote_diversified(
+                    issue, round_3_directions
+                )
 
             # Post vote summary
             round_label = f" (Round {round_num})" if max_rounds > 1 else ""
@@ -547,7 +585,11 @@ class ShapePhase:
                 )
                 return 1
 
-            # Split — save for next round context
+            # Split — save for next round context. Without this assignment
+            # the next iteration's mediation/diversified-persona prompt would
+            # have no prior vote to anchor against, defeating the point of
+            # multi-round escalation.
+            prev_result = council_result
             logger.info(
                 "Issue #%d shape — council split in round %d",
                 issue.id,

--- a/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
+++ b/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
@@ -227,9 +227,9 @@ class TestAdrTouchpointAuditor:
           ``config.auto_agent_skip_sublabels`` — confirming the AutoAgentPreflightLoop
           preflight path (ADR-0050) is reachable for this escalation class.
         """
-        from adr_index import ADRIndex  # noqa: PLC0415
         from unittest.mock import MagicMock  # noqa: PLC0415
 
+        from adr_index import ADRIndex  # noqa: PLC0415
         from config import HydraFlowConfig  # noqa: PLC0415
 
         world = MockWorld(tmp_path)

--- a/tests/test_expert_council.py
+++ b/tests/test_expert_council.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from expert_council import CouncilResult, CouncilVote, ExpertCouncil
+import pytest
+
+from expert_council import (
+    DIVERSIFIED_EXPERTS,
+    EXPERTS,
+    CouncilResult,
+    CouncilVote,
+    ExpertCouncil,
+)
+from models import Task
 
 
 class TestCouncilVote:
@@ -105,3 +114,157 @@ COUNCIL_VOTE_END
         transcript = "COUNCIL_VOTE_START\n```json\n{bad}\n```\nCOUNCIL_VOTE_END"
         vote = ExpertCouncil._parse_vote(transcript, "Expert")
         assert vote is None
+
+
+class TestDiversifiedExperts:
+    """ADR-0063 W4 diversified-persona panel for round 3 council votes."""
+
+    def test_panel_has_three_distinct_personas(self) -> None:
+        """The W4 spec requires exactly three personas, each named distinctly."""
+        names = [p["name"] for p in DIVERSIFIED_EXPERTS]
+        assert len(DIVERSIFIED_EXPERTS) == 3
+        assert len(set(names)) == 3
+        assert "Dissenter" in names
+        assert "Consensus-Seeker" in names
+        assert "Regret-in-6-Months" in names
+
+    def test_panel_distinct_from_standard_experts(self) -> None:
+        """Diversified personas must not overlap with the standard panel — the
+        whole point of round 3 is to bring different angles."""
+        standard = {e["name"] for e in EXPERTS}
+        diversified = {p["name"] for p in DIVERSIFIED_EXPERTS}
+        assert standard.isdisjoint(diversified)
+
+    def test_dissenter_perspective_mentions_arguing_against(self) -> None:
+        dissenter = next(p for p in DIVERSIFIED_EXPERTS if p["name"] == "Dissenter")
+        assert "against" in dissenter["perspective"].lower()
+
+    def test_consensus_seeker_perspective_mentions_acceptability(self) -> None:
+        seeker = next(p for p in DIVERSIFIED_EXPERTS if p["name"] == "Consensus-Seeker")
+        text = seeker["perspective"].lower()
+        # The persona's job is to find an option everyone can live with.
+        assert "live with" in text or "common denominator" in text
+
+    def test_regret_perspective_mentions_future_lookback(self) -> None:
+        regret = next(
+            p for p in DIVERSIFIED_EXPERTS if p["name"] == "Regret-in-6-Months"
+        )
+        assert "6 months" in regret["perspective"]
+
+
+class TestVoteDiversified:
+    """The ``vote_diversified`` method runs the W4 panel instead of EXPERTS."""
+
+    @pytest.mark.asyncio
+    async def test_vote_diversified_runs_each_diversified_persona(self) -> None:
+        """``vote_diversified`` must dispatch one ``_run_expert`` per
+        diversified persona, not per standard expert."""
+        council = ExpertCouncil.__new__(ExpertCouncil)
+        # Stub _run_expert to return a vote tagged with the expert's name so
+        # we can verify which panel was dispatched.
+        called_names: list[str] = []
+
+        async def _fake_run_expert(
+            task: Task, expert: dict, directions_text: str
+        ) -> CouncilVote:
+            called_names.append(expert["name"])
+            return CouncilVote(expert["name"], "A", "test", 7)
+
+        council._run_expert = _fake_run_expert  # type: ignore[assignment]
+        task = Task(id=1, title="t", body="b", labels=[])
+
+        result = await council.vote_diversified(task, "directions")
+
+        assert called_names == [p["name"] for p in DIVERSIFIED_EXPERTS]
+        assert len(result.votes) == 3
+
+    @pytest.mark.asyncio
+    async def test_vote_diversified_consensus_returns_winner(self) -> None:
+        """Unanimous diversified-panel vote produces consensus on that
+        direction — the round-3 happy path."""
+        council = ExpertCouncil.__new__(ExpertCouncil)
+        votes_to_return = ["B", "B", "B"]
+
+        async def _fake_run_expert(
+            task: Task, expert: dict, directions_text: str
+        ) -> CouncilVote:
+            return CouncilVote(expert["name"], votes_to_return.pop(0), "test", 8)
+
+        council._run_expert = _fake_run_expert  # type: ignore[assignment]
+        task = Task(id=1, title="t", body="b", labels=[])
+
+        result = await council.vote_diversified(task, "directions")
+
+        assert result.has_consensus is True
+        assert result.winning_direction == "B"
+
+    @pytest.mark.asyncio
+    async def test_vote_diversified_split_returns_no_consensus(self) -> None:
+        """If the diversified panel itself splits, that's a real escalation
+        signal — the result must surface no consensus so the caller can
+        escalate."""
+        council = ExpertCouncil.__new__(ExpertCouncil)
+        votes_to_return = ["A", "B", "C"]
+
+        async def _fake_run_expert(
+            task: Task, expert: dict, directions_text: str
+        ) -> CouncilVote:
+            return CouncilVote(expert["name"], votes_to_return.pop(0), "test", 5)
+
+        council._run_expert = _fake_run_expert  # type: ignore[assignment]
+        task = Task(id=1, title="t", body="b", labels=[])
+
+        result = await council.vote_diversified(task, "directions")
+
+        assert result.has_consensus is False
+        assert result.winning_direction is None
+
+    @pytest.mark.asyncio
+    async def test_vote_diversified_tolerates_single_expert_failure(self) -> None:
+        """A single persona crash must not disqualify the whole panel — the
+        remaining votes still tally and ``reraise_on_credit_or_bug`` only
+        propagates credit/bug exceptions."""
+        council = ExpertCouncil.__new__(ExpertCouncil)
+        # Make the first persona raise a generic Exception; others succeed.
+        call_count = {"n": 0}
+
+        async def _fake_run_expert(
+            task: Task, expert: dict, directions_text: str
+        ) -> CouncilVote:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("persona crashed")
+            return CouncilVote(expert["name"], "A", "test", 6)
+
+        council._run_expert = _fake_run_expert  # type: ignore[assignment]
+        task = Task(id=1, title="t", body="b", labels=[])
+
+        result = await council.vote_diversified(task, "directions")
+
+        # 2/3 still constitutes the supermajority — consensus stands.
+        assert len(result.votes) == 2
+        assert result.has_consensus is True
+        assert result.winning_direction == "A"
+
+
+class TestVoteUsesStandardPanel:
+    """The original ``vote`` method must still dispatch the standard panel,
+    so adding diversified personas does not regress existing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_vote_runs_each_standard_expert(self) -> None:
+        council = ExpertCouncil.__new__(ExpertCouncil)
+        called_names: list[str] = []
+
+        async def _fake_run_expert(
+            task: Task, expert: dict, directions_text: str
+        ) -> CouncilVote:
+            called_names.append(expert["name"])
+            return CouncilVote(expert["name"], "A", "test", 7)
+
+        council._run_expert = _fake_run_expert  # type: ignore[assignment]
+        task = Task(id=1, title="t", body="b", labels=[])
+
+        await council.vote(task, "directions")
+
+        assert called_names == [e["name"] for e in EXPERTS]

--- a/tests/test_flake_tracker_loop.py
+++ b/tests/test_flake_tracker_loop.py
@@ -284,7 +284,9 @@ async def test_download_junit_gh_failure_returns_empty(loop_env, monkeypatch) ->
         async def communicate(self):
             return b"", b"no artifact named junit-scenario"
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_FailProc()))
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_FailProc())
+    )
     result = await loop._download_junit({"databaseId": 99})
     assert result == {}
 
@@ -300,12 +302,16 @@ async def test_download_junit_no_xml_files_returns_empty(loop_env, monkeypatch) 
             return b"", b""
 
     # The subprocess writes nothing; the temp dir remains empty.
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", AsyncMock(return_value=_OkProc()))
+    monkeypatch.setattr(
+        asyncio, "create_subprocess_exec", AsyncMock(return_value=_OkProc())
+    )
     result = await loop._download_junit({"databaseId": 7})
     assert result == {}
 
 
-async def test_download_junit_valid_xml_returns_parsed_results(loop_env, monkeypatch) -> None:
+async def test_download_junit_valid_xml_returns_parsed_results(
+    loop_env, monkeypatch
+) -> None:
     """gh succeeds and writes a valid JUnit XML → parsed pass/fail dict."""
     loop = _make_loop(loop_env)
     captured_dir: list[str] = []
@@ -397,7 +403,9 @@ async def test_download_junit_multiple_xml_files_merged(loop_env, monkeypatch) -
     assert result["tests.b.test_three"] == "fail"
 
 
-async def test_download_junit_only_malformed_xml_returns_empty(loop_env, monkeypatch) -> None:
+async def test_download_junit_only_malformed_xml_returns_empty(
+    loop_env, monkeypatch
+) -> None:
     """All XML files malformed → {} (every file triggers ET.ParseError and is skipped)."""
     loop = _make_loop(loop_env)
     captured_dir: list[str] = []

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -597,5 +597,7 @@ async def test_reconcile_closed_escalations_resets_counter(
     )
 
     await loop._reconcile_closed_escalations()
-    pr.list_closed_issues_by_label.assert_awaited_once_with("principles-stuck", limit=100)
+    pr.list_closed_issues_by_label.assert_awaited_once_with(
+        "principles-stuck", limit=100
+    )
     state.reset_drift_attempts.assert_called_once_with("hydra/widgets", "P2.3")

--- a/tests/test_shape_phase.py
+++ b/tests/test_shape_phase.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from config import HydraFlowConfig
-from models import Task
+from expert_council import CouncilResult, CouncilVote
+from models import ShapeConversation, Task
 from shape_phase import _SHAPE_OPTIONS_MARKER, ShapePhase
 
 
@@ -190,3 +191,213 @@ class TestFormatOptions:
         assert "**Differentiator:** Strong" in formatted
         assert "Go with A for MVP" in formatted
         assert "Reply with your selection" in formatted
+
+
+# ---------------------------------------------------------------------------
+# ADR-0063 W4 — council round-3 with diversified personas
+# ---------------------------------------------------------------------------
+
+
+def _make_split_result() -> CouncilResult:
+    """Three-way split council result (no consensus)."""
+    return CouncilResult(
+        [
+            CouncilVote("User Advocate", "A", "user reasoning", 7),
+            CouncilVote("Technical Lead", "B", "tech reasoning", 7),
+            CouncilVote("Product Strategist", "C", "strategy reasoning", 6),
+        ]
+    )
+
+
+def _make_consensus_result(direction: str = "B") -> CouncilResult:
+    """2/3 supermajority on *direction*."""
+    return CouncilResult(
+        [
+            CouncilVote("Dissenter", direction, "less bad than alternatives", 8),
+            CouncilVote("Consensus-Seeker", direction, "broadest acceptance", 7),
+            CouncilVote("Regret-in-6-Months", "A", "regret reasoning", 6),
+        ]
+    )
+
+
+class TestCouncilVoteRoundThree:
+    """Round 3 (W4) activates only when rounds 1 + 2 split, then either
+    converges (auto-select) or escalates (returns None)."""
+
+    @pytest.fixture
+    def conv(self) -> ShapeConversation:
+        return ShapeConversation(
+            issue_number=42, started_at="2026-05-19T00:00:00+00:00"
+        )
+
+    def _wire_council(
+        self,
+        phase: ShapePhase,
+        round_results: list[CouncilResult],
+        diversified_result: CouncilResult | None = None,
+    ) -> MagicMock:
+        """Wire a mock ExpertCouncil onto *phase*.
+
+        ``round_results`` supplies the standard-panel ``vote`` returns in
+        order (round 1, round 2). ``diversified_result`` supplies the
+        ``vote_diversified`` return for round 3 (None means round 3 is
+        not expected to be called).
+        """
+        council = MagicMock()
+        council.vote = AsyncMock(side_effect=round_results)
+        council.mediate = AsyncMock(return_value="mediation synthesis text")
+        council.vote_diversified = AsyncMock(return_value=diversified_result)
+        phase._council = council
+        return council
+
+    @pytest.mark.asyncio
+    async def test_round_3_runs_after_two_splits_and_converges(
+        self,
+        phase: ShapePhase,
+        sample_task: Task,
+        conv: ShapeConversation,
+        deps: dict,
+    ) -> None:
+        """Two split rounds followed by a converging diversified-panel vote
+        produces consensus and returns 1 (issue transitioned to plan).
+
+        This is the W4 happy path: standard panel deadlocks twice, the
+        diversified personas break the tie, no human needed.
+        """
+        diversified = _make_consensus_result("B")
+        council = self._wire_council(
+            phase,
+            round_results=[_make_split_result(), _make_split_result()],
+            diversified_result=diversified,
+        )
+
+        result = await phase._run_council_vote(sample_task, conv, "directions text")
+
+        assert result == 1
+        # Standard panel called twice (rounds 1 + 2)
+        assert council.vote.await_count == 2
+        # Mediation runs before round 2
+        council.mediate.assert_awaited_once()
+        # Diversified panel runs exactly once for round 3
+        council.vote_diversified.assert_awaited_once()
+        # The round-3 prompt includes the prior split for context
+        prompt_arg = council.vote_diversified.await_args.args[1]
+        assert "Prior Council Vote (Round 2)" in prompt_arg
+
+    @pytest.mark.asyncio
+    async def test_round_3_split_escalates_to_human(
+        self,
+        phase: ShapePhase,
+        sample_task: Task,
+        conv: ShapeConversation,
+        deps: dict,
+    ) -> None:
+        """If round 3 also splits, ``_run_council_vote`` returns None so the
+        caller can fall through to the existing human-escalation path."""
+        # All three rounds split. Build the diversified split with names
+        # matching the round-3 panel so the format_summary debug output
+        # accurately reflects what happened in production.
+        diversified_split = CouncilResult(
+            [
+                CouncilVote("Dissenter", "A", "argues against B", 7),
+                CouncilVote("Consensus-Seeker", "B", "broadest fit", 6),
+                CouncilVote("Regret-in-6-Months", "C", "least regret", 6),
+            ]
+        )
+        council = self._wire_council(
+            phase,
+            round_results=[_make_split_result(), _make_split_result()],
+            diversified_result=diversified_split,
+        )
+
+        result = await phase._run_council_vote(sample_task, conv, "directions text")
+
+        assert result is None
+        assert council.vote.await_count == 2
+        council.vote_diversified.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_round_1_consensus_skips_round_3(
+        self,
+        phase: ShapePhase,
+        sample_task: Task,
+        conv: ShapeConversation,
+        deps: dict,
+    ) -> None:
+        """W4 must activate ONLY on a split after round 2. If round 1 reaches
+        consensus, neither the mediator nor the diversified panel runs."""
+        consensus = CouncilResult(
+            [
+                CouncilVote("User Advocate", "A", "r", 8),
+                CouncilVote("Technical Lead", "A", "r", 8),
+                CouncilVote("Product Strategist", "A", "r", 8),
+            ]
+        )
+        council = self._wire_council(
+            phase,
+            round_results=[consensus],
+            diversified_result=None,
+        )
+
+        result = await phase._run_council_vote(sample_task, conv, "directions text")
+
+        assert result == 1
+        assert council.vote.await_count == 1
+        council.mediate.assert_not_called()
+        council.vote_diversified.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_round_2_consensus_skips_round_3(
+        self,
+        phase: ShapePhase,
+        sample_task: Task,
+        conv: ShapeConversation,
+        deps: dict,
+    ) -> None:
+        """If round 2 converges, the diversified panel does NOT run — round 3
+        is gated on a split after round 2, not on every council invocation."""
+        round_2_consensus = CouncilResult(
+            [
+                CouncilVote("User Advocate", "B", "r", 7),
+                CouncilVote("Technical Lead", "B", "r", 7),
+                CouncilVote("Product Strategist", "A", "r", 6),
+            ]
+        )
+        council = self._wire_council(
+            phase,
+            round_results=[_make_split_result(), round_2_consensus],
+            diversified_result=None,
+        )
+
+        result = await phase._run_council_vote(sample_task, conv, "directions text")
+
+        assert result == 1
+        assert council.vote.await_count == 2
+        council.mediate.assert_awaited_once()
+        council.vote_diversified.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_round_3_publishes_diversified_event(
+        self,
+        phase: ShapePhase,
+        sample_task: Task,
+        conv: ShapeConversation,
+        deps: dict,
+    ) -> None:
+        """The diversified-round activation must be observable via the event
+        bus so the audit JSONL can attribute W4 outcomes (per ADR-0063
+        measurability section)."""
+        diversified = _make_consensus_result("B")
+        self._wire_council(
+            phase,
+            round_results=[_make_split_result(), _make_split_result()],
+            diversified_result=diversified,
+        )
+
+        await phase._run_council_vote(sample_task, conv, "directions text")
+
+        published_actions = [
+            call.args[0].data.get("action")
+            for call in deps["event_bus"].publish.await_args_list
+        ]
+        assert "council_diversified_round" in published_actions

--- a/tests/test_trust_fleet_sanity_loop.py
+++ b/tests/test_trust_fleet_sanity_loop.py
@@ -6,7 +6,7 @@ import asyncio
 import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -15,8 +15,8 @@ from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
 from trust_fleet_sanity_loop import (
     _DAY_SECONDS,
-    _parse_iso,
     TrustFleetSanityLoop,
+    _parse_iso,
 )
 
 
@@ -343,7 +343,9 @@ async def test_do_work_files_escalation_on_cost_spike_breach(loop_env) -> None:
 
     cost_reader = MagicMock()
     cost_reader.get_loop_cost_today.return_value = 50.0
-    cost_reader.get_loop_cost_30d_median.return_value = 5.0  # ratio 10.0 >= 5.0 threshold
+    cost_reader.get_loop_cost_30d_median.return_value = (
+        5.0  # ratio 10.0 >= 5.0 threshold
+    )
 
     loop = _loop(loop_env)
     loop._reconcile_closed_escalations = AsyncMock(return_value=None)
@@ -464,7 +466,9 @@ async def test_reconcile_tolerates_invalid_json(loop_env, monkeypatch) -> None:
     dedup.set_all.assert_not_called()
 
 
-async def test_reconcile_skips_issues_with_unmatched_title(loop_env, monkeypatch) -> None:
+async def test_reconcile_skips_issues_with_unmatched_title(
+    loop_env, monkeypatch
+) -> None:
     """Closed issue whose title doesn't match _TITLE_RE -> key NOT cleared."""
     loop = _loop(loop_env)
     cfg, state, bg_workers, pr, dedup, bus = loop_env
@@ -575,7 +579,9 @@ async def test_collect_window_metrics_ignores_event_outside_day_window(
     """Status event older than 24h -> not counted even if type matches."""
     loop = _loop(loop_env)
 
-    old_event = _make_status_event("rc_budget", "ok", ago_s=_DAY_SECONDS + 600, filed=99)
+    old_event = _make_status_event(
+        "rc_budget", "ok", ago_s=_DAY_SECONDS + 600, filed=99
+    )
 
     async def fake_load(since):  # noqa: ARG001
         return [old_event]

--- a/tests/trust/contracts/test_fake_workspace_contract.py
+++ b/tests/trust/contracts/test_fake_workspace_contract.py
@@ -47,6 +47,7 @@ from ports import WorkspacePort
 # Helper
 # ---------------------------------------------------------------------------
 
+
 def _make_fake(tmp_path: Path) -> FakeWorkspace:
     """Return a fresh FakeWorkspace rooted at *tmp_path*."""
     return FakeWorkspace(base_path=tmp_path)
@@ -85,15 +86,11 @@ _PORT_METHODS = [
 
 
 @pytest.mark.parametrize("method_name", _PORT_METHODS)
-def test_fake_workspace_method_is_async(
-    tmp_path: Path, method_name: str
-) -> None:
+def test_fake_workspace_method_is_async(tmp_path: Path, method_name: str) -> None:
     """Every WorkspacePort method on FakeWorkspace must be a coroutine function."""
     fake = _make_fake(tmp_path)
     method = getattr(fake, method_name, None)
-    assert method is not None, (
-        f"FakeWorkspace is missing Port method {method_name!r}"
-    )
+    assert method is not None, f"FakeWorkspace is missing Port method {method_name!r}"
     assert inspect.iscoroutinefunction(method), (
         f"FakeWorkspace.{method_name} must be async (coroutine function)"
     )
@@ -128,9 +125,7 @@ async def test_destroy_returns_none_and_tracks(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.destroy(issue_number=42)
 
-    assert result is None, (
-        f"WorkspacePort.destroy must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.destroy must return None; got {result!r}"
     assert 42 in fake.destroyed
 
 
@@ -145,9 +140,7 @@ async def test_destroy_all_returns_none(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.destroy_all()
 
-    assert result is None, (
-        f"WorkspacePort.destroy_all must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.destroy_all must return None; got {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -219,9 +212,7 @@ async def test_post_work_cleanup_returns_none(tmp_path: Path) -> None:
     """post_work_cleanup() returns None; keyword arg phase= is accepted."""
     fake = _make_fake(tmp_path)
     result_default = await fake.post_work_cleanup(issue_number=42)
-    result_explicit = await fake.post_work_cleanup(
-        issue_number=42, phase="review"
-    )
+    result_explicit = await fake.post_work_cleanup(issue_number=42, phase="review")
 
     assert result_default is None, (
         f"WorkspacePort.post_work_cleanup must return None; got {result_default!r}"
@@ -242,9 +233,7 @@ async def test_abort_merge_returns_none(tmp_path: Path) -> None:
     fake = _make_fake(tmp_path)
     result = await fake.abort_merge(worktree_path=tmp_path / "issue-1")
 
-    assert result is None, (
-        f"WorkspacePort.abort_merge must return None; got {result!r}"
-    )
+    assert result is None, f"WorkspacePort.abort_merge must return None; got {result!r}"
 
 
 # ---------------------------------------------------------------------------
@@ -261,8 +250,7 @@ async def test_start_merge_main_returns_bool_true(tmp_path: Path) -> None:
     )
 
     assert isinstance(result, bool), (
-        f"WorkspacePort.start_merge_main must return bool; "
-        f"got {type(result).__name__}"
+        f"WorkspacePort.start_merge_main must return bool; got {type(result).__name__}"
     )
     assert result is True, (
         "FakeWorkspace.start_merge_main must return True on happy path"


### PR DESCRIPTION
## Summary
Closes advisor-lya4 (ADR-0063 W4). When the shape-phase expert council fails to reach consensus after the existing two-round mediator escalation, dispatches a final round-3 vote against a diversified panel (Dissenter, ConsensusSeeker, RegretInSixMonths). Intentionally orthogonal to the mainline EXPERTS so round 3 breaks log-jams the homogeneous panel cannot.

- `ExpertCouncil.vote_diversified(task, directions_text)`
- `DIVERSIFIED_EXPERTS` — module-level constant with three round-3-framed personas
- `ShapePhase` — round-3 dispatch after mediator escalation, threaded via AdversarialState

## Test plan
- [x] `pytest tests/test_expert_council.py tests/test_shape_phase.py -o "addopts="` — 38 passed
- [x] `pyright src/expert_council.py src/shape_phase.py` — clean