### PR TITLE
docs(wiki+standards+adr): bulk backfill 19 coverage-gap beads (batch 2)

### DIFF
--- a/docs/adr/0073-runs-gc-loop.md
+++ b/docs/adr/0073-runs-gc-loop.md
@@ -1,0 +1,45 @@
+# ADR-0073 — RunsGCLoop: Artifact Retention Enforcement
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+HydraFlow's `RunRecorder` persists per-run artifacts (transcripts, diffs, outputs) under `<data_root>/runs/`. As the factory operates continuously, the runs directory grows unbounded unless something enforces the configured retention policy. Without a caretaker, operators discover oversized run directories during incident response — not before.
+
+Two config knobs govern retention:
+
+- `artifact_retention_days` — time-to-live for run directories (default: 7 days).
+- `artifact_max_size_mb` — total size cap for the runs directory (default: 500 MB).
+
+These are already enforced by `RunRecorder.purge_expired` and `RunRecorder.purge_oversized`; the gap is autonomous scheduling.
+
+## Decision
+
+`RunsGCLoop` (`src/runs_gc_loop.py`) subclasses `BaseBackgroundLoop` (ADR-0001, ADR-0029) and runs on the interval set by `config.runs_gc_interval`. Each tick:
+
+1. Calls `RunRecorder.purge_expired(config.artifact_retention_days)`.
+2. Calls `RunRecorder.purge_oversized(config.artifact_max_size_mb)`.
+3. Calls `RunRecorder.get_storage_stats()` and logs the result.
+
+The loop follows the kill-switch convention (ADR-0049): `enabled_cb("runs_gc")` is checked first, then `config.runs_gc_loop_enabled`. No external I/O beyond the local filesystem; no GitHub or LLM calls.
+
+## Consequences
+
+- The runs directory never grows beyond the configured caps during normal operation.
+- Purge events are logged with counts (expired, oversized) for observability.
+- Operators can still manually purge by deleting directories directly; the loop does not conflict with manual cleanup.
+- If `artifact_retention_days` or `artifact_max_size_mb` are misconfigured to zero or negative, the loop delegates error handling to `RunRecorder`.
+
+## Alternatives considered
+
+- **Cron job.** Rejected: adds external scheduling infrastructure the dark-factory pattern avoids.
+- **Purge on startup only.** Rejected: long-running deployments need continuous enforcement, not just at boot.
+
+## Related
+
+- [ADR-0001](0001-five-concurrent-async-loops.md) — loop runtime
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/runs_gc_loop.py:RunsGCLoop`
+- `src/run_recorder.py:RunRecorder`

--- a/docs/adr/0074-retrospective-loop.md
+++ b/docs/adr/0074-retrospective-loop.md
@@ -1,0 +1,41 @@
+# ADR-0074 — RetrospectiveLoop: Durable-Queue Pattern Analysis
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+After each successful PR merge and after each review phase, HydraFlow has the raw material to detect cross-pipeline patterns: recurring review findings, code areas with repeated implementation failures, slow phases, and model-output trends. Without a dedicated worker, this analysis either runs synchronously on the merge path (blocking) or never runs at all.
+
+The retrospective concerns are also temporally decoupled from the work that produces them: a PR merges in seconds; the useful analysis window spans days or weeks of prior merges. A synchronous callback can't see that history.
+
+## Decision
+
+`RetrospectiveLoop` (`src/retrospective_loop.py`) processes analysis work from a durable `RetrospectiveQueue`. Producers (`PostMergeHandler`, `ReviewPhase`) append items asynchronously; the loop polls and processes. Items are acknowledged only after successful processing so unacknowledged items survive crashes and replay on restart.
+
+The loop delegates to `RetrospectiveCollector` for:
+- Pattern detection across the recent merge history.
+- Review-insight proposal verification against current state.
+
+Events are published to the dashboard via `EventType`. The loop deduplicates HITL stale-insight filings within a 1-hour window (`_HITL_DEDUP_WINDOW`) to avoid issue spam when the GitHub search index lags a freshly-created issue.
+
+Kill-switch: `enabled_cb("retrospective")` (ADR-0049). Default interval: `config.retrospective_interval`.
+
+## Consequences
+
+- The merge path stays non-blocking; retrospective analysis runs asynchronously.
+- Items survive process restarts: the durable queue is the safety net.
+- The 1-hour dedup window trades recency for accuracy on back-to-back ticks; it is intentionally much shorter than the default interval.
+
+## Alternatives considered
+
+- **Inline on merge.** Rejected: synchronous analysis blocks the merge handler and doesn't have access to historical patterns.
+- **GitHub Actions trigger.** Rejected: adds external CI dependency for internal pattern analysis.
+
+## Related
+
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/retrospective_loop.py:RetrospectiveLoop`
+- `src/retrospective_queue.py:RetrospectiveQueue`
+- `src/retrospective.py:RetrospectiveCollector`

--- a/docs/adr/0075-merge-state-watcher-loop.md
+++ b/docs/adr/0075-merge-state-watcher-loop.md
@@ -1,0 +1,41 @@
+# ADR-0075 — MergeStateWatcherLoop: Autonomous Conflict Detection and Rebase
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+Any open PR can go DIRTY against `main` at any time — when another PR lands ahead of it, when a Dependabot bump changes a lockfile, or when an agent PR lags behind a staging promotion. Without a watcher, dirty PRs sit unresolved until a human or another loop trips over them.
+
+`PRUnstickerLoop` handles HITL-labeled PRs with known stuck causes. What's missing is a broader, periodic scan that catches PRs going dirty before they reach HITL, and auto-rebases them preemptively.
+
+## Decision
+
+`MergeStateWatcherLoop` (`src/merge_state_watcher_loop.py`) subclasses `BaseBackgroundLoop` and runs every 600 seconds (10 minutes). Each tick it delegates to `MergeStateWatcher.unstick_conflicts()`, which:
+
+1. Queries `PRPort` for open PRs across the managed repository.
+2. Filters out PRs labeled `hydraflow-hitl` (already being handled by `PRUnstickerLoop`) and `hydraflow-review` (active reviewer worktree) to avoid stepping on in-progress work.
+3. For remaining DIRTY PRs, attempts an auto-rebase.
+4. If rebase fails, escalates via the HITL path.
+
+The filter is intentionally broad: RC promotion PRs, Dependabot bumps, agent PRs, and manual PRs all benefit from auto-rebase. Narrowing the scope would leave dirty PRs on the floor.
+
+Kill-switch: `enabled_cb("merge_state_watcher")` and `config.merge_state_watcher_loop_enabled` (ADR-0049).
+
+## Consequences
+
+- Dirty PRs are detected and rebased within a 10-minute window in steady state.
+- PRs already in active human or bot review are not touched.
+- The combination of `MergeStateWatcherLoop` (broad periodic) and `PRUnstickerLoop` (HITL-specific) covers the full PR lifecycle without overlap.
+
+## Alternatives considered
+
+- **Single unified unsticker.** Rejected: HITL PRs need cause-specific logic (conflict resolution, CI triage, generic stuck) that would bloat a general-purpose watcher.
+- **Event-driven on PR state change.** Rejected: requires GitHub webhook infrastructure; the polling model is consistent with other caretaker loops.
+
+## Related
+
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/merge_state_watcher_loop.py:MergeStateWatcherLoop`
+- `src/merge_state_watcher.py:MergeStateWatcher`

--- a/docs/adr/0076-github-cache-loop.md
+++ b/docs/adr/0076-github-cache-loop.md
@@ -1,0 +1,44 @@
+# ADR-0076 — GitHubCacheLoop: Centralized GitHub Data Cache
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+In the original architecture, every dashboard endpoint and background worker that needed GitHub data (open PRs, HITL items, label counts, open issues) made its own `gh api` call. This produced:
+
+- **Rate-limit exposure:** many concurrent read calls hit the GitHub API at the same time during busy factory periods.
+- **Latency:** dashboard endpoints blocked on `gh api` round-trips before returning to the browser.
+- **Redundancy:** 10+ callers each fetching the same PR list independently within the same second.
+
+ADR-0041 declared GitHub as source of truth with a local cache as sidecar. `GitHubCacheLoop` is the implementation of that sidecar.
+
+## Decision
+
+`GitHubCacheLoop` (`src/github_cache_loop.py`) is a single background loop per repo runtime. It polls GitHub on a fixed interval and stores results in `GitHubDataCache`. The cache stores each dataset as a `CacheSnapshot` with a `fetched_at` timestamp.
+
+All read consumers (dashboard routes, background loops) read from `GitHubDataCache` via its `get_*` methods. Write operations (create PR, merge, comment, label swap) remain direct `gh` calls — they need immediate confirmation and are low-frequency.
+
+The cache is persisted to disk (JSON) so that a process restart does not immediately produce stale reads. On first boot, `age_seconds` returns infinity until the loop completes its first poll.
+
+Kill-switch: `enabled_cb("github_cache")` (ADR-0049).
+
+## Consequences
+
+- Dashboard endpoint latency drops from `gh api` round-trip time (~300ms) to in-memory dict read (~0ms).
+- GitHub API read rate drops proportionally to the number of consumers that were previously making independent calls.
+- Cache is eventually consistent: reads may lag by up to one poll interval.
+- Write operations are unaffected; they bypass the cache entirely.
+
+## Alternatives considered
+
+- **Per-caller caching.** Rejected: each caller would implement its own TTL logic redundantly, and calls would still race with each other.
+- **Redis or external cache.** Rejected: adds an external dependency for a concern the factory can handle locally with simpler disk-backed JSON.
+
+## Related
+
+- [ADR-0041](0041-github-source-of-truth-cache-as-sidecar.md) — GitHub as source of truth
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/github_cache_loop.py:GitHubCacheLoop`
+- `src/github_cache_loop.py:GitHubDataCache`

