### PR TITLE
Refs #8932: stream onboarding design chat

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T10:53:34.616680+00:00",
-  "commit_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663",
+  "regenerated_at": "2026-05-23T11:32:29.955561+00:00",
+  "commit_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d",
   "artifacts": {
     "loops.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "ports.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "labels.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "modules.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "events.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "adr_xref.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "mockworld.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "changelog.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "coverage_matrix.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "functional_areas.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "ubiquitous-language.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "c3a9a46093a64deb1a88ca4abd109b751a976663"
+      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `8728fc2` — Refs #8932: persist wizard spec edits *(2026-05-23)*
 - `9362727` — Refs #8932: harden design chat extraction *(2026-05-23)*
 - `72eae73` — Refs #8933: add repo metrics dashboard payload *(2026-05-23)*
 - `43b1e0a` — Refs #8933: wire onboarding format upgrade *(2026-05-23)*
@@ -353,4 +354,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `c3a9a46` on 2026-05-23 10:53 UTC. Source last changed at `c3a9a46`. Status: 🟢 fresh._
+_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -12,10 +12,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import ValidationError
 
-from onboarding.design_ai import DesignAIService, apply_field_updates
+from onboarding.design_ai import DesignAIService, DesignTurn, apply_field_updates
 from onboarding.models import (
     BootstrapDraft,
     BootstrapSpec,
@@ -62,6 +62,40 @@ def _allowed_output_dir(raw_path: str | None, default_parent: Path) -> Path | No
 def _persist_draft(ctx: RouteContext, draft: BootstrapDraft) -> None:
     draft.touch()
     ctx.state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+
+
+async def _apply_design_turn(
+    ctx: RouteContext,
+    draft: BootstrapDraft,
+    request: DesignChatRequest,
+) -> tuple[BootstrapDraft, DesignTurn] | JSONResponse:
+    turn = await design_ai.chat(draft, request.message)
+    draft.chat_messages.append({"role": "user", "content": request.message})
+    draft.chat_messages.append({"role": "assistant", "content": turn.reply})
+    draft.extracted_fields.update(turn.field_updates)
+    try:
+        draft.spec = apply_field_updates(draft.spec, turn.field_updates)
+    except ValidationError:
+        return JSONResponse({"error": "Design update is invalid"}, status_code=422)
+    event_message = "design chat updated fields"
+    if turn.source == "claude":
+        event_message = "claude design chat updated fields"
+    if turn.fallback_reason:
+        event_message = f"design chat used form-fill fallback: {turn.fallback_reason}"
+    draft.events.append({"level": "info", "message": event_message})
+    _persist_draft(ctx, draft)
+    return draft, turn
+
+
+def _chat_response_payload(
+    draft: BootstrapDraft, turn: DesignTurn
+) -> dict[str, object]:
+    return {
+        "draft": draft.model_dump(mode="json"),
+        "reply": turn.reply,
+        "field_updates": turn.field_updates,
+        "clarification": turn.clarification,
+    }
 
 
 def _load_draft_response(
@@ -425,30 +459,47 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         if draft is None:
             return JSONResponse({"error": "Draft is invalid"}, status_code=500)
 
-        turn = await design_ai.chat(draft, request.message)
-        draft.chat_messages.append({"role": "user", "content": request.message})
-        draft.chat_messages.append({"role": "assistant", "content": turn.reply})
-        draft.extracted_fields.update(turn.field_updates)
-        try:
-            draft.spec = apply_field_updates(draft.spec, turn.field_updates)
-        except ValidationError:
-            return JSONResponse({"error": "Design update is invalid"}, status_code=422)
-        event_message = "design chat updated fields"
-        if turn.source == "claude":
-            event_message = "claude design chat updated fields"
-        if turn.fallback_reason:
-            event_message = (
-                f"design chat used form-fill fallback: {turn.fallback_reason}"
+        result = await _apply_design_turn(ctx, draft, request)
+        if isinstance(result, JSONResponse):
+            return result
+        updated_draft, turn = result
+        return JSONResponse(_chat_response_payload(updated_draft, turn))
+
+    @router.post(
+        "/api/onboarding/drafts/{draft_id}/design/chat/stream", response_model=None
+    )
+    async def stream_onboarding_draft_chat(
+        draft_id: str, request: DesignChatRequest
+    ) -> StreamingResponse | JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+
+        result = await _apply_design_turn(ctx, draft, request)
+        if isinstance(result, JSONResponse):
+            return result
+        updated_draft, turn = result
+
+        async def generate():
+            reply = turn.reply or ""
+            for index in range(0, len(reply), 32):
+                chunk = reply[index : index + 32]
+                yield json.dumps({"type": "reply_delta", "text": chunk}) + "\n"
+                await asyncio.sleep(0)
+            yield (
+                json.dumps(
+                    {"type": "final", **_chat_response_payload(updated_draft, turn)}
+                )
+                + "\n"
             )
-        draft.events.append({"level": "info", "message": event_message})
-        _persist_draft(ctx, draft)
-        return JSONResponse(
-            {
-                "draft": draft.model_dump(mode="json"),
-                "reply": turn.reply,
-                "field_updates": turn.field_updates,
-                "clarification": turn.clarification,
-            }
+
+        return StreamingResponse(
+            generate(),
+            media_type="application/x-ndjson",
+            headers={"Cache-Control": "no-cache"},
         )
 
     @router.post("/api/onboarding/drafts/{draft_id}/design/spec")

--- a/src/ui/src/components/BootstrapWizard.jsx
+++ b/src/ui/src/components/BootstrapWizard.jsx
@@ -140,9 +140,28 @@ export function BootstrapWizard({ isOpen, onClose }) {
     if (!message || submitting) return
     const activeDraft = await ensureDraft()
     if (!activeDraft) return
+    const streamingDraft = {
+      ...activeDraft,
+      chat_messages: [
+        ...(activeDraft.chat_messages || []),
+        { role: 'user', content: message },
+        { role: 'assistant', content: '' },
+      ],
+    }
+    setDraft(streamingDraft)
     setSubmitting(true)
     setError('')
-    const result = await chatOnboardingDraft?.(activeDraft.id, message)
+    const result = await chatOnboardingDraft?.(activeDraft.id, message, {
+      onReplyDelta: (text) => {
+        setDraft(prev => {
+          const messages = [...(prev?.chat_messages || streamingDraft.chat_messages)]
+          const last = messages[messages.length - 1]
+          if (!last || last.role !== 'assistant') return prev
+          messages[messages.length - 1] = { ...last, content: `${last.content || ''}${text}` }
+          return { ...(prev || streamingDraft), chat_messages: messages }
+        })
+      },
+    })
     setSubmitting(false)
     if (!result?.ok) {
       setDraft(result?.draft || activeDraft)

--- a/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
+++ b/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
@@ -119,31 +119,37 @@ describe('BootstrapWizard', () => {
   })
 
   it('uses design chat to auto-fill fields while keeping them editable', async () => {
-    const chatOnboardingDraft = vi.fn().mockResolvedValue({
-      ok: true,
-      draft: {
-        id: 'draft-1',
-        spec: {
-          name: 'finance-tool',
-          description: 'Finance automation',
-          owner: 'T-rav',
-          visibility: 'public',
-          tech_stack: ['python', 'FastAPI', 'React'],
-          safety_guards: ['branch-protection'],
-          coverage_floor: 92,
-          label_prefix: 'hydraflow',
-          main_branch: 'main',
-          staging_branch: 'staging',
-        },
-        chat_messages: [
-          { role: 'user', content: 'Build finance-tool with FastAPI and React' },
-          { role: 'assistant', content: 'I updated the project fields.' },
-        ],
-        events: [{ level: 'info', message: 'design chat updated fields' }],
-      },
-      reply: 'I updated the project fields.',
-      field_updates: { name: 'finance-tool' },
-    })
+    const chatOnboardingDraft = vi
+      .fn()
+      .mockImplementation(async (_draftId, _message, options) => {
+        options?.onReplyDelta?.('I updated ')
+        options?.onReplyDelta?.('the project fields.')
+        return {
+          ok: true,
+          draft: {
+            id: 'draft-1',
+            spec: {
+              name: 'finance-tool',
+              description: 'Finance automation',
+              owner: 'T-rav',
+              visibility: 'public',
+              tech_stack: ['python', 'FastAPI', 'React'],
+              safety_guards: ['branch-protection'],
+              coverage_floor: 92,
+              label_prefix: 'hydraflow',
+              main_branch: 'main',
+              staging_branch: 'staging',
+            },
+            chat_messages: [
+              { role: 'user', content: 'Build finance-tool with FastAPI and React' },
+              { role: 'assistant', content: 'I updated the project fields.' },
+            ],
+            events: [{ level: 'info', message: 'design chat updated fields' }],
+          },
+          reply: 'I updated the project fields.',
+          field_updates: { name: 'finance-tool' },
+        }
+      })
     mockUseHydraFlow.mockReturnValue(makeContext({ chatOnboardingDraft }))
 
     render(<BootstrapWizard isOpen onClose={() => {}} />)
@@ -154,8 +160,10 @@ describe('BootstrapWizard', () => {
 
     await waitFor(() => expect(chatOnboardingDraft).toHaveBeenCalledWith(
       'draft-1',
-      'Build finance-tool as a public FastAPI React app with 92% coverage'
+      'Build finance-tool as a public FastAPI React app with 92% coverage',
+      expect.objectContaining({ onReplyDelta: expect.any(Function) })
     ))
+    expect(screen.getByTestId('design-chat-log')).toHaveTextContent('I updated the project fields.')
     expect(screen.getByDisplayValue('finance-tool')).toBeInTheDocument()
     expect(screen.getByLabelText('Visibility')).toHaveValue('public')
     fireEvent.change(screen.getByDisplayValue('finance-tool'), { target: { value: 'ledger-lab' } })

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1419,19 +1419,65 @@ export function HydraFlowProvider({ children }) {
     }
   }, [parseApiError])
 
-  const chatOnboardingDraft = useCallback(async (draftId, message) => {
+  const chatOnboardingDraft = useCallback(async (draftId, message, options = {}) => {
     if (!draftId) return { ok: false, error: 'Draft id required' }
     try {
-      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/design/chat`, {
+      const draftPath = `/api/onboarding/drafts/${encodeURIComponent(draftId)}`
+      const request = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message }),
-      })
-      const data = await res.json().catch(() => ({}))
+      }
+      if (typeof ReadableStream === 'undefined' || typeof TextDecoder === 'undefined') {
+        const fallbackRes = await fetch(`${draftPath}/design/chat`, request)
+        const data = await fallbackRes.json().catch(() => ({}))
+        if (!fallbackRes.ok) {
+          return {
+            ok: false,
+            error: data?.error || `Design chat failed (${fallbackRes.status})`,
+            draft: data?.draft,
+          }
+        }
+        return { ok: true, ...data }
+      }
+
+      const res = await fetch(`${draftPath}/design/chat/stream`, request)
       if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
         return { ok: false, error: data?.error || `Design chat failed (${res.status})`, draft: data?.draft }
       }
-      return { ok: true, ...data }
+      if (!res.body?.getReader) return { ok: false, error: 'Design chat streaming is unavailable' }
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      let finalPayload = null
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() || ''
+        for (const line of lines) {
+          if (!line.trim()) continue
+          const event = JSON.parse(line)
+          if (event.type === 'reply_delta') {
+            options?.onReplyDelta?.(event.text || '')
+          } else if (event.type === 'final') {
+            finalPayload = event
+          }
+        }
+      }
+      buffer += decoder.decode()
+      if (buffer.trim()) {
+        const event = JSON.parse(buffer)
+        if (event.type === 'reply_delta') {
+          options?.onReplyDelta?.(event.text || '')
+        } else if (event.type === 'final') {
+          finalPayload = event
+        }
+      }
+      if (!finalPayload) return { ok: false, error: 'Design chat stream ended without final payload' }
+      return { ok: true, ...finalPayload }
     } catch (err) {
       return { ok: false, error: err?.message || 'Design chat failed' }
     }

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -330,6 +330,41 @@ class TestOnboardingDraftRoutes:
         )
 
     @pytest.mark.asyncio
+    async def test_design_chat_streams_reply_then_final_payload(
+        self, config, event_bus, state, tmp_path, monkeypatch
+    ) -> None:
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("HYDRAFLOW_ONBOARDING_ANTHROPIC_API_KEY", raising=False)
+        draft = BootstrapDraft(spec=BootstrapSpec.model_validate(_spec_payload()))
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/design/chat/stream",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            DesignChatRequest(
+                message=(
+                    "Build finance-tool as a public FastAPI React app with "
+                    "branch protection and 92% coverage."
+                )
+            ),
+        )
+        chunks = [chunk async for chunk in response.body_iterator]
+        events = [json.loads(chunk) for chunk in chunks]
+
+        assert response.media_type == "application/x-ndjson"
+        assert any(event["type"] == "reply_delta" for event in events)
+        assert events[-1]["type"] == "final"
+        assert events[-1]["draft"]["spec"]["name"] == "finance-tool"
+        assert events[-1]["field_updates"]["visibility"] == "public"
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["chat_messages"][-1]["role"] == "assistant"
+
+    @pytest.mark.asyncio
     async def test_design_chat_falls_back_when_live_provider_fails(
         self, config, event_bus, state, tmp_path, monkeypatch
     ) -> None:


### PR DESCRIPTION
## Summary
- add an NDJSON streaming design-chat endpoint for onboarding draft conversations
- update the Step 1 wizard chat to render assistant deltas as they arrive, with a JSON fallback for streamless clients
- cover the stream payload and UI delta handling in backend/frontend tests

## Verification
- uv run pytest tests/test_onboarding_api.py -q
- npm test -- --run src/components/__tests__/BootstrapWizard.test.jsx
- make quality