### PR TITLE
Refs #8932: add Claude design provider fallback

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T06:30:36.796544+00:00",
-  "commit_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212",
+  "regenerated_at": "2026-05-23T07:14:03.697784+00:00",
+  "commit_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf",
   "artifacts": {
     "loops.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "ports.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "labels.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "modules.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "events.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "adr_xref.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "mockworld.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "changelog.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "coverage_matrix.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "functional_areas.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "ubiquitous-language.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "185020fe68b06af481bd15b4ff18d208ae7a5212"
+      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `adbcc6a` — Refs #8931: add onboarding push endpoint *(2026-05-23)*
 - `f4915b8` — Refs #8933: add onboarding dashboard repo slice *(2026-05-22)*
 - `6b74497` — Refs #8932: add onboarding design chat slice *(2026-05-22)*
 - `091f166` — Refs #8931: add onboarding wizard UI slice *(2026-05-22)*
@@ -347,4 +348,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `185020f` on 2026-05-23 06:30 UTC. Source last changed at `185020f`. Status: 🟢 fresh._
+_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -224,7 +224,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         if draft is None:
             return JSONResponse({"error": "Draft is invalid"}, status_code=500)
 
-        turn = design_ai.chat(draft, request.message)
+        turn = await design_ai.chat(draft, request.message)
         draft.chat_messages.append({"role": "user", "content": request.message})
         draft.chat_messages.append({"role": "assistant", "content": turn.reply})
         draft.extracted_fields.update(turn.field_updates)
@@ -232,7 +232,14 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             draft.spec = apply_field_updates(draft.spec, turn.field_updates)
         except ValidationError:
             return JSONResponse({"error": "Design update is invalid"}, status_code=422)
-        draft.events.append({"level": "info", "message": "design chat updated fields"})
+        event_message = "design chat updated fields"
+        if turn.source == "claude":
+            event_message = "claude design chat updated fields"
+        if turn.fallback_reason:
+            event_message = (
+                f"design chat used form-fill fallback: {turn.fallback_reason}"
+            )
+        draft.events.append({"level": "info", "message": event_message})
         _persist_draft(ctx, draft)
         return JSONResponse(
             {

--- a/src/onboarding/design_ai.py
+++ b/src/onboarding/design_ai.py
@@ -2,10 +2,25 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field, ValidationError
 
 from onboarding.models import BootstrapDraft, BootstrapSpec
+
+METHODOLOGY_PROMPT = (
+    "Use docs/methodology/onboarding-hydraflow-format-repos.md as the canonical "
+    "HydraFlow-format bootstrap methodology. Produce hypothesis-quality wizard "
+    "output only; factory SHAPE will refine it after push."
+)
+ANTHROPIC_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_VERSION = "2023-06-01"
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
 
 _NAME_RE = re.compile(r"\b[a-z][a-z0-9]+(?:-[a-z0-9]+)+\b")
 _OWNER_RE = re.compile(
@@ -21,6 +36,14 @@ class DesignTurn:
     reply: str
     field_updates: dict[str, object]
     clarification: str | None = None
+    source: str = "deterministic"
+    fallback_reason: str | None = None
+
+
+class _ClaudeDesignTurn(BaseModel):
+    reply: str = Field(min_length=1, max_length=2000)
+    field_updates: dict[str, object] = Field(default_factory=dict)
+    clarification: str | None = Field(default=None, max_length=1000)
 
 
 def apply_field_updates(
@@ -44,7 +67,27 @@ class DesignAIService:
     ``chat`` behind this interface without changing the route or UI contracts.
     """
 
-    def chat(self, draft: BootstrapDraft, message: str) -> DesignTurn:
+    def __init__(self, provider: AnthropicDesignProvider | None = None) -> None:
+        self._provider = provider or AnthropicDesignProvider.from_env()
+
+    async def chat(self, draft: BootstrapDraft, message: str) -> DesignTurn:
+        if self._provider is not None:
+            try:
+                return await self._provider.chat(draft, message)
+            except DesignProviderError as exc:
+                fallback = self._deterministic_chat(draft, message)
+                return DesignTurn(
+                    reply=(
+                        f"{fallback.reply} Claude design chat is temporarily "
+                        "unavailable, so I kept form-fill mode active."
+                    ),
+                    field_updates=fallback.field_updates,
+                    clarification=fallback.clarification,
+                    fallback_reason=str(exc),
+                )
+        return self._deterministic_chat(draft, message)
+
+    def _deterministic_chat(self, draft: BootstrapDraft, message: str) -> DesignTurn:
         updates = self._extract_fields(message, draft.spec)
         updated = apply_field_updates(draft.spec, updates)
         clarification = self._clarification_for(message, updated)
@@ -203,6 +246,132 @@ class DesignAIService:
         if clarification:
             return f"{base} {clarification}"
         return f"{base} Draft the spec when these fields look right."
+
+
+class DesignProviderError(RuntimeError):
+    """Raised when the live design provider cannot produce valid output."""
+
+
+class AnthropicDesignProvider:
+    """Claude-backed structured design chat provider."""
+
+    def __init__(self, api_key: str, model: str = DEFAULT_CLAUDE_MODEL) -> None:
+        self.api_key = api_key
+        self.model = model
+
+    @classmethod
+    def from_env(cls) -> AnthropicDesignProvider | None:
+        api_key = (
+            os.environ.get("HYDRAFLOW_ONBOARDING_ANTHROPIC_API_KEY")
+            or os.environ.get("ANTHROPIC_API_KEY")
+            or ""
+        ).strip()
+        if not api_key:
+            return None
+        model = os.environ.get("HYDRAFLOW_ONBOARDING_CLAUDE_MODEL", "").strip()
+        return cls(api_key=api_key, model=model or DEFAULT_CLAUDE_MODEL)
+
+    async def chat(self, draft: BootstrapDraft, message: str) -> DesignTurn:
+        prompt = _build_claude_prompt(draft, message)
+        raw = await self._request(prompt)
+        try:
+            parsed = _parse_claude_turn(raw)
+        except DesignProviderError:
+            raw = await self._request(
+                f"{prompt}\n\nYour previous response was invalid. Return only valid JSON."
+            )
+            parsed = _parse_claude_turn(raw)
+        updates = _sanitize_field_updates(parsed.field_updates)
+        return DesignTurn(
+            reply=parsed.reply,
+            field_updates=updates,
+            clarification=parsed.clarification,
+            source="claude",
+        )
+
+    async def _request(self, prompt: str) -> str:
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": 1200,
+            "temperature": 0,
+            "system": METHODOLOGY_PROMPT,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": ANTHROPIC_VERSION,
+            "content-type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    ANTHROPIC_MESSAGES_URL, headers=headers, json=payload
+                )
+                response.raise_for_status()
+                data = response.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise DesignProviderError("Claude request failed") from exc
+        return _extract_text_content(data)
+
+
+def _build_claude_prompt(draft: BootstrapDraft, message: str) -> str:
+    conversation = "\n".join(
+        f"{item.get('role', 'unknown')}: {item.get('content', '')}"
+        for item in draft.chat_messages[-12:]
+    )
+    return (
+        "You are HydraFlow's onboarding design assistant.\n"
+        "Return ONLY JSON with this schema:\n"
+        "{"
+        '"reply": "operator-facing response", '
+        '"field_updates": {"name": "...", "description": "...", '
+        '"owner": "...", "visibility": "private|public", '
+        '"tech_stack": ["python", "FastAPI"], '
+        '"safety_guards": ["branch-protection"], "coverage_floor": 85}, '
+        '"clarification": "optional question or null"'
+        "}\n"
+        "Only include field_updates when the operator supplied or revised the field. "
+        "Surface ambiguity as clarification instead of guessing.\n\n"
+        f"Current spec JSON:\n{draft.spec.model_dump_json()}\n\n"
+        f"Recent conversation:\n{conversation or '(none)'}\n\n"
+        f"Operator message:\n{message}"
+    )
+
+
+def _extract_text_content(data: dict[str, Any]) -> str:
+    parts = data.get("content")
+    if not isinstance(parts, list):
+        raise DesignProviderError("Claude response has no text content")
+    text = "".join(
+        str(part.get("text", "")) for part in parts if part.get("type") == "text"
+    ).strip()
+    if not text:
+        raise DesignProviderError("Claude response text is empty")
+    return text
+
+
+def _parse_claude_turn(raw: str) -> _ClaudeDesignTurn:
+    text = raw.strip()
+    if not text.startswith("{"):
+        start = text.find("{")
+        end = text.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise DesignProviderError("Claude response was not JSON")
+        text = text[start : end + 1]
+    try:
+        payload = json.loads(text)
+        return _ClaudeDesignTurn.model_validate(payload)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        raise DesignProviderError("Claude response did not match schema") from exc
+
+
+def _sanitize_field_updates(updates: dict[str, object]) -> dict[str, object]:
+    allowed = set(BootstrapSpec.model_fields)
+    sanitized: dict[str, object] = {}
+    for key, value in updates.items():
+        if key in allowed and value is not None:
+            sanitized[key] = value
+    return sanitized
 
 
 def _description_for(message: str) -> str:

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -8,6 +8,12 @@ import json
 import pytest
 from pydantic import ValidationError
 
+from onboarding.design_ai import (
+    AnthropicDesignProvider,
+    DesignAIService,
+    DesignProviderError,
+    DesignTurn,
+)
 from onboarding.models import (
     BootstrapDraft,
     BootstrapSpec,
@@ -282,8 +288,10 @@ class TestOnboardingDraftRoutes:
 
     @pytest.mark.asyncio
     async def test_design_chat_persists_conversation_and_field_updates(
-        self, config, event_bus, state, tmp_path
+        self, config, event_bus, state, tmp_path, monkeypatch
     ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("HYDRAFLOW_ONBOARDING_ANTHROPIC_API_KEY", raising=False)
         draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
         state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
         router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
@@ -315,6 +323,121 @@ class TestOnboardingDraftRoutes:
         assert state.get_onboarding_draft(draft.id)["extracted_fields"]["name"] == (
             "finance-tool"
         )
+
+    @pytest.mark.asyncio
+    async def test_design_chat_falls_back_when_live_provider_fails(
+        self, config, event_bus, state, tmp_path, monkeypatch
+    ) -> None:
+        class FailingProvider:
+            async def chat(self, _draft, _message):
+                raise DesignProviderError("rate limited")
+
+        import dashboard_routes._onboarding_routes as onboarding_routes
+
+        monkeypatch.setattr(
+            onboarding_routes,
+            "design_ai",
+            DesignAIService(provider=FailingProvider()),
+        )
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/chat",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            DesignChatRequest(message="Build finance-tool with FastAPI and no UI."),
+        )
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["draft"]["spec"]["name"] == "finance-tool"
+        assert data["draft"]["events"][-1]["message"] == (
+            "design chat used form-fill fallback: rate limited"
+        )
+
+    @pytest.mark.asyncio
+    async def test_anthropic_provider_returns_structured_turn(
+        self, monkeypatch
+    ) -> None:
+        requests: list[dict[str, object]] = []
+
+        class Response:
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, object]:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": json.dumps(
+                                {
+                                    "reply": "I updated the backend and UI.",
+                                    "field_updates": {
+                                        "name": "finance-tool",
+                                        "tech_stack": ["python", "FastAPI", "React"],
+                                        "unknown": "ignored",
+                                    },
+                                    "clarification": None,
+                                }
+                            ),
+                        }
+                    ]
+                }
+
+        class Client:
+            def __init__(self, **_kwargs) -> None:
+                return None
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args) -> None:
+                return None
+
+            async def post(self, url, **kwargs):
+                requests.append({"url": url, **kwargs})
+                return Response()
+
+        import onboarding.design_ai as design_ai_module
+
+        monkeypatch.setattr(design_ai_module.httpx, "AsyncClient", Client)
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        provider = AnthropicDesignProvider(api_key="sk-test", model="claude-test")
+
+        turn = await provider.chat(draft, "Use FastAPI and React.")
+
+        assert turn.source == "claude"
+        assert turn.reply == "I updated the backend and UI."
+        assert turn.field_updates == {
+            "name": "finance-tool",
+            "tech_stack": ["python", "FastAPI", "React"],
+        }
+        assert requests[0]["url"] == "https://api.anthropic.com/v1/messages"
+        assert requests[0]["headers"]["x-api-key"] == "sk-test"
+
+    @pytest.mark.asyncio
+    async def test_design_service_uses_live_provider_when_configured(self) -> None:
+        class Provider:
+            async def chat(self, _draft, _message):
+                return DesignTurn(
+                    reply="Claude reply",
+                    field_updates={"name": "finance-tool"},
+                    source="claude",
+                )
+
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        service = DesignAIService(provider=Provider())
+
+        turn = await service.chat(draft, "Build finance-tool.")
+
+        assert turn.source == "claude"
+        assert turn.field_updates == {"name": "finance-tool"}
 
     @pytest.mark.asyncio
     async def test_design_spec_and_plan_are_persisted(

--- a/tests/test_onboarding_design_ai.py
+++ b/tests/test_onboarding_design_ai.py
@@ -1,3 +1,5 @@
+import pytest
+
 from onboarding.design_ai import DesignAIService, apply_field_updates
 from onboarding.models import BootstrapDraft, BootstrapSpec
 
@@ -19,10 +21,11 @@ def _draft(**overrides: object) -> BootstrapDraft:
     return BootstrapDraft(spec=BootstrapSpec.model_validate(payload))
 
 
-def test_design_chat_extracts_six_core_fields() -> None:
+@pytest.mark.asyncio
+async def test_design_chat_extracts_six_core_fields() -> None:
     service = DesignAIService()
 
-    turn = service.chat(
+    turn = await service.chat(
         _draft(),
         (
             "Build ledger-lab as a public FastAPI React app for owner finance-org "


### PR DESCRIPTION
## Summary
- add an httpx-based Anthropic Messages provider for onboarding design chat when HYDRAFLOW_ONBOARDING_ANTHROPIC_API_KEY or ANTHROPIC_API_KEY is configured
- keep deterministic field extraction as no-key and live-provider failure fallback
- retry malformed Claude JSON once, sanitize field updates to BootstrapSpec fields, and record fallback events on drafts
- update direct and route tests for async design chat/provider behavior

## Verification
- uv run pytest tests/test_onboarding_api.py tests/test_onboarding_design_ai.py -q
- uv run ruff check src/onboarding/design_ai.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py tests/test_onboarding_design_ai.py
- uv run pyright src/onboarding/design_ai.py src/dashboard_routes/_onboarding_routes.py
- make quality

Refs #8932