### PR TITLE
Fixes #8674: refresh arch artifacts before bot push

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-22T23:08:51.337044+00:00",
-  "commit_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186",
+  "regenerated_at": "2026-05-22T23:41:34.796213+00:00",
+  "commit_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "ports.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "labels.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "modules.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "events.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "adr_xref.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "mockworld.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "changelog.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "coverage_matrix.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "functional_areas.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "ubiquitous-language.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "d21165646ecbe747b6b480d2d29b47999e9d5186"
+      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `700bc6b` — Fixes #8658: update Opus 4.7 pricing *(2026-05-22)*
 - `72fea53` — Fixes #8979: fold epic sweep into monitor *(2026-05-22)*
 - `527bea0` — Fixes #8928: make issue creation failure explicit *(2026-05-22)*
 - `e7d4296` — Fixes #8481: register caretaker escalation labels *(2026-05-22)*
@@ -336,4 +337,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `d211656` on 2026-05-22 23:08 UTC. Source last changed at `d211656`. Status: 🟢 fresh._
+_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -190,10 +190,12 @@ class PRManager:
             logger.info("[dry-run] Would %s branch %s", action, branch)
             return True
 
+        if not await self._refresh_arch_artifacts_before_push(worktree_path, branch):
+            return False
+
         cmd = [
             "git",
             "push",
-            "--no-verify",
         ]
         if force:
             cmd.append("--force-with-lease")
@@ -212,6 +214,63 @@ class PRManager:
             action = "Force-push" if force else "Push"
             logger.warning("%s failed for %s: %s", action, branch, exc)
             return False
