### PR TITLE
fix(label-drift): widen regex + drop dead branch + tailor reconcile comment

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:56:04.955529+00:00",
-  "commit_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37",
+  "regenerated_at": "2026-05-20T19:56:41.731265+00:00",
+  "commit_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb",
   "artifacts": {
     "loops.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "ports.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "labels.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "modules.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "events.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "adr_xref.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "mockworld.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "changelog.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "coverage_matrix.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "functional_areas.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "ubiquitous-language.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
+      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:56:41.731265+00:00",
-  "commit_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb",
+  "regenerated_at": "2026-05-20T19:57:58.999006+00:00",
+  "commit_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "ports.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "labels.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "modules.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "events.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "adr_xref.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "mockworld.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "changelog.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "coverage_matrix.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "functional_areas.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "ubiquitous-language.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "f8aa46c5c73901f141e59913584a0a0fbb966dcb"
+      "source_sha": "81ce3ea6410ca40c51b006a6c245b3a8b03f4540"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -375,4 +375,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `81ce3ea` — chore(arch): regen post-rebase against staging *(2026-05-20)*
+- `ffd5f38` — chore(arch): regen post-rebase against staging *(2026-05-20)*
 - `049ec06` — test(sandbox): ADR-0063 W3a/W3b/W4/W5 recovery-path scenarios (s36/s37/s39/s40 rewrite) *(2026-05-20)*
 - `23def6e` — feat(mockworld): FakeLLM scripting hooks for discover/plan-review/shape-council/spec-review failure paths *(2026-05-20)*
 - `3b9ea23` — test(sandbox): ADR-0063 workstream e2e coverage (s35-s40) *(2026-05-20)*
@@ -375,4 +377,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._
+_Regenerated from commit `81ce3ea` on 2026-05-20 19:57 UTC. Source last changed at `81ce3ea`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._
+_Regenerated from commit `f8aa46c` on 2026-05-20 19:56 UTC. Source last changed at `f8aa46c`. Status: 🟢 fresh._

--- a/src/label_drift_watcher_loop.py
+++ b/src/label_drift_watcher_loop.py
@@ -79,21 +79,27 @@ class LabelDriftWatcherLoop(BaseBackgroundLoop):
         - ``pr_at_pre_pr_stage``: PR has commits but a pre-PR label
           (ready/plan/find); push the PR forward to ``hydraflow-review``.
           Issue label stays.
-        - ``pr_behind_issue``: PR at ready/plan while issue at review;
-          push the PR forward to ``hydraflow-review``.
         """
         if d.kind == "pr_ahead_of_issue":
             await self._prs.swap_pipeline_labels(d.issue, "hydraflow-review")
-        elif d.kind in {"pr_at_pre_pr_stage", "pr_behind_issue"}:
+            moved_clause = (
+                f"Issue #{d.issue} moved from `{d.issue_label}` to "
+                f"`hydraflow-review` to match PR #{d.pr} (which was already "
+                f"at `{d.pr_label}`)."
+            )
+        else:  # pr_at_pre_pr_stage
             await self._prs.swap_pipeline_labels(d.pr, "hydraflow-review")
+            moved_clause = (
+                f"PR #{d.pr} moved from `{d.pr_label}` to `hydraflow-review` "
+                f"to match issue #{d.issue} (which was already at "
+                f"`{d.issue_label}`)."
+            )
 
         await self._prs.post_comment(
             d.issue,
             (
                 f"**LabelDriftWatcher** reconciled label drift "
-                f"(issue was at `{d.issue_label}`, PR #{d.pr} was at "
-                f"`{d.pr_label}`, kind={d.kind}). Both should now be aligned "
-                f"at `hydraflow-review`.\n\n"
+                f"(kind=`{d.kind}`). {moved_clause}\n\n"
                 "---\n*Automated by HydraFlow Label Drift Watcher (ADR-0056)*"
             ),
         )

--- a/src/models.py
+++ b/src/models.py
@@ -885,8 +885,6 @@ class LabelDrift(BaseModel):
         - ``pr_ahead_of_issue``: issue labelled ``hydraflow-ready`` /
           ``hydraflow-plan`` while the PR is at ``hydraflow-review`` /
           ``hydraflow-fixed`` / ``hydraflow-hitl`` with commits.
-        - ``pr_behind_issue``: PR at ``hydraflow-ready`` /
-          ``hydraflow-plan`` while issue is at ``hydraflow-review``.
         - ``pr_at_pre_pr_stage``: PR labelled ``hydraflow-ready`` /
           ``hydraflow-plan`` / ``hydraflow-find`` while it has commits
           (PR-stage labels are review/hitl/fixed only).
@@ -897,7 +895,7 @@ class LabelDrift(BaseModel):
     pr_commits: int = Field(ge=0, description="Number of commits on the PR")
     issue_label: str = Field(description="Current pipeline label on the issue")
     pr_label: str = Field(description="Current pipeline label on the PR")
-    kind: Literal["pr_ahead_of_issue", "pr_behind_issue", "pr_at_pre_pr_stage"] = Field(
+    kind: Literal["pr_ahead_of_issue", "pr_at_pre_pr_stage"] = Field(
         description="Drift category — see ADR-0056"
     )
     detected_at: datetime = Field(

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1729,7 +1729,7 @@ class PRManager:
         out: list[LabelDrift] = []
         pre_pr_labels = {"hydraflow-ready", "hydraflow-plan", "hydraflow-find"}
         post_pr_labels = {"hydraflow-fixed", "hydraflow-hitl"}
-        fixes_re = re.compile(r"[Ff]ixes\s+#(\d+)")
+        fixes_re = re.compile(r"(?:fixes|closes|resolves)\s+#(\d+)", re.IGNORECASE)
 
         for pr in raw:
             if not isinstance(pr, dict):

--- a/tests/test_label_drift_watcher_loop.py
+++ b/tests/test_label_drift_watcher_loop.py
@@ -183,3 +183,74 @@ async def test_disabled_returns_status(loop_env) -> None:
 
     assert stats == {"status": "disabled"}
     pr.find_label_drift.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pr_ahead_of_issue_comment_describes_issue_move(loop_env) -> None:
+    """For ``pr_ahead_of_issue`` the issue is the entity that moved — the
+    comment must describe only the issue relabel, not claim both ends moved.
+    See #8727."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=42,
+        pr=100,
+        pr_commits=2,
+        issue_label="hydraflow-ready",
+        pr_label="hydraflow-review",
+        kind="pr_ahead_of_issue",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(return_value=[drift])
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    await loop._do_work()
+
+    body = pr.post_comment.await_args.args[1]
+    # The PR stayed at hydraflow-review; only the issue moved.
+    assert "Both should now be aligned" not in body, (
+        "Misleading: PR did not move for pr_ahead_of_issue"
+    )
+    assert "issue" in body.lower()
+
+
+@pytest.mark.asyncio
+async def test_pr_at_pre_pr_stage_comment_describes_pr_move(loop_env) -> None:
+    """For ``pr_at_pre_pr_stage`` the PR is the entity that moved — the
+    comment must say so. See #8727."""
+    cfg, pr = loop_env
+    drift = LabelDrift(
+        issue=99,
+        pr=200,
+        pr_commits=3,
+        issue_label="hydraflow-review",
+        pr_label="hydraflow-ready",
+        kind="pr_at_pre_pr_stage",
+        detected_at=datetime.now(UTC),
+    )
+    pr.find_label_drift = AsyncMock(return_value=[drift])
+    stop = asyncio.Event()
+    loop = LabelDriftWatcherLoop(config=cfg, pr_manager=pr, deps=_deps(stop))
+
+    await loop._do_work()
+
+    body = pr.post_comment.await_args.args[1]
+    assert "PR" in body
+    assert "hydraflow-review" in body
+
+
+def test_label_drift_kind_rejects_pr_behind_issue() -> None:
+    """``LabelDrift.kind`` Literal must no longer accept ``pr_behind_issue``
+    — the value was unreachable (no producer in find_label_drift). See #8726."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        LabelDrift(
+            issue=1,
+            pr=2,
+            pr_commits=1,
+            issue_label="hydraflow-review",
+            pr_label="hydraflow-ready",
+            kind="pr_behind_issue",  # type: ignore[arg-type]
+            detected_at=datetime.now(UTC),
+        )

--- a/tests/test_pr_manager_drift.py
+++ b/tests/test_pr_manager_drift.py
@@ -1,9 +1,8 @@
 """PRManager.find_label_drift — detects cross-entity issue/PR drift.
 
-See ADR-0056. Three drift kinds:
+See ADR-0056. Two drift kinds:
 - ``pr_ahead_of_issue``: issue at ready/plan, PR at review with commits
 - ``pr_at_pre_pr_stage``: PR labelled ready/plan but has commits
-- ``pr_behind_issue``: PR at ready/plan while issue at review
 """
 
 from __future__ import annotations
@@ -166,3 +165,52 @@ class TestFindLabelDrift:
             drift = await mgr.find_label_drift()
 
         assert drift == []
+
+
+class TestFindLabelDriftAutoCloseKeywords:
+    """``find_label_drift`` must recognize every auto-close keyword GitHub does
+    (``Fixes``, ``Closes``, ``Resolves`` — case insensitive). Regex previously
+    matched only ``[Ff]ixes`` so PRs using ``Closes``/``Resolves`` were
+    silently skipped. See #8725.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "keyword",
+        ["Fixes", "fixes", "Closes", "closes", "Resolves", "resolves", "FIXES"],
+    )
+    async def test_detects_each_auto_close_keyword(
+        self, keyword: str, config, event_bus
+    ) -> None:
+        mgr = make_pr_manager(config, event_bus)
+
+        prs_json = json.dumps(
+            [
+                {
+                    "number": 500,
+                    "labels": [{"name": "hydraflow-review"}],
+                    "body": f"## Summary\n\n{keyword} #42.\n",
+                    "commits": [{"oid": "a"}],
+                }
+            ]
+        )
+        issue_json = json.dumps({"labels": [{"name": "hydraflow-ready"}]})
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(
+                side_effect=_gh_responder(
+                    {
+                        ("pr", "list"): prs_json,
+                        ("issue", "view"): issue_json,
+                    }
+                )
+            ),
+        ):
+            drift = await mgr.find_label_drift()
+
+        assert len(drift) == 1, (
+            f"Keyword {keyword!r} should be detected as an auto-close link"
+        )
+        assert drift[0].issue == 42
+        assert drift[0].pr == 500


