### PR TITLE
test(trust): WorkspacePort contract test

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T19:49:54.342171+00:00",
-  "commit_sha": "4c42f53330695b41c767695784da09331b985870",
+  "regenerated_at": "2026-05-20T15:06:44.283679+00:00",
+  "commit_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "ports.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "labels.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "modules.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "events.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "adr_xref.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "mockworld.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "changelog.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "coverage_matrix.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "functional_areas.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "ubiquitous-language.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "4c42f53330695b41c767695784da09331b985870"
+      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T15:05:21.895164+00:00",
-  "commit_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99",
+  "regenerated_at": "2026-05-19T19:49:54.342171+00:00",
+  "commit_sha": "4c42f53330695b41c767695784da09331b985870",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "ports.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "labels.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "modules.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "events.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "adr_xref.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "mockworld.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "changelog.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "coverage_matrix.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "functional_areas.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "ubiquitous-language.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "d15e32aa43d80d8d42d782bec6e9d579935e1f99"
+      "source_sha": "4c42f53330695b41c767695784da09331b985870"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -76,13 +76,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 | ADR-0064 | `src.adversarial_labels`, `src.adversarial_retry_loop`, `src.assumption_surfacer`, `src.complexity_gate`, `src.discovery_council`, `src.discovery_council_prompts`, `src.events`, `src.models`, `src.pending_concerns`, `src.plan_council`, `src.plan_council_prompts`, `src.plan_phase`, `src.post_merge_handler`, `src.shape_challenger`, `src.shape_expert_council`, `src.shape_phase`, `src.spec_ac_generator`, `src.spec_judge`, `src.wiki_carryover` |
 | ADR-0065 | `src.code_grooming_loop`, `src.config`, `src.skill_registry` |
-| ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` |
-| ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` |
-| ADR-0075 | `src.merge_state_watcher`, `src.merge_state_watcher_loop` |
-| ADR-0076 | `src.github_cache_loop` |
-| ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
-| ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
-| ADR-0079 | `src.adr_reviewer`, `src.adr_reviewer_loop` |
 
 ## Module → ADRs
 
@@ -90,8 +83,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|
 | `src.adr_drift` | ADR-0056 |
 | `src.adr_pre_validator` | ADR-0037 |
-| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040, ADR-0079 |
-| `src.adr_reviewer_loop` | ADR-0079 |
+| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040 |
 | `src.adr_touchpoint_auditor_loop` | ADR-0056 |
 | `src.adversarial_labels` | ADR-0064 |
 | `src.adversarial_retry_loop` | ADR-0064 |
@@ -132,7 +124,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
 | `src.file_util` | ADR-0021 |
 | `src.flake_tracker_loop` | ADR-0045 |
