### PR TITLE
fix(subprocess_util): lock-guard _get_gh_semaphore lazy init

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-20T19:03:09.429897+00:00",
-  "commit_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5",
+  "regenerated_at": "2026-05-20T19:56:04.955529+00:00",
+  "commit_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "ports.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "labels.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "modules.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "events.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "adr_xref.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "mockworld.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "changelog.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "coverage_matrix.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "functional_areas.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ea1634e999f08aa74af68b23e597c4ab62dd77f5"
+      "source_sha": "27c084e0febf9b13c3ee6a5c7ab0c4e052f75a37"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -241,4 +241,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `049ec06` — test(sandbox): ADR-0063 W3a/W3b/W4/W5 recovery-path scenarios (s36/s37/s39/s40 rewrite) *(2026-05-20)*
 - `23def6e` — feat(mockworld): FakeLLM scripting hooks for discover/plan-review/shape-council/spec-review failure paths *(2026-05-20)*
 - `3b9ea23` — test(sandbox): ADR-0063 workstream e2e coverage (s35-s40) *(2026-05-20)*
 - `6981598` — chore(arch): regen post-rebase round 3 *(2026-05-20)*
@@ -374,4 +375,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `ea1634e` on 2026-05-20 19:03 UTC. Source last changed at `ea1634e`. Status: 🟢 fresh._
+_Regenerated from commit `27c084e` on 2026-05-20 19:56 UTC. Source last changed at `27c084e`. Status: 🟢 fresh._

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -131,10 +131,18 @@ def configure_gh_concurrency(limit: int) -> None:
 
 
 def _get_gh_semaphore() -> asyncio.Semaphore:
-    """Return the global semaphore, creating with defaults if not configured."""
+    """Return the global semaphore, creating with defaults if not configured.
+
+    The None-check + construct + assign sequence is guarded by
+    ``_rate_limit_lock`` so two threads racing the lazy init can't each
+    construct a fresh ``Semaphore`` and silently overwrite each other
+    (issue #8657 — same TOCTOU anti-pattern as #7838 and #7839).
+    """
     global _gh_semaphore  # noqa: PLW0603
     if _gh_semaphore is None:
-        _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
+        with _rate_limit_lock:
+            if _gh_semaphore is None:
+                _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
     return _gh_semaphore
 
 

