### PR TITLE
test(ports): signature conformance for ObservabilityPort

### DIFF
--- a/tests/test_ports.py
+++ b/tests/test_ports.py
@@ -543,3 +543,38 @@ class TestAgentPortSignatures:
 
         result = _assert_param_names_match(AgentPort, AgentRunner, method)
         assert result is None
+
+
+class TestObservabilityPortSignatures:
+    """ObservabilityPort signatures must match both the production adapter
+    (SentryObservabilityAdapter) and the test fake (FakeSentry).
+
+    ``isinstance(obj, ObservabilityPort)`` (covered in test_sentry_adapter.py)
+    only checks method *existence*, not parameter names/counts. The port is
+    now load-bearing — injected throughout via service_registry — so a
+    signature drift on either implementation must fail CI (slice 5.2
+    hexagonal-boundaries; sibling of TestAgentPortSignatures /
+    TestPRPortSignatures).
+    """
+
+    _SIGNED_METHODS = [
+        "capture_exception",
+        "capture_message",
+        "breadcrumb",
+        "set_measurement",
+        "flush",
+    ]
+
+    @pytest.mark.parametrize("method", _SIGNED_METHODS)
+    def test_signature_matches_sentry_adapter(self, method: str) -> None:
+        from observability.sentry_adapter import SentryObservabilityAdapter
+        from ports import ObservabilityPort
+
+        _assert_param_names_match(ObservabilityPort, SentryObservabilityAdapter, method)
+
+    @pytest.mark.parametrize("method", _SIGNED_METHODS)
+    def test_signature_matches_fake_sentry(self, method: str) -> None:
+        from mockworld.fakes.fake_sentry import FakeSentry
+        from ports import ObservabilityPort
+
+        _assert_param_names_match(ObservabilityPort, FakeSentry, method)


### PR DESCRIPTION
## Summary

Adds the missing `inspect.signature` conformance test for `ObservabilityPort`.

Background: the slice 5.2 hexagonal-boundaries review added signature-conformance tests for `AgentPort` (#8792) and `PRPort` (#8804) but skipped `ObservabilityPort` — even though that port became load-bearing in PR #8834 (injected throughout via `service_registry`).

`test_sentry_adapter.py` already asserts `isinstance(obj, ObservabilityPort)`, but `runtime_checkable` `isinstance` only checks method **existence**, not parameter names/counts. A signature drift between the port and either `SentryObservabilityAdapter` or `FakeSentry` would slip past CI.

## Change

`TestObservabilityPortSignatures` in `tests/test_ports.py`, mirroring the existing `TestAgentPortSignatures` / `TestPRPortSignatures` pattern — parametrized over `capture_exception` / `capture_message` / `breadcrumb` / `set_measurement` / `flush`, asserting param-name parity for **both** the production adapter and the test fake (10 cases).

Verified the comparison is meaningful (compares actual non-self param sets, not a vacuous pass).

## Verification

- [x] `make quality` — 13,678 passed, 0 failures
- [x] `tests/test_ports.py` — full suite green
- [x] `ruff check tests/test_ports.py` — clean

## Context: #8798 / #8800

While investigating the ObservabilityPort hex-boundary issues I confirmed both are **already resolved by PR #8834** (adapter + `FakeSentry` + service_registry injection + 8/9 call-site migrations). This PR fills the one remaining gap — drift protection for the port contract. The two issues are being closed separately with evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)