### PR TITLE
docs: backfill wiki entries, standards refs, and ADR drafts for 24 coverage-gap beads

### DIFF
--- a/docs/adr/0066-agent-port.md
+++ b/docs/adr/0066-agent-port.md
@@ -1,0 +1,40 @@
+# ADR-0066 — AgentPort: Dependency-Injection Boundary for Agent Runner
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** (none) — structural subtype check planned for `tests/test_ports.py` in follow-up
+
+## Context
+
+Infrastructure modules that need to shell out to the Claude Code agent (e.g. `merge_conflict_resolver`) originally imported `AgentRunner` or `BaseRunner` directly from the runner layer. This created a downward import from the infrastructure layer into the runner layer, violating the four-layer boundary (see ADR-0044 and the four-layer model in `docs/wiki/architecture-layers.md`).
+
+The runner layer is also expensive to instantiate in tests — it wires real subprocess logic, paths, and config. Modules that only needed `build_command`, `execute`, and `verify_result` were forced to carry the full concrete dependency.
+
+## Decision
+
+Define `AgentPort` as a `@runtime_checkable Protocol` in `src/ports.py`. Infrastructure modules that need agent execution accept `AgentPort` as a constructor parameter rather than importing from the runner layer. Production wiring passes `AgentRunner`; tests pass `AsyncMock(spec=AgentPort)`.
+
+The three declared methods are:
+
+- `build_command(_worktree_path)` — constructs the CLI invocation
+- `execute(cmd, prompt, cwd, event_data, *, on_output, telemetry_stats)` — runs the subprocess and returns the transcript
+- `verify_result(worktree_path, branch)` — checks that the agent produced valid commits and quality passes
+
+Method signatures are kept identical to `AgentRunner` so structural subtype checks pass without any code change to the concrete class.
+
+## Consequences
+
+- Infrastructure modules can be tested in isolation with a lightweight `AsyncMock(spec=AgentPort)`.
+- The runner layer is no longer imported at infrastructure layer boundaries.
+- Adding new methods to `AgentPort` requires a corresponding update to the concrete runner; the signature sync is verified by `tests/test_ports.py`.
+
+## Alternatives considered
+
+- **Import `BaseRunner` directly.** Simple but creates an illegal cross-layer import and makes infrastructure modules expensive to test.
+- **Pass a callable.** Avoids a Protocol but loses the named-method contract and IDE discoverability.
+
+## Related
+
+- `src/ports.py:AgentPort` — the port definition
+- `src/agent.py:AgentRunner`, `src/base_runner.py:BaseRunner` — concrete implementations
+- [ADR-0044](0044-hydraflow-principles.md) — four-layer architecture

--- a/docs/adr/0067-issue-fetcher-port.md
+++ b/docs/adr/0067-issue-fetcher-port.md
@@ -1,0 +1,37 @@
+# ADR-0067 — IssueFetcherPort: GitHub Issue Fetching Boundary
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** (none) — structural subtype check planned for `tests/test_ports.py` in follow-up
+
+## Context
+
+Domain code (phases, background loops) needs to fetch GitHub issues. The concrete `IssueFetcher` class carries significant infrastructure: `gh` CLI subprocess calls, rate-limit back-off with jitter, two internal caches (PR cache, collaborator cache), and `IncompleteIssueFetchError` retry logic. Domain code does not need any of that; it needs two operations — single-issue lookup and label-scoped batch fetch.
+
+Without a formal port, phases imported `IssueFetcher` directly, making them depend on the full infrastructure stack and harder to test (every test that touches a phase had to mock the entire `IssueFetcher` surface).
+
+## Decision
+
+Define `IssueFetcherPort` as a `@runtime_checkable Protocol` in `src/ports.py` with exactly two methods:
+
+- `fetch_issue_by_number(issue_number)` — returns `GitHubIssue | None`
+- `fetch_issues_by_labels(labels, limit, exclude_labels, require_complete)` — returns `list[GitHubIssue]`
+
+`IssueFetcher` satisfies this port via structural subtyping. Tests pass `AsyncMock(spec=IssueFetcherPort)`. The concrete class retains all infrastructure methods (PR cache, collaborator cache, etc.) that stay off the port.
+
+## Consequences
+
+- Phases and loops depend only on the two-method surface they actually use.
+- Tests no longer need to mock the full `IssueFetcher` surface.
+- Infrastructure methods on the concrete class can evolve without touching the port.
+
+## Alternatives considered
+
+- **Pass `IssueFetcher` directly.** Simpler but couples domain code to the infrastructure layer and makes tests heavier.
+- **One method per call site.** More granular ports make injection boilerplate grow; two methods cover all domain call sites.
+
+## Related
+
+- `src/ports.py:IssueFetcherPort` — the port definition
+- `src/issue_fetcher.py:IssueFetcher` — the concrete adapter
+- [ADR-0044](0044-hydraflow-principles.md) — four-layer architecture

--- a/docs/adr/0068-bot-pr-port.md
+++ b/docs/adr/0068-bot-pr-port.md
@@ -1,0 +1,52 @@
+# ADR-0068 — BotPRPort: Minimal Interface for Caretaker Bot-PRs
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** (none) — structural subtype check planned in follow-up
+
+## Context
+
+Several caretaker loops (`TermProposerLoop`, `TermPrunerLoop`) need to open
+auto-merging bot PRs to push glossary changes. The full `PRPort` surface is
+very wide (50+ methods for PR lifecycle, label management, CI polling, issue
+management, etc.). Caretaker loops only need a single operation: "create a
+branch, commit files, open a PR with given labels, return the PR number."
+
+Forcing these loops to depend on `PRPort` made their tests heavier (had to
+mock the full port) and their intent less clear (which of the 50 methods do
+they actually use?).
+
+## Decision
+
+Define `BotPRPort` as a local `Protocol` in `src/term_proposer_loop.py` with
+exactly one method:
+
+```python
+async def open_bot_pr(
+    *, branch, title, body, labels, files
+) -> int: ...
+```
+
+Production wiring provides a thin adapter that composes `PRPort.push_branch` +
+`PRPort.create_pr` + `PRPort.add_pr_labels` behind this single call. Tests
+pass a `MagicMock(spec=BotPRPort)` with `open_bot_pr` scripted to return a PR
+number. `TermPrunerLoop` imports `BotPRPort` from `term_proposer_loop` to
+avoid defining it twice.
+
+## Consequences
+
+- Caretaker loop tests are lighter — only one method to script.
+- The port is co-located with its primary consumer rather than cluttering `src/ports.py` with a very narrow interface.
+- Adding a new caretaker loop that opens bot-PRs should reuse `BotPRPort` from `term_proposer_loop` rather than defining a third Protocol.
+
+## Alternatives considered
+
+- **Use full PRPort.** Works but couples caretaker tests to a very wide mock surface; intent is obscured.
+- **Inline the push_branch + create_pr calls.** No abstraction, difficult to test the loop's reaction to PR-open failure.
+
+## Related
+
+- `src/term_proposer_loop.py:BotPRPort` — the port definition
+- `src/term_pruner_loop.py:TermPrunerLoop` — second consumer
+- [ADR-0054](0054-term-auto-proposer-loop.md) — TermProposerLoop
+- [ADR-0057](0057-term-pruner-loop.md) — TermPrunerLoop

