### PR TITLE
test(preflight): cover sentry/git-log degradation + template KeyError

### DIFF
--- a/tests/test_preflight_context.py
+++ b/tests/test_preflight_context.py
@@ -97,3 +97,80 @@ async def test_prior_attempts_loaded(tmp_path: Path) -> None:
     )
     assert len(ctx.prior_attempts) == 1
     assert ctx.prior_attempts[0].attempt_n == 1
+
+
+@pytest.mark.asyncio
+async def test_sentry_lookup_failure_degrades_to_empty(tmp_path: Path) -> None:
+    """Spec §3.2: a failing sentry reverse-lookup logs a warning and degrades
+    to an empty events list rather than aborting context gathering (#8816)."""
+    pr = AsyncMock()
+    pr.list_issue_comments = AsyncMock(return_value=[])
+    state = MagicMock()
+    state.get_escalation_context = MagicMock(return_value=None)
+    sentry_lookup = AsyncMock(side_effect=RuntimeError("sentry unreachable"))
+
+    ctx = await gather_context(
+        issue_number=1,
+        issue_body="x",
+        sub_label="x",
+        pr_port=pr,
+        wiki_store=None,
+        state=state,
+        audit_store=PreflightAuditStore(tmp_path),
+        repo_slug="x/y",
+        sentry_lookup=sentry_lookup,
+    )
+    assert ctx.sentry_events == []
+    sentry_lookup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_git_log_failure_degrades_to_empty(tmp_path: Path) -> None:
+    """Spec §3.2: a failing git-log lookup logs a warning and degrades to an
+    empty recent-commits list (#8816). The issue body mentions a file so the
+    file-extraction path actually invokes git_log_fn."""
+    pr = AsyncMock()
+    pr.list_issue_comments = AsyncMock(return_value=[])
+    state = MagicMock()
+    state.get_escalation_context = MagicMock(return_value=None)
+
+    called = {"n": 0}
+
+    def boom(files: list[str], since_days: int) -> list:
+        called["n"] += 1
+        raise RuntimeError("git log failed")
+
+    ctx = await gather_context(
+        issue_number=1,
+        issue_body="The bug is in src/widget.py around the loop.",
+        sub_label="x",
+        pr_port=pr,
+        wiki_store=None,
+        state=state,
+        audit_store=PreflightAuditStore(tmp_path),
+        repo_slug="x/y",
+        git_log_fn=boom,
+    )
+    assert ctx.recent_commits == []
+    assert called["n"] == 1  # git_log_fn was actually invoked then degraded
+
+
+def test_sublabel_extras_field_holds_populated_dict() -> None:
+    """The PreflightContext.sublabel_extras field round-trips a populated dict
+    (#8816). gather_context currently seeds it empty, but the field must carry
+    per-sub-label payloads when later iterations populate it."""
+    from preflight.context import PreflightContext
+
+    ctx = PreflightContext(
+        issue_number=7,
+        issue_body="b",
+        issue_comments=[],
+        sub_label="flaky-test-stuck",
+        escalation_context=None,
+        wiki_excerpts="",
+        sentry_events=[],
+        recent_commits=[],
+        sublabel_extras={"flake_signature": "TimeoutError", "retries": 3},
+    )
+    assert ctx.sublabel_extras == {"flake_signature": "TimeoutError", "retries": 3}
+    assert ctx.prior_attempts == []  # default still applies

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from preflight.runner import (
     parse_agent_response,
     render_prompt,
@@ -106,3 +108,42 @@ def test_parse_agent_response_needs_human() -> None:
     )
     assert out["status"] == "needs_human"
     assert out["pr_url"] is None
+
+
+def test_prompt_template_with_unknown_field_raises_keyerror(
+    tmp_path, monkeypatch
+) -> None:
+    """A prompt file referencing a ``{field}`` not in render_prompt's kwargs
+    raises KeyError — every sub-label run would go fatal if a prompt file is
+    edited to use a new placeholder without updating the render call signature
+    (#8816). This locks the failure mode so a future resilience change has a
+    baseline, and documents the coupling between prompt files and runner.py.
+    """
+    import preflight.runner as runner_mod
+
+    prompt_dir = tmp_path / "prompts"
+    prompt_dir.mkdir()
+    # Envelope partial referenced by the inliner.
+    (prompt_dir / "_envelope.md").write_text("ENVELOPE", encoding="utf-8")
+    # Template references a placeholder render_prompt does not supply.
+    (prompt_dir / "bad-template.md").write_text(
+        "Persona: {persona}\nUnknown: {not_a_render_field}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(runner_mod, "_PROMPT_DIR", prompt_dir)
+
+    with pytest.raises(KeyError):
+        runner_mod.render_prompt(
+            sub_label="whatever",
+            persona="x",
+            issue_number=1,
+            repo_slug="r/s",
+            worktree_path="/tmp",
+            issue_body="b",
+            issue_comments_block="x",
+            escalation_context_block="x",
+            wiki_excerpts_block="x",
+            sentry_events_block="x",
+            recent_commits_block="x",
+            prior_attempts_block="x",
+            prompt_template="bad-template",
+        )


### PR DESCRIPTION
## Summary

Closes #8816 (slice 5.3 area-review gap). Test-only — no production changes.

Adds the four coverage gaps the review flagged:

**`gather_context` graceful degradation (`preflight/context.py`):**
- sentry reverse-lookup failure → empty `sentry_events`
- git-log lookup failure → empty `recent_commits` (issue body mentions a file so `git_log_fn` is actually invoked, then degrades)
- `PreflightContext.sublabel_extras` round-trips a populated dict (field was never exercised with a payload)

**`render_prompt` (`preflight/runner.py`):**
- a prompt file referencing a placeholder absent from `render_prompt`'s kwargs raises `KeyError` — locks the prompt-file ↔ runner coupling so the footgun is documented and a future resilience change has a baseline.

## Verification

- [x] 13 tests pass across `test_preflight_context.py` + `test_preflight_runner.py`
- [x] `pyright` CLI — 0 errors
- [x] `ruff check` — clean
- [x] Full suite verified by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)