--- a/tests/regressions/test_issue_8657.py
+++ b/tests/regressions/test_issue_8657.py
@@ -1,0 +1,104 @@
+"""Regression test for issue #8657.
+
+Bug: ``subprocess_util._get_gh_semaphore()`` is a check-then-set TOCTOU
+pattern that can construct two ``asyncio.Semaphore`` objects when two
+threads race past the ``if _gh_semaphore is None`` guard before either
+store happens.  The second STORE silently replaces the first; any caller
+that captured the first reference now holds a semaphore disconnected
+from the global, breaking the global concurrency limit invariant.
+
+Sibling: issue #7838 (``EpicManager._release_locks``) and issue #7839 /
+PR #8665 (``workspace._FETCH_LOCKS`` / ``_WORKTREE_LOCKS``) — same
+anti-pattern, fixed the same way (atomic operation that cannot be
+fooled by ``__contains__`` / TOCTOU).
+
+Expected behaviour after fix:
+    ``_get_gh_semaphore()`` guards the None-check + construct + assign
+    sequence with the existing module-level ``_rate_limit_lock``
+    (``threading.Lock``).  Two threads that race the lazy init still
+    construct exactly one ``Semaphore`` between them.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from collections.abc import Generator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+import subprocess_util  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_semaphore_global() -> Generator[None, None, None]:
+    """Isolate the semaphore global from other tests in the suite."""
+    original = subprocess_util._gh_semaphore
+    subprocess_util._gh_semaphore = None
+    yield
+    subprocess_util._gh_semaphore = original
+
+
+class TestSemaphoreLazyInitTOCTOU:
+    """Issue #8657 — ``_get_gh_semaphore()`` must guard the lazy init so two
+    concurrent first-callers construct exactly one ``Semaphore`` between them.
+    """
+
+    def test_two_threads_racing_lazy_init_construct_one_semaphore(self) -> None:
+        """Without the fix, both threads pass the ``is None`` check and both
+        construct a fresh ``Semaphore``; the second STORE silently overwrites
+        the first.
+
+        Strategy: slow down the constructor so the second thread observes
+        ``_gh_semaphore is None`` while the first thread is mid-construct.
+        With the lock-guarded fix, the second thread blocks on the lock
+        until the first finishes and stores, then short-circuits to the
+        existing global without constructing.
+        """
+        constructions: list[object] = []
+        construction_started = threading.Event()
+        real_semaphore_cls = subprocess_util.asyncio.Semaphore
+
+        def slow_constructor(*args: object, **kwargs: object) -> object:
+            construction_started.set()
+            # Hold the would-be race window open long enough for the second
+            # thread to reach the None check.
+            time.sleep(0.05)
+            sem = real_semaphore_cls(*args, **kwargs)  # type: ignore[arg-type]
+            constructions.append(sem)
+            return sem
+
+        def call_first() -> None:
+            subprocess_util._get_gh_semaphore()
+
+        def call_second() -> None:
+            # Wait until the first thread is mid-construction (inside the
+            # racy window) before our own _get_gh_semaphore call. This
+            # forces both threads to observe ``is None`` simultaneously
+            # without the fix; with the fix, this thread blocks on the
+            # lock until the first thread's store completes.
+            assert construction_started.wait(timeout=2.0)
+            subprocess_util._get_gh_semaphore()
+
+        with patch("subprocess_util.asyncio.Semaphore", side_effect=slow_constructor):
+            t1 = threading.Thread(target=call_first)
+            t2 = threading.Thread(target=call_second)
+            t1.start()
+            t2.start()
+            t1.join(timeout=3.0)
+            t2.join(timeout=3.0)
+
+        assert not t1.is_alive() and not t2.is_alive(), (
+            "Threads did not finish — the lazy-init lock should not deadlock."
+        )
+        assert len(constructions) == 1, (
+            f"_get_gh_semaphore must lock-guard the None-check + construct + "
+            f"assign sequence — got {len(constructions)} concurrent Semaphore "
+            "constructions when both threads observed _gh_semaphore is None."
+        )


### PR DESCRIPTION
## Summary

Closes #8657. Sibling #8659 was already addressed by PR #8665 (closed separately, no diff here).

The bug is the same TOCTOU anti-pattern as #7838 and #7839 — check-then-set on a module-level singleton:

\`\`\`python
def _get_gh_semaphore() -> asyncio.Semaphore:
    global _gh_semaphore
    if _gh_semaphore is None:
        _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
    return _gh_semaphore
\`\`\`

Two threads can both observe \`is None\` before either store happens, each construct a fresh Semaphore, and the second STORE silently replaces the first. Any caller that captured the first reference via \`async with _get_gh_semaphore():\` now holds a semaphore disconnected from the global, breaking the global GitHub concurrency invariant.

## Fix

Double-checked locking using the existing \`_rate_limit_lock\` (a module-level \`threading.Lock\` already used by the rate-limit cooldown state). Only the rare unconfigured first-call path pays the lock cost.

\`\`\`python
if _gh_semaphore is None:
    with _rate_limit_lock:
        if _gh_semaphore is None:
            _gh_semaphore = asyncio.Semaphore(_GH_DEFAULT_CONCURRENCY)
return _gh_semaphore
\`\`\`

## Tests

\`tests/regressions/test_issue_8657.py\` — slow-constructor pattern (precedent: #7991 pass #2). Patches \`asyncio.Semaphore\` to sleep mid-construction so a second thread reaches the None check while the first is still constructing. RED on the buggy code (2 constructions), GREEN with the fix (1 construction).

## Verification

- [x] \`make test\` — 13,616 passed (same 5 pre-existing failures as PRs #9032 / #9034: mkdocs strict, catalog \`entry_evidence\`, sandbox \`s23/s25/s27\`)
- [x] \`make lint-check\` — clean
- [x] \`tests/test_subprocess_util.py\` + \`tests/regressions/test_issue_7991.py\` + new test — 108 passed

## Note on drive-by

Same 6 unrelated test files re-formatted by ruff as in PR #9032 / #9034 to unblock \`lint-check\`. Branched off the same pre-merge \`origin/staging\` tip — when any of the three lands first, the others resolve trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)