### PR TITLE
Refs #8932: persist wizard spec edits

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T10:19:30.072807+00:00",
-  "commit_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739",
+  "regenerated_at": "2026-05-23T10:53:34.616680+00:00",
+  "commit_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663",
   "artifacts": {
     "loops.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "ports.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "labels.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "modules.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "events.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "adr_xref.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "mockworld.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "changelog.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "coverage_matrix.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "functional_areas.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "ubiquitous-language.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "6c17af10c7e2fe850f3ee20863f08eada0a83739"
+      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `9362727` — Refs #8932: harden design chat extraction *(2026-05-23)*
 - `72eae73` — Refs #8933: add repo metrics dashboard payload *(2026-05-23)*
 - `43b1e0a` — Refs #8933: wire onboarding format upgrade *(2026-05-23)*
 - `bab9837` — Fixes #8933: wire onboarding continue plan *(2026-05-23)*
@@ -352,4 +353,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `6c17af1` on 2026-05-23 10:19 UTC. Source last changed at `6c17af1`. Status: 🟢 fresh._
+_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -23,6 +23,7 @@ from onboarding.models import (
     DesignChatRequest,
     DesignRevisionRequest,
     MaterializeRequest,
+    SaveSpecDraftRequest,
 )
 from onboarding.templating import MaterializeError, materialize_repository
 
@@ -465,6 +466,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             draft, request.note if request else None
         )
         draft.events.append({"level": "info", "message": "wizard spec drafted"})
+        _persist_draft(ctx, draft)
+        return JSONResponse(
+            {"draft": draft.model_dump(mode="json"), "spec_draft": draft.spec_draft}
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/design/spec/save")
+    async def save_onboarding_spec_draft(
+        draft_id: str, request: SaveSpecDraftRequest
+    ) -> JSONResponse:
+        draft, error_response = _load_draft_response(ctx, draft_id)
+        if error_response is not None:
+            return error_response
+        assert draft is not None
+
+        draft.spec_draft = request.spec_draft
+        draft.events.append({"level": "info", "message": "wizard spec edits saved"})
         _persist_draft(ctx, draft)
         return JSONResponse(
             {"draft": draft.model_dump(mode="json"), "spec_draft": draft.spec_draft}

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -142,6 +142,20 @@ class DesignRevisionRequest(BaseModel):
         return normalized or None
 
 
+class SaveSpecDraftRequest(BaseModel):
+    """Operator-edited wizard spec draft content."""
+
+    spec_draft: str = Field(min_length=1, max_length=20000)
+
+    @field_validator("spec_draft")
+    @classmethod
+    def normalize_spec_draft(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("spec_draft is required")
+        return normalized
+
+
 class ContinuePlanRequest(BaseModel):
     """Request body for filing the next onboarding plan issue batch."""
 

--- a/src/ui/src/components/BootstrapWizard.jsx
+++ b/src/ui/src/components/BootstrapWizard.jsx
@@ -76,6 +76,7 @@ export function BootstrapWizard({ isOpen, onClose }) {
     createOnboardingDraft,
     chatOnboardingDraft,
     draftOnboardingSpec,
+    saveOnboardingSpecDraft,
     draftOnboardingPlan,
     materializeOnboardingDraft,
     selectRepo,
@@ -179,6 +180,20 @@ export function BootstrapWizard({ isOpen, onClose }) {
     return result.draft
   }, [draftOnboardingPlan])
 
+  const saveSpecDraft = useCallback(async (activeDraft) => {
+    const content = (specDraft || '').trim()
+    if (!content) return activeDraft
+    const result = await saveOnboardingSpecDraft?.(activeDraft.id, content)
+    if (!result?.ok) {
+      setDraft(result?.draft || activeDraft)
+      setError(result?.error || 'Spec save failed')
+      return null
+    }
+    setDraft(result.draft)
+    setSpecDraft(result.spec_draft || result.draft?.spec_draft || content)
+    return result.draft
+  }, [saveOnboardingSpecDraft, specDraft])
+
   const handleNext = useCallback(async () => {
     if (step === 0) {
       const created = await ensureDraft()
@@ -194,12 +209,17 @@ export function BootstrapWizard({ isOpen, onClose }) {
       if (!activeDraft) return
       setSubmitting(true)
       setError('')
-      const updated = await generatePlanDraft(activeDraft)
+      const saved = await saveSpecDraft(activeDraft)
+      if (!saved) {
+        setSubmitting(false)
+        return
+      }
+      const updated = await generatePlanDraft(saved)
       setSubmitting(false)
       if (!updated) return
     }
     setStep(prev => Math.min(prev + 1, STEPS.length - 1))
-  }, [ensureDraft, generatePlanDraft, generateSpecDraft, step])
+  }, [ensureDraft, generatePlanDraft, generateSpecDraft, saveSpecDraft, step])
 
   const handleMaterialize = useCallback(async () => {
     const activeDraft = await ensureDraft()

--- a/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
+++ b/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
@@ -54,6 +54,16 @@ function makeContext(overrides = {}) {
       },
       spec_draft: '# finance-tool\n\n## 10-file Invariant Kernel\n\n## V1 IN',
     }),
+    saveOnboardingSpecDraft: vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        spec_draft: '# finance-tool\n\n## Edited',
+        events: [{ level: 'info', message: 'wizard spec edits saved' }],
+      },
+      spec_draft: '# finance-tool\n\n## Edited',
+    }),
     draftOnboardingPlan: vi.fn().mockResolvedValue({
       ok: true,
       draft: {
@@ -172,6 +182,44 @@ describe('BootstrapWizard', () => {
     await waitFor(() => expect(materializeOnboardingDraft).toHaveBeenCalledWith('draft-1', { output_dir: null }))
     expect(selectRepo).toHaveBeenCalledWith('finance-tool')
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('persists manual spec edits before generating Plan 01', async () => {
+    const saveOnboardingSpecDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        spec_draft: '# finance-tool\n\n## Edited invariant kernel',
+        events: [{ level: 'info', message: 'wizard spec edits saved' }],
+      },
+      spec_draft: '# finance-tool\n\n## Edited invariant kernel',
+    })
+    const draftOnboardingPlan = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-1',
+        spec: { name: 'finance-tool' },
+        plan_draft: ['Create invariant kernel'],
+        events: [{ level: 'info', message: 'wizard plan drafted' }],
+      },
+      plan_draft: ['Create invariant kernel'],
+    })
+    mockUseHydraFlow.mockReturnValue(makeContext({ saveOnboardingSpecDraft, draftOnboardingPlan }))
+
+    render(<BootstrapWizard isOpen onClose={() => {}} />)
+    fireEvent.click(screen.getByText('Next'))
+    const specEditor = await screen.findByLabelText('Generated spec draft')
+    fireEvent.change(specEditor, {
+      target: { value: '# finance-tool\n\n## Edited invariant kernel' },
+    })
+    fireEvent.click(screen.getByText('Next'))
+
+    await waitFor(() => expect(saveOnboardingSpecDraft).toHaveBeenCalledWith(
+      'draft-1',
+      '# finance-tool\n\n## Edited invariant kernel'
+    ))
+    await waitFor(() => expect(draftOnboardingPlan).toHaveBeenCalledWith('draft-1'))
   })
 
   it('keeps the wizard open and expands activity on materialize failure', async () => {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1455,6 +1455,24 @@ export function HydraFlowProvider({ children }) {
     }
   }, [])
 
