### PR TITLE
Refs #8932: harden design chat extraction

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T09:43:19.915945+00:00",
-  "commit_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695",
+  "regenerated_at": "2026-05-23T10:19:30.072807+00:00",
+  "commit_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "ports.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "labels.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "modules.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "events.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "adr_xref.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "mockworld.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "changelog.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "coverage_matrix.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "functional_areas.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "ubiquitous-language.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "5e16ae5b5410ac492f82b70f3cc0bc31f52d6695"
+      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `72eae73` — Refs #8933: add repo metrics dashboard payload *(2026-05-23)*
 - `43b1e0a` — Refs #8933: wire onboarding format upgrade *(2026-05-23)*
 - `bab9837` — Fixes #8933: wire onboarding continue plan *(2026-05-23)*
 - `553bd1d` — Refs #8932: add Claude design provider fallback *(2026-05-23)*
@@ -351,4 +352,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `5e16ae5` on 2026-05-23 09:43 UTC. Source last changed at `5e16ae5`. Status: 🟢 fresh._
+_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._

--- a/src/onboarding/design_ai.py
+++ b/src/onboarding/design_ai.py
@@ -24,9 +24,13 @@ DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
 
 _NAME_RE = re.compile(r"\b[a-z][a-z0-9]+(?:-[a-z0-9]+)+\b")
 _OWNER_RE = re.compile(
-    r"\b(?:owner|org|organization)\s+([A-Za-z0-9_.-]{1,100})\b", re.I
+    r"\b(?:owner|org|organization)(?:\s+is|\s*:)?\s+([A-Za-z0-9_.-]{1,100})\b"
+    r"|\bowned\s+by\s+([A-Za-z0-9_.-]{1,100})\b"
+    r"|\bunder\s+(?:the\s+)?(?:org|organization)\s+([A-Za-z0-9_.-]{1,100})\b",
+    re.I,
 )
 _COVERAGE_RE = re.compile(r"\b(\d{2,3})\s*%\s*(?:coverage|test coverage)\b", re.I)
+_REVISION_CUES = ("actually", "instead", "switch", "change", "use", "prefer")
 
 
 @dataclass(frozen=True)
@@ -177,11 +181,15 @@ class DesignAIService:
 
         owner_match = _OWNER_RE.search(message)
         if owner_match:
-            updates["owner"] = owner_match.group(1)
+            updates["owner"] = next(
+                group for group in owner_match.groups() if group is not None
+            )
 
-        if "public" in lowered:
+        if (
+            "public" in lowered or "open source" in lowered or "open-source" in lowered
+        ) and "not public" not in lowered:
             updates["visibility"] = "public"
-        elif "private" in lowered:
+        elif "private" in lowered or "internal" in lowered or "not public" in lowered:
             updates["visibility"] = "private"
 
         coverage_match = _COVERAGE_RE.search(message)
@@ -189,6 +197,43 @@ class DesignAIService:
             updates["coverage_floor"] = min(100, max(0, int(coverage_match.group(1))))
 
         stack = list(current.tech_stack)
+        revising = any(cue in lowered for cue in _REVISION_CUES)
+        if "no ui" in lowered or "none ui" in lowered or "ui none" in lowered:
+            stack = [
+                item
+                for item in stack
+                if item.lower() not in {"react", "next.js", "nextjs"}
+            ]
+        elif revising and (
+            "react" in lowered or "next.js" in lowered or "nextjs" in lowered
+        ):
+            stack = [item for item in stack if item.lower() != "ui=none"]
+            if "next.js" in lowered or "nextjs" in lowered:
+                stack = [item for item in stack if item.lower() != "react"]
+            if (
+                "react" in lowered
+                and "next.js" not in lowered
+                and "nextjs" not in lowered
+            ):
+                stack = [
+                    item for item in stack if item.lower() not in {"next.js", "nextjs"}
+                ]
+        if "sqlite" in lowered and revising:
+            stack = [item for item in stack if item.lower() != "postgres"]
+        if ("postgres" in lowered or "postgresql" in lowered) and revising:
+            stack = [item for item in stack if item.lower() != "sqlite"]
+        skip_stack_labels: set[str] = set()
+        instead_of = (
+            lowered.split("instead of", 1)[1] if "instead of" in lowered else ""
+        )
+        if "postgres" in instead_of or "not postgres" in lowered:
+            skip_stack_labels.add("Postgres")
+        if "react" in instead_of or "not react" in lowered:
+            skip_stack_labels.add("React")
+        if "sqlite" in instead_of or "not sqlite" in lowered:
+            skip_stack_labels.add("SQLite")
+        if "next.js" in instead_of or "nextjs" in instead_of or "not next" in lowered:
+            skip_stack_labels.add("Next.js")
         for keyword, label in (
             ("fastapi", "FastAPI"),
             ("django", "Django"),
@@ -202,8 +247,13 @@ class DesignAIService:
             ("postgresql", "Postgres"),
             ("none ui", "UI=None"),
             ("no ui", "UI=None"),
+            ("ui none", "UI=None"),
         ):