-| `src.github_cache_loop` | ADR-0076 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
@@ -145,8 +136,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
-| `src.merge_state_watcher` | ADR-0075 |
-| `src.merge_state_watcher_loop` | ADR-0075 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
@@ -161,8 +150,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.ports` | ADR-0003, ADR-0044 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
-| `src.pr_unsticker` | ADR-0077 |
-| `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -171,8 +158,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
-| `src.pricing_refresh_diff` | ADR-0078 |
-| `src.pricing_refresh_loop` | ADR-0078 |
 | `src.principles_audit_loop` | ADR-0045 |
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
@@ -181,16 +166,11 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
-| `src.retrospective` | ADR-0074 |
-| `src.retrospective_loop` | ADR-0074 |
-| `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
 | `src.review_phase._phase` | ADR-0063 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059 |
 | `src.route_back` | ADR-0041 |
-| `src.run_recorder` | ADR-0073 |
-| `src.runs_gc_loop` | ADR-0073 |
 | `src.screenshot_scanner` | ADR-0018 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
@@ -227,4 +207,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -76,6 +76,13 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 | ADR-0064 | `src.adversarial_labels`, `src.adversarial_retry_loop`, `src.assumption_surfacer`, `src.complexity_gate`, `src.discovery_council`, `src.discovery_council_prompts`, `src.events`, `src.models`, `src.pending_concerns`, `src.plan_council`, `src.plan_council_prompts`, `src.plan_phase`, `src.post_merge_handler`, `src.shape_challenger`, `src.shape_expert_council`, `src.shape_phase`, `src.spec_ac_generator`, `src.spec_judge`, `src.wiki_carryover` |
 | ADR-0065 | `src.code_grooming_loop`, `src.config`, `src.skill_registry` |
+| ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` |
+| ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` |
+| ADR-0075 | `src.merge_state_watcher`, `src.merge_state_watcher_loop` |
+| ADR-0076 | `src.github_cache_loop` |
+| ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
+| ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
+| ADR-0079 | `src.adr_reviewer`, `src.adr_reviewer_loop` |
 
 ## Module → ADRs
 
@@ -83,7 +90,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|
 | `src.adr_drift` | ADR-0056 |
 | `src.adr_pre_validator` | ADR-0037 |
-| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040 |
+| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040, ADR-0079 |
+| `src.adr_reviewer_loop` | ADR-0079 |
 | `src.adr_touchpoint_auditor_loop` | ADR-0056 |
 | `src.adversarial_labels` | ADR-0064 |
 | `src.adversarial_retry_loop` | ADR-0064 |
@@ -124,6 +132,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
 | `src.file_util` | ADR-0021 |
 | `src.flake_tracker_loop` | ADR-0045 |
+| `src.github_cache_loop` | ADR-0076 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
@@ -136,6 +145,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
+| `src.merge_state_watcher` | ADR-0075 |
+| `src.merge_state_watcher_loop` | ADR-0075 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
@@ -150,6 +161,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.ports` | ADR-0003, ADR-0044 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
+| `src.pr_unsticker` | ADR-0077 |
+| `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -158,6 +171,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
+| `src.pricing_refresh_diff` | ADR-0078 |
+| `src.pricing_refresh_loop` | ADR-0078 |
 | `src.principles_audit_loop` | ADR-0045 |
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
@@ -166,11 +181,16 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
+| `src.retrospective` | ADR-0074 |
+| `src.retrospective_loop` | ADR-0074 |
+| `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
 | `src.review_phase._phase` | ADR-0063 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059 |
 | `src.route_back` | ADR-0041 |
+| `src.run_recorder` | ADR-0073 |
+| `src.runs_gc_loop` | ADR-0073 |
 | `src.screenshot_scanner` | ADR-0018 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