+
+    async def _refresh_arch_artifacts_before_push(
+        self, worktree_path: Path, branch: str
+    ) -> bool:
+        """Regenerate and commit architecture artifacts before bot pushes."""
+        try:
+            await run_subprocess(
+                "make",
+                "arch-regen",
+                cwd=worktree_path,
+                gh_token=self._credentials.gh_token,
+            )
+            status = await run_subprocess(
+                "git",
+                "status",
+                "--porcelain",
+                "docs/arch",
+                cwd=worktree_path,
+                gh_token=self._credentials.gh_token,
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "Architecture regeneration failed before pushing %s: %s",
+                branch,
+                exc,
+            )
+            return False
+
+        if not status.strip():
+            return True
+
+        try:
+            await run_subprocess(
+                "git",
+                "add",
+                "docs/arch",
+                cwd=worktree_path,
+                gh_token=self._credentials.gh_token,
+            )
+            await run_subprocess(
+                "git",
+                "commit",
+                "-m",
+                f"chore: refresh architecture docs before push ({branch})",
+                cwd=worktree_path,
+                gh_token=self._credentials.gh_token,
+            )
+        except RuntimeError as exc:
+            logger.warning(
+                "Could not commit regenerated architecture artifacts for %s: %s",
+                branch,
+                exc,
+            )
+            return False
+
+        logger.info("Committed regenerated architecture artifacts for %s", branch)
+        return True
 
     @staticmethod
     def expected_pr_title(issue_number: int, issue_title: str) -> str:

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -266,6 +266,12 @@ class WorkspaceManager:
 
         try:
             await run_subprocess(
+                "make",
+                "arch-regen",
+                cwd=wt_path,
+                gh_token=gh,
+            )
+            await run_subprocess(
                 "git",
                 "add",
                 "-A",
@@ -284,7 +290,6 @@ class WorkspaceManager:
             await run_subprocess(
                 "git",
                 "push",
-                "--no-verify",
                 "-u",
                 "origin",
                 branch,

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -770,11 +770,64 @@ async def test_push_branch_calls_git_push(config, event_bus, tmp_path):
     args = mock_create.call_args[0]
     assert args[0] == "git"
     assert args[1] == "push"
-    assert "--no-verify" in args
+    assert "--no-verify" not in args
     assert "-u" in args
     assert "origin" in args
     assert "agent/issue-42" in args
     assert "--force-with-lease" not in args
+
+
+@pytest.mark.asyncio
+async def test_push_branch_runs_arch_regen_before_push(config, event_bus, tmp_path):
+    manager = make_pr_manager(config, event_bus)
+
+    with patch("pr_manager.run_subprocess", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = ""
+        result = await manager.push_branch(tmp_path, "agent/issue-42")
+
+    assert result is True
+    calls = [call.args for call in mock_run.await_args_list]
+    assert calls[0] == ("make", "arch-regen")
+    assert calls[1] == ("git", "status", "--porcelain", "docs/arch")
+    assert calls[-1][:2] == ("git", "push")
+    assert "--no-verify" not in calls[-1]
+
+
+@pytest.mark.asyncio
+async def test_push_branch_commits_regenerated_arch_docs(config, event_bus, tmp_path):
+    manager = make_pr_manager(config, event_bus)
+
+    async def fake_run(*args, cwd=None, gh_token=None):
+        if args == ("git", "status", "--porcelain", "docs/arch"):
+            return " M docs/arch/generated/modules.md\n"
+        return ""
+
+    with patch("pr_manager.run_subprocess", side_effect=fake_run) as mock_run:
+        result = await manager.push_branch(tmp_path, "agent/issue-42")
+
+    assert result is True
+    calls = [call.args for call in mock_run.await_args_list]
+    assert ("git", "add", "docs/arch") in calls
+    assert any(call[:3] == ("git", "commit", "-m") for call in calls)
+    assert calls[-1][:2] == ("git", "push")
+
+
+@pytest.mark.asyncio
+async def test_push_branch_arch_regen_failure_returns_false(
+    config, event_bus, tmp_path, caplog
+):
+    manager = make_pr_manager(config, event_bus)
+
+    with (
+        caplog.at_level(logging.WARNING, logger="hydraflow.pr_manager"),
+        patch("pr_manager.run_subprocess", new_callable=AsyncMock) as mock_run,
+    ):
+        mock_run.side_effect = RuntimeError("arch failed")
+        result = await manager.push_branch(tmp_path, "agent/issue-42")
+
+    assert result is False
+    assert "Architecture regeneration failed" in caplog.text
+    mock_run.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -798,16 +851,15 @@ async def test_push_branch_failure_logs_warning_not_error(
     config, event_bus, tmp_path, caplog
 ):
     manager = make_pr_manager(config, event_bus)
-    mock_create = (
-        SubprocessMockBuilder()
-        .with_returncode(1)
-        .with_stderr("error: failed to push")
-        .build()
-    )
+
+    async def fake_run(*args, cwd=None, gh_token=None):
+        if args[:2] == ("git", "push"):
+            raise RuntimeError("error: failed to push")
+        return ""
 
     with (
         caplog.at_level(logging.WARNING, logger="hydraflow.pr_manager"),
-        patch("asyncio.create_subprocess_exec", mock_create),
+        patch("pr_manager.run_subprocess", side_effect=fake_run),
     ):
         result = await manager.push_branch(tmp_path, "agent/issue-99")
 

--- a/tests/test_pr_manager_queries.py
+++ b/tests/test_pr_manager_queries.py
@@ -364,7 +364,7 @@ class TestRetryWrapperUsage:
             mock_plain.return_value = ""
             await mgr.push_branch(tmp_path, "agent/issue-42")
 
-        mock_plain.assert_awaited_once()
+        assert mock_plain.await_count == 3
         mock_retry.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_workspace_docker.py
+++ b/tests/test_workspace_docker.py
@@ -731,9 +731,12 @@ class TestPostWorkCleanup:
             await manager.post_work_cleanup(42)
 
         cmd_strs = [" ".join(c) for c in calls]
+        assert any("make arch-regen" in c for c in cmd_strs)
         assert any("git add -A" in c for c in cmd_strs)
         assert any("git commit" in c for c in cmd_strs)
         assert any("git push" in c for c in cmd_strs)
+        push_cmd = next(c for c in calls if c[:2] == ("git", "push"))
+        assert "--no-verify" not in push_cmd
 
     @pytest.mark.asyncio
     async def test_post_work_skips_salvage_when_clean(self, config) -> None:


### PR DESCRIPTION
## Summary
- run `make arch-regen` before `PRManager.push_branch` pushes bot-created branches
- commit regenerated `docs/arch` artifacts when arch regen changes them
- remove `--no-verify` from bot push paths in `PRManager` and workspace salvage pushes
- add regression coverage for arch regen, generated-doc commit, push failure logging, and no push bypass

## Tests
- uv run pytest tests/test_pr_manager_core.py tests/test_pr_manager_queries.py tests/test_workspace_docker.py -q
- make quality
- pre-push make arch-check + make quality-lite

Fixes #8674