### PR TITLE
test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft

### DIFF
--- a/docs/adr/0079-adr-reviewer-loop.md
+++ b/docs/adr/0079-adr-reviewer-loop.md
@@ -1,0 +1,61 @@
+# ADR-0079 — ADRReviewerLoop: Autonomous Council Review for Proposed ADRs
+
+**Status:** Proposed
+**Date:** 2026-05-19
+
+## Context
+
+HydraFlow accumulates proposed ADRs as architectural decisions are drafted.
+Without an automated review path, proposed ADRs wait indefinitely for a human
+to run the council review process manually. The `ADRCouncilReviewer` in
+`src/adr_reviewer.py` already encapsulates the full review pipeline
+(`review_proposed_adrs` scans for Proposed-status files, runs duplicate
+detection, scores against the 8-criterion rubric, and advances status to
+Accepted or escalates for human review), but nothing called it on a schedule.
+
+The review is a bounded, deterministic operation: find Proposed ADRs, run
+the council review, update status. There is no reason to require human
+initiation of each cycle.
+
+## Decision
+
+`ADRReviewerLoop` (`src/adr_reviewer_loop.py`) subclasses `BaseBackgroundLoop`
+and runs on the `adr_review_interval` cadence (default: 3600 seconds). Each tick:
+
+1. Checks the `enabled_cb` kill-switch (`worker_name="adr_reviewer"`).
+2. Checks `config.adr_reviewer_loop_enabled`; returns `{status: config_disabled}` if false.
+3. Delegates to `ADRCouncilReviewer.review_proposed_adrs()`, which:
+   - Scans `docs/adr/` for files with `**Status:** Proposed`.
+   - Runs duplicate detection and the 8-criterion rubric review.
+   - Advances ADR status to Accepted or files a `hydraflow-find` issue for
+     council escalation (per ADR-0040 — Proposed-only filter is the intentional scope).
+
+The loop is wired into the orchestrator and registered in the caretaker catalog
+via the `"adr_reviewer"` key. It follows the ADR-0029 caretaker loop pattern
+and the ADR-0049 kill-switch convention.
+
+## Consequences
+
+- Proposed ADRs receive automated council review without operator scheduling.
+- The review scope is intentionally bounded to Proposed-status ADRs (ADR-0040);
+  Accepted, Rejected, and Superseded ADRs are not re-processed.
+- Operators who want to pause review can set the kill-switch or disable
+  `adr_reviewer_loop_enabled` in config.
+- The loop does not open PRs; ADR status changes land via the
+  `ADRCouncilReviewer` toolchain, which writes files directly.
+
+## Alternatives considered
+
+- **Manual invocation only.** Rejected: the existing `ADRCouncilReviewer`
+  already supports the full pipeline; the loop is the steady-state driver.
+- **Trigger on PR merge.** Rejected: PR hooks are unreliable for long-running
+  reviews; a background loop with a configurable cadence is simpler and
+  consistent with all other caretaker loops.
+
+## Related
+
+- [ADR-0029](0029-caretaker-loop-pattern.md) — caretaker background loop pattern
+- [ADR-0040](0040-adr-reviewer-proposed-only-filter.md) — Proposed-only filter scope (Rejected: content below threshold, but design is valid)
+- [ADR-0049](0049-trust-loop-kill-switch-convention.md) — kill-switch convention
+- `src/adr_reviewer_loop.py:ADRReviewerLoop`
+- `src/adr_reviewer.py:ADRCouncilReviewer`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -102,6 +102,7 @@ ADR and that named test files actually exist.
 | [0076](0076-github-cache-loop.md) | GitHubCacheLoop: Centralized GitHub Data Cache | Proposed |
 | [0077](0077-pr-unsticker-loop.md) | PRUnstickerLoop: Goal-Driven HITL PR Resolution | Proposed |
 | [0078](0078-pricing-refresh-loop.md) | PricingRefreshLoop: Autonomous LLM Pricing Drift Detection | Proposed |
