### PR TITLE
chore(workers): remove stale memory_sync from UI + control surface

### DIFF
--- a/src/dashboard_routes/_common.py
+++ b/src/dashboard_routes/_common.py
@@ -19,10 +19,9 @@ from issue_store import IssueStoreStage
 _SAFE_SLUG_COMPONENT = re.compile(r"^[A-Za-z0-9_.\-]+$")
 
 # Interval bounds per editable worker.
-# memory_sync, metrics, pr_unsticker, adr_reviewer bounds must match config.py Field constraints.
+# metrics, pr_unsticker, adr_reviewer bounds must match config.py Field constraints.
 # pipeline_poller has no config Field; 5s minimum matches the hardcoded default.
 _INTERVAL_BOUNDS: dict[str, tuple[int, int]] = {
-    "memory_sync": (10, 14400),
     "metrics": (30, 14400),
     "pr_unsticker": (60, 86400),
     "merge_state_watcher": (60, 86400),  # 1m min, 1d max (default 10m)

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -77,11 +77,6 @@ _bg_worker_defs = [
         "Reviews PRs, applies fixes, and merges approved work when checks pass.",
     ),
     (
-        "memory_sync",
-        "Memory Manager",
-        "Ingests memory and transcript issues into durable learnings and proposals.",
-    ),
-    (
         "retrospective",
         "Retrospective",
         "Captures post-merge outcomes and identifies recurring delivery patterns.",
@@ -176,7 +171,6 @@ _bg_worker_defs = [
 
 # Workers that have independent configurable intervals
 _INTERVAL_WORKERS = {
-    "memory_sync",
     "pr_unsticker",
     "pipeline_poller",
     "report_issue",
@@ -532,9 +526,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             if name in _INTERVAL_WORKERS and orch:
                 interval = orch.get_bg_worker_interval(name)
             elif name in _INTERVAL_WORKERS:
-                if name == "memory_sync":
-                    interval = _cfg.memory_sync_interval
-                elif name == "pr_unsticker":
+                if name == "pr_unsticker":
                     interval = _cfg.pr_unstick_interval
                 elif name == "pipeline_poller":
                     interval = 5

--- a/src/ui/src/components/__tests__/constants.test.js
+++ b/src/ui/src/components/__tests__/constants.test.js
@@ -166,10 +166,6 @@ describe('INTERVAL_PRESETS', () => {
 })
 
 describe('EDITABLE_INTERVAL_WORKERS', () => {
-  it('includes memory_sync', () => {
-    expect(EDITABLE_INTERVAL_WORKERS.has('memory_sync')).toBe(true)
-  })
-
   it('includes report_issue', () => {
     expect(EDITABLE_INTERVAL_WORKERS.has('report_issue')).toBe(true)
   })

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -238,7 +238,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['memory_sync', 'pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -249,7 +249,6 @@ export const SYSTEM_WORKER_INTERVALS = {
   pipeline_poller: 5,
   pr_unsticker: 3600,
   merge_state_watcher: 600,
-  memory_sync: 3600,
   report_issue: 30,
   worktree_gc: 1800,
   adr_reviewer: 86400,
@@ -304,7 +303,6 @@ export const CRATE_STATUSES = ['open', 'closed']
 export const BACKGROUND_WORKERS = [
   { key: 'retrospective', label: 'Retrospective', description: 'Periodic analysis of delivery patterns and review feedback. Runs pattern detection, proposal verification, and improvement filing.', color: theme.purple, group: 'learning', tags: ['insights'] },
   { key: 'pipeline_poller', label: 'Pipeline Poller', description: 'Refreshes live pipeline snapshots for queue and status visibility.', color: theme.textMuted, system: true, group: 'operations', tags: ['infra'] },
-  { key: 'memory_sync',     label: 'Memory Manager', description: 'Ingests memory and transcript issues into durable learnings.', color: theme.accent, system: true, group: 'intake', tags: ['memory'] },
   { key: 'pr_unsticker',    label: 'PR Unsticker',   description: 'Requeues stalled HITL PRs once requirements are actionable.', color: theme.orange, system: true, group: 'operations', tags: ['recovery'] },
   { key: 'merge_state_watcher', label: 'Merge State Watcher', description: 'Auto-rebases or HITL-escalates open PRs flagged mergeable=CONFLICTING (RC, dependabot, agent).', color: theme.orange, system: true, group: 'operations', tags: ['recovery'] },
   { key: 'report_issue',   label: 'Report Issue',   description: 'Processes queued bug reports into GitHub issues.', color: theme.red, group: 'intake', tags: ['issues'] },

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -283,14 +283,13 @@ class TestSystemWorkersEndpoint:
 
         response = await endpoint()
         data = json.loads(response.body)
-        assert len(data["workers"]) == 23
+        assert len(data["workers"]) == 22
         names = [w["name"] for w in data["workers"]]
         assert names == [
             "triage",
             "plan",
             "implement",
             "review",
-            "memory_sync",
             "retrospective",
             "review_insights",
             "pipeline_poller",
@@ -336,14 +335,14 @@ class TestSystemWorkersEndpoint:
         from orchestrator import HydraFlowOrchestrator
 
         orch = HydraFlowOrchestrator(config, event_bus=event_bus)
-        orch.update_bg_worker_status("memory_sync", "ok", {"item_count": 12})
+        orch.update_bg_worker_status("pr_unsticker", "ok", {"item_count": 12})
 
         router = self._make_router(config, event_bus, state, tmp_path, orch=orch)
         endpoint = self._find_endpoint(router, "/api/system/workers")
         response = await endpoint()
         data = json.loads(response.body)
 
-        ms = next(w for w in data["workers"] if w["name"] == "memory_sync")
+        ms = next(w for w in data["workers"] if w["name"] == "pr_unsticker")
         assert ms["status"] == "ok"
         assert ms["details"]["item_count"] == 12
         assert ms["last_run"] is not None
@@ -357,9 +356,9 @@ class TestSystemWorkersEndpoint:
         self, config, event_bus: EventBus, state, tmp_path: Path
     ) -> None:
         state.set_bg_worker_state(
-            "memory_sync",
+            "pr_unsticker",
             BackgroundWorkerState(
-                name="memory_sync",
+                name="pr_unsticker",
                 status="ok",
                 last_run="2026-02-20T10:00:00Z",
                 details={"count": 7},
@@ -371,7 +370,7 @@ class TestSystemWorkersEndpoint:
         response = await endpoint()
         data = json.loads(response.body)
 
-        ms = next(w for w in data["workers"] if w["name"] == "memory_sync")
+        ms = next(w for w in data["workers"] if w["name"] == "pr_unsticker")
         assert ms["status"] == "ok"
         assert ms["last_run"] == "2026-02-20T10:00:00Z"
         assert ms["details"]["count"] == 7
@@ -539,8 +538,8 @@ class TestSystemWorkersEndpointIntervals:
         response = await endpoint()
         data = json.loads(response.body)
 
-        ms = next(w for w in data["workers"] if w["name"] == "memory_sync")
-        assert ms["interval_seconds"] == config.memory_sync_interval
+        ms = next(w for w in data["workers"] if w["name"] == "pr_unsticker")
+        assert ms["interval_seconds"] == config.pr_unstick_interval
 
         # Pipeline workers should have poll_interval
         triage = next(w for w in data["workers"] if w["name"] == "triage")
@@ -553,13 +552,13 @@ class TestSystemWorkersEndpointIntervals:
         from orchestrator import HydraFlowOrchestrator
 
         orch = HydraFlowOrchestrator(config, event_bus=event_bus)
-        orch.update_bg_worker_status("memory_sync", "ok", {"count": 1})
+        orch.update_bg_worker_status("pr_unsticker", "ok", {"count": 1})
         router = self._make_router(config, event_bus, tmp_path, orch=orch)
         endpoint = self._find_endpoint(router, "/api/system/workers")
         response = await endpoint()
         data = json.loads(response.body)
 
-        ms = next(w for w in data["workers"] if w["name"] == "memory_sync")
+        ms = next(w for w in data["workers"] if w["name"] == "pr_unsticker")
         assert ms["next_run"] is not None  # computed from last_run + interval
         assert ms["last_run"] is not None
 
@@ -620,7 +619,7 @@ class TestSystemWorkersEndpointIntervals:
         response = await endpoint()
         data = json.loads(response.body)
 
-        ms = next(w for w in data["workers"] if w["name"] == "memory_sync")
+        ms = next(w for w in data["workers"] if w["name"] == "pr_unsticker")
         assert ms["next_run"] is None  # no last_run yet
 
 
@@ -703,12 +702,12 @@ class TestBgWorkerIntervalEndpoint:
         )
         endpoint = self._find_endpoint(router, "/api/control/bg-worker/interval")
 
-        # Too low for memory_sync (min 10)
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 5})
+        # Too low for pr_unsticker (min 60)
+        response = await endpoint({"name": "pr_unsticker", "interval_seconds": 5})
         assert response.status_code == 422
 
-        # Too high (max 14400)
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 99999})
+        # Too high (max 86400)
+        response = await endpoint({"name": "pr_unsticker", "interval_seconds": 99999})
         assert response.status_code == 422
 
     @pytest.mark.asyncio
@@ -723,12 +722,12 @@ class TestBgWorkerIntervalEndpoint:
         )
         endpoint = self._find_endpoint(router, "/api/control/bg-worker/interval")
 
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 7200})
+        response = await endpoint({"name": "pr_unsticker", "interval_seconds": 7200})
         data = json.loads(response.body)
         assert data["status"] == "ok"
-        assert data["name"] == "memory_sync"
+        assert data["name"] == "pr_unsticker"
         assert data["interval_seconds"] == 7200
-        mock_orch.set_bg_worker_interval.assert_called_once_with("memory_sync", 7200)
+        mock_orch.set_bg_worker_interval.assert_called_once_with("pr_unsticker", 7200)
 
     @pytest.mark.asyncio
     async def test_interval_update_returns_error_without_orchestrator(

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -34,6 +34,11 @@ _INTERVAL_BOUNDS_SKIP: set[str] = {
     "sentry_poll_interval",
     # Dark-launched; the StagingPromotionLoop is not yet wired (flag-gated).
     "staging_promotion_interval",
+    # Retained-but-inert: the memory_sync worker was removed from the UI/control
+    # surface (#8585, post-Hindsight #8389). The config field is kept (harmless;
+    # extra=ignore tolerates stale .env), but it no longer has an _INTERVAL_BOUNDS
+    # entry because the worker is no longer operator-controllable.
+    "memory_sync_interval",
 }
 
 
@@ -130,7 +135,6 @@ class TestIntervalFieldsHaveBounds:
         # Convention: remove the _interval suffix to get the worker name,
         # but some have custom mappings.
         _FIELD_TO_BOUNDS_KEY: dict[str, str] = {
-            "memory_sync_interval": "memory_sync",
             "pr_unstick_interval": "pr_unsticker",
             "adr_review_interval": "adr_reviewer",
             "stale_issue_gc_interval": "stale_issue_gc",

--- a/tests/test_dashboard_routes_control.py
+++ b/tests/test_dashboard_routes_control.py
@@ -398,15 +398,6 @@ class TestBgWorkerIntervalEndpoint:
         mock_orch.set_bg_worker_interval.assert_called_once_with("pr_unsticker", 7200)
 
     @pytest.mark.asyncio
-    async def test_interval_update_succeeds_for_memory_sync(self, _endpoint) -> None:
-        endpoint, mock_orch = _endpoint
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 3600})
-        data = json.loads(response.body)
-        assert response.status_code == 200
-        assert data["status"] == "ok"
-        mock_orch.set_bg_worker_interval.assert_called_once_with("memory_sync", 3600)
-
-    @pytest.mark.asyncio
     async def test_interval_update_succeeds_for_metrics(self, _endpoint) -> None:
         endpoint, mock_orch = _endpoint
         response = await endpoint({"name": "metrics", "interval_seconds": 1800})
@@ -512,30 +503,10 @@ class TestBgWorkerIntervalEndpoint:
         endpoint = find_endpoint(router, "/api/control/bg-worker/interval")
         assert endpoint is not None
 
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 3600})
+        response = await endpoint({"name": "metrics", "interval_seconds": 3600})
         data = json.loads(response.body)
         assert response.status_code == 400
         assert data["error"] == "no orchestrator"
