### PR TITLE
Add onboarding draft API foundation

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T01:41:30.953725+00:00",
-  "commit_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772",
+  "regenerated_at": "2026-05-23T02:08:00.348947+00:00",
+  "commit_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076",
   "artifacts": {
     "loops.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "ports.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "labels.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "modules.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "events.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "adr_xref.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "mockworld.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "changelog.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "coverage_matrix.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "functional_areas.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "ubiquitous-language.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "8794262f09fb9794c4838ba2d7f84e1f5df78772"
+      "source_sha": "f7d0be7c44141fd58204a5913358fae9d8cf6076"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `52784fb` — Fixes #8368: resolve dashboard a11y violations *(2026-05-22)*
 - `3381e36` — Refs #8475: preserve managed repo config models *(2026-05-22)*
 - `22b8cee` — Fixes #8617: expose repo pipeline enabled state *(2026-05-22)*
 - `90279ad` — Fixes #8651: collapse crowded pipeline dots *(2026-05-22)*
@@ -341,4 +342,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -15,6 +15,7 @@ graph LR
     src_mockworld["src.mockworld"]
     src_mockworld_fakes["src.mockworld.fakes"]
     src_observability["src.observability"]
+    src_onboarding["src.onboarding"]
     src_preflight["src.preflight"]
     src_review_phase["src.review_phase"]
     src_runners["src.runners"]
@@ -31,6 +32,7 @@ graph LR
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch
+    src_dashboard_routes -- "1" --> src_onboarding
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
     src_mockworld_fakes -- "25" --> src_mockworld
@@ -41,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `8794262` on 2026-05-23 01:41 UTC. Source last changed at `8794262`. Status: 🟢 fresh._
+_Regenerated from commit `f7d0be7` on 2026-05-23 02:08 UTC. Source last changed at `f7d0be7`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -1,0 +1,58 @@
+"""Headless onboarding draft API routes."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+
+from onboarding.models import BootstrapDraft, BootstrapSpec
+
+if TYPE_CHECKING:
+    from dashboard_routes._routes import RouteContext
+
+logger = logging.getLogger("hydraflow.dashboard.onboarding")
+
+
+def _decode_draft(raw: dict[str, object]) -> BootstrapDraft | None:
+    try:
+        return BootstrapDraft.model_validate(raw)
+    except ValidationError:
+        logger.warning("Ignoring invalid onboarding draft payload", exc_info=True)
+        return None
+
+
+def register(router: APIRouter, ctx: RouteContext) -> None:
+    """Register onboarding API routes on *router*."""
+
+    @router.post("/api/onboarding/drafts")
+    async def create_onboarding_draft(spec: BootstrapSpec) -> JSONResponse:
+        draft = BootstrapDraft(spec=spec)
+        ctx.state.set_onboarding_draft(
+            draft.id,
+            draft.model_dump(mode="json"),
+        )
+        return JSONResponse(draft.model_dump(mode="json"), status_code=201)
+
+    @router.get("/api/onboarding/drafts")
+    async def list_onboarding_drafts() -> JSONResponse:
+        drafts = [
+            draft.model_dump(mode="json")
+            for raw in ctx.state.list_onboarding_drafts()
+            if (draft := _decode_draft(raw)) is not None
+        ]
+        drafts.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
+        return JSONResponse({"drafts": drafts})
+
+    @router.get("/api/onboarding/drafts/{draft_id}")
+    async def get_onboarding_draft(draft_id: str) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+        return JSONResponse(draft.model_dump(mode="json"))

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1823,6 +1823,11 @@ def create_router(
 
     _register_state(router, ctx)
 
+    # --- Headless onboarding draft routes ---
+    from dashboard_routes._onboarding_routes import register as _register_onboarding
+
+    _register_onboarding(router, ctx)
+
     @router.post("/api/intent")
     async def submit_intent(request: IntentRequest) -> JSONResponse:
         """Create a GitHub issue from a user intent typed in the dashboard."""

--- a/src/models.py
+++ b/src/models.py
@@ -1863,6 +1863,7 @@ class StateData(BaseModel):
         default_factory=dict
     )
     diagnosis_severities: dict[str, str] = Field(default_factory=dict)
+    onboarding_drafts: dict[str, dict[str, object]] = Field(default_factory=dict)
     sentry_creation_attempts: dict[str, int] = Field(default_factory=dict)
     trace_runs: TraceRunsContainer = Field(default_factory=TraceRunsContainer)
     # StagingBisectLoop state (spec §4.3 + §8). Written by StagingPromotionLoop

--- a/src/onboarding/__init__.py
+++ b/src/onboarding/__init__.py
@@ -1,0 +1,5 @@
+"""HydraFlow-format repository onboarding primitives."""
+
+from .models import BootstrapDraft, BootstrapSpec
+
+__all__ = ["BootstrapDraft", "BootstrapSpec"]

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -1,0 +1,90 @@
+"""Typed models for HydraFlow-format repository onboarding."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+_PROJECT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{1,62}[a-z0-9]$")
+_OWNER_RE = re.compile(r"^[A-Za-z0-9_.-]{1,100}$")
+_LABEL_PREFIX_RE = re.compile(r"^[a-z][a-z0-9-]{1,40}$")
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class BootstrapSpec(BaseModel):
+    """Operator-provided customization knobs for a new HydraFlow-format repo."""
+
+    name: str = Field(
+        min_length=3,
+        max_length=64,
+        description="GitHub repository name, lowercase kebab-case.",
+    )
+    description: str = Field(min_length=10, max_length=500)
+    owner: str = Field(min_length=1, max_length=100)
+    visibility: Literal["private", "public"] = "private"
+    tech_stack: list[str] = Field(default_factory=lambda: ["python"])
+    safety_guards: list[str] = Field(default_factory=list)
+    coverage_floor: int = Field(default=80, ge=0, le=100)
+    package_name: str | None = Field(default=None, max_length=100)
+    label_prefix: str = Field(default="hydraflow", max_length=40)
+    main_branch: str = Field(default="main", min_length=1, max_length=100)
+    staging_branch: str = Field(default="staging", min_length=1, max_length=100)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not _PROJECT_NAME_RE.fullmatch(normalized):
+            raise ValueError("name must be lowercase kebab-case")
+        return normalized
+
+    @field_validator("owner")
+    @classmethod
+    def validate_owner(cls, value: str) -> str:
+        normalized = value.strip()
+        if not _OWNER_RE.fullmatch(normalized):
+            raise ValueError("owner must be a GitHub owner or organization name")
+        return normalized
+
+    @field_validator("label_prefix")
+    @classmethod
+    def validate_label_prefix(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not _LABEL_PREFIX_RE.fullmatch(normalized):
+            raise ValueError("label_prefix must be lowercase kebab-case")
+        return normalized
+
+    @field_validator("tech_stack", "safety_guards")
+    @classmethod
+    def normalize_string_list(cls, values: list[str]) -> list[str]:
+        normalized = [str(value).strip() for value in values if str(value).strip()]
+        return list(dict.fromkeys(normalized))
+
+
+class BootstrapDraft(BaseModel):
+    """Persisted onboarding draft state exposed by `/api/onboarding/drafts`."""
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    spec: BootstrapSpec
+    status: Literal[
+        "draft", "materializing", "materialized", "pushing", "pushed", "error"
+    ] = "draft"
+    materialize_status: Literal["not_started", "running", "succeeded", "failed"] = (
+        "not_started"
+    )
+    push_status: Literal["not_started", "running", "succeeded", "failed"] = (
+        "not_started"
+    )
+    created_at: str = Field(default_factory=_utc_now)
+    updated_at: str = Field(default_factory=_utc_now)
+    events: list[dict[str, str]] = Field(default_factory=list)
+
+    def touch(self) -> None:
+        self.updated_at = _utc_now()

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -38,6 +38,7 @@ from ._issue import IssueStateMixin
 from ._lifetime import LifetimeStatsMixin
 from ._live_corpus_replay import LiveCorpusReplayStateMixin
 from ._memory_backlog import MemoryBacklogStateMixin
+from ._onboarding import OnboardingStateMixin
 from ._principles_audit import PrinciplesAuditStateMixin
 from ._rc_budget import RCBudgetStateMixin
 from ._report import ReportStateMixin
@@ -74,6 +75,7 @@ class StateTracker(
     LifetimeStatsMixin,
     SessionStateMixin,
     WorkerStateMixin,
+    OnboardingStateMixin,
     PrinciplesAuditStateMixin,
     CorpusLearningStateMixin,
     ReportStateMixin,

--- a/src/state/_onboarding.py
+++ b/src/state/_onboarding.py
@@ -1,0 +1,27 @@
+"""Onboarding wizard draft state."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from models import StateData
+
+
+class OnboardingStateMixin:
+    """Persist onboarding draft payloads in the shared StateTracker store."""
+
+    _data: StateData
+
+    def save(self) -> None: ...  # provided by core StateTracker
+
+    def list_onboarding_drafts(self) -> list[dict[str, Any]]:
+        return list(self._data.onboarding_drafts.values())
+
+    def get_onboarding_draft(self, draft_id: str) -> dict[str, Any] | None:
+        draft = self._data.onboarding_drafts.get(draft_id)
+        return dict(draft) if draft is not None else None
+
+    def set_onboarding_draft(self, draft_id: str, draft: dict[str, Any]) -> None:
+        self._data.onboarding_drafts[draft_id] = dict(draft)
+        self.save()

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -1,0 +1,119 @@
+"""Tests for the headless onboarding draft API."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from onboarding.models import BootstrapDraft, BootstrapSpec
+from tests.helpers import find_endpoint, make_dashboard_router
+
+
+def _spec_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "observability-tool",
+        "description": "A repo for experimenting with observability workflows.",
+        "owner": "T-rav",
+        "visibility": "private",
+        "tech_stack": ["python", "python", "react"],
+        "safety_guards": ["branch-protection"],
+        "coverage_floor": 85,
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestBootstrapSpec:
+    def test_normalizes_project_name_and_dedupes_stack(self) -> None:
+        spec = BootstrapSpec.model_validate(_spec_payload(name="Observability-Tool"))
+
+        assert spec.name == "observability-tool"
+        assert spec.tech_stack == ["python", "react"]
+
+    def test_rejects_non_kebab_project_name(self) -> None:
+        with pytest.raises(ValidationError, match="name must be lowercase kebab-case"):
+            BootstrapSpec.model_validate(_spec_payload(name="bad name"))
+
+
+class TestOnboardingDraftRoutes:
+    def test_routes_are_registered(self, config, event_bus, state, tmp_path) -> None:
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        paths = {route.path for route in router.routes if hasattr(route, "path")}
+
+        assert "/api/onboarding/drafts" in paths
+        assert "/api/onboarding/drafts/{draft_id}" in paths
+
+    @pytest.mark.asyncio
+    async def test_create_draft_persists_state(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(router, "/api/onboarding/drafts", method="POST")
+
+        response = await endpoint(BootstrapSpec.model_validate(_spec_payload()))
+        data = json.loads(response.body)
+
+        assert response.status_code == 201
+        assert data["status"] == "draft"
+        assert data["spec"]["name"] == "observability-tool"
+        assert data["materialize_status"] == "not_started"
+        assert state.get_onboarding_draft(data["id"])["id"] == data["id"]
+
+    @pytest.mark.asyncio
+    async def test_get_draft_returns_persisted_state(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="writing-tool"))
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(router, "/api/onboarding/drafts/{draft_id}")
+
+        response = await endpoint(draft.id)
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["id"] == draft.id
+        assert data["spec"]["name"] == "writing-tool"
+
+    @pytest.mark.asyncio
+    async def test_get_draft_404s_for_unknown_id(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(router, "/api/onboarding/drafts/{draft_id}")
+
+        response = await endpoint("missing")
+
+        assert response.status_code == 404
+        assert json.loads(response.body)["error"] == "Draft not found"
+
+    @pytest.mark.asyncio
+    async def test_list_drafts_returns_newest_first(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        older = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="older-tool")),
+            created_at="2026-05-20T00:00:00+00:00",
+            updated_at="2026-05-20T00:00:00+00:00",
+        )
+        newer = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="newer-tool")),
+            created_at="2026-05-21T00:00:00+00:00",
+            updated_at="2026-05-21T00:00:00+00:00",
+        )
+        state.set_onboarding_draft(older.id, older.model_dump(mode="json"))
+        state.set_onboarding_draft(newer.id, newer.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(router, "/api/onboarding/drafts", method="GET")
+
+        response = await endpoint()
+        data = json.loads(response.body)
+
+        assert [draft["spec"]["name"] for draft in data["drafts"]] == [
+            "newer-tool",
+            "older-tool",
+        ]

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -112,6 +112,7 @@ class TestInitialization:
             "last_green_rc_sha",
             "last_rc_red_sha",
             "managed_repos_onboarding_status",
+            "onboarding_drafts",
             "principles_drift_attempts",
             "corpus_learning_validation_attempts",
             "retry_lineage_attempts",


### PR DESCRIPTION
## Summary

Refs #8930.

This is the first non-destructive backend slice for the Phase 1 onboarding API:

- Adds `BootstrapSpec` and `BootstrapDraft` Pydantic models for the operator-provided repo bootstrap knobs.
- Persists onboarding drafts in the existing `StateTracker` state store.
- Registers headless draft endpoints:
  - `POST /api/onboarding/drafts`
  - `GET /api/onboarding/drafts`
  - `GET /api/onboarding/drafts/{draft_id}`
- Adds route/model/state regression coverage.
- Regenerates architecture artifacts for the new `src.onboarding` package.

This intentionally does not implement live materialize/push/SSE yet. Those paths invoke filesystem, git, and GitHub side effects and need the failure-mode recovery design from #8930 before being wired.

## Verification

- `uv run pytest tests/test_onboarding_api.py -q`
- `uv run pytest tests/test_onboarding_api.py tests/test_route_context.py tests/test_state_principles_audit.py -q`
- `uv run pytest tests/architecture/test_curated_drift.py tests/test_state_tracking.py::TestInitialization::test_defaults_structure_matches_expected_keys tests/test_onboarding_api.py -q`
- `make quality`
- pre-push `make arch-check`
- pre-push `make quality-lite`
