### PR TITLE
fix(service-registry): construct IssueCache once

### DIFF
--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -541,12 +541,11 @@ def build_services(
     beads_mgr = BeadsManager()
 
     # Phase coordinators
-    # Local JSONL issue cache — append-only mirror of GitHub issue state.
-    # See src/issue_cache.py and issue #6422.
-    issue_cache = IssueCache(
-        config.data_path("cache"),
-        enabled=config.issue_cache_enabled,
-    )
+    # NOTE: reuse the single `issue_cache` constructed above (#8790 F1).
+    # A second construction here would give the read-through CachingIssueStore
+    # decorator and the phase coordinators *separate* IssueCache instances over
+    # the same directory — splitting the in-memory index mirror and per-issue
+    # version locks, which can corrupt versioned-write serialization.
 
     # Route-back coordinator + precondition gate (#6423). The coordinator
     # ties label swap + cache record + counter + escalation. The gate


### PR DESCRIPTION
## Summary

Closes #8790 (slice 5.10 orchestration review). Fixes finding **F1**; the other six findings are already resolved on staging.

**F1 — IssueCache double-construction.** `build_services` constructed `IssueCache` twice over the same cache directory. The first instance fed the read-through `CachingIssueStore` decorator; the second (identical) instance rebound `issue_cache` and was passed to every phase coordinator.

`IssueCache` holds per-process in-memory state — the index mirror (`_index_ids` / `_indexed_on_disk`) and per-issue version locks (`_version_locks`). Two instances over the same directory split that state: the decorator and the phases saw divergent in-memory indexes, and versioned-write serialization was guarded by two separate lock dicts, so concurrent `record_plan_stored` / `record_review_stored` calls routed through different instances could allocate the same version number.

Removes the duplicate construction — the single instance now backs both the decorator and all phases.

## Other findings (already resolved on staging — verified)

- F2: the 6 missing loops have catalog builders in `loop_registrations.py`
- F3: `test_catalog_completeness.py::test_catalog_covers_bg_loop_registry` cross-checks `bg_loop_registry`
- F4: `functional_areas.yml` no longer references `agent_runner.py` / `review_phase.py`
- F5: `_PRE_ASSIGNED` is now empty (DiagramLoop exemption removed)
- F6: the `gh_cache` `# noqa: F841` is gone
- F7: `request_stop = stop` already carries the load-bearing comment

## Verification
- [x] `make quality` — full green
- [x] `pyright` CLI + `ruff` — clean
- [x] `test_service_registry.py` + catalog/architecture tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)