### PR TITLE
docs: refresh architecture artifacts

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T11:32:29.955561+00:00",
-  "commit_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d",
+  "regenerated_at": "2026-05-23T12:01:08.523627+00:00",
+  "commit_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "ports.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "labels.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "modules.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "events.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "adr_xref.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "mockworld.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "changelog.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "coverage_matrix.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "functional_areas.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "ubiquitous-language.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "d37b2ef54673c909f7ae50d219ccd75dad83da4d"
+      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `66a1b1f` — Refs #8932: stream onboarding design chat *(2026-05-23)*
 - `8728fc2` — Refs #8932: persist wizard spec edits *(2026-05-23)*
 - `9362727` — Refs #8932: harden design chat extraction *(2026-05-23)*
 - `72eae73` — Refs #8933: add repo metrics dashboard payload *(2026-05-23)*
@@ -354,4 +355,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `d37b2ef` on 2026-05-23 11:32 UTC. Source last changed at `d37b2ef`. Status: 🟢 fresh._
+_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._


### PR DESCRIPTION
## Summary
- refresh generated architecture artifact metadata after the #9076 merge commit
- keep generated architecture docs fresh on main

## Verification
- uv run pytest tests/test_epic_monitor_loop.py tests/test_epic.py -q
- make arch-check
- pre-push quality-lite