### PR TITLE
test(scenarios): coverage bulk backfill B

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T20:27:10.453777+00:00",
-  "commit_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f",
+  "regenerated_at": "2026-05-19T20:28:57.755224+00:00",
+  "commit_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c",
   "artifacts": {
     "loops.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "ports.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "labels.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "modules.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "events.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "adr_xref.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "mockworld.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "changelog.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "coverage_matrix.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "functional_areas.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "ubiquitous-language.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "7e4fc62d0801b85fa7c1e5a4a0d29e1a393d085f"
+      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -225,4 +225,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `06a3de7` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
+- `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
 - `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
 - `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
 - `007c86c` — fix(tests): import AgentPort + FakeAgent in conformance test *(2026-05-19)*
@@ -352,4 +354,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -31,25 +31,25 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ❌ | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
 | `LiveCorpusReplayLoop` | ❌ | ❌ | ❌ | ❌ | ✅ `test_live_corpus_replay_loop.py` | ❌ | ❌ |
 | `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ❌ | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ❌ | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
 | `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ❌ | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
 | `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
 | `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
-| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ❌ |
+| `RCBudgetLoop` | ✅ [0045] | ✅ [rc-budget-loop.md] | ❌ | ✅ README.md | ✅ `test_rc_budget_loop.py` | ✅ in catalog | ✅ `s20_rc_budget_no_regression.py` |
 | `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
-| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ❌ |
-| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ❌ |
+| `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ❌ | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
+| `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
 | `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
 | `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ❌ |
-| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ❌ |
+| `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
 | `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ❌ | ✅ README.md | ✅ `test_sentry_loop.py` | ❌ | ❌ |
-| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ❌ |
+| `SkillPromptEvalLoop` | ✅ [0045] | ✅ [skill-prompt-eval-loop.md] | ❌ | ✅ README.md | ✅ `test_skill_prompt_eval_loop.py` | ✅ in catalog | ✅ `s17_skill_prompt_eval_clean_corpus.py` |
 | `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ❌ | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ❌ | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ✅ `s13_rc_rebase_recovery.py` |
 | `StaleIssueGCLoop` | ✅ [0029] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ❌ |
-| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
-| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ⚠️ in catalog (no scenario file) | ❌ |
+| `StaleIssueLoop` | ❌ | ✅ [gotchas.md, stale-issue-gc-loop.md] | ❌ | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
+| `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062] | ✅ [bot-pr-port.md, task.md] | ❌ | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
+| `TermPrunerLoop` | ✅ [0057, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ❌ | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `7e4fc62` on 2026-05-19 20:27 UTC. Source last changed at `7e4fc62`. Status: 🟢 fresh._
+_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._

--- a/tests/sandbox_scenarios/scenarios/s16_stale_issue_scan.py
+++ b/tests/sandbox_scenarios/scenarios/s16_stale_issue_scan.py
@@ -1,0 +1,48 @@
+"""s16 — StaleIssueLoop scans open issues and emits a worker-status event.
+
+Golden path: with no stale issues in FakeGitHub (no issues seeded), the loop
+runs one tick, reports scanned=0 / closed=0, and emits a BACKGROUND_WORKER_STATUS
+event for ``stale_issue``. This proves the loop is wired into the caretaker
+registry and fires without crashing under the air-gapped sandbox.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s16_stale_issue_scan"
+DESCRIPTION = (
+    "StaleIssueLoop scans issues (empty repo) → emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["stale_issue"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by stale_issue."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "stale_issue"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    stale_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "stale_issue"
+    ]
+    assert len(stale_events) >= 1, (
+        f"Expected at least one stale_issue worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s17_skill_prompt_eval_clean_corpus.py
+++ b/tests/sandbox_scenarios/scenarios/s17_skill_prompt_eval_clean_corpus.py
@@ -1,0 +1,48 @@
+"""s17 — SkillPromptEvalLoop runs with a clean corpus and emits a worker-status event.
+
+Golden path: the loop is wired into the sandbox's caretaker registry.
+With no corpus cases to run (corpus runner returns empty list), the loop
+finishes with zero drift regressions and zero weak-case issues, emitting
+a BACKGROUND_WORKER_STATUS event for ``skill_prompt_eval``.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s17_skill_prompt_eval_clean_corpus"
+DESCRIPTION = (
+    "SkillPromptEvalLoop fires with empty corpus → emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["skill_prompt_eval"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by skill_prompt_eval."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "skill_prompt_eval"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    skill_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "skill_prompt_eval"
+    ]
+    assert len(skill_events) >= 1, (
+        f"Expected at least one skill_prompt_eval worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s18_retrospective_empty_queue.py
+++ b/tests/sandbox_scenarios/scenarios/s18_retrospective_empty_queue.py
@@ -1,0 +1,47 @@
+"""s18 — RetrospectiveLoop drains an empty queue and emits a worker-status event.
+
+Golden path: with no queued retrospective items, the loop finishes in one tick
+with processed=0 and emits a BACKGROUND_WORKER_STATUS event for ``retrospective``.
+This proves the loop is wired into the caretaker registry and fires cleanly.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s18_retrospective_empty_queue"
+DESCRIPTION = (
+    "RetrospectiveLoop drains empty queue → emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["retrospective"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by retrospective."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "retrospective"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    retro_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "retrospective"
+    ]
+    assert len(retro_events) >= 1, (
+        f"Expected at least one retrospective worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s19_report_issue_empty_queue.py
+++ b/tests/sandbox_scenarios/scenarios/s19_report_issue_empty_queue.py
@@ -1,0 +1,47 @@
+"""s19 — ReportIssueLoop drains an empty report queue and emits a worker-status event.
+
+Golden path: with no pending bug reports, the loop returns None (no work)
+but must still emit a BACKGROUND_WORKER_STATUS event for ``report_issue``,
+proving the loop is wired into the caretaker registry.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s19_report_issue_empty_queue"
+DESCRIPTION = (
+    "ReportIssueLoop sees empty queue → emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["report_issue"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by report_issue."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "report_issue"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    report_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "report_issue"
+    ]
+    assert len(report_events) >= 1, (
+        f"Expected at least one report_issue worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s20_rc_budget_no_regression.py
+++ b/tests/sandbox_scenarios/scenarios/s20_rc_budget_no_regression.py
@@ -1,0 +1,48 @@
+"""s20 — RCBudgetLoop runs with no RC history and emits a worker-status event.
+
+Golden path: with no RC promotion history (FakeGitHub returns an empty run
+list), the loop completes without filing a regression issue and emits a
+BACKGROUND_WORKER_STATUS event for ``rc_budget``.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s20_rc_budget_no_regression"
+DESCRIPTION = (
+    "RCBudgetLoop sees empty RC run history → no regression filed, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["rc_budget"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by rc_budget."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "rc_budget"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    rc_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "rc_budget"
+    ]
+    assert len(rc_events) >= 1, (
+        f"Expected at least one rc_budget worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s21_security_patch_no_alerts.py
+++ b/tests/sandbox_scenarios/scenarios/s21_security_patch_no_alerts.py
@@ -1,0 +1,48 @@
+"""s21 — SecurityPatchLoop runs with no Dependabot alerts and emits a worker-status event.
+
+Golden path: FakeGitHub returns an empty Dependabot alert list, so the loop
+files zero issues and emits a BACKGROUND_WORKER_STATUS event for
+``security_patch``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s21_security_patch_no_alerts"
+DESCRIPTION = (
+    "SecurityPatchLoop sees no Dependabot alerts → files nothing, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["security_patch"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by security_patch."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "security_patch"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    sec_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "security_patch"
+    ]
+    assert len(sec_events) >= 1, (
+        f"Expected at least one security_patch worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -179,8 +179,16 @@ def _build_diagnostic(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 def _build_report_issue(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from report_issue_loop import ReportIssueLoop  # noqa: PLC0415
 
-    state = ports.get("report_issue_state") or MagicMock()
-    ports.setdefault("report_issue_state", state)
+    state = ports.get("report_issue_state")
+    if state is None:
+        state = MagicMock()
+        # Return None from peek_report so _do_work takes the empty-queue path
+        # without constructing a report object whose MagicMock attributes cause
+        # TypeError in scan_base64_for_secrets (parity test safety).
+        state.peek_report.return_value = None
+        state.get_pending_reports.return_value = []
+        state.get_filed_reports.return_value = []
+        ports["report_issue_state"] = state
     return ReportIssueLoop(
         config=config,
         state=state,
@@ -212,10 +220,17 @@ def _build_security_patch(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 
 
 def _build_stale_issue(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    from models import StaleIssueSettings  # noqa: PLC0415
     from stale_issue_loop import StaleIssueLoop  # noqa: PLC0415
 
-    state = ports.get("stale_issue_state") or MagicMock()
-    ports.setdefault("stale_issue_state", state)
+    state = ports.get("stale_issue_state")
+    if state is None:
+        state = MagicMock()
+        # Provide a real StaleIssueSettings so staleness_days is an int, not
+        # a MagicMock — prevents TypeError in timedelta() during parity tests.
+        state.get_stale_issue_settings.return_value = StaleIssueSettings()
+        state.get_stale_issue_closed.return_value = set()
+        ports["stale_issue_state"] = state
     return StaleIssueLoop(config=config, prs=ports["github"], state=state, deps=deps)
 
 

--- a/tests/scenarios/test_term_proposer_loop_scenario.py
+++ b/tests/scenarios/test_term_proposer_loop_scenario.py
@@ -1,0 +1,59 @@
+"""MockWorld scenario for TermProposerLoop (advisor-y6vf coverage gap).
+
+Happy-path scenario: with no source files and no existing terms, the loop
+detects zero candidates and returns the ok stats dict without calling the LLM
+or opening a bot-PR.
+
+The loop does real filesystem scanning (``build_symbol_index`` + ``build_import_graph``
++ ``detect_candidates``); pointing it at an empty ``tmp_path`` makes every
+collection return empty, exercising the no-candidates early-return path cleanly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestTermProposerLoopScenario:
+    """MockWorld scenario coverage for TermProposerLoop (ADR-0054)."""
+
+    async def test_no_candidates_returns_zero_stats_without_calling_llm(
+        self, tmp_path
+    ) -> None:
+        """No source files → 0 candidates → LLM never called, no PR opened.
+
+        This is the minimal happy-path scenario that satisfies the MockWorld
+        scenario coverage criterion: loop is in the catalog AND a scenario file
+        invokes it via ``run_with_loops``.
+        """
+        world = MockWorld(tmp_path)
+
+        fake_llm = AsyncMock()
+        fake_llm.draft = AsyncMock()
+
+        # Point the loop at tmp_path (empty); symbol index + candidates are empty.
+        _seed_ports(
+            world,
+            term_proposer_repo_root=tmp_path,
+            term_proposer_llm=fake_llm,
+        )
+
+        stats = await world.run_with_loops(["term_proposer"], cycles=1)
+
+        result = stats["term_proposer"]
+        assert result is not None
+        assert result["status"] == "ok"
+        assert result["candidates"] == 0
+        assert result["drafted"] == 0
+        assert result["validated"] == 0
+        assert result["opened_pr"] is False
+
+        # LLM must never be called if there are no candidates.
+        fake_llm.draft.assert_not_awaited()

--- a/tests/scenarios/test_term_pruner_loop_scenario.py
+++ b/tests/scenarios/test_term_pruner_loop_scenario.py
@@ -1,0 +1,43 @@
+"""MockWorld scenario for TermPrunerLoop (advisor-y4e7 coverage gap).
+
+Happy-path scenario: when no terms exist on disk, the loop reports
+``deprecated=0`` and does not open a bot-PR.
+
+The loop does real filesystem scanning (``TermStore.list`` + ``build_symbol_index``);
+we point it at an empty ``tmp_path`` so both return empty collections, exercising
+the no-candidates short-circuit path cleanly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestTermPrunerLoopScenario:
+    """MockWorld scenario coverage for TermPrunerLoop (ADR-0057)."""
+
+    async def test_empty_terms_dir_returns_zero_deprecated(self, tmp_path) -> None:
+        """No terms on disk → 0 candidates, 0 deprecated, loop returns ok with no PR.
+
+        This is the minimal happy-path scenario that satisfies the MockWorld
+        scenario coverage criterion: loop is in the catalog AND a scenario file
+        invokes it via ``run_with_loops``.
+        """
+        world = MockWorld(tmp_path)
+
+        # Point the loop at tmp_path (empty); TermStore.list() returns [].
+        _seed_ports(world, term_pruner_repo_root=tmp_path)
+
+        stats = await world.run_with_loops(["term_pruner"], cycles=1)
+
+        result = stats["term_pruner"]
+        assert result is not None
+        assert result["status"] == "ok"
+        assert result["checked"] == 0
+        assert result["deprecated"] == 0
+        assert result["opened_pr"] is False

--- a/tests/test_merge_state_watcher_loop.py
+++ b/tests/test_merge_state_watcher_loop.py
@@ -1,0 +1,110 @@
+"""Unit tests for MergeStateWatcherLoop (advisor-2mf coverage gap).
+
+Closes the unit-test gap identified in the coverage matrix audit.  The
+watcher's underlying logic is already covered by ``test_merge_state_watcher.py``;
+these tests focus on the loop shell: enabled/disabled path, default interval,
+and that ``_do_work`` delegates to and propagates the watcher's stats.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from events import EventBus
+from merge_state_watcher_loop import MergeStateWatcherLoop
+
+
+def _make_loop(
+    tmp_path,
+    *,
+    enabled: bool = True,
+    conflicting_prs: list | None = None,
+    rebase_result: bool = True,
+    mergeable: bool = True,
+) -> MergeStateWatcherLoop:
+    """Factory: return a MergeStateWatcherLoop with stubbed dependencies."""
+    cfg = HydraFlowConfig(repo="acme/widgets")
+    stop = asyncio.Event()
+    stop.set()
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda name: enabled or name != "merge_state_watcher",
+    )
+    prs = AsyncMock()
+    prs.list_conflicting_prs = AsyncMock(return_value=conflicting_prs or [])
+    prs.update_pr_branch = AsyncMock(return_value=rebase_result)
+    prs.get_pr_mergeable = AsyncMock(return_value=mergeable)
+    prs.add_pr_labels = AsyncMock()
+    return MergeStateWatcherLoop(config=cfg, prs=prs, deps=deps)
+
+
+class TestMergeStateWatcherLoopShell:
+    """Loop shell: enabled/disabled gate, default interval, stats pass-through."""
+
+    async def test_disabled_via_kill_switch_returns_disabled_status(
+        self, tmp_path
+    ) -> None:
+        """When the kill-switch is off the loop short-circuits without calling prs."""
+        loop = _make_loop(tmp_path, enabled=False)
+        result = await loop._do_work()
+        assert result == {"status": "disabled"}
+
+    async def test_default_interval_is_ten_minutes(self, tmp_path) -> None:
+        """The default poll cadence is 600 s (10 min)."""
+        loop = _make_loop(tmp_path)
+        assert loop._get_default_interval() == 600
+
+    async def test_worker_name_is_merge_state_watcher(self, tmp_path) -> None:
+        """Worker name must match the constant used for kill-switch routing."""
+        loop = _make_loop(tmp_path)
+        assert loop._worker_name == "merge_state_watcher"
+
+    async def test_no_conflicting_prs_returns_zero_stats(self, tmp_path) -> None:
+        """Empty conflict list propagates as all-zero stats dict."""
+        loop = _make_loop(tmp_path, conflicting_prs=[])
+        result = await loop._do_work()
+        assert result is not None
+        assert result["checked"] == 0
+        assert result["rebased"] == 0
+        assert result["escalated"] == 0
+        assert result["skipped"] == 0
+
+    async def test_one_rebased_pr_reflected_in_stats(self, tmp_path) -> None:
+        """One conflicting PR that rebases cleanly: checked=1, rebased=1."""
+        from merge_state_watcher import ConflictingPR  # noqa: PLC0415
+
+        pr = ConflictingPR(number=42, branch="feat/x", labels=[])
+        loop = _make_loop(
+            tmp_path,
+            conflicting_prs=[pr],
+            rebase_result=True,
+            mergeable=True,
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["checked"] == 1
+        assert result["rebased"] == 1
+        assert result["escalated"] == 0
+
+    async def test_unresolvable_conflict_escalated(self, tmp_path) -> None:
+        """PR that cannot be rebased is escalated (HITL label applied)."""
+        from merge_state_watcher import ConflictingPR  # noqa: PLC0415
+
+        pr = ConflictingPR(number=99, branch="feat/y", labels=[])
+        loop = _make_loop(
+            tmp_path,
+            conflicting_prs=[pr],
+            rebase_result=False,
+            mergeable=False,
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["escalated"] == 1
+        assert result["rebased"] == 0


### PR DESCRIPTION
## Summary

Drains the remaining 10 sandbox-e2e / MockWorld / unit-test coverage-gap beads from the audit campaign.

### What was added

| Bead | Loop | Layer | File |
|------|------|-------|------|
| advisor-ry6s | StaleIssueLoop | sandbox-e2e | `s16_stale_issue_scan.py` |
| advisor-si37 | SkillPromptEvalLoop | sandbox-e2e | `s17_skill_prompt_eval_clean_corpus.py` |
| advisor-t2y | RetrospectiveLoop | sandbox-e2e | `s18_retrospective_empty_queue.py` |
| advisor-ttm | ReportIssueLoop | sandbox-e2e | `s19_report_issue_empty_queue.py` |
| advisor-x0v | RCBudgetLoop | sandbox-e2e | `s20_rc_budget_no_regression.py` |
| advisor-ym6 | SecurityPatchLoop | sandbox-e2e | `s21_security_patch_no_alerts.py` |
| advisor-y4e7 | TermPrunerLoop | MockWorld scenario | `test_term_pruner_loop_scenario.py` |
| advisor-y6vf | TermProposerLoop | MockWorld scenario | `test_term_proposer_loop_scenario.py` |
| advisor-2mf | MergeStateWatcherLoop | unit test | `test_merge_state_watcher_loop.py` |

### Supporting changes

- Hardened `_build_stale_issue` and `_build_report_issue` catalog defaults to provide proper `StaleIssueSettings()` and `peek_report=None` so parity tests pass without pre-seeded state ports.
- Ran `make arch-regen` to refresh `docs/arch/generated/coverage_matrix.md` — picks up all new test coverage in the generated output.

## Closes

advisor-ry6s, advisor-si37, advisor-t2y, advisor-ttm, advisor-x0v, advisor-ym6, advisor-y4e7, advisor-y6vf, advisor-2mf

🤖 Generated with [Claude Code](https://claude.com/claude-code)