### PR TITLE
Fix #8617 repo pipeline enabled state

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T00:15:49.491072+00:00",
-  "commit_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b",
+  "regenerated_at": "2026-05-23T00:33:49.362207+00:00",
+  "commit_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "ports.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "labels.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "modules.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "events.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "adr_xref.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "mockworld.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "changelog.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "coverage_matrix.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "functional_areas.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "ubiquitous-language.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "f4205af973c82346f354fdeceb1798aaf2d1946b"
+      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `90279ad` — Fixes #8651: collapse crowded pipeline dots *(2026-05-22)*
 - `1e94520` — Fixes #8674: refresh arch artifacts before bot push *(2026-05-22)*
 - `700bc6b` — Fixes #8658: update Opus 4.7 pricing *(2026-05-22)*
 - `72fea53` — Fixes #8979: fold epic sweep into monitor *(2026-05-22)*
@@ -338,4 +339,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `f4205af` on 2026-05-23 00:15 UTC. Source last changed at `f4205af`. Status: 🟢 fresh._
+_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_state_routes.py
+++ b/src/dashboard_routes/_state_routes.py
@@ -44,6 +44,30 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             return False
         return orch.pipeline_enabled
 
+    def _repo_pipeline_enabled(rec: Any, runtime: Any | None) -> bool:
+        if runtime is not None:
+            pipeline_enabled = getattr(runtime, "pipeline_enabled", None)
+            if pipeline_enabled is not None:
+                return bool(pipeline_enabled)
+            return bool(getattr(runtime, "running", False))
+        if _is_default_repo(str(getattr(rec, "slug", ""))) or _is_default_repo(
+            str(getattr(rec, "repo", ""))
+        ):
+            return _default_repo_pipeline_running()
+        return False
+
+    def _repo_session_id(runtime: Any | None, pipeline_enabled: bool) -> str | None:
+        if runtime is not None:
+            return (
+                runtime.orchestrator.current_session_id
+                if runtime and runtime.running
+                else None
+            )
+        orch = get_orchestrator()
+        if pipeline_enabled and orch and orch.running:
+            return orch.current_session_id
+        return None
+
     def _list_repo_records() -> list[Any]:
         return ctx.list_repo_records()
 
@@ -104,6 +128,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                     slug=default_slug,
                     repo=config.repo,
                     running=pipeline_active,
+                    pipeline_enabled=pipeline_active,
                     session_id=orch.current_session_id
                     if orch and orch.running
                     else None,
@@ -117,6 +142,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                         slug=rt.slug,
                         repo=rt.config.repo,
                         running=rt.running,
+                        pipeline_enabled=rt.running,
                         session_id=rt.orchestrator.current_session_id
                         if rt.running
                         else None,
@@ -136,6 +162,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 slug=default_slug,
                 repo=config.repo,
                 running=pipeline_active,
+                pipeline_enabled=pipeline_active,
                 session_id=orch.current_session_id if orch and orch.running else None,
             )
             return JSONResponse(info.model_dump())
@@ -151,6 +178,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             slug=rt.slug,
             repo=rt.config.repo,
             running=rt.running,
+            pipeline_enabled=rt.running,
             session_id=rt.orchestrator.current_session_id if rt.running else None,
             last_error=rt.last_error,
         )
@@ -240,15 +268,15 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             for rec in records:
                 runtime = registry.get(rec.slug) if registry else None
                 safe_slug = rec.slug.replace("/", "-") if rec.slug else rec.slug
+                pipeline_enabled = _repo_pipeline_enabled(rec, runtime)
                 payload.append(
                     {
                         "slug": safe_slug,
                         "repo": rec.repo,
                         "path": rec.path,
                         "running": bool(runtime.running) if runtime else False,
-                        "session_id": runtime.orchestrator.current_session_id
-                        if runtime and runtime.running
-                        else None,
+                        "pipeline_enabled": pipeline_enabled,
+                        "session_id": _repo_session_id(runtime, pipeline_enabled),
                     }
                 )
             return JSONResponse({"repos": payload, "can_register": True})

--- a/src/models.py
+++ b/src/models.py
@@ -1365,6 +1365,7 @@ class RepoRuntimeInfo(BaseModel):
     slug: str
     repo: str = ""
     running: bool = False
+    pipeline_enabled: bool = False
     session_id: str | None = None
     uptime_seconds: float = 0.0
     last_error: str | None = None

