### PR TITLE
fix(loops): add reraise_on_credit_or_bug to 8 missed broad-except sites

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:57:58.999006+00:00",
-  "commit_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540",
+  "regenerated_at": "2026-05-20T19:57:14.409690+00:00",
+  "commit_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a",
   "artifacts": {
     "loops.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "ports.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "labels.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "modules.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "events.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "adr_xref.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "mockworld.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "changelog.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "coverage_matrix.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "functional_areas.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "ubiquitous-language.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
+      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:57:14.409690+00:00",
-  "commit_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a",
+  "regenerated_at": "2026-05-20T19:58:28.502098+00:00",
+  "commit_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "ports.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "labels.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "modules.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "events.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "adr_xref.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "mockworld.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "changelog.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "coverage_matrix.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "functional_areas.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "db6bcdb0db804bec1d639ea1fd9c2e5846b7a80a"
+      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:58:28.502098+00:00",
-  "commit_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b",
+  "regenerated_at": "2026-05-20T19:59:04.112194+00:00",
+  "commit_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598",
   "artifacts": {
     "loops.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "ports.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "labels.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "modules.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "events.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "adr_xref.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "mockworld.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "changelog.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "coverage_matrix.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "functional_areas.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "ubiquitous-language.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "c9baf4cf4994be13b679eccd539a920a0d0ad66b"
+      "source_sha": "2efdbb14e55aedf94a0d2cfc32940baeb9422598"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `c9baf4c` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `2efdbb1` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `fecc6a8` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `10e9737` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `81ce3ea` — chore(arch): regen post-rebase against staging *(2026-05-20)*
 - `ffd5f38` — chore(arch): regen post-rebase against staging *(2026-05-20)*
 - `049ec06` — test(sandbox): ADR-0063 W3a/W3b/W4/W5 recovery-path scenarios (s36/s37/s39/s40 rewrite) *(2026-05-20)*
 - `23def6e` — feat(mockworld): FakeLLM scripting hooks for discover/plan-review/shape-council/spec-review failure paths *(2026-05-20)*
@@ -377,4 +380,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `81ce3ea` — chore(arch): regen post-rebase against staging *(2026-05-20)*
-- `ffd5f38` — chore(arch): regen post-rebase against staging *(2026-05-20)*
 - `049ec06` — test(sandbox): ADR-0063 W3a/W3b/W4/W5 recovery-path scenarios (s36/s37/s39/s40 rewrite) *(2026-05-20)*
 - `23def6e` — feat(mockworld): FakeLLM scripting hooks for discover/plan-review/shape-council/spec-review failure paths *(2026-05-20)*
 - `3b9ea23` — test(sandbox): ADR-0063 workstream e2e coverage (s35-s40) *(2026-05-20)*
@@ -377,4 +375,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `c9baf4c` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `ffd5f38` — chore(arch): regen post-rebase against staging *(2026-05-20)*
 - `049ec06` — test(sandbox): ADR-0063 W3a/W3b/W4/W5 recovery-path scenarios (s36/s37/s39/s40 rewrite) *(2026-05-20)*
 - `23def6e` — feat(mockworld): FakeLLM scripting hooks for discover/plan-review/shape-council/spec-review failure paths *(2026-05-20)*
 - `3b9ea23` — test(sandbox): ADR-0063 workstream e2e coverage (s35-s40) *(2026-05-20)*
@@ -375,4 +377,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._
+_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `db6bcdb` on 2026-05-20 19:57 UTC. Source last changed at `db6bcdb`. Status: 🟢 fresh._
+_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `c9baf4c` on 2026-05-20 19:58 UTC. Source last changed at `c9baf4c`. Status: 🟢 fresh._
+_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._

--- a/src/bug_reproducer.py
+++ b/src/bug_reproducer.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
+from exception_classify import reraise_on_credit_or_bug
 from models import (
     ReproductionOutcome,
     ReproductionResult,
@@ -99,6 +100,7 @@ class BugReproducer(BaseRunner):
         try:
             transcript = await self._run_reproducer_subprocess(task)
         except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             result.error = f"reproducer subprocess failed: {exc}"
             result.investigation = f"subprocess raised: {exc}"
             result.duration_seconds = time.monotonic() - start

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
+from exception_classify import reraise_on_credit_or_bug
 from models import PipelineIssueStatus, PipelineSnapshotEntry, QueueStats, Task
 from subprocess_util import AuthenticationError
 from task_source import TaskFetcher
@@ -199,7 +200,8 @@ class IssueStore:
             issues = await self._fetcher.fetch_all()
         except AuthenticationError:
             raise
-        except Exception:
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
             logger.exception("IssueStore refresh failed — will retry next cycle")
             return
 

--- a/src/metrics_manager.py
+++ b/src/metrics_manager.py
@@ -11,6 +11,7 @@ from pydantic import ValidationError
 
 from config import HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
+from exception_classify import reraise_on_credit_or_bug
 from models import MetricsSnapshot, MetricsSyncResult, QueueStats
 from pr_manager import PRManager
 from state import StateTracker
@@ -197,16 +198,19 @@ class MetricsManager:
         if queue_stats:
             queue_depth = dict(queue_stats.queue_depth)
 
-        # GitHub label counts
+        # GitHub label counts.  Each key is independently defaulted so a
+        # partial response surfaces what was returned rather than discarding
+        # all of it via the broad except (#6722).
         github_open_by_label: dict[str, int] = {}
         github_total_closed = 0
         github_total_merged = 0
         try:
             counts = await self._prs.get_label_counts(self._config)
-            github_open_by_label = counts["open_by_label"]
-            github_total_closed = counts["total_closed"]
-            github_total_merged = counts["total_merged"]
-        except Exception:
+            github_open_by_label = counts.get("open_by_label", {})
+            github_total_closed = counts.get("total_closed", 0)
+            github_total_merged = counts.get("total_merged", 0)
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
             logger.warning(
                 "Could not fetch GitHub label counts for snapshot", exc_info=True
             )

--- a/src/plan_reviewer.py
+++ b/src/plan_reviewer.py
@@ -36,6 +36,7 @@ from typing import TYPE_CHECKING
 
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
+from exception_classify import reraise_on_credit_or_bug
 from models import (
     PlanFinding,
     PlanFindingSeverity,
@@ -174,6 +175,7 @@ class PlanReviewer(BaseRunner):
         try:
             transcript = await self._run_review_subprocess(task, plan_result)
         except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             review.error = f"reviewer subprocess failed: {exc}"
             review.summary = "Reviewer subprocess raised"
             review.duration_seconds = time.monotonic() - start

--- a/src/report_issue_loop.py
+++ b/src/report_issue_loop.py
@@ -257,7 +257,8 @@ class ReportIssueLoop(BaseBackgroundLoop):
                     event_bus=self._bus,
                     total_cost_24h=total_cost_24h,
                 )
-            except Exception:
+            except Exception as exc:
+                reraise_on_credit_or_bug(exc)
                 logger.warning("Daily cost-budget sweep failed", exc_info=True)
             return None
 

--- a/src/retrospective_loop.py
+++ b/src/retrospective_loop.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 from events import EventType, HydraFlowEvent
+from exception_classify import reraise_on_credit_or_bug
 from retrospective_queue import QueueKind
 
 if TYPE_CHECKING:
@@ -91,7 +92,8 @@ class RetrospectiveLoop(BaseBackgroundLoop):
                 stale_proposals += result.get("stale_proposals", 0)
                 acknowledged.append(item.id)
                 await self._publish_update(item, "processed")
-            except Exception:
+            except Exception as exc:
+                reraise_on_credit_or_bug(exc)
                 logger.warning(
                     "Retrospective: failed to process %s item (id=%s) — will retry",
                     item.kind,
@@ -286,7 +288,8 @@ class RetrospectiveLoop(BaseBackgroundLoop):
 
         try:
             closed = await self._prs.list_closed_issues_by_label(hitl_labels[0])
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
             # The lookup is best-effort; reraising would block the entire
             # verify-proposals tick on a transient GitHub fault.
             logger.debug(

--- a/tests/regressions/test_credit_exhausted_reraise.py
+++ b/tests/regressions/test_credit_exhausted_reraise.py
@@ -9,7 +9,7 @@ same reraise_on_credit_or_bug pattern covers all 7.
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,11 +21,8 @@ import pytest
 # isinstance checks (e.g. reraise_on_credit_or_bug uses bare imports).
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "src"))
 
-from adversarial_retry_loop import AdversarialRetryLoop
-from pending_concerns import Concern
 from subprocess_util import CreditExhaustedError
 from tests.helpers import make_bg_loop_deps
-
 
 # ---------------------------------------------------------------------------
 # CorpusLearningLoop — wraps gh issue list subprocess + escape-signal query
@@ -70,14 +67,16 @@ class TestCorpusLearningCreditExhaustedReraise:
 
         loop, _ = self._make_loop(tmp_path)
 
-        with patch.object(
-            loop,
-            "_list_escape_signals",
-            new_callable=AsyncMock,
-            side_effect=CreditExhaustedError("credits exhausted"),
+        with (
+            patch.object(
+                loop,
+                "_list_escape_signals",
+                new_callable=AsyncMock,
+                side_effect=CreditExhaustedError("credits exhausted"),
+            ),
+            pytest.raises(CreditExhaustedError, match="credits exhausted"),
         ):
-            with pytest.raises(CreditExhaustedError, match="credits exhausted"):
-                await loop._do_work()
+            await loop._do_work()
 
     @pytest.mark.asyncio
     async def test_credit_exhausted_propagates_through_create_issue(
@@ -105,3 +104,287 @@ class TestCorpusLearningCreditExhaustedReraise:
             CreditExhaustedError, match="credits exhausted during issue creation"
         ):
             await loop._record_validation_failure(signal, result)
+
+
+# ---------------------------------------------------------------------------
+# PlanReviewer — wraps _run_review_subprocess (LLM call)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanReviewerCreditExhaustedReraise:
+    """CreditExhaustedError raised by the review subprocess must propagate
+    out of the broad except in PlanReviewer.review()."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_review_subprocess(self) -> None:
+        from unittest.mock import patch
+
+        from models import PlanResult, Task
+        from plan_reviewer import PlanReviewer
+
+        @dataclass
+        class _StubConfig:
+            dry_run: bool = False
+            repo_root: Path = Path("/tmp")
+            state_dir: Path = Path("/tmp/state")
+            log_dir: Path = Path("/tmp/logs")
+            transcript_dir: Path = Path("/tmp/transcripts")
+
+        reviewer = PlanReviewer.__new__(PlanReviewer)
+        reviewer._config = _StubConfig()  # type: ignore[assignment]
+        reviewer._bus = AsyncMock()  # type: ignore[assignment]
+
+        task = Task(id=42, title="t", body="b")
+        plan = PlanResult(
+            issue_number=42, success=True, plan="PLAN_START\nstep\nPLAN_END"
+        )
+
+        with (
+            patch.object(
+                PlanReviewer,
+                "_run_review_subprocess",
+                side_effect=CreditExhaustedError("credits exhausted in plan review"),
+            ),
+            pytest.raises(
+                CreditExhaustedError, match="credits exhausted in plan review"
+            ),
+        ):
+            await reviewer.review(task, plan)
+
+
+# ---------------------------------------------------------------------------
+# BugReproducer — wraps _run_reproducer_subprocess (LLM call)
+# ---------------------------------------------------------------------------
+
+
+class TestBugReproducerCreditExhaustedReraise:
+    """CreditExhaustedError raised by the reproducer subprocess must propagate
+    out of the broad except in BugReproducer.reproduce()."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_reproducer_subprocess(
+        self,
+    ) -> None:
+        from unittest.mock import patch
+
+        from bug_reproducer import BugReproducer
+        from models import Task
+
+        @dataclass
+        class _StubConfig:
+            dry_run: bool = False
+            repo_root: Path = Path("/tmp")
+            state_dir: Path = Path("/tmp/state")
+            log_dir: Path = Path("/tmp/logs")
+            transcript_dir: Path = Path("/tmp/transcripts")
+
+        reproducer = BugReproducer.__new__(BugReproducer)
+        reproducer._config = _StubConfig()  # type: ignore[assignment]
+        reproducer._bus = AsyncMock()  # type: ignore[assignment]
+
+        task = Task(id=99, title="Bug", body="repro me")
+
+        with (
+            patch.object(
+                BugReproducer,
+                "_run_reproducer_subprocess",
+                side_effect=CreditExhaustedError("credits exhausted in bug reproducer"),
+            ),
+            pytest.raises(
+                CreditExhaustedError, match="credits exhausted in bug reproducer"
+            ),
+        ):
+            await reproducer.reproduce(task)
+
+
+# ---------------------------------------------------------------------------
+# IssueStore — wraps TaskFetcher.fetch_all (GitHub poll)
+# ---------------------------------------------------------------------------
+
+
+class TestIssueStoreCreditExhaustedReraise:
+    """CreditExhaustedError raised by fetch_all must propagate out of the broad
+    except in IssueStore.refresh()."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_refresh(
+        self, tmp_path: Path
+    ) -> None:
+        from events import EventBus
+        from issue_store import IssueStore
+
+        deps = make_bg_loop_deps(tmp_path)
+        fetcher = MagicMock()
+        fetcher.fetch_all = AsyncMock(
+            side_effect=CreditExhaustedError("credits exhausted in issue store refresh")
+        )
+        store = IssueStore(deps.config, fetcher, EventBus())
+
+        with pytest.raises(
+            CreditExhaustedError, match="credits exhausted in issue store refresh"
+        ):
+            await store.refresh()
+
+
+# ---------------------------------------------------------------------------
+# MetricsManager — wraps pr_manager.get_label_counts (gh subprocess)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsManagerCreditExhaustedReraise:
+    """CreditExhaustedError raised by get_label_counts must propagate out of
+    the broad except in MetricsManager._build_snapshot()."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_build_snapshot(
+        self, tmp_path: Path
+    ) -> None:
+        from events import EventBus
+        from metrics_manager import MetricsManager
+        from models import LifetimeStats
+
+        deps = make_bg_loop_deps(tmp_path)
+        state = MagicMock()
+        state.get_lifetime_stats = MagicMock(return_value=LifetimeStats())
+        pr_manager = AsyncMock()
+        pr_manager.get_label_counts = AsyncMock(
+            side_effect=CreditExhaustedError(
+                "credits exhausted in metrics get_label_counts"
+            )
+        )
+        manager = MetricsManager(deps.config, state, pr_manager, EventBus())
+
+        with pytest.raises(
+            CreditExhaustedError, match="credits exhausted in metrics get_label_counts"
+        ):
+            await manager._build_snapshot(None)
+
+
+# ---------------------------------------------------------------------------
+# RetrospectiveLoop — _do_work catches process-item exceptions, and
+# _reconcile_closed_hitl_issues catches list_closed_issues_by_label
+# ---------------------------------------------------------------------------
+
+
+class TestRetrospectiveLoopCreditExhaustedReraise:
+    """CreditExhaustedError raised inside RetrospectiveLoop's broad-except sites
+    must propagate, not be swallowed."""
+
+    def _make_loop(self, tmp_path: Path):
+        from retrospective_loop import RetrospectiveLoop
+
+        deps = make_bg_loop_deps(tmp_path)
+        retro = MagicMock()
+        insights = MagicMock()
+        queue = MagicMock()
+        prs = AsyncMock()
+        loop = RetrospectiveLoop(
+            config=deps.config,
+            deps=deps.loop_deps,
+            retrospective=retro,
+            insights=insights,
+            queue=queue,
+            prs=prs,
+        )
+        return loop, queue, prs
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_process_item(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        loop, queue, _ = self._make_loop(tmp_path)
+        item = MagicMock()
+        item.id = "item-1"
+        item.kind = "retro"
+        queue.load = MagicMock(return_value=[item])
+
+        with (
+            patch.object(
+                loop,
+                "_process_item",
+                new_callable=AsyncMock,
+                side_effect=CreditExhaustedError(
+                    "credits exhausted in retro process_item"
+                ),
+            ),
+            pytest.raises(
+                CreditExhaustedError, match="credits exhausted in retro process_item"
+            ),
+        ):
+            await loop._do_work()
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_reconcile_closed_hitl(
+        self, tmp_path: Path
+    ) -> None:
+        from datetime import UTC, datetime
+
+        loop, _, prs = self._make_loop(tmp_path)
+        prs.list_closed_issues_by_label = AsyncMock(
+            side_effect=CreditExhaustedError(
+                "credits exhausted in list_closed_issues_by_label"
+            )
+        )
+        # Seed the in-memory window so the early-return on empty doesn't fire.
+        loop._hitl_filed_at["recurring_feedback"] = datetime.now(UTC)
+
+        with pytest.raises(
+            CreditExhaustedError,
+            match="credits exhausted in list_closed_issues_by_label",
+        ):
+            await loop._reconcile_closed_hitl_issues()
+
+
+# ---------------------------------------------------------------------------
+# ReportIssueLoop — cost-budget sweep (peek_report=None branch)
+# ---------------------------------------------------------------------------
+
+
+class TestReportIssueLoopCreditExhaustedReraise:
+    """CreditExhaustedError raised inside the cost-budget sweep must propagate
+    out of the broad except guarding the rollup read."""
+
+    @pytest.mark.asyncio
+    async def test_credit_exhausted_propagates_through_cost_budget_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        from report_issue_loop import ReportIssueLoop
+
+        deps = make_bg_loop_deps(tmp_path)
+        state = MagicMock()
+        state.peek_report = MagicMock(return_value=None)
+        pr_manager = AsyncMock()
+
+        loop = ReportIssueLoop(
+            config=deps.config,
+            state=state,
+            pr_manager=pr_manager,
+            deps=deps.loop_deps,
+        )
+
+        async def _noop_sweep() -> int:
+            return 0
+
+        with (
+            patch.object(
+                loop, "_sweep_stale_reports", new_callable=AsyncMock, return_value=0
+            ),
+            patch.object(
+                loop, "_sync_filed_reports", new_callable=AsyncMock, return_value=0
+            ),
+            patch(
+                "report_issue_loop.build_rolling_24h",
+                side_effect=CreditExhaustedError(
+                    "credits exhausted in cost budget sweep"
+                ),
+            ),
+            pytest.raises(
+                CreditExhaustedError, match="credits exhausted in cost budget sweep"
+            ),
+        ):
+            _ = _noop_sweep  # keep helper name referenced for clarity
+            await loop._do_work()

--- a/tests/regressions/test_issue_6722.py
+++ b/tests/regressions/test_issue_6722.py
@@ -70,7 +70,6 @@ class TestPartialLabelCountsMissingFirstKey:
     """
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(reason="Regression for issue #6722 — fix not yet landed", strict=False)
     async def test_partial_dict_missing_open_by_label(
         self, state: StateTracker, event_bus: EventBus
     ) -> None:


### PR DESCRIPTION
## Summary

Closes #8180. Covers remaining sites in #8058 not addressed by PR #7521 or PR #8788. Folds in #6722 (uncovered by the reraise).

Per `docs/wiki/dark-factory.md` §2.2, every broad except guarding a subprocess-spawning runner must call `reraise_on_credit_or_bug(exc)` first so `CreditExhaustedError` / `AuthenticationError` surface to the loop supervisor instead of being silently swallowed.

## Sites fixed

| File | Line | Wrapped call |
|------|------|--------------|
| `src/plan_reviewer.py` | 134 | `_run_review_subprocess` (LLM) |
| `src/bug_reproducer.py` | 101 | `_run_reproducer_subprocess` (LLM) |
| `src/issue_store.py` | 202 | `TaskFetcher.fetch_all` (gh poll) |
| `src/metrics_manager.py` | 209 | `pr_manager.get_label_counts` (gh) |
| `src/retrospective_loop.py` | 94 | `_process_item` per-item loop |
| `src/retrospective_loop.py` | 289 | `list_closed_issues_by_label` (HITL re-arm) |
| `src/report_issue_loop.py` | 260 | daily cost-budget sweep |

7 new parametrized regression tests in `tests/regressions/test_credit_exhausted_reraise.py` following the existing `CorpusLearningLoop` pattern.

## Issue #6722 folded in

`metrics_manager._build_snapshot` now uses `.get()` with defaults for each label-count key. The pre-existing broad except was masking partial-dict `KeyError`s by discarding every successfully-read key; my reraise unmasked that latent bug, so the `.get()` defaulting goes in the same PR. `xfail` removed from `test_partial_dict_missing_open_by_label`.

## Already-addressed siblings (not in this diff)

- #8760 (RepoWikiLoop) — fixed in PR #8788 (commit 692a06fc); will close separately
- #8761 (SkillPromptEvalLoop) reraise portion — fixed in PR #8788; exit-code-differentiation half remains open

## Test plan

- [x] `make test` — 13,620 passed (4 pre-existing failures on `origin/staging` confirmed: catalog `entry_evidence`, sandbox `s23/s25/s27`, mkdocs strict — all unrelated to this PR)
- [x] `make lint-check` — clean
- [x] `pyright` on touched files — clean
- [x] `tests/regressions/test_credit_exhausted_reraise.py` — 9 tests, all pass
- [x] `tests/regressions/test_issue_6722.py` — 3 tests, all pass (1 xfail removed)

Drive-by: 6 unrelated test files re-formatted by ruff to unblock `lint-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)