### PR TITLE
feat(mockworld): FakeDocker bd-CLI emulation for bead lifecycle coverage

### DIFF
--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -9,7 +9,7 @@ All Fake adapters under `src/mockworld/fakes/` (classes with ``_is_fake_adapter 
 | Fake | Implements | Used in scenarios |
 |---|---|---|
 | **FakeAgent** | `AgentPort` | — |
-| **FakeBeads** | `BeadsPort` | `tests/scenarios/fakes/test_fake_beads.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_bead_workflow.py` |
+| **FakeBeads** | `BeadsPort` | `tests/scenarios/fakes/test_fake_beads.py`<br>`tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_bead_workflow.py` |
 | **FakeBotPR** | `BotPRPort` | — |
 | **FakeClock** | `ClockPort` | `tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/fakes/test_fake_clock.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py`<br>`tests/scenarios/test_fidelity.py` |
 | **FakeDocker** | `DockerPort` | `tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_fake_subprocess_runner.py` |
@@ -34,8 +34,8 @@ graph LR
     FakeAgent -.-> AgentPort
     FakeBeads -.-> BeadsPort
     tests_scenarios_fakes_test_fake_beads_py([tests/scenarios/fakes/test_fake_beads.py]) --> FakeBeads
+    tests_scenarios_fakes_test_fake_docker_py([tests/scenarios/fakes/test_fake_docker.py]) --> FakeBeads
     tests_scenarios_fakes_test_mock_world_py([tests/scenarios/fakes/test_mock_world.py]) --> FakeBeads
-    tests_scenarios_fuzz_test_invariants_py([tests/scenarios/fuzz/test_invariants.py]) --> FakeBeads
     FakeBotPR -.-> BotPRPort
     FakeClock -.-> ClockPort
     tests_scenarios_behaviors_test_latency_py([tests/scenarios/behaviors/test_latency.py]) --> FakeClock
@@ -74,4 +74,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `2efdbb1` on 2026-05-20 19:59 UTC. Source last changed at `2efdbb1`. Status: 🟢 fresh._
+_Regenerated from commit `9f11f79` on 2026-05-21 19:14 UTC. Source last changed at `9f11f79`. Status: 🟢 fresh._

--- a/src/mockworld/fakes/fake_docker.py
+++ b/src/mockworld/fakes/fake_docker.py
@@ -28,10 +28,16 @@ class FakeDocker:
 
     _is_fake_adapter = True
 
-    def __init__(self) -> None:
+    def __init__(self, *, beads: Any = None) -> None:
         self._scripts: deque[list[dict[str, Any]]] = deque()
         self._next_fault: FaultKind | None = None
         self.invocations: list[_Invocation] = []
+        # Optional FakeBeads instance. The real agent runs `bd claim` / `bd
+        # close` inside the container; with a beads reference, a scripted run
+        # can emulate those CLI calls so the bead lifecycle gets pipeline-level
+        # coverage (the methods are otherwise only validated by the fake's own
+        # unit tests). See ``script_run_with_beads`` (#8367).
+        self._beads = beads
 
     def script_run(self, events: list[dict[str, Any]]) -> None:
         """Queue the events that the NEXT run_agent call will yield."""
@@ -76,6 +82,36 @@ class FakeDocker:
                 *events,
             ]
         )
+
+    def script_run_with_beads(
+        self,
+        *,
+        events: list[dict[str, Any]],
+        bead_ops: list[dict[str, Any]],
+        cwd: Path,
+        commits: list[tuple[str, str]] | None = None,
+    ) -> None:
+        """Queue *events*, emulating the agent's in-container ``bd`` CLI calls.
+
+        The real implement agent runs ``bd claim <id>`` when it starts work on
+        a bead and ``bd close <id> --reason ...`` when done — inside the
+        container, so the pipeline never touches ``BeadsManager.claim`` /
+        ``.close`` directly. This routes those agent-side calls to the injected
+        FakeBeads so the lifecycle gets integration coverage (#8367).
+
+        Each entry in *bead_ops* is a dict ``{"action": "claim"|"close",
+        "bead_id": "<id>", ...}``; ``close`` also accepts ``"reason"``. Ops are
+        applied (in order) BEFORE the scripted events yield. When *commits* is
+        given, they are committed first (same as ``script_run_with_commits``)
+        so a bead-closing run can also satisfy the commit-check gate.
+
+        Requires a FakeDocker constructed with ``beads=<FakeBeads>``.
+        """
+        hooks: list[dict[str, Any]] = []
+        if commits is not None:
+            hooks.append({"__commit_hook__": {"cwd": str(cwd), "files": commits}})
+        hooks.append({"__bd_hook__": {"cwd": str(cwd), "ops": list(bead_ops)}})
+        self._scripts.append([*hooks, *events])
 
     def fail_next(self, *, kind: FaultKind) -> None:
         """Inject a single-shot fault into the next run_agent call."""
