### PR TITLE
feat(implement): two-stage review (ADR-0063 W5)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -372,6 +372,11 @@ _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
         False,
     ),
     ("auto_agent_preflight_enabled", "HYDRAFLOW_AUTO_AGENT_PREFLIGHT_ENABLED", True),
+    (
+        "implement_two_stage_review_enabled",
+        "HYDRAFLOW_IMPLEMENT_TWO_STAGE_REVIEW_ENABLED",
+        True,
+    ),
     ("staging_enabled", "HYDRAFLOW_STAGING_ENABLED", False),
     ("otel_enabled", "HYDRAFLOW_OTEL_ENABLED", False),
     ("term_proposer_enabled", "HYDRAFLOW_TERM_PROPOSER_ENABLED", True),
@@ -2390,6 +2395,17 @@ class HydraFlowConfig(BaseModel):
     auto_agent_preflight_enabled: bool = Field(
         default=True,
         description="UI kill-switch for AutoAgentPreflightLoop (ADR-0049).",
+    )
+    implement_two_stage_review_enabled: bool = Field(
+        default=True,
+        description=(
+            "Kill-switch for the ImplementPhase two-stage spec-compliance "
+            "review (ADR-0063 W5). When enabled, a spec-compliance reviewer "
+            "subagent runs after each failed implementation attempt and the "
+            "gaps it surfaces are fed into the next attempt's prior_failure "
+            "context. Disable to revert to the pre-W5 retry-with-error-only "
+            "behavior."
+        ),
     )
     auto_agent_preflight_interval: int = Field(
         default=120,

--- a/src/implement_phase.py
+++ b/src/implement_phase.py
@@ -15,6 +15,12 @@ from agent import AgentRunner
 from beads_manager import BeadsManager
 from config import HydraFlowConfig
 from harness_insights import FailureCategory, HarnessInsightStore
+from implement_spec_reviewer import (
+    SpecComplianceReviewer,
+    SpecReviewInput,
+    compute_branch_diff,
+    format_gaps_for_prior_failure,
+)
 from models import (
     GitHubIssue,
     PipelineStage,
@@ -64,6 +70,7 @@ class ImplementPhase:
         active_issues_cb: Callable[[], None] | None = None,
         transcript_summarizer: TranscriptSummarizer | None = None,
         precondition_gate: PreconditionGate | None = None,
+        spec_reviewer: SpecComplianceReviewer | None = None,
     ) -> None:
         self._config = config
         self._state = state
@@ -83,6 +90,11 @@ class ImplementPhase:
         self._suggest_memory = MemorySuggester(config)
         self._zero_diff_memory_filed: set[int] = set()
         self._precondition_gate = precondition_gate
+        # ADR-0063 W5: spec-compliance reviewer dispatched after failed
+        # attempts. None disables the two-stage flow entirely (used by tests
+        # that don't care, and by production when ``spec_reviewer`` isn't
+        # wired into the service registry).
+        self._spec_reviewer = spec_reviewer
         self._escalator = PipelineEscalator(
             state,
             prs,
@@ -554,7 +566,18 @@ class ImplementPhase:
         # focus on reviewer comments, not a potentially-resolved quality gate error.
         if last_meta and not review_feedback:
             prior_error = last_meta.get("error") or ""
-            if prior_error:
+            # ADR-0063 W5: spec-compliance gaps from the prior attempt's
+            # post-failure review take priority — they describe *what* was
+            # missing (or wrong), which is more actionable than the runner's
+            # error string. Both are included when both exist.
+            spec_gaps = last_meta.get("spec_review_gaps") or ""
+            if spec_gaps and prior_error:
+                prior_failure = f"{spec_gaps}\n\nRunner error: {prior_error}"
+                reset_for_retry = True
+            elif spec_gaps:
+                prior_failure = spec_gaps
+                reset_for_retry = True
+            elif prior_error:
                 prior_failure = prior_error
                 reset_for_retry = True
 
@@ -653,7 +676,9 @@ class ImplementPhase:
     ) -> WorkerResult:
         """Handle the result of an agent run: close, create PR, swap labels."""
         if self._is_zero_commit_failure(result):
-            return await self._handle_zero_commits(issue, result)
+            await self._handle_zero_commits(issue, result)
+            await self._run_spec_compliance_review(issue, result)
+            return result
 
         # Fresh failed attempts skip the push entirely — partial commits
         # never land on origin, so there is no orphan branch and no
@@ -677,6 +702,11 @@ class ImplementPhase:
 
         status = "success" if result.success else "failed"
         self._state.mark_issue(issue.id, status)
+        # ADR-0063 W5: spec-compliance review runs on any failed attempt
+        # (with or without commits) so the next attempt sees concrete gaps
+        # instead of just the prior error string.
+        if not result.success:
+            await self._run_spec_compliance_review(issue, result)
         return result
 
     @staticmethod
@@ -690,6 +720,135 @@ class ImplementPhase:
         commits=0 must route to _handle_zero_commits, not push/PR.
         """
         return not result.success and result.commits == 0
+
+    async def _run_spec_compliance_review(
+        self, issue: Task, result: WorkerResult
+    ) -> None:
+        """Run spec-compliance review on a failed attempt (ADR-0063 W5).
+
+        Best-effort, never raises (except auth/credit/bug exceptions which
+        propagate through the reviewer module). On success, persists gaps
+        into ``WorkerResultMeta.spec_review_gaps`` for the next attempt.
+
+        Skips silently when:
+        - the kill-switch ``implement_two_stage_review_enabled`` is False
+        - no ``spec_reviewer`` was wired into ``__init__``
+        - the issue has already reached the attempt cap (no next attempt
+          will run, so gathering gaps wastes a subagent dispatch)
+        """
+        if not self._config.implement_two_stage_review_enabled:
+            return
+        if self._spec_reviewer is None:
+            return
+        attempts = self._state.get_issue_attempts(issue.id)
+        if attempts >= self._config.max_issue_attempts:
+            # The next call to _check_attempt_cap will escalate this issue
+            # to HITL; the gaps would never be read.
+            return
+
+        diff = await self._compute_diff_for_review(result)
+        plan = self._read_plan_for_recording(issue.id)
+        inp = SpecReviewInput(
+            issue_number=issue.id,
+            issue_title=issue.title,
+            issue_body=issue.body or "",
+            plan=plan,
+            diff=diff,
+            commits=result.commits,
+            error=result.error or "",
+        )
+
+        try:
+            review = await self._spec_reviewer.review(inp)
+        except Exception as exc:
+            from exception_classify import (  # noqa: PLC0415
+                reraise_on_credit_or_bug,
+            )
+
+            reraise_on_credit_or_bug(exc)
+            log_exception_with_bug_classification(
+                logger,
+                exc,
+                f"Spec-compliance review failed for issue #{issue.id}",
+            )
+            return
+
+        if review.degraded:
+            logger.info(
+                "Spec-compliance reviewer degraded for issue #%d — "
+                "falling through to prior_failure-only retry",
+                issue.id,
+            )
+            return
+
+        if review.compliant or not review.gaps:
+            logger.info(
+                "Spec-compliance review found no gaps for issue #%d "
+                "(failure mode is not spec drift)",
+                issue.id,
+            )
+            return
+
+        formatted = format_gaps_for_prior_failure(review.gaps, review.reasoning)
+        self._persist_spec_review_gaps(issue.id, formatted)
+        await self._post_spec_review_comment(issue, review.gaps, review.reasoning)
+        logger.info(
+            "Spec-compliance review captured %d gap(s) for issue #%d — "
+            "will be fed into next attempt",
+            len(review.gaps),
+            issue.id,
+        )
+
+    async def _compute_diff_for_review(self, result: WorkerResult) -> str:
+        """Return the unified diff of the result's branch vs base, or ''."""
+        if not result.workspace_path:
+            return ""
+        if not Path(result.workspace_path).is_dir():
+            return ""
+        # AgentRunner exposes a ``_runner`` with run_simple — use it via the
+        # injected agents instance so we share the same subprocess plumbing.
+        runner = getattr(self._agents, "_runner", None)
+        run_simple = getattr(runner, "run_simple", None) if runner else None
+        if run_simple is None:
+            return ""
+        return await compute_branch_diff(
+            Path(result.workspace_path),
+            result.branch,
+            self._config.base_branch(),
+            runner_run_simple=run_simple,
+            timeout=self._config.git_command_timeout,
+        )
+
+    def _persist_spec_review_gaps(self, issue_id: int, formatted: str) -> None:
+        """Update WorkerResultMeta with spec_review_gaps, preserving other fields."""
+        meta = dict(self._state.get_worker_result_meta(issue_id) or {})
+        meta["spec_review_gaps"] = formatted
+        self._state.set_worker_result_meta(issue_id, meta)  # type: ignore[arg-type]
+
+    async def _post_spec_review_comment(
+        self, issue: Task, gaps: list[str], reasoning: str
+    ) -> None:
+        """Post the spec-compliance review verdict as an issue comment."""
+        lines = ["## Spec-Compliance Review (ADR-0063 W5)\n"]
+        lines.append(
+            "The previous implementation attempt failed. A spec-compliance "
+            "reviewer ran against the diff and surfaced these gaps; the next "
+            "attempt will see them as prior-failure context.\n"
+        )
+        for g in gaps:
+            lines.append(f"- {g}")
+        if reasoning.strip():
+            lines.append("")
+            lines.append(f"**Reasoning.** {reasoning.strip()}")
+        lines.append("\n---\n*Generated by HydraFlow ImplementPhase*")
+        try:
+            await self._transitioner.post_comment(issue.id, "\n".join(lines))
+        except Exception as exc:
+            log_exception_with_bug_classification(
+                logger,
+                exc,
+                f"Failed to post spec-review comment for issue #{issue.id}",
+            )
 
     async def _flag_requirements_gaps(self, issue: Task, transcript: str) -> None:
         """Detect and post requirements gaps discovered during implementation."""

--- a/src/implement_spec_reviewer.py
+++ b/src/implement_spec_reviewer.py
@@ -1,0 +1,366 @@
+"""Spec-compliance review for ImplementPhase (ADR-0063 W5).
+
+Runs after a failed implementation attempt to capture *why* the agent's
+output diverged from the spec, so the next attempt can be fed concrete
+gaps instead of just "your last try failed."
+
+The pattern mirrors ``superpowers:subagent-driven-development``'s two-stage
+review (spec-compliance first, code-quality second). The implementer subagent
+is dispatched by ``ImplementPhase``; the spec-compliance reviewer is a
+*separate* subagent that reads the spec + the actual diff and reports either
+``COMPLIANT`` or a list of specific gaps. Gaps are then persisted via
+``WorkerResultMeta.spec_review_gaps`` and prepended to the next attempt's
+``prior_failure`` context.
+
+Two failure modes this addresses (ADR-0063):
+
+1. **Zero-diff branches.** Implementation produced no diff (or no commits).
+   The reviewer reports "implementation produced no changes for the requested
+   feature" as the gap, so the next attempt sees an explicit anchor — not
+   just the prior error string ``"No commits found on branch"`` which is
+   uninformative.
+
+2. **Attempt-cap reaches.** Multiple attempts re-implement without learning
+   from prior misses. With spec gaps in ``prior_failure``, the next attempt
+   sees what the reviewer thought was missing, not just the agent's error log.
+
+All subagent dispatches go through Claude Code's subagent dispatch interface
+(see ``docs/wiki/dark-factory.md`` — no direct Anthropic SDK calls).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+logger = logging.getLogger("hydraflow.implement_spec_reviewer")
+
+
+_JSON_FENCE_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_JSON_BLOCK_RE = re.compile(r"(\{.*\})", re.DOTALL)
+
+
+def _extract_json_block(payload: str) -> str:
+    """Extract the JSON object from an agent transcript.
+
+    Subagent responses can contain prose, fenced code blocks, or stream
+    events. Prefer fenced JSON, fall back to the greediest ``{...}`` block,
+    and finally return the raw payload (which will fail to parse but at
+    least surfaces what the agent actually said).
+    """
+    m = _JSON_FENCE_RE.search(payload)
+    if m:
+        return m.group(1)
+    m = _JSON_BLOCK_RE.search(payload)
+    if m:
+        return m.group(1)
+    return payload
+
+
+@dataclass
+class SpecReviewInput:
+    """Inputs for one spec-compliance review call."""
+
+    issue_number: int
+    issue_title: str
+    issue_body: str
+    plan: str
+    diff: str
+    """Unified diff of ``branch`` against the configured base branch.
+
+    May be empty — that itself is a finding (the reviewer should report a
+    zero-diff gap rather than ``COMPLIANT``).
+    """
+    commits: int
+    """Number of commits the implementation produced on the branch."""
+    error: str
+    """The implementation runner's error string (or empty on success-with-no-diff).
+    Used as a hint for the reviewer but not authoritative — the diff is the truth."""
+
+
+@dataclass
+class SpecReviewResult:
+    """Verdict from one spec-compliance review."""
+
+    compliant: bool
+    """True when the reviewer found no material gaps. False = at least one gap."""
+    gaps: list[str] = field(default_factory=list)
+    """Specific findings (missing requirements, wrong feature, zero diff, etc.).
+
+    Each entry is human-readable; the next attempt sees these prepended to
+    ``prior_failure`` so the agent has an explicit anchor.
+    """
+    reasoning: str = ""
+    """Brief explanation from the reviewer, included in the comment posted to
+    the issue when gaps exist."""
+    degraded: bool = False
+    """True when the reviewer subagent itself failed (runner error, parse
+    error). In degraded mode ``compliant=True`` and ``gaps=[]`` so the
+    fallback behavior matches the pre-W5 flow."""
+
+
+class SpecComplianceReviewer(Protocol):
+    """Callable interface ImplementPhase consumes.
+
+    Production wiring (``service_registry.py``) provides a subagent-dispatch
+    implementation. Tests substitute a synchronous stub that returns a fixed
+    ``SpecReviewResult``.
+    """
+
+    async def review(self, inp: SpecReviewInput) -> SpecReviewResult: ...
+
+
+class SubagentRunnerProtocol(Protocol):
+    """The minimal subagent dispatch the default reviewer needs.
+
+    Compatible with the reviewer-runner adapter used by ``review_advisor.py``.
+    """
+
+    async def run(
+        self,
+        *,
+        model: str,
+        subagent_type: str,
+        prompt: str,
+    ) -> str: ...
+
+
+# Cap the diff fed to the reviewer. Bigger diffs are uncommon in failed
+# attempts (failed attempts often produce small or zero diffs); keep the
+# prompt focused and predictable.
+_DEFAULT_MAX_DIFF_CHARS = 12_000
+
+
+def build_spec_review_prompt(
+    inp: SpecReviewInput, *, max_diff_chars: int = _DEFAULT_MAX_DIFF_CHARS
+) -> str:
+    """Compose the spec-compliance reviewer prompt.
+
+    The structure mirrors ``superpowers:subagent-driven-development``'s
+    ``spec-reviewer-prompt.md``: state what was requested, state what was
+    produced, demand independent verification, ask for a JSON verdict.
+    """
+    diff_block = inp.diff[:max_diff_chars] if inp.diff else ""
+    if not diff_block:
+        diff_block = (
+            "(no diff — branch produced zero changes from the base branch; "
+            "this is itself a finding)"
+        )
+    plan_block = inp.plan.strip() if inp.plan else "(no plan was attached)"
+    body_block = inp.issue_body.strip() if inp.issue_body else "(no body)"
+
+    return f"""You are a spec-compliance reviewer for an autonomous coding agent.
+
+Your job is to verify whether the implementation matches what was requested,
+*by reading the diff*. Do not trust prose claims; the diff is the truth.
+
+## Issue #{inp.issue_number}: {inp.issue_title}
+
+{body_block}
+
+## Implementation plan
+
+{plan_block}
+
+## Implementation result
+
+- commits produced: {inp.commits}
+- runner error: {inp.error or "(none)"}
+
+## Diff (truncated to {max_diff_chars} chars)
+
+```diff
+{diff_block}
+```
+
+## Your job
+
+Compare the diff to the requested work. Report gaps in three categories:
+
+1. **Missing requirements** — things the spec asked for that the diff does
+   not implement (or only stubs out).
+2. **Wrong feature** — the diff implements something else, or interprets the
+   spec wrongly.
+3. **Zero/no-op work** — the diff is empty, only touches comments, or only
+   moves text around without delivering the requested behavior.
+
+If the diff genuinely covers the spec, report compliant.
+
+## Response format — JSON only
+
+Respond with a single JSON object matching this schema. No prose outside the JSON.
+
+```json
+{{
+  "compliant": true | false,
+  "gaps": ["short specific gap 1", "short specific gap 2"],
+  "reasoning": "1-3 sentences explaining the verdict"
+}}
+```
+
+If ``compliant`` is true, ``gaps`` MUST be an empty list. If ``compliant`` is
+false, ``gaps`` MUST contain at least one entry.
+"""
+
+
+class DefaultSpecComplianceReviewer:
+    """Default reviewer that dispatches a Claude Code subagent.
+
+    Used in production. Failures (runner errors, parse errors) degrade to
+    ``compliant=True, gaps=[], degraded=True`` so the pre-W5 flow continues
+    unchanged — we never block on a flaky reviewer.
+    """
+
+    def __init__(
+        self,
+        runner: SubagentRunnerProtocol,
+        *,
+        model: str = "sonnet",
+        subagent_type: str = "general-purpose",
+        max_diff_chars: int = _DEFAULT_MAX_DIFF_CHARS,
+    ) -> None:
+        self._runner = runner
+        self._model = model
+        self._subagent_type = subagent_type
+        self._max_diff_chars = max_diff_chars
+
+    async def review(self, inp: SpecReviewInput) -> SpecReviewResult:
+        prompt = build_spec_review_prompt(inp, max_diff_chars=self._max_diff_chars)
+        try:
+            payload = await self._runner.run(
+                model=self._model,
+                subagent_type=self._subagent_type,
+                prompt=prompt,
+            )
+        except Exception as exc:
+            # Auth/credit/likely-bug exceptions must propagate per
+            # docs/wiki/dark-factory.md §2.2 — they signal infrastructure
+            # state the orchestrator needs to see, not transient reviewer
+            # failures.
+            from exception_classify import (  # noqa: PLC0415
+                reraise_on_credit_or_bug,
+            )
+
+            try:
+                reraise_on_credit_or_bug(exc)
+            except BaseException:
+                raise
+            logger.warning(
+                "Spec-compliance reviewer subagent failed for issue #%d: %r",
+                inp.issue_number,
+                exc,
+            )
+            return SpecReviewResult(compliant=True, gaps=[], degraded=True)
+
+        try:
+            data = json.loads(_extract_json_block(payload))
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.warning(
+                "Spec-compliance reviewer payload not JSON for issue #%d: %r",
+                inp.issue_number,
+                exc,
+            )
+            return SpecReviewResult(compliant=True, gaps=[], degraded=True)
+
+        if not isinstance(data, dict):
+            return SpecReviewResult(compliant=True, gaps=[], degraded=True)
+
+        compliant = bool(data.get("compliant", True))
+        gaps_raw = data.get("gaps", []) or []
+        if not isinstance(gaps_raw, list):
+            gaps_raw = []
+        gaps: list[str] = [str(g) for g in gaps_raw if str(g).strip()]
+        reasoning = str(data.get("reasoning", "") or "")
+
+        # Schema integrity: if the reviewer says "compliant" but lists gaps,
+        # trust the gaps (the JSON was generated by an LLM; gaps win).
+        if gaps:
+            compliant = False
+        return SpecReviewResult(
+            compliant=compliant, gaps=gaps, reasoning=reasoning, degraded=False
+        )
+
+
+def format_gaps_for_prior_failure(gaps: list[str], reasoning: str = "") -> str:
+    """Render gaps + reasoning into a text block for ``prior_failure``.
+
+    The next implementation attempt sees this text under the "Prior Attempt
+    Failure" section of its prompt (see ``agent._build_prompt_with_stats``).
+    Kept compact — the surrounding prompt machinery already truncates.
+    """
+    if not gaps:
+        return ""
+    lines = ["Spec-compliance gaps from prior attempt:"]
+    for g in gaps:
+        lines.append(f"- {g}")
+    if reasoning.strip():
+        lines.append("")
+        lines.append(f"Reviewer reasoning: {reasoning.strip()}")
+    return "\n".join(lines)
+
+
+class AgentSubagentRunnerAdapter:
+    """Adapts an ``AgentRunner`` into the ``SubagentRunnerProtocol``.
+
+    Production wiring uses ``AgentRunner._execute`` so the reviewer's
+    subagent share the same subprocess plumbing, tracing context, and
+    auth-retry behavior as the implementer itself. The runner is invoked
+    in read-only mode (``Write,Edit,NotebookEdit`` disallowed) — the
+    reviewer must never modify the codebase.
+    """
+
+    def __init__(self, agents, config) -> None:  # noqa: ANN001 — duck-typed
+        self._agents = agents
+        self._config = config
+
+    async def run(self, *, model: str, subagent_type: str, prompt: str) -> str:
+        from agent_cli import build_agent_command  # noqa: PLC0415
+
+        _ = subagent_type  # subagent_type isn't surfaced through _execute today
+        cmd = build_agent_command(
+            tool=self._config.review_tool,
+            model=model,
+            disallowed_tools="Write,Edit,NotebookEdit",
+        )
+        # Use the executor's public AgentPort entry point (forwards to
+        # _execute under the hood). cwd is repo_root so the reviewer can
+        # read source for cross-references.
+        return await self._agents.execute(
+            cmd,
+            prompt,
+            self._config.repo_root,
+            {"source": "implement_spec_reviewer"},
+        )
+
+
+async def compute_branch_diff(
+    workspace: Path,
+    branch: str,
+    base_branch: str,
+    *,
+    runner_run_simple,  # noqa: ANN001 — duck-typed run_simple callable
+    timeout: int = 30,
+) -> str:
+    """Compute the unified diff of ``branch`` vs ``base_branch`` in a worktree.
+
+    Uses ``git diff`` (not ``git log -p``) so the reviewer sees the *aggregate*
+    change set, not per-commit history. Returns empty string on any error or
+    when there is no diff — the reviewer treats empty diff as a finding.
+    """
+    try:
+        result = await runner_run_simple(
+            [
+                "git",
+                "diff",
+                f"origin/{base_branch}...{branch}",
+            ],
+            cwd=str(workspace),
+            timeout=timeout,
+        )
+    except (TimeoutError, FileNotFoundError, OSError):
+        return ""
+    return getattr(result, "stdout", "") or ""

--- a/src/models.py
+++ b/src/models.py
@@ -2730,6 +2730,12 @@ class WorkerResultMeta(TypedDict, total=False):
     duration_seconds: float
     error: str | None
     commits: int
+    # ADR-0063 W5: spec-compliance gaps captured by the two-stage reviewer
+    # after a failed implementation attempt. Prepended to the next attempt's
+    # ``prior_failure`` context so the agent sees concrete gaps, not just
+    # the prior error string. Empty/absent means no review ran or no gaps
+    # were found.
+    spec_review_gaps: str
 
 
 class TimelineStageMetadata(TypedDict, total=False):

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -739,6 +739,22 @@ def build_services(
         active_issues_cb=active_issues_cb,
     )
     run_recorder = RunRecorder(config)
+
+    # ADR-0063 W5: wire the spec-compliance reviewer when the kill-switch
+    # is on. The adapter reuses the AgentRunner's subprocess plumbing so
+    # the reviewer shares tracing/auth-retry behavior with the implementer.
+    spec_reviewer = None
+    if config.implement_two_stage_review_enabled:
+        from implement_spec_reviewer import (  # noqa: PLC0415
+            AgentSubagentRunnerAdapter,
+            DefaultSpecComplianceReviewer,
+        )
+
+        spec_reviewer = DefaultSpecComplianceReviewer(
+            AgentSubagentRunnerAdapter(agents, config),
+            model=config.review_model,
+        )
+
     implementer = ImplementPhase(
         config,
         state,
@@ -753,6 +769,7 @@ def build_services(
         active_issues_cb=active_issues_cb,
         transcript_summarizer=summarizer,
         precondition_gate=precondition_gate,
+        spec_reviewer=spec_reviewer,
     )
 
     from metrics_manager import MetricsManager

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -403,6 +403,7 @@ class ConfigFactory:
             "leaves regression tests, doesn't over-engineer."
         ),
         auto_agent_preflight_enabled: bool = True,
+        implement_two_stage_review_enabled: bool = True,
     ):
         """Create a HydraFlowConfig with test-friendly defaults."""
         from config import HydraFlowConfig
@@ -639,6 +640,7 @@ class ConfigFactory:
                 else ["principles-stuck", "cultural-check"],
                 auto_agent_persona=auto_agent_persona,
                 auto_agent_preflight_enabled=auto_agent_preflight_enabled,
+                implement_two_stage_review_enabled=implement_two_stage_review_enabled,
             )
 
 
@@ -1141,6 +1143,7 @@ def make_implement_phase(
     success=True,
     push_return=True,
     create_pr_return=None,
+    spec_reviewer=None,
 ):
     """Build an ImplementPhase with standard mocks.
 
@@ -1246,6 +1249,7 @@ def make_implement_phase(
         prs=mock_prs,
         store=mock_store,
         stop_event=stop_event,
+        spec_reviewer=spec_reviewer,
     )
 
     return phase, mock_wt, mock_prs
@@ -1280,6 +1284,7 @@ class ImplementPhaseMockBuilder:
         self._success: bool = True
         self._prs_overrides: dict[str, object] = {}
         self._wt_overrides: dict[str, object] = {}
+        self._spec_reviewer: object | None = None
 
     def with_issues(self, issues: list[object]) -> ImplementPhaseMockBuilder:
         """Set the issues to be returned by get_implementable."""
@@ -1328,6 +1333,11 @@ class ImplementPhaseMockBuilder:
         self._wt_overrides[name] = mock
         return self
 
+    def with_spec_reviewer(self, reviewer: object) -> ImplementPhaseMockBuilder:
+        """Attach a SpecComplianceReviewer (ADR-0063 W5)."""
+        self._spec_reviewer = reviewer
+        return self
+
     def build(self) -> tuple[Any, Any, Any]:
         """Build and return ``(phase, mock_wt, mock_prs)``."""
         create_pr_kwarg: dict[str, Any] = (
@@ -1341,6 +1351,7 @@ class ImplementPhaseMockBuilder:
             agent_run=self._agent_run,
             success=self._success,
             push_return=self._push_return,
+            spec_reviewer=self._spec_reviewer,
             **create_pr_kwarg,
         )
         for name, mock in self._prs_overrides.items():

--- a/tests/test_implement_spec_reviewer.py
+++ b/tests/test_implement_spec_reviewer.py
@@ -1,0 +1,614 @@
+"""Tests for the ImplementPhase two-stage spec-compliance review (ADR-0063 W5).
+
+Covers:
+- The default reviewer parses subagent JSON output (compliant / gaps / degraded).
+- The ImplementPhase invokes the reviewer on failed attempts, persists gaps
+  into ``WorkerResultMeta.spec_review_gaps``, and the next attempt's
+  ``prior_failure`` carries those gaps.
+- Kill-switch (``implement_two_stage_review_enabled=False``) disables the flow.
+- Zero-diff branches are picked up by the reviewer and surfaced as gaps.
+- Attempt-cap-with-context: the gaps survive into the next attempt's prompt.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from models import Task, WorkerResult
+from tests.conftest import TaskFactory, WorkerResultFactory
+from tests.helpers import ConfigFactory, ImplementPhaseMockBuilder
+
+# ---------------------------------------------------------------------------
+# DefaultSpecComplianceReviewer
+# ---------------------------------------------------------------------------
+
+
+class _StubRunner:
+    """Records calls and returns a fixed payload."""
+
+    def __init__(self, payload: str, *, exc: Exception | None = None) -> None:
+        self._payload = payload
+        self._exc = exc
+        self.calls: list[dict[str, str]] = []
+
+    async def run(self, *, model: str, subagent_type: str, prompt: str) -> str:
+        self.calls.append(
+            {"model": model, "subagent_type": subagent_type, "prompt": prompt}
+        )
+        if self._exc is not None:
+            raise self._exc
+        return self._payload
+
+
+class TestDefaultSpecComplianceReviewer:
+    @pytest.mark.asyncio
+    async def test_compliant_verdict_is_parsed(self) -> None:
+        from implement_spec_reviewer import (
+            DefaultSpecComplianceReviewer,
+            SpecReviewInput,
+        )
+
+        payload = (
+            '```json\n{"compliant": true, "gaps": [], "reasoning": "matches spec"}\n```'
+        )
+        reviewer = DefaultSpecComplianceReviewer(_StubRunner(payload))
+        result = await reviewer.review(
+            SpecReviewInput(
+                issue_number=1,
+                issue_title="t",
+                issue_body="b",
+                plan="p",
+                diff="diff --git a/x b/x\n+ new",
+                commits=1,
+                error="",
+            )
+        )
+        assert result.compliant is True
+        assert result.gaps == []
+        assert result.degraded is False
+
+    @pytest.mark.asyncio
+    async def test_gaps_are_parsed_and_force_compliant_false(self) -> None:
+        from implement_spec_reviewer import (
+            DefaultSpecComplianceReviewer,
+            SpecReviewInput,
+        )
+
+        # Reviewer claims compliant but lists gaps — gaps win.
+        payload = (
+            '{"compliant": true, '
+            '"gaps": ["missing implement_two_stage_review_enabled flag"], '
+            '"reasoning": "config field absent"}'
+        )
+        reviewer = DefaultSpecComplianceReviewer(_StubRunner(payload))
+        result = await reviewer.review(
+            SpecReviewInput(
+                issue_number=1,
+                issue_title="t",
+                issue_body="b",
+                plan="p",
+                diff="",
+                commits=0,
+                error="",
+            )
+        )
+        assert result.compliant is False
+        assert result.gaps == ["missing implement_two_stage_review_enabled flag"]
+        assert "config field absent" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_runner_exception_returns_degraded(self) -> None:
+        from implement_spec_reviewer import (
+            DefaultSpecComplianceReviewer,
+            SpecReviewInput,
+        )
+
+        reviewer = DefaultSpecComplianceReviewer(
+            _StubRunner("", exc=RuntimeError("subagent crashed"))
+        )
+        result = await reviewer.review(
+            SpecReviewInput(
+                issue_number=1,
+                issue_title="t",
+                issue_body="b",
+                plan="p",
+                diff="",
+                commits=0,
+                error="",
+            )
+        )
+        assert result.degraded is True
+        assert result.compliant is True
+        assert result.gaps == []
+
+    @pytest.mark.asyncio
+    async def test_unparseable_payload_returns_degraded(self) -> None:
+        from implement_spec_reviewer import (
+            DefaultSpecComplianceReviewer,
+            SpecReviewInput,
+        )
+
+        reviewer = DefaultSpecComplianceReviewer(
+            _StubRunner("not json at all just prose")
+        )
+        result = await reviewer.review(
+            SpecReviewInput(
+                issue_number=1,
+                issue_title="t",
+                issue_body="b",
+                plan="p",
+                diff="",
+                commits=0,
+                error="",
+            )
+        )
+        assert result.degraded is True
+
+    @pytest.mark.asyncio
+    async def test_zero_diff_appears_in_prompt(self) -> None:
+        """The reviewer's prompt should explicitly state that the diff is empty
+        when no changes were produced — so zero-diff is a first-class
+        finding mode, not an implicit one.
+        """
+        from implement_spec_reviewer import (
+            DefaultSpecComplianceReviewer,
+            SpecReviewInput,
+        )
+
+        runner = _StubRunner('{"compliant": false, "gaps": ["nothing changed"]}')
+        reviewer = DefaultSpecComplianceReviewer(runner)
+        await reviewer.review(
+            SpecReviewInput(
+                issue_number=1,
+                issue_title="t",
+                issue_body="b",
+                plan="p",
+                diff="",
+                commits=0,
+                error="",
+            )
+        )
+        prompt = runner.calls[0]["prompt"]
+        assert "no diff" in prompt.lower()
+        assert "zero changes" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# format_gaps_for_prior_failure
+# ---------------------------------------------------------------------------
+
+
+class TestFormatGapsForPriorFailure:
+    def test_empty_gaps_returns_empty_string(self) -> None:
+        from implement_spec_reviewer import format_gaps_for_prior_failure
+
+        assert format_gaps_for_prior_failure([]) == ""
+
+    def test_gaps_render_as_bulleted_list(self) -> None:
+        from implement_spec_reviewer import format_gaps_for_prior_failure
+
+        text = format_gaps_for_prior_failure(["gap A", "gap B"], reasoning="explained")
+        assert "gap A" in text
+        assert "gap B" in text
+        assert "explained" in text
+        assert text.startswith("Spec-compliance gaps from prior attempt:")
+
+
+# ---------------------------------------------------------------------------
+# ImplementPhase wiring — kill switch and reviewer dispatch
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpecReviewer:
+    """Records calls and returns a scripted SpecReviewResult."""
+
+    def __init__(self, result) -> None:  # noqa: ANN001
+        self._result = result
+        self.calls = []
+
+    async def review(self, inp):  # noqa: ANN001, ANN202
+        self.calls.append(inp)
+        return self._result
+
+
+class TestSpecReviewKillSwitch:
+    @pytest.mark.asyncio
+    async def test_reviewer_not_called_when_flag_off(self, tmp_path: Path) -> None:
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            implement_two_stage_review_enabled=False,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create()
+        result = WorkerResultFactory.create(
+            success=False,
+            error="No commits found on branch",
+            commits=0,
+        )
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(compliant=False, gaps=["should not be called"])
+        )
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+
+        await phase._run_spec_compliance_review(issue, result)
+
+        assert reviewer.calls == []
+
+    @pytest.mark.asyncio
+    async def test_reviewer_not_called_when_no_reviewer_wired(
+        self, tmp_path: Path
+    ) -> None:
+        """When no reviewer is wired (production fallback), the flow is a no-op."""
+        config = ConfigFactory.create(
+            implement_two_stage_review_enabled=True,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create()
+        result = WorkerResultFactory.create(success=False, error="x", commits=0)
+        phase, _, _ = ImplementPhaseMockBuilder(config).with_issues([issue]).build()
+        # Should not raise, should not error.
+        await phase._run_spec_compliance_review(issue, result)
+
+
+class TestSpecReviewPersistence:
+    @pytest.mark.asyncio
+    async def test_gaps_persisted_into_meta(self, tmp_path: Path) -> None:
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242,
+            success=False,
+            error="No commits found on branch",
+            commits=0,
+        )
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(
+                compliant=False,
+                gaps=["did not add the requested env-var override"],
+                reasoning="only modified tests, no source change",
+            )
+        )
+        phase, _, mock_prs = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        # Simulate one prior attempt already recorded.
+        phase._state.increment_issue_attempts(4242)
+
+        await phase._run_spec_compliance_review(issue, result)
+
+        meta = phase._state.get_worker_result_meta(4242)
+        gaps_text = meta.get("spec_review_gaps", "")
+        assert "did not add the requested env-var override" in gaps_text
+        assert "only modified tests" in gaps_text
+        # Comment was posted to the issue with the gaps section.
+        comment_bodies = [c.args[1] for c in mock_prs.post_comment.call_args_list]
+        assert any("Spec-Compliance Review" in b for b in comment_bodies)
+        # Reviewer received the right inputs.
+        assert len(reviewer.calls) == 1
+        assert reviewer.calls[0].issue_number == 4242
+        assert reviewer.calls[0].commits == 0
+
+    @pytest.mark.asyncio
+    async def test_compliant_review_does_not_persist_gaps(self, tmp_path: Path) -> None:
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242, success=False, error="quality-gate failed", commits=2
+        )
+        reviewer = _FakeSpecReviewer(SpecReviewResult(compliant=True))
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        phase._state.increment_issue_attempts(4242)
+
+        await phase._run_spec_compliance_review(issue, result)
+
+        meta = phase._state.get_worker_result_meta(4242)
+        assert "spec_review_gaps" not in meta or not meta.get("spec_review_gaps")
+
+    @pytest.mark.asyncio
+    async def test_degraded_review_does_not_persist_gaps(self, tmp_path: Path) -> None:
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242, success=False, error="x", commits=0
+        )
+        # A degraded result has compliant=True, gaps=[], degraded=True
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(compliant=True, gaps=[], degraded=True)
+        )
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        phase._state.increment_issue_attempts(4242)
+
+        await phase._run_spec_compliance_review(issue, result)
+
+        meta = phase._state.get_worker_result_meta(4242)
+        assert not meta.get("spec_review_gaps")
+
+    @pytest.mark.asyncio
+    async def test_reviewer_skipped_at_attempt_cap(self, tmp_path: Path) -> None:
+        """When the next call would escalate to HITL, don't waste a subagent
+        dispatch on gathering gaps that will never be read.
+        """
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=2,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242, success=False, error="x", commits=0
+        )
+        reviewer = _FakeSpecReviewer(SpecReviewResult(compliant=False, gaps=["x"]))
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        # Bump attempts to the cap.
+        phase._state.increment_issue_attempts(4242)
+        phase._state.increment_issue_attempts(4242)
+        assert phase._state.get_issue_attempts(4242) == 2
+
+        await phase._run_spec_compliance_review(issue, result)
+
+        assert reviewer.calls == []
+
+
+class TestSpecReviewFeedsNextAttempt:
+    @pytest.mark.asyncio
+    async def test_gaps_fed_into_prior_failure_on_next_attempt(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: a failed attempt persists gaps; the next attempt's
+        ``prior_failure`` contains those gaps.
+        """
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        captured: list[str] = []
+
+        async def capturing_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+        ) -> WorkerResult:
+            captured.append(prior_failure)
+            return WorkerResultFactory.create(
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
+            )
+
+        phase, _, _ = ImplementPhaseMockBuilder(config).with_issues([issue]).build()
+
+        # Simulate: prior attempt recorded an error AND the spec reviewer
+        # captured gaps for it.
+        phase._state.set_worker_result_meta(
+            4242,
+            {
+                "error": "No commits found on branch",
+                "spec_review_gaps": "Spec-compliance gaps from prior attempt:\n- did not implement feature X",
+            },
+        )
+
+        # Now run the next attempt directly through _run_implementation, which
+        # is what receives the prior_failure construction.
+        phase._agents.run = capturing_agent  # type: ignore[method-assign]
+        await phase._run_implementation(issue, "agent/issue-4242", 0, "")
+
+        assert len(captured) == 1
+        assert "did not implement feature X" in captured[0]
+        assert "Runner error: No commits found on branch" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_gaps_only_when_no_runner_error(self, tmp_path: Path) -> None:
+        """Spec gaps without a runner error still get fed forward."""
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=99)
+        captured: list[str] = []
+
+        async def capturing_agent(
+            issue: Task,
+            wt_path: Path,
+            branch: str,
+            worker_id: int = 0,
+            review_feedback: str = "",
+            prior_failure: str = "",
+        ) -> WorkerResult:
+            captured.append(prior_failure)
+            return WorkerResultFactory.create(
+                issue_number=issue.id, success=True, workspace_path=str(wt_path)
+            )
+
+        phase, _, _ = ImplementPhaseMockBuilder(config).with_issues([issue]).build()
+
+        phase._state.set_worker_result_meta(
+            99,
+            {
+                "error": None,
+                "spec_review_gaps": (
+                    "Spec-compliance gaps from prior attempt:\n- forgot kill-switch"
+                ),
+            },
+        )
+
+        phase._agents.run = capturing_agent  # type: ignore[method-assign]
+        await phase._run_implementation(issue, "agent/issue-99", 0, "")
+
+        assert captured[0].startswith("Spec-compliance gaps from prior attempt:")
+        assert "forgot kill-switch" in captured[0]
+        assert "Runner error" not in captured[0]
+
+
+class TestHandleImplementationResultDispatchesReview:
+    @pytest.mark.asyncio
+    async def test_zero_commit_failure_triggers_reviewer(self, tmp_path: Path) -> None:
+        """The end-to-end failure-result handler dispatches the reviewer for
+        zero-commit failures (the canonical zero-diff failure mode).
+        """
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242,
+            success=False,
+            error="No commits found on branch",
+            commits=0,
+            workspace_path=str(config.workspace_path_for_issue(4242)),
+        )
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(compliant=False, gaps=["produced zero diff against spec"])
+        )
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        phase._state.increment_issue_attempts(4242)
+
+        await phase._handle_implementation_result(issue, result, is_retry=False)
+
+        assert len(reviewer.calls) == 1
+        meta = phase._state.get_worker_result_meta(4242)
+        assert "produced zero diff against spec" in meta.get("spec_review_gaps", "")
+
+    @pytest.mark.asyncio
+    async def test_blocking_skill_failure_with_commits_triggers_reviewer(
+        self, tmp_path: Path
+    ) -> None:
+        """A non-zero-commit failure (e.g. blocking skill) also runs the reviewer."""
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        wt_path = config.workspace_path_for_issue(4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242,
+            success=False,
+            error="diff-sanity failed: Missing implementation",
+            commits=2,
+            workspace_path=str(wt_path),
+        )
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(compliant=False, gaps=["only modified tests"])
+        )
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+        phase._state.increment_issue_attempts(4242)
+
+        await phase._handle_implementation_result(issue, result, is_retry=False)
+
+        assert len(reviewer.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_successful_result_does_not_trigger_reviewer(
+        self, tmp_path: Path
+    ) -> None:
+        """The reviewer is only for failed attempts."""
+        from implement_spec_reviewer import SpecReviewResult
+
+        config = ConfigFactory.create(
+            max_issue_attempts=3,
+            repo_root=tmp_path / "repo",
+            workspace_base=tmp_path / "worktrees",
+            state_file=tmp_path / "state.json",
+        )
+        issue = TaskFactory.create(id=4242)
+        wt_path = config.workspace_path_for_issue(4242)
+        result = WorkerResultFactory.create(
+            issue_number=4242,
+            success=True,
+            commits=3,
+            workspace_path=str(wt_path),
+        )
+        reviewer = _FakeSpecReviewer(
+            SpecReviewResult(compliant=False, gaps=["should not be called"])
+        )
+        phase, _, _ = (
+            ImplementPhaseMockBuilder(config)
+            .with_issues([issue])
+            .with_spec_reviewer(reviewer)
+            .build()
+        )
+
+        await phase._handle_implementation_result(issue, result, is_retry=False)
+
+        assert reviewer.calls == []


### PR DESCRIPTION
Closes advisor-5uuc.

## Summary

- Promotes `superpowers:subagent-driven-development`'s two-stage review pattern into `ImplementPhase`: after every failed attempt, a spec-compliance reviewer subagent reads the spec + diff and reports either compliant or specific gaps.
- Gaps are persisted into `WorkerResultMeta.spec_review_gaps` and prepended to the next attempt's `prior_failure` context, so the next implementer sees concrete anchors instead of just the prior error string.
- New config flag `implement_two_stage_review_enabled` (env: `HYDRAFLOW_IMPLEMENT_TWO_STAGE_REVIEW_ENABLED`, default True).
- Reviewer is skipped at the attempt cap (no point gathering gaps that will never be read) and degrades cleanly on runner/parse errors (compliant=True, gaps=[], degraded=True) so the pre-W5 flow continues unchanged on reviewer failure.

## What this addresses (per ADR-0063)

1. **Zero-diff branches.** The runner-error `"No commits found on branch"` is uninformative; the reviewer's gap ("produced zero diff for feature X") becomes an explicit prompt anchor for retry.
2. **Attempt-cap reaches.** Multi-attempt issues stop re-implementing the same mistake — each retry sees the prior pass's spec-compliance findings.

## Files

- `src/implement_spec_reviewer.py` (new) — `SpecReviewInput`, `SpecReviewResult`, `DefaultSpecComplianceReviewer`, `AgentSubagentRunnerAdapter`, `build_spec_review_prompt`, `format_gaps_for_prior_failure`, `compute_branch_diff`.
- `src/implement_phase.py` — accepts optional `spec_reviewer`; `_handle_implementation_result` dispatches it on failed attempts (both zero-commit and skill-blocking); `_run_implementation` prepends persisted gaps to `prior_failure`.
- `src/models.py` — `WorkerResultMeta.spec_review_gaps` field.
- `src/config.py` — kill-switch flag + Pydantic field.
- `src/service_registry.py` — wires the default reviewer through a thin adapter over the existing AgentRunner subprocess plumbing (shares tracing + auth-retry).
- `tests/test_implement_spec_reviewer.py` (new) — 18 unit tests covering JSON parsing, zero-diff prompt, kill-switch off, no-reviewer-wired, gap persistence, attempt-cap skip, end-to-end feed-forward, dispatch from `_handle_implementation_result`.
- `tests/helpers.py` — threads the new flag/reviewer through `ConfigFactory`, `make_implement_phase`, and `ImplementPhaseMockBuilder`.

## Test plan

- [x] `tests/test_implement_spec_reviewer.py` — 18 new tests pass
- [x] `tests/test_implement_phase.py` (103 tests) — no regressions
- [x] `tests/test_implement_phase_hooks.py`, `tests/test_implement_phase_tracing.py`, `tests/test_active_issue_ownership.py`, `tests/test_race_condition_guards.py` — all pass
- [x] `tests/test_service_registry.py`, `tests/test_orchestrator_core.py`, `tests/test_orchestrator_integration.py` — all pass (124 total)
- [x] `tests/scenarios/test_happy.py`, `tests/scenarios/test_loops.py`, `tests/scenarios/test_adversarial_pipeline.py` — all pass
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [x] `pyright` clean on the new module + the modified implement_phase
- [x] Env override works (`HYDRAFLOW_IMPLEMENT_TWO_STAGE_REVIEW_ENABLED=false` flips the flag)
- [ ] Sandbox e2e scenario for two-stage recovery — deferred (acknowledged gap; existing s_advisor_full_loop pattern is the reference for follow-up work; happy-path scenarios remain green with the default reviewer wired)

## Notes for review

- The reviewer dispatches *per failed attempt*, not *per escalation* (which the bead description initially suggested). This is intentional: the goal is to feed gaps into the NEXT attempt's prompt, which only happens if the issue retries. Bounded by `max_issue_attempts` (default 3), so cost is capped at 2 reviewer dispatches per issue.
- The reviewer runs in read-only mode (`Write,Edit,NotebookEdit` disallowed) — it must never modify the codebase, only inspect the diff.
- Gaps survive `_record_impl_metrics`'s meta overwrite via a read-update-write pattern in `_persist_spec_review_gaps`.
- Existing default-scenario tests (`test_happy.py`) still pass with the production reviewer wired in — because successful agent runs never trigger the reviewer.

ADR-0063 status remains Proposed (this is W5 of W1-W5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)