### PR TITLE
Fixes #8658: update Opus 4.7 pricing

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-22T22:14:52.771294+00:00",
-  "commit_sha": "41abb41cca4c0e15d75927d689204ac799c1182a",
+  "regenerated_at": "2026-05-22T23:08:51.337044+00:00",
+  "commit_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186",
   "artifacts": {
     "loops.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "ports.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "labels.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "modules.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "events.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "adr_xref.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "mockworld.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "changelog.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "coverage_matrix.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "functional_areas.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "ubiquitous-language.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "41abb41cca4c0e15d75927d689204ac799c1182a"
+      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
-- `41abb41` — Fixes #8979: fold epic sweep into monitor *(2026-05-22)*
+- `72fea53` — Fixes #8979: fold epic sweep into monitor *(2026-05-22)*
 - `527bea0` — Fixes #8928: make issue creation failure explicit *(2026-05-22)*
 - `e7d4296` — Fixes #8481: register caretaker escalation labels *(2026-05-22)*
 - `8c85c14` — fix(sandbox): wire FakeSubprocessRunner — the actual claude bypass (#8965) (#8965) *(2026-05-18)*
@@ -336,4 +336,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `41abb41` on 2026-05-22 22:14 UTC. Source last changed at `41abb41`. Status: 🟢 fresh._
+_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._

--- a/src/assets/model_pricing.json
+++ b/src/assets/model_pricing.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "currency": "USD",
-  "updated_at": "2026-04-26",
-  "source": "https://docs.anthropic.com/en/docs/about-claude/models",
+  "updated_at": "2026-05-22",
+  "source": "https://platform.claude.com/docs/en/about-claude/pricing",
   "models": {
     "claude-haiku-4-5-20251001": {
       "provider": "anthropic",
@@ -23,10 +23,10 @@
     "claude-opus-4-7": {
       "provider": "anthropic",
       "aliases": ["opus", "claude-opus-4-7", "claude-4-7-opus", "claude-opus-4-7[1m]"],
-      "input_cost_per_million": 15.00,
-      "output_cost_per_million": 75.00,
-      "cache_write_cost_per_million": 18.75,
-      "cache_read_cost_per_million": 1.50
+      "input_cost_per_million": 5.00,
+      "output_cost_per_million": 25.00,
+      "cache_write_cost_per_million": 6.25,
+      "cache_read_cost_per_million": 0.50
     },
     "claude-3-5-haiku-20241022": {
       "provider": "anthropic",

--- a/tests/test_model_pricing.py
+++ b/tests/test_model_pricing.py
@@ -234,3 +234,14 @@ class TestLoadPricing:
         path.write_text(json.dumps({"schema_version": 1, "models": {}}))
         table = load_pricing(path)
         assert isinstance(table, ModelPricingTable)
+
+    def test_bundled_opus_47_rates_match_verified_pricing(self):
+        table = load_pricing()
+
+        rate = table.get_rate("claude-opus-4-7")
+
+        assert rate is not None
+        assert rate.input_cost_per_million == 5.0
+        assert rate.output_cost_per_million == 25.0
+        assert rate.cache_write_cost_per_million == 6.25
+        assert rate.cache_read_cost_per_million == 0.50


### PR DESCRIPTION
## Summary
- update bundled Claude Opus 4.7 pricing to the verified current Claude pricing values: $5 input, $25 output, $6.25 5m cache write, $0.50 cache hit per MTok
- point pricing metadata at the current Claude pricing docs
- add a regression test for the bundled Opus 4.7 rates
- include regenerated architecture metadata from the quality pipeline

Official source checked: https://platform.claude.com/docs/en/about-claude/pricing

## Tests
- uv run pytest tests/test_model_pricing.py tests/test_pricing_refresh_loop_scenario.py -q
- make quality
- pre-push make arch-check + make quality-lite

Fixes #8658