-            if keyword in lowered and label not in stack:
+            if (
+                keyword in lowered
+                and label not in stack
+                and label not in skip_stack_labels
+            ):
                 stack.append(label)
         if stack != current.tech_stack:
             updates["tech_stack"] = stack

--- a/tests/test_onboarding_design_ai.py
+++ b/tests/test_onboarding_design_ai.py
@@ -4,6 +4,12 @@ from onboarding.design_ai import DesignAIService, apply_field_updates
 from onboarding.models import BootstrapDraft, BootstrapSpec
 
 
+@pytest.fixture(autouse=True)
+def _disable_live_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HYDRAFLOW_ONBOARDING_ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+
 def _draft(**overrides: object) -> BootstrapDraft:
     payload = {
         "name": "new-project",
@@ -42,6 +48,96 @@ async def test_design_chat_extracts_six_core_fields() -> None:
     assert "branch-protection" in turn.field_updates["safety_guards"]
     assert "deterministic-tests" in turn.field_updates["safety_guards"]
     assert turn.clarification is None
+
+
+@pytest.mark.asyncio
+async def test_design_chat_extraction_reliability_corpus() -> None:
+    service = DesignAIService()
+    messages = [
+        "Build ledger-lab as a public FastAPI React app for owner finance-org with branch protection and 91% coverage.",
+        "The repo is ledger-lab; org finance-org; open source; FastAPI API with React and branch protection, 91% test coverage.",
+        "I want ledger-lab under organization finance-org, public, Python FastAPI plus React, branch protection, 91% coverage.",
+        "Create ledger-lab owned by finance-org as public. Backend FastAPI, frontend React, branch protection, 91% coverage.",
+        "Let's call it ledger-lab. Owner is finance-org. It should be public with FastAPI, React, branch protection, and 91% coverage.",
+        "For owner finance-org, make public project ledger-lab using FastAPI and React; require branch protection and 91% coverage.",
+        "ledger-lab should live under org finance-org; make it open source with FastAPI/React, branch protection, 91% coverage.",
+        "Please draft ledger-lab for organization finance-org: public FastAPI service, React UI, branch protection, 91% coverage.",
+        "Project ledger-lab, owner: finance-org, visibility public, stack Python + FastAPI + React, branch protection, 91% coverage.",
+        "Use finance-org as owner for ledger-lab. Public repo, FastAPI backend, React UI, branch protection, 91% coverage.",
+        "Bootstrap ledger-lab in org finance-org as public; FastAPI for the API, React for UI, branch protection, 91% coverage.",
+        "Repo ledger-lab, owned by finance-org, is open-source. FastAPI and React, branch protection, 91% coverage.",
+        "I need a public ledger-lab repository for owner finance-org; Python FastAPI, React, branch protection, 91% coverage.",
+        "Make ledger-lab public for org finance-org. It uses FastAPI, has a React frontend, branch protection, 91% coverage.",
+        "The app is ledger-lab, organization finance-org, public visibility, FastAPI backend, React UI, branch protection, 91% coverage.",
+        "Start ledger-lab under the org finance-org. It is public, with FastAPI, React, branch protection, and 91% test coverage.",
+        "I'd like ledger-lab owned by finance-org, public, FastAPI with React, branch protection enabled, 91% coverage.",
+        "Configure ledger-lab for owner finance-org as a public FastAPI + React bootstrap with branch protection and 91% coverage.",
+        "Set up ledger-lab; owner finance-org; public; API in FastAPI; React UI; branch protection; 91% coverage.",
+        "finance-org owns ledger-lab. Make it public and use Python FastAPI, React, branch protection, 91% coverage.",
+        "Build the public ledger-lab repo for org finance-org using FastAPI, React, branch protection, and 91% coverage.",
+        "For finance-org, create ledger-lab as an open source FastAPI React service with branch protection and 91% coverage.",
+        "ledger-lab is the name, finance-org is the owner, public is the visibility, stack FastAPI React, branch protection, 91% coverage.",
+        "Use ledger-lab for the repo name under organization finance-org; public, FastAPI, React, branch protection, 91% coverage.",
+        "Create a public FastAPI/React repo named ledger-lab for owner finance-org, with branch protection and 91% coverage.",
+        "I am building ledger-lab for org finance-org: public repository, FastAPI backend, React app, branch protection, 91% coverage.",
+        "Please make ledger-lab an open-source repo owned by finance-org; FastAPI + React; branch protection; 91% test coverage.",
+        "ledger-lab should be public in organization finance-org, with FastAPI, React, branch protection, and 91% coverage.",
+        "The target is ledger-lab, owner finance-org, public GitHub repo, FastAPI API, React client, branch protection, 91% coverage.",
+        "Generate ledger-lab for owner finance-org as public; choose FastAPI, React, branch protection, and 91% coverage.",
+    ]
+    expected_checks = 0
+    passed_checks = 0
+
+    for message in messages:
+        turn = await service.chat(_draft(), message)
+        updates = turn.field_updates
+        checks = [
+            updates.get("name") == "ledger-lab",
+            updates.get("owner") == "finance-org",
+            updates.get("visibility") == "public",
+            updates.get("coverage_floor") == 91,
+            "FastAPI" in updates.get("tech_stack", []),
+            "React" in updates.get("tech_stack", []),
+            "branch-protection" in updates.get("safety_guards", []),
+        ]
+        expected_checks += len(checks)
+        passed_checks += sum(1 for check in checks if check)
+
+    assert len(messages) == 30
+    assert passed_checks / expected_checks >= 0.95
+
+
+@pytest.mark.asyncio
+async def test_design_chat_revision_updates_sidebar_fields_within_one_turn() -> None:
+    service = DesignAIService()
+    draft = _draft(tech_stack=["python", "FastAPI", "Postgres", "React"])
+
+    turn = await service.chat(
+        draft,
+        "Actually switch ledger-lab to SQLite and Next.js instead of Postgres and React.",
+    )
+    updated = apply_field_updates(draft.spec, turn.field_updates)
+
+    assert "SQLite" in updated.tech_stack
+    assert "Postgres" not in updated.tech_stack
+    assert "Next.js" in updated.tech_stack
+    assert "React" not in updated.tech_stack
+
+
+@pytest.mark.asyncio
+async def test_design_chat_surfaces_ambiguity_instead_of_guessing() -> None:
+    service = DesignAIService()
+
+    turn = await service.chat(
+        _draft(tech_stack=["python", "FastAPI"]),
+        "ledger-lab needs a UI, but I have not picked which one yet.",
+    )
+
+    assert (
+        turn.clarification == "Do you want React, Next.js, or no UI for the bootstrap?"
+    )
+    assert "React" not in turn.field_updates.get("tech_stack", [])
+    assert "Next.js" not in turn.field_updates.get("tech_stack", [])
 
 
 def test_apply_field_updates_preserves_manual_fields() -> None:


### PR DESCRIPTION
## Summary\n- add a 30-phrase design-chat extraction corpus with a >=95% reliability gate across core sidebar fields\n- handle common owner/visibility phrasings like owned by, under org, open source, and internal\n- update one-turn revision handling for UI/database choices and keep ambiguous UI requests as clarifying questions\n- refresh generated architecture docs expected by the quality gate\n\n## Tests\n- uv run pytest tests/test_onboarding_design_ai.py -q\n- uv run pytest tests/test_onboarding_api.py tests/test_onboarding_design_ai.py -q\n- uv run ruff format src/onboarding/design_ai.py tests/test_onboarding_design_ai.py\n- uv run ruff check src/onboarding/design_ai.py tests/test_onboarding_design_ai.py\n- make quality