### PR TITLE
Refs #8933: add repo metrics dashboard payload

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T08:55:16.259425+00:00",
-  "commit_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926",
+  "regenerated_at": "2026-05-23T09:43:19.915945+00:00",
+  "commit_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695",
   "artifacts": {
     "loops.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "ports.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "labels.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "modules.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "events.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "adr_xref.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "mockworld.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "changelog.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "coverage_matrix.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "functional_areas.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "ubiquitous-language.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "cdd399f1f045aaed9783bb3da2eb7b7ead17a926"
+      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `43b1e0a` — Refs #8933: wire onboarding format upgrade *(2026-05-23)*
 - `bab9837` — Fixes #8933: wire onboarding continue plan *(2026-05-23)*
 - `553bd1d` — Refs #8932: add Claude design provider fallback *(2026-05-23)*
 - `adbcc6a` — Refs #8931: add onboarding push endpoint *(2026-05-23)*
@@ -350,4 +351,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `cdd399f` on 2026-05-23 08:55 UTC. Source last changed at `cdd399f`. Status: 🟢 fresh._
+_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_metrics_routes.py
+++ b/src/dashboard_routes/_metrics_routes.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, Response
 from fastapi.responses import JSONResponse
@@ -15,6 +15,7 @@ from config import HydraFlowConfig
 from dashboard_routes._routes import RouteContext
 from metrics_manager import get_metrics_cache_dir
 from models import (
+    LifetimeStats,
     MetricsHistoryResponse,
     MetricsResponse,
     MetricsSnapshot,
@@ -62,6 +63,36 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             )
             return []
         return snapshots[-limit:]
+
+    def _build_repo_metrics(
+        target_config: HydraFlowConfig,
+        target_state: Any,
+        lifetime: LifetimeStats,
+        rates: dict[str, float],
+        time_to_merge: dict[str, float],
+        retries: dict[str, int],
+    ) -> dict[str, object]:
+        """Build the repo-scoped metrics payload consumed by the dashboard."""
+        total_retries = sum(retries.values())
+        return {
+            "repo": target_config.repo,
+            "repo_slug": target_config.repo_slug,
+            "throughput": target_state.compute_session_throughput(),
+            "time_to_merge": time_to_merge,
+            "friction": {
+                "quality_fix_rounds": lifetime.total_quality_fix_rounds,
+                "ci_fix_rounds": lifetime.total_ci_fix_rounds,
+                "hitl_escalations": lifetime.total_hitl_escalations,
+                "reviewer_fixes": lifetime.total_reviewer_fixes,
+                "stage_retries": total_retries,
+                "failed_outcomes": lifetime.total_outcomes_failed,
+                "manual_closes": lifetime.total_outcomes_manual_close,
+                "quality_fix_rate": rates.get("quality_fix_rate", 0.0),
+                "hitl_escalation_rate": rates.get("hitl_escalation_rate", 0.0),
+                "reviewer_fix_rate": rates.get("reviewer_fix_rate", 0.0),
+            },
+            "retries_by_stage": retries,
+        }
 
     @router.get("/api/issues/outcomes")
     async def get_issue_outcomes() -> JSONResponse:
@@ -122,6 +153,14 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 thresholds=thresholds,
                 inference_lifetime=inference_lifetime,
                 inference_session=inference_session,
+                repo_metrics=_build_repo_metrics(
+                    _cfg,
+                    _state,
+                    lifetime,
+                    rates,
+                    time_to_merge,
+                    retries,
+                ),
             ).model_dump()
         )
 

--- a/src/models.py
+++ b/src/models.py
@@ -2879,6 +2879,7 @@ class MetricsResponse(BaseModel):
     thresholds: list[ThresholdProposal] = Field(default_factory=list)
     inference_lifetime: dict[str, int] = Field(default_factory=dict)
     inference_session: dict[str, int] = Field(default_factory=dict)
+    repo_metrics: dict[str, Any] = Field(default_factory=dict)
 
 
 class IssueHistoryLink(BaseModel):

--- a/src/ui/src/components/MetricsPanel.jsx
+++ b/src/ui/src/components/MetricsPanel.jsx
@@ -82,6 +82,71 @@ function formatTokens(n) {
   return value.toLocaleString()
 }
 