@@ -207,4 +227,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,15 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `d15e32a` — style(trust-fleet-sanity): ruff lint + format fixes on breach-path tests *(2026-05-20)*
-- `18041e1` — feat(adversarial): remove the switch — adversarial pipeline always on (#9036) (#9036) *(2026-05-19)*
-- `31313f7` — feat(adversarial): flip pipeline ON by default (#9025) (#9025) *(2026-05-19)*
-- `6d6ed95` — test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft *(2026-05-19)*
-- `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
-- `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
-- `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
-- `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
-- `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -359,4 +350,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,18 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `b1bbffe` — chore(arch): regen after rebase against staging *(2026-05-20)*
+- `a8e86d7` — chore: ruff format + arch-regen refresh *(2026-05-20)*
+- `4ff3f88` — chore(arch): regen after rebase against staging *(2026-05-20)*
+- `d15e32a` — style(trust-fleet-sanity): ruff lint + format fixes on breach-path tests *(2026-05-20)*
+- `18041e1` — feat(adversarial): remove the switch — adversarial pipeline always on (#9036) (#9036) *(2026-05-19)*
+- `31313f7` — feat(adversarial): flip pipeline ON by default (#9025) (#9025) *(2026-05-19)*
+- `6d6ed95` — test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft *(2026-05-19)*
+- `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
+- `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
+- `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
+- `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
+- `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -350,4 +362,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,50 +10,50 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
-| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ❌ | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ❌ | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
-| `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
-| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
-| `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `ADRReviewerLoop` | ✅ [0079] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ✅ `s33_adr_touchpoint_auditor_no_drift.py` |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ✅ `s31_auto_agent_preflight_no_escalations.py` |
+| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
+| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
+| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
+| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
+| `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
-| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `PRUnstickerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
-| `PricingRefreshLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
-| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
-| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ (caretaker loop) | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
-| `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
-| `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
-| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
-| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
+| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
+| `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
+| `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
+| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ✅ `s20_rc_budget_no_regression.py` |
+| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
+| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
+| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
+| `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
+| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
-| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ❌ | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ (caretaker loop) | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ❌ | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
-| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ❌ | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
-| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
+| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
+| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
+| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
+| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are
@@ -61,15 +61,15 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ✅ README.md | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056, 0075, 0077] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 ## Section 3: Factory phases
 
 Section 3 contains hand-curated prose (Loops driving it / Escalation path /
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,50 +10,50 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ✅ [0079] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ✅ `s33_adr_touchpoint_auditor_no_drift.py` |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ✅ `s31_auto_agent_preflight_no_escalations.py` |
-| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
-| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
-| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
-| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
-| `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
+| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ❌ | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ❌ | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
+| `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
+| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
+| `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
-| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
-| `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
-| `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
-| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ✅ `s20_rc_budget_no_regression.py` |
-| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
-| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
-| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
-| `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
-| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
+| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `PRUnstickerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
+| `PricingRefreshLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
+| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
+| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ (caretaker loop) | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
+| `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
+| `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
+| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
+| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
-| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
-| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
-| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
-| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
+| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueLoop` | ❌ | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ (caretaker loop) | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ❌ | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
+| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ❌ | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
+| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are
@@ -61,15 +61,15 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ✅ README.md | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052, 0056, 0075, 0077] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 ## Section 3: Factory phases
 
 Section 3 contains hand-curated prose (Loops driving it / Escalation path /
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,7 +16,6 @@ graph LR
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
     src_preflight["src.preflight"]
-    src_preflight_playbooks["src.preflight.playbooks"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
     src_sentry["src.sentry"]
@@ -44,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,6 +16,7 @@ graph LR
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
     src_preflight["src.preflight"]
+    src_preflight_playbooks["src.preflight.playbooks"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
     src_sentry["src.sentry"]
@@ -43,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -71,7 +71,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `get_pr_recent_commit_diffs`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._
+_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -71,7 +71,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `get_pr_recent_commit_diffs`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `d15e32a` on 2026-05-20 15:05 UTC. Source last changed at `d15e32a`. Status: 🟢 fresh._
+_Regenerated from commit `4c42f53` on 2026-05-19 19:49 UTC. Source last changed at `4c42f53`. Status: 🟢 fresh._


### PR DESCRIPTION
## Summary

Adds the missing fake contract test for `WorkspacePort` (ADR-0047).

Closes bead `advisor-1mpg` (dark-factory gap).

## What this verifies

The test asserts schema-based parity between `FakeWorkspace` and the
`WorkspacePort` Protocol (24 tests, ~0.5s):

1. `FakeWorkspace` satisfies the `@runtime_checkable` `WorkspacePort` Protocol.
2. Every Port method on `FakeWorkspace` is async with a matching signature.
3. Return-type parity for all 9 Port methods (`create`, `destroy`,
   `destroy_all`, `merge_main`, `get_conflicting_files`, `reset_to_main`,
   `post_work_cleanup`, `abort_merge`, `start_merge_main`).
4. Fault injection (`fail_next_create`) raises `PermissionError`,
   `OSError(28, ...)` (disk full), and `RuntimeError` (branch conflict),
   single-shot.
5. Stateful tracking (`created` / `destroyed` lists) accumulates correctly.
6. `create()` path is rooted under `base_path`.

## Why no cassette

The cassette/replay pattern (ADR-0047 §Part 1) targets CLI-based adapters
(github, git, docker). `FakeWorkspace` wraps in-process Python objects —
there is no CLI, no subprocess, no external service output to snapshot.
This is consistent with `FakeHoneycomb` (PR #9004), which followed the
same schema-based approach for the same reason. `workspace` is correctly
absent from both `KNOWN_ADAPTERS` (`src/contracts/_schema.py`) and
`_FAKE_TO_CASSETTE_DIR` (`src/fake_coverage_auditor_loop.py`).

## Test plan

- [x] `pytest tests/trust/contracts/test_fake_workspace_contract.py` — 24 passed in 0.5s
- [x] Full `make quality` pytest run — 13417 passed, 0 failed
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `pyright` on the new file — 0 errors