@@ -123,7 +159,7 @@ class FakeDocker:
             events = self._scripts.popleft()
         else:
             events = [{"type": "result", "success": True, "exit_code": 0}]
-        return _aiter_with_hooks(events)
+        return _aiter_with_hooks(events, beads=self._beads)
 
 
 async def _aiter(events: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
@@ -133,12 +169,35 @@ async def _aiter(events: list[dict[str, Any]]) -> AsyncIterator[dict[str, Any]]:
 
 async def _aiter_with_hooks(
     events: list[dict[str, Any]],
+    *,
+    beads: Any = None,
 ) -> AsyncIterator[dict[str, Any]]:
-    """Like ``_aiter`` but processes ``__commit_hook__`` side-effect entries."""
+    """Like ``_aiter`` but processes ``__commit_hook__`` / ``__bd_hook__``
+    side-effect entries before yielding the remaining events."""
     import subprocess
 
     for event in events:
         if isinstance(event, dict):
+            bd_hook = event.get("__bd_hook__")
+            if bd_hook:
+                if beads is None:
+                    raise RuntimeError(
+                        "FakeDocker: a __bd_hook__ was scripted but no FakeBeads "
+                        "was injected — construct FakeDocker(beads=...) (or "
+                        "MockWorld(beads_manager=...)) to emulate bd CLI calls."
+                    )
+                cwd = Path(bd_hook["cwd"])
+                for op in bd_hook["ops"]:
+                    action = op["action"]
+                    if action == "claim":
+                        await beads.claim(op["bead_id"], cwd)
+                    elif action == "close":
+                        await beads.close(
+                            op["bead_id"], op.get("reason", "Phase complete"), cwd
+                        )
+                    else:
+                        raise ValueError(f"FakeDocker: unknown bd op action {action!r}")
+                continue
             hook = event.get("__commit_hook__")
             multi_hook = event.get("__multi_commit_hook__")
             if hook:

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -243,7 +243,7 @@ class MockWorld:
         self._clock = FakeClock(start=time.time())
         if clock_start is not None:
             self._clock.freeze(clock_start)
-        self._docker = FakeDocker()
+        self._docker = FakeDocker(beads=beads_manager)
         self._git = FakeGit()
         self._fs = FakeFS()
         self._http = FakeHTTP()

--- a/tests/scenarios/fakes/test_fake_docker.py
+++ b/tests/scenarios/fakes/test_fake_docker.py
@@ -304,3 +304,45 @@ async def test_script_run_with_multiple_commits_creates_N_commits(tmp_path) -> N
     assert "fake-commit-3" in lines[0]
     assert "fake-commit-2" in lines[1]
     assert "fake-commit-1" in lines[2]
+
+
+@pytest.mark.asyncio
+async def test_bd_hook_applies_claim_and_close_to_fake_beads(tmp_path) -> None:
+    """script_run_with_beads routes the agent's in-container bd claim/close
+    calls to the injected FakeBeads (#8367)."""
+    from mockworld.fakes.fake_beads import FakeBeads
+
+    beads = FakeBeads()
+    bead_id = await beads.create_task("do the thing", "1", tmp_path)
+    assert beads._tasks[bead_id].status == "open"
+
+    fake = FakeDocker(beads=beads)
+    fake.script_run_with_beads(
+        events=[{"type": "result", "success": True, "exit_code": 0}],
+        bead_ops=[
+            {"action": "claim", "bead_id": bead_id},
+            {"action": "close", "bead_id": bead_id, "reason": "done"},
+        ],
+        cwd=tmp_path,
+    )
+
+    events = [e async for e in await fake.run_agent(command=["agent"])]
+
+    # The bd hook is consumed (not yielded); the scripted result still streams.
+    assert [e["type"] for e in events] == ["result"]
+    # claim → in_progress → close → closed lifecycle ran against FakeBeads.
+    assert beads._tasks[bead_id].status == "closed"
+
+
+@pytest.mark.asyncio
+async def test_bd_hook_without_beads_raises(tmp_path) -> None:
+    """A scripted bd hook with no injected FakeBeads fails loudly rather than
+    silently no-op'ing (#8367)."""
+    fake = FakeDocker()  # no beads
+    fake.script_run_with_beads(
+        events=[{"type": "result", "success": True, "exit_code": 0}],
+        bead_ops=[{"action": "claim", "bead_id": "bd-fake-0"}],
+        cwd=tmp_path,
+    )
+    with pytest.raises(RuntimeError, match="no FakeBeads was injected"):
+        _ = [e async for e in await fake.run_agent(command=["agent"])]

--- a/tests/scenarios/test_bead_workflow.py
+++ b/tests/scenarios/test_bead_workflow.py
@@ -199,3 +199,51 @@ async def test_B1_no_beads_without_task_graph_headers(tmp_path) -> None:
         "implement_phase.py:577 gates init on get_bead_mapping returning truthy."
     )
     assert result.issue(2) is not None, "Pipeline returned no outcome for issue #2"
