### PR TITLE
feat(adversarial): remove the switch — pipeline always on

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-19T22:24:57.591567+00:00",
-  "commit_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d",
+  "regenerated_at": "2026-05-19T23:08:57.924401+00:00",
+  "commit_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023",
   "artifacts": {
     "loops.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "ports.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "labels.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "modules.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "events.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "adr_xref.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "mockworld.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "changelog.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "coverage_matrix.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "functional_areas.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "ubiquitous-language.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "1adda7d911df54863923a018c2ac49aa29dfa69d"
+      "source_sha": "31313f71ba98a67b97b384b814eb6fd7887b9023"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -227,4 +227,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,13 +6,10 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `1adda7d` — merge: integrate origin/staging (PRs #9027/#9028/#9030) *(2026-05-19)*
+- `31313f7` — feat(adversarial): flip pipeline ON by default (#9025) (#9025) *(2026-05-19)*
 - `6d6ed95` — test+docs(coverage): final cleanup wave — 6 sandbox scenarios + 1 ADR draft *(2026-05-19)*
 - `cb8508c` — test(scenarios): bulk coverage backfill C (9 beads) *(2026-05-19)*
-- `c96d91d` — merge: integrate origin/staging (PR #9026 bulk-B scenarios) *(2026-05-19)*
-- `1147674` — merge: integrate latest origin/staging into adversarial-pipeline-default-on *(2026-05-19)*
 - `c32919f` — test(scenarios): coverage backfill for 10 loops (bulk B) *(2026-05-19)*
-- `194894a` — feat(adversarial): flip pipeline ON by default *(2026-05-19)*
 - `2cc3d81` — chore(arch): regen after UL lint updates generated views *(2026-05-19)*
 - `7e4fc62` — docs(wiki+standards+adr): backfill 19 coverage-gap beads (batch 2) *(2026-05-19)*
 - `52a6c17` — test(flake-tracker): cover _download_junit paths (closes advisor-q08q) *(2026-05-19)*
@@ -360,4 +357,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -77,4 +77,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -277,4 +277,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -51,4 +51,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `1adda7d` on 2026-05-19 22:24 UTC. Source last changed at `1adda7d`. Status: 🟢 fresh._
+_Regenerated from commit `31313f7` on 2026-05-19 23:08 UTC. Source last changed at `31313f7`. Status: 🟢 fresh._

--- a/src/config.py
+++ b/src/config.py
@@ -1371,23 +1371,6 @@ class HydraFlowConfig(BaseModel):
         ),
     )
 
-    # Earlier-adversarial pipeline (ADR-0064). Flipped ON by default — the
-    # four adversarial stages (AssumptionSurfacer, PlanCouncil,
-    # SpecACGenerator, SpecJudge in plan; ComplexityGate + DiscoveryCouncil
-    # in discover; ShapeChallenger + ShapeExpertCouncil in shape) wire onto
-    # the phases at factory construction. Operators can set this to False
-    # to disable, but the intent is one-way-on: the pipeline is the new
-    # baseline for load-bearing work in the dark factory.
-    adversarial_pipeline_enabled: bool = Field(
-        default=True,
-        description=(
-            "Enable the earlier-adversarial pipeline: ComplexityGate routing "
-            "+ AssumptionSurfacer / Council / SpecJudge stages around the "
-            "existing planner. ON by default — the pipeline is now the "
-            "baseline for load-bearing work."
-        ),
-    )
-
     # Shadow corpus (#8786) — opt-in live sampling of production
     # subprocess calls. When enabled, every gh/git/docker/claude call
     # feeds a bounded, normalized, PII-scrubbed YAML corpus that

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -645,19 +645,16 @@ def build_services(
 
     shape_phase._council = ExpertCouncil(config, event_bus)
 
-    # Earlier-adversarial pipeline (ADR-0064). Opt-in via
-    # ``adversarial_pipeline_enabled`` so the pipeline ships dark by
-    # default. The ComplexityGate wiring is colocated here because it
-    # only depends on ``discover_phase``; the full AgentLike wiring for
-    # plan/discover/shape happens after ``planner_phase`` is
-    # constructed (see _wire_adversarial_agents below).
-    if config.adversarial_pipeline_enabled:
-        from complexity_gate import ComplexityGate  # noqa: PLC0415
+    # Earlier-adversarial pipeline (ADR-0064). Always-on baseline; the
+    # ComplexityGate wiring is colocated here because it only depends on
+    # ``discover_phase``; the full AgentLike wiring for plan/discover/shape
+    # happens after ``planner_phase`` is constructed (below).
+    from complexity_gate import ComplexityGate  # noqa: PLC0415
 
-        # ``llm=None`` falls back to label + keyword heuristics; the
-        # gate defaults to LOAD_BEARING when uncertain, so a heuristic-
-        # only gate is safe (it never silently skips real work).
-        discover_phase.attach_complexity_gate(ComplexityGate(llm=None))
+    # ``llm=None`` falls back to label + keyword heuristics; the gate
+    # defaults to LOAD_BEARING when uncertain, so a heuristic-only gate
+    # is safe (it never silently skips real work).
+    discover_phase.attach_complexity_gate(ComplexityGate(llm=None))
 
     planner_phase = PlanPhase(
         config,
@@ -680,59 +677,58 @@ def build_services(
 
     # Earlier-adversarial pipeline AgentLike wiring (ADR-0064).
     #
-    # Once the config flag is on, attach ``SubprocessAgentRunner``
-    # adapters to every adversarial-stage slot across plan, discover,
-    # and shape phases. Each adapter is stateless (the per-call
-    # ``system_prompt`` differentiates a surfacer from a council
-    # voter), so a single instance is shared across all slots.
+    # Attach ``SubprocessAgentRunner`` adapters to every adversarial-stage
+    # slot across plan, discover, and shape phases. Each adapter is
+    # stateless (the per-call ``system_prompt`` differentiates a surfacer
+    # from a council voter), so a single instance is shared across all
+    # slots.
     #
     # Why one shared instance: the AgentLike contract is
     # ``run(system_prompt, user_message) -> str``. The adapter holds
-    # only the SubprocessRunner + model/tool config — no per-stage
-    # state. Sharing also keeps the factory small; tests still verify
-    # each slot is non-None per-phase.
-    if config.adversarial_pipeline_enabled:
-        from adversarial_agent_runner import SubprocessAgentRunner  # noqa: PLC0415
+    # only the SubprocessRunner + model/tool config — no per-stage state.
+    # Sharing keeps the factory small; tests verify each slot is
+    # non-None per-phase.
+    from adversarial_agent_runner import SubprocessAgentRunner  # noqa: PLC0415
 
-        adversarial_agent = SubprocessAgentRunner(
-            runner=subprocess_runner,
-            tool=config.implementation_tool,
-            credentials=credentials,
-        )
+    adversarial_agent = SubprocessAgentRunner(
+        runner=subprocess_runner,
+        tool=config.implementation_tool,
+        credentials=credentials,
+    )
 
-        planner_phase.attach_adversarial_agents(
-            surfacer_agent=adversarial_agent,
-            council_agents={
-                "builder": adversarial_agent,
-                "tester": adversarial_agent,
-                "risk_skeptic": adversarial_agent,
-            },
-            spec_ac_agent=adversarial_agent,
-            spec_judge_agent=adversarial_agent,
-        )
-        # ADR-0063 W3b: the plan touchpoint-expander shares the same
-        # AgentLike contract and the same enablement gate. Wired post-
-        # construction (mirrors ``attach_adversarial_agents``) so the
-        # field default stays ``None`` for legacy code paths and tests.
-        planner_phase._touchpoint_expander = PlanTouchpointExpander(
-            agent=adversarial_agent,
-        )
-        discover_phase.attach_adversarial_agents(
-            surfacer_agent=adversarial_agent,
-            council_agents={
-                "problem_sharpener": adversarial_agent,
-                "existing_solution_hunter": adversarial_agent,
-                "cheapest_test_advocate": adversarial_agent,
-            },
-        )
-        shape_phase.attach_adversarial_agents(
-            challenger_agent=adversarial_agent,
-            council_agents={
-                "user_advocate": adversarial_agent,
-                "tech_lead": adversarial_agent,
-                "product_strategist": adversarial_agent,
-            },
-        )
+    planner_phase.attach_adversarial_agents(
+        surfacer_agent=adversarial_agent,
+        council_agents={
+            "builder": adversarial_agent,
+            "tester": adversarial_agent,
+            "risk_skeptic": adversarial_agent,
+        },
+        spec_ac_agent=adversarial_agent,
+        spec_judge_agent=adversarial_agent,
+    )
+    # ADR-0063 W3b: the plan touchpoint-expander shares the same
+    # AgentLike contract. Wired post-construction (mirrors
+    # ``attach_adversarial_agents``) so the field default stays ``None``
+    # for tests that build PlanPhase directly without the factory.
+    planner_phase._touchpoint_expander = PlanTouchpointExpander(
+        agent=adversarial_agent,
+    )
+    discover_phase.attach_adversarial_agents(
+        surfacer_agent=adversarial_agent,
+        council_agents={
+            "problem_sharpener": adversarial_agent,
+            "existing_solution_hunter": adversarial_agent,
+            "cheapest_test_advocate": adversarial_agent,
+        },
+    )
+    shape_phase.attach_adversarial_agents(
+        challenger_agent=adversarial_agent,
+        council_agents={
+            "user_advocate": adversarial_agent,
+            "tech_lead": adversarial_agent,
+            "product_strategist": adversarial_agent,
+        },
+    )
 
     hitl_phase = HITLPhase(
         config,

--- a/tests/test_service_registry.py
+++ b/tests/test_service_registry.py
@@ -326,11 +326,10 @@ class TestWorkerRegistryCallbacks:
 class TestAdversarialPipelineWiring:
     """Factory wiring for the earlier-adversarial pipeline (ADR-0064).
 
-    Per ``HydraFlowConfig.adversarial_pipeline_enabled``: defaults True
-    (the pipeline is the new baseline). ``DiscoverPhase`` gets a
+    The pipeline is now unconditional: ``DiscoverPhase`` always gets a
     ``ComplexityGate`` attached AND all three phases (plan, discover,
-    shape) get ``SubprocessAgentRunner`` adapters wired into every
-    adversarial-stage slot. Operators can flip it False to disable.
+    shape) always get ``SubprocessAgentRunner`` adapters wired into
+    every adversarial-stage slot. No config flag, no opt-out.
     """
 
     @staticmethod
@@ -341,81 +340,11 @@ class TestAdversarialPipelineWiring:
         callbacks = _make_callbacks()
         return build_services(config, bus, state, stop_event, callbacks)
 
-    def test_disabled_no_complexity_gate_attached(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """``adversarial_pipeline_enabled=False`` (explicit opt-out) leaves
-        DiscoverPhase without a ComplexityGate — every discover-labeled
-        issue runs the full discovery flow with no bypass.
-        """
-        disabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": False}
-        )
-        registry = self._build(disabled_config)
-        assert registry.discover_phase._complexity_gate is None
-
-    def test_disabled_no_adversarial_agents_attached(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """``adversarial_pipeline_enabled=False`` (explicit opt-out) leaves
-        every adversarial agent slot at None across plan, discover, and shape.
-        """
-        disabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": False}
-        )
-        registry = self._build(disabled_config)
-        # PlanPhase
-        assert registry.planner_phase._surfacer_agent is None
-        assert registry.planner_phase._council_agents is None
-        assert registry.planner_phase._spec_ac_agent is None
-        assert registry.planner_phase._spec_judge_agent is None
-        # DiscoverPhase
-        assert registry.discover_phase._surfacer_agent is None
-        assert registry.discover_phase._council_agents is None
-        # ShapePhase
-        assert registry.shape_phase._challenger_agent is None
-        assert registry.shape_phase._shape_council_agents is None
-
-    def test_default_enabled_attaches_complexity_gate(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """Default ``adversarial_pipeline_enabled=True`` attaches the gate."""
-        assert config.adversarial_pipeline_enabled is True  # default
-        registry = self._build(config)
-        assert registry.discover_phase._complexity_gate is not None
-
-    def test_default_enabled_attaches_all_adversarial_agents(
-        self, config: HydraFlowConfig
-    ) -> None:
-        """Default ``adversarial_pipeline_enabled=True`` wires every slot."""
-        from adversarial_agent_runner import SubprocessAgentRunner
-
-        assert config.adversarial_pipeline_enabled is True  # default
-        registry = self._build(config)
-        # PlanPhase
-        assert isinstance(registry.planner_phase._surfacer_agent, SubprocessAgentRunner)
-        assert registry.planner_phase._council_agents is not None
-        assert isinstance(registry.planner_phase._spec_ac_agent, SubprocessAgentRunner)
-        assert isinstance(
-            registry.planner_phase._spec_judge_agent, SubprocessAgentRunner
-        )
-        # DiscoverPhase
-        assert isinstance(
-            registry.discover_phase._surfacer_agent, SubprocessAgentRunner
-        )
-        assert registry.discover_phase._council_agents is not None
-        # ShapePhase
-        assert isinstance(registry.shape_phase._challenger_agent, SubprocessAgentRunner)
-        assert registry.shape_phase._shape_council_agents is not None
-
-    def test_enabled_attaches_complexity_gate(self, config: HydraFlowConfig) -> None:
-        """``adversarial_pipeline_enabled=True`` attaches the ComplexityGate."""
+    def test_complexity_gate_attached(self, config: HydraFlowConfig) -> None:
+        """DiscoverPhase gets a heuristic-only ComplexityGate."""
         from complexity_gate import ComplexityGate
 
-        enabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": True}
-        )
-        registry = self._build(enabled_config)
+        registry = self._build(config)
         gate = registry.discover_phase._complexity_gate
         assert gate is not None
         assert isinstance(gate, ComplexityGate)
@@ -423,16 +352,13 @@ class TestAdversarialPipelineWiring:
         # LOAD_BEARING on uncertainty so this is safe.
         assert gate.llm is None
 
-    def test_enabled_attaches_plan_phase_adversarial_agents(
+    def test_plan_phase_adversarial_agents_attached(
         self, config: HydraFlowConfig
     ) -> None:
         """All four PlanPhase adversarial slots get SubprocessAgentRunner adapters."""
         from adversarial_agent_runner import SubprocessAgentRunner
 
-        enabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": True}
-        )
-        registry = self._build(enabled_config)
+        registry = self._build(config)
         plan_phase = registry.planner_phase
 
         assert isinstance(plan_phase._surfacer_agent, SubprocessAgentRunner)
@@ -447,16 +373,13 @@ class TestAdversarialPipelineWiring:
         assert isinstance(plan_phase._spec_ac_agent, SubprocessAgentRunner)
         assert isinstance(plan_phase._spec_judge_agent, SubprocessAgentRunner)
 
-    def test_enabled_attaches_discover_phase_adversarial_agents(
+    def test_discover_phase_adversarial_agents_attached(
         self, config: HydraFlowConfig
     ) -> None:
         """DiscoverPhase surfacer + three-voter council both wired."""
         from adversarial_agent_runner import SubprocessAgentRunner
 
-        enabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": True}
-        )
-        registry = self._build(enabled_config)
+        registry = self._build(config)
         discover_phase = registry.discover_phase
 
         assert isinstance(discover_phase._surfacer_agent, SubprocessAgentRunner)
@@ -469,16 +392,13 @@ class TestAdversarialPipelineWiring:
         for voter in discover_phase._council_agents.values():
             assert isinstance(voter, SubprocessAgentRunner)
 
-    def test_enabled_attaches_shape_phase_adversarial_agents(
+    def test_shape_phase_adversarial_agents_attached(
         self, config: HydraFlowConfig
     ) -> None:
         """ShapePhase challenger + three-voter council both wired."""
         from adversarial_agent_runner import SubprocessAgentRunner
 
-        enabled_config = config.model_copy(
-            update={"adversarial_pipeline_enabled": True}
-        )
-        registry = self._build(enabled_config)
+        registry = self._build(config)
         shape_phase = registry.shape_phase
 
         assert isinstance(shape_phase._challenger_agent, SubprocessAgentRunner)


### PR DESCRIPTION
## Summary

Removes the \`adversarial_pipeline_enabled\` config flag entirely. Per the one-way-on intent set when the flag was flipped True by default (PR #9025, commit \`6d7319a\`), the disabled path is now dead code.

## What's removed

- \`src/config.py\` — \`adversarial_pipeline_enabled\` field
- \`src/service_registry.py\` — both \`if config.adversarial_pipeline_enabled:\` gates (ComplexityGate attach + AgentLike wiring). Bodies de-indented; pipeline is now wired unconditionally.
- \`tests/test_service_registry.py\` — \`test_disabled_*\` tests (assert the impossible disabled path); 8 tests → 4 after consolidation. Both \`default-enabled\` and \`explicit-enabled\` paths are identical now.

## Net effect

- 14 files changed, +95 -199 (net -104 lines)
- \`make quality\` exit 0, 13616 tests passing
- Adversarial pipeline ships unconditional baseline

## Test plan

- [x] Local \`make quality\` exit 0
- [x] 4 wiring tests verify all 9 agent slots attached (PlanPhase × 4, DiscoverPhase × 2, ShapePhase × 2, ComplexityGate)
- [ ] CI green on staging
- [ ] Auto-promotes to main via next rc/* PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)