### PR TITLE
Fixes #8651: collapse crowded pipeline dots

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-22T23:41:34.796213+00:00",
-  "commit_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f",
+  "regenerated_at": "2026-05-23T00:15:49.491072+00:00",
+  "commit_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "ports.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "labels.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "modules.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "events.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "adr_xref.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "mockworld.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "changelog.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "coverage_matrix.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "functional_areas.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "2ec17ae1af7b166729ccf9d584e7018d4078772f"
+      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `1e94520` — Fixes #8674: refresh arch artifacts before bot push *(2026-05-22)*
 - `700bc6b` — Fixes #8658: update Opus 4.7 pricing *(2026-05-22)*
 - `72fea53` — Fixes #8979: fold epic sweep into monitor *(2026-05-22)*
 - `527bea0` — Fixes #8928: make issue creation failure explicit *(2026-05-22)*
@@ -337,4 +338,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `2ec17ae` on 2026-05-22 23:41 UTC. Source last changed at `2ec17ae`. Status: 🟢 fresh._
+_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._

--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -2,7 +2,12 @@ import React, { useMemo, useCallback, useState } from 'react'
 import { theme } from '../theme'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { StreamCard } from './StreamCard'
-import { PIPELINE_STAGES, PRODUCT_TRACK_KEYS, PULSE_ANIMATION } from '../constants'
+import {
+  PIPELINE_FLOW_COLLAPSE_THRESHOLD,
+  PIPELINE_STAGES,
+  PRODUCT_TRACK_KEYS,
+  PULSE_ANIMATION,
+} from '../constants'
 import { STAGE_KEYS } from '../hooks/useTimeline'
 import {
   sectionHeaderStyles,
@@ -33,12 +38,26 @@ function PipelineFlow({ stageGroups }) {
     return { mergedCount: merged, failedCount: failed }
   }, [stageGroups])
 
