### PR TITLE
refactor(ports): enforce ReviewInsightStorePort discipline

### DIFF
--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -521,7 +521,7 @@ _PROPOSAL_IMPROVEMENT_THRESHOLD = 0.5  # >50% reduction marks as verified
 
 
 def verify_proposals(
-    store: ReviewInsightStore | ReviewInsightStorePort,
+    store: ReviewInsightStorePort,
     records: list[ReviewRecord],
 ) -> list[str]:
     """Check filed improvement proposals and classify outcomes.

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -161,9 +161,9 @@ class ReviewPhase:
         store: IssueStorePort,
         conflict_resolver: MergeConflictResolver,
         post_merge: PostMergeHandler,
+        review_insights: ReviewInsightStorePort,
         event_bus: EventBus | None = None,
         harness_insights: HarnessInsightStore | None = None,
-        review_insights: ReviewInsightStorePort | None = None,
         update_bg_worker_status: StatusCallback | None = None,
         baseline_policy: BaselinePolicy | None = None,
         active_issues_cb: Callable[[], None] | None = None,
@@ -189,12 +189,7 @@ class ReviewPhase:
         self._wiki_compiler = wiki_compiler
         self._update_bg_worker_status = update_bg_worker_status
         self._harness_insights = harness_insights
-        if review_insights is not None:
-            self._insights = review_insights
-        else:
-            from review_insights import ReviewInsightStore  # noqa: PLC0415
-
-            self._insights = ReviewInsightStore(config.memory_dir)
+        self._insights: ReviewInsightStorePort = review_insights
         self._active_issues_cb = active_issues_cb
         self._active_issues: set[int] = set()
         # In-memory window guard for the stale-HITL fallback branch

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -692,6 +692,7 @@ class PipelineHarness:
         from issue_store import IssueStore
         from plan_phase import PlanPhase
         from post_merge_handler import PostMergeHandler
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from state import StateTracker
         from triage_phase import TriagePhase
@@ -804,6 +805,7 @@ class PipelineHarness:
             store=self.store,
             conflict_resolver=self._conflict_resolver,
             post_merge=self.post_merge,
+            review_insights=ReviewInsightStore(self.config.memory_dir),
             event_bus=self.bus,
         )
         self.hitl_phase = HITLPhase(
@@ -1607,6 +1609,7 @@ def make_review_phase(
     from issue_store import IssueStore
     from merge_conflict_resolver import MergeConflictResolver
     from post_merge_handler import PostMergeHandler
+    from review_insights import ReviewInsightStore
     from review_phase import ReviewPhase
     from state import StateTracker
 
@@ -1663,6 +1666,7 @@ def make_review_phase(
         store=mock_store,
         conflict_resolver=conflict_resolver,
         post_merge=post_merge,
+        review_insights=ReviewInsightStore(config.memory_dir),
         event_bus=bus,
         baseline_policy=baseline_policy,
     )

--- a/tests/regressions/test_issue_6679.py
+++ b/tests/regressions/test_issue_6679.py
@@ -35,6 +35,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "src"))
 
 from models import Task
+from review_insights import ReviewInsightStore
 from review_phase import ReviewPhase
 
 
@@ -102,6 +103,7 @@ def _make_review_phase(tmp_path: Path) -> ReviewPhase:
         store=mock_store,
         conflict_resolver=conflict_resolver,
         post_merge=post_merge,
+        review_insights=ReviewInsightStore(config.memory_dir),
         event_bus=bus,
     )
     return phase

--- a/tests/test_active_issue_ownership.py
+++ b/tests/test_active_issue_ownership.py
@@ -144,6 +144,7 @@ class TestReviewPhaseActiveIssueOwnership:
 
     def _make_phase(self, tmp_path, *, active_issues_cb=None):
         from events import EventBus
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from state import StateTracker
 
@@ -173,6 +174,7 @@ class TestReviewPhaseActiveIssueOwnership:
             mock_store,
             MagicMock(),  # conflict_resolver
             MagicMock(),  # post_merge
+            review_insights=ReviewInsightStore(config.memory_dir),
             event_bus=bus,
             active_issues_cb=active_issues_cb,
         )

--- a/tests/test_review_insights.py
+++ b/tests/test_review_insights.py
@@ -837,6 +837,40 @@ class TestVerifyProposals:
         stale = verify_proposals(store, [])
         assert stale == []
 
+    def test_accepts_port_only_implementation(self) -> None:
+        """verify_proposals must depend only on ReviewInsightStorePort, not the
+        concrete ReviewInsightStore (#8807). A minimal port implementation that
+        does NOT inherit ReviewInsightStore must work — guarding against the
+        function re-coupling to concrete-only methods."""
+
+        class _PortOnlyStore:
+            """Implements only the two ReviewInsightStorePort methods that
+            verify_proposals uses — no inheritance from ReviewInsightStore."""
+
+            def __init__(self) -> None:
+                self.verified: list[str] = []
+                self._meta = {
+                    "missing_tests": ProposalMetadata(
+                        pre_count=10,
+                        proposed_at=_old_timestamp(40),
+                        verified=False,
+                    )
+                }
+
+            def load_proposal_metadata(self) -> dict[str, ProposalMetadata]:
+                return self._meta
+
+            def update_proposal_verified(
+                self, category: str, *, verified: bool
+            ) -> None:
+                self.verified.append(category)
+
+        store = _PortOnlyStore()
+        records = self._records_with_category("missing_tests", 2)  # 10 → 2 = verify
+        stale = verify_proposals(store, records)  # type: ignore[arg-type]
+        assert stale == []
+        assert "missing_tests" in store.verified
+
 
 # ---------------------------------------------------------------------------
 # Sentry breadcrumb tests

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -45,6 +45,23 @@ from tests.helpers import make_review_phase
 # ---------------------------------------------------------------------------
 
 
+class TestReviewInsightsInjection:
+    """#8807 — ReviewPhase must receive its ReviewInsightStorePort via injection
+    from the composition root, not construct the concrete adapter internally."""
+
+    def test_review_insights_is_a_required_parameter(self) -> None:
+        import inspect
+
+        sig = inspect.signature(ReviewPhase.__init__)
+        param = sig.parameters["review_insights"]
+        assert param.default is inspect.Parameter.empty, (
+            "ReviewPhase.review_insights must be a required injected parameter "
+            "(port discipline, #8807). The concrete ReviewInsightStore default "
+            "belongs in the composition root (service_registry), not in the "
+            "application object's constructor."
+        )
+
+
 def _setup_escalate_to_hitl_mocks(phase: ReviewPhase) -> None:
     """Set up the PR manager mocks required by _escalate_to_hitl."""
     phase._prs.post_pr_comment = AsyncMock()

--- a/tests/test_review_phase_hooks.py
+++ b/tests/test_review_phase_hooks.py
@@ -11,6 +11,7 @@ import pytest
 if TYPE_CHECKING:
     from config import HydraFlowConfig
 from events import EventBus
+from review_insights import ReviewInsightStore
 from review_phase import ReviewPhase
 from state import StateTracker
 from tests.conftest import ReviewResultFactory
@@ -31,6 +32,7 @@ def _build_phase(config: HydraFlowConfig) -> ReviewPhase:
         store=MagicMock(),
         conflict_resolver=MagicMock(),
         post_merge=MagicMock(),
+        review_insights=ReviewInsightStore(config.memory_dir),
         event_bus=EventBus(),
         transcript_summarizer=summarizer,
     )
@@ -223,6 +225,7 @@ class TestPostReviewTranscript:
             store=MagicMock(),
             conflict_resolver=MagicMock(),
             post_merge=MagicMock(),
+            review_insights=ReviewInsightStore(config.memory_dir),
             # No transcript_summarizer
         )
         result = make_review_result(

--- a/tests/test_verification_judge.py
+++ b/tests/test_verification_judge.py
@@ -1121,6 +1121,7 @@ class TestReviewPhaseWiring:
         self, config, tmp_path, event_bus
     ):
         """When verification_judge is provided, it should be called after merge."""
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from state import StateTracker
 
@@ -1188,6 +1189,7 @@ class TestReviewPhaseWiring:
             store=MagicMock(),
             conflict_resolver=conflict_resolver,
             post_merge=post_merge,
+            review_insights=ReviewInsightStore(config.memory_dir),
             event_bus=event_bus,
         )
 
@@ -1209,6 +1211,7 @@ class TestReviewPhaseWiring:
         self, config, tmp_path, event_bus
     ):
         """When verification_judge is None, no judge call should happen."""
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from state import StateTracker
 
@@ -1272,6 +1275,7 @@ class TestReviewPhaseWiring:
             store=MagicMock(),
             conflict_resolver=conflict_resolver,
             post_merge=post_merge,
+            review_insights=ReviewInsightStore(config.memory_dir),
             event_bus=event_bus,
         )
 

--- a/tests/test_visual_validation.py
+++ b/tests/test_visual_validation.py
@@ -470,6 +470,7 @@ class TestReviewPhaseVisualValidation:
         from issue_store import IssueStore
         from merge_conflict_resolver import MergeConflictResolver
         from post_merge_handler import PostMergeHandler
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from reviewer import ReviewRunner
         from state import StateTracker
@@ -508,6 +509,7 @@ class TestReviewPhaseVisualValidation:
             store=AsyncMock(spec=IssueStore),
             conflict_resolver=conflict_resolver,
             post_merge=post_merge,
+            review_insights=ReviewInsightStore(config.memory_dir),
             event_bus=bus,
         )
 
@@ -525,6 +527,7 @@ class TestReviewPhaseVisualValidation:
         from issue_store import IssueStore
         from merge_conflict_resolver import MergeConflictResolver
         from post_merge_handler import PostMergeHandler
+        from review_insights import ReviewInsightStore
         from review_phase import ReviewPhase
         from reviewer import ReviewRunner
         from state import StateTracker
@@ -563,6 +566,7 @@ class TestReviewPhaseVisualValidation:
             store=AsyncMock(spec=IssueStore),
             conflict_resolver=conflict_resolver,
             post_merge=post_merge,
+            review_insights=ReviewInsightStore(config.memory_dir),
             event_bus=bus,
         )
 


### PR DESCRIPTION
## Summary

Closes #8807. Two port-discipline fixes from the slice 5.2 hexagonal-boundaries area review.

**1. Narrow `verify_proposals` signature.** `review_insights.py` changed `store: ReviewInsightStore | ReviewInsightStorePort` → `store: ReviewInsightStorePort`. The union collapsed the adapter and the port into one type, signalling the port wasn't being used consistently. `verify_proposals` only calls `load_proposal_metadata` + `update_proposal_verified`, both on the port.

**2. Require port injection in `ReviewPhase`.** The constructor no longer builds `ReviewInsightStore(config.memory_dir)` internally when `review_insights` is omitted — the parameter is now required. The concrete adapter is wired at the composition root (`service_registry`, which already injects it). Application objects receive ports; they don't construct adapters.

## Test callers updated

All callers that relied on the internal fallback now inject a real `ReviewInsightStore(config.memory_dir)`:
- `make_review_phase` (central helper, covers ~9 test files)
- the integration scaffold in `tests/helpers.py`
- direct constructions in `test_review_phase_hooks`, `test_verification_judge`, `test_visual_validation`, `test_active_issue_ownership`, `regressions/test_issue_6679`

## Tests

- `test_review_insights_is_a_required_parameter` — asserts the constructor requires injection (RED before, GREEN after).
- `test_accepts_port_only_implementation` — `verify_proposals` works with a minimal object implementing only the two port methods it uses, guarding against re-coupling to concrete-only methods.

## Verification

- [x] `make quality` — **13,670 passed, 0 failures** (full green)
- [x] `make lint-check` — clean
- [x] `pyright` on `src/review_insights.py` + `src/review_phase/_phase.py` — 0 errors
- [x] 390 tests across the affected review-phase / review-insights suites pass

## Related hex-boundary issues (this session)

- #8792, #8804 (signature conformance) — found already-resolved by PRs #8861 / #8825; closed with evidence.
- #8798, #8800 (ObservabilityPort adapter + injection) — larger multi-step work, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)