### PR TITLE
Preserve managed repo config models

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T00:33:49.362207+00:00",
-  "commit_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac",
+  "regenerated_at": "2026-05-23T01:14:02.163732+00:00",
+  "commit_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "ports.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "labels.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "modules.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "events.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "adr_xref.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "mockworld.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "changelog.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "coverage_matrix.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "functional_areas.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "ubiquitous-language.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "4d1f3a643488595e3e84ea02396e38c512a37cac"
+      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `22b8cee` — Fixes #8617: expose repo pipeline enabled state *(2026-05-22)*
 - `90279ad` — Fixes #8651: collapse crowded pipeline dots *(2026-05-22)*
 - `1e94520` — Fixes #8674: refresh arch artifacts before bot push *(2026-05-22)*
 - `700bc6b` — Fixes #8658: update Opus 4.7 pricing *(2026-05-22)*
@@ -339,4 +340,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `4d1f3a6` on 2026-05-23 00:33 UTC. Source last changed at `4d1f3a6`. Status: 🟢 fresh._
+_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._

--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -34,7 +34,10 @@ def apply_repo_config_overlay(
     known_fields = set(HydraFlowConfig.model_fields.keys())
     for key, val in repo_cfg.items():
         if key in known_fields and key not in explicit:
-            object.__setattr__(config, key, val)
+            candidate_values = config.model_dump(mode="python")
+            candidate_values[key] = val
+            validated = HydraFlowConfig(**candidate_values)
+            object.__setattr__(config, key, getattr(validated, key))
 
 
 def load_runtime_config(

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -39,6 +39,15 @@ class TestLoadRuntimeConfig:
         assert cfg.max_workers == 9
         assert cfg.model == "opus"
 
+    def test_managed_repos_from_config_file_stay_typed(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "config.json"
+        config_path.write_text(json.dumps({"managed_repos": [{"slug": "acme/widget"}]}))
+
+        cfg = load_runtime_config(config_file=config_path)
+
+        assert cfg.managed_repos[0].slug == "acme/widget"
+        assert cfg.managed_repos[0].enabled is True
+
 
 class TestApplyRepoConfigOverlay:
     def test_repo_config_overrides_shared_values(self, tmp_path: Path) -> None:
@@ -61,6 +70,23 @@ class TestApplyRepoConfigOverlay:
         apply_repo_config_overlay(cfg, cli_explicit=set())
 
         assert cfg.batch_size == 42
+
+    def test_repo_config_overlay_preserves_managed_repo_models(
+        self, tmp_path: Path
+    ) -> None:
+        repo_cfg = tmp_path / "repo-config.json"
+        repo_cfg.write_text(json.dumps({"managed_repos": [{"slug": "acme/widget"}]}))
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            data_root=tmp_path,
+            repo="owner/example",
+            config_file=repo_cfg,
+        )
+
+        apply_repo_config_overlay(cfg, cli_explicit=set())
+
+        assert cfg.managed_repos[0].slug == "acme/widget"
+        assert cfg.managed_repos[0].enabled is True
 
     def test_cli_explicit_values_are_preserved(self, tmp_path: Path) -> None:
         repo_cfg = tmp_path / "repo-config.json"


### PR DESCRIPTION
## Summary
- validate repo config overlay values before assigning them back onto the runtime config
- keep managed_repos entries as ManagedRepo models after load_runtime_config()
- add regressions for config-file and overlay managed_repos loading

Refs #8475. This fixes a loader bug discovered while applying the PSH config entry; it does not auto-close #8475 because live onboarding verification is blocked by the PSH repo slug not resolving for current credentials and the local dashboard API being offline.

## Tests
- uv run pytest tests/test_runtime_config.py tests/test_config_managed_repos.py -q
- make quality