### PR TITLE
Refs #8932: add onboarding design chat slice

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T04:32:18.774557+00:00",
-  "commit_sha": "063468b3385cf00abbcbe832a8a4fd577e172006",
+  "regenerated_at": "2026-05-23T05:05:12.871437+00:00",
+  "commit_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f",
   "artifacts": {
     "loops.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "ports.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "labels.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "modules.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "events.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "adr_xref.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "mockworld.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "changelog.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "coverage_matrix.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "functional_areas.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "ubiquitous-language.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "063468b3385cf00abbcbe832a8a4fd577e172006"
+      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `091f166` — Refs #8931: add onboarding wizard UI slice *(2026-05-22)*
 - `e439049` — Refs #8930: add onboarding materialize API slice *(2026-05-22)*
 - `e5e3dbd` — Refs #8930: add onboarding draft API foundation *(2026-05-22)*
 - `52784fb` — Fixes #8368: resolve dashboard a11y violations *(2026-05-22)*
@@ -344,4 +345,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -32,7 +32,7 @@ graph LR
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch
-    src_dashboard_routes -- "2" --> src_onboarding
+    src_dashboard_routes -- "3" --> src_onboarding
     src_dashboard_routes -- "1" --> src_preflight
     src_dashboard_routes -- "1" --> src_state
     src_mockworld_fakes -- "25" --> src_mockworld
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `063468b` on 2026-05-23 04:32 UTC. Source last changed at `063468b`. Status: 🟢 fresh._
+_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -12,13 +12,21 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
-from onboarding.models import BootstrapDraft, BootstrapSpec, MaterializeRequest
+from onboarding.design_ai import DesignAIService, apply_field_updates
+from onboarding.models import (
+    BootstrapDraft,
+    BootstrapSpec,
+    DesignChatRequest,
+    DesignRevisionRequest,
+    MaterializeRequest,
+)
 from onboarding.templating import MaterializeError, materialize_repository
 
 if TYPE_CHECKING:
     from dashboard_routes._routes import RouteContext
 
 logger = logging.getLogger("hydraflow.dashboard.onboarding")
+design_ai = DesignAIService()
 
 
 def _decode_draft(raw: dict[str, object]) -> BootstrapDraft | None:
@@ -82,6 +90,76 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         if draft is None:
             return JSONResponse({"error": "Draft is invalid"}, status_code=500)
         return JSONResponse(draft.model_dump(mode="json"))
+
+    @router.post("/api/onboarding/drafts/{draft_id}/design/chat")
+    async def chat_onboarding_draft(
+        draft_id: str, request: DesignChatRequest
+    ) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+
+        turn = design_ai.chat(draft, request.message)
+        draft.chat_messages.append({"role": "user", "content": request.message})
+        draft.chat_messages.append({"role": "assistant", "content": turn.reply})
+        draft.extracted_fields.update(turn.field_updates)
+        try:
+            draft.spec = apply_field_updates(draft.spec, turn.field_updates)
+        except ValidationError:
+            return JSONResponse({"error": "Design update is invalid"}, status_code=422)
+        draft.events.append({"level": "info", "message": "design chat updated fields"})
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {
+                "draft": draft.model_dump(mode="json"),
+                "reply": turn.reply,
+                "field_updates": turn.field_updates,
+                "clarification": turn.clarification,
+            }
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/design/spec")
+    async def draft_onboarding_spec(
+        draft_id: str, request: DesignRevisionRequest | None = None
+    ) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+
+        draft.spec_draft = design_ai.draft_spec(
+            draft, request.note if request else None
+        )
+        draft.events.append({"level": "info", "message": "wizard spec drafted"})
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {"draft": draft.model_dump(mode="json"), "spec_draft": draft.spec_draft}
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/design/plan")
+    async def draft_onboarding_plan(
+        draft_id: str, request: DesignRevisionRequest | None = None
+    ) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+
+        draft.plan_draft = design_ai.draft_plan(
+            draft, request.note if request else None
+        )
+        draft.events.append({"level": "info", "message": "wizard plan drafted"})
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {"draft": draft.model_dump(mode="json"), "plan_draft": draft.plan_draft}
+        )
 
     @router.post("/api/onboarding/drafts/{draft_id}/materialize")
     async def materialize_onboarding_draft(

--- a/src/onboarding/design_ai.py
+++ b/src/onboarding/design_ai.py
@@ -1,0 +1,239 @@
+"""Design-chat extraction for onboarding bootstrap drafts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from onboarding.models import BootstrapDraft, BootstrapSpec
+
+_NAME_RE = re.compile(r"\b[a-z][a-z0-9]+(?:-[a-z0-9]+)+\b")
+_OWNER_RE = re.compile(
+    r"\b(?:owner|org|organization)\s+([A-Za-z0-9_.-]{1,100})\b", re.I
+)
+_COVERAGE_RE = re.compile(r"\b(\d{2,3})\s*%\s*(?:coverage|test coverage)\b", re.I)
+
+
+@dataclass(frozen=True)
+class DesignTurn:
+    """Structured output for one onboarding design-chat turn."""
+
+    reply: str
+    field_updates: dict[str, object]
+    clarification: str | None = None
+
+
+def apply_field_updates(
+    spec: BootstrapSpec, updates: dict[str, object]
+) -> BootstrapSpec:
+    """Return a new spec with validated structured updates applied."""
+
+    payload = spec.model_dump()
+    for key, value in updates.items():
+        if value is None or key not in payload:
+            continue
+        payload[key] = value
+    return BootstrapSpec.model_validate(payload)
+
+
+class DesignAIService:
+    """Lightweight design assistant with a Claude-provider seam.
+
+    The deterministic extractor keeps the dashboard usable and testable when no
+    external API key is configured. A production Claude provider can replace
+    ``chat`` behind this interface without changing the route or UI contracts.
+    """
+
+    def chat(self, draft: BootstrapDraft, message: str) -> DesignTurn:
+        updates = self._extract_fields(message, draft.spec)
+        updated = apply_field_updates(draft.spec, updates)
+        clarification = self._clarification_for(message, updated)
+        reply = self._reply_for(updated, updates, clarification)
+        return DesignTurn(
+            reply=reply, field_updates=updates, clarification=clarification
+        )
+
+    def draft_spec(self, draft: BootstrapDraft, note: str | None = None) -> str:
+        spec = draft.spec
+        ui_choice = _ui_choice(spec.tech_stack)
+        backend = _backend_choice(spec.tech_stack)
+        note_line = f"\nRevision note: {note}" if note else ""
+        return (
+            "---\n"
+            "status: wizard-draft\n"
+            "generated_by: hydraflow-wizard\n"
+            "needs_refinement: true\n"
+            "methodology_refs:\n"
+            "  - docs/methodology/onboarding-hydraflow-format-repos.md\n"
+            "---\n\n"
+            f"# {spec.name} Bootstrap Spec\n\n"
+            f"## Name\n{spec.name}\n\n"
+            f"## Description\n{spec.description}\n\n"
+            "## Architecture Overview\n"
+            f"- Backend: {backend}\n"
+            f"- UI: {ui_choice}\n"
+            f"- Owner: {spec.owner}\n"
+            f"- Branches: {spec.main_branch} + {spec.staging_branch}\n\n"
+            "## 10-file Invariant Kernel\n"
+            "1. README.md\n"
+            "2. CLAUDE.md\n"
+            "3. pyproject.toml\n"
+            "4. .env.example\n"
+            "5. .github/workflows/ci.yml\n"
+            "6. .github/ISSUE_TEMPLATE/feature.yml\n"
+            "7. .github/pull_request_template.md\n"
+            "8. docs/adr/0001-record-architecture-baseline.md\n"
+            "9. docs/specs/bootstrap-spec.md\n"
+            "10. docs/plans/plan-01-bootstrap.md\n\n"
+            "## V1 IN\n"
+            f"- {backend} implementation skeleton\n"
+            f"- {spec.coverage_floor}% coverage gate\n"
+            f"- Safety guards: {', '.join(spec.safety_guards) or 'standard HydraFlow guards'}\n\n"
+            "## V1 OUT\n"
+            "- Production credentials\n"
+            "- Deep fleet-wide SHAPE refinement\n"
+            "- Post-bootstrap feature backlog\n"
+            f"{note_line}\n"
+        )
+
+    def draft_plan(self, draft: BootstrapDraft, note: str | None = None) -> list[str]:
+        spec = draft.spec
+        has_ui = _has_ui(spec.tech_stack)
+        tasks = [
+            f"Create the {spec.name} repository shell and invariant kernel",
+            "Write README, CLAUDE.md, and environment template",
+            "Add CI workflow with lint, typecheck, security scan, and tests",
+            f"Set coverage floor to {spec.coverage_floor}%",
+            "Create ADR-0001 and bootstrap spec handoff docs",
+            "Add issue and PR templates with wizard-draft frontmatter",
+            "Add smoke test for generated CLI entry point",
+            "Run local quality gate before GitHub provisioning",
+        ]
+        if has_ui:
+            tasks.insert(3, "Add UI scaffold and browser-smoke placeholder")
+        if any("branch" in guard.lower() for guard in spec.safety_guards):
+            tasks.append("Configure branch-protection expectations and fallback notes")
+        if any("decimal" in guard.lower() for guard in spec.safety_guards):
+            tasks.append("Add decimal-purity guardrail test")
+        tasks.append(
+            "Push wizard-drafted spec and Plan 01 for factory SHAPE refinement"
+        )
+        if note:
+            tasks.append(f"Apply operator revision note: {note}")
+        return tasks
+
+    def _extract_fields(
+        self, message: str, current: BootstrapSpec
+    ) -> dict[str, object]:
+        lowered = message.lower()
+        updates: dict[str, object] = {}
+
+        name_match = _NAME_RE.search(lowered)
+        if name_match:
+            updates["name"] = name_match.group(0)
+
+        owner_match = _OWNER_RE.search(message)
+        if owner_match:
+            updates["owner"] = owner_match.group(1)
+
+        if "public" in lowered:
+            updates["visibility"] = "public"
+        elif "private" in lowered:
+            updates["visibility"] = "private"
+
+        coverage_match = _COVERAGE_RE.search(message)
+        if coverage_match:
+            updates["coverage_floor"] = min(100, max(0, int(coverage_match.group(1))))
+
+        stack = list(current.tech_stack)
+        for keyword, label in (
+            ("fastapi", "FastAPI"),
+            ("django", "Django"),
+            ("flask", "Flask"),
+            ("python", "python"),
+            ("react", "React"),
+            ("next.js", "Next.js"),
+            ("nextjs", "Next.js"),
+            ("sqlite", "SQLite"),
+            ("postgres", "Postgres"),
+            ("postgresql", "Postgres"),
+            ("none ui", "UI=None"),
+            ("no ui", "UI=None"),
+        ):
+            if keyword in lowered and label not in stack:
+                stack.append(label)
+        if stack != current.tech_stack:
+            updates["tech_stack"] = stack
+
+        guards = list(current.safety_guards)
+        for keyword, label in (
+            ("branch protection", "branch-protection"),
+            ("deterministic", "deterministic-tests"),
+            ("decimal", "decimal-purity"),
+            ("quality gate", "quality-gates"),
+            ("quality gates", "quality-gates"),
+            ("adr", "adr-review"),
+        ):
+            if keyword in lowered and label not in guards:
+                guards.append(label)
+        if guards != current.safety_guards:
+            updates["safety_guards"] = guards
+
+        if len(message.strip()) >= 20:
+            updates["description"] = _description_for(message)
+
+        return updates
+
+    def _clarification_for(self, message: str, spec: BootstrapSpec) -> str | None:
+        lowered = message.lower()
+        if "i don't know" in lowered or "not sure" in lowered:
+            return "I can keep the standard Python path unless you want a specific backend or UI."
+        if "ui" in lowered and not _has_ui(spec.tech_stack) and "no ui" not in lowered:
+            return "Do you want React, Next.js, or no UI for the bootstrap?"
+        return None
+
+    def _reply_for(
+        self, spec: BootstrapSpec, updates: dict[str, object], clarification: str | None
+    ) -> str:
+        changed = ", ".join(sorted(updates)) if updates else "no fields"
+        base = (
+            f"Updated {changed}. Current draft is {spec.name} "
+            f"({spec.visibility}) with {_backend_choice(spec.tech_stack)}."
+        )
+        if clarification:
+            return f"{base} {clarification}"
+        return f"{base} Draft the spec when these fields look right."
+
+
+def _description_for(message: str) -> str:
+    normalized = " ".join(message.strip().split())
+    if len(normalized) > 500:
+        normalized = normalized[:497].rstrip() + "..."
+    if len(normalized) < 10:
+        return "HydraFlow-format bootstrap project."
+    return normalized
+
+
+def _has_ui(stack: list[str]) -> bool:
+    lowered = {item.lower() for item in stack}
+    return bool({"react", "next.js", "nextjs"} & lowered) and "ui=none" not in lowered
+
+
+def _ui_choice(stack: list[str]) -> str:
+    lowered = {item.lower() for item in stack}
+    if "next.js" in lowered or "nextjs" in lowered:
+        return "Next.js"
+    if "react" in lowered:
+        return "React"
+    return "None"
+
+
+def _backend_choice(stack: list[str]) -> str:
+    lowered = {item.lower() for item in stack}
+    if "fastapi" in lowered:
+        return "Python 3.11 + FastAPI"
+    if "django" in lowered:
+        return "Python 3.11 + Django"
+    if "flask" in lowered:
+        return "Python 3.11 + Flask"
+    return "Python 3.11"

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -85,6 +85,10 @@ class BootstrapDraft(BaseModel):
     created_at: str = Field(default_factory=_utc_now)
     updated_at: str = Field(default_factory=_utc_now)
     events: list[dict[str, str]] = Field(default_factory=list)
+    chat_messages: list[dict[str, str]] = Field(default_factory=list)
+    extracted_fields: dict[str, object] = Field(default_factory=dict)
+    spec_draft: str | None = None
+    plan_draft: list[str] = Field(default_factory=list)
 
     def touch(self) -> None:
         self.updated_at = _utc_now()
@@ -102,6 +106,34 @@ class MaterializeRequest(BaseModel):
     @field_validator("output_dir")
     @classmethod
     def normalize_output_dir(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+
+class DesignChatRequest(BaseModel):
+    """Operator chat turn for onboarding design extraction."""
+
+    message: str = Field(min_length=1, max_length=2000)
+
+    @field_validator("message")
+    @classmethod
+    def normalize_message(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("message is required")
+        return normalized
+
+
+class DesignRevisionRequest(BaseModel):
+    """Optional operator note for regenerating wizard-drafted artifacts."""
+
+    note: str | None = Field(default=None, max_length=2000)
+
+    @field_validator("note")
+    @classmethod
+    def normalize_note(cls, value: str | None) -> str | None:
         if value is None:
             return None
         normalized = value.strip()

--- a/src/ui/src/components/BootstrapWizard.jsx
+++ b/src/ui/src/components/BootstrapWizard.jsx
@@ -42,6 +42,24 @@ function buildSpec(form) {
   }
 }
 
+function formFromSpec(spec, previous = DEFAULT_FORM) {
+  if (!spec) return previous
+  return {
+    ...previous,
+    name: spec.name || previous.name,
+    description: spec.description || previous.description,
+    owner: spec.owner || previous.owner,
+    visibility: spec.visibility || previous.visibility,
+    tech_stack: Array.isArray(spec.tech_stack) ? spec.tech_stack.join(', ') : previous.tech_stack,
+    safety_guards: Array.isArray(spec.safety_guards) ? spec.safety_guards.join(', ') : previous.safety_guards,
+    coverage_floor: spec.coverage_floor ?? previous.coverage_floor,
+    package_name: spec.package_name || previous.package_name,
+    label_prefix: spec.label_prefix || previous.label_prefix,
+    main_branch: spec.main_branch || previous.main_branch,
+    staging_branch: spec.staging_branch || previous.staging_branch,
+  }
+}
+
 function buildPlanItems(spec) {
   return [
     `Create ${spec.name} with HydraFlow invariant-kernel files`,
@@ -56,12 +74,18 @@ function buildPlanItems(spec) {
 export function BootstrapWizard({ isOpen, onClose }) {
   const {
     createOnboardingDraft,
+    chatOnboardingDraft,
+    draftOnboardingSpec,
+    draftOnboardingPlan,
     materializeOnboardingDraft,
     selectRepo,
   } = useHydraFlow()
   const [step, setStep] = useState(0)
   const [form, setForm] = useState(DEFAULT_FORM)
   const [draft, setDraft] = useState(null)
+  const [chatInput, setChatInput] = useState('')
+  const [specDraft, setSpecDraft] = useState('')
+  const [planDraft, setPlanDraft] = useState([])
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [activityOpen, setActivityOpen] = useState(false)
@@ -71,6 +95,9 @@ export function BootstrapWizard({ isOpen, onClose }) {
       setStep(0)
       setForm(DEFAULT_FORM)
       setDraft(null)
+      setChatInput('')
+      setSpecDraft('')
+      setPlanDraft([])
       setSubmitting(false)
       setError('')
       setActivityOpen(false)
@@ -101,16 +128,78 @@ export function BootstrapWizard({ isOpen, onClose }) {
       return null
     }
     setDraft(result.draft)
+    setForm(prev => formFromSpec(result.draft?.spec, prev))
+    setSpecDraft(result.draft?.spec_draft || '')
+    setPlanDraft(result.draft?.plan_draft || [])
     return result.draft
   }, [createOnboardingDraft, draft, spec])
+
+  const handleChatSubmit = useCallback(async () => {
+    const message = chatInput.trim()
+    if (!message || submitting) return
+    const activeDraft = await ensureDraft()
+    if (!activeDraft) return
+    setSubmitting(true)
+    setError('')
+    const result = await chatOnboardingDraft?.(activeDraft.id, message)
+    setSubmitting(false)
+    if (!result?.ok) {
+      setDraft(result?.draft || activeDraft)
+      setError(result?.error || 'Design chat failed')
+      return
+    }
+    setChatInput('')
+    setDraft(result.draft)
+    setForm(prev => formFromSpec(result.draft?.spec, prev))
+    setSpecDraft(result.draft?.spec_draft || '')
+    setPlanDraft(result.draft?.plan_draft || [])
+  }, [chatInput, chatOnboardingDraft, ensureDraft, submitting])
+
+  const generateSpecDraft = useCallback(async (activeDraft) => {
+    const result = await draftOnboardingSpec?.(activeDraft.id)
+    if (!result?.ok) {
+      setDraft(result?.draft || activeDraft)
+      setError(result?.error || 'Spec draft failed')
+      return null
+    }
+    setDraft(result.draft)
+    setSpecDraft(result.spec_draft || result.draft?.spec_draft || '')
+    return result.draft
+  }, [draftOnboardingSpec])
+
+  const generatePlanDraft = useCallback(async (activeDraft) => {
+    const result = await draftOnboardingPlan?.(activeDraft.id)
+    if (!result?.ok) {
+      setDraft(result?.draft || activeDraft)
+      setError(result?.error || 'Plan draft failed')
+      return null
+    }
+    setDraft(result.draft)
+    setPlanDraft(result.plan_draft || result.draft?.plan_draft || [])
+    return result.draft
+  }, [draftOnboardingPlan])
 
   const handleNext = useCallback(async () => {
     if (step === 0) {
       const created = await ensureDraft()
       if (!created) return
+      setSubmitting(true)
+      setError('')
+      const updated = await generateSpecDraft(created)
+      setSubmitting(false)
+      if (!updated) return
+    }
+    if (step === 1) {
+      const activeDraft = await ensureDraft()
+      if (!activeDraft) return
+      setSubmitting(true)
+      setError('')
+      const updated = await generatePlanDraft(activeDraft)
+      setSubmitting(false)
+      if (!updated) return
     }
     setStep(prev => Math.min(prev + 1, STEPS.length - 1))
-  }, [ensureDraft, step])
+  }, [ensureDraft, generatePlanDraft, generateSpecDraft, step])
 
   const handleMaterialize = useCallback(async () => {
     const activeDraft = await ensureDraft()
@@ -166,26 +255,55 @@ export function BootstrapWizard({ isOpen, onClose }) {
 
         <div style={styles.body}>
           {step === 0 && (
-            <div style={styles.grid}>
-              <label style={styles.field}>Repo name<input style={styles.input} value={form.name} onChange={updateField('name')} /></label>
-              <label style={styles.field}>Owner<input style={styles.input} value={form.owner} onChange={updateField('owner')} /></label>
-              <label style={styles.fieldWide}>Description<textarea style={styles.textarea} value={form.description} onChange={updateField('description')} /></label>
-              <label style={styles.field}>Visibility<select style={styles.input} value={form.visibility} onChange={updateField('visibility')}><option value="private">Private</option><option value="public">Public</option></select></label>
-              <label style={styles.field}>Coverage floor<input style={styles.input} type="number" min="0" max="100" value={form.coverage_floor} onChange={updateField('coverage_floor')} /></label>
-              <label style={styles.fieldWide}>Tech stack<input style={styles.input} value={form.tech_stack} onChange={updateField('tech_stack')} /></label>
-              <label style={styles.fieldWide}>Safety guards<input style={styles.input} value={form.safety_guards} onChange={updateField('safety_guards')} /></label>
+            <div style={styles.describeLayout}>
+              <div style={styles.chatColumn}>
+                <div style={styles.chatLog} data-testid="design-chat-log">
+                  {(draft?.chat_messages || []).length === 0 ? (
+                    <div style={styles.muted}>Describe the repo, runtime, UI, safety constraints, and coverage target.</div>
+                  ) : draft.chat_messages.map((message, index) => (
+                    <div key={`${message.role}-${index}`} style={message.role === 'assistant' ? styles.assistantMessage : styles.userMessage}>
+                      <span style={styles.messageRole}>{message.role}</span>
+                      <span>{message.content}</span>
+                    </div>
+                  ))}
+                </div>
+                <textarea
+                  style={styles.chatInput}
+                  value={chatInput}
+                  onChange={(event) => setChatInput(event.target.value)}
+                  placeholder="Build finance-tool as a public FastAPI React app with branch protection and 92% coverage."
+                  aria-label="Design chat message"
+                />
+                <button type="button" style={submitting ? styles.primaryDisabled : styles.primary} disabled={submitting || !chatInput.trim()} onClick={handleChatSubmit}>
+                  Send
+                </button>
+              </div>
+              <div style={styles.grid}>
+                <label style={styles.field}>Repo name<input style={styles.input} value={form.name} onChange={updateField('name')} /></label>
+                <label style={styles.field}>Owner<input style={styles.input} value={form.owner} onChange={updateField('owner')} /></label>
+                <label style={styles.fieldWide}>Description<textarea style={styles.textarea} value={form.description} onChange={updateField('description')} /></label>
+                <label style={styles.field}>Visibility<select style={styles.input} value={form.visibility} onChange={updateField('visibility')}><option value="private">Private</option><option value="public">Public</option></select></label>
+                <label style={styles.field}>Coverage floor<input style={styles.input} type="number" min="0" max="100" value={form.coverage_floor} onChange={updateField('coverage_floor')} /></label>
+                <label style={styles.fieldWide}>Tech stack<input style={styles.input} value={form.tech_stack} onChange={updateField('tech_stack')} /></label>
+                <label style={styles.fieldWide}>Safety guards<input style={styles.input} value={form.safety_guards} onChange={updateField('safety_guards')} /></label>
+              </div>
             </div>
           )}
 
           {step === 1 && (
             <div style={styles.specBox}>
-              <pre style={styles.pre}>{JSON.stringify(spec, null, 2)}</pre>
+              <textarea
+                style={styles.specTextarea}
+                value={specDraft || JSON.stringify(spec, null, 2)}
+                onChange={(event) => setSpecDraft(event.target.value)}
+                aria-label="Generated spec draft"
+              />
             </div>
           )}
 
           {step === 2 && (
             <div style={styles.planList}>
-              {planItems.map(item => (
+              {(planDraft.length ? planDraft : planItems).map(item => (
                 <label key={item} style={styles.planItem}>
                   <input type="checkbox" checked readOnly />
                   <span>{item}</span>
@@ -262,12 +380,20 @@ const styles = {
   stepActive: { border: 'none', background: theme.accentSubtle, color: theme.textBright, padding: '10px 8px', fontSize: 11, fontWeight: 700, cursor: 'pointer' },
   stepIndex: { display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: 18, height: 18, borderRadius: '50%', border: `1px solid ${theme.border}`, marginRight: 6, fontSize: 10 },
   body: { padding: 16, overflowY: 'auto' },
-  grid: { display: 'grid', gridTemplateColumns: 'repeat(2, minmax(0, 1fr))', gap: 12 },
+  describeLayout: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))', gap: 14 },
+  chatColumn: { display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 },
+  chatLog: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 8, padding: 10, minHeight: 192, maxHeight: 260, overflowY: 'auto', display: 'flex', flexDirection: 'column', gap: 8 },
+  userMessage: { alignSelf: 'flex-end', maxWidth: '88%', background: theme.accentSubtle, color: theme.text, borderRadius: 8, padding: '8px 10px', fontSize: 12, lineHeight: 1.4 },
+  assistantMessage: { alignSelf: 'flex-start', maxWidth: '88%', background: theme.surface, color: theme.text, border: `1px solid ${theme.border}`, borderRadius: 8, padding: '8px 10px', fontSize: 12, lineHeight: 1.4 },
+  messageRole: { display: 'block', color: theme.textMuted, fontSize: 10, fontWeight: 700, textTransform: 'uppercase', marginBottom: 3 },
+  chatInput: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 6, color: theme.text, padding: '8px 10px', fontSize: 12, minHeight: 72, resize: 'vertical' },
+  grid: { display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 180px), 1fr))', gap: 12 },
   field: { display: 'flex', flexDirection: 'column', gap: 6, fontSize: 11, fontWeight: 600, color: theme.textMuted },
   fieldWide: { display: 'flex', flexDirection: 'column', gap: 6, fontSize: 11, fontWeight: 600, color: theme.textMuted, gridColumn: '1 / -1' },
   input: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 6, color: theme.text, padding: '8px 10px', fontSize: 12 },
   textarea: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 6, color: theme.text, padding: '8px 10px', fontSize: 12, minHeight: 76, resize: 'vertical' },
   specBox: { background: theme.surfaceInset, border: `1px solid ${theme.border}`, borderRadius: 8, padding: 12 },
+  specTextarea: { width: '100%', minHeight: 360, boxSizing: 'border-box', background: theme.surfaceInset, border: 'none', color: theme.codeText, fontSize: 12, lineHeight: 1.5, resize: 'vertical', outline: 'none', fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace' },
   pre: { margin: 0, color: theme.codeText, fontSize: 12, overflowX: 'auto' },
   planList: { display: 'flex', flexDirection: 'column', gap: 10 },
   planItem: { display: 'flex', alignItems: 'center', gap: 8, color: theme.text, fontSize: 12 },

--- a/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
+++ b/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
@@ -15,9 +15,54 @@ function makeContext(overrides = {}) {
       ok: true,
       draft: {
         id: 'draft-1',
-        spec: { name: 'finance-tool' },
+        spec: { name: 'finance-tool', tech_stack: ['python'], safety_guards: [] },
         events: [{ level: 'info', message: 'draft created' }],
       },
+    }),
+    chatOnboardingDraft: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: {
+          name: 'finance-tool',
+          description: 'Finance automation',
+          owner: 'T-rav',
+          visibility: 'public',
+          tech_stack: ['python', 'FastAPI', 'React'],
+          safety_guards: ['branch-protection'],
+          coverage_floor: 92,
+          label_prefix: 'hydraflow',
+          main_branch: 'main',
+          staging_branch: 'staging',
+        },
+        chat_messages: [
+          { role: 'user', content: 'Build finance-tool with FastAPI and React' },
+          { role: 'assistant', content: 'I updated the project fields.' },
+        ],
+        events: [{ level: 'info', message: 'design chat updated fields' }],
+      },
+      reply: 'I updated the project fields.',
+      field_updates: { name: 'finance-tool' },
+    }),
+    draftOnboardingSpec: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        spec_draft: '# finance-tool\n\n## 10-file Invariant Kernel\n\n## V1 IN',
+        events: [{ level: 'info', message: 'wizard spec drafted' }],
+      },
+      spec_draft: '# finance-tool\n\n## 10-file Invariant Kernel\n\n## V1 IN',
+    }),
+    draftOnboardingPlan: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        plan_draft: ['Create invariant kernel', 'Build UI scaffold'],
+        events: [{ level: 'info', message: 'wizard plan drafted' }],
+      },
+      plan_draft: ['Create invariant kernel', 'Build UI scaffold'],
     }),
     materializeOnboardingDraft: vi.fn().mockResolvedValue({
       ok: true,
@@ -48,13 +93,63 @@ describe('BootstrapWizard', () => {
       ok: true,
       draft: { id: 'draft-2', spec: { name: 'new-project' }, events: [] },
     })
-    mockUseHydraFlow.mockReturnValue(makeContext({ createOnboardingDraft }))
+    const draftOnboardingSpec = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: { id: 'draft-2', spec: { name: 'new-project' }, spec_draft: '# new-project' },
+      spec_draft: '# new-project',
+    })
+    mockUseHydraFlow.mockReturnValue(makeContext({ createOnboardingDraft, draftOnboardingSpec }))
 
     render(<BootstrapWizard isOpen onClose={() => {}} />)
     fireEvent.click(screen.getByText('Next'))
 
     await waitFor(() => expect(createOnboardingDraft).toHaveBeenCalled())
-    expect(screen.getByText(/"name": "new-project"/)).toBeInTheDocument()
+    await waitFor(() => expect(draftOnboardingSpec).toHaveBeenCalledWith('draft-2'))
+    expect(screen.getByDisplayValue('# new-project')).toBeInTheDocument()
+  })
+
+  it('uses design chat to auto-fill fields while keeping them editable', async () => {
+    const chatOnboardingDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: {
+          name: 'finance-tool',
+          description: 'Finance automation',
+          owner: 'T-rav',
+          visibility: 'public',
+          tech_stack: ['python', 'FastAPI', 'React'],
+          safety_guards: ['branch-protection'],
+          coverage_floor: 92,
+          label_prefix: 'hydraflow',
+          main_branch: 'main',
+          staging_branch: 'staging',
+        },
+        chat_messages: [
+          { role: 'user', content: 'Build finance-tool with FastAPI and React' },
+          { role: 'assistant', content: 'I updated the project fields.' },
+        ],
+        events: [{ level: 'info', message: 'design chat updated fields' }],
+      },
+      reply: 'I updated the project fields.',
+      field_updates: { name: 'finance-tool' },
+    })
+    mockUseHydraFlow.mockReturnValue(makeContext({ chatOnboardingDraft }))
+
+    render(<BootstrapWizard isOpen onClose={() => {}} />)
+    fireEvent.change(screen.getByLabelText('Design chat message'), {
+      target: { value: 'Build finance-tool as a public FastAPI React app with 92% coverage' },
+    })
+    fireEvent.click(screen.getByText('Send'))
+
+    await waitFor(() => expect(chatOnboardingDraft).toHaveBeenCalledWith(
+      'draft-1',
+      'Build finance-tool as a public FastAPI React app with 92% coverage'
+    ))
+    expect(screen.getByDisplayValue('finance-tool')).toBeInTheDocument()
+    expect(screen.getByLabelText('Visibility')).toHaveValue('public')
+    fireEvent.change(screen.getByDisplayValue('finance-tool'), { target: { value: 'ledger-lab' } })
+    expect(screen.getByDisplayValue('ledger-lab')).toBeInTheDocument()
   })
 
   it('materializes the active draft and selects the generated repo', async () => {
@@ -68,8 +163,9 @@ describe('BootstrapWizard', () => {
 
     render(<BootstrapWizard isOpen onClose={onClose} />)
     fireEvent.click(screen.getByText('Next'))
-    await screen.findByText(/"name": "new-project"/)
+    await screen.findByDisplayValue(/10-file Invariant Kernel/)
     fireEvent.click(screen.getByText('Next'))
+    await screen.findByText('Build UI scaffold')
     fireEvent.click(screen.getByText('Next'))
     fireEvent.click(screen.getByTestId('materialize-project'))
 
@@ -93,8 +189,9 @@ describe('BootstrapWizard', () => {
 
     render(<BootstrapWizard isOpen onClose={() => {}} />)
     fireEvent.click(screen.getByText('Next'))
-    await screen.findByText(/"name": "new-project"/)
+    await screen.findByDisplayValue(/10-file Invariant Kernel/)
     fireEvent.click(screen.getByText('Next'))
+    await screen.findByText('Build UI scaffold')
     fireEvent.click(screen.getByText('Next'))
     fireEvent.click(screen.getByTestId('materialize-project'))
 

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1332,6 +1332,60 @@ export function HydraFlowProvider({ children }) {
     }
   }, [parseApiError])
 
+  const chatOnboardingDraft = useCallback(async (draftId, message) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/design/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Design chat failed (${res.status})`, draft: data?.draft }
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Design chat failed' }
+    }
+  }, [])
+
+  const draftOnboardingSpec = useCallback(async (draftId, note = null) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/design/spec`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Spec draft failed (${res.status})`, draft: data?.draft }
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Spec draft failed' }
+    }
+  }, [])
+
+  const draftOnboardingPlan = useCallback(async (draftId, note = null) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/design/plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Plan draft failed (${res.status})`, draft: data?.draft }
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Plan draft failed' }
+    }
+  }, [])
+
   const materializeOnboardingDraft = useCallback(async (draftId, request = {}) => {
     try {
       const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/materialize`, {
@@ -1843,6 +1897,9 @@ export function HydraFlowProvider({ children }) {
     addRepoBySlug,
     addRepoByPath,
     createOnboardingDraft,
+    chatOnboardingDraft,
+    draftOnboardingSpec,
+    draftOnboardingPlan,
     materializeOnboardingDraft,
     pushOnboardingDraft,
     fetchRepos,

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -7,7 +7,13 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from onboarding.models import BootstrapDraft, BootstrapSpec, MaterializeRequest
+from onboarding.models import (
+    BootstrapDraft,
+    BootstrapSpec,
+    DesignChatRequest,
+    DesignRevisionRequest,
+    MaterializeRequest,
+)
 from tests.helpers import find_endpoint, make_dashboard_router
 
 
@@ -44,6 +50,9 @@ class TestOnboardingDraftRoutes:
 
         assert "/api/onboarding/drafts" in paths
         assert "/api/onboarding/drafts/{draft_id}" in paths
+        assert "/api/onboarding/drafts/{draft_id}/design/chat" in paths
+        assert "/api/onboarding/drafts/{draft_id}/design/spec" in paths
+        assert "/api/onboarding/drafts/{draft_id}/design/plan" in paths
         assert "/api/onboarding/drafts/{draft_id}/materialize" in paths
 
     @pytest.mark.asyncio
@@ -147,6 +156,86 @@ class TestOnboardingDraftRoutes:
         assert (tmp_path / "generated" / "finance-tool" / "pyproject.toml").exists()
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["materialize_status"] == "succeeded"
+
+    @pytest.mark.asyncio
+    async def test_design_chat_persists_conversation_and_field_updates(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/chat",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            DesignChatRequest(
+                message=(
+                    "Build finance-tool as a public Python FastAPI React app "
+                    "with Postgres, branch protection, deterministic tests, and 92% coverage."
+                )
+            ),
+        )
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["draft"]["spec"]["name"] == "finance-tool"
+        assert data["draft"]["spec"]["visibility"] == "public"
+        assert data["draft"]["spec"]["coverage_floor"] == 92
+        assert "FastAPI" in data["draft"]["spec"]["tech_stack"]
+        assert "React" in data["draft"]["spec"]["tech_stack"]
+        assert "branch-protection" in data["draft"]["spec"]["safety_guards"]
+        assert data["draft"]["chat_messages"][-1]["role"] == "assistant"
+        assert state.get_onboarding_draft(draft.id)["extracted_fields"]["name"] == (
+            "finance-tool"
+        )
+
+    @pytest.mark.asyncio
+    async def test_design_spec_and_plan_are_persisted(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(
+                _spec_payload(
+                    name="finance-tool",
+                    tech_stack=["python", "FastAPI", "React"],
+                    safety_guards=["branch-protection", "decimal-purity"],
+                )
+            )
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        spec_endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/spec",
+            method="POST",
+        )
+        plan_endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/plan",
+            method="POST",
+        )
+
+        spec_response = await spec_endpoint(
+            draft.id, DesignRevisionRequest(note="include v1 boundaries")
+        )
+        plan_response = await plan_endpoint(draft.id, DesignRevisionRequest())
+        spec_data = json.loads(spec_response.body)
+        plan_data = json.loads(plan_response.body)
+
+        assert spec_response.status_code == 200
+        assert "10-file Invariant Kernel" in spec_data["spec_draft"]
+        assert "V1 IN" in spec_data["spec_draft"]
+        assert plan_response.status_code == 200
+        assert len(plan_data["plan_draft"]) >= 10
+        assert any("UI scaffold" in task for task in plan_data["plan_draft"])
+        assert any("decimal-purity" in task for task in plan_data["plan_draft"])
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["spec_draft"] == spec_data["spec_draft"]
+        assert persisted["plan_draft"] == plan_data["plan_draft"]
 
     @pytest.mark.asyncio
     async def test_materialize_draft_records_failure_for_existing_target(

--- a/tests/test_onboarding_design_ai.py
+++ b/tests/test_onboarding_design_ai.py
@@ -1,0 +1,71 @@
+from onboarding.design_ai import DesignAIService, apply_field_updates
+from onboarding.models import BootstrapDraft, BootstrapSpec
+
+
+def _draft(**overrides: object) -> BootstrapDraft:
+    payload = {
+        "name": "new-project",
+        "description": "Dashboard-created project",
+        "owner": "T-rav",
+        "visibility": "private",
+        "tech_stack": ["python"],
+        "safety_guards": ["quality-gates"],
+        "coverage_floor": 80,
+        "label_prefix": "hydraflow",
+        "main_branch": "main",
+        "staging_branch": "staging",
+    }
+    payload.update(overrides)
+    return BootstrapDraft(spec=BootstrapSpec.model_validate(payload))
+
+
+def test_design_chat_extracts_six_core_fields() -> None:
+    service = DesignAIService()
+
+    turn = service.chat(
+        _draft(),
+        (
+            "Build ledger-lab as a public FastAPI React app for owner finance-org "
+            "with Postgres, branch protection, deterministic tests, and 91% coverage."
+        ),
+    )
+
+    assert turn.field_updates["name"] == "ledger-lab"
+    assert turn.field_updates["owner"] == "finance-org"
+    assert turn.field_updates["visibility"] == "public"
+    assert turn.field_updates["coverage_floor"] == 91
+    assert "FastAPI" in turn.field_updates["tech_stack"]
+    assert "React" in turn.field_updates["tech_stack"]
+    assert "branch-protection" in turn.field_updates["safety_guards"]
+    assert "deterministic-tests" in turn.field_updates["safety_guards"]
+    assert turn.clarification is None
+
+
+def test_apply_field_updates_preserves_manual_fields() -> None:
+    spec = _draft(package_name="ledger_lab", main_branch="trunk").spec
+
+    updated = apply_field_updates(spec, {"name": "ledger-lab", "visibility": "public"})
+
+    assert updated.name == "ledger-lab"
+    assert updated.visibility == "public"
+    assert updated.package_name == "ledger_lab"
+    assert updated.main_branch == "trunk"
+
+
+def test_spec_and_plan_adapt_to_ui_and_safety_choices() -> None:
+    service = DesignAIService()
+    draft = _draft(
+        name="ledger-lab",
+        tech_stack=["python", "FastAPI", "React"],
+        safety_guards=["branch-protection", "decimal-purity"],
+    )
+
+    spec_text = service.draft_spec(draft, note="include boundaries")
+    plan = service.draft_plan(draft)
+
+    assert "## 10-file Invariant Kernel" in spec_text
+    assert "## V1 IN" in spec_text
+    assert "Revision note: include boundaries" in spec_text
+    assert any("UI scaffold" in task for task in plan)
+    assert any("branch-protection" in task for task in plan)
+    assert any("decimal-purity" in task for task in plan)


### PR DESCRIPTION
## Summary
- adds persisted onboarding design chat state, extracted fields, spec draft, and Plan 01 draft data to bootstrap drafts
- adds deterministic design-chat/spec/plan API endpoints behind a Claude-provider seam
- wires the dashboard wizard to chat-driven field extraction, editable generated spec text, and adaptive generated plan tasks
- refreshes generated architecture docs for the new onboarding dependency

## Verification
- uv run pytest tests/test_onboarding_design_ai.py tests/test_onboarding_api.py -q
- uv run ruff check src/onboarding/design_ai.py src/onboarding/models.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py tests/test_onboarding_design_ai.py
- uv run pyright src/onboarding/design_ai.py src/onboarding/models.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py tests/test_onboarding_design_ai.py
- cd src/ui && npm test -- src/components/__tests__/BootstrapWizard.test.jsx src/context/__tests__/HydraFlowContext.test.jsx
- cd src/ui && npm run build
- make quality
- cd src/ui && npm test

## Scope note
This intentionally lands the backend/UI contract and deterministic provider seam. It does not yet implement real Claude streaming, server-side Anthropic configuration, or the reliability corpus from the full issue acceptance criteria.

Refs #8932