### PR TITLE
fix(memory-backlog): propagate auth/credit errors from issue filing

### DIFF
--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps  # noqa: TCH001
+from exception_classify import reraise_on_credit_or_bug
 from memory_backlog_mirror import (
     dedup_key_for,
     pending_entries,
@@ -103,7 +104,8 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
                     update_status(entry.path, status="issue-open", issue=issue_num)
                     filed += 1
                     filed_issue_numbers.append(issue_num)
-            except Exception:  # noqa: BLE001
+            except Exception as exc:  # noqa: BLE001
+                reraise_on_credit_or_bug(exc)
                 logger.exception("filing memory-backlog issue for %s", entry.slug)
                 continue
             dedup.add(key)

--- a/tests/test_memory_backlog_loop.py
+++ b/tests/test_memory_backlog_loop.py
@@ -283,3 +283,27 @@ async def test_no_commit_when_nothing_filed(env) -> None:
     assert result["filed"] == 0
     pr.create_issue.assert_not_called()
     loop._commit_mirror_updates.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auth_error_propagates_not_swallowed(env) -> None:
+    """An AuthenticationError from create_issue must propagate out of _do_work,
+    not be swallowed by the per-entry broad except (#8981).
+
+    The attempt counter is incremented before the filing try-block, so
+    silently swallowing an auth outage would burn the 3-strikes budget and
+    eventually false-escalate the entry as 'unresolved' when GitHub auth was
+    simply down. Propagating lets the loop supervisor pause cleanly instead.
+    """
+    from subprocess_util import AuthenticationError
+
+    _, _, pr, _, mirror_dir = env
+    _write_mirror_entry(mirror_dir, "feedback-auth")
+    pr.create_issue = AsyncMock(side_effect=AuthenticationError("gh token expired"))
+
+    loop = _make_loop(env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._commit_mirror_updates = AsyncMock(return_value=None)
+
+    with pytest.raises(AuthenticationError):
+        await loop._do_work()


### PR DESCRIPTION
## Summary

Closes #8981 (bg-worker-loop audit of MemoryBacklogLoop).

The per-entry filing loop's broad `except Exception` swallowed everything — including `AuthenticationError` from `pr.create_issue` (gh auth failure) and likely-bugs.

This is **load-bearing** because `inc_memory_backlog_attempts(key)` runs *before* the filing try-block. A transient gh-auth outage burned the 3-strikes attempt budget on every tick and, after `_MAX_ATTEMPTS`, false-escalated the entry as "unresolved after N attempts" when the real problem was a credentials outage.

Adds `reraise_on_credit_or_bug(exc)` at the top of the except (dark-factory §2.2) so auth/credit/likely-bugs propagate to the supervisor and pause cleanly, while genuine transient per-entry failures still log + continue.

## Audit findings (the rest of the loop is sound)
- kill-switch `_enabled_cb` gate present
- dedup keyed on entry slug; 3-strikes ratchet via `StateTracker`
- only this one broad-except lacked the reraise

## Verification
- [x] Regression test: `AuthenticationError` from `create_issue` propagates out of `_do_work`
- [x] 10 tests pass in `test_memory_backlog_loop.py`; pyright CLI + ruff clean
- [x] Full suite verified by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)