### PR TITLE
Add onboarding wizard UI slice

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T02:51:38.960000+00:00",
-  "commit_sha": "9017989a344941bf89f1287cb33bd11ad963dbee",
+  "regenerated_at": "2026-05-23T04:32:18.774557+00:00",
+  "commit_sha": "063468b3385cf00abbcbe832a8a4fd577e172006",
   "artifacts": {
     "loops.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "ports.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "labels.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "modules.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "events.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "adr_xref.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "mockworld.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "changelog.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "coverage_matrix.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "functional_areas.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "ubiquitous-language.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "9017989a344941bf89f1287cb33bd11ad963dbee"
+      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `e439049` — Refs #8930: add onboarding materialize API slice *(2026-05-22)*
 - `e5e3dbd` — Refs #8930: add onboarding draft API foundation *(2026-05-22)*
 - `52784fb` — Fixes #8368: resolve dashboard a11y violations *(2026-05-22)*
 - `3381e36` — Refs #8475: preserve managed repo config models *(2026-05-22)*
@@ -343,4 +344,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `9017989` on 2026-05-23 02:51 UTC. Source last changed at `9017989`. Status: 🟢 fresh._
+_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._

--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -9,7 +9,9 @@ import { OutcomesPanel } from './components/IssueHistoryPanel'
 import { StreamView } from './components/StreamView'
 import { SessionSidebar } from './components/SessionSidebar'
 import { AtlasExplorer } from './components/atlas/AtlasExplorer'
+import { ProjectView } from './components/ProjectView'
 import { theme } from './theme'
+import { canonicalRepoSlug } from './constants'
 
 const TABS = ['issues', 'hitl', 'outcomes', 'atlas', 'system']
 
@@ -160,6 +162,8 @@ function AppContent() {
     config,
     reporterId,
     mockworldActive,
+    selectedRepoSlug,
+    supervisedRepos = [],
   } = useHydraFlow()
   const [activeTab, setActiveTab] = useState(_initialTabFromUrl)
   const [expandedStages, setExpandedStages] = useState({})
@@ -174,6 +178,13 @@ function AppContent() {
   }, [requestChanges])
 
   const configWarning = useMemo(() => detectConfigWarning(config), [config])