+function formatRate(value) {
+  return `${(Number(value || 0) * 100).toFixed(1)}%`
+}
+
+function formatStageName(stage) {
+  return String(stage || '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase())
+}
+
+function RepoMetrics({ data }) {
+  if (!data || Object.keys(data).length === 0) return null
+  const throughput = data.throughput || {}
+  const friction = data.friction || {}
+  const retriesByStage = data.retries_by_stage || {}
+  const throughputEntries = Object.entries(throughput)
+    .filter(([, value]) => Number(value || 0) > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+  const retryEntries = Object.entries(retriesByStage)
+    .filter(([, value]) => Number(value || 0) > 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+
+  return (
+    <div data-testid="metrics-grid-repo">
+      <div style={styles.repoHeader}>
+        <span style={styles.repoName}>{data.repo || data.repo_slug}</span>
+        <span style={styles.repoSlug}>{data.repo_slug}</span>
+      </div>
+      {throughputEntries.length > 0 && (
+        <>
+          <div style={styles.subheading}>Throughput</div>
+          <div className="metrics-grid">
+            {throughputEntries.map(([stage, value]) => (
+              <StatCard
+                key={stage}
+                label={`${formatStageName(stage)} / hr`}
+                value={Number(value || 0).toFixed(2)}
+                subtle
+              />
+            ))}
+          </div>
+        </>
+      )}
+      <div style={styles.subheading}>Friction</div>
+      <div className="metrics-grid">
+        <StatCard label="Quality Fix Rounds" value={Number(friction.quality_fix_rounds || 0)} subtle />
+        <StatCard label="CI Fix Rounds" value={Number(friction.ci_fix_rounds || 0)} subtle />
+        <StatCard label="HITL Escalations" value={Number(friction.hitl_escalations || 0)} subtle />
+        <StatCard label="Stage Retries" value={Number(friction.stage_retries || 0)} subtle />
+        <StatCard label="Quality Fix Rate" value={formatRate(friction.quality_fix_rate)} subtle />
+        <StatCard label="HITL Escalation Rate" value={formatRate(friction.hitl_escalation_rate)} subtle />
+      </div>
+      {retryEntries.length > 0 && (
+        <div style={styles.retryList}>
+          {retryEntries.map(([stage, value]) => (
+            <span key={stage} style={styles.retryBadge}>
+              {formatStageName(stage)}: {value}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 function SectionCard({ title, children, fullWidth = false }) {
   const className = fullWidth ? 'metrics-section-card metrics-section-card--full' : 'metrics-section-card'
   return (
@@ -111,6 +176,7 @@ export function MetricsPanel() {
   const githubOpenIssueTotal = Object.values(openByLabel).reduce((a, b) => a + Number(b || 0), 0)
 
   const timeToMerge = metrics?.time_to_merge || {}
+  const repoMetrics = metrics?.repo_metrics || {}
   const thresholds = metrics?.thresholds || []
   const inferenceLifetime = metrics?.inference_lifetime || {}
   const inferenceSession = metrics?.inference_session || {}
@@ -137,6 +203,11 @@ export function MetricsPanel() {
     sessionImplemented > 0 || sessionReviewed > 0 || mergedCount > 0
   const hasLifetime = useGithubTotals || lifetimeIssuesCompleted > 0 ||
     lifetimePrsMerged > 0
+  const hasRepoMetrics = Object.keys(repoMetrics).length > 0 && (
+    Object.values(repoMetrics.throughput || {}).some(value => Number(value || 0) > 0) ||
+    Object.values(repoMetrics.friction || {}).some(value => Number(value || 0) > 0) ||
+    Object.keys(repoMetrics.time_to_merge || {}).length > 0
+  )
 
   // Extract history data
   const historyData = metricsHistory || {}
@@ -144,7 +215,7 @@ export function MetricsPanel() {
   const current = historyData.current
   const prev = snapshots.length > 0 ? snapshots[snapshots.length - 1] : null
 
-  if (!hasGithub && !hasSession && !hasLifetime && !current) {
+  if (!hasGithub && !hasSession && !hasLifetime && !current && !hasRepoMetrics) {
     return (
       <div style={styles.container} data-testid="metrics-panel-root">
         <div style={styles.empty}>No metrics data available yet.</div>
@@ -248,6 +319,12 @@ export function MetricsPanel() {
       title: 'Time to Merge',
       content: <TimeToMerge data={timeToMerge} dataTestId="metrics-grid-time-to-merge" />,
       shouldRender: Object.keys(timeToMerge).length > 0,
+    },
+    {
+      key: 'repo',
+      title: 'Repo Metrics',
+      content: <RepoMetrics data={repoMetrics} />,
+      shouldRender: hasRepoMetrics,
     },
     {
       key: 'session',
@@ -417,6 +494,44 @@ const styles = {
   thresholdText: {
     fontSize: 12,
     color: theme.textBright,
+  },
+  repoHeader: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: 10,
+    marginBottom: 12,
+    flexWrap: 'wrap',
+  },
+  repoName: {
+    fontSize: 14,
+    fontWeight: 700,
+    color: theme.textBright,
+  },
+  repoSlug: {
+    fontSize: 12,
+    color: theme.textMuted,
+  },
+  subheading: {
+    fontSize: 12,
+    fontWeight: 700,
+    color: theme.text,
+    marginTop: 12,
+    marginBottom: 8,
+    textTransform: 'uppercase',
+  },
+  retryList: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginTop: 12,
+  },
+  retryBadge: {
+    fontSize: 12,
+    color: theme.text,
+    background: theme.surfaceInset,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 8,
+    padding: '4px 8px',
   },
   outcomeSummary: {
     display: 'flex',

--- a/src/ui/src/components/__tests__/MetricsPanel.test.jsx
+++ b/src/ui/src/components/__tests__/MetricsPanel.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 
 const mockUseHydraFlow = vi.fn()
 
@@ -245,6 +245,45 @@ describe('MetricsPanel', () => {
     expect(screen.getByText('234')).toBeInTheDocument()
     expect(screen.getByText('8,000')).toBeInTheDocument()
     expect(screen.getByText('400')).toBeInTheDocument()
+  })
+
+  it('renders repo-scoped throughput and friction metrics', () => {
+    mockUseHydraFlow.mockReturnValue(defaultContext({
+      metrics: {
+        lifetime: { issues_completed: 0, prs_merged: 0 },
+        rates: {},
+        repo_metrics: {
+          repo: 'T-rav/hydraflow',
+          repo_slug: 'T-rav-hydraflow',
+          throughput: { implemented: 1.5, merged: 0.5 },
+          time_to_merge: { avg: 120, p50: 120, p90: 120 },
+          friction: {
+            quality_fix_rounds: 2,
+            ci_fix_rounds: 1,
+            hitl_escalations: 3,
+            stage_retries: 4,
+            quality_fix_rate: 0.25,
+            hitl_escalation_rate: 0.5,
+          },
+          retries_by_stage: { implement: 2, review: 2 },
+        },
+      },
+    }))
+
+    render(<MetricsPanel />)
+
+    const repoGrid = screen.getByTestId('metrics-grid-repo')
+    expect(screen.getByText('Repo Metrics')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('T-rav/hydraflow')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Implemented / hr')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Merged / hr')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Quality Fix Rounds')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('CI Fix Rounds')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Stage Retries')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('25.0%')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('50.0%')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Implement: 2')).toBeInTheDocument()
+    expect(within(repoGrid).getByText('Review: 2')).toBeInTheDocument()
   })
 
   it('uses metrics-grid layout wrappers with data test ids', () => {

--- a/tests/test_dashboard_routes_metrics.py
+++ b/tests/test_dashboard_routes_metrics.py
@@ -131,6 +131,47 @@ class TestMetricsEndpoint:
         assert data["inference_lifetime"]["total_tokens"] == 60
         assert data["inference_session"]["total_tokens"] == 60
 
+    @pytest.mark.asyncio
+    async def test_metrics_includes_repo_scoped_throughput_and_friction(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        import json
+        from datetime import UTC, datetime, timedelta
+
+        for _ in range(4):
+            state.record_issue_completed()
+        state.record_quality_fix_rounds(2)
+        state.record_ci_fix_rounds(1)
+        state.record_hitl_escalation()
+        state.record_review_verdict("request-changes", fixes_made=True)
+        state.record_stage_retry(123, "implement")
+        state.record_stage_retry(124, "review")
+        state.record_merge_duration(120.0)
+        state.reset_session_counters(
+            (datetime.now(UTC) - timedelta(hours=2)).isoformat()
+        )
+        state.increment_session_counter("implemented")
+        state.increment_session_counter("merged")
+
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        get_metrics = find_endpoint(router, "/api/metrics")
+        response = await get_metrics()
+        data = json.loads(response.body)
+        repo_metrics = data["repo_metrics"]
+
+        assert repo_metrics["repo_slug"] == config.repo_slug
+        assert repo_metrics["throughput"]["implemented"] == pytest.approx(0.5, abs=0.05)
+        assert repo_metrics["throughput"]["merged"] == pytest.approx(0.5, abs=0.05)
+        assert repo_metrics["time_to_merge"]["avg"] == 120.0
+        assert repo_metrics["retries_by_stage"] == {"implement": 1, "review": 1}
+        assert repo_metrics["friction"]["quality_fix_rounds"] == 2
+        assert repo_metrics["friction"]["ci_fix_rounds"] == 1
+        assert repo_metrics["friction"]["hitl_escalations"] == 1
+        assert repo_metrics["friction"]["reviewer_fixes"] == 1
+        assert repo_metrics["friction"]["stage_retries"] == 2
+        assert repo_metrics["friction"]["quality_fix_rate"] == pytest.approx(0.5)
+        assert repo_metrics["friction"]["hitl_escalation_rate"] == pytest.approx(0.25)
+
 
 class TestGitHubMetricsEndpoint:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- add a repo-scoped metrics payload to /api/metrics with throughput, time-to-merge, retries, and friction counters\n- render repo throughput and friction metrics in MetricsPanel\n- refresh generated architecture docs expected by the quality gate\n\n## Tests\n- uv run pytest tests/test_dashboard_routes_metrics.py tests/test_bg_worker_status.py -q\n- npm test -- --run src/components/__tests__/MetricsPanel.test.jsx\n- make arch-check\n- make quality