+  const saveOnboardingSpecDraft = useCallback(async (draftId, specDraft) => {
+    if (!draftId) return { ok: false, error: 'Draft id required' }
+    try {
+      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/design/spec/save`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ spec_draft: specDraft }),
+      })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) {
+        return { ok: false, error: data?.error || `Spec save failed (${res.status})`, draft: data?.draft }
+      }
+      return { ok: true, ...data }
+    } catch (err) {
+      return { ok: false, error: err?.message || 'Spec save failed' }
+    }
+  }, [])
+
   const draftOnboardingPlan = useCallback(async (draftId, note = null) => {
     if (!draftId) return { ok: false, error: 'Draft id required' }
     try {
@@ -2045,6 +2063,7 @@ export function HydraFlowProvider({ children }) {
     createOnboardingDraft,
     chatOnboardingDraft,
     draftOnboardingSpec,
+    saveOnboardingSpecDraft,
     draftOnboardingPlan,
     materializeOnboardingDraft,
     pushOnboardingDraft,

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -22,6 +22,7 @@ from onboarding.models import (
     DesignChatRequest,
     DesignRevisionRequest,
     MaterializeRequest,
+    SaveSpecDraftRequest,
 )
 from tests.helpers import find_endpoint, make_dashboard_router
 
@@ -486,6 +487,36 @@ class TestOnboardingDraftRoutes:
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["spec_draft"] == spec_data["spec_draft"]
         assert persisted["plan_draft"] == plan_data["plan_draft"]
+
+    @pytest.mark.asyncio
+    async def test_manual_spec_edits_are_persisted(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="finance-tool")),
+            spec_draft="# finance-tool\n\nOriginal draft",
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/spec/save",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            SaveSpecDraftRequest(
+                spec_draft="# finance-tool\n\nEdited invariant kernel"
+            ),
+        )
+        data = json.loads(response.body)
+
+        assert response.status_code == 200
+        assert data["spec_draft"] == "# finance-tool\n\nEdited invariant kernel"
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["spec_draft"] == "# finance-tool\n\nEdited invariant kernel"
+        assert persisted["events"][-1]["message"] == "wizard spec edits saved"
 
     @pytest.mark.asyncio
     async def test_continue_plan_drafts_next_plan_and_files_find_issues(


### PR DESCRIPTION
## Summary\n- add a backend save endpoint for operator-edited onboarding spec drafts\n- wire HydraFlowContext and BootstrapWizard so Step 2 edits persist before Plan 01 generation\n- add API and wizard tests for the manual edit save path\n- refresh generated architecture docs expected by the quality gate\n\n## Tests\n- uv run pytest tests/test_onboarding_api.py -q\n- npm test -- --run src/components/__tests__/BootstrapWizard.test.jsx\n- uv run ruff format src/onboarding/models.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py\n- uv run ruff check src/onboarding/models.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py\n- make quality