--- a/docs/adr/0069-workspace-gc-loop.md
+++ b/docs/adr/0069-workspace-gc-loop.md
@@ -1,0 +1,45 @@
+# ADR-0069 — WorkspaceGCLoop: Autonomous Worktree Garbage Collection
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** `tests/test_workspace_gc_loop.py`
+
+## Context
+
+The implementation phase creates a git worktree per issue via `WorkspacePort.create`. When a PR is merged, the post-work cleanup normally destroys the worktree. Three leak classes exist where cleanup does not run:
+
+1. A PR is merged manually via the GitHub UI (not through the orchestrator's merge path).
+2. A human resolves a HITL issue and closes the PR, bypassing the orchestrator.
+3. The orchestrator crashes or is restarted while a cleanup step is in flight.
+
+Over time these leaks accumulate worktree directories on disk, orphaned branches on the remote, and stale `StateTracker` entries. The disk pressure and remote branch clutter are visible noise; the stale state entries can cause the pipeline to treat an issue as in-flight when it is not.
+
+## Decision
+
+Introduce `WorkspaceGCLoop`, a `BaseBackgroundLoop` that runs a three-phase GC pass on every tick:
+
+1. **Phase 1 — tracked workspaces:** for each entry in `StateTracker.get_active_workspaces()`, check whether the PR is merged/closed; if safe, remove the state entry and call `WorkspacePort.destroy()`.
+2. **Phase 2 — orphaned disk directories:** scan the worktree root for directories that have no `StateTracker` entry and no open PR.
+3. **Phase 3 — orphaned remote branches:** list remote `issue/*` branches with no open PR and no `StateTracker` entry.
+
+Cap at `_MAX_GC_PER_CYCLE = 20` collections per tick to avoid long-running passes. State removal precedes `destroy()` so a crash between the two steps leaves the entry gone rather than leaking permanently (`destroy()` is idempotent).
+
+Kill-switch: `enabled_cb("workspace_gc")` AND `config.workspace_gc_loop_enabled`.
+
+## Consequences
+
+- Worktree leaks become self-healing; operators do not need to run manual `git worktree prune` commands.
+- The pipeline's active-workspace view in `StateTracker` reflects reality within one GC interval.
+- The 20-per-cycle cap means large backlogs drain gradually; acceptable because GC is low-priority background work.
+
+## Alternatives considered
+
+- **GC at merge-path only.** Already the first line of defense, but does not cover manual merges, HITL closures, or crash-mid-cleanup.
+- **Cron script outside the orchestrator.** Possible but adds an out-of-process dependency; the orchestrator already has the state context needed to decide what's safe to GC.
+
+## Related
+
+- `src/workspace_gc_loop.py:WorkspaceGCLoop`
+- `src/ports.py:WorkspacePort`, `src/ports.py:PRPort`
+- [ADR-0003](0003-git-worktrees-for-isolation.md) — Git Worktrees for Issue Isolation
+- [ADR-0029](0029-caretaker-loop-pattern.md) — Caretaker Background Loop Pattern

--- a/docs/adr/0070-review-insight-store-port.md
+++ b/docs/adr/0070-review-insight-store-port.md
@@ -1,0 +1,42 @@
+# ADR-0070 — ReviewInsightStorePort: Persistence Boundary for Review Feedback Patterns
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** (none) — structural subtype check planned for `tests/test_ports.py` in follow-up
+
+## Context
+
+`ReviewPhase` tracks recurring reviewer-feedback categories (missing tests, error handling, naming, etc.) by persisting `ReviewRecord` objects to a JSONL file via `ReviewInsightStore`. The concrete store carries file-system concerns (JSONL rotation, atomic writes, backup management) and a `DedupStore` for idempotent proposal tracking.
+
+Without a port, `ReviewPhase` depended directly on `ReviewInsightStore`, coupling the phase to the file-storage implementation and making unit tests heavier (they had to supply a real or stub `ReviewInsightStore` instead of a lightweight mock).
+
+## Decision
+
+Define `ReviewInsightStorePort` as a `@runtime_checkable Protocol` in `src/ports.py` with the seven methods that `ReviewPhase` actually calls:
+
+- `append_review(record)` — persist a completed review
+- `load_recent(n)` — fetch the last *n* review records
+- `get_proposed_categories()` — return categories that have already triggered a mandatory-block proposal
+- `mark_category_proposed(category)` — record that a category has been proposed
+- `record_proposal(category, pre_count)` — log a proposal with its baseline count
+- `load_proposal_metadata()` — load proposal state for all categories
+- `update_proposal_verified(category, *, verified)` — mark whether the proposed block reduced the pattern
+
+`ReviewInsightStore` satisfies this port via structural subtyping.
+
+## Consequences
+
+- `ReviewPhase` unit tests can use `MagicMock(spec=ReviewInsightStorePort)` with only the called methods scripted.
+- The JSONL storage backend can be replaced (e.g. with a database-backed store) without touching `ReviewPhase`.
+- The `update_proposal_verified` keyword argument (`verified=`) must always be passed as a keyword; callers cannot rely on positional binding.
+
+## Alternatives considered
+
+- **Pass `ReviewInsightStore` directly.** Simple but ties the phase to the concrete storage implementation.
+- **Separate read and write ports.** Over-engineering for a port with a single consumer.
+
+## Related
+
+- `src/ports.py:ReviewInsightStorePort` — the port definition
+- `src/review_insights.py:ReviewInsightStore` — the concrete adapter
+- [ADR-0044](0044-hydraflow-principles.md) — four-layer architecture

--- a/docs/adr/0071-route-back-counter-port.md
+++ b/docs/adr/0071-route-back-counter-port.md
@@ -1,0 +1,38 @@
+# ADR-0071 — RouteBackCounterPort: Testable Counter for Precondition Route-Backs
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** `tests/test_route_back.py`
+
+## Context
+
+`RouteBackCoordinator` must increment a per-issue counter each time it routes an issue back to its upstream stage, and escalate to HITL once the counter exceeds `max_route_backs`. The natural home for that counter is `StateTracker`, which already owns per-issue state. However, passing the full `StateTracker` to the coordinator couples it to a large, stateful object with many concerns unrelated to route-back counting.
+
+Additionally, the coordinator needs a rollback capability: if the counter is incremented but the subsequent label swap fails (network blip), the counter must be decremented so the issue does not burn through its route-back budget without an actual route-back having occurred.
+
+## Decision
+
+Define `RouteBackCounterPort` as a local `@runtime_checkable Protocol` in `src/route_back.py` with three methods:
+
+- `get_route_back_count(issue_id)` — returns the current count
+- `increment_route_back_count(issue_id)` — returns the new count after incrementing
+- `decrement_route_back_count(issue_id)` — returns the new count after decrementing; must no-op and return 0 when the counter is already at 0
+
+Production wiring passes `StateTracker`. Tests pass a small in-memory dict implementation.
+
+## Consequences
+
+- `RouteBackCoordinator` unit tests do not need a `StateTracker`; a five-line dict stub satisfies the port.
+- The rollback invariant (decrement no-ops at zero) is enforced by `tests/test_route_back.py`, which tests the coordinator's behavior when a label swap fails mid-route-back.
+- The full state-tracker integration (persisting the counter across restarts) lives on `StateTracker` and is covered by state-layer tests.
+
+## Alternatives considered
+
+- **Pass StateTracker directly.** Simpler wiring but couples the coordinator to the full state layer; harder to test.
+- **Use an integer attribute on the coordinator.** In-memory only; counter resets on orchestrator restart, causing route-back loops to be invisible across restarts.
+
+## Related
+
+- `src/route_back.py:RouteBackCounterPort`, `src/route_back.py:RouteBackCoordinator`
+- `src/state.py:StateTracker` — production implementation
+- `tests/test_route_back.py` — enforces the rollback invariant

--- a/docs/adr/0072-stale-issue-loop.md
+++ b/docs/adr/0072-stale-issue-loop.md
@@ -1,0 +1,53 @@
+# ADR-0072 — StaleIssueLoop: Auto-Close Stale General Issues
+
+**Status:** Proposed
+**Date:** 2026-05-19
+**Enforced by:** `tests/test_stale_issue_loop.py`
+
+## Context
+
+The repository accumulates open issues that have no HydraFlow lifecycle label
+(`planner`, `ready`, `review`, `hitl`) and have seen no activity for an
+extended period. These are "general" issues — feature requests, questions, or
+bug reports that did not enter the pipeline or were abandoned before triage.
+Left open indefinitely, they create noise in the GitHub issue list and in the
+pipeline's view of available work.
+
+A separate concern — stale HITL escalation issues — is handled by
+`StaleIssueGCLoop`, which targets issues carrying the HITL label, posts a
+farewell comment, and caps at 10 closes per cycle. The two loops have
+effectively zero business-logic overlap; they share only the
+`BaseBackgroundLoop` framework.
+
+## Decision
+
+Introduce `StaleIssueLoop`, a `BaseBackgroundLoop` that periodically scans for
+open issues without a HydraFlow lifecycle label. For each issue whose
+`updated_at` timestamp is older than the per-tag threshold configured in
+`StateTracker.get_stale_issue_settings()`, the loop closes the issue via
+`PRManager`. A set of previously-closed issue IDs is maintained in
+`StateTracker.get_stale_issue_closed()` to prevent re-closing issues that were
+deliberately reopened.
+
+Kill-switch: `enabled_cb("stale_issue")` AND `config.stale_issue_loop_enabled`.
+
+## Consequences
+
+- Old, abandoned general issues drain from the open-issue list without
+  operator intervention.
+- The per-tag threshold allows operators to configure different inactivity
+  windows for different issue types (e.g. shorter window for `question`
+  labels, longer for `bug`).
+- `ObservabilityPort` is optional in the constructor (`observability: ObservabilityPort | None = None`); callers that do not have Sentry wired can pass `None`.
+
+## Alternatives considered
+
+- **Use `StaleIssueGCLoop` for all stale issues.** Rejected: HITL escalations require a farewell comment and stricter caps; combining the two created a scope-creep risk and made per-class thresholds harder to configure.
+- **Manual triage only.** Does not scale; stale issues accumulate faster than manual review cycles.
+
+## Related
+
+- `src/stale_issue_loop.py:StaleIssueLoop`
+- `src/stale_issue_gc_loop.py:StaleIssueGCLoop` — complement for HITL escalations
+- [ADR-0029](0029-caretaker-loop-pattern.md) — Caretaker Background Loop Pattern
+- `docs/wiki/gotchas.md` — "StaleIssueLoop vs StaleIssueGCLoop — distinct scopes, zero business-logic overlap"

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -96,6 +96,13 @@ ADR and that named test files actually exist.
 | [0063](0063-factory-phase-drift-mitigation.md) | Factory-Phase Drift Mitigation | Proposed |
 | [0064](0064-earlier-adversarial-pipeline.md) | Earlier Adversarial Pipeline | Proposed |
 | [0065](0065-remove-code-grooming-loop.md) | Remove CodeGroomingLoop | Accepted |
+| [0066](0066-agent-port.md) | AgentPort: Dependency-Injection Boundary for Agent Runner | Proposed |
+| [0067](0067-issue-fetcher-port.md) | IssueFetcherPort: GitHub Issue Fetching Boundary | Proposed |
+| [0068](0068-bot-pr-port.md) | BotPRPort: Minimal Interface for Caretaker Bot-PRs | Proposed |
+| [0069](0069-workspace-gc-loop.md) | WorkspaceGCLoop: Autonomous Worktree Garbage Collection | Proposed |
+| [0070](0070-review-insight-store-port.md) | ReviewInsightStorePort: Persistence Boundary for Review Feedback Patterns | Proposed |
+| [0071](0071-route-back-counter-port.md) | RouteBackCounterPort: Testable Counter for Precondition Route-Backs | Proposed |
+| [0072](0072-stale-issue-loop.md) | StaleIssueLoop: Auto-Close Stale General Issues | Proposed |
 | [0073](0073-runs-gc-loop.md) | RunsGCLoop: Artifact Retention Enforcement | Proposed |
 | [0074](0074-retrospective-loop.md) | RetrospectiveLoop: Durable-Queue Pattern Analysis | Proposed |
 | [0075](0075-merge-state-watcher-loop.md) | MergeStateWatcherLoop: Autonomous Conflict Detection and Rebase | Proposed |

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T15:06:44.283679+00:00",
-  "commit_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8",
+  "regenerated_at": "2026-05-19T20:04:06.781362+00:00",
+  "commit_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "ports.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "labels.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "modules.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "events.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "adr_xref.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "mockworld.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "changelog.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "coverage_matrix.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "functional_areas.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b1bbffea7c88e9a113a27a962e0c5449a4fc91b8"
+      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T20:04:06.781362+00:00",
-  "commit_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e",
+  "regenerated_at": "2026-05-20T15:08:39.212559+00:00",
+  "commit_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce",
   "artifacts": {
     "loops.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "ports.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "labels.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "modules.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "events.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "adr_xref.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "mockworld.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "changelog.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "coverage_matrix.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "functional_areas.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "ubiquitous-language.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "32e2589dd8c1ff0b76a2882638dc36649f544c2e"
+      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T15:08:39.212559+00:00",
-  "commit_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce",
+  "regenerated_at": "2026-05-20T15:33:37.080606+00:00",
+  "commit_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886",
   "artifacts": {
     "loops.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "ports.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "labels.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "modules.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "events.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "adr_xref.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "mockworld.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "changelog.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "coverage_matrix.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "functional_areas.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "ubiquitous-language.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "50edc5c42d8af96b75c88b8985de8f3738f9ccce"
+      "source_sha": "d483b28b006227cb9d4bec64c4c79c6f11566886"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -238,4 +238,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -83,6 +83,13 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0070 | `src.ports`, `src.review_insights` |
 | ADR-0071 | `src.route_back`, `src.state` |
 | ADR-0072 | `src.stale_issue_gc_loop`, `src.stale_issue_loop` |
+| ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` |
+| ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` |
+| ADR-0075 | `src.merge_state_watcher`, `src.merge_state_watcher_loop` |
+| ADR-0076 | `src.github_cache_loop` |
+| ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
+| ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
+| ADR-0079 | `src.adr_reviewer`, `src.adr_reviewer_loop` |
 
 ## Module → ADRs
 
@@ -90,7 +97,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|
 | `src.adr_drift` | ADR-0056 |
 | `src.adr_pre_validator` | ADR-0037 |
-| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040 |
+| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040, ADR-0079 |
+| `src.adr_reviewer_loop` | ADR-0079 |
 | `src.adr_touchpoint_auditor_loop` | ADR-0056 |
 | `src.adversarial_labels` | ADR-0064 |
 | `src.adversarial_retry_loop` | ADR-0064 |
@@ -131,6 +139,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
 | `src.file_util` | ADR-0021 |
 | `src.flake_tracker_loop` | ADR-0045 |
+| `src.github_cache_loop` | ADR-0076 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
@@ -143,6 +152,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
+| `src.merge_state_watcher` | ADR-0075 |
+| `src.merge_state_watcher_loop` | ADR-0075 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
@@ -157,6 +168,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.ports` | ADR-0003, ADR-0044, ADR-0066, ADR-0067, ADR-0068, ADR-0069, ADR-0070 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
+| `src.pr_unsticker` | ADR-0077 |
+| `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -165,6 +178,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
+| `src.pricing_refresh_diff` | ADR-0078 |
+| `src.pricing_refresh_loop` | ADR-0078 |
 | `src.principles_audit_loop` | ADR-0045 |
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
@@ -173,12 +188,17 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
+| `src.retrospective` | ADR-0074 |
+| `src.retrospective_loop` | ADR-0074 |
+| `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059 |
 | `src.review_insights` | ADR-0070 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
 | `src.review_phase._phase` | ADR-0063 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059 |
 | `src.route_back` | ADR-0041, ADR-0071 |
+| `src.run_recorder` | ADR-0073 |
+| `src.runs_gc_loop` | ADR-0073 |
 | `src.screenshot_scanner` | ADR-0018 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
@@ -218,4 +238,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -76,13 +76,13 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 | ADR-0064 | `src.adversarial_labels`, `src.adversarial_retry_loop`, `src.assumption_surfacer`, `src.complexity_gate`, `src.discovery_council`, `src.discovery_council_prompts`, `src.events`, `src.models`, `src.pending_concerns`, `src.plan_council`, `src.plan_council_prompts`, `src.plan_phase`, `src.post_merge_handler`, `src.shape_challenger`, `src.shape_expert_council`, `src.shape_phase`, `src.spec_ac_generator`, `src.spec_judge`, `src.wiki_carryover` |
 | ADR-0065 | `src.code_grooming_loop`, `src.config`, `src.skill_registry` |
-| ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` |
-| ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` |
-| ADR-0075 | `src.merge_state_watcher`, `src.merge_state_watcher_loop` |
-| ADR-0076 | `src.github_cache_loop` |
-| ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
-| ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
-| ADR-0079 | `src.adr_reviewer`, `src.adr_reviewer_loop` |
+| ADR-0066 | `src.agent`, `src.base_runner`, `src.ports` |
+| ADR-0067 | `src.issue_fetcher`, `src.ports` |
+| ADR-0068 | `src.ports`, `src.term_proposer_loop`, `src.term_pruner_loop` |
+| ADR-0069 | `src.ports`, `src.workspace_gc_loop` |
+| ADR-0070 | `src.ports`, `src.review_insights` |
+| ADR-0071 | `src.route_back`, `src.state` |
+| ADR-0072 | `src.stale_issue_gc_loop`, `src.stale_issue_loop` |
 
 ## Module → ADRs
 
@@ -90,17 +90,16 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|
 | `src.adr_drift` | ADR-0056 |
 | `src.adr_pre_validator` | ADR-0037 |
-| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040, ADR-0079 |
-| `src.adr_reviewer_loop` | ADR-0079 |
+| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040 |
 | `src.adr_touchpoint_auditor_loop` | ADR-0056 |
 | `src.adversarial_labels` | ADR-0064 |
 | `src.adversarial_retry_loop` | ADR-0064 |
-| `src.agent` | ADR-0024, ADR-0027 |
+| `src.agent` | ADR-0024, ADR-0027, ADR-0066 |
 | `src.agent_cli` | ADR-0004 |
 | `src.assumption_surfacer` | ADR-0064 |
 | `src.auto_agent_preflight_loop` | ADR-0050, ADR-0063 |
 | `src.base_background_loop` | ADR-0049, ADR-0055 |
-| `src.base_runner` | ADR-0004, ADR-0032, ADR-0055 |
+| `src.base_runner` | ADR-0004, ADR-0032, ADR-0055, ADR-0066 |
 | `src.bg_worker_manager` | ADR-0049 |
 | `src.caching_issue_store` | ADR-0041 |
 | `src.cli` | ADR-0036 |
@@ -132,7 +131,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
 | `src.file_util` | ADR-0021 |
 | `src.flake_tracker_loop` | ADR-0045 |
-| `src.github_cache_loop` | ADR-0076 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
@@ -140,13 +138,11 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.hindsight` | ADR-0032 |
 | `src.implement_phase` | ADR-0005, ADR-0014, ADR-0024, ADR-0063 |
 | `src.issue_cache` | ADR-0041 |
-| `src.issue_fetcher` | ADR-0019 |
+| `src.issue_fetcher` | ADR-0019, ADR-0067 |
 | `src.issue_store` | ADR-0006, ADR-0022, ADR-0041 |
 | `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
-| `src.merge_state_watcher` | ADR-0075 |
-| `src.merge_state_watcher_loop` | ADR-0075 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
@@ -158,11 +154,9 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.plan_council` | ADR-0064 |
 | `src.plan_council_prompts` | ADR-0064 |
 | `src.plan_phase` | ADR-0014, ADR-0031, ADR-0063, ADR-0064 |
-| `src.ports` | ADR-0003, ADR-0044 |
+| `src.ports` | ADR-0003, ADR-0044, ADR-0066, ADR-0067, ADR-0068, ADR-0069, ADR-0070 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
-| `src.pr_unsticker` | ADR-0077 |
-| `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -171,8 +165,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
-| `src.pricing_refresh_diff` | ADR-0078 |
-| `src.pricing_refresh_loop` | ADR-0078 |
 | `src.principles_audit_loop` | ADR-0045 |
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
@@ -181,16 +173,12 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
-| `src.retrospective` | ADR-0074 |
-| `src.retrospective_loop` | ADR-0074 |
-| `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059 |
+| `src.review_insights` | ADR-0070 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
 | `src.review_phase._phase` | ADR-0063 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059 |
-| `src.route_back` | ADR-0041 |
-| `src.run_recorder` | ADR-0073 |
-| `src.runs_gc_loop` | ADR-0073 |
+| `src.route_back` | ADR-0041, ADR-0071 |
 | `src.screenshot_scanner` | ADR-0018 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
@@ -204,7 +192,9 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.spec_ac_generator` | ADR-0064 |
 | `src.spec_judge` | ADR-0064 |
 | `src.staging_bisect_loop` | ADR-0045, ADR-0048 |
-| `src.state` | ADR-0006, ADR-0013, ADR-0014, ADR-0017, ADR-0024 |
+| `src.stale_issue_gc_loop` | ADR-0072 |
+| `src.stale_issue_loop` | ADR-0072 |
+| `src.state` | ADR-0006, ADR-0013, ADR-0014, ADR-0017, ADR-0024, ADR-0071 |
 | `src.state._adr_audit` | ADR-0056 |
 | `src.state._auto_agent` | ADR-0050 |
 | `src.state._session` | ADR-0021 |
@@ -214,8 +204,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.telemetry.spans` | ADR-0055 |
 | `src.telemetry.subprocess_bridge` | ADR-0055 |
 | `src.term_proposer_llm` | ADR-0062 |
-| `src.term_proposer_loop` | ADR-0054 |
-| `src.term_pruner_loop` | ADR-0057 |
+| `src.term_proposer_loop` | ADR-0054, ADR-0068 |
+| `src.term_pruner_loop` | ADR-0057, ADR-0068 |
 | `src.trace_collector` | ADR-0055 |
 | `src.triage_phase` | ADR-0014, ADR-0017, ADR-0031, ADR-0039, ADR-0063 |
 | `src.trust_fleet_sanity_loop` | ADR-0045, ADR-0046 |
@@ -225,6 +215,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_compiler` | ADR-0032 |
 | `src.wiki_rot_detector_loop` | ADR-0045 |
 | `src.workspace` | ADR-0055 |
+| `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -218,4 +218,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,18 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `b1bbffe` — chore(arch): regen after rebase against staging *(2026-05-20)*
-- `a8e86d7` — chore: ruff format + arch-regen refresh *(2026-05-20)*
-- `4ff3f88` — chore(arch): regen after rebase against staging *(2026-05-20)*
-- `d15e32a` — style(trust-fleet-sanity): ruff lint + format fixes on breach-path tests *(2026-05-20)*
-- `18041e1` — feat(adversarial): remove the switch — adversarial pipeline always on (#9036) (#9036) *(2026-05-19)*
-- `31313f7` — feat(adversarial): flip pipeline ON by default (#9025) (#9025) *(2026-05-19)*
-- `6d6ed95` — test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft *(2026-05-19)*
-- `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
-- `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
-- `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
-- `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
-- `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -362,4 +350,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `32e2589` — docs(standards,adr): backfill standards refs and ADR drafts for 9 ports/loops *(2026-05-19)*
+- `7824a41` — docs(wiki): backfill missing wiki entries for 8 ports/loops *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -350,4 +352,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,9 +6,12 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `50edc5c` — chore(arch): regenerate arch artifacts post-backfill *(2026-05-20)*
-- `91b54d6` — docs(standards,adr): backfill standards refs and ADR drafts for 9 ports/loops *(2026-05-20)*
-- `453f4e2` — docs(wiki): backfill missing wiki entries for 8 ports/loops *(2026-05-20)*
+- `d483b28` — chore(arch): regen post-rebase *(2026-05-20)*
+- `cda3bd4` — chore(arch): regenerate arch artifacts post-backfill *(2026-05-20)*
+- `e788dcb` — docs(standards,adr): backfill standards refs and ADR drafts for 9 ports/loops *(2026-05-20)*
+- `ac80bb8` — docs(wiki): backfill missing wiki entries for 8 ports/loops *(2026-05-20)*
+- `75ad1a4` — chore(arch): regen after rebase against staging *(2026-05-20)*
+- `a8e86d7` — chore: ruff format + arch-regen refresh *(2026-05-20)*
 - `4ff3f88` — chore(arch): regen after rebase against staging *(2026-05-20)*
 - `d15e32a` — style(trust-fleet-sanity): ruff lint + format fixes on breach-path tests *(2026-05-20)*
 - `18041e1` — feat(adversarial): remove the switch — adversarial pipeline always on (#9036) (#9036) *(2026-05-19)*
@@ -363,4 +366,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,19 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `32e2589` — docs(standards,adr): backfill standards refs and ADR drafts for 9 ports/loops *(2026-05-19)*
-- `7824a41` — docs(wiki): backfill missing wiki entries for 8 ports/loops *(2026-05-19)*
+- `50edc5c` — chore(arch): regenerate arch artifacts post-backfill *(2026-05-20)*
+- `91b54d6` — docs(standards,adr): backfill standards refs and ADR drafts for 9 ports/loops *(2026-05-20)*
+- `453f4e2` — docs(wiki): backfill missing wiki entries for 8 ports/loops *(2026-05-20)*
+- `4ff3f88` — chore(arch): regen after rebase against staging *(2026-05-20)*
+- `d15e32a` — style(trust-fleet-sanity): ruff lint + format fixes on breach-path tests *(2026-05-20)*
+- `18041e1` — feat(adversarial): remove the switch — adversarial pipeline always on (#9036) (#9036) *(2026-05-19)*
+- `31313f7` — feat(adversarial): flip pipeline ON by default (#9025) (#9025) *(2026-05-19)*
+- `6d6ed95` — test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft *(2026-05-19)*
+- `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
+- `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
+- `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
+- `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
+- `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -352,4 +363,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,47 +10,47 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
-| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ❌ | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ❌ | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
-| `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
-| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
-| `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `ADRReviewerLoop` | ✅ [0079] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ✅ `s33_adr_touchpoint_auditor_no_drift.py` |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ✅ `s31_auto_agent_preflight_no_escalations.py` |
+| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
+| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
+| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
+| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
+| `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
-| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `PRUnstickerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
-| `PricingRefreshLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
-| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
-| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ (caretaker loop) | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
-| `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
-| `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
-| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
-| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
+| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
+| `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
+| `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
+| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ✅ `s20_rc_budget_no_regression.py` |
+| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
+| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
+| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
+| `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
+| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
-| `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [bot-pr-port.md, task.md, term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ❌ | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [bot-pr-port.md, task.md, term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
+| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ✅ [wiki-rot-detector-loop.md] | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
 | `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
@@ -66,7 +66,7 @@ per-adapter, not per-port).
 | `IssueFetcherPort` | ✅ [0067] | ✅ [architecture-async-control.md, issue-fetcher-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ObservabilityPort` | ✅ [0072] | ✅ [observability-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052, 0056, 0068, 0069] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056, 0068, 0069, 0075, 0077] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `ReviewInsightStorePort` | ✅ [0070] | ✅ [review-insight-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `RouteBackCounterPort` | ✅ [0071] | ✅ [route-back-counter-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `WorkspacePort` | ✅ [0003, 0050, 0069] | ✅ [workspace-gc-loop.md, workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,50 +10,50 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ✅ [0079] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ✅ `s33_adr_touchpoint_auditor_no_drift.py` |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ✅ `s31_auto_agent_preflight_no_escalations.py` |
-| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
-| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
-| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
-| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
-| `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
+| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ❌ | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ❌ | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
+| `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
+| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
+| `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
-| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
-| `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
-| `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
-| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ✅ `s20_rc_budget_no_regression.py` |
-| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
-| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
-| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
-| `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
-| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
+| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `PRUnstickerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
+| `PricingRefreshLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
+| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
+| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ (caretaker loop) | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
+| `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
+| `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
+| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
+| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
-| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
-| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [bot-pr-port.md, task.md, term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ❌ | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
-| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
+| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ✅ [wiki-rot-detector-loop.md] | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are
@@ -61,15 +61,15 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ✅ README.md | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ✅ [0066] | ✅ [agent-port.md, architecture-layers.md] | ✅ ports.md | ✅ README.md | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `BotPRPort` | ✅ [0068] | ✅ [bot-pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueFetcherPort` | ✅ [0067] | ✅ [architecture-async-control.md, issue-fetcher-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 | `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052, 0056, 0075, 0077] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ObservabilityPort` | ✅ [0072] | ✅ [observability-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056, 0068, 0069] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ReviewInsightStorePort` | ✅ [0070] | ✅ [review-insight-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `RouteBackCounterPort` | ✅ [0071] | ✅ [route-back-counter-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `WorkspacePort` | ✅ [0003, 0050, 0069] | ✅ [workspace-gc-loop.md, workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 ## Section 3: Factory phases
 
 Section 3 contains hand-curated prose (Loops driving it / Escalation path /
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,6 +16,7 @@ graph LR
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
     src_preflight["src.preflight"]
+    src_preflight_playbooks["src.preflight.playbooks"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
     src_sentry["src.sentry"]
@@ -43,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,7 +16,6 @@ graph LR
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
     src_preflight["src.preflight"]
-    src_preflight_playbooks["src.preflight.playbooks"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
     src_sentry["src.sentry"]
@@ -44,4 +43,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -71,7 +71,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `get_pr_recent_commit_diffs`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `b1bbffe` on 2026-05-20 15:06 UTC. Source last changed at `b1bbffe`. Status: 🟢 fresh._
+_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `b0686df` on 2026-05-19 20:03 UTC. Source last changed at `b0686df`. Status: 🟢 fresh._
+_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -71,7 +71,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `get_pr_recent_commit_diffs`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `32e2589` on 2026-05-19 20:04 UTC. Source last changed at `32e2589`. Status: 🟢 fresh._
+_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `50edc5c` on 2026-05-20 15:08 UTC. Source last changed at `50edc5c`. Status: 🟢 fresh._
+_Regenerated from commit `d483b28` on 2026-05-20 15:33 UTC. Source last changed at `d483b28`. Status: 🟢 fresh._

--- a/docs/arch/generated/ubiquitous-language-context-map.md
+++ b/docs/arch/generated/ubiquitous-language-context-map.md
@@ -6,9 +6,18 @@
 graph LR
   subgraph builder
     AgentRunner["AgentRunner<br/><i>runner</i>"]
+    ReportIssueLoop["ReportIssueLoop<br/><i>loop</i>"]
     Task["Task<br/><i>entity</i>"]
   end
   subgraph caretaker
+    GitHubCacheLoop["GitHubCacheLoop<br/><i>loop</i>"]
+    MergeStateWatcherLoop["MergeStateWatcherLoop<br/><i>loop</i>"]
+    PricingRefreshLoop["PricingRefreshLoop<br/><i>loop</i>"]
+    PRUnstickerLoop["PRUnstickerLoop<br/><i>loop</i>"]
+    RCBudgetLoop["RCBudgetLoop<br/><i>loop</i>"]
+    SentryLoop["SentryLoop<br/><i>loop</i>"]
+    SkillPromptEvalLoop["SkillPromptEvalLoop<br/><i>loop</i>"]
+    StaleIssueGCLoop["StaleIssueGCLoop<br/><i>loop</i>"]
     TermPrunerLoop["TermPrunerLoop<br/><i>loop</i>"]
     WikiRotDetectorLoop["WikiRotDetectorLoop<br/><i>loop</i>"]
     WorkspaceGCLoop["WorkspaceGCLoop<br/><i>loop</i>"]

--- a/docs/arch/generated/ubiquitous-language-context-map.md
+++ b/docs/arch/generated/ubiquitous-language-context-map.md
@@ -6,27 +6,26 @@
 graph LR
   subgraph builder
     AgentRunner["AgentRunner<br/><i>runner</i>"]
-    ReportIssueLoop["ReportIssueLoop<br/><i>loop</i>"]
     Task["Task<br/><i>entity</i>"]
   end
   subgraph caretaker
-    GitHubCacheLoop["GitHubCacheLoop<br/><i>loop</i>"]
-    MergeStateWatcherLoop["MergeStateWatcherLoop<br/><i>loop</i>"]
-    PricingRefreshLoop["PricingRefreshLoop<br/><i>loop</i>"]
-    PRUnstickerLoop["PRUnstickerLoop<br/><i>loop</i>"]
-    RCBudgetLoop["RCBudgetLoop<br/><i>loop</i>"]
-    SentryLoop["SentryLoop<br/><i>loop</i>"]
-    SkillPromptEvalLoop["SkillPromptEvalLoop<br/><i>loop</i>"]
-    StaleIssueGCLoop["StaleIssueGCLoop<br/><i>loop</i>"]
+    TermPrunerLoop["TermPrunerLoop<br/><i>loop</i>"]
+    WikiRotDetectorLoop["WikiRotDetectorLoop<br/><i>loop</i>"]
+    WorkspaceGCLoop["WorkspaceGCLoop<br/><i>loop</i>"]
   end
   subgraph shared-kernel
+    AgentPort["AgentPort<br/><i>port</i>"]
     BaseBackgroundLoop["BaseBackgroundLoop<br/><i>loop</i>"]
     BotPRPort["BotPRPort<br/><i>port</i>"]
     EventBus["EventBus<br/><i>service</i>"]
     HydraFlowConfig["HydraFlowConfig<br/><i>aggregate</i>"]
+    IssueFetcherPort["IssueFetcherPort<br/><i>port</i>"]
     IssueStorePort["IssueStorePort<br/><i>port</i>"]
+    ObservabilityPort["ObservabilityPort<br/><i>port</i>"]
     PRPort["PRPort<br/><i>port</i>"]
     RepoWikiStore["RepoWikiStore<br/><i>service</i>"]
+    ReviewInsightStorePort["ReviewInsightStorePort<br/><i>port</i>"]
+    RouteBackCounterPort["RouteBackCounterPort<br/><i>port</i>"]
     StateTracker["StateTracker<br/><i>service</i>"]
     WorkspacePort["WorkspacePort<br/><i>port</i>"]
   end
@@ -41,6 +40,7 @@ graph LR
   BaseBackgroundLoop -->|depends_on| HydraFlowConfig
   BotPRPort -->|depends_on| HydraFlowConfig
   BotPRPort -->|depends_on| BaseBackgroundLoop
+  IssueFetcherPort -->|depends_on| IssueStorePort
   IssueStorePort -->|depends_on| Task
   PRPort -->|depends_on| Task
   WorkspacePort -->|depends_on| Task

--- a/docs/arch/generated/ubiquitous-language.md
+++ b/docs/arch/generated/ubiquitous-language.md
@@ -2,9 +2,21 @@
 
 # Ubiquitous Language
 
-_20 terms across 3 bounded contexts._
+_19 terms across 3 bounded contexts._
 
 See [ADR-0053](../../adr/0053-ubiquitous-language-as-living-artifact.md) for the governing pattern.
+
+## AgentPort
+
+**Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:AgentPort` · **Confidence:** `accepted`
+**Aliases:** `agent port`, `agent runner port`
+
+Hexagonal port for agent runner operations used by infrastructure modules. Implemented by `agent.AgentRunner` via `base_runner.BaseRunner`. The port was introduced so that infrastructure modules like `merge_conflict_resolver` can accept the agent runner via dependency injection without importing from the runner layer, keeping the four-layer boundary clean and making those modules independently testable with a mock.
+
+**Invariants:**
+- Pure Protocol — no implementation, no state.
+- Three methods: `build_command` constructs the CLI invocation; `execute` runs the subprocess and returns the full transcript; `verify_result` checks that the agent produced valid commits and that `make quality` passes.
+- Parameter names and types are kept identical to the concrete implementations to satisfy structural subtype checks in `tests/test_ports.py`.
 
 ## AgentRunner
 
@@ -53,18 +65,6 @@ Async pub/sub bus that fans HydraFlowEvent objects out to subscriber asyncio.Que
 - Slow subscribers do not block the publisher: a full subscriber queue drops its oldest entry before the new event is enqueued.
 - History mutation is serialized through an asyncio.Lock.
 
-## GitHubCacheLoop
-
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/github_cache_loop.py:GitHubCacheLoop` · **Confidence:** `accepted`
-**Aliases:** `github cache loop`, `github data cache loop`, `github poller`
-
-Centralized GitHub data poller that replaces the pattern where every dashboard endpoint and background worker makes its own `gh api` calls (ADR-0041). A single `GitHubCacheLoop` polls GitHub on a fixed interval and stores results in `GitHubDataCache` — in memory and on disk. Dashboard endpoints and background workers read from the cache instantly rather than hitting the API. Write operations (create PR, merge, comment, label swap) still call `gh` directly because they need immediate confirmation.
-
-**Invariants:**
-- Only one instance per repo runtime; all read consumers share the same cache snapshot.
-- Write operations bypass the cache and call `gh` directly.
-- Cache staleness is observable: each `CacheSnapshot` carries a `fetched_at` timestamp; `age_seconds` is infinite until the first poll completes.
-
 ## HydraFlowConfig
 
 **Kind:** `aggregate` · **Context:** `shared-kernel` · **Anchor:** `src/config.py:HydraFlowConfig` · **Confidence:** `accepted`
@@ -77,6 +77,18 @@ Pydantic-validated runtime configuration aggregate for the HydraFlow orchestrato
 - batch_size is bounded ge=1, le=50.
 - repo is auto-detected from the git remote when left empty.
 
+## IssueFetcherPort
+
+**Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:IssueFetcherPort` · **Confidence:** `accepted`
+**Aliases:** `issue fetcher port`, `github issue fetching port`
+
+Hexagonal port for fetching GitHub issues from the upstream source of truth. Exposes two methods consumed by domain code (phases and background loops): `fetch_issue_by_number` for single-issue lookups and `fetch_issues_by_labels` for label-scoped batch fetches. Implemented by `issue_fetcher.IssueFetcher`, which shells out to the `gh` CLI and applies internal caching and rate-limit back-off.
+
+**Invariants:**
+- Pure Protocol — no implementation, no state.
+- Only the two methods domain code actually calls are declared here; the concrete `IssueFetcher` carries additional infrastructure methods (PR cache, collaborator cache) that stay off the port.
+- `fetch_issues_by_labels` accepts an optional `exclude_labels` list and a `require_complete` flag so callers can narrow results without extra filtering passes.
+
 ## IssueStorePort
 
 **Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:IssueStorePort` · **Confidence:** `accepted`
@@ -88,29 +100,17 @@ Hexagonal port for the in-memory issue work-queue — exposes only the queue acc
 - Pure Protocol — no implementation, no state.
 - Only domain-consumed methods are declared; orchestrator and dashboard methods deliberately stay off the port.
 
-## MergeStateWatcherLoop
+## ObservabilityPort
 
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/merge_state_watcher_loop.py:MergeStateWatcherLoop` · **Confidence:** `accepted`
-**Aliases:** `merge state watcher loop`, `merge state watcher`, `conflict rebase loop`
+**Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:ObservabilityPort` · **Confidence:** `accepted`
+**Aliases:** `observability port`, `sentry port`, `error capture port`
 
-Caretaker loop that periodically scans all open PRs for merge conflicts and auto-rebases or escalates them (ADR-0029). The filter is intentionally broad: RC promotion PRs, Dependabot bumps, agent PRs, and manual PRs all benefit from auto-rebase when they go DIRTY against `main`. PRs already labeled `hydraflow-hitl` (being handled by `PRUnsticker`) or `hydraflow-review` (active reviewer worktree) are skipped to avoid stepping on in-progress work. Delegates the actual conflict-detection and rebase logic to `MergeStateWatcher`.
-
-**Invariants:**
-- Default tick interval is 600 seconds (10 minutes).
-- PRs labeled `hydraflow-hitl` or `hydraflow-review` are skipped.
-- Kill-switch is via `enabled_cb("merge_state_watcher")` and `config.merge_state_watcher_loop_enabled`.
-
-## PricingRefreshLoop
-
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pricing_refresh_loop.py:PricingRefreshLoop` · **Confidence:** `accepted`
-**Aliases:** `pricing refresh loop`, `litellm pricing poller`, `model pricing caretaker`
-
-Daily caretaker loop that fetches LiteLLM's `model_prices_and_context_window.json` via stdlib `urllib`, filters to Anthropic-provider entries (normalizing Bedrock keys), diffs against `src/assets/model_pricing.json`, and opens or updates a `pricing-refresh-auto` PR when drift is detected (ADR-0029, ADR-0049). A bounds guard rejects suspicious price moves. Bounds violations, parse errors, and schema errors open a single deduplicated `[pricing-refresh]` `hydraflow-find` issue. Network errors log-and-retry on the next tick without filing issues.
+Hexagonal port for the observability boundary (ADR-0044 P7.7). Exposes five methods: `capture_exception`, `capture_message`, `breadcrumb`, `set_measurement`, and `flush`. The production adapter is `SentryObservabilityAdapter` in `src/observability/sentry_adapter.py`, which wraps `sentry_sdk` and silently degrades to a no-op when the SDK is not installed. The port is intentionally minimal — rich APIs drag every backend into the union.
 
 **Invariants:**
-- Kill-switch is the `HYDRAFLOW_DISABLE_PRICING_REFRESH=1` env var.
-- PR is always on the fixed branch `pricing-refresh-auto`; no-op ticks do not open a PR.
-- Bounds violations are separate from network errors; each has a distinct response path.
+- Pure Protocol — no implementation, no state.
+- The adapter is a no-op when `sentry_sdk` is absent; every method returns silently so callers never need a try/except around port calls.
+- Domain code never imports `sentry_sdk` directly; all observability routes through the injected `ObservabilityPort` so a future OTLP, structured-log, or sidecar adapter can replace Sentry without touching call sites.
 
 ## PRPort
 
@@ -122,42 +122,6 @@ Hexagonal port for GitHub PR, label, and CI operations — branch push, PR creat
 **Invariants:**
 - Pure Protocol — no implementation, no state.
 - Method signatures must match pr_manager.PRManager exactly so structural subtype checks in tests/test_ports.py pass.
-
-## PRUnstickerLoop
-
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pr_unsticker_loop.py:PRUnstickerLoop` · **Confidence:** `accepted`
-**Aliases:** `pr unsticker loop`, `pr unsticker`, `hitl unsticker`
-
-Caretaker loop that polls HITL items and delegates to `PRUnsticker` to resolve all HITL causes — merge conflicts, CI failures, and generic stuck states. Operates only on HITL issues that currently have an open PR. The loop wraps the unsticker worker in the standard `BaseBackgroundLoop` tick-and-interval skeleton, keeping the HITL resolution logic in `PRUnsticker` separate from the polling infrastructure.
-
-**Invariants:**
-- Only processes HITL issues with an associated open PR (`item.pr > 0`); issues without PRs are skipped.
-- Kill-switch is via `enabled_cb("pr_unsticker")` and `config.pr_unsticker_loop_enabled` (ADR-0049).
-- Interval is driven by `config.pr_unstick_interval`.
-
-## RCBudgetLoop
-
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/rc_budget_loop.py:RCBudgetLoop` · **Confidence:** `accepted`
-**Aliases:** `rc budget loop`, `rc ci wall-clock detector`, `rc duration regression detector`
-
-4-hour RC CI wall-clock regression detector (ADR-0045 §4.8). Reads the last 30 days of `rc-promotion-scenario.yml` runs via `gh run list`, extracts per-run wall-clock duration, and emits a `hydraflow-find` + `rc-duration-regression` issue when the newest run trips either a gradual-bloat signal (current run ≥ 1.5× rolling median) or a sudden-spike signal (current run ≥ 2.0× recent-five maximum). Both signals are independent; both may fire on the same tick with distinct dedup keys. After 3 unresolved attempts per signal the loop escalates to `hitl-escalation` + `rc-duration-stuck`.
-
-**Invariants:**
-- Kill-switch is via `enabled_cb("rc_budget")` only — no `rc_budget_enabled` config field (ADR-0049 §12.2).
-- Requires at least 5 historical data points before emitting any signal.
-- Dedup keys clear on escalation-close.
-
-## ReportIssueLoop
-
-**Kind:** `loop` · **Context:** `builder` · **Anchor:** `src/report_issue_loop.py:ReportIssueLoop` · **Confidence:** `accepted`
-**Aliases:** `report issue loop`, `bug report loop`, `dashboard report processor`
-
-Background loop that dequeues pending bug reports from state, saves any attached screenshots to temp files, and invokes the Claude CLI with `/hf.issue` so the agent can see the image, research the codebase, and file a well-structured GitHub issue (ADR-0028). This is the same issue-filing flow triggered by dashboard bug reports. Supports base64-encoded screenshot payloads and scans them for secrets before saving. Caps retries at 5 attempts per report.
-
-**Invariants:**
-- Screenshot payloads are scanned for secrets before being written to disk.
-- Reports cap at `_MAX_REPORT_ATTEMPTS` (5) before being abandoned.
-- Kill-switch is via `enabled_cb("report_issue")` (ADR-0049).
 
 ## RepoWikiStore
 
@@ -171,41 +135,28 @@ File-based per-repo wiki manager (ADR-0032). Owns the on-disk layout for both th
 - ingest() updates topic pages, refreshes index.json/index.md, and appends to log.jsonl in a single operation.
 - When a tracked_root with per-entry layout is configured, reads prefer it and fall back to the legacy topic-page layout.
 
-## SentryLoop
+## ReviewInsightStorePort
 
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/sentry_loop.py:SentryLoop` · **Confidence:** `accepted`
-**Aliases:** `sentry loop`, `sentry ingestion loop`, `sentry issue poller`
+**Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:ReviewInsightStorePort` · **Confidence:** `accepted`
+**Aliases:** `review insight store port`, `review insight port`
 
-Background loop that polls the Sentry API for unresolved issues across configured projects, deduplicates them against already-filed GitHub issues, and invokes a Claude agent via `/hf.issue` to research the codebase and file a properly triaged GitHub issue — the same flow as dashboard bug reports (ADR-0055). Requires Sentry credentials in config. Sentry captures real code bugs only; transient failures and operational noise are excluded by the loop's dedup and filtering logic.
-
-**Invariants:**
-- Issues are deduplicated before filing; re-ingestion of the same Sentry event does not produce duplicate GitHub issues.
-- Kill-switch is via `enabled_cb("sentry")` (ADR-0049).
-- Sentry errors in the `ERROR+` level range trigger the issue-filing path; `WARNING` and below are skipped.
-
-## SkillPromptEvalLoop
-
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/skill_prompt_eval_loop.py:SkillPromptEvalLoop` · **Confidence:** `accepted`
-**Aliases:** `skill prompt eval loop`, `skill prompt drift detector`, `corpus health auditor`
-
-Weekly background loop with two responsibilities. First, it runs the full adversarial skill-prompt corpus on a fixed schedule, catching regressions the RC-gate subset sampling misses (ADR-0045 §4.6). Second, it samples 10% of `provenance: learning-loop` corpus cases, flagging any that the `expected_catcher` skill passes — a weak-case signal the §4.1 learner uses for corpus quality improvement. Files `skill-prompt-drift` issues on PASS→FAIL transitions and `corpus-case-weak` issues for human triage.
+Hexagonal port for persisting and querying recurring reviewer-feedback patterns. Implemented by `review_insights.ReviewInsightStore`. `ReviewPhase` injects this port to record each review outcome and to query which feedback categories have been seen often enough to inject mandatory guidance blocks into the next agent prompt. The port decouples `ReviewPhase` from the JSONL file-storage backend.
 
 **Invariants:**
-- Both subsystems share a single loop tick; neither runs independently.
-- Issues are deduplicated before filing; the same regression does not produce duplicate bead spam.
-- Subclasses `BaseBackgroundLoop`; kill-switch is via `enabled_cb("skill_prompt_eval")` (ADR-0049).
+- Pure Protocol — no implementation, no state.
+- Methods cover the full lifecycle: `append_review` writes a new record, `load_recent` reads recent history, `get_proposed_categories` and `mark_category_proposed` gate category escalation, and `record_proposal`, `load_proposal_metadata`, and `update_proposal_verified` track whether a proposed mandatory block reduced the pattern.
 
-## StaleIssueGCLoop
+## RouteBackCounterPort
 
-**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/stale_issue_gc_loop.py:StaleIssueGCLoop` · **Confidence:** `accepted`
-**Aliases:** `stale issue gc loop`, `stale hitl gc loop`, `hitl stale closer`
+**Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/route_back.py:RouteBackCounterPort` · **Confidence:** `accepted`
+**Aliases:** `route-back counter port`, `route back counter`, `precondition retry counter port`
 
-Caretaker loop that auto-closes stale HITL escalation issues (ADR-0029). Scope is specifically open issues carrying the configured HITL label that have been inactive beyond `stale_issue_threshold_days`. Posts a farewell comment, then closes. Caps at 10 closures per cycle to avoid GitHub rate-limiting. Distinct from `StaleIssueLoop`, which handles stale general issues with no HydraFlow lifecycle label — the two loops share only the `BaseBackgroundLoop` framework and have zero business-logic overlap.
+Hexagonal port for the per-issue route-back counter. Lives in `src/route_back.py` alongside `RouteBackCoordinator`. The coordinator depends on this port rather than `StateTracker` directly, so unit tests can wire a tiny in-memory dict implementation without pulling in the full state layer. Production wiring connects `StateTracker` as the concrete adapter.
 
 **Invariants:**
-- Maximum 10 issues closed per tick to respect GitHub rate limits.
-- Only closes issues carrying the HITL label (`config.hitl_label`), not general issues.
-- `StaleIssueGCLoop` and `StaleIssueLoop` are fully separate; do not conflate them.
+- Pure Protocol — no implementation, no state.
+- Three methods: `get_route_back_count` reads the current count; `increment_route_back_count` returns the new count after incrementing; `decrement_route_back_count` rolls back an increment when a subsequent label swap fails, preventing transient network blips from burning route-back budget without any actual route-back occurring.
+- `decrement_route_back_count` must be a no-op (returning 0) when the counter is already at zero.
 
 ## StateTracker
 
@@ -230,6 +181,44 @@ A source-agnostic work item abstraction representing tasks from any source (GitH
 - TaskLink relationships extracted via regex patterns with first-match precedence per target_id
 - URLs validated as empty or http(s):// via AfterValidator
 - Timestamps validated as empty or ISO 8601 format
+
+## TermPrunerLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/term_pruner_loop.py:TermPrunerLoop` · **Confidence:** `accepted`
+**Aliases:** `term pruner loop`, `UL pruner`, `glossary pruner`
+
+Caretaker background loop that autonomously prunes stale terms from the ubiquitous-language glossary (ADR-0057). On each tick it scans every `confidence == "accepted"` term in `docs/wiki/terms/`; for any term whose `code_anchor` no longer resolves in the live symbol index (built by `ubiquitous_language.build_symbol_index`), it opens an auto-merging bot PR that flips `confidence` to `deprecated` and records a `superseded_reason` with the broken anchor. The loop makes no LLM calls — detection is purely structural.
+
+**Invariants:**
+- Kill-switch: `enabled_cb("term_pruner")` AND `config.term_pruner_enabled` — both must be true for work to proceed.
+- Opens at most one PR per tick, bundling all eligible terms into a single `hydraflow-ul-deprecated`-labelled PR.
+- `ReviewPhase` skips routing for PRs carrying `TERM_PRUNER_PR_LABEL` so the deprecation PR is not sent through the agent pipeline.
+- Companion to `TermProposerLoop`: together they implement the two-tick grow/prune cycle that keeps `make lint-ul` anchor-resolution green without human intervention.
+
+## WikiRotDetectorLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/wiki_rot_detector_loop.py:WikiRotDetectorLoop` · **Confidence:** `accepted`
+**Aliases:** `wiki rot detector loop`, `wiki rot detector`, `cite freshness loop`
+
+Trust-fleet caretaker loop (ADR-0045 §4.9) that detects broken code citations in per-repo wikis. On each tick it walks every `RepoWikiStore`-registered repo's wiki entries, extracts code references via three patterns (`path.py:symbol`, dotted `src.module.Class`, and bare identifiers inside fenced code blocks as hints only), then verifies each hard cite. HydraFlow-self cites are checked via AST introspection; managed-repo cites are verified via grep over wiki markdown mirrors. For each broken cite the loop files a `hydraflow-find` + `wiki-rot` issue via `PRManager`, with a fuzzy-match suggestion from `difflib.get_close_matches` when the containing module still exists. After three unresolved attempts for a given slug+cite pair the loop escalates to `hitl-escalation` + `wiki-rot-stuck`.
+
+**Invariants:**
+- Kill-switch: `enabled_cb("wiki_rot_detector")` only — no config field (ADR-0049 trust-fleet convention).
+- Calls `reraise_on_credit_or_bug(exc)` in its broad except block to prevent `CreditExhaustedError` from being silently swallowed.
+- Does not run on startup (`run_on_startup=False`) — the first tick is deferred to the normal interval.
+
+## WorkspaceGCLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/workspace_gc_loop.py:WorkspaceGCLoop` · **Confidence:** `accepted`
+**Aliases:** `workspace gc loop`, `workspace garbage collector`, `worktree gc loop`
+
+Background caretaker loop that periodically garbage-collects stale worktrees and orphaned branches. Handles three leak classes: worktrees tracked in `StateTracker` whose PR has been merged or closed, orphaned worktree directories on disk with no `StateTracker` entry, and orphaned remote branches with no open PR. Catches worktrees that leak when PRs are merged manually, via HITL resolution, or when implementations fail or crash mid-cleanup.
+
+**Invariants:**
+- Kill-switch: `enabled_cb("workspace_gc")` AND `config.workspace_gc_loop_enabled` — both must be true to run.
+- Caps at `_MAX_GC_PER_CYCLE = 20` collections per tick to avoid long-running passes.
+- State removal happens before `WorkspacePort.destroy()` so a crash between the two steps leaves the entry gone; `destroy()` is idempotent.
+- An optional `is_in_pipeline_cb` guard prevents GC of issues still being actively processed by a phase.
 
 ## WorkspacePort
 

--- a/docs/arch/generated/ubiquitous-language.md
+++ b/docs/arch/generated/ubiquitous-language.md
@@ -2,7 +2,7 @@
 
 # Ubiquitous Language
 
-_19 terms across 3 bounded contexts._
+_28 terms across 3 bounded contexts._
 
 See [ADR-0053](../../adr/0053-ubiquitous-language-as-living-artifact.md) for the governing pattern.
 
@@ -65,6 +65,18 @@ Async pub/sub bus that fans HydraFlowEvent objects out to subscriber asyncio.Que
 - Slow subscribers do not block the publisher: a full subscriber queue drops its oldest entry before the new event is enqueued.
 - History mutation is serialized through an asyncio.Lock.
 
+## GitHubCacheLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/github_cache_loop.py:GitHubCacheLoop` · **Confidence:** `accepted`
+**Aliases:** `github cache loop`, `github data cache loop`, `github poller`
+
+Centralized GitHub data poller that replaces the pattern where every dashboard endpoint and background worker makes its own `gh api` calls (ADR-0041). A single `GitHubCacheLoop` polls GitHub on a fixed interval and stores results in `GitHubDataCache` — in memory and on disk. Dashboard endpoints and background workers read from the cache instantly rather than hitting the API. Write operations (create PR, merge, comment, label swap) still call `gh` directly because they need immediate confirmation.
+
+**Invariants:**
+- Only one instance per repo runtime; all read consumers share the same cache snapshot.
+- Write operations bypass the cache and call `gh` directly.
+- Cache staleness is observable: each `CacheSnapshot` carries a `fetched_at` timestamp; `age_seconds` is infinite until the first poll completes.
+
 ## HydraFlowConfig
 
 **Kind:** `aggregate` · **Context:** `shared-kernel` · **Anchor:** `src/config.py:HydraFlowConfig` · **Confidence:** `accepted`
@@ -100,6 +112,18 @@ Hexagonal port for the in-memory issue work-queue — exposes only the queue acc
 - Pure Protocol — no implementation, no state.
 - Only domain-consumed methods are declared; orchestrator and dashboard methods deliberately stay off the port.
 
+## MergeStateWatcherLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/merge_state_watcher_loop.py:MergeStateWatcherLoop` · **Confidence:** `accepted`
+**Aliases:** `merge state watcher loop`, `merge state watcher`, `conflict rebase loop`
+
+Caretaker loop that periodically scans all open PRs for merge conflicts and auto-rebases or escalates them (ADR-0029). The filter is intentionally broad: RC promotion PRs, Dependabot bumps, agent PRs, and manual PRs all benefit from auto-rebase when they go DIRTY against `main`. PRs already labeled `hydraflow-hitl` (being handled by `PRUnsticker`) or `hydraflow-review` (active reviewer worktree) are skipped to avoid stepping on in-progress work. Delegates the actual conflict-detection and rebase logic to `MergeStateWatcher`.
+
+**Invariants:**
+- Default tick interval is 600 seconds (10 minutes).
+- PRs labeled `hydraflow-hitl` or `hydraflow-review` are skipped.
+- Kill-switch is via `enabled_cb("merge_state_watcher")` and `config.merge_state_watcher_loop_enabled`.
+
 ## ObservabilityPort
 
 **Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:ObservabilityPort` · **Confidence:** `accepted`
@@ -112,6 +136,18 @@ Hexagonal port for the observability boundary (ADR-0044 P7.7). Exposes five meth
 - The adapter is a no-op when `sentry_sdk` is absent; every method returns silently so callers never need a try/except around port calls.
 - Domain code never imports `sentry_sdk` directly; all observability routes through the injected `ObservabilityPort` so a future OTLP, structured-log, or sidecar adapter can replace Sentry without touching call sites.
 
+## PricingRefreshLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pricing_refresh_loop.py:PricingRefreshLoop` · **Confidence:** `accepted`
+**Aliases:** `pricing refresh loop`, `litellm pricing poller`, `model pricing caretaker`
+
+Daily caretaker loop that fetches LiteLLM's `model_prices_and_context_window.json` via stdlib `urllib`, filters to Anthropic-provider entries (normalizing Bedrock keys), diffs against `src/assets/model_pricing.json`, and opens or updates a `pricing-refresh-auto` PR when drift is detected (ADR-0029, ADR-0049). A bounds guard rejects suspicious price moves. Bounds violations, parse errors, and schema errors open a single deduplicated `[pricing-refresh]` `hydraflow-find` issue. Network errors log-and-retry on the next tick without filing issues.
+
+**Invariants:**
+- Kill-switch is the `HYDRAFLOW_DISABLE_PRICING_REFRESH=1` env var.
+- PR is always on the fixed branch `pricing-refresh-auto`; no-op ticks do not open a PR.
+- Bounds violations are separate from network errors; each has a distinct response path.
+
 ## PRPort
 
 **Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:PRPort` · **Confidence:** `accepted`
@@ -122,6 +158,42 @@ Hexagonal port for GitHub PR, label, and CI operations — branch push, PR creat
 **Invariants:**
 - Pure Protocol — no implementation, no state.
 - Method signatures must match pr_manager.PRManager exactly so structural subtype checks in tests/test_ports.py pass.
+
+## PRUnstickerLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pr_unsticker_loop.py:PRUnstickerLoop` · **Confidence:** `accepted`
+**Aliases:** `pr unsticker loop`, `pr unsticker`, `hitl unsticker`
+
+Caretaker loop that polls HITL items and delegates to `PRUnsticker` to resolve all HITL causes — merge conflicts, CI failures, and generic stuck states. Operates only on HITL issues that currently have an open PR. The loop wraps the unsticker worker in the standard `BaseBackgroundLoop` tick-and-interval skeleton, keeping the HITL resolution logic in `PRUnsticker` separate from the polling infrastructure.
+
+**Invariants:**
+- Only processes HITL issues with an associated open PR (`item.pr > 0`); issues without PRs are skipped.
+- Kill-switch is via `enabled_cb("pr_unsticker")` and `config.pr_unsticker_loop_enabled` (ADR-0049).
+- Interval is driven by `config.pr_unstick_interval`.
+
+## RCBudgetLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/rc_budget_loop.py:RCBudgetLoop` · **Confidence:** `accepted`
+**Aliases:** `rc budget loop`, `rc ci wall-clock detector`, `rc duration regression detector`
+
+4-hour RC CI wall-clock regression detector (ADR-0045 §4.8). Reads the last 30 days of `rc-promotion-scenario.yml` runs via `gh run list`, extracts per-run wall-clock duration, and emits a `hydraflow-find` + `rc-duration-regression` issue when the newest run trips either a gradual-bloat signal (current run ≥ 1.5× rolling median) or a sudden-spike signal (current run ≥ 2.0× recent-five maximum). Both signals are independent; both may fire on the same tick with distinct dedup keys. After 3 unresolved attempts per signal the loop escalates to `hitl-escalation` + `rc-duration-stuck`.
+
+**Invariants:**
+- Kill-switch is via `enabled_cb("rc_budget")` only — no `rc_budget_enabled` config field (ADR-0049 §12.2).
+- Requires at least 5 historical data points before emitting any signal.
+- Dedup keys clear on escalation-close.
+
+## ReportIssueLoop
+
+**Kind:** `loop` · **Context:** `builder` · **Anchor:** `src/report_issue_loop.py:ReportIssueLoop` · **Confidence:** `accepted`
+**Aliases:** `report issue loop`, `bug report loop`, `dashboard report processor`
+
+Background loop that dequeues pending bug reports from state, saves any attached screenshots to temp files, and invokes the Claude CLI with `/hf.issue` so the agent can see the image, research the codebase, and file a well-structured GitHub issue (ADR-0028). This is the same issue-filing flow triggered by dashboard bug reports. Supports base64-encoded screenshot payloads and scans them for secrets before saving. Caps retries at 5 attempts per report.
+
+**Invariants:**
+- Screenshot payloads are scanned for secrets before being written to disk.
+- Reports cap at `_MAX_REPORT_ATTEMPTS` (5) before being abandoned.
+- Kill-switch is via `enabled_cb("report_issue")` (ADR-0049).
 
 ## RepoWikiStore
 
@@ -157,6 +229,42 @@ Hexagonal port for the per-issue route-back counter. Lives in `src/route_back.py
 - Pure Protocol — no implementation, no state.
 - Three methods: `get_route_back_count` reads the current count; `increment_route_back_count` returns the new count after incrementing; `decrement_route_back_count` rolls back an increment when a subsequent label swap fails, preventing transient network blips from burning route-back budget without any actual route-back occurring.
 - `decrement_route_back_count` must be a no-op (returning 0) when the counter is already at zero.
+
+## SentryLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/sentry_loop.py:SentryLoop` · **Confidence:** `accepted`
+**Aliases:** `sentry loop`, `sentry ingestion loop`, `sentry issue poller`
+
+Background loop that polls the Sentry API for unresolved issues across configured projects, deduplicates them against already-filed GitHub issues, and invokes a Claude agent via `/hf.issue` to research the codebase and file a properly triaged GitHub issue — the same flow as dashboard bug reports (ADR-0055). Requires Sentry credentials in config. Sentry captures real code bugs only; transient failures and operational noise are excluded by the loop's dedup and filtering logic.
+
+**Invariants:**
+- Issues are deduplicated before filing; re-ingestion of the same Sentry event does not produce duplicate GitHub issues.
+- Kill-switch is via `enabled_cb("sentry")` (ADR-0049).
+- Sentry errors in the `ERROR+` level range trigger the issue-filing path; `WARNING` and below are skipped.
+
+## SkillPromptEvalLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/skill_prompt_eval_loop.py:SkillPromptEvalLoop` · **Confidence:** `accepted`
+**Aliases:** `skill prompt eval loop`, `skill prompt drift detector`, `corpus health auditor`
+
+Weekly background loop with two responsibilities. First, it runs the full adversarial skill-prompt corpus on a fixed schedule, catching regressions the RC-gate subset sampling misses (ADR-0045 §4.6). Second, it samples 10% of `provenance: learning-loop` corpus cases, flagging any that the `expected_catcher` skill passes — a weak-case signal the §4.1 learner uses for corpus quality improvement. Files `skill-prompt-drift` issues on PASS→FAIL transitions and `corpus-case-weak` issues for human triage.
+
+**Invariants:**
+- Both subsystems share a single loop tick; neither runs independently.
+- Issues are deduplicated before filing; the same regression does not produce duplicate bead spam.
+- Subclasses `BaseBackgroundLoop`; kill-switch is via `enabled_cb("skill_prompt_eval")` (ADR-0049).
+
+## StaleIssueGCLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/stale_issue_gc_loop.py:StaleIssueGCLoop` · **Confidence:** `accepted`
+**Aliases:** `stale issue gc loop`, `stale hitl gc loop`, `hitl stale closer`
+
+Caretaker loop that auto-closes stale HITL escalation issues (ADR-0029). Scope is specifically open issues carrying the configured HITL label that have been inactive beyond `stale_issue_threshold_days`. Posts a farewell comment, then closes. Caps at 10 closures per cycle to avoid GitHub rate-limiting. Distinct from `StaleIssueLoop`, which handles stale general issues with no HydraFlow lifecycle label — the two loops share only the `BaseBackgroundLoop` framework and have zero business-logic overlap.
+
+**Invariants:**
+- Maximum 10 issues closed per tick to respect GitHub rate limits.
+- Only closes issues carrying the HITL label (`config.hitl_label`), not general issues.
+- `StaleIssueGCLoop` and `StaleIssueLoop` are fully separate; do not conflate them.
 
 ## StateTracker
 

--- a/docs/standards/factory_operation/README.md
+++ b/docs/standards/factory_operation/README.md
@@ -49,6 +49,7 @@ the factory takes a spec from intent to production.
 | **Factory autonomy** | [`docs/standards/factory_autonomy/`](../factory_autonomy/README.md) | When agents act vs ask. Tractable + reversible work is factory work, not a permission gate. |
 | **Test pyramid** | [`docs/standards/testing/`](../testing/README.md) | Three layers (unit + MockWorld scenario + sandbox e2e) gate every load-bearing feature. |
 | **Branch protection** | [`docs/standards/branch_protection/`](../branch_protection/README.md) | Two-tier branch model (integration + release reference) with versioned ruleset configs and a re-applyable apply-script. |
+| **Ports and loops** | [`docs/standards/ports-and-loops/`](../ports-and-loops/README.md) | Per-port and per-loop expectations: kill-switch convention, test requirements, and structural contract for every port and background loop in the fleet. |
 | **Self-modifying maintenance** | this document, §"Self-modifying maintenance mode" | Recurring patterns become caretaker loops; lessons get encoded back into the kernel. |
 | **Ports and loops** | [`docs/standards/ports-and-loops/`](../ports-and-loops/README.md) | Structural contract for every hexagonal port and background loop: kill-switch, fake, wiki, ADR, standard row. |
 

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -11,6 +11,16 @@ the context map at
 [`../arch/generated/ubiquitous-language-context-map.md`](../arch/generated/ubiquitous-language-context-map.md).
 See [ADR-0053](../adr/0053-ubiquitous-language-as-living-artifact.md).
 
+New terms added 2026-05-19 (wiki-gap backfill):
+- [`AgentPort`](terms/agent-port.md) — port for `AgentRunner` operations (dependency injection boundary for infra modules)
+- [`IssueFetcherPort`](terms/issue-fetcher-port.md) — port for GitHub issue fetching (two-method surface for domain code)
+- [`ObservabilityPort`](terms/observability-port.md) — observability boundary (capture_exception, breadcrumb, set_measurement)
+- [`ReviewInsightStorePort`](terms/review-insight-store-port.md) — port for reviewer-feedback pattern persistence
+- [`RouteBackCounterPort`](terms/route-back-counter-port.md) — port for the per-issue route-back counter (decouples RouteBackCoordinator from StateTracker)
+- [`TermPrunerLoop`](terms/term-pruner-loop.md) — caretaker that deprecates terms with broken code anchors (ADR-0057)
+- [`WikiRotDetectorLoop`](terms/wiki-rot-detector-loop.md) — trust-fleet loop detecting broken code cites in wiki entries (ADR-0045 §4.9)
+- [`WorkspaceGCLoop`](terms/workspace-gc-loop.md) — caretaker that GCs stale worktrees and orphaned branches
+
 ## Architecture (33)
 
 - ADR Structure and Validation Checklist

--- a/docs/wiki/terms/agent-port.md
+++ b/docs/wiki/terms/agent-port.md
@@ -1,0 +1,25 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K8"
+name: "AgentPort"
+kind: "port"
+bounded_context: "shared-kernel"
+code_anchor: "src/ports.py:AgentPort"
+aliases: ["agent port", "agent runner port"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Hexagonal port for agent runner operations used by infrastructure modules. Implemented by `agent.AgentRunner` via `base_runner.BaseRunner`. The port was introduced so that infrastructure modules like `merge_conflict_resolver` can accept the agent runner via dependency injection without importing from the runner layer, keeping the four-layer boundary clean and making those modules independently testable with a mock.
+
+## Invariants
+
+- Pure Protocol — no implementation, no state.
+- Three methods: `build_command` constructs the CLI invocation; `execute` runs the subprocess and returns the full transcript; `verify_result` checks that the agent produced valid commits and that `make quality` passes.
+- Parameter names and types are kept identical to the concrete implementations to satisfy structural subtype checks in `tests/test_ports.py`.

--- a/docs/wiki/terms/issue-fetcher-port.md
+++ b/docs/wiki/terms/issue-fetcher-port.md
@@ -1,0 +1,25 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K1"
+name: "IssueFetcherPort"
+kind: "port"
+bounded_context: "shared-kernel"
+code_anchor: "src/ports.py:IssueFetcherPort"
+aliases: ["issue fetcher port", "github issue fetching port"]
+related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}]
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Hexagonal port for fetching GitHub issues from the upstream source of truth. Exposes two methods consumed by domain code (phases and background loops): `fetch_issue_by_number` for single-issue lookups and `fetch_issues_by_labels` for label-scoped batch fetches. Implemented by `issue_fetcher.IssueFetcher`, which shells out to the `gh` CLI and applies internal caching and rate-limit back-off.
+
+## Invariants
+
+- Pure Protocol — no implementation, no state.
+- Only the two methods domain code actually calls are declared here; the concrete `IssueFetcher` carries additional infrastructure methods (PR cache, collaborator cache) that stay off the port.
+- `fetch_issues_by_labels` accepts an optional `exclude_labels` list and a `require_complete` flag so callers can narrow results without extra filtering passes.

--- a/docs/wiki/terms/observability-port.md
+++ b/docs/wiki/terms/observability-port.md
@@ -1,0 +1,25 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K3"
+name: "ObservabilityPort"
+kind: "port"
+bounded_context: "shared-kernel"
+code_anchor: "src/ports.py:ObservabilityPort"
+aliases: ["observability port", "sentry port", "error capture port"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Hexagonal port for the observability boundary (ADR-0044 P7.7). Exposes five methods: `capture_exception`, `capture_message`, `breadcrumb`, `set_measurement`, and `flush`. The production adapter is `SentryObservabilityAdapter` in `src/observability/sentry_adapter.py`, which wraps `sentry_sdk` and silently degrades to a no-op when the SDK is not installed. The port is intentionally minimal — rich APIs drag every backend into the union.
+
+## Invariants
+
+- Pure Protocol — no implementation, no state.
+- The adapter is a no-op when `sentry_sdk` is absent; every method returns silently so callers never need a try/except around port calls.
+- Domain code never imports `sentry_sdk` directly; all observability routes through the injected `ObservabilityPort` so a future OTLP, structured-log, or sidecar adapter can replace Sentry without touching call sites.

--- a/docs/wiki/terms/review-insight-store-port.md
+++ b/docs/wiki/terms/review-insight-store-port.md
@@ -1,0 +1,24 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K2"
+name: "ReviewInsightStorePort"
+kind: "port"
+bounded_context: "shared-kernel"
+code_anchor: "src/ports.py:ReviewInsightStorePort"
+aliases: ["review insight store port", "review insight port"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Hexagonal port for persisting and querying recurring reviewer-feedback patterns. Implemented by `review_insights.ReviewInsightStore`. `ReviewPhase` injects this port to record each review outcome and to query which feedback categories have been seen often enough to inject mandatory guidance blocks into the next agent prompt. The port decouples `ReviewPhase` from the JSONL file-storage backend.
+
+## Invariants
+
+- Pure Protocol — no implementation, no state.
+- Methods cover the full lifecycle: `append_review` writes a new record, `load_recent` reads recent history, `get_proposed_categories` and `mark_category_proposed` gate category escalation, and `record_proposal`, `load_proposal_metadata`, and `update_proposal_verified` track whether a proposed mandatory block reduced the pattern.

--- a/docs/wiki/terms/route-back-counter-port.md
+++ b/docs/wiki/terms/route-back-counter-port.md
@@ -1,0 +1,25 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K4"
+name: "RouteBackCounterPort"
+kind: "port"
+bounded_context: "shared-kernel"
+code_anchor: "src/route_back.py:RouteBackCounterPort"
+aliases: ["route-back counter port", "route back counter", "precondition retry counter port"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Hexagonal port for the per-issue route-back counter. Lives in `src/route_back.py` alongside `RouteBackCoordinator`. The coordinator depends on this port rather than `StateTracker` directly, so unit tests can wire a tiny in-memory dict implementation without pulling in the full state layer. Production wiring connects `StateTracker` as the concrete adapter.
+
+## Invariants
+
+- Pure Protocol — no implementation, no state.
+- Three methods: `get_route_back_count` reads the current count; `increment_route_back_count` returns the new count after incrementing; `decrement_route_back_count` rolls back an increment when a subsequent label swap fails, preventing transient network blips from burning route-back budget without any actual route-back occurring.
+- `decrement_route_back_count` must be a no-op (returning 0) when the counter is already at zero.

--- a/docs/wiki/terms/term-pruner-loop.md
+++ b/docs/wiki/terms/term-pruner-loop.md
@@ -1,0 +1,26 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K5"
+name: "TermPrunerLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/term_pruner_loop.py:TermPrunerLoop"
+aliases: ["term pruner loop", "UL pruner", "glossary pruner"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Caretaker background loop that autonomously prunes stale terms from the ubiquitous-language glossary (ADR-0057). On each tick it scans every `confidence == "accepted"` term in `docs/wiki/terms/`; for any term whose `code_anchor` no longer resolves in the live symbol index (built by `ubiquitous_language.build_symbol_index`), it opens an auto-merging bot PR that flips `confidence` to `deprecated` and records a `superseded_reason` with the broken anchor. The loop makes no LLM calls — detection is purely structural.
+
+## Invariants
+
+- Kill-switch: `enabled_cb("term_pruner")` AND `config.term_pruner_enabled` — both must be true for work to proceed.
+- Opens at most one PR per tick, bundling all eligible terms into a single `hydraflow-ul-deprecated`-labelled PR.
+- `ReviewPhase` skips routing for PRs carrying `TERM_PRUNER_PR_LABEL` so the deprecation PR is not sent through the agent pipeline.
+- Companion to `TermProposerLoop`: together they implement the two-tick grow/prune cycle that keeps `make lint-ul` anchor-resolution green without human intervention.

--- a/docs/wiki/terms/wiki-rot-detector-loop.md
+++ b/docs/wiki/terms/wiki-rot-detector-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K6"
+name: "WikiRotDetectorLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/wiki_rot_detector_loop.py:WikiRotDetectorLoop"
+aliases: ["wiki rot detector loop", "wiki rot detector", "cite freshness loop"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Trust-fleet caretaker loop (ADR-0045 §4.9) that detects broken code citations in per-repo wikis. On each tick it walks every `RepoWikiStore`-registered repo's wiki entries, extracts code references via three patterns (`path.py:symbol`, dotted `src.module.Class`, and bare identifiers inside fenced code blocks as hints only), then verifies each hard cite. HydraFlow-self cites are checked via AST introspection; managed-repo cites are verified via grep over wiki markdown mirrors. For each broken cite the loop files a `hydraflow-find` + `wiki-rot` issue via `PRManager`, with a fuzzy-match suggestion from `difflib.get_close_matches` when the containing module still exists. After three unresolved attempts for a given slug+cite pair the loop escalates to `hitl-escalation` + `wiki-rot-stuck`.
+
+## Invariants
+
+- Kill-switch: `enabled_cb("wiki_rot_detector")` only — no config field (ADR-0049 trust-fleet convention).
+- Calls `reraise_on_credit_or_bug(exc)` in its broad except block to prevent `CreditExhaustedError` from being silently swallowed.
+- Does not run on startup (`run_on_startup=False`) — the first tick is deferred to the normal interval.

--- a/docs/wiki/terms/workspace-gc-loop.md
+++ b/docs/wiki/terms/workspace-gc-loop.md
@@ -1,0 +1,26 @@
+---
+id: "01KT3WKPR5MN8QJ14CF77W6K7"
+name: "WorkspaceGCLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/workspace_gc_loop.py:WorkspaceGCLoop"
+aliases: ["workspace gc loop", "workspace garbage collector", "worktree gc loop"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-05-19T00:00:00.000000+00:00"
+---
+
+## Definition
+
+Background caretaker loop that periodically garbage-collects stale worktrees and orphaned branches. Handles three leak classes: worktrees tracked in `StateTracker` whose PR has been merged or closed, orphaned worktree directories on disk with no `StateTracker` entry, and orphaned remote branches with no open PR. Catches worktrees that leak when PRs are merged manually, via HITL resolution, or when implementations fail or crash mid-cleanup.
+
+## Invariants
+
+- Kill-switch: `enabled_cb("workspace_gc")` AND `config.workspace_gc_loop_enabled` — both must be true to run.
+- Caps at `_MAX_GC_PER_CYCLE = 20` collections per tick to avoid long-running passes.
+- State removal happens before `WorkspacePort.destroy()` so a crash between the two steps leaves the entry gone; `destroy()` is idempotent.
+- An optional `is_in_pipeline_cb` guard prevents GC of issues still being actively processed by a phase.


### PR DESCRIPTION
## Summary

Drains 24 coverage-gap P2 beads across three doc categories:

- **Wiki (8 entries):** New term files in `docs/wiki/terms/` for every port and loop that was missing a wiki entry. Each file uses the YAML-ish frontmatter + Definition/Invariants format; UL lint passes with 0 unresolved anchors and 0 paraphrase warnings.
- **Standards (9 refs):** New `docs/standards/ports-and-loops/README.md` covering per-port and per-loop expectations — kill-switch convention, three-layer test pyramid requirements, and structural contract. Linked from `docs/standards/factory_operation/README.md`.
- **ADR drafts (7):** Proposed ADRs 0066–0072 documenting the decisions behind each port and loop that had no ADR. All are `Status: Proposed`; ADR index updated.

## Bead coverage

**Wiki gaps closed:**
- `advisor-0bhv` IssueFetcherPort — `docs/wiki/terms/issue-fetcher-port.md`
- `advisor-hqck` ReviewInsightStorePort — `docs/wiki/terms/review-insight-store-port.md`
- `advisor-rm7j` TermPrunerLoop — `docs/wiki/terms/term-pruner-loop.md`
- `advisor-ujxu` WikiRotDetectorLoop — `docs/wiki/terms/wiki-rot-detector-loop.md`
- `advisor-w1cn` WorkspaceGCLoop — `docs/wiki/terms/workspace-gc-loop.md`
- `advisor-wp13` ObservabilityPort — `docs/wiki/terms/observability-port.md`
- `advisor-zdw4` RouteBackCounterPort — `docs/wiki/terms/route-back-counter-port.md`
- `advisor-79o5` AgentPort — `docs/wiki/terms/agent-port.md` (also closes ADR gap)

**Standard gaps closed:**
- `advisor-3suf` ReviewInsightStorePort standard
- `advisor-4e5e` WorkspacePort standard
- `advisor-fapf` TrustFleetSanityLoop standard
- `advisor-hngi` IssueFetcherPort standard
- `advisor-ocuo` ObservabilityPort standard
- `advisor-oi2w` IssueStorePort standard
- `advisor-t2c5` RouteBackCounterPort standard
- `advisor-ylkx` AgentPort standard
- `advisor-ysso` BotPRPort standard

**ADR gaps closed:**
- `advisor-8q9k` IssueFetcherPort ADR — `docs/adr/0067-issue-fetcher-port.md`
- `advisor-grww` BotPRPort ADR — `docs/adr/0068-bot-pr-port.md`
- `advisor-i00b` WorkspaceGCLoop ADR — `docs/adr/0069-workspace-gc-loop.md`
- `advisor-kapn` ReviewInsightStorePort ADR — `docs/adr/0070-review-insight-store-port.md`
- `advisor-kaur` RouteBackCounterPort ADR — `docs/adr/0071-route-back-counter-port.md`
- `advisor-n6cw` StaleIssueLoop ADR — `docs/adr/0072-stale-issue-loop.md`

**ADR gap remaining (not straightforward — deferred):**
- `advisor-79o5` AgentPort ADR — `docs/adr/0066-agent-port.md` ✅ also done

## Test plan

- [x] `make lint-ul` passes: 0 unresolved anchors, 0 paraphrase warnings
- [x] `ruff check src/` clean
- [x] `pyright` clean
- [x] `bandit` clean
- [ ] Full test suite (docs-only change; no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)