### PR DESCRIPTION
## Summary

Three small fixes from retroactive review of PR #8723 (ADR-0056). Closes #8725, #8726, #8727.

| Issue | Fix |
|-------|-----|
| #8725 | `find_label_drift` regex widened from `[Ff]ixes` to `(?:fixes\|closes\|resolves)` with `re.IGNORECASE` so PRs using GitHub's other auto-close keywords aren't silently skipped. |
| #8726 | Drop the unused `pr_behind_issue` value from the `LabelDrift.kind` Literal and the corresponding `_reconcile` branch. No producer in `find_label_drift` ever emitted it. |
| #8727 | Tailor the reconciliation comment per `d.kind`. Old template was misleading for `pr_ahead_of_issue` because it claimed both ends were now aligned at `hydraflow-review` when in fact only the issue moved. |

## Tests

- `tests/test_pr_manager_drift.py` — parametrized regex coverage for `Fixes`, `fixes`, `Closes`, `closes`, `Resolves`, `resolves`, `FIXES`
- `tests/test_label_drift_watcher_loop.py` — per-kind comment-text assertions + `ValidationError` on `pr_behind_issue`

## Verification

- [x] `make test` — 13,625 passed (same 5 pre-existing failures as PR #9032: catalog `entry_evidence`, sandbox `s23/s25/s27`, mkdocs strict — all unrelated)
- [x] `make lint-check` — clean
- [x] All 23 tests in the touched drift suite pass

## Note on drive-by

The same 6 unrelated test files re-formatted by ruff in PR #9032 are also in this diff — branched off the same pre-merge `origin/staging` tip. When both PRs land, the duplication resolves trivially via git's auto-merge of identical hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)