### PR TITLE
Refs #8931: add onboarding push endpoint

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T05:43:10.086841+00:00",
-  "commit_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25",
+  "regenerated_at": "2026-05-23T06:30:36.796544+00:00",
+  "commit_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "ports.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "labels.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "modules.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "events.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "adr_xref.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "mockworld.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "changelog.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "coverage_matrix.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "functional_areas.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "ubiquitous-language.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "5209d6e2ca8371ffbdc0bd2cc04eac8f67b03f25"
+      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `f4915b8` — Refs #8933: add onboarding dashboard repo slice *(2026-05-22)*
 - `6b74497` — Refs #8932: add onboarding design chat slice *(2026-05-22)*
 - `091f166` — Refs #8931: add onboarding wizard UI slice *(2026-05-22)*
 - `e439049` — Refs #8930: add onboarding materialize API slice *(2026-05-22)*
@@ -346,4 +347,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `5209d6e` on 2026-05-23 05:43 UTC. Source last changed at `5209d6e`. Status: 🟢 fresh._
+_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import logging
 import os
 import tempfile
@@ -57,6 +59,126 @@ def _allowed_output_dir(raw_path: str | None, default_parent: Path) -> Path | No
 def _persist_draft(ctx: RouteContext, draft: BootstrapDraft) -> None:
     draft.touch()
     ctx.state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+
+
+def _safe_materialized_path(
+    draft: BootstrapDraft, fallback_parent: Path
+) -> Path | None:
+    raw_path = draft.materialized_path or str(fallback_parent / draft.spec.name)
+    candidate = Path(raw_path).expanduser().resolve(strict=False)
+    allowed_roots = (
+        Path.home().resolve(strict=False),
+        Path(tempfile.gettempdir()).resolve(strict=False),
+    )
+    for root in allowed_roots:
+        try:
+            common = os.path.commonpath([str(candidate), str(root)])
+        except ValueError:
+            continue
+        if common == str(root):
+            return candidate
+    return None
+
+
+async def _run_checked(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    timeout: float = 120.0,
+    allowed_error_fragments: tuple[str, ...] = (),
+) -> str:
+    proc: asyncio.subprocess.Process | None = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(cwd) if cwd else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"{cmd[0]} CLI not found") from exc
+    except TimeoutError as exc:
+        if proc is not None:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+        raise RuntimeError(f"{cmd[0]} command timed out") from exc
+    if proc.returncode != 0:
+        detail = (stderr or stdout or b"").decode(errors="replace").strip()
+        if any(fragment in detail.lower() for fragment in allowed_error_fragments):
+            return detail
+        raise RuntimeError(detail or f"{cmd[0]} command failed")
+    return (stdout or b"").decode(errors="replace").strip()
+
+
+async def _push_materialized_draft(draft: BootstrapDraft, repo_dir: Path) -> str:
+    if not repo_dir.exists() or not repo_dir.is_dir():
+        raise RuntimeError("materialized repository path is missing")
+
+    repo_slug = f"{draft.spec.owner}/{draft.spec.name}"
+    visibility_flag = "--public" if draft.spec.visibility == "public" else "--private"
+    main_branch = draft.spec.main_branch
+    staging_branch = draft.spec.staging_branch
+    remote_url = f"https://github.com/{repo_slug}.git"
+
+    if not (repo_dir / ".git").exists():
+        await _run_checked(["git", "init", "-b", main_branch], cwd=repo_dir, timeout=30)
+    await _run_checked(
+        ["git", "config", "user.name", "HydraFlow Onboarding"], cwd=repo_dir, timeout=30
+    )
+    await _run_checked(
+        [
+            "git",
+            "config",
+            "user.email",
+            "hydraflow-onboarding@users.noreply.github.com",
+        ],
+        cwd=repo_dir,
+        timeout=30,
+    )
+    await _run_checked(["git", "add", "-A"], cwd=repo_dir, timeout=30)
+    await _run_checked(
+        ["git", "commit", "-m", "Initial HydraFlow bootstrap"],
+        cwd=repo_dir,
+        timeout=60,
+        allowed_error_fragments=("nothing to commit", "no changes added to commit"),
+    )
+    await _run_checked(
+        [
+            "gh",
+            "repo",
+            "create",
+            repo_slug,
+            visibility_flag,
+            "--description",
+            draft.spec.description,
+        ],
+        timeout=120,
+    )
+    try:
+        await _run_checked(
+            ["git", "remote", "add", "origin", remote_url], cwd=repo_dir, timeout=30
+        )
+    except RuntimeError as exc:
+        if "remote origin already exists" not in str(exc).lower():
+            raise
+        await _run_checked(
+            ["git", "remote", "set-url", "origin", remote_url],
+            cwd=repo_dir,
+            timeout=30,
+        )
+    await _run_checked(["git", "push", "-u", "origin", main_branch], cwd=repo_dir)
+    if staging_branch != main_branch:
+        await _run_checked(
+            ["git", "checkout", "-B", staging_branch, main_branch],
+            cwd=repo_dir,
+            timeout=30,
+        )
+        await _run_checked(
+            ["git", "push", "-u", "origin", staging_branch], cwd=repo_dir
+        )
+        await _run_checked(["git", "checkout", main_branch], cwd=repo_dir, timeout=30)
+    return f"https://github.com/{repo_slug}"
 
 
 def register(router: APIRouter, ctx: RouteContext) -> None:
