### PR TITLE
Fixes #8933: wire onboarding continue plan

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T07:14:03.697784+00:00",
-  "commit_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf",
+  "regenerated_at": "2026-05-23T07:59:48.688335+00:00",
+  "commit_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "ports.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "labels.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "modules.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "events.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "adr_xref.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "mockworld.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "changelog.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "coverage_matrix.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "functional_areas.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ec402ff5038db2049999c42e1db80ce6b7d432cf"
+      "source_sha": "59db8811d9595a8bf2f796b9f4aba7b20f37bcce"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `553bd1d` — Refs #8932: add Claude design provider fallback *(2026-05-23)*
 - `adbcc6a` — Refs #8931: add onboarding push endpoint *(2026-05-23)*
 - `f4915b8` — Refs #8933: add onboarding dashboard repo slice *(2026-05-22)*
 - `6b74497` — Refs #8932: add onboarding design chat slice *(2026-05-22)*
@@ -348,4 +349,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `ec402ff` on 2026-05-23 07:14 UTC. Source last changed at `ec402ff`. Status: 🟢 fresh._
+_Regenerated from commit `59db881` on 2026-05-23 07:59 UTC. Source last changed at `59db881`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -18,6 +18,7 @@ from onboarding.design_ai import DesignAIService, apply_field_updates
 from onboarding.models import (
     BootstrapDraft,
     BootstrapSpec,
+    ContinuePlanRequest,
     DesignChatRequest,
     DesignRevisionRequest,
     MaterializeRequest,
@@ -78,6 +79,35 @@ def _safe_materialized_path(
         if common == str(root):
             return candidate
     return None
+
+
+def _next_plan_label(current_plan: str | None) -> str:
+    if not current_plan:
+        return "Plan 02"
+    digits = "".join(ch for ch in current_plan if ch.isdigit())
+    if not digits:
+        return "Plan 02"
+    return f"Plan {int(digits) + 1:02d}"
+
+
+def _issue_title(plan_label: str, task: str) -> str:
+    return f"[{plan_label}] {task}"[:120]
+
+
+def _issue_body(draft: BootstrapDraft, plan_label: str, task: str, index: int) -> str:
+    spec = draft.spec
+    return (
+        f"HydraFlow onboarding task generated from draft `{draft.id}`.\n\n"
+        f"Plan: {plan_label}\n"
+        f"Sequence: {index}\n"
+        f"Target repo: {spec.owner}/{spec.name}\n\n"
+        "## Task\n"
+        f"{task}\n\n"
+        "## Bootstrap Context\n"
+        f"- Tech stack: {', '.join(spec.tech_stack) or 'unspecified'}\n"
+        f"- Safety guards: {', '.join(spec.safety_guards) or 'standard'}\n"
+        f"- Coverage floor: {spec.coverage_floor}%\n"
+    )
 
 
 async def _run_checked(
@@ -288,6 +318,75 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         _persist_draft(ctx, draft)
         return JSONResponse(
             {"draft": draft.model_dump(mode="json"), "plan_draft": draft.plan_draft}
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/continue-plan")
+    async def continue_onboarding_plan(
+        draft_id: str, request: ContinuePlanRequest | None = None
+    ) -> JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+
+        next_plan = _next_plan_label(request.current_plan if request else None)
+        note_parts = [f"Continue onboarding with {next_plan}."]
+        if request and request.note:
+            note_parts.append(request.note)
+        plan_tasks = design_ai.draft_plan(draft, " ".join(note_parts))
+        labels = [f"{draft.spec.label_prefix}-find"]
+        created_issues: list[dict[str, object]] = []
+
+        draft.events.append(
+            {"level": "info", "message": f"{next_plan} issue creation started"}
+        )
+        _persist_draft(ctx, draft)
+
+        try:
+            for index, task in enumerate(plan_tasks, start=1):
+                issue_number = await ctx.pr_manager.create_issue(
+                    title=_issue_title(next_plan, task),
+                    body=_issue_body(draft, next_plan, task, index),
+                    labels=labels,
+                )
+                if issue_number is None:
+                    raise RuntimeError("GitHub issue creation returned no issue number")
+                created_issues.append(
+                    {
+                        "number": issue_number,
+                        "title": _issue_title(next_plan, task),
+                        "task": task,
+                    }
+                )
+        except Exception as exc:  # pragma: no cover - defensive around PRPort impls
+            draft.events.append({"level": "error", "message": str(exc)})
+            _persist_draft(ctx, draft)
+            return JSONResponse(
+                {
+                    "error": "Next plan issues could not be created",
+                    "draft": draft.model_dump(mode="json"),
+                    "created_issues": created_issues,
+                },
+                status_code=502,
+            )
+
+        draft.plan_draft = plan_tasks
+        draft.events.append(
+            {
+                "level": "info",
+                "message": f"{next_plan} filed {len(created_issues)} hydraflow-find issues",
+            }
+        )
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {
+                "draft": draft.model_dump(mode="json"),
+                "plan": next_plan,
+                "plan_draft": plan_tasks,
+                "created_issues": created_issues,
+            }
         )
 
     @router.post("/api/onboarding/drafts/{draft_id}/materialize")

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -140,3 +140,18 @@ class DesignRevisionRequest(BaseModel):
             return None
         normalized = value.strip()
         return normalized or None
+
+
+class ContinuePlanRequest(BaseModel):
+    """Request body for filing the next onboarding plan issue batch."""
+
+    current_plan: str | None = Field(default=None, max_length=100)
+    note: str | None = Field(default=None, max_length=2000)
+
+    @field_validator("current_plan", "note")
+    @classmethod
+    def normalize_optional_text(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None

--- a/src/ui/src/components/ProjectView.jsx
+++ b/src/ui/src/components/ProjectView.jsx
@@ -22,10 +22,12 @@ function readCurrentPlan(project) {
 }
 
 export function ProjectView({ project }) {
-  const { pushOnboardingDraft } = useHydraFlow()
+  const { continueOnboardingPlan, pushOnboardingDraft } = useHydraFlow()
   const [activityOpen, setActivityOpen] = useState(false)
   const [pushState, setPushState] = useState('idle')
   const [pushError, setPushError] = useState('')
+  const [continueState, setContinueState] = useState('idle')
+  const [continueError, setContinueError] = useState('')
 
   const handlePush = useCallback(async () => {
     if (!project?.onboarding_draft_id || pushState === 'running') return
@@ -41,6 +43,22 @@ export function ProjectView({ project }) {
     setPushState('succeeded')
   }, [project?.onboarding_draft_id, pushOnboardingDraft, pushState])
 
+  const handleContinuePlan = useCallback(async () => {
+    if (!project?.onboarding_draft_id || continueState === 'running') return
+    setContinueState('running')
+    setContinueError('')
+    const result = await continueOnboardingPlan?.(project.onboarding_draft_id, {
+      current_plan: readCurrentPlan(project),
+    })
+    if (!result?.ok) {
+      setContinueState('failed')
+      setContinueError(result?.error || 'Continue plan failed')
+      setActivityOpen(true)
+      return
+    }
+    setContinueState('succeeded')
+  }, [continueOnboardingPlan, continueState, project])
+
   if (!project) return null
 
   const events = project.onboarding_events || []
@@ -49,6 +67,7 @@ export function ProjectView({ project }) {
   const currentPlan = readCurrentPlan(project)
   const planComplete = progress.total > 0 && progress.completed >= progress.total
   const showContinue = project.continue_plan_available === true || planComplete
+  const canContinue = Boolean(project.onboarding_draft_id) && continueState !== 'running'
   const showUpgrade = project.upgrade_available === true || project.format_upgrade_available === true
   const repoStatus = project.local_only
     ? pushState === 'failed' ? 'Push failed' : pushState === 'succeeded' ? 'Pushed' : 'Ready locally'
@@ -66,17 +85,18 @@ export function ProjectView({ project }) {
           {showContinue && (
             <button
               type="button"
-              style={styles.secondaryAction}
-              disabled
-              title="Next-plan execution endpoint is not wired yet"
+              style={canContinue ? styles.secondaryAction : styles.secondaryDisabled}
+              disabled={!canContinue}
+              onClick={handleContinuePlan}
+              title={canContinue ? undefined : 'Waiting for onboarding draft state'}
             >
-              Continue to next plan
+              {continueState === 'running' ? 'Continuing...' : continueState === 'succeeded' ? 'Plan continued' : 'Continue to next plan'}
             </button>
           )}
           {showUpgrade && (
             <button
               type="button"
-              style={styles.secondaryAction}
+              style={styles.secondaryDisabled}
               disabled
               title="Format upgrade endpoint is not wired yet"
             >
@@ -110,6 +130,7 @@ export function ProjectView({ project }) {
         )}
       </div>
       {pushError && <div style={styles.error}>{pushError}</div>}
+      {continueError && <div style={styles.error}>{continueError}</div>}
       {activityOpen && (
         <div style={styles.activityLog} data-testid="project-activity-log">
           {events.length === 0 ? (
@@ -216,6 +237,17 @@ const styles = {
     justifyContent: 'flex-end',
   },
   secondaryAction: {
+    border: `1px solid ${theme.accent}`,
+    borderRadius: 6,
+    background: theme.surface,
+    color: theme.accent,
+    padding: '7px 10px',
+    fontSize: 12,
+    fontWeight: 700,
+    cursor: 'pointer',
+    flexShrink: 0,
+  },
+  secondaryDisabled: {
     border: `1px solid ${theme.border}`,
     borderRadius: 6,
     background: theme.surfaceInset,

--- a/src/ui/src/components/__tests__/ProjectView.test.jsx
+++ b/src/ui/src/components/__tests__/ProjectView.test.jsx
@@ -13,6 +13,7 @@ describe('ProjectView', () => {
   beforeEach(() => {
     mockUseHydraFlow.mockReturnValue({
       pushOnboardingDraft: vi.fn().mockResolvedValue({ ok: false, error: 'Push failed (404)' }),
+      continueOnboardingPlan: vi.fn().mockResolvedValue({ ok: false, error: 'Continue plan failed (404)' }),
     })
   })
 
@@ -65,6 +66,44 @@ describe('ProjectView', () => {
 
     expect(screen.getByText('Continue to next plan')).toBeInTheDocument()
     expect(screen.getByText('Upgrade format')).toBeInTheDocument()
+  })
+
+  it('calls the continue endpoint when a completed onboarding plan has a draft id', async () => {
+    const continueOnboardingPlan = vi.fn().mockResolvedValue({ ok: true, plan: 'Plan 02' })
+    mockUseHydraFlow.mockReturnValue({ continueOnboardingPlan, pushOnboardingDraft: vi.fn() })
+
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      onboarding_draft_id: 'draft-1',
+      onboarding_current_plan: 'Plan 01',
+      plan_progress: { completed: 2, total: 2 },
+    }} />)
+
+    fireEvent.click(screen.getByText('Continue to next plan'))
+    await waitFor(() => expect(continueOnboardingPlan).toHaveBeenCalledWith('draft-1', {
+      current_plan: 'Plan 01',
+    }))
+    expect(screen.getByText('Plan continued')).toBeInTheDocument()
+  })
+
+  it('shows continue failure state and opens activity', async () => {
+    const continueOnboardingPlan = vi.fn().mockResolvedValue({ ok: false, error: 'Issue creation failed' })
+    mockUseHydraFlow.mockReturnValue({ continueOnboardingPlan, pushOnboardingDraft: vi.fn() })
+
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      onboarding_draft_id: 'draft-1',
+      onboarding_current_plan: 'Plan 01',
+      plan_progress: { completed: 1, total: 1 },
+      onboarding_events: [{ level: 'error', message: 'gh auth failed' }],
+    }} />)
+
+    fireEvent.click(screen.getByText('Continue to next plan'))
+    await waitFor(() => expect(continueOnboardingPlan).toHaveBeenCalledWith('draft-1', {
+      current_plan: 'Plan 01',
+    }))
+    expect(screen.getByText('Issue creation failed')).toBeInTheDocument()
+    expect(screen.getByTestId('project-activity-log')).toHaveTextContent('gh auth failed')
   })
 
   it('calls the push endpoint and shows failure state', async () => {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -806,6 +806,38 @@ export function reducer(state, action) {
       return { ...state, localOnlyProjects, supervisedRepos }
     }
 
+    case 'LOCAL_ONLY_PROJECT_CONTINUED': {
+      const draftId = action.data?.draftId
+      const draft = action.data?.draft || {}
+      const plan = action.data?.plan || 'Plan 02'
+      if (!draftId) return state
+      const updateProject = project => {
+        if (project?.onboarding_draft_id !== draftId) return project
+        const planDraft = Array.isArray(action.data?.planDraft)
+          ? action.data.planDraft
+          : Array.isArray(draft.plan_draft) ? draft.plan_draft : project.onboarding_plan_draft
+        return {
+          ...project,
+          onboarding_current_plan: plan,
+          onboarding_plan_draft: planDraft,
+          onboarding_events: Array.isArray(draft.events) ? draft.events : project.onboarding_events,
+          continue_plan_available: false,
+          plan_progress: {
+            completed: 0,
+            total: Array.isArray(planDraft) ? planDraft.length : 0,
+          },
+        }
+      }
+      const localOnlyProjects = (state.localOnlyProjects || []).map(updateProject)
+      const supervisedRepos = (state.supervisedRepos || []).map(updateProject)
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem('hydraflow.localOnlyProjects', JSON.stringify(localOnlyProjects))
+        } catch { /* ignore */ }
+      }
+      return { ...state, localOnlyProjects, supervisedRepos }
+    }
+
     case 'SELECT_REPO': {
       const newSlug = normalizeRepoSlug(action.data.slug)
       const changed = newSlug !== state.selectedRepoSlug
@@ -1475,6 +1507,34 @@ export function HydraFlowProvider({ children }) {
     }
   }, [])
 
+  const continueOnboardingPlan = useCallback(async (draftId, request = {}) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/continue-plan`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Continue plan failed (${res.status})`, draft: data?.draft }
+      }
+      dispatch({
+        type: 'LOCAL_ONLY_PROJECT_CONTINUED',
+        data: {
+          draftId,
+          draft: data?.draft,
+          plan: data?.plan,
+          planDraft: data?.plan_draft,
+          createdIssues: data?.created_issues,
+        },
+      })
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Continue plan failed' }
+    }
+  }, [])
+
   const removeRepoShortcut = useCallback((repoSlug) => {
     removeRepo(repoSlug)
   }, [removeRepo])
@@ -1944,6 +2004,7 @@ export function HydraFlowProvider({ children }) {
     draftOnboardingPlan,
     materializeOnboardingDraft,
     pushOnboardingDraft,
+    continueOnboardingPlan,
     fetchRepos,
     removeRepoShortcut,
     startRuntime,

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -114,6 +114,40 @@ describe('HydraFlowContext reducer', () => {
     expect(next.supervisedRepos[0].local_only).toBe(false)
   })
 
+  it('LOCAL_ONLY_PROJECT_CONTINUED advances draft-backed project metadata', () => {
+    const state = {
+      ...initialState,
+      localOnlyProjects: [
+        {
+          slug: 'finance-tool',
+          onboarding_draft_id: 'draft-1',
+          onboarding_current_plan: 'Plan 01',
+          onboarding_plan_draft: ['old task'],
+          plan_progress: { completed: 1, total: 1 },
+        },
+      ],
+    }
+
+    const next = reducer(state, {
+      type: 'LOCAL_ONLY_PROJECT_CONTINUED',
+      data: {
+        draftId: 'draft-1',
+        plan: 'Plan 02',
+        planDraft: ['next task', 'second task'],
+        draft: {
+          events: [{ level: 'info', message: 'Plan 02 filed 2 hydraflow-find issues' }],
+        },
+      },
+    })
+
+    expect(next.localOnlyProjects[0]).toMatchObject({
+      onboarding_current_plan: 'Plan 02',
+      onboarding_plan_draft: ['next task', 'second task'],
+      continue_plan_available: false,
+      plan_progress: { completed: 0, total: 2 },
+    })
+  })
+
   it('GITHUB_METRICS action sets githubMetrics state', () => {
     const data = {
       open_by_label: { 'hydraflow-plan': 3, 'hydraflow-ready': 1 },

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
@@ -17,6 +18,7 @@ from onboarding.design_ai import (
 from onboarding.models import (
     BootstrapDraft,
     BootstrapSpec,
+    ContinuePlanRequest,
     DesignChatRequest,
     DesignRevisionRequest,
     MaterializeRequest,
@@ -60,6 +62,7 @@ class TestOnboardingDraftRoutes:
         assert "/api/onboarding/drafts/{draft_id}/design/chat" in paths
         assert "/api/onboarding/drafts/{draft_id}/design/spec" in paths
         assert "/api/onboarding/drafts/{draft_id}/design/plan" in paths
+        assert "/api/onboarding/drafts/{draft_id}/continue-plan" in paths
         assert "/api/onboarding/drafts/{draft_id}/materialize" in paths
         assert "/api/onboarding/drafts/{draft_id}/push" in paths
 
@@ -482,6 +485,47 @@ class TestOnboardingDraftRoutes:
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["spec_draft"] == spec_data["spec_draft"]
         assert persisted["plan_draft"] == plan_data["plan_draft"]
+
+    @pytest.mark.asyncio
+    async def test_continue_plan_drafts_next_plan_and_files_find_issues(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(
+                _spec_payload(
+                    name="finance-tool",
+                    tech_stack=["python", "FastAPI", "React"],
+                    safety_guards=["branch-protection"],
+                )
+            )
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, pr_mgr = make_dashboard_router(config, event_bus, state, tmp_path)
+        pr_mgr.create_issue = AsyncMock(side_effect=list(range(501, 520)))  # type: ignore[method-assign]
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/continue-plan",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            ContinuePlanRequest(note="prioritize factory registry handoff"),
+        )
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["plan"] == "Plan 02"
+        assert len(data["created_issues"]) == len(data["plan_draft"])
+        assert data["created_issues"][0]["number"] == 501
+        assert pr_mgr.create_issue.await_count == len(data["plan_draft"])
+        first_call = pr_mgr.create_issue.await_args_list[0].kwargs
+        assert first_call["title"].startswith("[Plan 02]")
+        assert first_call["labels"] == ["hydraflow-find"]
+        assert "Target repo: T-rav/finance-tool" in first_call["body"]
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["plan_draft"] == data["plan_draft"]
+        assert persisted["events"][-1]["message"].startswith("Plan 02 filed")
 
     @pytest.mark.asyncio
     async def test_materialize_draft_records_failure_for_existing_target(


### PR DESCRIPTION
## Summary
- add a backend continue-plan endpoint for onboarding drafts that generates Plan N+1 tasks and files hydraflow-find GitHub issues
- wire the dashboard Continue to next plan action through context state and ProjectView feedback
- cover route registration, issue filing, reducer state updates, and UI success/failure states

## Tests
- uv run pytest tests/test_onboarding_api.py -q
- npm test -- --run src/components/__tests__/ProjectView.test.jsx src/context/__tests__/HydraFlowContext.test.jsx
- make quality