### PR TITLE
Refs #8933: validate third-domain onboarding dashboard flow

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T12:01:08.523627+00:00",
-  "commit_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec",
+  "regenerated_at": "2026-05-23T12:18:25.281568+00:00",
+  "commit_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "ports.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "labels.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "modules.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "events.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "adr_xref.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "mockworld.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "changelog.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "coverage_matrix.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "functional_areas.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "ubiquitous-language.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "d5c5f53b6f470ae47e32108acafe61b54388b0ec"
+      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `01b5854` — docs: refresh architecture artifacts *(2026-05-23)*
 - `66a1b1f` — Refs #8932: stream onboarding design chat *(2026-05-23)*
 - `8728fc2` — Refs #8932: persist wizard spec edits *(2026-05-23)*
 - `9362727` — Refs #8932: harden design chat extraction *(2026-05-23)*
@@ -355,4 +356,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `d5c5f53` on 2026-05-23 12:01 UTC. Source last changed at `d5c5f53`. Status: 🟢 fresh._
+_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -610,6 +610,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 status_code=502,
             )
 
+        draft.current_plan = next_plan
         draft.plan_draft = plan_tasks
         draft.events.append(
             {

--- a/src/onboarding/models.py
+++ b/src/onboarding/models.py
@@ -88,6 +88,7 @@ class BootstrapDraft(BaseModel):
     chat_messages: list[dict[str, str]] = Field(default_factory=list)
     extracted_fields: dict[str, object] = Field(default_factory=dict)
     spec_draft: str | None = None
+    current_plan: str = Field(default="Plan 01", max_length=100)
     plan_draft: list[str] = Field(default_factory=list)
     materialized_path: str | None = Field(default=None, max_length=1000)
     repo_url: str | None = Field(default=None, max_length=1000)

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 from pydantic import ValidationError
 
+from events import EventBus
 from onboarding.design_ai import (
     AnthropicDesignProvider,
     DesignAIService,
@@ -24,6 +27,8 @@ from onboarding.models import (
     MaterializeRequest,
     SaveSpecDraftRequest,
 )
+from repo_store import RepoRecord, RepoStore
+from tests.conftest import EventFactory
 from tests.helpers import find_endpoint, make_dashboard_router
 
 
@@ -592,6 +597,135 @@ class TestOnboardingDraftRoutes:
         assert "Target repo: T-rav/finance-tool" in first_call["body"]
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["plan_draft"] == data["plan_draft"]
+        assert persisted["events"][-1]["message"].startswith("Plan 02 filed")
+
+    @pytest.mark.asyncio
+    async def test_third_domain_plan02_is_operable_from_dashboard_surfaces(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        repo_path = tmp_path / "claims-ledger"
+        repo_path.mkdir()
+        repo_config = config.model_copy(update={"repo": "Acme/claims-ledger"})
+        repo_bus = EventBus()
+        repo_store = RepoStore(tmp_path / "repos")
+        repo_store.upsert(
+            RepoRecord(
+                slug=repo_config.repo_slug,
+                repo=repo_config.repo,
+                path=str(repo_path),
+                auto_registered=True,
+            )
+        )
+        runtime = SimpleNamespace(
+            slug=repo_config.repo_slug,
+            config=repo_config,
+            state=state,
+            event_bus=repo_bus,
+            orchestrator=SimpleNamespace(current_session_id="claims-ledger-plan02"),
+            running=True,
+        )
+
+        class Registry:
+            all = [runtime]
+
+            def get(self, slug: str):
+                if slug in {repo_config.repo, repo_config.repo_slug}:
+                    return runtime
+                return None
+
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(
+                _spec_payload(
+                    name="claims-ledger",
+                    description="Claims workflow orchestration for audit teams.",
+                    owner="Acme",
+                    tech_stack=["python", "FastAPI", "React"],
+                    coverage_floor=91,
+                )
+            ),
+            status="pushed",
+            materialize_status="succeeded",
+            push_status="succeeded",
+            materialized_path=str(repo_path),
+            repo_url="https://github.com/Acme/claims-ledger",
+            current_plan="Plan 01",
+            plan_draft=["Create invariant kernel", "Add claims workflow API"],
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        state.record_issue_completed()
+        state.record_pr_merged()
+        state.record_quality_fix_rounds(1)
+        state.record_merge_duration(300.0)
+        state.reset_session_counters(
+            (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+        )
+        state.increment_session_counter("implemented")
+        state.increment_session_counter("merged")
+        await event_bus.publish(EventFactory.create(data={"repo": "default"}))
+        await repo_bus.publish(
+            EventFactory.create(
+                data={"repo": repo_config.repo, "message": "Plan 02 issue merged"}
+            )
+        )
+
+        router, pr_mgr = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=Registry(),
+            repo_store=repo_store,
+        )
+        pr_mgr.create_issue = AsyncMock(side_effect=list(range(801, 840)))  # type: ignore[method-assign]
+
+        continue_endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/continue-plan",
+            method="POST",
+        )
+        continue_response = await continue_endpoint(
+            draft.id,
+            ContinuePlanRequest(
+                current_plan="Plan 01",
+                note="first Plan 02 issue completed by the factory",
+            ),
+        )
+        continue_data = json.loads(continue_response.body)
+
+        assert continue_response.status_code == 200
+        assert continue_data["plan"] == "Plan 02"
+        assert continue_data["created_issues"][0]["number"] == 801
+        assert pr_mgr.create_issue.await_count == len(continue_data["plan_draft"])
+        first_issue = pr_mgr.create_issue.await_args_list[0].kwargs
+        assert first_issue["labels"] == ["hydraflow-find"]
+        assert "Target repo: Acme/claims-ledger" in first_issue["body"]
+
+        repos_endpoint = find_endpoint(router, "/api/repos")
+        repos_response = await repos_endpoint()
+        repos_data = json.loads(repos_response.body)
+        selected_repo = next(
+            repo
+            for repo in repos_data["repos"]
+            if repo["slug"] == repo_config.repo_slug
+        )
+        assert selected_repo["repo"] == "Acme/claims-ledger"
+        assert selected_repo["running"] is True
+
+        events_endpoint = find_endpoint(router, "/api/events")
+        events_response = await events_endpoint(since=None, repo=repo_config.repo_slug)
+        events_data = json.loads(events_response.body)
+        assert [event["data"]["repo"] for event in events_data] == [repo_config.repo]
+
+        metrics_endpoint = find_endpoint(router, "/api/metrics")
+        metrics_response = await metrics_endpoint(repo=repo_config.repo_slug)
+        metrics_data = json.loads(metrics_response.body)
+        assert metrics_data["repo_metrics"]["repo"] == "Acme/claims-ledger"
+        assert metrics_data["repo_metrics"]["throughput"]["implemented"] > 0
+        assert metrics_data["repo_metrics"]["time_to_merge"]["avg"] == 300.0
+        assert metrics_data["repo_metrics"]["friction"]["quality_fix_rounds"] == 1
+
+        persisted = state.get_onboarding_draft(draft.id)
+        assert persisted["current_plan"] == "Plan 02"
         assert persisted["events"][-1]["message"].startswith("Plan 02 filed")
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- persist the onboarding draft current plan when Continue to next plan files Plan N+1 issues
- add a third-domain validation regression for an Acme/claims-ledger onboarded repo after push and Plan 02 continuation
- verify the dashboard-facing repo list, repo-scoped event stream, repo metrics, and generated hydraflow-find issue bodies from one route surface

## Verification
- uv run pytest tests/test_onboarding_api.py tests/test_dashboard_routes_metrics.py::TestMetricsEndpoint::test_metrics_includes_repo_scoped_throughput_and_friction tests/test_dashboard_routes_state.py::TestGetEventsEndpoint::test_repo_query_uses_repo_runtime_event_bus -q
- npm test -- --run src/components/__tests__/ProjectView.test.jsx src/context/__tests__/HydraFlowContext.test.jsx src/components/__tests__/MetricsPanel.test.jsx src/components/__tests__/RepoSelector.test.jsx
- uv run pyright src/onboarding/models.py src/dashboard_routes/_onboarding_routes.py tests/test_onboarding_api.py
- make quality