--- a/docs/adr/0077-pr-unsticker-loop.md
+++ b/docs/adr/0077-pr-unsticker-loop.md
@@ -1,0 +1,41 @@
+# ADR-0077 — PRUnstickerLoop: Goal-Driven HITL PR Resolution
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+HITL-labeled PRs get stuck for three distinct reasons: merge conflicts, CI failures, and generic stuck states where the auto-agent ran out of attempts. Each cause requires different resolution logic. Without an autonomous resolution path, stuck PRs accumulate in the HITL queue and require human intervention even when the fix is mechanical (rebase, re-trigger CI, supply missing context).
+
+`MergeStateWatcherLoop` handles conflict detection broadly across all PRs. `PRUnstickerLoop` handles the narrower case: open PRs that already carry a HITL label with a known stuck cause, and need targeted resolution.
+
+## Decision
+
+`PRUnstickerLoop` (`src/pr_unsticker_loop.py`) subclasses `BaseBackgroundLoop` and delegates to `PRUnsticker` to resolve all HITL causes on each tick. The loop:
+
+1. Queries `PRPort.list_hitl_items(config.hitl_label)` for open HITL issues.
+2. Filters to items with an associated open PR (`item.pr > 0`).
+3. Calls `PRUnsticker.unstick(active_pr_items)` which dispatches by cause.
+
+The separation of `PRUnstickerLoop` (tick scheduling, filtering) from `PRUnsticker` (resolution logic) keeps the resolution strategies independently testable and lets new resolution strategies be added to `PRUnsticker` without touching the loop.
+
+Kill-switch: `enabled_cb("pr_unsticker")` and `config.pr_unsticker_loop_enabled` (ADR-0049). Interval: `config.pr_unstick_interval`.
+
+## Consequences
+
+- HITL issues with associated PRs are processed autonomously; human intervention is needed only when all resolution strategies are exhausted.
+- HITL issues without PRs are ignored (they have a different resolution path — the preflight loop).
+- The loop's output is structured stats from `PRUnsticker.unstick`, making it observable via the dashboard.
+
+## Alternatives considered
+
+- **Fold into `MergeStateWatcherLoop`.** Rejected: the watcher is a broad periodic scan; the unsticker is a targeted HITL resolver. The two have different scopes, different filters, and different resolution logic. Merging them would couple unrelated concerns.
+- **Inline in HITL phase.** Rejected: the HITL phase runs synchronously in the pipeline; autonomous resolution must be asynchronous to avoid blocking.
+
+## Related
+
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- [ADR-0075](0075-merge-state-watcher-loop.md) — `MergeStateWatcherLoop` (complementary)
+- `src/pr_unsticker_loop.py:PRUnstickerLoop`
+- `src/pr_unsticker.py:PRUnsticker`

--- a/docs/adr/0078-pricing-refresh-loop.md
+++ b/docs/adr/0078-pricing-refresh-loop.md
@@ -1,0 +1,44 @@
+# ADR-0078 — PricingRefreshLoop: Autonomous LLM Pricing Drift Detection
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+`src/assets/model_pricing.json` is the source of truth for per-token cost estimates used by HydraFlow's budget-tracking subsystems. LiteLLM maintains an upstream `model_prices_and_context_window.json` that covers all Anthropic-provider models. Without an autonomous refresh path, the local pricing file drifts from upstream as models are updated, new models ship, and price changes land — causing budget estimates to become inaccurate.
+
+The refresh is a bounded, deterministic operation: fetch, filter, diff, bounds-check, open PR if changed. There is no reason to require human involvement unless the bounds check flags a suspicious price movement.
+
+## Decision
+
+`PricingRefreshLoop` (`src/pricing_refresh_loop.py`) subclasses `BaseBackgroundLoop` and runs daily. Each tick:
+
+1. Fetches LiteLLM's JSON via stdlib `urllib` (30-second timeout).
+2. Filters to Anthropic-provider entries; normalizes Bedrock key naming via `filter_anthropic_entries`.
+3. Computes a diff against `src/assets/model_pricing.json` via `compute_pricing_diff`.
+4. If no drift: logs "no drift", returns `{drift: False}`, no PR.
+5. If drift passes the bounds guard: writes the proposed file, opens or updates the `pricing-refresh-auto` PR via `auto_pr.open_automated_pr_async`.
+6. Bounds violations, parse errors, schema errors: opens one deduplicated `[pricing-refresh] <title>` `hydraflow-find` issue (dedup by title prefix).
+7. Network errors: log-and-retry on next tick; no issue filing to avoid noise.
+
+Kill-switch: `HYDRAFLOW_DISABLE_PRICING_REFRESH=1` env var (ADR-0049 convention; no config field).
+
+## Consequences
+
+- Pricing file stays current with upstream without operator involvement.
+- Suspicious price movements (bounds violation) surface as `hydraflow-find` issues for human review before the PR merges.
+- The PR always targets the fixed branch `pricing-refresh-auto`; updates to an existing open PR rather than opening duplicates.
+- Operators who want to block a specific refresh can close the PR and label it `no-auto-fix`.
+
+## Alternatives considered
+
+- **Manual script.** Rejected: already implemented as a one-shot; the loop is the steady-state replacement, same as `EntryEvidenceLoop` replacing its migration script (ADR-0062).
+- **Dependabot-style file sync.** Rejected: requires GitHub App configuration; the in-process loop is simpler and already available.
+
+## Related
+
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker loop pattern
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/pricing_refresh_loop.py:PricingRefreshLoop`
+- `src/pricing_refresh_diff.py:compute_pricing_diff`
+- `src/assets/model_pricing.json` — the file under management

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,6 +89,19 @@ ADR and that named test files actually exist.
 | [0055](0055-otel-honeycomb-instrumentation.md) | OpenTelemetry Instrumentation as the Telemetry Layer | Accepted |
 | [0057](0057-term-pruner-loop.md) | Term-Pruner Loop (Dark-Factory Glossary Hygiene) | Accepted |
 | [0058](0058-edge-proposer-loop.md) | Edge-Proposer Loop (Dark-Factory Graph Densification) | Accepted |
+| [0059](0059-advisor-pattern-self-repairing-review.md) | Advisor Pattern — Self-Repairing Review | Proposed |
+| [0060](0060-atlas-graph-view-and-provenance.md) | Atlas Graph View and Provenance | Proposed |
+| [0061](0061-atlas-entries-as-evidence.md) | Atlas Entries as Evidence | Proposed |
+| [0062](0062-entry-evidence-loop.md) | Entry-Evidence Loop | Accepted |
+| [0063](0063-factory-phase-drift-mitigation.md) | Factory-Phase Drift Mitigation | Proposed |
+| [0064](0064-earlier-adversarial-pipeline.md) | Earlier Adversarial Pipeline | Proposed |
+| [0065](0065-remove-code-grooming-loop.md) | Remove CodeGroomingLoop | Accepted |
+| [0073](0073-runs-gc-loop.md) | RunsGCLoop: Artifact Retention Enforcement | Proposed |
+| [0074](0074-retrospective-loop.md) | RetrospectiveLoop: Durable-Queue Pattern Analysis | Proposed |
+| [0075](0075-merge-state-watcher-loop.md) | MergeStateWatcherLoop: Autonomous Conflict Detection and Rebase | Proposed |
+| [0076](0076-github-cache-loop.md) | GitHubCacheLoop: Centralized GitHub Data Cache | Proposed |
+| [0077](0077-pr-unsticker-loop.md) | PRUnstickerLoop: Goal-Driven HITL PR Resolution | Proposed |
+| [0078](0078-pricing-refresh-loop.md) | PricingRefreshLoop: Autonomous LLM Pricing Drift Detection | Proposed |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T20:25:23.806280+00:00",
-  "commit_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda",
+  "regenerated_at": "2026-05-19T20:27:10.453777+00:00",
+  "commit_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f",
   "artifacts": {
     "loops.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "ports.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "labels.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "modules.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "events.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "adr_xref.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "mockworld.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "changelog.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "coverage_matrix.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "functional_areas.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "ubiquitous-language.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
+      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T19:47:58.080133+00:00",
-  "commit_sha": "612f04523503c770d7f3860df6c616007e17a4c1",
+  "regenerated_at": "2026-05-19T20:25:23.806280+00:00",
+  "commit_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda",
   "artifacts": {
     "loops.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "ports.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "labels.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "modules.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "events.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "adr_xref.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "mockworld.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "changelog.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "coverage_matrix.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "functional_areas.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "ubiquitous-language.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "612f04523503c770d7f3860df6c616007e17a4c1"
+      "source_sha": "8f0e9d3343f43575b86c484254d48b5d63b16cda"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -225,4 +225,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -76,6 +76,12 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0063 | `src.auto_agent_preflight_loop`, `src.discover_runner`, `src.implement_phase`, `src.plan_phase`, `src.review_phase._phase`, `src.shape_phase`, `src.triage_phase` |
 | ADR-0064 | `src.adversarial_labels`, `src.adversarial_retry_loop`, `src.assumption_surfacer`, `src.complexity_gate`, `src.discovery_council`, `src.discovery_council_prompts`, `src.events`, `src.models`, `src.pending_concerns`, `src.plan_council`, `src.plan_council_prompts`, `src.plan_phase`, `src.post_merge_handler`, `src.shape_challenger`, `src.shape_expert_council`, `src.shape_phase`, `src.spec_ac_generator`, `src.spec_judge`, `src.wiki_carryover` |
 | ADR-0065 | `src.code_grooming_loop`, `src.config`, `src.skill_registry` |
+| ADR-0073 | `src.run_recorder`, `src.runs_gc_loop` |
+| ADR-0074 | `src.retrospective`, `src.retrospective_loop`, `src.retrospective_queue` |
+| ADR-0075 | `src.merge_state_watcher`, `src.merge_state_watcher_loop` |
+| ADR-0076 | `src.github_cache_loop` |
+| ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
+| ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
 
 ## Module → ADRs
 
@@ -124,6 +130,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.fake_coverage_auditor_loop` | ADR-0045 |
 | `src.file_util` | ADR-0021 |
 | `src.flake_tracker_loop` | ADR-0045 |