+
+
+async def test_B2_agent_bd_claim_close_lifecycle_through_pipeline(tmp_path) -> None:
+    """The agent's in-container ``bd claim`` / ``bd close`` calls run against
+    FakeBeads through a full pipeline (#8367).
+
+    `claim`/`close` are agent-driven (the implement agent runs the bd CLI
+    inside the container), so they were previously validated only by FakeBeads'
+    own unit tests — never exercised through the pipeline. FakeDocker's
+    ``script_run_with_beads`` now emulates those CLI calls: scripting the
+    implement-phase agent run with ``bead_ops`` routes claim/close to the
+    injected FakeBeads, giving the lifecycle pipeline-level coverage.
+
+    A bead is pre-seeded as ``open``; the scripted implement run claims it
+    (→ in_progress) then closes it (→ closed) alongside a real commit so the
+    issue still merges. After the pipeline the bead is ``closed``.
+    """
+    beads = FakeBeads()
+    bead_id = await beads.create_task("implement the fix", "1", tmp_path)
+    assert beads._tasks[bead_id].status == "open"
+
+    world = MockWorld(tmp_path, use_real_agent_runner=True, beads_manager=beads)
+    world.add_issue(1, "add feature X", "body", labels=["hydraflow-ready"])
+
+    worktree_cwd = tmp_path / "worktrees" / "issue-1"
+    init_test_worktree(worktree_cwd)
+
+    # Implement-phase agent run: emulate `bd claim <id>` then
+    # `bd close <id> --reason ...`, plus a commit so _verify_result passes.
+    world.docker.script_run_with_beads(
+        events=[{"type": "result", "success": True, "exit_code": 0}],
+        bead_ops=[
+            {"action": "claim", "bead_id": bead_id},
+            {"action": "close", "bead_id": bead_id, "reason": "feature implemented"},
+        ],
+        commits=[("x.py", "ok")],
+        cwd=worktree_cwd,
+    )
+
+    result = await world.run_pipeline()
+
+    # The agent-driven claim → close lifecycle ran through the pipeline.
+    assert beads._tasks[bead_id].status == "closed", (
+        f"expected bead {bead_id} closed via the agent's scripted bd calls; "
+        f"got status={beads._tasks[bead_id].status!r}"
+    )
+    # The issue still merged (commit gate satisfied by the scripted commit).
+    assert result.issue(1).merged, f"expected merge; outcome={result.issue(1)}"


### PR DESCRIPTION
## Summary

Closes #8367. `BeadsManager.claim`/`.close` are **agent-driven** — the implement agent runs `bd claim`/`bd close` inside the container, so the pipeline never calls them directly. They were validated only by FakeBeads' own unit tests, with no pipeline-level coverage.

## Design

Added a `__bd_hook__` to FakeDocker mirroring the existing `__commit_hook__`. `script_run_with_beads(events=, bead_ops=, cwd=, commits=)` emulates the agent's in-container `bd` calls by routing claim/close ops to the injected FakeBeads when the scripted run executes. `MockWorld` passes its `beads_manager` into FakeDocker so wiring is automatic. A bd hook with no injected FakeBeads raises loudly.

Chose the scripted-event-hook shape (Option 1 in the issue) over a real bd-subprocess interceptor — the fake agent yields scripted events and never execs `bd`, so a hook entry is the scenario-suite-native fit and matches the commit-hook precedent.

## Coverage

- **2 FakeDocker unit tests** — hook applies claim→close to FakeBeads; missing-beads raises
- **1 integration scenario** (`test_B2`) — a pre-seeded bead is claimed then closed via the scripted implement-agent run through a full pipeline, ending `closed` with the issue merged

## Verification
- [x] `make quality` — passes (regenerated `mockworld.md`: `test_fake_docker` now references FakeBeads; the curated-drift check is green)
- [x] 47 tests pass across the affected fake/scenario suites; pyright CLI + ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)