### PR TITLE
test(caretakers): operator kill-switch + manager-error path coverage

### DIFF
--- a/tests/test_epic_monitor_loop.py
+++ b/tests/test_epic_monitor_loop.py
@@ -61,6 +61,17 @@ class TestEpicMonitorLoop:
 
         mgr.check_stale_epics.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_manager_error_propagates(self, tmp_path: Path) -> None:
+        """A raise from the EpicManager must propagate out of ``_do_work`` so the
+        BaseBackgroundLoop supervisor handles it — the loop must not silently
+        swallow manager failures (#8771)."""
+        loop, _, mgr = _make_loop(tmp_path)
+        mgr.check_stale_epics = AsyncMock(side_effect=RuntimeError("github boom"))
+
+        with pytest.raises(RuntimeError, match="github boom"):
+            await loop._do_work()
+
     def test_default_interval(self, tmp_path: Path) -> None:
         loop, _, _ = _make_loop(tmp_path, interval=900)
         assert loop._get_default_interval() == 900

--- a/tests/test_term_proposer_loop.py
+++ b/tests/test_term_proposer_loop.py
@@ -83,6 +83,21 @@ class TestTermProposerLoopFlow:
         assert port.calls == []
 
     @pytest.mark.asyncio
+    async def test_operator_kill_switch_returns_disabled(
+        self, synthetic_repo: Path
+    ) -> None:
+        """The canonical ADR-0049 operator kill-switch (``_enabled_cb``) must
+        gate work independently of the static config flag (#8770). With the
+        config flag left ON, an ``_enabled_cb`` returning False must still
+        short-circuit to ``disabled`` and touch no PR port."""
+        loop, _, port = _build_loop(synthetic_repo, fake_llm_response={})
+        loop._config.term_proposer_enabled = True
+        loop._enabled_cb = lambda _name: False
+        result = await loop._do_work()
+        assert result == {"status": "disabled"}
+        assert port.calls == []
+
+    @pytest.mark.asyncio
     async def test_drafts_validates_and_opens_pr(self, synthetic_repo: Path) -> None:
         loop, llm_client, port = _build_loop(
             synthetic_repo,

--- a/tests/test_term_pruner_loop.py
+++ b/tests/test_term_pruner_loop.py
@@ -77,6 +77,21 @@ class TestTermPrunerLoopFlow:
         assert port.calls == []
 
     @pytest.mark.asyncio
+    async def test_operator_kill_switch_returns_disabled(
+        self, synthetic_repo: Path
+    ) -> None:
+        """The canonical ADR-0049 operator kill-switch (``_enabled_cb``) must
+        gate work independently of the static config flag (#8770). With the
+        config flag left ON, an ``_enabled_cb`` returning False must still
+        short-circuit to ``disabled`` and touch no PR port."""
+        loop, port = _build_loop(synthetic_repo)
+        loop._config.term_pruner_enabled = True
+        loop._enabled_cb = lambda _name: False
+        result = await loop._do_work()
+        assert result == {"status": "disabled"}
+        assert port.calls == []
+
+    @pytest.mark.asyncio
     async def test_orphan_term_deprecated_via_pr(self, synthetic_repo: Path) -> None:
         loop, port = _build_loop(synthetic_repo)
         result = await loop._do_work()


### PR DESCRIPTION
## Summary

Closes #8770, #8771 (slice 5.0 caretaking area-review gaps). Test-only — no production changes.

### #8770 — operator kill-switch coverage

`TermProposerLoop` and `TermPrunerLoop` each gate `_do_work` with **two** checks:
1. the canonical ADR-0049 operator kill-switch — `_enabled_cb(worker_name)`
2. a static config flag — `term_*_enabled`

The existing `test_kill_switch_returns_disabled` only exercised gate 2 (the config flag); `_enabled_cb` was a truthy `MagicMock`, so the canonical operator kill-switch path was never tested. Adds `test_operator_kill_switch_returns_disabled` to each loop: config flag left **ON**, `_enabled_cb` forced `False`, asserting `{"status": "disabled"}` with no PR-port calls — isolating gate 1.

### #8771 — EpicMonitorLoop error path

`EpicMonitorLoop` had no error-path test. Adds `test_manager_error_propagates` asserting a raise from `EpicManager.check_stale_epics` propagates out of `_do_work` — the loop adds no try/except, so manager failures reach the `BaseBackgroundLoop` supervisor rather than being silently swallowed. Guards against a future swallow.

## Verification

- [x] `make quality` — 13,671 passed, 0 failures
- [x] Each new test isolates its intended gap (config flag ON for the kill-switch tests; no-swallow for the error path)
- [x] `ruff check` — clean

## Related (this session)

#8759 (CodeGroomingLoop credit-exhaustion) closed as obsolete — the loop was removed in ADR-0064/0065 (PR #8995).

🤖 Generated with [Claude Code](https://claude.com/claude-code)