### PR TITLE
Resolve dashboard a11y baseline violations

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T01:14:02.163732+00:00",
-  "commit_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a",
+  "regenerated_at": "2026-05-23T01:41:30.953725+00:00",
+  "commit_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "ports.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "labels.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "modules.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "events.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "adr_xref.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "mockworld.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "changelog.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "coverage_matrix.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "functional_areas.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "ubiquitous-language.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "f1e28d270ca8fb05cbd70d4133de9c23f4ae972a"
+      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `3381e36` — Refs #8475: preserve managed repo config models *(2026-05-22)*
 - `22b8cee` — Fixes #8617: expose repo pipeline enabled state *(2026-05-22)*
 - `90279ad` — Fixes #8651: collapse crowded pipeline dots *(2026-05-22)*
 - `1e94520` — Fixes #8674: refresh arch artifacts before bot push *(2026-05-22)*
@@ -340,4 +341,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -41,4 +41,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `f1e28d2` on 2026-05-23 01:14 UTC. Source last changed at `f1e28d2`. Status: 🟢 fresh._
+_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -14,11 +14,11 @@
       --text: #c9d1d9;
       --text-bright: #e6edf3;
       --text-muted: #8b949e;
-      --text-inactive: #484f58;
+      --text-inactive: #8b949e;
 
       --accent: #58a6ff;
       --green: #3fb950;
-      --red: #f85149;
+      --red: #ff7b72;
       --yellow: #f2cc60;
       --orange: #d18616;
       --purple: #a371f7;