+  const renderFlowIssueCount = (group) => {
+    const activeCount = group.issues.filter(issue => issue.overallStatus === 'active').length
+    const displayCount = activeCount || group.issues.length
+    return (
+      <span
+        style={flowCountBadgeStyles[group.stage.key]}
+        title={`${group.issues.length} issues in ${group.stage.label}, ${activeCount} active`}
+        data-testid={`flow-count-${group.stage.key}`}
+      >
+        {displayCount}
+      </span>
+    )
+  }
+
   const renderFlowStage = (group) => (
     <div style={styles.flowStage} key={group.stage.key}>
       <span style={flowLabelStyles[group.stage.key]}>{group.stage.label}</span>
       {group.issues.length > 0 && (
         <div style={styles.flowDots}>
-          {group.issues.map(issue => {
+          {group.issues.length > PIPELINE_FLOW_COLLAPSE_THRESHOLD ? renderFlowIssueCount(group) : group.issues.map(issue => {
             const isEpic = issue.isEpicChild || issue.epicNumber > 0
             const dotStyles = isEpic ? epicFlowDotStyleMap : regularFlowDotStyleMap
             const dotStyle =
@@ -562,6 +581,29 @@ const flowDotFailedStyles = Object.fromEntries(
 
 const flowDotHitlStyles = Object.fromEntries(
   PIPELINE_STAGES.map(s => [s.key, { ...flowDotBase, background: theme.yellow }])
+)
+
+const flowCountBadgeBase = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 24,
+  height: 16,
+  padding: '0 6px',
+  borderRadius: 8,
+  border: '1px solid currentColor',
+  flexShrink: 0,
+  fontSize: 10,
+  fontWeight: 700,
+  lineHeight: 1,
+}
+
+const flowCountBadgeStyles = Object.fromEntries(
+  PIPELINE_STAGES.map(s => [s.key, {
+    ...flowCountBadgeBase,
+    color: s.color,
+    background: s.subtleColor,
+  }])
 )
 
 // Epic dot styles — 12px circles with centered "e" text

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { PIPELINE_STAGES } from '../../constants'
+import { PIPELINE_FLOW_COLLAPSE_THRESHOLD, PIPELINE_STAGES } from '../../constants'
 import { deriveStageStatus } from '../../hooks/useStageStatus'
 import { STAGE_KEYS } from '../../hooks/useTimeline'
 
@@ -57,6 +57,14 @@ const basePipeIssue = {
   issue_number: 42,
   title: 'Test issue',
   url: 'https://github.com/test/42',
+}
+
+function makePipelineIssues(count, status = 'queued', start = 100) {
+  return Array.from({ length: count }, (_, idx) => ({
+    issue_number: start + idx,
+    title: `Issue ${start + idx}`,
+    status: typeof status === 'function' ? status(idx) : status,
+  }))
 }
 
 describe('StreamView stage indicators', () => {
@@ -576,6 +584,67 @@ describe('PipelineFlow visualization', () => {
     const queuedDot = screen.getByTestId('flow-dot-11')
     expect(activeDot.style.animation).toContain('stream-pulse')
     expect(queuedDot.style.animation).toBe('')
+  })
+
+  it('keeps individual dots when a stage has exactly the collapse threshold', () => {
+    const issues = makePipelineIssues(PIPELINE_FLOW_COLLAPSE_THRESHOLD, 'queued')
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: {
+        triage: [],
+        plan: issues,
+        implement: [],
+        review: [],
+      },
+    }))
+
+    render(<StreamView {...defaultProps} />)
+
+    expect(screen.queryByTestId('flow-count-plan')).not.toBeInTheDocument()
+    issues.forEach(issue => {
+      expect(screen.getByTestId(`flow-dot-${issue.issue_number}`)).toBeInTheDocument()
+    })
+  })
+
+  it('collapses dots to an active count badge when a stage exceeds the threshold', () => {
+    const issues = makePipelineIssues(
+      PIPELINE_FLOW_COLLAPSE_THRESHOLD + 1,
+      idx => (idx < 3 ? 'active' : 'queued')
+    )
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: {
+        triage: [],
+        plan: issues,
+        implement: [],
+        review: [],
+      },
+    }))
+
+    render(<StreamView {...defaultProps} />)
+
+    const badge = screen.getByTestId('flow-count-plan')
+    expect(badge).toBeInTheDocument()
+    expect(badge.textContent).toBe('3')
+    expect(badge.style.color).toBe('var(--purple)')
+    expect(badge.style.background).toBe('var(--purple-subtle)')
+    issues.forEach(issue => {
+      expect(screen.queryByTestId(`flow-dot-${issue.issue_number}`)).not.toBeInTheDocument()
+    })
+  })
+
+  it('falls back to total count when a collapsed stage has no active issues', () => {
+    const issues = makePipelineIssues(PIPELINE_FLOW_COLLAPSE_THRESHOLD + 1, 'queued')
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: {
+        triage: [],
+        plan: issues,
+        implement: [],
+        review: [],
+      },
+    }))
+
+    render(<StreamView {...defaultProps} />)
+
+    expect(screen.getByTestId('flow-count-plan').textContent).toBe('11')
   })
 })
 

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -21,6 +21,9 @@ export const ACTIVE_STATUSES = [
 /** Maximum number of events retained in the frontend event buffer. */
 export const MAX_EVENTS = 5000
 
+/** Collapse pipeline-flow issue dots into a count badge above this per-stage count. */
+export const PIPELINE_FLOW_COLLAPSE_THRESHOLD = 10
+
 /**
  * Canonical pipeline stage definitions.
  * All stage metadata lives here to prevent drift across components.


### PR DESCRIPTION
## Summary
- add `PIPELINE_FLOW_COLLAPSE_THRESHOLD = 10` for the Pipeline Flow visualization
- keep per-issue dots for stages with 10 or fewer issues
- replace stages with more than 10 issues with a compact per-stage count badge showing active count, falling back to total when no active issues exist
- add StreamView tests for the 10/11 boundary, active-count display, and zero-active fallback
- include regenerated architecture metadata from the quality pipeline

## Tests
- npm test -- --run src/components/__tests__/StreamView.test.jsx
- npm run build
- make quality
- pre-push make arch-check + make quality-lite

Fixes #8651