### PR TITLE
test(scenarios): bulk backfill C — 9 coverage-gap beads

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T20:28:57.755224+00:00",
-  "commit_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c",
+  "regenerated_at": "2026-05-19T20:48:22.968862+00:00",
+  "commit_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "ports.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "labels.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "modules.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "events.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "adr_xref.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "mockworld.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "changelog.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "coverage_matrix.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "functional_areas.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "06a3de7a87389d53c08c3666c90ec3641264a72c"
+      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -225,4 +225,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `06a3de7` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
+- `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
 - `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
 - `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
 - `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
@@ -354,4 +354,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,20 +10,20 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ❌ |
+| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
 | `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
 | `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
 | `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
 | `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
-| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ❌ |
-| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ❌ | ⚠️ in catalog (no scenario file) | ❌ |
+| `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
+| `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
 | `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
 | `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
-| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ❌ |
-| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ❌ | ❌ |
-| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ❌ |
-| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ❌ |
+| `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
+| `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
+| `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
+| `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
 | `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `06a3de7` on 2026-05-19 20:28 UTC. Source last changed at `06a3de7`. Status: 🟢 fresh._
+_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._

--- a/tests/sandbox_scenarios/scenarios/s22_corpus_learning_no_escape_issues.py
+++ b/tests/sandbox_scenarios/scenarios/s22_corpus_learning_no_escape_issues.py
@@ -1,0 +1,48 @@
+"""s22 — CorpusLearningLoop runs with no escape issues and emits a worker-status event.
+
+Golden path: FakeGitHub returns an empty escape-issue list, so the loop
+finds no candidates and emits a BACKGROUND_WORKER_STATUS event for
+``corpus_learning``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s22_corpus_learning_no_escape_issues"
+DESCRIPTION = (
+    "CorpusLearningLoop sees no open escape issues → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["corpus_learning"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by corpus_learning."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "corpus_learning"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    cl_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "corpus_learning"
+    ]
+    assert len(cl_events) >= 1, (
+        f"Expected at least one corpus_learning worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s23_epic_sweeper_no_epics.py
+++ b/tests/sandbox_scenarios/scenarios/s23_epic_sweeper_no_epics.py
@@ -1,0 +1,47 @@
+"""s23 — EpicSweeperLoop scans open epics (empty) and emits a worker-status event.
+
+Golden path: with no open epics in FakeGitHub, the loop runs one tick,
+sweeps nothing, and emits a BACKGROUND_WORKER_STATUS event for
+``epic_sweeper``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s23_epic_sweeper_no_epics"
+DESCRIPTION = (
+    "EpicSweeperLoop sees no open epics → sweeps nothing, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["epic_sweeper"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by epic_sweeper."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "epic_sweeper"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    sweep_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "epic_sweeper"
+    ]
+    assert len(sweep_events) >= 1, (
+        f"Expected at least one epic_sweeper worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s24_entry_evidence_no_terms.py
+++ b/tests/sandbox_scenarios/scenarios/s24_entry_evidence_no_terms.py
@@ -1,0 +1,47 @@
+"""s24 — EntryEvidenceLoop runs with no UL terms and emits a worker-status event.
+
+Golden path: with no term files on disk, the loop skips LLM matching,
+opens no bot PR, and emits a BACKGROUND_WORKER_STATUS event for
+``entry_evidence``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s24_entry_evidence_no_terms"
+DESCRIPTION = (
+    "EntryEvidenceLoop finds no UL terms → idle tick, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["entry_evidence"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by entry_evidence."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "entry_evidence"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    ee_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "entry_evidence"
+    ]
+    assert len(ee_events) >= 1, (
+        f"Expected at least one entry_evidence worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s25_adr_reviewer_no_proposed_adrs.py
+++ b/tests/sandbox_scenarios/scenarios/s25_adr_reviewer_no_proposed_adrs.py
@@ -1,0 +1,47 @@
+"""s25 — ADRReviewerLoop runs with no proposed ADRs and emits a worker-status event.
+
+Golden path: the reviewer delegate returns no reviewed ADRs and the loop
+emits a BACKGROUND_WORKER_STATUS event for ``adr_reviewer``, proving
+caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s25_adr_reviewer_no_proposed_adrs"
+DESCRIPTION = (
+    "ADRReviewerLoop sees no proposed ADRs → idle tick, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["adr_reviewer"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by adr_reviewer."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "adr_reviewer"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    adr_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "adr_reviewer"
+    ]
+    assert len(adr_events) >= 1, (
+        f"Expected at least one adr_reviewer worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s26_cost_budget_watcher_unlimited.py
+++ b/tests/sandbox_scenarios/scenarios/s26_cost_budget_watcher_unlimited.py
@@ -1,0 +1,48 @@
+"""s26 — CostBudgetWatcherLoop runs in unlimited mode and emits a worker-status event.
+
+Golden path: ``daily_cost_budget_usd`` is None (unlimited mode), so the loop
+takes no action and emits a BACKGROUND_WORKER_STATUS event for
+``cost_budget_watcher``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s26_cost_budget_watcher_unlimited"
+DESCRIPTION = (
+    "CostBudgetWatcherLoop in unlimited mode (no cap) → no-op tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["cost_budget_watcher"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by cost_budget_watcher."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "cost_budget_watcher"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    cbw_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "cost_budget_watcher"
+    ]
+    assert len(cbw_events) >= 1, (
+        f"Expected at least one cost_budget_watcher worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s27_epic_monitor_no_epics.py
+++ b/tests/sandbox_scenarios/scenarios/s27_epic_monitor_no_epics.py
@@ -1,0 +1,47 @@
+"""s27 — EpicMonitorLoop runs with no open epics and emits a worker-status event.
+
+Golden path: the epic_manager delegate returns an empty result and the loop
+emits a BACKGROUND_WORKER_STATUS event for ``epic_monitor``, proving
+caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s27_epic_monitor_no_epics"
+DESCRIPTION = (
+    "EpicMonitorLoop sees no open epics → idle tick, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["epic_monitor"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by epic_monitor."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "epic_monitor"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    em_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "epic_monitor"
+    ]
+    assert len(em_events) >= 1, (
+        f"Expected at least one epic_monitor worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s28_edge_proposer_no_proposals.py
+++ b/tests/sandbox_scenarios/scenarios/s28_edge_proposer_no_proposals.py
@@ -1,0 +1,48 @@
+"""s28 — EdgeProposerLoop runs with no pending edge proposals and emits a worker-status event.
+
+Golden path: the loop finds no missing wiki edges and opens no bot PR.
+It emits a BACKGROUND_WORKER_STATUS event for ``edge_proposer``, proving
+caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s28_edge_proposer_no_proposals"
+DESCRIPTION = (
+    "EdgeProposerLoop finds no missing wiki edges → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["edge_proposer"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by edge_proposer."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "edge_proposer"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    ep_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "edge_proposer"
+    ]
+    assert len(ep_events) >= 1, (
+        f"Expected at least one edge_proposer worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -1026,6 +1026,49 @@ def _build_edge_proposer(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     )
 
 
+def _build_entry_evidence(ports: dict[str, Any], config: Any, deps: Any) -> Any:
+    """Build EntryEvidenceLoop for scenarios (ADR-0062).
+
+    The loop's external surface — ``LLMClient.complete_structured`` and
+    ``BotPRPort.open_bot_pr`` — cannot run inside a scenario. Tests seed:
+
+    * ``entry_evidence_llm`` — an LLMClient duck-type; defaults to a
+      MagicMock whose ``complete_structured`` resolves to ``{"term_ids": []}``.
+    * ``entry_evidence_pr_port`` — a BotPRPort duck-type; defaults to a
+      MagicMock whose ``open_bot_pr`` resolves to ``0``.
+    * ``entry_evidence_repo_root`` — ``Path``; defaults to ``config.repo_root``.
+
+    Mirrors the ``_build_edge_proposer`` / ``_build_term_proposer`` pattern.
+    """
+    from entry_evidence_loop import EntryEvidenceLoop  # noqa: PLC0415
+
+    llm = ports.get("entry_evidence_llm")
+    if llm is None:
+        llm = MagicMock()
+        llm.complete_structured = AsyncMock(return_value={"term_ids": []})
+        ports["entry_evidence_llm"] = llm
+
+    pr_port = ports.get("entry_evidence_pr_port")
+    if pr_port is None:
+        pr_port = MagicMock()
+        pr_port.open_bot_pr = AsyncMock(return_value=0)
+        ports["entry_evidence_pr_port"] = pr_port
+
+    repo_root = ports.get("entry_evidence_repo_root") or config.repo_root
+    dedup_path = ports.get("entry_evidence_dedup_path") or (
+        config.repo_root / ".entry_evidence_dedup.json"
+    )
+
+    return EntryEvidenceLoop(
+        config=config,
+        deps=deps,
+        llm=llm,
+        pr_port=pr_port,
+        repo_root=repo_root,
+        dedup_path=dedup_path,
+    )
+
+
 def _build_label_drift_watcher(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     """Build LabelDriftWatcherLoop for scenarios (ADR-0056).
 
@@ -1259,8 +1302,9 @@ _BUILDERS: dict[str, Any] = {
     # auto-agent (spec §1–§11; ADR-0050)
     "auto_agent_preflight": _build_auto_agent_preflight,
     "sandbox_failure_fixer": _build_sandbox_failure_fixer,
-    # ubiquitous-language (ADR-0054 + ADR-0057 + ADR-0058)
+    # ubiquitous-language (ADR-0054 + ADR-0057 + ADR-0058 + ADR-0062)
     "edge_proposer": _build_edge_proposer,
+    "entry_evidence": _build_entry_evidence,
     "term_proposer": _build_term_proposer,
     "term_pruner": _build_term_pruner,
     # label drift (ADR-0056)

--- a/tests/scenarios/test_cost_budget_watcher_loop_scenario.py
+++ b/tests/scenarios/test_cost_budget_watcher_loop_scenario.py
@@ -1,0 +1,47 @@
+"""MockWorld scenario for CostBudgetWatcherLoop (ADR-0029 caretaker pattern).
+
+Drives the loop through MockWorld with ``daily_cost_budget_usd = None``
+(unlimited mode). The loop short-circuits immediately and returns
+``{"action": "unlimited"}``. This proves the catalog builder is wired
+correctly and the loop runs without crashing under the MockWorld sandbox.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
+
+pytestmark = pytest.mark.scenario_loops
+
+
+class TestCostBudgetWatcherLoopScenario:
+    """MockWorld scenario coverage for CostBudgetWatcherLoop."""
+
+    async def test_unlimited_mode_no_op_tick(self, tmp_path) -> None:
+        """Loop in unlimited mode (cap=None) completes a tick without error."""
+        world = MockWorld(tmp_path)
+
+        # The catalog builder uses ports["state"] directly (StateTracker).
+        # Seed a mock that satisfies the CostBudgetWatcher surface.
+        state = MagicMock()
+        state.get_cost_budget_killed_workers.return_value = set()
+        state.set_cost_budget_killed_workers = MagicMock()
+
+        # BGWorkerManager must be injected post-construction.
+        bg_workers = MagicMock()
+        bg_workers.is_enabled = MagicMock(return_value=True)
+        bg_workers.set_enabled = MagicMock()
+
+        _seed_ports(world, state=state, bg_workers=bg_workers)
+
+        stats = await world.run_with_loops(["cost_budget_watcher"], cycles=1)
+
+        result = stats["cost_budget_watcher"]
+        # With daily_cost_budget_usd=None (the MockWorld default config),
+        # _do_work returns {"action": "unlimited"}.
+        assert result is not None
+        assert result.get("action") in ("unlimited", "config_disabled", "skipped")

--- a/tests/test_cost_budget_watcher_loop.py
+++ b/tests/test_cost_budget_watcher_loop.py
@@ -1,0 +1,62 @@
+"""Unit tests for CostBudgetWatcherLoop (advisor-a03 coverage gap).
+
+Closes the unit-test gap identified in the coverage-matrix audit.
+The canonical name ``test_cost_budget_watcher_loop.py`` satisfies the
+``_unit_check`` naming pattern used by the coverage-matrix generator.
+
+Substantive behavioural tests live in ``test_cost_budget_watcher_scenario.py``
+(filed before the naming convention was settled). This module adds a
+lightweight smoke test that confirms the loop constructs successfully and
+honours the ``daily_cost_budget_usd = None`` (unlimited) short-circuit —
+the concrete signal that closes the matrix gap.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cost_budget_watcher_loop import CostBudgetWatcherLoop
+
+
+def _make_loop(cap: float | None = None) -> CostBudgetWatcherLoop:
+    config = MagicMock()
+    config.daily_cost_budget_usd = cap
+    config.cost_budget_watcher_loop_enabled = True
+    state = MagicMock()
+    state.get_cost_budget_killed_workers.return_value = set()
+    pr_manager = AsyncMock()
+    deps = MagicMock()
+    loop = CostBudgetWatcherLoop(
+        config=config,
+        pr_manager=pr_manager,
+        state=state,
+        deps=deps,
+    )
+    bg = MagicMock()
+    bg.is_enabled.return_value = True
+    loop.set_bg_workers(bg)
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_unlimited_mode_returns_action_unlimited() -> None:
+    """``daily_cost_budget_usd = None`` → action=unlimited, no I/O."""
+    loop = _make_loop(cap=None)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        result = await loop._do_work()  # noqa: SLF001
+    mock_build.assert_not_called()
+    assert result == {"action": "unlimited"}
+
+
+@pytest.mark.asyncio
+async def test_under_cap_returns_ok() -> None:
+    """Spend below cap → action=ok, nothing disabled."""
+    loop = _make_loop(cap=50.0)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_build:
+        mock_build.return_value = {"total": {"cost_usd": 20.0}}
+        result = await loop._do_work()  # noqa: SLF001
+    assert result["action"] == "ok"
+    assert result["cap"] == 50.0
+    assert result["total"] == 20.0


### PR DESCRIPTION
## Summary

Drains 9 open `[coverage-gap]` beads from the audit campaign (Sandbox/Scenario/Unit tier).

| Bead | Loop | Layer | File |
|------|------|-------|------|
| advisor-2ad | CorpusLearningLoop | sandbox-e2e | `s22_corpus_learning_no_escape_issues.py` |
| advisor-538 | EpicSweeperLoop | sandbox-e2e | `s23_epic_sweeper_no_epics.py` |
| advisor-7m5 | EntryEvidenceLoop | sandbox-e2e | `s24_entry_evidence_no_terms.py` |
| advisor-dqz | ADRReviewerLoop | sandbox-e2e | `s25_adr_reviewer_no_proposed_adrs.py` |
| advisor-hn9 | CostBudgetWatcherLoop | sandbox-e2e | `s26_cost_budget_watcher_unlimited.py` |
| advisor-lgd | EpicMonitorLoop | sandbox-e2e | `s27_epic_monitor_no_epics.py` |
| advisor-vwh | EdgeProposerLoop | sandbox-e2e | `s28_edge_proposer_no_proposals.py` |
| advisor-a03 | CostBudgetWatcherLoop | unit | `test_cost_budget_watcher_loop.py` |
| (bonus) | CostBudgetWatcherLoop | MockWorld scenario | `test_cost_budget_watcher_loop_scenario.py` |

### Supporting changes

- Added `EntryEvidenceLoop` to `loop_registrations.py` (`_build_entry_evidence` builder) so the MockWorld scenario tier resolves to ✅ in the coverage matrix.
- `test_cost_budget_watcher_loop.py` added as the canonical name for the matrix generator's `_unit_check` (existing `test_cost_budget_watcher_scenario.py` was not detected by naming convention).
- Ran `make arch-regen` — all 7 target loops now show ✅ for Sandbox in `docs/arch/generated/coverage_matrix.md`.

### Pre-existing coverage (verified, no new test needed)

- advisor-2mf (MergeStateWatcherLoop unit): closed by PR #9026
- advisor-2kq (EdgeProposerLoop scenario): pre-existing `test_edge_proposer_scenario.py`

## Test plan

- [x] `make quality` passes (ruff lint + format + pyright + bandit + pytest)
- [x] All 37 collected tests pass (2 new unit + 1 new scenario + existing caretaker loops + entry evidence + edge proposer)
- [x] `make arch-regen` confirms coverage matrix updated
- [x] Tests-only PR — no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)