### PR TITLE
fix(log-ingestion): atomic write for save_known_patterns

### DIFF
--- a/src/log_ingestion.py
+++ b/src/log_ingestion.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field  # noqa: TCH002
 
+from file_util import atomic_write
+
 if TYPE_CHECKING:
     from config import HydraFlowConfig
     from ports import ObservabilityPort
@@ -278,12 +280,16 @@ def load_known_patterns(memory_dir: Path) -> dict[str, KnownLogPattern]:
 
 
 def save_known_patterns(memory_dir: Path, patterns: dict[str, KnownLogPattern]) -> None:
-    """Persist known patterns to ``log_patterns.jsonl``."""
+    """Persist known patterns to ``log_patterns.jsonl``.
+
+    Uses an atomic temp-file + ``os.replace`` write (#8080) so a crash
+    mid-write can't truncate the file and force every known pattern to be
+    re-filed as novel on the next restart.
+    """
     try:
-        memory_dir.mkdir(parents=True, exist_ok=True)
         path = memory_dir / _LOG_PATTERNS_FILE
         lines = [p.model_dump_json() for p in patterns.values()]
-        path.write_text("\n".join(lines) + "\n" if lines else "", encoding="utf-8")
+        atomic_write(path, "\n".join(lines) + "\n" if lines else "")
     except OSError:
         logger.warning("Failed to save known log patterns", exc_info=True)
 

--- a/tests/test_log_ingestion.py
+++ b/tests/test_log_ingestion.py
@@ -439,6 +439,38 @@ class TestKnownPatterns:
         save_known_patterns(nested, patterns)
         assert (nested / "log_patterns.jsonl").exists()
 
+    def test_save_is_atomic_on_write_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A crash during the write must not truncate the existing file (#8080).
+
+        Pre-existing good content is written, then the atomic ``os.replace``
+        step is forced to fail mid-save. The original file must survive intact
+        rather than being left empty/partial. A non-atomic ``write_text`` would
+        truncate the target on open and leave the new (or partial) content,
+        failing this assertion.
+        """
+        import file_util
+
+        good = {"mod.a:fp <N>": self._make_known("fp <N>", "mod.a")}
+        save_known_patterns(tmp_path, good)
+        original = (tmp_path / "log_patterns.jsonl").read_text(encoding="utf-8")
+        assert original  # sanity: file has content
+
+        def _boom(*_a: object, **_k: object) -> None:
+            raise OSError("simulated crash during atomic rename")
+
+        monkeypatch.setattr(file_util.os, "replace", _boom)
+
+        # A second save that crashes during the rename — swallowed internally.
+        new = {"mod.b:other <S>": self._make_known("other <S>", "mod.b")}
+        save_known_patterns(tmp_path, new)
+
+        # Original content must be intact, not truncated or replaced.
+        assert (tmp_path / "log_patterns.jsonl").read_text(encoding="utf-8") == original
+        # No leftover temp files in the directory.
+        assert not list(tmp_path.glob(".log_patterns-*.tmp"))
+
 
 # ---------------------------------------------------------------------------
 # TestFileLogPatterns


### PR DESCRIPTION
## Summary

Closes #8080.

`save_known_patterns` used `path.write_text()`, which truncates the target on open. A crash or SIGKILL mid-write leaves `log_patterns.jsonl` empty or partial; on restart `load_known_patterns` returns `{}` and every previously-known pattern is re-filed as novel — duplicate HITL recommendations and Sentry breadcrumbs for patterns already actioned. `health_monitor_loop` calls this on every ingestion cycle.

## Fix

Use the existing `file_util.atomic_write` (temp file + `fsync` + `os.replace`) — the same crash-safe pattern `health_monitor_loop` already uses for its decisions file. `atomic_write` also creates parent dirs, so the explicit `mkdir` is dropped.

## Tests

`test_save_is_atomic_on_write_failure` forces the `os.replace` step to fail mid-save and asserts the pre-existing file is intact (not truncated) with no leftover temp files. RED on the old `write_text` path (original overwritten with new content), GREEN with `atomic_write`.

## Verification

- [x] `make quality` — **13,669 passed, 0 failures** (full green; the 5 transient failures seen in earlier session PRs are resolved on the current staging tip)
- [x] `make lint-check` — clean
- [x] `pyright src/log_ingestion.py` — 0 errors
- [x] 65 tests in `tests/test_log_ingestion.py` + `tests/regressions/test_issue_6622.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)