--- a/src/ui/src/components/RepoSelector.jsx
+++ b/src/ui/src/components/RepoSelector.jsx
@@ -24,6 +24,14 @@ const statusDotBase = {
 const statusDotRunning = { ...statusDotBase, background: theme.green }
 const statusDotStopped = { ...statusDotBase, background: theme.textMuted }
 
+function isPipelineEnabled(runtime, repo) {
+  return runtime?.pipeline_enabled
+    ?? repo?.pipeline_enabled
+    ?? runtime?.running
+    ?? repo?.running
+    ?? repo?.status === 'running'
+}
+
 export function RepoSelector({ onOpenRegister }) {
   const {
     canRegisterRepos = false,
@@ -57,7 +65,7 @@ export function RepoSelector({ onOpenRegister }) {
       const rawSlug = repo.slug || repo.repo || repo.full_name || repo.path || `repo-${index + 1}`
       const filterSlug = canonicalRepoSlug(rawSlug)
       const runtime = runtimeMap.get(filterSlug)
-      const isRunning = runtime?.running ?? repo.running ?? repo.status === 'running'
+      const isRunning = isPipelineEnabled(runtime, repo)
       return {
         key: `${filterSlug || rawSlug}-${index}`,
         label: buildDisplayName(repo),

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -17,6 +17,14 @@ function pickLatestSession(sessions) {
   return latest
 }
 
+function isPipelineEnabled(runtime, repoInfo) {
+  return runtime?.pipeline_enabled
+    ?? repoInfo?.pipeline_enabled
+    ?? runtime?.running
+    ?? repoInfo?.running
+    ?? false
+}
+
 function LastRunLine({ session, repoRunning, stageStatus }) {
   if (!session) {
     return <span style={styles.lastRunMuted}>never run</span>
@@ -157,7 +165,7 @@ export function SessionSidebar() {
         {repoEntries.map(entry => {
           const isRepoSelected = selectedRepoSlug === entry.filterSlug
           const rt = entry.runtime
-          const isRunning = rt?.running ?? entry.info?.running ?? false
+          const isRunning = isPipelineEnabled(rt, entry.info)
           const lastError = rt?.last_error || null
           const orchRunning = orchestratorStatus === 'running'
           const disabled = !orchRunning && !isRunning

--- a/src/ui/src/components/__tests__/RepoSelector.test.jsx
+++ b/src/ui/src/components/__tests__/RepoSelector.test.jsx
@@ -125,6 +125,15 @@ describe('RepoSelector', () => {
     expect(screen.getByText('Running')).toBeInTheDocument()
   })
 
+  it('uses pipeline_enabled over repo.running for enabled repos', () => {
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      supervisedRepos: [{ slug: 'acme/app', running: false, pipeline_enabled: true }],
+    }))
+    render(<RepoSelector />)
+    fireEvent.click(screen.getByTestId('repo-selector-trigger'))
+    expect(screen.getByText('Running')).toBeInTheDocument()
+  })
+
   it('closes dropdown on outside click', () => {
     render(<RepoSelector />)
     fireEvent.click(screen.getByTestId('repo-selector-trigger'))

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -40,6 +40,18 @@ describe('SessionSidebar last-run summary', () => {
     expect(screen.getByText(/never run/i)).toBeInTheDocument()
   })
 
+  it('uses pipeline_enabled for the repo start button state', () => {
+    mockContext.orchestratorStatus = 'running'
+    mockContext.supervisedRepos = [{
+      slug: 'owner/alpha',
+      path: '/p/alpha',
+      running: false,
+      pipeline_enabled: true,
+    }]
+    render(<SessionSidebar />)
+    expect(screen.getByLabelText('Stop repo')).toBeInTheDocument()
+  })
+
   it('shows "ran Xago · Yduration · N ✓ M ✗" for a completed session with failures', () => {
     mockContext.supervisedRepos = [{ slug: 'owner/beta', path: '/p/beta', running: false }]
     mockContext.sessions = [{

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -778,13 +778,16 @@ export function reducer(state, action) {
         return {
           ...state,
           runtimes: state.runtimes.map(rt =>
-            rt.slug === slug ? { ...rt, running } : rt,
+            rt.slug === slug ? { ...rt, running, pipeline_enabled: running } : rt,
           ),
         }
       }
       return {
         ...state,
-        runtimes: [...(state.runtimes || []), { slug, running }],
+        runtimes: [
+          ...(state.runtimes || []),
+          { slug, running, pipeline_enabled: running },
+        ],
       }
     }
 

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -1958,7 +1958,11 @@ describe('OPTIMISTIC_RUNTIME reducer', () => {
       data: { slug: 'owner/repo-a', running: true },
     })
     expect(next.runtimes).toHaveLength(2)
-    expect(next.runtimes[0]).toEqual({ slug: 'owner/repo-a', running: true })
+    expect(next.runtimes[0]).toEqual({
+      slug: 'owner/repo-a',
+      running: true,
+      pipeline_enabled: true,
+    })
     expect(next.runtimes[1]).toEqual({ slug: 'owner/repo-b', running: true })
   })
 
@@ -1972,7 +1976,11 @@ describe('OPTIMISTIC_RUNTIME reducer', () => {
       data: { slug: 'owner/repo-b', running: true },
     })
     expect(next.runtimes).toHaveLength(2)
-    expect(next.runtimes[1]).toEqual({ slug: 'owner/repo-b', running: true })
+    expect(next.runtimes[1]).toEqual({
+      slug: 'owner/repo-b',
+      running: true,
+      pipeline_enabled: true,
+    })
   })
 
   it('sets running to false for stop', () => {
@@ -1993,7 +2001,11 @@ describe('OPTIMISTIC_RUNTIME reducer', () => {
       data: { slug: 'owner/repo-a', running: true },
     })
     expect(next.runtimes).toHaveLength(1)
-    expect(next.runtimes[0]).toEqual({ slug: 'owner/repo-a', running: true })
+    expect(next.runtimes[0]).toEqual({
+      slug: 'owner/repo-a',
+      running: true,
+      pipeline_enabled: true,
+    })
   })
 })
 

--- a/tests/test_dashboard_routes_repo.py
+++ b/tests/test_dashboard_routes_repo.py
@@ -1220,4 +1220,48 @@ class TestListSupervisedReposWithStore:
         data = json.loads(resp.body)
         assert resp.status_code == 200
         assert data["repos"][0]["running"] is True
+        assert data["repos"][0]["pipeline_enabled"] is True
         assert data["repos"][0]["session_id"] == "sess-abc"
+
+    @pytest.mark.asyncio
+    async def test_default_repo_start_reflected_by_repos_pipeline_enabled(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        import json
+        from types import SimpleNamespace
+
+        from repo_store import RepoRecord, RepoStore
+
+        store = RepoStore(tmp_path)
+        repo_path = tmp_path / "test-repo"
+        repo_path.mkdir()
+        store.upsert(
+            RepoRecord(slug="test-org-test-repo", repo=config.repo, path=str(repo_path))
+        )
+        orch = SimpleNamespace(
+            running=True,
+            pipeline_enabled=False,
+            current_session_id="sess-default",
+        )
+
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            get_orch=lambda: orch,
+            repo_store=store,
+            registry=None,
+        )
+        start_endpoint = find_endpoint(router, "/api/runtimes/{slug}/start", "POST")
+        repos_endpoint = find_endpoint(router, "/api/repos")
+
+        start_resp = await start_endpoint("test-org-test-repo")
+        repos_resp = await repos_endpoint()
+
+        data = json.loads(repos_resp.body)
+        assert start_resp.status_code == 200
+        assert orch.pipeline_enabled is True
+        assert data["repos"][0]["running"] is False
+        assert data["repos"][0]["pipeline_enabled"] is True
+        assert data["repos"][0]["session_id"] == "sess-default"


### PR DESCRIPTION
## Summary
- add a pipeline_enabled field to runtime/repo dashboard payloads
- make repo selector/sidebar prefer pipeline_enabled for started/enabled UI state while preserving running semantics
- add backend and UI regressions for start -> repos and enabled-state rendering

## Tests
- uv run pytest tests/test_dashboard_routes_repo.py::TestListSupervisedReposWithStore -q
- uv run pytest tests/test_dashboard_routes_repo.py tests/test_dashboard_routes_state.py -q
- npm test -- --run src/context/__tests__/HydraFlowContext.test.jsx src/components/__tests__/SessionSidebar.test.jsx src/components/__tests__/RepoSelector.test.jsx
- npm run build
- make quality