### PR TITLE
refactor(state): type 3 StateData fields with Pydantic sub-models

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -1736,6 +1736,22 @@ class TraceRunsContainer(BaseModel):
     next_run_id: dict[str, int] = Field(default_factory=dict)
 
 
+class RcBudgetDurationEntry(BaseModel):
+    """One RC-pipeline run recorded by RCBudgetLoop (spec §4.8).
+
+    Mirrors the dict shape written by ``rc_budget_loop.py`` so that old
+    on-disk JSON (plain dicts with these four keys) is auto-coerced by
+    Pydantic v2 on load.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    run_id: int
+    created_at: str
+    duration_s: int
+    conclusion: str
+
+
 class StateData(BaseModel):
     """Typed schema for the JSON-backed crash-recovery state."""
 
@@ -1813,7 +1829,9 @@ class StateData(BaseModel):
     ci_monitor_settings: CIMonitorSettings = Field(default_factory=CIMonitorSettings)
     ci_monitor_tracked_failures: dict[str, str] = Field(default_factory=dict)
     # Trust fleet — RCBudgetLoop (spec §4.8)
-    rc_budget_duration_history: list[dict[str, Any]] = Field(default_factory=list)
+    rc_budget_duration_history: list[RcBudgetDurationEntry] = Field(
+        default_factory=list
+    )
     rc_budget_attempts: dict[str, int] = Field(default_factory=dict)
     # Trust fleet — WikiRotDetectorLoop (spec §4.9)
     wiki_rot_attempts: dict[str, int] = Field(default_factory=dict)
@@ -1860,10 +1878,8 @@ class StateData(BaseModel):
     # LiveCorpusReplayLoop (#8786 Phase 3) — per-drift-signature attempt
     # counters for the 3-attempt escalation chain.
     live_corpus_drift_attempts: dict[str, int] = Field(default_factory=dict)
-    escalation_contexts: dict[str, dict[str, object]] = Field(default_factory=dict)
-    diagnostic_attempts: dict[str, list[dict[str, object]]] = Field(
-        default_factory=dict
-    )
+    escalation_contexts: dict[str, EscalationContext] = Field(default_factory=dict)
+    diagnostic_attempts: dict[str, list[AttemptRecord]] = Field(default_factory=dict)
     diagnosis_severities: dict[str, str] = Field(default_factory=dict)
     sentry_creation_attempts: dict[str, int] = Field(default_factory=dict)
     trace_runs: TraceRunsContainer = Field(default_factory=TraceRunsContainer)

--- a/src/state/_diagnostic.py
+++ b/src/state/_diagnostic.py
@@ -27,34 +27,26 @@ class DiagnosticStateMixin:
         self, issue_number: int, context: EscalationContext
     ) -> None:
         """Persist escalation context for *issue_number*."""
-        self._data.escalation_contexts[self._key(issue_number)] = context.model_dump()
+        self._data.escalation_contexts[self._key(issue_number)] = context
         self.save()
 
     def get_escalation_context(self, issue_number: int) -> EscalationContext | None:
         """Return escalation context for *issue_number*, or ``None`` if absent."""
-        from models import EscalationContext as EC  # noqa: PLC0415
-
-        raw = self._data.escalation_contexts.get(self._key(issue_number))
-        if raw is None:
-            return None
-        return EC.model_validate(raw)
+        return self._data.escalation_contexts.get(self._key(issue_number))
 
     # --- diagnostic attempts ---
 
     def add_diagnostic_attempt(self, issue_number: int, record: AttemptRecord) -> None:
         """Append a diagnostic fix attempt record for *issue_number*."""
         key = self._key(issue_number)
-        attempts = self._data.diagnostic_attempts.get(key, [])
-        attempts.append(record.model_dump())
+        attempts = list(self._data.diagnostic_attempts.get(key, []))
+        attempts.append(record)
         self._data.diagnostic_attempts[key] = attempts
         self.save()
 
     def get_diagnostic_attempts(self, issue_number: int) -> list[AttemptRecord]:
         """Return all diagnostic attempt records for *issue_number*."""
-        from models import AttemptRecord as AR  # noqa: PLC0415
-
-        raw_list = self._data.diagnostic_attempts.get(self._key(issue_number), [])
-        return [AR.model_validate(r) for r in raw_list]
+        return list(self._data.diagnostic_attempts.get(self._key(issue_number), []))
 
     # --- severity classification ---
 

--- a/src/state/_rc_budget.py
+++ b/src/state/_rc_budget.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from models import StateData
+    from models import RcBudgetDurationEntry, StateData
 
 
 class RCBudgetStateMixin:
@@ -15,11 +15,15 @@ class RCBudgetStateMixin:
 
     def save(self) -> None: ...  # provided by CoreMixin
 
-    def get_rc_budget_duration_history(self) -> list[dict[str, Any]]:
-        return [dict(entry) for entry in self._data.rc_budget_duration_history]
+    def get_rc_budget_duration_history(self) -> list[RcBudgetDurationEntry]:
+        return list(self._data.rc_budget_duration_history)
 
     def set_rc_budget_duration_history(self, history: list[dict[str, Any]]) -> None:
-        self._data.rc_budget_duration_history = [dict(entry) for entry in history]
+        from models import RcBudgetDurationEntry as Entry  # noqa: PLC0415
+
+        self._data.rc_budget_duration_history = [
+            Entry.model_validate(entry) for entry in history
+        ]
         self.save()
 
     def get_rc_budget_attempts(self, subject: str) -> int:

--- a/tests/test_diagnostic_state.py
+++ b/tests/test_diagnostic_state.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from models import AttemptRecord, EscalationContext, Severity
@@ -76,3 +78,58 @@ class TestDiagnosticState:
         assert state.get_escalation_context(42) is None
         assert state.get_diagnosis_severity(42) is None
         assert state.get_diagnostic_attempts(42) == []
+
+
+class TestDiagnosticStatePersistenceCompat:
+    """Old on-disk JSON (plain dicts) must load as typed sub-models."""
+
+    def test_escalation_context_old_disk_format(self, tmp_path) -> None:
+        """Plain-dict escalation_contexts in state.json coerces to EscalationContext."""
+        state_file = tmp_path / "state.json"
+        old_state = {
+            "schema_version": 1,
+            "escalation_contexts": {
+                "42": {
+                    "cause": "CI failed",
+                    "origin_phase": "review",
+                    "ci_logs": None,
+                    "review_comments": [],
+                    "pr_diff": None,
+                    "pr_number": 123,
+                    "code_scanning_alerts": [],
+                    "previous_attempts": [],
+                    "agent_transcript": None,
+                }
+            },
+        }
+        state_file.write_text(json.dumps(old_state))
+        st = StateTracker(state_file=state_file)
+        ctx = st.get_escalation_context(42)
+        assert ctx is not None
+        assert isinstance(ctx, EscalationContext)
+        assert ctx.cause == "CI failed"
+        assert ctx.pr_number == 123
+
+    def test_diagnostic_attempts_old_disk_format(self, tmp_path) -> None:
+        """Plain-dict diagnostic_attempts in state.json coerces to list[AttemptRecord]."""
+        state_file = tmp_path / "state.json"
+        old_state = {
+            "schema_version": 1,
+            "diagnostic_attempts": {
+                "42": [
+                    {
+                        "attempt_number": 1,
+                        "changes_made": True,
+                        "error_summary": "still failing",
+                        "timestamp": "2026-04-05T12:00:00Z",
+                    }
+                ]
+            },
+        }
+        state_file.write_text(json.dumps(old_state))
+        st = StateTracker(state_file=state_file)
+        attempts = st.get_diagnostic_attempts(42)
+        assert len(attempts) == 1
+        assert isinstance(attempts[0], AttemptRecord)
+        assert attempts[0].attempt_number == 1
+        assert attempts[0].changes_made is True

--- a/tests/test_state_rc_budget.py
+++ b/tests/test_state_rc_budget.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from models import RcBudgetDurationEntry
 from state import StateTracker
 
 
@@ -13,7 +14,7 @@ def _tracker(tmp_path: Path) -> StateTracker:
 
 def test_set_and_get_duration_history(tmp_path: Path) -> None:
     st = _tracker(tmp_path)
-    history = [
+    history_dicts = [
         {
             "run_id": 1,
             "created_at": "2026-04-01T00:00:00Z",
@@ -27,8 +28,42 @@ def test_set_and_get_duration_history(tmp_path: Path) -> None:
             "conclusion": "success",
         },
     ]
-    st.set_rc_budget_duration_history(history)
-    assert st.get_rc_budget_duration_history() == history
+    st.set_rc_budget_duration_history(history_dicts)
+    result = st.get_rc_budget_duration_history()
+    assert len(result) == 2
+    assert all(isinstance(e, RcBudgetDurationEntry) for e in result)
+    assert result[0].run_id == 1
+    assert result[0].created_at == "2026-04-01T00:00:00Z"
+    assert result[0].duration_s == 300
+    assert result[0].conclusion == "success"
+    assert result[1].run_id == 2
+
+
+def test_duration_history_persists_round_trip(tmp_path: Path) -> None:
+    """Old on-disk JSON (plain dicts) must deserialise to RcBudgetDurationEntry."""
+    import json
+
+    state_file = tmp_path / "state.json"
+    # Simulate a state file written by an older version of the code (plain dicts).
+    old_state = {
+        "schema_version": 1,
+        "rc_budget_duration_history": [
+            {
+                "run_id": 42,
+                "created_at": "2026-01-15T10:00:00Z",
+                "duration_s": 600,
+                "conclusion": "failure",
+            }
+        ],
+    }
+    state_file.write_text(json.dumps(old_state))
+    st = StateTracker(state_file=state_file)
+    history = st.get_rc_budget_duration_history()
+    assert len(history) == 1
+    assert isinstance(history[0], RcBudgetDurationEntry)
+    assert history[0].run_id == 42
+    assert history[0].duration_s == 600
+    assert history[0].conclusion == "failure"
 
 
 def test_inc_rc_budget_attempts_is_monotonic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- `rc_budget_duration_history`: `list[dict[str, Any]]` → `list[RcBudgetDurationEntry]` (new sub-model with `run_id`, `created_at`, `duration_s`, `conclusion`)
- `escalation_contexts`: `dict[str, dict[str, object]]` → `dict[str, EscalationContext]` (existing model, already in models.py)
- `diagnostic_attempts`: `dict[str, list[dict[str, object]]]` → `dict[str, list[AttemptRecord]]` (existing model, already in models.py)

All three changes are backwards-compatible: Pydantic v2 auto-coerces old on-disk plain-dict JSON on load. Regression tests added for each field's persistence round-trip.

`DiagnosticStateMixin` accessors simplified by removing `model_dump()` / `model_validate()` round-trips — the typed fields remove the need for manual coercion on every read/write.

Closes:
- advisor-7s7a (rc_budget_duration_history)
- advisor-i7fi (escalation_contexts)
- advisor-po1j (diagnostic_attempts)

## Test plan

- [x] `tests/test_state_rc_budget.py` — set/get round-trip + old-disk-format persistence regression
- [x] `tests/test_diagnostic_state.py` — escalation_context + diagnostic_attempts round-trips + old-disk-format persistence regressions for both fields
- [x] All 213 tests in the state/persistence/rc_budget/diagnostic suite pass
- [x] `make quality` green (only pre-existing `test_mkdocs_strict` failure unrelated to this change)
- [x] `ruff check` + `ruff format` clean on all changed files
- [x] `pyright` 0 errors on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)