### PR TITLE
test(scenarios): sandbox-e2e bulk backfill A (3 loops)

### DIFF
--- a/tests/scenarios/test_merge_state_watcher_scenario.py
+++ b/tests/scenarios/test_merge_state_watcher_scenario.py
@@ -1,0 +1,84 @@
+"""Sandbox-e2e scenario for MergeStateWatcherLoop (advisor-rxi).
+
+Two minimal ticks (Pattern B — direct instantiation):
+
+* ``test_conflicting_pr_gets_rebased`` — one conflicting PR with no
+  skip-labels; ``update_pr_branch`` succeeds and the loop returns
+  ``checked=1, rebased=1``.
+* ``test_no_conflicting_prs_returns_zero_counts`` — empty conflict list;
+  all counters zero.
+
+Pattern B is required because ``run_with_loops`` always forces
+``ports["github"] = world._github`` (FakeGitHub), which does not implement
+``list_conflicting_prs``.  Direct instantiation avoids that override.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from base_background_loop import LoopDeps
+from events import EventBus
+from merge_state_watcher import ConflictingPR
+from merge_state_watcher_loop import MergeStateWatcherLoop
+from tests.helpers import ConfigFactory
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _make_loop(tmp_path, fake_prs):
+    """Instantiate MergeStateWatcherLoop with a controlled fake PRPort."""
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
+    bus = EventBus()
+    stop_event = asyncio.Event()
+    stop_event.set()
+    deps = LoopDeps(
+        event_bus=bus,
+        stop_event=stop_event,
+        status_cb=MagicMock(),
+        enabled_cb=lambda _: True,
+        sleep_fn=AsyncMock(),
+    )
+    return MergeStateWatcherLoop(config=config, prs=fake_prs, deps=deps)
+
+
+class TestMergeStateWatcherScenario:
+    """advisor-rxi — sandbox-e2e for MergeStateWatcherLoop."""
+
+    async def test_conflicting_pr_gets_rebased(self, tmp_path) -> None:
+        """One conflicting PR with no skip-labels -> update_pr_branch called, rebased=1."""
+        fake_prs = MagicMock()
+        fake_prs.list_conflicting_prs = AsyncMock(
+            return_value=[ConflictingPR(number=77, branch="feat/thing", labels=[])]
+        )
+        fake_prs.update_pr_branch = AsyncMock(return_value=True)
+        # After update_pr_branch succeeds, the loop checks mergeability.
+        # Returning True means the conflict is resolved -> "rebased" path taken.
+        fake_prs.get_pr_mergeable = AsyncMock(return_value=True)
+        fake_prs.add_pr_labels = AsyncMock(return_value=None)
+
+        loop = _make_loop(tmp_path, fake_prs)
+        result = await loop._do_work()
+
+        assert result is not None, result
+        assert result["checked"] == 1
+        assert result["rebased"] == 1
+        assert result["escalated"] == 0
+        fake_prs.update_pr_branch.assert_awaited_once_with(77)
+
+    async def test_no_conflicting_prs_returns_zero_counts(self, tmp_path) -> None:
+        """No conflicting PRs -> all counters zero, update_pr_branch not called."""
+        fake_prs = MagicMock()
+        fake_prs.list_conflicting_prs = AsyncMock(return_value=[])
+        fake_prs.update_pr_branch = AsyncMock(return_value=True)
+
+        loop = _make_loop(tmp_path, fake_prs)
+        result = await loop._do_work()
+
+        assert result is not None, result
+        assert result["checked"] == 0
+        assert result["rebased"] == 0
+        fake_prs.update_pr_branch.assert_not_awaited()

--- a/tests/scenarios/test_term_proposer_scenario.py
+++ b/tests/scenarios/test_term_proposer_scenario.py
@@ -1,0 +1,111 @@
+"""Sandbox-e2e scenario for TermProposerLoop (advisor-7qvd).
+
+Two minimal ticks:
+
+* ``test_no_candidates_returns_zero_stats`` — an empty src/ tree with no
+  load-bearing-suffix classes means ``detect_candidates`` returns nothing
+  and the loop exits with ``candidates=0, opened_pr=False``.
+
+* ``test_draft_accepted_opens_pr`` — a src/ tree with one ``*Loop`` class,
+  an LLM stub that returns a valid draft, and a seeded ``BotPRPort`` fake.
+  The loop should propose the term and open one bot PR.
+
+The loop's external surface (``TermProposerLLM.draft`` and
+``BotPRPort.open_bot_pr``) is stubbed via pre-seeded port keys.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
+from ubiquitous_language import BoundedContext, TermDraft, TermKind
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _seed_src_with_loop_class(repo_root) -> None:
+    """Seed src/ with one FreshLoop class that detect_candidates can pick up."""
+    src = repo_root / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "fresh_loop.py").write_text("class FreshLoop:\n    pass\n")
+
+
+class TestTermProposerScenario:
+    """advisor-7qvd — sandbox-e2e for TermProposerLoop."""
+
+    async def test_no_candidates_returns_zero_stats(self, tmp_path) -> None:
+        """Empty src/ -> detect_candidates finds nothing, loop returns candidates=0."""
+        world = MockWorld(tmp_path)
+
+        repo_root = world.harness.config.repo_root
+        (repo_root / "src").mkdir(parents=True, exist_ok=True)
+
+        fake_llm = MagicMock()
+        fake_llm.draft = AsyncMock(return_value=None)
+
+        fake_pr_port = MagicMock()
+        fake_pr_port.open_bot_pr = AsyncMock(return_value=0)
+
+        _seed_ports(
+            world,
+            term_proposer_llm=fake_llm,
+            term_proposer_pr_port=fake_pr_port,
+            term_proposer_repo_root=repo_root,
+        )
+
+        stats = await world.run_with_loops(["term_proposer"], cycles=1)
+
+        result = stats["term_proposer"]
+        assert result is not None, result
+        assert result["candidates"] == 0
+        assert result["opened_pr"] is False
+        fake_pr_port.open_bot_pr.assert_not_awaited()
+
+    async def test_draft_accepted_opens_pr(self, tmp_path) -> None:
+        """FreshLoop class in src/ + LLM returns valid draft -> one bot PR opened."""
+        world = MockWorld(tmp_path)
+
+        repo_root = world.harness.config.repo_root
+        _seed_src_with_loop_class(repo_root)
+
+        # The LLM stub returns a draft that passes validate_draft.
+        valid_draft = TermDraft(
+            include=True,
+            name="FreshLoop",
+            kind=TermKind.LOOP,
+            bounded_context=BoundedContext.CARETAKER,
+            definition=(
+                "A caretaker loop that periodically refreshes stale data"
+                " and enforces freshness invariants across the system."
+            ),
+            invariants=["Freshness invariant: data is never more than N minutes old"],
+            aliases=[],
+        )
+
+        fake_llm = MagicMock()
+        fake_llm.draft = AsyncMock(return_value=valid_draft)
+
+        fake_pr_port = MagicMock()
+        fake_pr_port.open_bot_pr = AsyncMock(return_value=99)
+
+        _seed_ports(
+            world,
+            term_proposer_llm=fake_llm,
+            term_proposer_pr_port=fake_pr_port,
+            term_proposer_repo_root=repo_root,
+        )
+
+        stats = await world.run_with_loops(["term_proposer"], cycles=1)
+
+        result = stats["term_proposer"]
+        assert result is not None, result
+        assert result["candidates"] >= 1
+        assert result["opened_pr"] is True
+        fake_pr_port.open_bot_pr.assert_awaited_once()
+        call_kwargs = fake_pr_port.open_bot_pr.await_args.kwargs
+        assert "ul-proposer/" in call_kwargs["branch"]
+        assert "FreshLoop" in call_kwargs["body"]