+  const selectedProject = useMemo(() => {
+    if (!selectedRepoSlug) return null
+    return supervisedRepos.find(repo => {
+      const raw = repo?.slug || repo?.repo || repo?.full_name || repo?.path || ''
+      return canonicalRepoSlug(raw) === selectedRepoSlug
+    }) || null
+  }, [selectedRepoSlug, supervisedRepos])
 
   return (
     <div style={styles.layout}>
@@ -190,6 +201,7 @@ function AppContent() {
         <SystemAlertBanner alert={systemAlert} onDismiss={dismissSystemAlert} onRefreshCredit={refreshCreditStatus} />
         <ConfigWarningBanner warning={configWarning} />
         <HumanInputBanner requests={humanInputRequests} onSubmit={submitHumanInput} />
+        <ProjectView project={selectedProject} />
 
         <div style={styles.tabs} data-testid="main-tabs" role="tablist">
           {TABS.map((tab) => (

--- a/src/ui/src/components/BootstrapWizard.jsx
+++ b/src/ui/src/components/BootstrapWizard.jsx
@@ -1,0 +1,287 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { useHydraFlow } from '../context/HydraFlowContext'
+import { theme } from '../theme'
+
+const STEPS = ['Describe', 'Spec', 'Plan 01', 'Materialize locally']
+
+const DEFAULT_FORM = {
+  name: 'new-project',
+  description: 'A HydraFlow-format project bootstrapped from the dashboard.',
+  owner: 'T-rav',
+  visibility: 'private',
+  tech_stack: 'python',
+  safety_guards: 'deterministic tests, quality gates, ADR review',
+  coverage_floor: 80,
+  package_name: '',
+  label_prefix: 'hydraflow',
+  main_branch: 'main',
+  staging_branch: 'staging',
+  output_dir: '',
+}
+
+function splitList(value) {
+  return String(value || '')
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function buildSpec(form) {
+  return {
+    name: form.name.trim(),
+    description: form.description.trim(),
+    owner: form.owner.trim(),
+    visibility: form.visibility,
+    tech_stack: splitList(form.tech_stack),
+    safety_guards: splitList(form.safety_guards),
+    coverage_floor: Number(form.coverage_floor),
+    package_name: form.package_name.trim() || null,
+    label_prefix: form.label_prefix.trim(),
+    main_branch: form.main_branch.trim(),
+    staging_branch: form.staging_branch.trim(),
+  }
+}
+
+function buildPlanItems(spec) {
+  return [
+    `Create ${spec.name} with HydraFlow invariant-kernel files`,
+    `Configure ${spec.main_branch} and ${spec.staging_branch} branch expectations`,
+    `Set ${spec.coverage_floor}% coverage floor in generated quality tooling`,
+    `Add ${spec.label_prefix}-scoped issue and PR templates`,
+    'Run local smoke tests before GitHub provisioning',
+    'Keep wizard-draft specs marked for refinement',
+  ]
+}
+
+export function BootstrapWizard({ isOpen, onClose }) {
+  const {
+    createOnboardingDraft,
+    materializeOnboardingDraft,
+    selectRepo,
+  } = useHydraFlow()
+  const [step, setStep] = useState(0)
+  const [form, setForm] = useState(DEFAULT_FORM)
+  const [draft, setDraft] = useState(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [activityOpen, setActivityOpen] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStep(0)
+      setForm(DEFAULT_FORM)
+      setDraft(null)
+      setSubmitting(false)
+      setError('')
+      setActivityOpen(false)
+      return
+    }
+    const handleKeyDown = (event) => {
+      if (event.key === 'Escape') onClose?.()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  const spec = useMemo(() => buildSpec(form), [form])
+  const planItems = useMemo(() => buildPlanItems(spec), [spec])
+
+  const updateField = (field) => (event) => {
+    setForm(prev => ({ ...prev, [field]: event.target.value }))
+  }
+
+  const ensureDraft = useCallback(async () => {
+    if (draft) return draft
+    setSubmitting(true)
+    setError('')
+    const result = await createOnboardingDraft(spec)
+    setSubmitting(false)
+    if (!result?.ok) {
+      setError(result?.error || 'Draft failed')
+      return null
+    }
+    setDraft(result.draft)
+    return result.draft
+  }, [createOnboardingDraft, draft, spec])
+
+  const handleNext = useCallback(async () => {
+    if (step === 0) {
+      const created = await ensureDraft()
+      if (!created) return
+    }
+    setStep(prev => Math.min(prev + 1, STEPS.length - 1))
+  }, [ensureDraft, step])
+
+  const handleMaterialize = useCallback(async () => {
+    const activeDraft = await ensureDraft()
+    if (!activeDraft || submitting) return
+    setSubmitting(true)
+    setError('')
+    setActivityOpen(false)
+    const result = await materializeOnboardingDraft(activeDraft.id, {
+      output_dir: form.output_dir.trim() || null,
+    })
+    setSubmitting(false)
+    if (!result?.ok) {
+      setDraft(result?.draft || activeDraft)
+      setError(result?.error || 'Materialize failed')
+      setActivityOpen(true)
+      return
+    }
+    const nextDraft = result.draft
+    setDraft(nextDraft)
+    selectRepo?.(nextDraft?.spec?.name)
+    onClose?.()
+  }, [ensureDraft, form.output_dir, materializeOnboardingDraft, onClose, selectRepo, submitting])
+
+  if (!isOpen) return null
+
+  const events = draft?.events || []
+
+  return (
+    <div style={styles.overlay} onClick={(event) => { if (event.target === event.currentTarget) onClose?.() }} data-testid="bootstrap-wizard-overlay">
+      <div style={styles.shell} role="dialog" aria-modal="true" aria-label="New project wizard">
+        <div style={styles.header}>
+          <div>
+            <div style={styles.title}>New Project</div>
+            <div style={styles.subtitle}>HydraFlow-format repo bootstrap</div>
+          </div>
+          <button type="button" style={styles.closeBtn} onClick={onClose} aria-label="Close new project wizard">x</button>
+        </div>
+
+        <div style={styles.stepRail}>
+          {STEPS.map((label, index) => (
+            <button
+              key={label}
+              type="button"
+              disabled={index > step + 1}
+              onClick={() => setStep(index)}
+              style={index === step ? styles.stepActive : styles.step}
+            >
+              <span style={styles.stepIndex}>{index + 1}</span>
+              <span>{label}</span>
+            </button>
+          ))}
+        </div>
+
+        <div style={styles.body}>
+          {step === 0 && (
+            <div style={styles.grid}>
+              <label style={styles.field}>Repo name<input style={styles.input} value={form.name} onChange={updateField('name')} /></label>
+              <label style={styles.field}>Owner<input style={styles.input} value={form.owner} onChange={updateField('owner')} /></label>
+              <label style={styles.fieldWide}>Description<textarea style={styles.textarea} value={form.description} onChange={updateField('description')} /></label>
+              <label style={styles.field}>Visibility<select style={styles.input} value={form.visibility} onChange={updateField('visibility')}><option value="private">Private</option><option value="public">Public</option></select></label>
+              <label style={styles.field}>Coverage floor<input style={styles.input} type="number" min="0" max="100" value={form.coverage_floor} onChange={updateField('coverage_floor')} /></label>
+              <label style={styles.fieldWide}>Tech stack<input style={styles.input} value={form.tech_stack} onChange={updateField('tech_stack')} /></label>
+              <label style={styles.fieldWide}>Safety guards<input style={styles.input} value={form.safety_guards} onChange={updateField('safety_guards')} /></label>
+            </div>
+          )}
+
+          {step === 1 && (
+            <div style={styles.specBox}>
+              <pre style={styles.pre}>{JSON.stringify(spec, null, 2)}</pre>
+            </div>
+          )}
+
+          {step === 2 && (
+            <div style={styles.planList}>
+              {planItems.map(item => (
+                <label key={item} style={styles.planItem}>
+                  <input type="checkbox" checked readOnly />
+                  <span>{item}</span>
+                </label>
+              ))}
+            </div>
+          )}
+
+          {step === 3 && (
+            <div style={styles.materializePanel}>
+              <label style={styles.fieldWide}>Output directory<input style={styles.input} value={form.output_dir} onChange={updateField('output_dir')} placeholder="Default workspace directory" /></label>
+              <button type="button" style={submitting ? styles.primaryDisabled : styles.primary} disabled={submitting} onClick={handleMaterialize} data-testid="materialize-project">
+                {submitting ? 'Materializing...' : 'Materialize locally'}
+              </button>
+              <button type="button" style={styles.activityToggle} onClick={() => setActivityOpen(prev => !prev)}>
+                Activity log {activityOpen ? 'up' : 'down'}
+              </button>
+              {activityOpen && (
+                <div style={styles.activityLog} data-testid="wizard-activity-log">
+                  {events.length === 0 ? <div style={styles.muted}>No activity yet</div> : events.map((event, index) => (
+                    <div key={`${event.message}-${index}`} style={event.level === 'error' ? styles.eventError : styles.event}>
+                      {event.message}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {error && <div style={styles.error}>{error}</div>}
+
+        <div style={styles.footer}>
+          <button type="button" style={styles.secondary} onClick={onClose}>Cancel</button>
+          <div style={styles.footerRight}>
+            <button type="button" style={step === 0 ? styles.secondaryDisabled : styles.secondary} disabled={step === 0} onClick={() => setStep(prev => Math.max(prev - 1, 0))}>Back</button>
+            {step < STEPS.length - 1 && (
+              <button type="button" style={submitting ? styles.primaryDisabled : styles.primary} disabled={submitting} onClick={handleNext}>Next</button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const styles = {
+  overlay: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.6)',
+    zIndex: 1200,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  shell: {
+    width: 'min(760px, 100%)',
+    maxHeight: '92vh',
+    background: theme.surface,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    display: 'flex',
+    flexDirection: 'column',
+    boxShadow: '0 16px 40px rgba(0,0,0,0.45)',
+  },
+  header: { display: 'flex', justifyContent: 'space-between', gap: 16, padding: 16, borderBottom: `1px solid ${theme.border}` },
+  title: { fontSize: 16, fontWeight: 700, color: theme.textBright },
+  subtitle: { fontSize: 12, color: theme.textMuted, marginTop: 4 },
+  closeBtn: { border: 'none', background: 'transparent', color: theme.textMuted, fontSize: 16, cursor: 'pointer' },
+  stepRail: { display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', borderBottom: `1px solid ${theme.border}` },
+  step: { border: 'none', background: theme.surface, color: theme.textMuted, padding: '10px 8px', fontSize: 11, fontWeight: 600, cursor: 'pointer' },
+  stepActive: { border: 'none', background: theme.accentSubtle, color: theme.textBright, padding: '10px 8px', fontSize: 11, fontWeight: 700, cursor: 'pointer' },
+  stepIndex: { display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: '50%', border: `1px solid ${theme.border}`, marginRight: 6, fontSize: 10 },
+  body: { padding: 16, overflowY: 'auto' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 12 },
+  field: { display: 'flex', flexDirection: 'column', gap: 6, fontSize: 11, fontWeight: 600, color: theme.textMuted },
+  fieldWide: { display: 'flex', flexDirection: 'column', gap: 6, fontSize: 11, fontWeight: 600, color: theme.textMuted, gridColumn: '1 / -1' },
+  input: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 6, color: theme.text, padding: '8px 10px', fontSize: 12 },
+  textarea: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 6, color: theme.text, padding: '8px 10px', fontSize: 12, minHeight: 76, resize: 'vertical' },
+  specBox: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 8, padding: 12 },
+  pre: { margin: 0, color: theme.codeText, fontSize: 12, overflowX: 'auto' },
+  planList: { display: 'flex', flexDirection: 'column', gap: 10 },
+  planItem: { display: 'flex', alignItems: 'center', gap: 8, color: theme.text, fontSize: 12 },
+  materializePanel: { display: 'flex', flexDirection: 'column', gap: 12 },
+  activityToggle: { alignSelf: 'flex-start', border: `1px solid ${theme.border}`, background: theme.surfaceInset, color: theme.text, borderRadius: 6, padding: '6px 10px', cursor: 'pointer', fontSize: 12 },
+  activityLog: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 8, padding: 10, maxHeight: 160, overflowY: 'auto' },
+  event: { color: theme.text, fontSize: 12, padding: '3px 0' },
+  eventError: { color: theme.red, fontSize: 12, padding: '3px 0' },
+  muted: { color: theme.textMuted, fontSize: 12 },
+  error: { margin: '0 16px 12px', color: theme.red, background: theme.redSubtle, border: `1px solid ${theme.red}`, borderRadius: 6, padding: '8px 10px', fontSize: 12 },
+  footer: { display: 'flex', justifyContent: 'space-between', gap: 12, padding: 16, borderTop: `1px solid ${theme.border}` },
+  footerRight: { display: 'flex', gap: 8 },
+  primary: { border: 'none', borderRadius: 6, background: theme.accent, color: theme.white, padding: '8px 14px', fontSize: 12, fontWeight: 700, cursor: 'pointer' },
+  primaryDisabled: { border: 'none', borderRadius: 6, background: theme.textMuted, color: theme.white, padding: '8px 14px', fontSize: 12, fontWeight: 700, cursor: 'not-allowed', opacity: 0.7 },
+  secondary: { border: `1px solid ${theme.border}`, borderRadius: 6, background: theme.surfaceInset, color: theme.text, padding: '8px 14px', fontSize: 12, fontWeight: 600, cursor: 'pointer' },
+  secondaryDisabled: { border: `1px solid ${theme.border}`, borderRadius: 6, background: theme.surfaceInset, color: theme.textMuted, padding: '8px 14px', fontSize: 12, fontWeight: 600, cursor: 'not-allowed', opacity: 0.5 },
+}

--- a/src/ui/src/components/ProjectView.jsx
+++ b/src/ui/src/components/ProjectView.jsx
@@ -1,0 +1,198 @@
+import React, { useCallback, useState } from 'react'
+import { useHydraFlow } from '../context/HydraFlowContext'
+import { theme } from '../theme'
+
+export function ProjectView({ project }) {
+  const { pushOnboardingDraft } = useHydraFlow()
+  const [activityOpen, setActivityOpen] = useState(false)
+  const [pushState, setPushState] = useState('idle')
+  const [pushError, setPushError] = useState('')
+
+  const handlePush = useCallback(async () => {
+    if (!project?.onboarding_draft_id || pushState === 'running') return
+    setPushState('running')
+    setPushError('')
+    const result = await pushOnboardingDraft?.(project.onboarding_draft_id)
+    if (!result?.ok) {
+      setPushState('failed')
+      setPushError(result?.error || 'Push failed')
+      setActivityOpen(true)
+      return
+    }
+    setPushState('succeeded')
+  }, [project?.onboarding_draft_id, pushOnboardingDraft, pushState])
+
+  if (!project?.local_only) return null
+
+  const events = project.onboarding_events || []
+  const canPush = Boolean(project.onboarding_draft_id) && pushState !== 'running'
+
+  return (
+    <div style={styles.wrapper} data-testid="project-view-local-only">
+      <div style={styles.header}>
+        <div style={styles.titleBlock}>
+          <span style={styles.badge}>local only</span>
+          <span style={styles.name}>{project.full_name || project.slug || project.path}</span>
+          {project.path && <span style={styles.path}>{project.path}</span>}
+        </div>
+        <button
+          type="button"
+          style={canPush ? styles.pushButton : styles.pushDisabled}
+          disabled={!canPush}
+          onClick={handlePush}
+          title={canPush ? undefined : 'Waiting for onboarding draft state'}
+        >
+          {pushState === 'running' ? 'Pushing...' : 'Push to GitHub'}
+        </button>
+      </div>
+      <div style={styles.statusRow}>
+        <span style={pushState === 'failed' ? styles.statusDotFailed : styles.statusDot} />
+        <span>{pushState === 'failed' ? 'Push failed' : pushState === 'succeeded' ? 'Pushed' : 'Ready locally'}</span>
+        <button type="button" style={styles.activityButton} onClick={() => setActivityOpen(prev => !prev)}>
+          Activity {activityOpen ? 'up' : 'down'}
+        </button>
+      </div>
+      {pushError && <div style={styles.error}>{pushError}</div>}
+      {activityOpen && (
+        <div style={styles.activityLog} data-testid="project-activity-log">
+          {events.length === 0 ? (
+            <span style={styles.muted}>No onboarding activity recorded</span>
+          ) : events.map((event, index) => (
+            <div key={`${event.message}-${index}`} style={event.level === 'error' ? styles.eventError : styles.event}>
+              {event.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+const styles = {
+  wrapper: {
+    border: `1px solid ${theme.orange}`,
+    background: theme.orangeSubtle,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: 12,
+    alignItems: 'flex-start',
+  },
+  titleBlock: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    minWidth: 0,
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    color: theme.orange,
+    border: `1px solid ${theme.orange}`,
+    borderRadius: 999,
+    padding: '2px 7px',
+    fontSize: 10,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+  },
+  name: {
+    color: theme.textBright,
+    fontSize: 14,
+    fontWeight: 700,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  path: {
+    color: theme.textMuted,
+    fontSize: 11,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  pushButton: {
+    border: `1px solid ${theme.orange}`,
+    borderRadius: 6,
+    background: theme.orange,
+    color: theme.white,
+    padding: '7px 10px',
+    fontSize: 12,
+    fontWeight: 700,
+    cursor: 'pointer',
+    flexShrink: 0,
+  },
+  pushDisabled: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 6,
+    background: theme.surfaceInset,
+    color: theme.textMuted,
+    padding: '7px 10px',
+    fontSize: 12,
+    fontWeight: 700,
+    cursor: 'not-allowed',
+    flexShrink: 0,
+  },
+  statusRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 10,
+    color: theme.text,
+    fontSize: 12,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    background: theme.orange,
+    flexShrink: 0,
+  },
+  statusDotFailed: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    background: theme.red,
+    flexShrink: 0,
+  },
+  error: {
+    marginTop: 8,
+    color: theme.red,
+    fontSize: 12,
+    fontWeight: 600,
+  },
+  activityButton: {
+    marginLeft: 'auto',
+    border: 'none',
+    background: 'transparent',
+    color: theme.accent,
+    fontSize: 12,
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  activityLog: {
+    marginTop: 10,
+    background: theme.surfaceInset,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 6,
+    padding: 10,
+    maxHeight: 140,
+    overflowY: 'auto',
+  },
+  event: {
+    color: theme.text,
+    fontSize: 12,
+    padding: '3px 0',
+  },
+  eventError: {
+    color: theme.red,
+    fontSize: 12,
+    padding: '3px 0',
+  },
+  muted: {
+    color: theme.textMuted,
+    fontSize: 12,
+  },
+}

--- a/src/ui/src/components/RepoSelector.jsx
+++ b/src/ui/src/components/RepoSelector.jsx
@@ -32,7 +32,7 @@ function isPipelineEnabled(runtime, repo) {
     ?? repo?.status === 'running'
 }
 
-export function RepoSelector({ onOpenRegister }) {
+export function RepoSelector({ onOpenRegister, onOpenNewProject }) {
   const {
     canRegisterRepos = false,
     supervisedRepos = [],
@@ -73,6 +73,7 @@ export function RepoSelector({ onOpenRegister }) {
         filterSlug,
         rawSlug,
         isRunning,
+        localOnly: repo.local_only === true,
       }
     })
     entries.sort((a, b) => a.label.localeCompare(b.label))
@@ -137,10 +138,22 @@ export function RepoSelector({ onOpenRegister }) {
                     {opt.subLabel && <span style={styles.optionSubLabel}>{opt.subLabel}</span>}
                   </span>
                 </span>
-                <span style={styles.optionStatus}>{opt.isRunning ? 'Running' : 'Stopped'}</span>
+                <span style={opt.localOnly ? styles.optionLocalOnly : styles.optionStatus}>
+                  {opt.localOnly ? 'Local only' : opt.isRunning ? 'Running' : 'Stopped'}
+                </span>
               </button>
             ))}
           </div>
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false)
+              onOpenNewProject?.()
+            }}
+            style={styles.newProjectBtn}
+          >
+            + New project
+          </button>
           <button
             type="button"
             disabled={!canRegisterRepos}
@@ -240,6 +253,12 @@ const styles = {
     color: theme.textMuted,
     flexShrink: 0,
   },
+  optionLocalOnly: {
+    fontSize: 11,
+    color: theme.orange,
+    flexShrink: 0,
+    fontWeight: 700,
+  },
   divider: {
     height: 1,
     background: theme.border,
@@ -258,6 +277,16 @@ const styles = {
     fontSize: 12,
     fontWeight: 600,
     color: theme.accent,
+    cursor: 'pointer',
+  },
+  newProjectBtn: {
+    border: 'none',
+    borderTop: `1px solid ${theme.border}`,
+    background: theme.surfaceInset,
+    padding: '8px 10px',
+    fontSize: 12,
+    fontWeight: 600,
+    color: theme.orange,
     cursor: 'pointer',
   },
   registerBtnDisabled: {

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -4,6 +4,7 @@ import { theme } from '../theme'
 import { canonicalRepoSlug } from '../constants'
 import { RepoSelector } from './RepoSelector'
 import { RegisterRepoDialog } from './RegisterRepoDialog'
+import { BootstrapWizard } from './BootstrapWizard'
 import { formatRelative, formatDuration } from '../utils/timeFormat'
 
 function pickLatestSession(sessions) {
@@ -77,8 +78,11 @@ export function SessionSidebar() {
     removeRepoShortcut,
   } = useHydraFlow()
   const [registerModalOpen, setRegisterModalOpen] = useState(false)
+  const [wizardOpen, setWizardOpen] = useState(false)
   const openRegister = useCallback(() => setRegisterModalOpen(true), [])
   const closeRegister = useCallback(() => setRegisterModalOpen(false), [])
+  const openWizard = useCallback(() => setWizardOpen(true), [])
+  const closeWizard = useCallback(() => setWizardOpen(false), [])
 
   const repoEntries = useMemo(() => {
     const entries = new Map()
@@ -158,7 +162,7 @@ export function SessionSidebar() {
   return (
     <div style={styles.sidebar}>
       <div style={styles.repoSelectorSection}>
-        <RepoSelector onOpenRegister={openRegister} />
+        <RepoSelector onOpenRegister={openRegister} onOpenNewProject={openWizard} />
       </div>
 
       <div style={styles.list}>
@@ -170,6 +174,7 @@ export function SessionSidebar() {
           const orchRunning = orchestratorStatus === 'running'
           const disabled = !orchRunning && !isRunning
           const slug = entry.repoSlug || entry.displayName
+          const localOnly = entry.info?.local_only === true
 
           return (
             <div
@@ -178,15 +183,16 @@ export function SessionSidebar() {
               style={isRepoSelected ? repoRowSelected : styles.repoRow}
             >
               <div style={styles.repoLineOne}>
-                <span style={isRunning ? styles.repoDotRunning : styles.repoDotStopped} />
+                <span style={localOnly ? styles.repoDotLocal : isRunning ? styles.repoDotRunning : styles.repoDotStopped} />
                 <div style={styles.repoText}>
                   <span style={styles.repoName}>{entry.displayName}</span>
+                  {localOnly && <span style={styles.localOnlyBadge}>local only</span>}
                   {entry.info?.path && entry.info.path !== entry.displayName && (
                     <span style={styles.repoSubLabel}>{entry.info.path}</span>
                   )}
                 </div>
                 <div style={styles.repoControls}>
-                  {(entry.info || entry.runtime) && (
+                  {(entry.info || entry.runtime) && !localOnly && (
                     <button
                       onClick={(e) => {
                         e.stopPropagation()
@@ -238,6 +244,7 @@ export function SessionSidebar() {
         )}
       </div>
       <RegisterRepoDialog isOpen={registerModalOpen} onClose={closeRegister} />
+      <BootstrapWizard isOpen={wizardOpen} onClose={closeWizard} />
     </div>
   )
 }
@@ -329,6 +336,19 @@ const styles = {
     borderRadius: '50%',
     background: theme.textMuted,
     flexShrink: 0,
+  },
+  repoDotLocal: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    background: theme.orange,
+    flexShrink: 0,
+  },
+  localOnlyBadge: {
+    color: theme.orange,
+    fontSize: 10,
+    fontWeight: 700,
+    textTransform: 'uppercase',
   },
   runtimeStartBtn: {
     background: 'none',

--- a/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
+++ b/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { BootstrapWizard } = await import('../BootstrapWizard')
+
+function makeContext(overrides = {}) {
+  return {
+    createOnboardingDraft: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        events: [{ level: 'info', message: 'draft created' }],
+      },
+    }),
+    materializeOnboardingDraft: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        events: [{ level: 'info', message: 'materialized invariant kernel' }],
+      },
+      materialized: { path: '/tmp/finance-tool' },
+    }),
+    selectRepo: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('BootstrapWizard', () => {
+  beforeEach(() => {
+    mockUseHydraFlow.mockReturnValue(makeContext())
+  })
+
+  it('does not render when closed', () => {
+    const { container } = render(<BootstrapWizard isOpen={false} onClose={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('creates a draft before entering the spec step', async () => {
+    const createOnboardingDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: { id: 'draft-2', spec: { name: 'new-project' }, events: [] },
+    })
+    mockUseHydraFlow.mockReturnValue(makeContext({ createOnboardingDraft }))
+
+    render(<BootstrapWizard isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByText('Next'))
+
+    await waitFor(() => expect(createOnboardingDraft).toHaveBeenCalled())
+    expect(screen.getByText(/"name": "new-project"/)).toBeInTheDocument()
+  })
+
+  it('materializes the active draft and selects the generated repo', async () => {
+    const materializeOnboardingDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: { id: 'draft-1', spec: { name: 'finance-tool' }, events: [] },
+    })
+    const selectRepo = vi.fn()
+    const onClose = vi.fn()
+    mockUseHydraFlow.mockReturnValue(makeContext({ materializeOnboardingDraft, selectRepo }))
+
+    render(<BootstrapWizard isOpen onClose={onClose} />)
+    fireEvent.click(screen.getByText('Next'))
+    await screen.findByText(/"name": "new-project"/)
+    fireEvent.click(screen.getByText('Next'))
+    fireEvent.click(screen.getByText('Next'))
+    fireEvent.click(screen.getByTestId('materialize-project'))
+
+    await waitFor(() => expect(materializeOnboardingDraft).toHaveBeenCalledWith('draft-1', { output_dir: null }))
+    expect(selectRepo).toHaveBeenCalledWith('finance-tool')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('keeps the wizard open and expands activity on materialize failure', async () => {
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      materializeOnboardingDraft: vi.fn().mockResolvedValue({
+        ok: false,
+        error: 'Draft could not be materialized',
+        draft: {
+          id: 'draft-1',
+          spec: { name: 'new-project' },
+          events: [{ level: 'error', message: 'target directory already exists' }],
+        },
+      }),
+    }))
+
+    render(<BootstrapWizard isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByText('Next'))
+    await screen.findByText(/"name": "new-project"/)
+    fireEvent.click(screen.getByText('Next'))
+    fireEvent.click(screen.getByText('Next'))
+    fireEvent.click(screen.getByTestId('materialize-project'))
+
+    await screen.findByText('Draft could not be materialized')
+    expect(screen.getByTestId('wizard-activity-log')).toHaveTextContent('target directory already exists')
+  })
+})

--- a/src/ui/src/components/__tests__/ProjectView.test.jsx
+++ b/src/ui/src/components/__tests__/ProjectView.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const mockUseHydraFlow = vi.fn()
+
+vi.mock('../../context/HydraFlowContext', () => ({
+  useHydraFlow: (...args) => mockUseHydraFlow(...args),
+}))
+
+const { ProjectView } = await import('../ProjectView')
+
+describe('ProjectView', () => {
+  beforeEach(() => {
+    mockUseHydraFlow.mockReturnValue({
+      pushOnboardingDraft: vi.fn().mockResolvedValue({ ok: false, error: 'Push failed (404)' }),
+    })
+  })
+
+  it('renders nothing for non-local projects', () => {
+    const { container } = render(<ProjectView project={{ slug: 'acme/app' }} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows local-only state and disabled push action', () => {
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      full_name: 'finance-tool',
+      path: '/tmp/finance-tool',
+      local_only: true,
+      onboarding_draft_id: 'draft-1',
+      onboarding_events: [{ level: 'info', message: 'materialized invariant kernel' }],
+    }} />)
+
+    expect(screen.getByText('local only')).toBeInTheDocument()
+    expect(screen.getByText('Ready locally')).toBeInTheDocument()
+    expect(screen.getByText('Push to GitHub')).not.toBeDisabled()
+    fireEvent.click(screen.getByText('Activity down'))
+    expect(screen.getByTestId('project-activity-log')).toHaveTextContent('materialized invariant kernel')
+  })
+
+  it('calls the push endpoint and shows failure state', async () => {
+    const pushOnboardingDraft = vi.fn().mockResolvedValue({ ok: false, error: 'Push endpoint unavailable' })
+    mockUseHydraFlow.mockReturnValue({ pushOnboardingDraft })
+
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      local_only: true,
+      onboarding_draft_id: 'draft-1',
+      onboarding_events: [],
+    }} />)
+
+    fireEvent.click(screen.getByText('Push to GitHub'))
+    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith('draft-1'))
+    expect(screen.getByText('Push failed')).toBeInTheDocument()
+    expect(screen.getByText('Push endpoint unavailable')).toBeInTheDocument()
+  })
+})

--- a/src/ui/src/components/__tests__/RepoSelector.test.jsx
+++ b/src/ui/src/components/__tests__/RepoSelector.test.jsx
@@ -50,6 +50,24 @@ describe('RepoSelector', () => {
     expect(onOpenRegister).toHaveBeenCalledTimes(1)
   })
 
+  it('opens new project wizard from dropdown action', () => {
+    const onOpenNewProject = vi.fn()
+    render(<RepoSelector onOpenNewProject={onOpenNewProject} />)
+    fireEvent.click(screen.getByTestId('repo-selector-trigger'))
+    fireEvent.click(screen.getByText('+ New project'))
+    expect(onOpenNewProject).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('repo-selector-dropdown')).toBeNull()
+  })
+
+  it('shows local-only status for materialized projects', () => {
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      supervisedRepos: [{ slug: 'finance-tool', path: '/tmp/finance-tool', local_only: true }],
+    }))
+    render(<RepoSelector />)
+    fireEvent.click(screen.getByTestId('repo-selector-trigger'))
+    expect(screen.getByText('Local only')).toBeInTheDocument()
+  })
+
   it('disables register button when canRegisterRepos is false', () => {
     mockUseHydraFlow.mockReturnValue(makeContext({ canRegisterRepos: false }))
     render(<RepoSelector />)

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -53,6 +53,7 @@ export const initialState = {
   retrospectives: null,
   troubleshooting: null,
   trackedReports: [],
+  localOnlyProjects: [],
   // True when the orchestrator backend is wired to Fake adapters (sandbox tier).
   // Set from /api/control/status. Drives the persistent MOCKWORLD MODE banner.
   mockworldActive: false,
@@ -61,6 +62,23 @@ export const initialState = {
 function normalizeRepoSlug(value) {
   if (value == null) return null
   return String(value).trim().replace(/[\\/]+/g, '-') || null
+}
+
+function mergeLocalOnlyProjects(supervisedRepos, localOnlyProjects) {
+  const repos = Array.isArray(supervisedRepos) ? supervisedRepos : []
+  const local = Array.isArray(localOnlyProjects) ? localOnlyProjects : []
+  const seen = new Set(
+    repos.flatMap(repo => [
+      normalizeRepoSlug(repo?.slug || repo?.repo || repo?.full_name || repo?.path),
+      repo?.path || null,
+    ]).filter(Boolean)
+  )
+  const missingLocal = local.filter(project => {
+    const slug = normalizeRepoSlug(project?.slug || project?.full_name || project?.path)
+    const path = project?.path || null
+    return !seen.has(slug) && (!path || !seen.has(path))
+  })
+  return [...repos, ...missingLocal]
 }
 
 function isDuplicate(state, action) {
@@ -746,6 +764,22 @@ export function reducer(state, action) {
           : [],
       }
 
+    case 'LOCAL_ONLY_PROJECT_ADDED': {
+      const project = action.data
+      if (!project?.slug) return state
+      const existing = state.localOnlyProjects || []
+      const next = [
+        project,
+        ...existing.filter(item => item.slug !== project.slug && item.path !== project.path),
+      ]
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem('hydraflow.localOnlyProjects', JSON.stringify(next))
+        } catch { /* ignore */ }
+      }
+      return { ...state, localOnlyProjects: next }
+    }
+
     case 'SELECT_REPO': {
       const newSlug = normalizeRepoSlug(action.data.slug)
       const changed = newSlug !== state.selectedRepoSlug
@@ -1043,6 +1077,17 @@ export function HydraFlowProvider({ children }) {
     } catch { /* ignore */ }
   }, [])
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    try {
+      const raw = window.localStorage.getItem('hydraflow.localOnlyProjects')
+      const projects = raw ? JSON.parse(raw) : []
+      if (Array.isArray(projects)) {
+        projects.forEach(project => dispatch({ type: 'LOCAL_ONLY_PROJECT_ADDED', data: project }))
+      }
+    } catch { /* ignore */ }
+  }, [])
+
   const parseApiError = useCallback(async (res, fallback) => {
     try {
       const body = await res.json()
@@ -1270,6 +1315,69 @@ export function HydraFlowProvider({ children }) {
       return { ok: false, error: err.message || 'Network error' }
     }
   }, [fetchRepos])
+
+  const createOnboardingDraft = useCallback(async (spec) => {
+    try {
+      const res = await fetch('/api/onboarding/drafts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(spec),
+      })
+      if (!res.ok) {
+        return { ok: false, error: await parseApiError(res, `Draft failed (${res.status})`) }
+      }
+      return { ok: true, draft: await res.json() }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Draft failed' }
+    }
+  }, [parseApiError])
+
+  const materializeOnboardingDraft = useCallback(async (draftId, request = {}) => {
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/materialize`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Materialize failed (${res.status})`, draft: data?.draft }
+      }
+      const spec = data?.draft?.spec || {}
+      const materializedPath = data?.materialized?.path || ''
+      const project = {
+        slug: spec.name || materializedPath,
+        full_name: spec.name || materializedPath,
+        path: materializedPath,
+        local_only: true,
+        onboarding_draft_id: data?.draft?.id || draftId,
+        onboarding_events: data?.draft?.events || [],
+      }
+      dispatch({ type: 'LOCAL_ONLY_PROJECT_ADDED', data: project })
+      if (materializedPath) {
+        await addRepoByPath(materializedPath)
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Materialize failed' }
+    }
+  }, [addRepoByPath])
+
+  const pushOnboardingDraft = useCallback(async (draftId) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/push`, {
+        method: 'POST',
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Push failed (${res.status})`, draft: data?.draft }
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Push failed' }
+    }
+  }, [])
 
   const removeRepoShortcut = useCallback((repoSlug) => {
     removeRepo(repoSlug)
@@ -1714,6 +1822,7 @@ export function HydraFlowProvider({ children }) {
   const value = {
     ...state,
     sessions: repoFilteredSessions,
+    supervisedRepos: mergeLocalOnlyProjects(state.supervisedRepos, state.localOnlyProjects),
     stageStatus,
     resetSession,
     submitIntent,
@@ -1733,6 +1842,9 @@ export function HydraFlowProvider({ children }) {
     selectRepo,
     addRepoBySlug,
     addRepoByPath,
+    createOnboardingDraft,
+    materializeOnboardingDraft,
+    pushOnboardingDraft,
     fetchRepos,
     removeRepoShortcut,
     startRuntime,

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, waitFor } from '@testing-library/react'
 import { reducer, getPipelineAction } from '../HydraFlowContext'
 
 const emptyPipeline = {
@@ -2107,8 +2107,10 @@ describe('HydraFlowProvider body[data-connected]', () => {
       )
     })
 
-    expect(document.body.getAttribute('data-connected')).toBe('true')
-    expect(screen.getByTestId('connected').textContent).toBe('true')
+    await waitFor(() => {
+      expect(document.body.getAttribute('data-connected')).toBe('true')
+      expect(screen.getByTestId('connected').textContent).toBe('true')
+    })
   })
 
   it('sets data-connected to false when not connected', async () => {


### PR DESCRIPTION
Refs #8931

## Summary
- adds the dashboard New Project wizard entry point from the existing repo picker
- adds a 4-step BootstrapWizard that creates Phase-1 drafts and materializes locally
- stores materialized local-only projects in dashboard state/localStorage and renders local-only sidebar/project status
- wires Push to GitHub CTA to the expected push endpoint and shows failure state until the backend push API lands

## Verification
- npm test -- src/components/__tests__/ProjectView.test.jsx src/components/__tests__/BootstrapWizard.test.jsx src/components/__tests__/RepoSelector.test.jsx src/context/__tests__/HydraFlowContext.test.jsx
- npm run build
- npm test
- make quality

## Notes
This is an internal-preview slice for #8931. The push endpoint and live SSE activity stream are still backend/API work; the UI now calls the expected push endpoint and surfaces unavailable/failure state instead of pretending push succeeded.