-
-    @pytest.mark.asyncio
-    async def test_interval_rejects_below_minimum_for_memory_sync(
-        self, _endpoint
-    ) -> None:
-        endpoint, _ = _endpoint
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 5})
-        data = json.loads(response.body)
-        assert response.status_code == 422
-        assert "between 10 and 14400" in data["error"]
-
-    @pytest.mark.asyncio
-    async def test_interval_rejects_above_maximum_for_memory_sync(
-        self, _endpoint
-    ) -> None:
-        endpoint, _ = _endpoint
-        response = await endpoint({"name": "memory_sync", "interval_seconds": 20000})
-        data = json.loads(response.body)
-        assert response.status_code == 422
-        assert "between 10 and 14400" in data["error"]
 
     @pytest.mark.asyncio
     async def test_interval_rejects_below_minimum_for_metrics(self, _endpoint) -> None:
@@ -589,7 +560,6 @@ class TestBgWorkerIntervalEndpoint:
         from dashboard_routes._common import _INTERVAL_BOUNDS
 
         assert isinstance(_INTERVAL_BOUNDS, dict)
-        assert "memory_sync" in _INTERVAL_BOUNDS
         assert "metrics" in _INTERVAL_BOUNDS
         assert "pr_unsticker" in _INTERVAL_BOUNDS
         assert "pipeline_poller" in _INTERVAL_BOUNDS