--- a/tests/scenarios/test_term_pruner_scenario.py
+++ b/tests/scenarios/test_term_pruner_scenario.py
@@ -1,0 +1,116 @@
+"""Sandbox-e2e scenario for TermPrunerLoop (advisor-eg1i).
+
+One happy-path tick: the loop discovers one accepted term whose
+``code_anchor`` no longer resolves in ``src/``, deprecates it, and opens
+a bot PR via the seeded ``BotPRPort`` fake.
+
+The loop's external surface (``open_bot_pr`` via ``BotPRPort``) is stubbed
+via pre-seeded port keys.  A real ``TermStore`` backed by tmp_path is seeded
+with one accepted term whose anchor points at a class that does NOT exist in
+the seeded source tree.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
+from ubiquitous_language import BoundedContext, Term, TermKind, TermStore, dump_term_file
+
+pytestmark = pytest.mark.scenario_loops
+
+
+def _seed_term_with_broken_anchor(terms_root: Path) -> None:
+    """Write one accepted term whose code_anchor does not resolve in src/."""
+    term = Term(
+        name="StaleLoop",
+        kind=TermKind.LOOP,
+        bounded_context=BoundedContext.CARETAKER,
+        definition="A loop whose anchor class was deleted from the codebase.",
+        code_anchor="src/deleted_loop.py:StaleLoop",
+        confidence="accepted",
+    )
+    terms_root.mkdir(parents=True, exist_ok=True)
+    dump_term_file(terms_root / "stale-loop.md", term)
+
+
+def _seed_src(repo_root: Path) -> None:
+    """Seed a src/ tree that does NOT contain StaleLoop."""
+    src = repo_root / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    (src / "other_module.py").write_text("class OtherThing:\n    pass\n")
+
+
+class TestTermPrunerScenario:
+    """advisor-eg1i — sandbox-e2e for TermPrunerLoop."""
+
+    async def test_broken_anchor_opens_deprecation_pr(self, tmp_path) -> None:
+        """Accepted term with missing anchor -> deprecated + bot PR opened."""
+        world = MockWorld(tmp_path)
+
+        repo_root = world.harness.config.repo_root
+        terms_root = repo_root / "docs" / "wiki" / "terms"
+        _seed_term_with_broken_anchor(terms_root)
+        _seed_src(repo_root)
+
+        fake_pr_port = MagicMock()
+        fake_pr_port.open_bot_pr = AsyncMock(return_value=42)
+
+        _seed_ports(
+            world,
+            term_pruner_pr_port=fake_pr_port,
+            term_pruner_repo_root=repo_root,
+        )
+
+        stats = await world.run_with_loops(["term_pruner"], cycles=1)
+
+        result = stats["term_pruner"]
+        assert result is not None, result
+        assert result["deprecated"] == 1
+        assert result["opened_pr"] is True
+        fake_pr_port.open_bot_pr.assert_awaited_once()
+        call_kwargs = fake_pr_port.open_bot_pr.await_args.kwargs
+        assert "ul-pruner/" in call_kwargs["branch"]
+        assert "StaleLoop" in call_kwargs["body"]
+
+    async def test_all_anchors_resolve_no_pr_opened(self, tmp_path) -> None:
+        """All accepted terms have live anchors -> no deprecation, no bot PR."""
+        world = MockWorld(tmp_path)
+
+        repo_root = world.harness.config.repo_root
+        terms_root = repo_root / "docs" / "wiki" / "terms"
+        src = repo_root / "src"
+        src.mkdir(parents=True, exist_ok=True)
+        (src / "live_module.py").write_text("class LiveLoop:\n    pass\n")
+
+        live_term = Term(
+            name="LiveLoop",
+            kind=TermKind.LOOP,
+            bounded_context=BoundedContext.CARETAKER,
+            definition="A loop that is alive and resolves in the codebase.",
+            code_anchor="src/live_module.py:LiveLoop",
+            confidence="accepted",
+        )
+        terms_root.mkdir(parents=True, exist_ok=True)
+        dump_term_file(terms_root / "live-loop.md", live_term)
+
+        fake_pr_port = MagicMock()
+        fake_pr_port.open_bot_pr = AsyncMock(return_value=0)
+
+        _seed_ports(
+            world,
+            term_pruner_pr_port=fake_pr_port,
+            term_pruner_repo_root=repo_root,
+        )
+
+        stats = await world.run_with_loops(["term_pruner"], cycles=1)
+
+        result = stats["term_pruner"]
+        assert result is not None, result
+        assert result["deprecated"] == 0
+        assert result["opened_pr"] is False
+        fake_pr_port.open_bot_pr.assert_not_awaited()


### PR DESCRIPTION
## Summary

Adds sandbox-e2e scenarios for the 3 loops in the coverage-gap batch that had no prior scenario coverage. The other 12 beads in the batch already had coverage confirmed in existing scenario files.

**New scenario files:**
- `test_merge_state_watcher_scenario.py` — advisor-rxi (Pattern B direct instantiation required; `run_with_loops` forces `ports["github"]` to `FakeGitHub` which lacks `list_conflicting_prs`)
- `test_term_proposer_scenario.py` — advisor-7qvd (happy-path: no candidates → noop; LLM draft accepted → bot PR opened)
- `test_term_pruner_scenario.py` — advisor-eg1i (broken anchor → deprecation PR opened; all anchors live → noop)

**Closes:**
- advisor-7qvd (TermProposerLoop)
- advisor-eg1i (TermPrunerLoop)
- advisor-rxi (MergeStateWatcherLoop)

**Pre-existing coverage confirmed (no new tests needed):**
- advisor-1rm PrinciplesAuditLoop: `test_principles_audit_scenario.py`
- advisor-3y4 GitHubCacheLoop: `test_caretaker_loops_part2.py` TestL17
- advisor-38v HealthMonitorLoop: `test_loops.py` TestL1
- advisor-5lgn WikiRotDetectorLoop: `test_wiki_rot_detector_scenario.py`
- advisor-5w20 TrustFleetSanityLoop: `test_trust_fleet_sanity_scenario.py`
- advisor-7w0 RunsGCLoop: `test_caretaker_loops_part2.py` TestL20
- advisor-au05 StaleIssueGCLoop: `test_loops.py` TestL3
- advisor-bsn2 StagingBisectLoop: `test_staging_bisect_scenario.py`
- advisor-ko9 SentryLoop: `test_caretaker_loops_part2.py` TestL21
- advisor-nv4 PricingRefreshLoop: `test_pricing_refresh_loop_mockworld.py`
- advisor-qzq RepoWikiLoop: `test_caretaker_loops_part2.py` TestL18
- advisor-r8i FlakeTrackerLoop: `test_flake_tracker_scenario.py`

## Test plan

- [x] `PYTHONPATH=src pytest tests/scenarios/ -m scenario_loops -k "merge_state_watcher or term_pruner or term_proposer"` — 6 passed
- [x] Tests-only PR: no production code modified
- [x] Each new scenario file: ≤120 lines, one happy-path tick, one concrete assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)