--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -307,6 +307,7 @@ function UnstickWorkersDropdown() {
         value={currentValue}
         onChange={handleChange}
         style={styles.workersSelect}
+        aria-label="Maximum PRs to unstick per cycle"
         data-testid="unstick-workers-dropdown"
       >
         {UNSTICK_BATCH_OPTIONS.map(n => (
@@ -579,8 +580,11 @@ function StagingPromotionSettingsPanel() {
         </label>
       </div>
       <div style={styles.depMergeSection}>
-        <div style={styles.depMergeSectionLabel}>Main branch</div>
+        <label style={styles.depMergeSectionLabel} htmlFor="main-branch-input">
+          Main branch
+        </label>
         <input
+          id="main-branch-input"
           type="text"
           value={current.main_branch}
           disabled={savingField === 'main_branch'}
@@ -594,8 +598,11 @@ function StagingPromotionSettingsPanel() {
         />
       </div>
       <div style={styles.depMergeSection}>
-        <div style={styles.depMergeSectionLabel}>Staging branch</div>
+        <label style={styles.depMergeSectionLabel} htmlFor="staging-branch-input">
+          Staging branch
+        </label>
         <input
+          id="staging-branch-input"
           type="text"
           value={current.staging_branch}
           disabled={savingField === 'staging_branch'}
@@ -609,8 +616,11 @@ function StagingPromotionSettingsPanel() {
         />
       </div>
       <div style={styles.depMergeSection}>
-        <div style={styles.depMergeSectionLabel}>RC cadence (hours)</div>
+        <label style={styles.depMergeSectionLabel} htmlFor="rc-cadence-hours-input">
+          RC cadence (hours)
+        </label>
         <input
+          id="rc-cadence-hours-input"
           type="number"
           min="1"
           max="168"
@@ -749,13 +759,15 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
 
   return (
     <div style={styles.container}>
-      <div style={styles.subTabSidebar}>
+      <div style={styles.subTabSidebar} role="tablist" aria-label="System sections">
         {SUB_TABS.map(tab => (
           <div
             key={tab.key}
             role="tab"
+            tabIndex={0}
             aria-selected={activeSubTab === tab.key}
             onClick={() => setActiveSubTab(tab.key)}
+            onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setActiveSubTab(tab.key) } }}
             data-testid={`system-subtab-${tab.key}`}
             style={activeSubTab === tab.key ? subTabActiveStyle : subTabInactiveStyle}
           >

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -238,6 +238,14 @@ describe('Main tab bar', () => {
     }
   })
 
+  it('wraps main tabs in a tablist', async () => {
+    const { default: App } = await import('../../App')
+    render(<App />)
+    const tablist = screen.getByRole('tablist')
+    expect(tablist).toHaveAttribute('data-testid', 'main-tabs')
+    expect(within(tablist).getAllByRole('tab')).toHaveLength(5)
+  })
+
   it('coerces ?tab=wiki query param to atlas on mount', async () => {
     const oldHref = window.location.href
     const oldFetch = global.fetch

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -381,6 +381,12 @@ describe('SystemPanel', () => {
       expect(screen.queryByText('Event Log')).not.toBeInTheDocument()
     })
 
+    it('wraps System sub-tabs in a tablist', () => {
+      render(<SystemPanel backgroundWorkers={[]} />)
+      const tablist = screen.getByRole('tablist', { name: 'System sections' })
+      expect(within(tablist).getAllByRole('tab')).toHaveLength(6)
+    })
+
     it('Workers sub-tab is active by default showing background worker content', () => {
       render(<SystemPanel backgroundWorkers={[]} />)
       expect(screen.getByText('Repo Health')).toBeInTheDocument()
@@ -391,6 +397,14 @@ describe('SystemPanel', () => {
       fireEvent.click(screen.getByText('Livestream'))
       expect(screen.getByText('Waiting for events...')).toBeInTheDocument()
       expect(screen.queryByText('Repo Health')).not.toBeInTheDocument()
+    })
+
+    it('activates System sub-tabs from the keyboard', () => {
+      render(<SystemPanel backgroundWorkers={[]} />)
+      fireEvent.keyDown(screen.getByText('Livestream'), { key: 'Enter' })
+      expect(screen.getByText('Waiting for events...')).toBeInTheDocument()
+      fireEvent.keyDown(screen.getByText('Workers'), { key: ' ' })
+      expect(screen.getByText('Repo Health')).toBeInTheDocument()
     })
 
     it('clicking Workers sub-tab returns to worker content', () => {
@@ -577,6 +591,33 @@ describe('SystemPanel', () => {
       // Log stream must also render alongside error details (not suppressed)
       const retroCard = screen.getByTestId('worker-card-retrospective')
       expect(within(retroCard).getByTestId('worker-log-stream')).toBeInTheDocument()
+    })
+  })
+
+  describe('Accessibility names', () => {
+    it('names the PR unstick batch select', () => {
+      render(<SystemPanel backgroundWorkers={mockBgWorkers} />)
+      expect(screen.getByLabelText('Maximum PRs to unstick per cycle')).toBeInTheDocument()
+    })
+
+    it('labels staging promotion config inputs', () => {
+      const workers = [
+        { name: 'staging_promotion', status: 'ok', enabled: true, last_run: null, details: {} },
+      ]
+      mockUseHydraFlow.mockReturnValue(defaultMockContext({
+        orchestratorStatus: 'running',
+        backgroundWorkers: workers,
+        config: {
+          staging_enabled: true,
+          main_branch: 'main',
+          staging_branch: 'staging',
+          rc_cadence_hours: 4,
+        },
+      }))
+      render(<SystemPanel backgroundWorkers={workers} />)
+      expect(screen.getByLabelText('Main branch')).toBeInTheDocument()
+      expect(screen.getByLabelText('Staging branch')).toBeInTheDocument()
+      expect(screen.getByLabelText('RC cadence (hours)')).toBeInTheDocument()
     })
   })
 })
@@ -929,5 +970,4 @@ describe('StagingPromotionSettingsPanel', () => {
     expect(call[1].method).toBe('POST')
   })
 })
-
 


### PR DESCRIPTION
## Summary

Fixes #8368.

- Raise low-contrast dark theme tokens used by subdued text and stop controls.
- Add required tablist semantics and keyboard activation to the System sub-tabs; keep main tablist covered by regression tests.
- Add accessible names for the unstick worker select and staging promotion config inputs.
- Add Vitest coverage for tablist structure, keyboard tab activation, and form control names.

Note: the issue references `src/ui/e2e/a11y.spec.js`, but that file no longer exists in the current repo and the UI package does not currently include a JS Playwright/axe setup. This PR fixes the documented violations directly and adds component-level regressions in the existing UI test suite.

## Verification

- `npm --prefix src/ui test -- --run src/components/__tests__/App.test.jsx src/components/__tests__/SystemPanel.test.jsx`
- `npm --prefix src/ui run build`
- contrast checks: `--text-inactive` on `--bg` = 6.15:1, `--red` on `--bg` = 7.51:1
- `make quality`
- pre-push `make arch-check`
- pre-push `make quality-lite`
