### PR TITLE
Refs #8933: add onboarding dashboard repo slice

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T05:05:12.871437+00:00",
-  "commit_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f",
+  "regenerated_at": "2026-05-23T05:43:10.086841+00:00",
+  "commit_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25",
   "artifacts": {
     "loops.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "ports.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "labels.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "modules.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "events.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "adr_xref.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "mockworld.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "changelog.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "coverage_matrix.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "functional_areas.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "ubiquitous-language.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "008649064895ff07f526aa1a2e3db5863cc79d3f"
+      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `6b74497` — Refs #8932: add onboarding design chat slice *(2026-05-22)*
 - `091f166` — Refs #8931: add onboarding wizard UI slice *(2026-05-22)*
 - `e439049` — Refs #8930: add onboarding materialize API slice *(2026-05-22)*
 - `e5e3dbd` — Refs #8930: add onboarding draft API foundation *(2026-05-22)*
@@ -345,4 +346,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `0086490` on 2026-05-23 05:05 UTC. Source last changed at `0086490`. Status: 🟢 fresh._
+_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1421,19 +1421,25 @@ def create_router(
         return JSONResponse({})
 
     @router.get("/api/events")
-    async def get_events(since: str | None = None) -> JSONResponse:
+    async def get_events(
+        since: str | None = None,
+        repo: RepoSlugParam = None,
+    ) -> JSONResponse:
         """Return event history, optionally filtered by a since timestamp."""
+        bus = event_bus
+        if repo:
+            _cfg, _state, bus, _get_orch = _resolve_runtime(repo)
         if since is not None:
             try:
                 since_dt = datetime.fromisoformat(since)
                 if since_dt.tzinfo is None:
                     since_dt = since_dt.replace(tzinfo=UTC)
-                events = await event_bus.load_events_since(since_dt)
+                events = await bus.load_events_since(since_dt)
                 if events is not None:
                     return JSONResponse([e.model_dump() for e in events])
             except (ValueError, TypeError):
                 pass  # Fall through to in-memory history
-        history = event_bus.get_history()
+        history = bus.get_history()
         return JSONResponse([e.model_dump() for e in history])
 
     @router.get("/api/prs")

--- a/src/ui/src/components/ProjectView.jsx
+++ b/src/ui/src/components/ProjectView.jsx
@@ -2,6 +2,25 @@ import React, { useCallback, useState } from 'react'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { theme } from '../theme'
 
+function readPlanProgress(project) {
+  const progress = project?.plan_progress || project?.onboarding_plan_progress
+  if (progress && Number.isFinite(Number(progress.completed)) && Number.isFinite(Number(progress.total))) {
+    return {
+      completed: Number(progress.completed),
+      total: Number(progress.total),
+    }
+  }
+  const planDraft = project?.onboarding_plan_draft || project?.plan_draft
+  if (Array.isArray(planDraft)) {
+    return { completed: 0, total: planDraft.length }
+  }
+  return { completed: 0, total: 0 }
+}
+
+function readCurrentPlan(project) {
+  return project?.current_plan || project?.onboarding_current_plan || project?.plan || 'Plan 01'
+}
+
 export function ProjectView({ project }) {
   const { pushOnboardingDraft } = useHydraFlow()
   const [activityOpen, setActivityOpen] = useState(false)
@@ -22,35 +41,73 @@ export function ProjectView({ project }) {
     setPushState('succeeded')
   }, [project?.onboarding_draft_id, pushOnboardingDraft, pushState])
 
-  if (!project?.local_only) return null
+  if (!project) return null
 
   const events = project.onboarding_events || []
   const canPush = Boolean(project.onboarding_draft_id) && pushState !== 'running'
+  const progress = readPlanProgress(project)
+  const currentPlan = readCurrentPlan(project)
+  const planComplete = progress.total > 0 && progress.completed >= progress.total
+  const showContinue = project.continue_plan_available === true || planComplete
+  const showUpgrade = project.upgrade_available === true || project.format_upgrade_available === true
+  const repoStatus = project.local_only
+    ? pushState === 'failed' ? 'Push failed' : pushState === 'succeeded' ? 'Pushed' : 'Ready locally'
+    : project.status === 'running' || project.running || project.pipeline_enabled ? 'Factory pipeline active' : 'Factory repo selected'
 
   return (
-    <div style={styles.wrapper} data-testid="project-view-local-only">
+    <div style={project.local_only ? styles.wrapperLocal : styles.wrapper} data-testid={project.local_only ? 'project-view-local-only' : 'project-view'}>
       <div style={styles.header}>
         <div style={styles.titleBlock}>
-          <span style={styles.badge}>local only</span>
+          <span style={project.local_only ? styles.badgeLocal : styles.badge}>{project.local_only ? 'local only' : 'selected repo'}</span>
           <span style={styles.name}>{project.full_name || project.slug || project.path}</span>
           {project.path && <span style={styles.path}>{project.path}</span>}
         </div>
-        <button
-          type="button"
-          style={canPush ? styles.pushButton : styles.pushDisabled}
-          disabled={!canPush}
-          onClick={handlePush}
-          title={canPush ? undefined : 'Waiting for onboarding draft state'}
-        >
-          {pushState === 'running' ? 'Pushing...' : 'Push to GitHub'}
-        </button>
+        <div style={styles.actions}>
+          {showContinue && (
+            <button
+              type="button"
+              style={styles.secondaryAction}
+              disabled
+              title="Next-plan execution endpoint is not wired yet"
+            >
+              Continue to next plan
+            </button>
+          )}
+          {showUpgrade && (
+            <button
+              type="button"
+              style={styles.secondaryAction}
+              disabled
+              title="Format upgrade endpoint is not wired yet"
+            >
+              Upgrade format
+            </button>
+          )}
+          {project.local_only && (
+            <button
+              type="button"
+              style={canPush ? styles.pushButton : styles.pushDisabled}
+              disabled={!canPush}
+              onClick={handlePush}
+              title={canPush ? undefined : 'Waiting for onboarding draft state'}
+            >
+              {pushState === 'running' ? 'Pushing...' : 'Push to GitHub'}
+            </button>
+          )}
+        </div>
+      </div>
+      <div style={styles.planRow}>
+        <span style={styles.planPill}>{currentPlan}</span>
+        <span style={styles.planText}>{progress.completed}/{progress.total} issues complete</span>
       </div>
       <div style={styles.statusRow}>
         <span style={pushState === 'failed' ? styles.statusDotFailed : styles.statusDot} />
-        <span>{pushState === 'failed' ? 'Push failed' : pushState === 'succeeded' ? 'Pushed' : 'Ready locally'}</span>
-        <button type="button" style={styles.activityButton} onClick={() => setActivityOpen(prev => !prev)}>
-          Activity {activityOpen ? 'up' : 'down'}
-        </button>
+        <span>{repoStatus}</span>
+        {(project.local_only || events.length > 0) && (
+          <button type="button" style={styles.activityButton} onClick={() => setActivityOpen(prev => !prev)}>
+            Activity {activityOpen ? 'up' : 'down'}
+          </button>
+        )}
       </div>
       {pushError && <div style={styles.error}>{pushError}</div>}
       {activityOpen && (
@@ -70,6 +127,13 @@ export function ProjectView({ project }) {
 
 const styles = {
   wrapper: {
+    border: `1px solid ${theme.border}`,
+    background: theme.surface,
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 12,
+  },
+  wrapperLocal: {
     border: `1px solid ${theme.orange}`,
     background: theme.orangeSubtle,
     borderRadius: 8,
@@ -89,6 +153,16 @@ const styles = {
     minWidth: 0,
   },
   badge: {
+    alignSelf: 'flex-start',
+    color: theme.accent,
+    border: `1px solid ${theme.accent}`,
+    borderRadius: 999,
+    padding: '2px 7px',
+    fontSize: 10,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+  },
+  badgeLocal: {
     alignSelf: 'flex-start',
     color: theme.orange,
     border: `1px solid ${theme.orange}`,
@@ -134,6 +208,43 @@ const styles = {
     fontWeight: 700,
     cursor: 'not-allowed',
     flexShrink: 0,
+  },
+  actions: {
+    display: 'flex',
+    gap: 8,
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
+  },
+  secondaryAction: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 6,
+    background: theme.surfaceInset,
+    color: theme.textMuted,
+    padding: '7px 10px',
+    fontSize: 12,
+    fontWeight: 700,
+    cursor: 'not-allowed',
+    flexShrink: 0,
+  },
+  planRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 10,
+    flexWrap: 'wrap',
+  },
+  planPill: {
+    border: `1px solid ${theme.border}`,
+    borderRadius: 999,
+    color: theme.textBright,
+    background: theme.surfaceInset,
+    padding: '2px 8px',
+    fontSize: 11,
+    fontWeight: 700,
+  },
+  planText: {
+    color: theme.text,
+    fontSize: 12,
   },
   statusRow: {
     display: 'flex',

--- a/src/ui/src/components/RepoSelector.jsx
+++ b/src/ui/src/components/RepoSelector.jsx
@@ -32,6 +32,41 @@ function isPipelineEnabled(runtime, repo) {
     ?? repo?.status === 'running'
 }
 
+function readPlanProgress(repo) {
+  const progress = repo?.plan_progress || repo?.onboarding_plan_progress
+  if (progress && Number.isFinite(Number(progress.completed)) && Number.isFinite(Number(progress.total))) {
+    return {
+      completed: Number(progress.completed),
+      total: Number(progress.total),
+    }
+  }
+  const planDraft = repo?.onboarding_plan_draft || repo?.plan_draft
+  if (Array.isArray(planDraft)) {
+    return { completed: 0, total: planDraft.length }
+  }
+  return null
+}
+
+function buildRepoSummary(repo, runtime) {
+  const pieces = []
+  const plan = repo?.current_plan || repo?.onboarding_current_plan || runtime?.current_plan
+  const progress = readPlanProgress(repo)
+  const inFlight = repo?.in_flight_issues ?? runtime?.in_flight_issues
+  const lastGreen = repo?.last_green_ci ?? runtime?.last_green_ci
+
+  if (plan) {
+    const progressText = progress ? ` ${progress.completed}/${progress.total}` : ''
+    pieces.push(`${plan}${progressText}`)
+  }
+  if (Number.isFinite(Number(inFlight)) && Number(inFlight) > 0) {
+    pieces.push(`${Number(inFlight)} in flight`)
+  }
+  if (lastGreen) {
+    pieces.push(`green ${lastGreen}`)
+  }
+  return pieces.join(' | ')
+}
+
 export function RepoSelector({ onOpenRegister, onOpenNewProject }) {
   const {
     canRegisterRepos = false,
@@ -66,10 +101,11 @@ export function RepoSelector({ onOpenRegister, onOpenNewProject }) {
       const filterSlug = canonicalRepoSlug(rawSlug)
       const runtime = runtimeMap.get(filterSlug)
       const isRunning = isPipelineEnabled(runtime, repo)
+      const summary = buildRepoSummary(repo, runtime)
       return {
         key: `${filterSlug || rawSlug}-${index}`,
         label: buildDisplayName(repo),
-        subLabel: repo.path || runtime?.repo || '',
+        subLabel: summary || repo.path || runtime?.repo || '',
         filterSlug,
         rawSlug,
         isRunning,

--- a/src/ui/src/components/__tests__/ProjectView.test.jsx
+++ b/src/ui/src/components/__tests__/ProjectView.test.jsx
@@ -16,9 +16,24 @@ describe('ProjectView', () => {
     })
   })
 
-  it('renders nothing for non-local projects', () => {
-    const { container } = render(<ProjectView project={{ slug: 'acme/app' }} />)
+  it('renders nothing when no project is selected', () => {
+    const { container } = render(<ProjectView project={null} />)
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows factory repo plan progress for selected repos', () => {
+    render(<ProjectView project={{
+      slug: 'acme/app',
+      full_name: 'acme/app',
+      current_plan: 'Plan 02',
+      plan_progress: { completed: 3, total: 8 },
+      running: true,
+    }} />)
+
+    expect(screen.getByTestId('project-view')).toHaveTextContent('selected repo')
+    expect(screen.getByText('Plan 02')).toBeInTheDocument()
+    expect(screen.getByText('3/8 issues complete')).toBeInTheDocument()
+    expect(screen.getByText('Factory pipeline active')).toBeInTheDocument()
   })
 
   it('shows local-only state and disabled push action', () => {
@@ -28,14 +43,28 @@ describe('ProjectView', () => {
       path: '/tmp/finance-tool',
       local_only: true,
       onboarding_draft_id: 'draft-1',
+      onboarding_plan_draft: ['Create invariant kernel', 'Build UI scaffold'],
       onboarding_events: [{ level: 'info', message: 'materialized invariant kernel' }],
     }} />)
 
     expect(screen.getByText('local only')).toBeInTheDocument()
     expect(screen.getByText('Ready locally')).toBeInTheDocument()
+    expect(screen.getByText('0/2 issues complete')).toBeInTheDocument()
     expect(screen.getByText('Push to GitHub')).not.toBeDisabled()
     fireEvent.click(screen.getByText('Activity down'))
     expect(screen.getByTestId('project-activity-log')).toHaveTextContent('materialized invariant kernel')
+  })
+
+  it('surfaces next-plan and upgrade affordances from project metadata', () => {
+    render(<ProjectView project={{
+      slug: 'acme/app',
+      current_plan: 'Plan 01',
+      plan_progress: { completed: 4, total: 4 },
+      upgrade_available: true,
+    }} />)
+
+    expect(screen.getByText('Continue to next plan')).toBeInTheDocument()
+    expect(screen.getByText('Upgrade format')).toBeInTheDocument()
   })
 
   it('calls the push endpoint and shows failure state', async () => {

--- a/src/ui/src/components/__tests__/RepoSelector.test.jsx
+++ b/src/ui/src/components/__tests__/RepoSelector.test.jsx
@@ -206,6 +206,22 @@ describe('RepoSelector', () => {
     expect(screen.getByText('/home/user/projects/app')).toBeInTheDocument()
   })
 
+  it('shows fleet health summary when repo metadata is available', () => {
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      supervisedRepos: [{
+        slug: 'acme/app',
+        path: '/home/user/projects/app',
+        current_plan: 'Plan 02',
+        plan_progress: { completed: 3, total: 7 },
+        in_flight_issues: 2,
+        last_green_ci: '2026-05-22',
+      }],
+    }))
+    render(<RepoSelector />)
+    fireEvent.click(screen.getByTestId('repo-selector-trigger'))
+    expect(screen.getByText('Plan 02 3/7 | 2 in flight | green 2026-05-22')).toBeInTheDocument()
+  })
+
   it('closes dropdown after selecting a repo', () => {
     mockUseHydraFlow.mockReturnValue(makeContext({
       supervisedRepos: [{ slug: 'acme/app' }],

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -795,6 +795,11 @@ export function reducer(state, action) {
           reviews: [],
           sessionPrsCount: 0,
           events: [],
+          queueStats: null,
+          metrics: null,
+          githubMetrics: null,
+          metricsHistory: null,
+          pipelineStats: null,
         }),
       }
     }
@@ -1406,6 +1411,13 @@ export function HydraFlowProvider({ children }) {
         local_only: true,
         onboarding_draft_id: data?.draft?.id || draftId,
         onboarding_events: data?.draft?.events || [],
+        onboarding_current_plan: 'Plan 01',
+        onboarding_spec_draft: data?.draft?.spec_draft || '',
+        onboarding_plan_draft: Array.isArray(data?.draft?.plan_draft) ? data.draft.plan_draft : [],
+        plan_progress: {
+          completed: 0,
+          total: Array.isArray(data?.draft?.plan_draft) ? data.draft.plan_draft.length : 0,
+        },
       }
       dispatch({ type: 'LOCAL_ONLY_PROJECT_ADDED', data: project })
       if (materializedPath) {
@@ -1708,7 +1720,7 @@ export function HydraFlowProvider({ children }) {
       fetchRepos()
       fetchRuntimes()
       if (lastEventTsRef.current) {
-        fetch(`/api/events?since=${encodeURIComponent(lastEventTsRef.current)}`)
+        fetchWithRepo(`/api/events?since=${encodeURIComponent(lastEventTsRef.current)}`)
           .then(r => r.json())
           .then(events => dispatch({ type: 'BACKFILL_EVENTS', data: events }))
           .catch(() => {})

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -1585,6 +1585,11 @@ describe('SELECT_REPO reducer', () => {
       reviews: [{ pr: 99, status: 'done' }],
       sessionPrsCount: 1,
       events: [{ type: 'worker_update', timestamp: '2024-01-01T00:00:00Z' }],
+      queueStats: { depth: 2 },
+      metrics: { open_prs: 3 },
+      githubMetrics: { total_merged: 4 },
+      metricsHistory: [{ date: '2026-05-22' }],
+      pipelineStats: { total: 3 },
     }
     const next = reducer(state, {
       type: 'SELECT_REPO',
@@ -1598,6 +1603,11 @@ describe('SELECT_REPO reducer', () => {
     expect(next.reviews).toEqual([])
     expect(next.sessionPrsCount).toBe(0)
     expect(next.events).toEqual([])
+    expect(next.queueStats).toBeNull()
+    expect(next.metrics).toBeNull()
+    expect(next.githubMetrics).toBeNull()
+    expect(next.metricsHistory).toBeNull()
+    expect(next.pipelineStats).toBeNull()
   })
 
   it('does not reset data when selecting the same repo', () => {

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -624,7 +624,7 @@ class TestGetEventsEndpoint:
     ) -> None:
         router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
         endpoint = find_endpoint(router, "/api/events")
-        response = await endpoint(since=None)
+        response = await endpoint(since=None, repo=None)
         data = json.loads(response.body)
         assert data == []
 
@@ -637,7 +637,7 @@ class TestGetEventsEndpoint:
         await event_bus.publish(EventFactory.create(data={"msg": "hello"}))
         router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
         endpoint = find_endpoint(router, "/api/events")
-        response = await endpoint(since=None)
+        response = await endpoint(since=None, repo=None)
         data = json.loads(response.body)
         assert len(data) >= 1
 
@@ -647,9 +647,41 @@ class TestGetEventsEndpoint:
     ) -> None:
         router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
         endpoint = find_endpoint(router, "/api/events")
-        response = await endpoint(since="not-a-date")
+        response = await endpoint(since="not-a-date", repo=None)
         data = json.loads(response.body)
         assert isinstance(data, list)
+
+    @pytest.mark.asyncio
+    async def test_repo_query_uses_repo_runtime_event_bus(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        from unittest.mock import MagicMock
+
+        from events import EventBus
+        from tests.conftest import EventFactory
+
+        repo_bus = EventBus()
+        await event_bus.publish(EventFactory.create(data={"msg": "default"}))
+        await repo_bus.publish(EventFactory.create(data={"msg": "selected"}))
+        runtime = MagicMock()
+        runtime.config = config
+        runtime.state = state
+        runtime.event_bus = repo_bus
+        runtime.orchestrator = None
+        registry = MagicMock()
+        registry.get.return_value = runtime
+
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+        )
+        endpoint = find_endpoint(router, "/api/events")
+        response = await endpoint(since=None, repo="acme/widgets")
+        data = json.loads(response.body)
+        assert [item["data"]["msg"] for item in data] == ["selected"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Scope `/api/events?repo=` to the selected repo runtime event bus so event backfill matches the WebSocket scope.
- Clear stale dashboard metrics/queue/pipeline state when switching repos and route reconnect backfill through the repo-aware fetch helper.
- Show selected-repo plan progress, fleet summary metadata, and next-plan/format-upgrade affordances when project metadata provides them.

## Verification
- `uv run pytest tests/test_dashboard_routes_state.py::TestGetEventsEndpoint -q`
- `uv run ruff check src/dashboard_routes/_routes.py tests/test_dashboard_routes_state.py`
- `uv run pyright src/dashboard_routes/_routes.py tests/test_dashboard_routes_state.py`
- `cd src/ui && npm test -- src/components/__tests__/ProjectView.test.jsx src/components/__tests__/RepoSelector.test.jsx src/context/__tests__/HydraFlowContext.test.jsx`
- `cd src/ui && npm test`
- `cd src/ui && npm run build`
- `make quality`

## Notes
This is a dashboard observability slice toward #8933. It does not close the full issue because real Plan 02 execution/issue filing and one-click format-upgrade PR automation still need backend wiring.