### PR TITLE
chore(make): add standalone ensure-hooks target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RESET := \033[0m
 DOCKER_IMAGE ?= ghcr.io/t-rav/hydraflow-agent:latest
 DOCKER_BASE_IMAGE ?= ghcr.io/t-rav/hydraflow-agent-base:latest
 
-.PHONY: help run dev dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels prep scaffold hot docker-build docker-ensure docker-test deps integration soak screenshot screenshot-update check-node-ui trust trust-adversarial auto-agent-adversarial
+.PHONY: help run dev dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels ensure-hooks prep scaffold hot docker-build docker-ensure docker-test deps integration soak screenshot screenshot-update check-node-ui trust trust-adversarial auto-agent-adversarial
 
 check-node-ui:
 	@cd $(HYDRAFLOW_DIR)src/ui && $(HYDRAFLOW_DIR)scripts/ui-npm.sh --version >/dev/null
@@ -508,6 +508,11 @@ scaffold: deps
 
 scaffold-loop:
 	@python scripts/scaffold_loop.py $(NAME) $(LABEL) $(DESC) --interval $(or $(INTERVAL),3600)
+
+ensure-hooks:
+	@git config core.hooksPath .githooks
+	@echo "$(GREEN)core.hooksPath set to .githooks$(RESET) (current: $$(git config core.hooksPath))"
+	@echo "  Canary: if pre-commit/pre-push hooks aren't firing, run 'make ensure-hooks'."
 
 ensure-labels: deps
 	@echo "$(BLUE)Creating HydraFlow lifecycle labels...$(RESET)"

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ curl -X POST "http://localhost:5556/api/runtimes/{slug}/start"
 ```bash
 make              # command help
 make setup        # bootstrap .env, hooks, labels, local assets
+make ensure-hooks # (canary) re-point core.hooksPath at .githooks if hooks aren't firing
 make prep         # repo audit + scaffold + hardening loop
 make run          # start backend + dashboard
 make dry-run      # print actions without executing


### PR DESCRIPTION
## Summary

Closes #8675. Adds a standalone `make ensure-hooks` target.

Contributors who clone HydraFlow and run commands without `make setup` end up with `core.hooksPath` at the default `.git/hooks`, so the `.githooks` pre-commit/pre-push hooks never fire (silent failure). `make setup` sets it, but only as part of the full bootstrap.

`make ensure-hooks` is idempotent — runs `git config core.hooksPath .githooks`, echoes the resulting value + canary hint, registered in `.PHONY`, documented in the README Core Commands list as the go-to when hooks aren't firing.

`setup`'s existing hooksPath line is untouched — it targets `TARGET_REPO_ROOT` (the scaffolded repo), a different concern from the contributor-on-hydraflow-itself case.

## Verification
- [x] `make ensure-hooks` runs and reports `core.hooksPath set to .githooks`
- [x] Makefile/README only — no source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)