+| `src.github_cache_loop` | ADR-0076 |
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
@@ -136,6 +143,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.label_drift_watcher_loop` | ADR-0056 |
 | `src.memory_backlog_loop` | ADR-0057 |
 | `src.memory_backlog_mirror` | ADR-0057 |
+| `src.merge_state_watcher` | ADR-0075 |
+| `src.merge_state_watcher_loop` | ADR-0075 |
 | `src.metrics_manager` | ADR-0010, ADR-0021 |
 | `src.mockworld.fakes.fake_honeycomb` | ADR-0055 |
 | `src.mockworld.fakes.fake_llm` | ADR-0059 |
@@ -150,6 +159,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.ports` | ADR-0003, ADR-0044 |
 | `src.post_merge_handler` | ADR-0012, ADR-0014, ADR-0015, ADR-0016, ADR-0019, ADR-0064 |
 | `src.pr_manager` | ADR-0002, ADR-0005, ADR-0011, ADR-0013, ADR-0018, ADR-0045, ADR-0055, ADR-0056 |
+| `src.pr_unsticker` | ADR-0077 |
+| `src.pr_unsticker_loop` | ADR-0077 |
 | `src.precondition_gate` | ADR-0041 |
 | `src.preflight` | ADR-0043 |
 | `src.preflight.agent` | ADR-0050 |
@@ -158,6 +169,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.preflight.context` | ADR-0050 |
 | `src.preflight.decision` | ADR-0050 |
 | `src.preflight.runner` | ADR-0050 |
+| `src.pricing_refresh_diff` | ADR-0078 |
+| `src.pricing_refresh_loop` | ADR-0078 |
 | `src.principles_audit_loop` | ADR-0045 |
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
@@ -166,11 +179,16 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
+| `src.retrospective` | ADR-0074 |
+| `src.retrospective_loop` | ADR-0074 |
+| `src.retrospective_queue` | ADR-0074 |
 | `src.review_advisor` | ADR-0059 |
 | `src.review_phase` | ADR-0012, ADR-0014, ADR-0015, ADR-0031, ADR-0059 |
 | `src.review_phase._phase` | ADR-0063 |
 | `src.reviewer` | ADR-0025, ADR-0027, ADR-0059 |
 | `src.route_back` | ADR-0041 |
+| `src.run_recorder` | ADR-0073 |
+| `src.runs_gc_loop` | ADR-0073 |
 | `src.screenshot_scanner` | ADR-0018 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
@@ -207,4 +225,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
 - `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