+| [0079](0079-adr-reviewer-loop.md) | ADRReviewerLoop: Autonomous Council Review for Proposed ADRs | Proposed |
 
 ## Adding a new ADR
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T20:48:22.968862+00:00",
-  "commit_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b",
+  "regenerated_at": "2026-05-19T21:10:47.131204+00:00",
+  "commit_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3",
   "artifacts": {
     "loops.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "ports.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "labels.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "modules.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "events.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "adr_xref.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "mockworld.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "changelog.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "coverage_matrix.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "functional_areas.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "ubiquitous-language.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "413ca5360e2ba4a602db6dfb6b62c19bb7e8cd0b"
+      "source_sha": "c54994ef996f8d7b98195af0b70cc2d8c31f09f3"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -82,6 +82,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0076 | `src.github_cache_loop` |
 | ADR-0077 | `src.pr_unsticker`, `src.pr_unsticker_loop` |
 | ADR-0078 | `src.pricing_refresh_diff`, `src.pricing_refresh_loop` |
+| ADR-0079 | `src.adr_reviewer`, `src.adr_reviewer_loop` |
 
 ## Module → ADRs
 
@@ -89,7 +90,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 |---|---|
 | `src.adr_drift` | ADR-0056 |
 | `src.adr_pre_validator` | ADR-0037 |
-| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040 |
+| `src.adr_reviewer` | ADR-0033, ADR-0034, ADR-0037, ADR-0039, ADR-0040, ADR-0079 |
+| `src.adr_reviewer_loop` | ADR-0079 |
 | `src.adr_touchpoint_auditor_loop` | ADR-0056 |
 | `src.adversarial_labels` | ADR-0064 |
 | `src.adversarial_retry_loop` | ADR-0064 |
@@ -225,4 +227,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
 - `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
 - `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
 - `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
@@ -354,4 +355,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -10,21 +10,21 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 
 | Loop | ADR | Wiki | Generated | Standard | Unit | Scenario | Sandbox |
 |---|---|---|---|---|---|---|---|
-| `ADRReviewerLoop` | ❌ | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
-| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ❌ |
-| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ❌ |
+| `ADRReviewerLoop` | ✅ [0079] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_reviewer_loop.py` | ✅ in catalog | ✅ `s25_adr_reviewer_no_proposed_adrs.py` |
+| `AdrTouchpointAuditorLoop` | ✅ [0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_adr_touchpoint_auditor_loop.py` | ✅ in catalog | ✅ `s33_adr_touchpoint_auditor_no_drift.py` |
+| `AutoAgentPreflightLoop` | ✅ [0050, 0063] | ✅ [dark-factory.md] | ❌ | ✅ README.md | ✅ `test_auto_agent_preflight_loop.py` | ✅ in catalog | ✅ `s31_auto_agent_preflight_no_escalations.py` |
 | `CIMonitorLoop` | ✅ [0029, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_ci_monitor_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s15_ci_monitor_main_branch_red.py` |
-| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ❌ |
+| `ContractRefreshLoop` | ✅ [0045, 0047] | ❌ | ❌ | ✅ README.md | ✅ `test_contract_refresh_loop.py` | ✅ in catalog | ✅ `s30_contract_refresh_clean.py` |
 | `CorpusLearningLoop` | ✅ [0045] | ❌ | ❌ | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
 | `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ❌ | ❌ | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ⚠️ in catalog (no scenario file) | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ❌ |
-| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ❌ |
+| `DiagnosticLoop` | ✅ [0050] | ❌ | ❌ | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
+| `DiagramLoop` | ✅ [0001] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
 | `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ❌ | ❌ | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
 | `EntryEvidenceLoop` | ✅ [0062, 0078] | ❌ | ❌ | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
 | `EpicMonitorLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
 | `EpicSweeperLoop` | ❌ | ✅ [architecture-async-control.md] | ❌ | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ❌ |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ❌ | ❌ | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ❌ | ❌ | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ❌ | ✅ README.md | ❌ | ❌ | ❌ |
 | `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ❌ | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ⚠️ in catalog (no scenario file) | ❌ |
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `413ca53` on 2026-05-19 20:48 UTC. Source last changed at `413ca53`. Status: 🟢 fresh._
+_Regenerated from commit `c54994e` on 2026-05-19 21:10 UTC. Source last changed at `c54994e`. Status: 🟢 fresh._

--- a/tests/sandbox_scenarios/scenarios/s29_fake_coverage_auditor_clean.py
+++ b/tests/sandbox_scenarios/scenarios/s29_fake_coverage_auditor_clean.py
@@ -1,0 +1,48 @@
+"""s29 — FakeCoverageAuditorLoop runs with a clean repo state and emits a worker-status event.
+
+Golden path: the loop finds no coverage gaps (empty last-known catalog,
+clean diff) and emits a BACKGROUND_WORKER_STATUS event for
+``fake_coverage_auditor``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s29_fake_coverage_auditor_clean"
+DESCRIPTION = (
+    "FakeCoverageAuditorLoop sees no coverage gaps → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["fake_coverage_auditor"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by fake_coverage_auditor."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "fake_coverage_auditor"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    fca_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "fake_coverage_auditor"
+    ]
+    assert len(fca_events) >= 1, (
+        f"Expected at least one fake_coverage_auditor worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s30_contract_refresh_clean.py
+++ b/tests/sandbox_scenarios/scenarios/s30_contract_refresh_clean.py
@@ -1,0 +1,47 @@
+"""s30 — ContractRefreshLoop runs with no contract drift and emits a worker-status event.
+
+Golden path: the loop records no drift across adapters (github, git, docker,
+claude) and opens no PR. It emits a BACKGROUND_WORKER_STATUS event for
+``contract_refresh``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s30_contract_refresh_clean"
+DESCRIPTION = (
+    "ContractRefreshLoop sees no adapter drift → idle tick, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["contract_refresh"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by contract_refresh."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "contract_refresh"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    cr_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "contract_refresh"
+    ]
+    assert len(cr_events) >= 1, (
+        f"Expected at least one contract_refresh worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s31_auto_agent_preflight_no_escalations.py
+++ b/tests/sandbox_scenarios/scenarios/s31_auto_agent_preflight_no_escalations.py
@@ -1,0 +1,48 @@
+"""s31 — AutoAgentPreflightLoop runs with an empty escalation queue and emits a worker-status event.
+
+Golden path: the loop finds no issues awaiting HITL preflight and emits a
+BACKGROUND_WORKER_STATUS event for ``auto_agent_preflight``, proving
+caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s31_auto_agent_preflight_no_escalations"
+DESCRIPTION = (
+    "AutoAgentPreflightLoop sees empty escalation queue → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["auto_agent_preflight"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by auto_agent_preflight."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "auto_agent_preflight"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    aap_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "auto_agent_preflight"
+    ]
+    assert len(aap_events) >= 1, (
+        f"Expected at least one auto_agent_preflight worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s32_diagnostic_no_failures.py
+++ b/tests/sandbox_scenarios/scenarios/s32_diagnostic_no_failures.py
@@ -1,0 +1,47 @@
+"""s32 — DiagnosticLoop runs with no recent failures and emits a worker-status event.
+
+Golden path: the loop scans recent CI runs, finds no failures requiring
+diagnosis, and emits a BACKGROUND_WORKER_STATUS event for ``diagnostic``,
+proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s32_diagnostic_no_failures"
+DESCRIPTION = (
+    "DiagnosticLoop sees no recent CI failures → idle tick, emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["diagnostic"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by diagnostic."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "diagnostic"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    diag_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "diagnostic"
+    ]
+    assert len(diag_events) >= 1, (
+        f"Expected at least one diagnostic worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s33_adr_touchpoint_auditor_no_drift.py
+++ b/tests/sandbox_scenarios/scenarios/s33_adr_touchpoint_auditor_no_drift.py
@@ -1,0 +1,48 @@
+"""s33 — AdrTouchpointAuditorLoop runs with no ADR drift and emits a worker-status event.
+
+Golden path: the loop scans recent merged PRs, finds no ADR touchpoint
+violations, and emits a BACKGROUND_WORKER_STATUS event for
+``adr_touchpoint_auditor``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s33_adr_touchpoint_auditor_no_drift"
+DESCRIPTION = (
+    "AdrTouchpointAuditorLoop finds no ADR drift in recent PRs → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["adr_touchpoint_auditor"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by adr_touchpoint_auditor."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "adr_touchpoint_auditor"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    ata_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "adr_touchpoint_auditor"
+    ]
+    assert len(ata_events) >= 1, (
+        f"Expected at least one adr_touchpoint_auditor worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s34_diagram_loop_no_changes.py
+++ b/tests/sandbox_scenarios/scenarios/s34_diagram_loop_no_changes.py
@@ -1,0 +1,48 @@
+"""s34 — DiagramLoop runs with no module changes and emits a worker-status event.
+
+Golden path: the loop checks for module-graph changes since the last
+architecture regen, finds none, and emits a BACKGROUND_WORKER_STATUS event
+for ``diagram-loop``, proving caretaker-registry wiring is intact.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s34_diagram_loop_no_changes"
+DESCRIPTION = (
+    "DiagramLoop finds no module changes since last regen → idle tick, "
+    "emits worker-status event."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["diagram_loop"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by diagram-loop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "diagram-loop"
+            for e in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    dl_events = [
+        e
+        for e in events_payload
+        if e.get("type") == "background_worker_status"
+        and e.get("data", {}).get("worker") == "diagram-loop"
+    ]
+    assert len(dl_events) >= 1, (
+        f"Expected at least one diagram-loop worker-status event; got none. "
+        f"All events: {events_payload!r}"
+    )


### PR DESCRIPTION
## Summary

- Adds sandbox-e2e happy-path scenarios s29–s34 for the 6 loops that were missing Sandbox coverage
- Adds ADR-0079 (Proposed) for ADRReviewerLoop, which had no architectural record
- Arch generated files updated automatically (coverage_matrix, adr_xref, meta)

## Scenarios added

| Scenario | Loop | Bead |
|---|---|---|
| s29_fake_coverage_auditor_clean | FakeCoverageAuditorLoop | advisor-ln3 |
| s30_contract_refresh_clean | ContractRefreshLoop | advisor-nwl |
| s31_auto_agent_preflight_no_escalations | AutoAgentPreflightLoop | advisor-pn6 |
| s32_diagnostic_no_failures | DiagnosticLoop | advisor-tjt |
| s33_adr_touchpoint_auditor_no_drift | AdrTouchpointAuditorLoop | advisor-vch |
| s34_diagram_loop_no_changes | DiagramLoop | advisor-ytt |

All follow the s22–s28 pattern: single happy-path tick assertion that `BACKGROUND_WORKER_STATUS` is emitted with the right worker name.

## ADR added

ADR-0079 — ADRReviewerLoop: Autonomous Council Review for Proposed ADRs (Proposed status, closes advisor-pg6)

## Test plan

- [x] `make quality` passed on this branch
- [x] All 6 new scenarios follow the established s22–s28 pattern and will be picked up by `test_sandbox_parity.py` automatically
- [x] ADR-0079 registered in `docs/adr/README.md` index
- [x] Coverage matrix updated automatically by `make arch-regen` during quality run

## Beads closed by this PR

advisor-ln3, advisor-nwl, advisor-pn6, advisor-tjt, advisor-vch, advisor-ytt, advisor-pg6

🤖 Generated with [Claude Code](https://claude.com/claude-code)