@@ -206,6 +328,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
 
         draft.status = "materialized"
         draft.materialize_status = "succeeded"
+        draft.materialized_path = str(result.root)
         draft.events.extend(result.events)
         _persist_draft(ctx, draft)
         return JSONResponse(
@@ -219,4 +342,60 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                     ],
                 },
             }
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/push")
+    async def push_onboarding_draft(draft_id: str) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+        if draft.materialize_status != "succeeded":
+            return JSONResponse(
+                {
+                    "error": "Draft must be materialized before it can be pushed",
+                    "draft": draft.model_dump(mode="json"),
+                },
+                status_code=409,
+            )
+
+        repo_dir = _safe_materialized_path(draft, ctx.config.repos_workspace_dir)
+        if repo_dir is None:
+            return JSONResponse(
+                {
+                    "error": "materialized_path must be inside your home directory or temp directory",
+                    "draft": draft.model_dump(mode="json"),
+                },
+                status_code=400,
+            )
+
+        draft.status = "pushing"
+        draft.push_status = "running"
+        draft.events.append({"level": "info", "message": "push started"})
+        _persist_draft(ctx, draft)
+
+        try:
+            repo_url = await _push_materialized_draft(draft, repo_dir)
+        except RuntimeError as exc:
+            draft.status = "materialized"
+            draft.push_status = "failed"
+            draft.events.append({"level": "error", "message": str(exc)})
+            _persist_draft(ctx, draft)
+            return JSONResponse(
+                {
+                    "error": "Draft could not be pushed",
+                    "draft": draft.model_dump(mode="json"),
+                },
+                status_code=502,
+            )
+
+        draft.status = "pushed"
+        draft.push_status = "succeeded"
+        draft.repo_url = repo_url
+        draft.events.append({"level": "info", "message": "push succeeded"})
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {"draft": draft.model_dump(mode="json"), "repo_url": repo_url}
         )

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -89,6 +89,8 @@ class BootstrapDraft(BaseModel):
     extracted_fields: dict[str, object] = Field(default_factory=dict)
     spec_draft: str | None = None
     plan_draft: list[str] = Field(default_factory=list)
+    materialized_path: str | None = Field(default=None, max_length=1000)
+    repo_url: str | None = Field(default=None, max_length=1000)
 
     def touch(self) -> None:
         self.updated_at = _utc_now()

--- a/src/ui/src/components/__tests__/ProjectView.test.jsx
+++ b/src/ui/src/components/__tests__/ProjectView.test.jsx
@@ -83,4 +83,20 @@ describe('ProjectView', () => {
     expect(screen.getByText('Push failed')).toBeInTheDocument()
     expect(screen.getByText('Push endpoint unavailable')).toBeInTheDocument()
   })