@@ -351,4 +352,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
 - `1a5b156` — test(contracts): FakeHoneycomb contract test (closes ADR-0047 gap for fake #5 of 11) *(2026-05-19)*
 - `d5f127d` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -350,4 +351,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,50 +10,50 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
-| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ❌ | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ❌ | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ❌ | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
-| `EntryEvidenceLoop` | ✅ [0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ❌ | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
-| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ❌ | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
-| `GitHubCacheLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ❌ | ❌ |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ (caretaker loop) | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
+| `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
+| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
+| `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
+| `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
-| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ (caretaker loop) | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
-| `PRUnstickerLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
-| `PricingRefreshLoop` | ❌ | ❌ | ✅ loops.md | ✅ (caretaker loop) | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
-| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ❌ | ❌ | ❌ | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
-| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ (caretaker loop) | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
-| `RetrospectiveLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
-| `RunsGCLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
-| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ❌ | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ (caretaker loop) | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
-| `SentryLoop` | ✅ [0055] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
-| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ❌ | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
+| `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
+| `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
+| `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
+| `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
+| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
+| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
+| `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
+| `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
-| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ❌ | ✅ [gotchas.md] | ❌ | ✅ (caretaker loop) | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ (caretaker loop) | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ❌ | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
-| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ❌ | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
-| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ (caretaker loop) | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
+| `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
+| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
+| `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
+| `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s07_workspace_gc_reaps_dead_worktree.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are
@@ -61,15 +61,15 @@ per-adapter, not per-port).
 
 | Port | ADR | Wiki | Generated | Standard | Fake | Cassette | Contract |
 |---|---|---|---|---|---|---|---|
-| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ❌ | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ❌ | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ❌ | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ❌ | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `PRPort` | ✅ [0045, 0052, 0056] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ❌ | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
-| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ❌ | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `AgentPort` | ❌ | ✅ [architecture-layers.md] | ✅ ports.md | ✅ README.md | ✅ `FakeAgent` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `BotPRPort` | ❌ | ✅ [bot-pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeBotPR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueFetcherPort` | ❌ | ✅ [architecture-async-control.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueFetcher` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `IssueStorePort` | ✅ [0041] | ✅ [architecture-layers.md, issue-store-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeIssueStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ObservabilityPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeSentry` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `PRPort` | ✅ [0045, 0052, 0056, 0075, 0077] | ✅ [architecture-async-control.md, architecture-layers.md, dark-factory.md, gotchas.md, pr-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakePR` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `ReviewInsightStorePort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeReviewInsightStore` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `RouteBackCounterPort` | ❌ | ❌ | ✅ ports.md | ✅ README.md | ✅ `FakeRouteBackCounter` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
+| `WorkspacePort` | ✅ [0003, 0050] | ✅ [workspace-port.md] | ✅ ports.md | ✅ README.md | ✅ `FakeWorkspace` | N/A (per-adapter, ADR-0047) | N/A (per-adapter, ADR-0047) |
 ## Section 3: Factory phases
 
 Section 3 contains hand-curated prose (Loops driving it / Escalation path /
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -16,6 +16,7 @@ graph LR
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
     src_preflight["src.preflight"]
+    src_preflight_playbooks["src.preflight.playbooks"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
     src_sentry["src.sentry"]
@@ -43,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -71,7 +71,7 @@ graph LR
 ### PRPort
 
 - Module: `src.ports`
-- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
+- Methods: `add_labels`, `add_pr_labels`, `branch_has_diff_from_main`, `close_issue`, `close_task`, `create_issue`, `create_pr`, `create_promotion_pr`, `create_rc_branch`, `create_task`, `delete_branch`, `expected_pr_title`, `fetch_ci_failure_logs`, `fetch_code_scanning_alerts`, `find_existing_issue`, `find_label_drift`, `find_open_pr_for_branch`, `find_open_promotion_pr`, `get_dependabot_alerts`, `get_issue_state`, `get_issue_updated_at`, `get_latest_ci_status`, `get_pr_approvers`, `get_pr_diff`, `get_pr_diff_names`, `get_pr_head_sha`, `get_pr_mergeable`, `get_pr_recent_commit_diffs`, `list_closed_issues_by_label`, `list_conflicting_prs`, `list_hitl_items`, `list_issue_comments`, `list_issues_by_label`, `list_prs_by_label`, `list_rc_branches`, `merge_pr`, `merge_promotion_pr`, `post_comment`, `post_pr_comment`, `pull_main`, `push_branch`, `push_synthetic_commit`, `remove_label`, `remove_pr_label`, `submit_review`, `swap_pipeline_labels`, `transition`, `update_issue_body`, `update_pr_base`, `update_pr_branch`, `update_pr_title`, `upload_screenshot`, `wait_for_ci`
 - Adapters:
   - `PRManager` (`src.pr_manager`)
 - Fake: `FakePR` (`mockworld.fakes.fake_github`)
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `612f045` on 2026-05-19 19:47 UTC. Source last changed at `612f045`. Status: 🟢 fresh._
+_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `8f0e9d3` on 2026-05-19 20:25 UTC. Source last changed at `8f0e9d3`. Status: 🟢 fresh._
+_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._

--- a/docs/arch/generated/ubiquitous-language-context-map.md
+++ b/docs/arch/generated/ubiquitous-language-context-map.md
@@ -6,7 +6,18 @@
 graph LR
   subgraph builder
     AgentRunner["AgentRunner<br/><i>runner</i>"]
+    ReportIssueLoop["ReportIssueLoop<br/><i>loop</i>"]
     Task["Task<br/><i>entity</i>"]
+  end
+  subgraph caretaker
+    GitHubCacheLoop["GitHubCacheLoop<br/><i>loop</i>"]
+    MergeStateWatcherLoop["MergeStateWatcherLoop<br/><i>loop</i>"]
+    PricingRefreshLoop["PricingRefreshLoop<br/><i>loop</i>"]
+    PRUnstickerLoop["PRUnstickerLoop<br/><i>loop</i>"]
+    RCBudgetLoop["RCBudgetLoop<br/><i>loop</i>"]
+    SentryLoop["SentryLoop<br/><i>loop</i>"]
+    SkillPromptEvalLoop["SkillPromptEvalLoop<br/><i>loop</i>"]
+    StaleIssueGCLoop["StaleIssueGCLoop<br/><i>loop</i>"]
   end
   subgraph shared-kernel
     BaseBackgroundLoop["BaseBackgroundLoop<br/><i>loop</i>"]

--- a/docs/arch/generated/ubiquitous-language.md
+++ b/docs/arch/generated/ubiquitous-language.md
@@ -2,7 +2,7 @@
 
 # Ubiquitous Language
 
-_11 terms across 2 bounded contexts._
+_20 terms across 3 bounded contexts._
 
 See [ADR-0053](../../adr/0053-ubiquitous-language-as-living-artifact.md) for the governing pattern.
 
@@ -53,6 +53,18 @@ Async pub/sub bus that fans HydraFlowEvent objects out to subscriber asyncio.Que
 - Slow subscribers do not block the publisher: a full subscriber queue drops its oldest entry before the new event is enqueued.
 - History mutation is serialized through an asyncio.Lock.
 
+## GitHubCacheLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/github_cache_loop.py:GitHubCacheLoop` · **Confidence:** `accepted`
+**Aliases:** `github cache loop`, `github data cache loop`, `github poller`
+
+Centralized GitHub data poller that replaces the pattern where every dashboard endpoint and background worker makes its own `gh api` calls (ADR-0041). A single `GitHubCacheLoop` polls GitHub on a fixed interval and stores results in `GitHubDataCache` — in memory and on disk. Dashboard endpoints and background workers read from the cache instantly rather than hitting the API. Write operations (create PR, merge, comment, label swap) still call `gh` directly because they need immediate confirmation.
+
+**Invariants:**
+- Only one instance per repo runtime; all read consumers share the same cache snapshot.
+- Write operations bypass the cache and call `gh` directly.
+- Cache staleness is observable: each `CacheSnapshot` carries a `fetched_at` timestamp; `age_seconds` is infinite until the first poll completes.
+
 ## HydraFlowConfig
 
 **Kind:** `aggregate` · **Context:** `shared-kernel` · **Anchor:** `src/config.py:HydraFlowConfig` · **Confidence:** `accepted`
@@ -76,6 +88,30 @@ Hexagonal port for the in-memory issue work-queue — exposes only the queue acc
 - Pure Protocol — no implementation, no state.
 - Only domain-consumed methods are declared; orchestrator and dashboard methods deliberately stay off the port.
 
+## MergeStateWatcherLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/merge_state_watcher_loop.py:MergeStateWatcherLoop` · **Confidence:** `accepted`
+**Aliases:** `merge state watcher loop`, `merge state watcher`, `conflict rebase loop`
+
+Caretaker loop that periodically scans all open PRs for merge conflicts and auto-rebases or escalates them (ADR-0029). The filter is intentionally broad: RC promotion PRs, Dependabot bumps, agent PRs, and manual PRs all benefit from auto-rebase when they go DIRTY against `main`. PRs already labeled `hydraflow-hitl` (being handled by `PRUnsticker`) or `hydraflow-review` (active reviewer worktree) are skipped to avoid stepping on in-progress work. Delegates the actual conflict-detection and rebase logic to `MergeStateWatcher`.
+
+**Invariants:**
+- Default tick interval is 600 seconds (10 minutes).
+- PRs labeled `hydraflow-hitl` or `hydraflow-review` are skipped.
+- Kill-switch is via `enabled_cb("merge_state_watcher")` and `config.merge_state_watcher_loop_enabled`.
+
+## PricingRefreshLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pricing_refresh_loop.py:PricingRefreshLoop` · **Confidence:** `accepted`
+**Aliases:** `pricing refresh loop`, `litellm pricing poller`, `model pricing caretaker`
+
+Daily caretaker loop that fetches LiteLLM's `model_prices_and_context_window.json` via stdlib `urllib`, filters to Anthropic-provider entries (normalizing Bedrock keys), diffs against `src/assets/model_pricing.json`, and opens or updates a `pricing-refresh-auto` PR when drift is detected (ADR-0029, ADR-0049). A bounds guard rejects suspicious price moves. Bounds violations, parse errors, and schema errors open a single deduplicated `[pricing-refresh]` `hydraflow-find` issue. Network errors log-and-retry on the next tick without filing issues.
+
+**Invariants:**
+- Kill-switch is the `HYDRAFLOW_DISABLE_PRICING_REFRESH=1` env var.
+- PR is always on the fixed branch `pricing-refresh-auto`; no-op ticks do not open a PR.
+- Bounds violations are separate from network errors; each has a distinct response path.
+
 ## PRPort
 
 **Kind:** `port` · **Context:** `shared-kernel` · **Anchor:** `src/ports.py:PRPort` · **Confidence:** `accepted`
@@ -86,6 +122,42 @@ Hexagonal port for GitHub PR, label, and CI operations — branch push, PR creat
 **Invariants:**
 - Pure Protocol — no implementation, no state.
 - Method signatures must match pr_manager.PRManager exactly so structural subtype checks in tests/test_ports.py pass.
+
+## PRUnstickerLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/pr_unsticker_loop.py:PRUnstickerLoop` · **Confidence:** `accepted`
+**Aliases:** `pr unsticker loop`, `pr unsticker`, `hitl unsticker`
+
+Caretaker loop that polls HITL items and delegates to `PRUnsticker` to resolve all HITL causes — merge conflicts, CI failures, and generic stuck states. Operates only on HITL issues that currently have an open PR. The loop wraps the unsticker worker in the standard `BaseBackgroundLoop` tick-and-interval skeleton, keeping the HITL resolution logic in `PRUnsticker` separate from the polling infrastructure.
+
+**Invariants:**
+- Only processes HITL issues with an associated open PR (`item.pr > 0`); issues without PRs are skipped.
+- Kill-switch is via `enabled_cb("pr_unsticker")` and `config.pr_unsticker_loop_enabled` (ADR-0049).
+- Interval is driven by `config.pr_unstick_interval`.
+
+## RCBudgetLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/rc_budget_loop.py:RCBudgetLoop` · **Confidence:** `accepted`
+**Aliases:** `rc budget loop`, `rc ci wall-clock detector`, `rc duration regression detector`
+
+4-hour RC CI wall-clock regression detector (ADR-0045 §4.8). Reads the last 30 days of `rc-promotion-scenario.yml` runs via `gh run list`, extracts per-run wall-clock duration, and emits a `hydraflow-find` + `rc-duration-regression` issue when the newest run trips either a gradual-bloat signal (current run ≥ 1.5× rolling median) or a sudden-spike signal (current run ≥ 2.0× recent-five maximum). Both signals are independent; both may fire on the same tick with distinct dedup keys. After 3 unresolved attempts per signal the loop escalates to `hitl-escalation` + `rc-duration-stuck`.
+
+**Invariants:**
+- Kill-switch is via `enabled_cb("rc_budget")` only — no `rc_budget_enabled` config field (ADR-0049 §12.2).
+- Requires at least 5 historical data points before emitting any signal.
+- Dedup keys clear on escalation-close.
+
+## ReportIssueLoop
+
+**Kind:** `loop` · **Context:** `builder` · **Anchor:** `src/report_issue_loop.py:ReportIssueLoop` · **Confidence:** `accepted`
+**Aliases:** `report issue loop`, `bug report loop`, `dashboard report processor`
+
+Background loop that dequeues pending bug reports from state, saves any attached screenshots to temp files, and invokes the Claude CLI with `/hf.issue` so the agent can see the image, research the codebase, and file a well-structured GitHub issue (ADR-0028). This is the same issue-filing flow triggered by dashboard bug reports. Supports base64-encoded screenshot payloads and scans them for secrets before saving. Caps retries at 5 attempts per report.
+
+**Invariants:**
+- Screenshot payloads are scanned for secrets before being written to disk.
+- Reports cap at `_MAX_REPORT_ATTEMPTS` (5) before being abandoned.
+- Kill-switch is via `enabled_cb("report_issue")` (ADR-0049).
 
 ## RepoWikiStore
 
@@ -98,6 +170,42 @@ File-based per-repo wiki manager (ADR-0032). Owns the on-disk layout for both th
 - Self-repo pages live directly under wiki_root; every other slug is nested under wiki_root/owner/repo.
 - ingest() updates topic pages, refreshes index.json/index.md, and appends to log.jsonl in a single operation.
 - When a tracked_root with per-entry layout is configured, reads prefer it and fall back to the legacy topic-page layout.
+
+## SentryLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/sentry_loop.py:SentryLoop` · **Confidence:** `accepted`
+**Aliases:** `sentry loop`, `sentry ingestion loop`, `sentry issue poller`
+
+Background loop that polls the Sentry API for unresolved issues across configured projects, deduplicates them against already-filed GitHub issues, and invokes a Claude agent via `/hf.issue` to research the codebase and file a properly triaged GitHub issue — the same flow as dashboard bug reports (ADR-0055). Requires Sentry credentials in config. Sentry captures real code bugs only; transient failures and operational noise are excluded by the loop's dedup and filtering logic.
+
+**Invariants:**
+- Issues are deduplicated before filing; re-ingestion of the same Sentry event does not produce duplicate GitHub issues.
+- Kill-switch is via `enabled_cb("sentry")` (ADR-0049).
+- Sentry errors in the `ERROR+` level range trigger the issue-filing path; `WARNING` and below are skipped.
+
+## SkillPromptEvalLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/skill_prompt_eval_loop.py:SkillPromptEvalLoop` · **Confidence:** `accepted`
+**Aliases:** `skill prompt eval loop`, `skill prompt drift detector`, `corpus health auditor`
+
+Weekly background loop with two responsibilities. First, it runs the full adversarial skill-prompt corpus on a fixed schedule, catching regressions the RC-gate subset sampling misses (ADR-0045 §4.6). Second, it samples 10% of `provenance: learning-loop` corpus cases, flagging any that the `expected_catcher` skill passes — a weak-case signal the §4.1 learner uses for corpus quality improvement. Files `skill-prompt-drift` issues on PASS→FAIL transitions and `corpus-case-weak` issues for human triage.
+
+**Invariants:**
+- Both subsystems share a single loop tick; neither runs independently.
+- Issues are deduplicated before filing; the same regression does not produce duplicate bead spam.
+- Subclasses `BaseBackgroundLoop`; kill-switch is via `enabled_cb("skill_prompt_eval")` (ADR-0049).
+
+## StaleIssueGCLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/stale_issue_gc_loop.py:StaleIssueGCLoop` · **Confidence:** `accepted`
+**Aliases:** `stale issue gc loop`, `stale hitl gc loop`, `hitl stale closer`
+
+Caretaker loop that auto-closes stale HITL escalation issues (ADR-0029). Scope is specifically open issues carrying the configured HITL label that have been inactive beyond `stale_issue_threshold_days`. Posts a farewell comment, then closes. Caps at 10 closures per cycle to avoid GitHub rate-limiting. Distinct from `StaleIssueLoop`, which handles stale general issues with no HydraFlow lifecycle label — the two loops share only the `BaseBackgroundLoop` framework and have zero business-logic overlap.
+
+**Invariants:**
+- Maximum 10 issues closed per tick to respect GitHub rate limits.
+- Only closes issues carrying the HITL label (`config.hitl_label`), not general issues.
+- `StaleIssueGCLoop` and `StaleIssueLoop` are fully separate; do not conflate them.
 
 ## StateTracker
 

--- a/docs/standards/factory_operation/README.md
+++ b/docs/standards/factory_operation/README.md
@@ -50,6 +50,7 @@ the factory takes a spec from intent to production.
 | **Test pyramid** | [`docs/standards/testing/`](../testing/README.md) | Three layers (unit + MockWorld scenario + sandbox e2e) gate every load-bearing feature. |
 | **Branch protection** | [`docs/standards/branch_protection/`](../branch_protection/README.md) | Two-tier branch model (integration + release reference) with versioned ruleset configs and a re-applyable apply-script. |
 | **Self-modifying maintenance** | this document, §"Self-modifying maintenance mode" | Recurring patterns become caretaker loops; lessons get encoded back into the kernel. |
+| **Ports and loops** | [`docs/standards/ports-and-loops/`](../ports-and-loops/README.md) | Structural contract for every hexagonal port and background loop: kill-switch, fake, wiki, ADR, standard row. |
 
 The factory's behavior emerges from **all four** running together. Removing
 any one breaks the contract:

--- a/docs/standards/ports-and-loops/README.md
+++ b/docs/standards/ports-and-loops/README.md
@@ -1,0 +1,114 @@
+# HydraFlow Standard — Ports and Loops
+
+Every hexagonal port and every background loop in HydraFlow follows a
+shared structural contract. This document defines that contract so that
+new ports and loops are consistent, testable, and observable from day
+one — without requiring a reviewer to catch missing pieces.
+
+## Ports
+
+A **port** is a `@runtime_checkable` `Protocol` in `src/ports.py` that
+abstracts an I/O boundary. Adapters implement ports; phases and loops
+depend on ports, not adapters.
+
+### Per-port requirements
+
+| Requirement | Where | Detail |
+|---|---|---|
+| **Protocol definition** | `src/ports.py` | `@runtime_checkable` `Protocol`; pure interface, no state. |
+| **Production adapter** | `src/<adapter>.py` | Concrete implementation; wired in the service registry. |
+| **Fake adapter** | `src/mockworld/fakes/fake_<name>.py` | `Fake<Name>` class used in MockWorld scenarios and unit tests. Must satisfy the Protocol structurally. |
+| **Wiki term entry** | `docs/wiki/terms/<kebab-name>.md` | YAML frontmatter + Definition + Invariants. UL lint must pass. |
+| **ADR** | `docs/adr/XXXX-<kebab-name>.md` | Documents the decision to introduce the port and its behavioral contract. |
+| **Standard entry** | This document, `§ Per-port registry` | One-line row in the table below. |
+
+### Per-port registry
+
+| Port | ADR | Fake | Wiki |
+|---|---|---|---|
+| `AgentPort` | [0066](../../../docs/adr/0066-agent-port.md) | `FakeAgent` | [agent-port.md](../../wiki/terms/agent-port.md) |
+| `BotPRPort` | [0068](../../../docs/adr/0068-bot-pr-port.md) | `FakeBotPR` | [bot-pr-port.md](../../wiki/terms/bot-pr-port.md) |
+| `IssueFetcherPort` | [0067](../../../docs/adr/0067-issue-fetcher-port.md) | `FakeIssueFetcher` | [issue-fetcher-port.md](../../wiki/terms/issue-fetcher-port.md) |
+| `IssueStorePort` | [0041](../../../docs/adr/0041-github-source-of-truth-cache-as-sidecar.md) | `FakeIssueStore` | [issue-store-port.md](../../wiki/terms/issue-store-port.md) |
+| `ObservabilityPort` | [0055](../../../docs/adr/0055-otel-honeycomb-instrumentation.md) | `FakeSentry` | [observability-port.md](../../wiki/terms/observability-port.md) |
+| `PRPort` | [0045](../../../docs/adr/0045-trust-architecture-hardening.md) | `FakePR` | [pr-port.md](../../wiki/terms/pr-port.md) |
+| `ReviewInsightStorePort` | [0070](../../../docs/adr/0070-review-insight-store-port.md) | `FakeReviewInsightStore` | [review-insight-store-port.md](../../wiki/terms/review-insight-store-port.md) |
+| `RouteBackCounterPort` | [0071](../../../docs/adr/0071-route-back-counter-port.md) | `FakeRouteBackCounter` | [route-back-counter-port.md](../../wiki/terms/route-back-counter-port.md) |
+| `WorkspacePort` | [0003](../../../docs/adr/0003-git-worktrees-for-isolation.md) | `FakeWorkspace` | [workspace-port.md](../../wiki/terms/workspace-port.md) |
+
+## Loops
+
+A **loop** is a `BaseBackgroundLoop` subclass that runs on a fixed interval
+inside the factory. Loops are the dark factory's autonomous workers —
+each is responsible for one caretaking concern.
+
+### Per-loop requirements
+
+| Requirement | Where | Detail |
+|---|---|---|
+| **Kill-switch** | `_do_work` method | First check: `if not self._enabled_cb(self._worker_name): return {"status": "disabled"}`. ADR-0049 mandates this on every loop. |
+| **Config gate** | `_do_work` method | Second check: `if not self._config.<loop>_loop_enabled: return {"status": "config_disabled"}` for static-config-gated loops. |
+| **Unit tests** | `tests/test_<loop>.py` | Full coverage including kill-switch path. |
+| **MockWorld scenario** | `tests/scenarios/test_<loop>_scenario.py` | Pattern A (catalog) or Pattern B (direct) — see `docs/standards/testing/`. |
+| **Wiki term entry** | `docs/wiki/terms/<kebab-loop>.md` | YAML frontmatter + Definition + Invariants. |
+| **ADR** | `docs/adr/XXXX-<kebab-loop>.md` | Documents the decision to introduce the loop. |
+| **Standard entry** | This document, `§ Per-loop registry` | One-line row in the table below. |
+
+### Per-loop registry
+
+Rows below capture the canonical standard status. Full coverage detail
+(unit, scenario, sandbox, generated) lives in `docs/arch/generated/coverage_matrix.md`.
+
+| Loop | ADR | Wiki | Notes |
+|---|---|---|---|
+| `ADRReviewerLoop` | (none) | (none) | Caretaker loop |
+| `AdrTouchpointAuditorLoop` | [0056, 0057] | (none) | Trust fleet |
+| `AutoAgentPreflightLoop` | [0050, 0063] | dark-factory.md | Phase gap mitigation |
+| `CIMonitorLoop` | [0029, 0065] | (none) | Caretaker loop |
+| `ContractRefreshLoop` | [0045, 0047] | (none) | Trust fleet |
+| `CorpusLearningLoop` | [0045] | (none) | Trust fleet |
+| `CostBudgetWatcherLoop` | [0054] | architecture.md | Caretaker loop |
+| `DependabotMergeLoop` | [0054, 0057, 0058] | (none) | Caretaker loop |
+| `DiagnosticLoop` | [0050] | (none) | Caretaker loop |
+| `DiagramLoop` | [0001] | (none) | Caretaker loop |
+| `EdgeProposerLoop` | [0058, 0060, 0062] | (none) | Caretaker loop |
+| `EntryEvidenceLoop` | [0062] | (none) | Caretaker loop |
+| `EpicMonitorLoop` | (none) | architecture-async-control.md | Caretaker loop |
+| `EpicSweeperLoop` | (none) | architecture-async-control.md | Caretaker loop |
+| `FakeCoverageAuditorLoop` | [0045, 0056, 0057] | (none) | Trust fleet |
+| `FlakeTrackerLoop` | [0045, 0056, 0057, 0065] | (none) | Trust fleet |
+| `GitHubCacheLoop` | (none) | [github-cache-loop.md](../../wiki/terms/github-cache-loop.md) | Caretaker loop |
+| `HealthMonitorLoop` | [0045, 0046] | testing.md | Caretaker loop |
+| `LabelDriftWatcherLoop` | [0056] | (none) | Caretaker loop |
+| `MemoryBacklogLoop` | [0057] | README.md | Caretaker loop |
+| `MergeStateWatcherLoop` | (none) | [merge-state-watcher-loop.md](../../wiki/terms/merge-state-watcher-loop.md) | Caretaker loop |
+| `PRUnstickerLoop` | (none) | [pr-unsticker-loop.md](../../wiki/terms/pr-unsticker-loop.md) | Caretaker loop |
+| `PricingRefreshLoop` | (none) | [pricing-refresh-loop.md](../../wiki/terms/pricing-refresh-loop.md) | Caretaker loop |
+| `PrinciplesAuditLoop` | [0045, 0056] | dark-factory.md | Trust fleet |
+| `RCBudgetLoop` | [0045] | [rc-budget-loop.md](../../wiki/terms/rc-budget-loop.md) | Trust fleet |
+| `RepoWikiLoop` | [0032, 0053, 0061, 0062, 0064] | dark-factory.md | Caretaker loop |
+| `ReportIssueLoop` | [0013, 0018, 0028] | [report-issue-loop.md](../../wiki/terms/report-issue-loop.md) | Caretaker loop |
+| `RetrospectiveLoop` | (none) | architecture-async-control.md | Caretaker loop |
+| `RunsGCLoop` | (none) | architecture-async-control.md | Caretaker loop |
+| `SandboxFailureFixerLoop` | [0052, 0063] | dark-factory.md | Caretaker loop |
+| `SecurityPatchLoop` | [0029, 0065] | architecture-async-control.md | Caretaker loop |
+| `SentryLoop` | [0055] | [sentry-loop.md](../../wiki/terms/sentry-loop.md) | Caretaker loop |
+| `SkillPromptEvalLoop` | [0045] | [skill-prompt-eval-loop.md](../../wiki/terms/skill-prompt-eval-loop.md) | Trust fleet |
+| `StagingBisectLoop` | [0045, 0048, 0063] | architecture.md | Trust fleet |
+| `StagingPromotionLoop` | [0042] | patterns.md | Caretaker loop |
+| `StaleIssueGCLoop` | [0029] | [stale-issue-gc-loop.md](../../wiki/terms/stale-issue-gc-loop.md) | Caretaker loop |
+| `StaleIssueLoop` | (none) | gotchas.md | Caretaker loop |
+| `TermProposerLoop` | [0054, 0057, 0060, 0061, 0062] | bot-pr-port.md | Caretaker loop |
+| `TermPrunerLoop` | [0057, 0060, 0062] | (none) | Caretaker loop |
+| `TriageRetryLoop` | [0063] | (none) | Caretaker loop |
+| `TrustFleetSanityLoop` | [0045, 0046] | testing.md | Trust fleet |
+| `WikiRotDetectorLoop` | [0045, 0056, 0057] | (none) | Trust fleet |
+| `WorkspaceGCLoop` | (none) | (none) | Caretaker loop |
+
+## Discoverability
+
+This standard is referenced from:
+
+- `docs/standards/factory_operation/README.md` — kernel standards table
+- `docs/wiki/gotchas.md` — "Background loop wiring: synchronize 5 locations"
+- `docs/arch/generated/coverage_matrix.md` — Standard column for each loop and port

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,6 +1,6 @@
 # Wiki Index: T-rav/hydraflow
 
-**300 entries** | Last updated: 2026-05-12T00:00:00.000000+00:00
+**309 entries** | Last updated: 2026-05-19T20:00:00.000000+00:00
 
 ## Terms — Ubiquitous Language
 

--- a/docs/wiki/terms/github-cache-loop.md
+++ b/docs/wiki/terms/github-cache-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A2"
+name: "GitHubCacheLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/github_cache_loop.py:GitHubCacheLoop"
+aliases: ["github cache loop", "github data cache loop", "github poller"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Centralized GitHub data poller that replaces the pattern where every dashboard endpoint and background worker makes its own `gh api` calls (ADR-0041). A single `GitHubCacheLoop` polls GitHub on a fixed interval and stores results in `GitHubDataCache` — in memory and on disk. Dashboard endpoints and background workers read from the cache instantly rather than hitting the API. Write operations (create PR, merge, comment, label swap) still call `gh` directly because they need immediate confirmation.
+
+## Invariants
+
+- Only one instance per repo runtime; all read consumers share the same cache snapshot.
+- Write operations bypass the cache and call `gh` directly.
+- Cache staleness is observable: each `CacheSnapshot` carries a `fetched_at` timestamp; `age_seconds` is infinite until the first poll completes.

--- a/docs/wiki/terms/merge-state-watcher-loop.md
+++ b/docs/wiki/terms/merge-state-watcher-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A5"
+name: "MergeStateWatcherLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/merge_state_watcher_loop.py:MergeStateWatcherLoop"
+aliases: ["merge state watcher loop", "merge state watcher", "conflict rebase loop"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Caretaker loop that periodically scans all open PRs for merge conflicts and auto-rebases or escalates them (ADR-0029). The filter is intentionally broad: RC promotion PRs, Dependabot bumps, agent PRs, and manual PRs all benefit from auto-rebase when they go DIRTY against `main`. PRs already labeled `hydraflow-hitl` (being handled by `PRUnsticker`) or `hydraflow-review` (active reviewer worktree) are skipped to avoid stepping on in-progress work. Delegates the actual conflict-detection and rebase logic to `MergeStateWatcher`.
+
+## Invariants
+
+- Default tick interval is 600 seconds (10 minutes).
+- PRs labeled `hydraflow-hitl` or `hydraflow-review` are skipped.
+- Kill-switch is via `enabled_cb("merge_state_watcher")` and `config.merge_state_watcher_loop_enabled`.

--- a/docs/wiki/terms/pr-unsticker-loop.md
+++ b/docs/wiki/terms/pr-unsticker-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A3"
+name: "PRUnstickerLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/pr_unsticker_loop.py:PRUnstickerLoop"
+aliases: ["pr unsticker loop", "pr unsticker", "hitl unsticker"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Caretaker loop that polls HITL items and delegates to `PRUnsticker` to resolve all HITL causes — merge conflicts, CI failures, and generic stuck states. Operates only on HITL issues that currently have an open PR. The loop wraps the unsticker worker in the standard `BaseBackgroundLoop` tick-and-interval skeleton, keeping the HITL resolution logic in `PRUnsticker` separate from the polling infrastructure.
+
+## Invariants
+
+- Only processes HITL issues with an associated open PR (`item.pr > 0`); issues without PRs are skipped.
+- Kill-switch is via `enabled_cb("pr_unsticker")` and `config.pr_unsticker_loop_enabled` (ADR-0049).
+- Interval is driven by `config.pr_unstick_interval`.

--- a/docs/wiki/terms/pricing-refresh-loop.md
+++ b/docs/wiki/terms/pricing-refresh-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A6"
+name: "PricingRefreshLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/pricing_refresh_loop.py:PricingRefreshLoop"
+aliases: ["pricing refresh loop", "litellm pricing poller", "model pricing caretaker"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Daily caretaker loop that fetches LiteLLM's `model_prices_and_context_window.json` via stdlib `urllib`, filters to Anthropic-provider entries (normalizing Bedrock keys), diffs against `src/assets/model_pricing.json`, and opens or updates a `pricing-refresh-auto` PR when drift is detected (ADR-0029, ADR-0049). A bounds guard rejects suspicious price moves. Bounds violations, parse errors, and schema errors open a single deduplicated `[pricing-refresh]` `hydraflow-find` issue. Network errors log-and-retry on the next tick without filing issues.
+
+## Invariants
+
+- Kill-switch is the `HYDRAFLOW_DISABLE_PRICING_REFRESH=1` env var.
+- PR is always on the fixed branch `pricing-refresh-auto`; no-op ticks do not open a PR.
+- Bounds violations are separate from network errors; each has a distinct response path.

--- a/docs/wiki/terms/rc-budget-loop.md
+++ b/docs/wiki/terms/rc-budget-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A4"
+name: "RCBudgetLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/rc_budget_loop.py:RCBudgetLoop"
+aliases: ["rc budget loop", "rc ci wall-clock detector", "rc duration regression detector"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+4-hour RC CI wall-clock regression detector (ADR-0045 §4.8). Reads the last 30 days of `rc-promotion-scenario.yml` runs via `gh run list`, extracts per-run wall-clock duration, and emits a `hydraflow-find` + `rc-duration-regression` issue when the newest run trips either a gradual-bloat signal (current run ≥ 1.5× rolling median) or a sudden-spike signal (current run ≥ 2.0× recent-five maximum). Both signals are independent; both may fire on the same tick with distinct dedup keys. After 3 unresolved attempts per signal the loop escalates to `hitl-escalation` + `rc-duration-stuck`.
+
+## Invariants
+
+- Kill-switch is via `enabled_cb("rc_budget")` only — no `rc_budget_enabled` config field (ADR-0049 §12.2).
+- Requires at least 5 historical data points before emitting any signal.
+- Dedup keys clear on escalation-close.

--- a/docs/wiki/terms/report-issue-loop.md
+++ b/docs/wiki/terms/report-issue-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A9"
+name: "ReportIssueLoop"
+kind: "loop"
+bounded_context: "builder"
+code_anchor: "src/report_issue_loop.py:ReportIssueLoop"
+aliases: ["report issue loop", "bug report loop", "dashboard report processor"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Background loop that dequeues pending bug reports from state, saves any attached screenshots to temp files, and invokes the Claude CLI with `/hf.issue` so the agent can see the image, research the codebase, and file a well-structured GitHub issue (ADR-0028). This is the same issue-filing flow triggered by dashboard bug reports. Supports base64-encoded screenshot payloads and scans them for secrets before saving. Caps retries at 5 attempts per report.
+
+## Invariants
+
+- Screenshot payloads are scanned for secrets before being written to disk.
+- Reports cap at `_MAX_REPORT_ATTEMPTS` (5) before being abandoned.
+- Kill-switch is via `enabled_cb("report_issue")` (ADR-0049).

--- a/docs/wiki/terms/sentry-loop.md
+++ b/docs/wiki/terms/sentry-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A7"
+name: "SentryLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/sentry_loop.py:SentryLoop"
+aliases: ["sentry loop", "sentry ingestion loop", "sentry issue poller"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Background loop that polls the Sentry API for unresolved issues across configured projects, deduplicates them against already-filed GitHub issues, and invokes a Claude agent via `/hf.issue` to research the codebase and file a properly triaged GitHub issue — the same flow as dashboard bug reports (ADR-0055). Requires Sentry credentials in config. Sentry captures real code bugs only; transient failures and operational noise are excluded by the loop's dedup and filtering logic.
+
+## Invariants
+
+- Issues are deduplicated before filing; re-ingestion of the same Sentry event does not produce duplicate GitHub issues.
+- Kill-switch is via `enabled_cb("sentry")` (ADR-0049).
+- Sentry errors in the `ERROR+` level range trigger the issue-filing path; `WARNING` and below are skipped.

--- a/docs/wiki/terms/skill-prompt-eval-loop.md
+++ b/docs/wiki/terms/skill-prompt-eval-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A1"
+name: "SkillPromptEvalLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/skill_prompt_eval_loop.py:SkillPromptEvalLoop"
+aliases: ["skill prompt eval loop", "skill prompt drift detector", "corpus health auditor"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Weekly background loop with two responsibilities. First, it runs the full adversarial skill-prompt corpus on a fixed schedule, catching regressions the RC-gate subset sampling misses (ADR-0045 §4.6). Second, it samples 10% of `provenance: learning-loop` corpus cases, flagging any that the `expected_catcher` skill passes — a weak-case signal the §4.1 learner uses for corpus quality improvement. Files `skill-prompt-drift` issues on PASS→FAIL transitions and `corpus-case-weak` issues for human triage.
+
+## Invariants
+
+- Both subsystems share a single loop tick; neither runs independently.
+- Issues are deduplicated before filing; the same regression does not produce duplicate bead spam.
+- Subclasses `BaseBackgroundLoop`; kill-switch is via `enabled_cb("skill_prompt_eval")` (ADR-0049).

--- a/docs/wiki/terms/stale-issue-gc-loop.md
+++ b/docs/wiki/terms/stale-issue-gc-loop.md
@@ -1,0 +1,25 @@
+---
+id: "01KR9A3F20M01PGF32CF88W9A8"
+name: "StaleIssueGCLoop"
+kind: "loop"
+bounded_context: "caretaker"
+code_anchor: "src/stale_issue_gc_loop.py:StaleIssueGCLoop"
+aliases: ["stale issue gc loop", "stale hitl gc loop", "hitl stale closer"]
+related: []
+evidence: []
+superseded_by: null
+superseded_reason: null
+confidence: "accepted"
+created_at: "2026-05-19T20:00:00.000000+00:00"
+updated_at: "2026-05-19T20:00:00.000000+00:00"
+---
+
+## Definition
+
+Caretaker loop that auto-closes stale HITL escalation issues (ADR-0029). Scope is specifically open issues carrying the configured HITL label that have been inactive beyond `stale_issue_threshold_days`. Posts a farewell comment, then closes. Caps at 10 closures per cycle to avoid GitHub rate-limiting. Distinct from `StaleIssueLoop`, which handles stale general issues with no HydraFlow lifecycle label — the two loops share only the `BaseBackgroundLoop` framework and have zero business-logic overlap.
+
+## Invariants
+
+- Maximum 10 issues closed per tick to respect GitHub rate limits.
+- Only closes issues carrying the HITL label (`config.hitl_label`), not general issues.
+- `StaleIssueGCLoop` and `StaleIssueLoop` are fully separate; do not conflate them.


### PR DESCRIPTION
## Summary

Drains 19 coverage-gap beads across three doc categories:

- **Wiki (9 entries):** New term files in `docs/wiki/terms/` for every loop that was missing a wiki entry. Each file uses YAML frontmatter + Definition/Invariants format; UL lint passes with 0 unresolved anchors.
- **Standards (4 gaps):** New `docs/standards/ports-and-loops/README.md` — structural contract covering kill-switch, fake, wiki, ADR, and standard-row requirements for every port and loop. Also adds the standard as a 5th row in the factory kernel table in `docs/standards/factory_operation/README.md`.
- **ADR drafts (6):** Proposed ADRs 0073–0078 documenting the decisions behind each loop that had no ADR. All status `Proposed`; ADR index updated.

Also includes `arch-regen` output: `coverage_matrix.md` and `ubiquitous-language.md` updated to reflect all new entries.

## Bead coverage

**Wiki gaps closed:**
- `advisor-1ena` SkillPromptEvalLoop — `docs/wiki/terms/skill-prompt-eval-loop.md`
- `advisor-2k3` GitHubCacheLoop — `docs/wiki/terms/github-cache-loop.md`
- `advisor-9ne` PRUnstickerLoop — `docs/wiki/terms/pr-unsticker-loop.md`
- `advisor-aph` RCBudgetLoop — `docs/wiki/terms/rc-budget-loop.md`
- `advisor-c82` MergeStateWatcherLoop — `docs/wiki/terms/merge-state-watcher-loop.md`
- `advisor-duo` PricingRefreshLoop — `docs/wiki/terms/pricing-refresh-loop.md`
- `advisor-efb` SentryLoop — `docs/wiki/terms/sentry-loop.md`
- `advisor-gvs9` StaleIssueGCLoop — `docs/wiki/terms/stale-issue-gc-loop.md`
- `advisor-uo8` ReportIssueLoop — `docs/wiki/terms/report-issue-loop.md`

**Standard gaps closed:**
- `advisor-4kb` PrinciplesAuditLoop standard — covered in ports-and-loops/README.md registry
- `advisor-4p5b` StagingBisectLoop standard — covered in ports-and-loops/README.md registry
- `advisor-5j0` RCBudgetLoop standard — covered in ports-and-loops/README.md registry
- `advisor-e7a` SandboxFailureFixerLoop standard — covered in ports-and-loops/README.md registry

**ADR gaps closed:**
- `advisor-09l` RunsGCLoop ADR — `docs/adr/0073-runs-gc-loop.md`
- `advisor-bub` RetrospectiveLoop ADR — `docs/adr/0074-retrospective-loop.md`
- `advisor-f5i` MergeStateWatcherLoop ADR — `docs/adr/0075-merge-state-watcher-loop.md`
- `advisor-k31` GitHubCacheLoop ADR — `docs/adr/0076-github-cache-loop.md`
- `advisor-kqr` PRUnstickerLoop ADR — `docs/adr/0077-pr-unsticker-loop.md`
- `advisor-vcn` PricingRefreshLoop ADR — `docs/adr/0078-pricing-refresh-loop.md`

**Closed without PR (already shipped):**
- `advisor-luab` FakeReviewInsightStore — already exists in PR #9002 (merged 2026-05-19)
- `advisor-o0av` FakeRouteBackCounter — already exists in PR #9000 (merged 2026-05-19)
- `advisor-qif3` RepoWikiLoop ADR ref outdated — ADR-0061 exists on staging; arch-regen confirms ✅
- `advisor-v79u` TermProposerLoop ADR ref outdated — ADR-0060 exists on staging; arch-regen confirms ✅

## Note on conflict with PR #9022

PR #9022 (docs/wiki-standard-backfill) also creates `docs/standards/ports-and-loops/README.md`. Whoever merges second will need a trivial rebase merge. ADR numbering does not conflict: #9022 uses 0066–0072; this PR uses 0073–0078.

## Test plan

- [x] `make lint-ul` passes: 0 unresolved anchors, 0 paraphrase warnings
- [x] `make arch-regen` clean: coverage_matrix.md shows ✅ for all 19 addressed loops
- [x] UL lint: 20 terms loaded, 0 errors
- [ ] Full test suite (docs-only change; no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)