### PR DESCRIPTION
## Summary

Closes #8585. `memory_sync` is a ghost worker — nothing has published the `MEMORY_SYNC` event since Hindsight was retired (#8389), yet the dashboard still rendered a "Memory Manager" tile and offered it as an editable/toggleable worker.

**Focused scope** (per maintainer decision): remove the user-visible UI entry + its control surface; leave the inert backend internals (`memory_sync_interval` config field, `MEMORY_SYNC` event enum). Their removal has wide test-fixture ripple disproportionate to the benefit, and `extra="ignore"` already tolerates the stale config field.

### Removed
- **UI** (`constants.js`): the "Memory Manager" `WORKER_META` tile, `EDITABLE_INTERVAL_WORKERS` entry, `SYSTEM_WORKER_INTERVALS` default
- **Backend control surface**: worker tuple in `_bg_worker_defs`, `_INTERVAL_WORKERS` membership + dead interval branch (`_control_routes.py`), `_INTERVAL_BOUNDS` entry (`_common.py`)

### Test updates
- `test_bg_worker_status`: swapped `memory_sync` → `pr_unsticker` as the example registered editable worker (8 tests); all-workers count 23 → 22
- `test_dashboard_routes_control`: dropped 3 redundant `memory_sync` interval tests (covered by pr_unsticker/metrics), swapped the no-orchestrator test to metrics, removed the bounds-membership assertion
- `test_config_consistency`: exempted `memory_sync_interval` from the field↔bounds invariant (retained-but-inert) + dropped its mapping
- UI `constants.test.js`: removed the redundant `EDITABLE_INTERVAL_WORKERS.has('memory_sync')` assertion

`types.js` EventType + state/orchestrator-machinery tests using `"memory_sync"` as an arbitrary worker-name string are intentionally left (mirror the retained enum / test generic machinery).

## Verification
- [x] `make quality` — 13,693 passed, 0 failures (incl `quality (src/ui)` vitest)
- [x] lint + arch-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)