+
+  it('shows pushed state after push succeeds', async () => {
+    const pushOnboardingDraft = vi.fn().mockResolvedValue({ ok: true, repo_url: 'https://github.com/T-rav/finance-tool' })
+    mockUseHydraFlow.mockReturnValue({ pushOnboardingDraft })
+
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      local_only: true,
+      onboarding_draft_id: 'draft-1',
+      onboarding_events: [],
+    }} />)
+
+    fireEvent.click(screen.getByText('Push to GitHub'))
+    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith('draft-1'))
+    expect(screen.getByText('Pushed')).toBeInTheDocument()
+  })
 })

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -780,6 +780,32 @@ export function reducer(state, action) {
       return { ...state, localOnlyProjects: next }
     }
 
+    case 'LOCAL_ONLY_PROJECT_PUSHED': {
+      const draftId = action.data?.draftId
+      const repoUrl = action.data?.repoUrl || action.data?.draft?.repo_url || null
+      const draft = action.data?.draft || {}
+      if (!draftId) return state
+      const updateProject = project => {
+        if (project?.onboarding_draft_id !== draftId) return project
+        return {
+          ...project,
+          local_only: false,
+          repo_url: repoUrl,
+          onboarding_events: Array.isArray(draft.events) ? draft.events : project.onboarding_events,
+          push_status: draft.push_status || 'succeeded',
+          status: draft.status || 'pushed',
+        }
+      }
+      const localOnlyProjects = (state.localOnlyProjects || []).map(updateProject)
+      const supervisedRepos = (state.supervisedRepos || []).map(updateProject)
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem('hydraflow.localOnlyProjects', JSON.stringify(localOnlyProjects))
+        } catch { /* ignore */ }
+      }
+      return { ...state, localOnlyProjects, supervisedRepos }
+    }
+
     case 'SELECT_REPO': {
       const newSlug = normalizeRepoSlug(action.data.slug)
       const changed = newSlug !== state.selectedRepoSlug
@@ -1439,6 +1465,10 @@ export function HydraFlowProvider({ children }) {
       if (!res.ok) {
         return { ok: false, error: data?.error || `Push failed (${res.status})`, draft: data?.draft }
       }
+      dispatch({
+        type: 'LOCAL_ONLY_PROJECT_PUSHED',
+        data: { draftId, draft: data?.draft, repoUrl: data?.repo_url },
+      })
       return { ok: true, ...data }
     } catch (err) {
       return { ok: false, error: err?.message || 'Push failed' }

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -81,6 +81,39 @@ describe('HydraFlowContext reducer', () => {
     expect(next.supervisedRepos).toEqual(repos)
   })
 
+  it('LOCAL_ONLY_PROJECT_PUSHED clears local-only state for matching draft', () => {
+    const state = {
+      ...initialState,
+      localOnlyProjects: [
+        { slug: 'finance-tool', local_only: true, onboarding_draft_id: 'draft-1' },
+      ],
+      supervisedRepos: [
+        { slug: 'finance-tool', local_only: true, onboarding_draft_id: 'draft-1' },
+      ],
+    }
+
+    const next = reducer(state, {
+      type: 'LOCAL_ONLY_PROJECT_PUSHED',
+      data: {
+        draftId: 'draft-1',
+        repoUrl: 'https://github.com/T-rav/finance-tool',
+        draft: {
+          status: 'pushed',
+          push_status: 'succeeded',
+          events: [{ level: 'info', message: 'push succeeded' }],
+        },
+      },
+    })
+
+    expect(next.localOnlyProjects[0]).toMatchObject({
+      local_only: false,
+      repo_url: 'https://github.com/T-rav/finance-tool',
+      push_status: 'succeeded',
+      status: 'pushed',
+    })
+    expect(next.supervisedRepos[0].local_only).toBe(false)
+  })
+
   it('GITHUB_METRICS action sets githubMetrics state', () => {
     const data = {
       open_by_label: { 'hydraflow-plan': 3, 'hydraflow-ready': 1 },

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -54,6 +55,7 @@ class TestOnboardingDraftRoutes:
         assert "/api/onboarding/drafts/{draft_id}/design/spec" in paths
         assert "/api/onboarding/drafts/{draft_id}/design/plan" in paths
         assert "/api/onboarding/drafts/{draft_id}/materialize" in paths
+        assert "/api/onboarding/drafts/{draft_id}/push" in paths
 
     @pytest.mark.asyncio
     async def test_create_draft_persists_state(
@@ -152,10 +154,131 @@ class TestOnboardingDraftRoutes:
         assert response.status_code == 200
         assert data["draft"]["status"] == "materialized"
         assert data["draft"]["materialize_status"] == "succeeded"
+        assert data["draft"]["materialized_path"].endswith("generated/finance-tool")
         assert data["materialized"]["path"].endswith("generated/finance-tool")
         assert (tmp_path / "generated" / "finance-tool" / "pyproject.toml").exists()
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["materialize_status"] == "succeeded"
+        assert persisted["materialized_path"].endswith("generated/finance-tool")
+
+    @pytest.mark.asyncio
+    async def test_push_draft_requires_materialized_repo(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/push",
+            method="POST",
+        )
+
+        response = await endpoint(draft.id)
+        data = json.loads(response.body)
+
+        assert response.status_code == 409
+        assert data["error"] == "Draft must be materialized before it can be pushed"
+
+    @pytest.mark.asyncio
+    async def test_push_draft_creates_and_pushes_github_repo(
+        self, config, event_bus, state, tmp_path, monkeypatch
+    ) -> None:
+        repo_dir = tmp_path / "generated" / "finance-tool"
+        repo_dir.mkdir(parents=True)
+        (repo_dir / "README.md").write_text("# finance-tool\n")
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="finance-tool")),
+            status="materialized",
+            materialize_status="succeeded",
+            materialized_path=str(repo_dir),
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        calls: list[tuple[str, ...]] = []
+
+        class Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+            def kill(self) -> None:
+                return None
+
+        async def fake_exec(*cmd, **_kwargs):
+            calls.append(tuple(cmd))
+            return Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/push",
+            method="POST",
+        )
+
+        response = await endpoint(draft.id)
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["draft"]["status"] == "pushed"
+        assert data["draft"]["push_status"] == "succeeded"
+        assert data["repo_url"] == "https://github.com/T-rav/finance-tool"
+        assert (
+            "gh",
+            "repo",
+            "create",
+            "T-rav/finance-tool",
+            "--private",
+            "--description",
+            "A repo for experimenting with observability workflows.",
+        ) in calls
+        assert ("git", "push", "-u", "origin", "main") in calls
+        assert ("git", "push", "-u", "origin", "staging") in calls
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["repo_url"] == "https://github.com/T-rav/finance-tool"
+
+    @pytest.mark.asyncio
+    async def test_push_draft_records_cli_failure(
+        self, config, event_bus, state, tmp_path, monkeypatch
+    ) -> None:
+        repo_dir = tmp_path / "generated" / "finance-tool"
+        repo_dir.mkdir(parents=True)
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="finance-tool")),
+            status="materialized",
+            materialize_status="succeeded",
+            materialized_path=str(repo_dir),
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+
+        class Proc:
+            returncode = 1
+
+            async def communicate(self):
+                return b"", b"gh auth required"
+
+            def kill(self) -> None:
+                return None
+
+        async def fake_exec(*_cmd, **_kwargs):
+            return Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/push",
+            method="POST",
+        )
+
+        response = await endpoint(draft.id)
+        data = json.loads(response.body)
+
+        assert response.status_code == 502
+        assert data["draft"]["status"] == "materialized"
+        assert data["draft"]["push_status"] == "failed"
+        assert "gh auth required" in data["draft"]["events"][-1]["message"]
 
     @pytest.mark.asyncio
     async def test_design_chat_persists_conversation_and_field_updates(


### PR DESCRIPTION
## Summary
- add POST /api/onboarding/drafts/{draft_id}/push to create and push a materialized bootstrap repo with gh/git
- persist materialized_path and repo_url on onboarding drafts
- update dashboard state so a successful push clears the local-only badge/state
- refresh generated architecture docs

## Verification
- uv run pytest tests/test_onboarding_api.py -q
- npm test -- --run src/components/__tests__/ProjectView.test.jsx src/context/__tests__/HydraFlowContext.test.jsx
- make quality

Refs #8931