### PR TITLE
Fixes #8931: stream onboarding activity in dashboard

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-23T12:18:25.281568+00:00",
-  "commit_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148",
+  "regenerated_at": "2026-05-23T13:06:33.162897+00:00",
+  "commit_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "ports.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "labels.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "modules.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "events.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "adr_xref.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "mockworld.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "changelog.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "coverage_matrix.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "functional_areas.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "ubiquitous-language.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "4e72c6f62df7476e1c11adf58eddabb1b28c6148"
+      "source_sha": "dd2f945a98585a09319905cc80b33cdb136eb4bd"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -190,4 +190,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace` | ADR-0055 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W21
 
+- `9dc0a8d` — Refs #8933: validate third-domain onboarding dashboard flow *(2026-05-23)*
 - `01b5854` — docs: refresh architecture artifacts *(2026-05-23)*
 - `66a1b1f` — Refs #8932: stream onboarding design chat *(2026-05-23)*
 - `8728fc2` — Refs #8932: persist wizard spec edits *(2026-05-23)*
@@ -356,4 +357,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `a76b946` — feat: adopt craft patterns — AGENTS.md, ports, property tests, ADRs (#1239) (#1239) *(2026-02-26)*
 
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -76,4 +76,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -47,4 +47,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -274,4 +274,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -50,4 +50,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -66,4 +66,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -43,4 +43,4 @@ graph LR
     src_runners -- "1" --> src_preflight
 ```
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -96,4 +96,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `4e72c6f` on 2026-05-23 12:18 UTC. Source last changed at `4e72c6f`. Status: 🟢 fresh._
+_Regenerated from commit `dd2f945` on 2026-05-23 13:06 UTC. Source last changed at `dd2f945`. Status: 🟢 fresh._

--- a/src/dashboard_routes/_onboarding_routes.py
+++ b/src/dashboard_routes/_onboarding_routes.py
@@ -98,6 +98,14 @@ def _chat_response_payload(
     }
 
 
+def _operation_event_payload(event: dict[str, object]) -> dict[str, object]:
+    return {"type": "activity", "event": event}
+
+
+def _json_response_payload(response: JSONResponse) -> dict[str, object]:
+    return json.loads(bytes(response.body).decode("utf-8"))
+
+
 def _load_draft_response(
     ctx: RouteContext, draft_id: str
 ) -> tuple[BootstrapDraft | None, JSONResponse | None]:
@@ -697,6 +705,56 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             }
         )
 
+    @router.post(
+        "/api/onboarding/drafts/{draft_id}/materialize/stream", response_model=None
+    )
+    async def stream_materialize_onboarding_draft(
+        draft_id: str, request: MaterializeRequest | None = None
+    ) -> StreamingResponse | JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+        initial_event_count = len(draft.events)
+
+        async def generate():
+            yield (
+                json.dumps(
+                    _operation_event_payload(
+                        {"level": "info", "message": "materialize queued"}
+                    )
+                )
+                + "\n"
+            )
+            await asyncio.sleep(0)
+            response = await materialize_onboarding_draft(draft_id, request)
+            payload = _json_response_payload(response)
+            draft_payload = payload.get("draft") if isinstance(payload, dict) else None
+            events = (
+                draft_payload.get("events", [])
+                if isinstance(draft_payload, dict)
+                else []
+            )
+            if isinstance(events, list):
+                for event in events[initial_event_count:]:
+                    yield json.dumps(_operation_event_payload(event)) + "\n"
+                    await asyncio.sleep(0)
+            final_payload = {
+                "type": "final",
+                "ok": response.status_code < 400,
+                "status": response.status_code,
+                **payload,
+            }
+            yield json.dumps(final_payload) + "\n"
+
+        return StreamingResponse(
+            generate(),
+            media_type="application/x-ndjson",
+            headers={"Cache-Control": "no-cache"},
+        )
+
     @router.post("/api/onboarding/drafts/{draft_id}/push")
     async def push_onboarding_draft(draft_id: str) -> JSONResponse:
         raw = ctx.state.get_onboarding_draft(draft_id)
@@ -751,4 +809,52 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         _persist_draft(ctx, draft)
         return JSONResponse(
             {"draft": draft.model_dump(mode="json"), "repo_url": repo_url}
+        )
+
+    @router.post("/api/onboarding/drafts/{draft_id}/push/stream", response_model=None)
+    async def stream_push_onboarding_draft(
+        draft_id: str,
+    ) -> StreamingResponse | JSONResponse:
+        raw = ctx.state.get_onboarding_draft(draft_id)
+        if raw is None:
+            return JSONResponse({"error": "Draft not found"}, status_code=404)
+        draft = _decode_draft(raw)
+        if draft is None:
+            return JSONResponse({"error": "Draft is invalid"}, status_code=500)
+        initial_event_count = len(draft.events)
+
+        async def generate():
+            yield (
+                json.dumps(
+                    _operation_event_payload(
+                        {"level": "info", "message": "push queued"}
+                    )
+                )
+                + "\n"
+            )
+            await asyncio.sleep(0)
+            response = await push_onboarding_draft(draft_id)
+            payload = _json_response_payload(response)
+            draft_payload = payload.get("draft") if isinstance(payload, dict) else None
+            events = (
+                draft_payload.get("events", [])
+                if isinstance(draft_payload, dict)
+                else []
+            )
+            if isinstance(events, list):
+                for event in events[initial_event_count:]:
+                    yield json.dumps(_operation_event_payload(event)) + "\n"
+                    await asyncio.sleep(0)
+            final_payload = {
+                "type": "final",
+                "ok": response.status_code < 400,
+                "status": response.status_code,
+                **payload,
+            }
+            yield json.dumps(final_payload) + "\n"
+
+        return StreamingResponse(
+            generate(),
+            media_type="application/x-ndjson",
+            headers={"Cache-Control": "no-cache"},
         )

--- a/src/ui/src/components/BootstrapWizard.jsx
+++ b/src/ui/src/components/BootstrapWizard.jsx
@@ -248,6 +248,13 @@ export function BootstrapWizard({ isOpen, onClose }) {
     setActivityOpen(false)
     const result = await materializeOnboardingDraft(activeDraft.id, {
       output_dir: form.output_dir.trim() || null,
+    }, {
+      onActivity: (event) => {
+        setDraft(prev => ({
+          ...(prev || activeDraft),
+          events: [...((prev || activeDraft)?.events || []), event],
+        }))
+      },
     })
     setSubmitting(false)
     if (!result?.ok) {

--- a/src/ui/src/components/ProjectView.jsx
+++ b/src/ui/src/components/ProjectView.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { theme } from '../theme'
 
@@ -30,12 +30,21 @@ export function ProjectView({ project }) {
   const [continueError, setContinueError] = useState('')
   const [upgradeState, setUpgradeState] = useState('idle')
   const [upgradeError, setUpgradeError] = useState('')
+  const [activityEvents, setActivityEvents] = useState(project?.onboarding_events || [])
+
+  useEffect(() => {
+    setActivityEvents(project?.onboarding_events || [])
+  }, [project?.onboarding_events])
 
   const handlePush = useCallback(async () => {
     if (!project?.onboarding_draft_id || pushState === 'running') return
     setPushState('running')
     setPushError('')
-    const result = await pushOnboardingDraft?.(project.onboarding_draft_id)
+    const result = await pushOnboardingDraft?.(project.onboarding_draft_id, {
+      onActivity: (event) => {
+        setActivityEvents(prev => [...prev, event])
+      },
+    })
     if (!result?.ok) {
       setPushState('failed')
       setPushError(result?.error || 'Push failed')
@@ -77,7 +86,7 @@ export function ProjectView({ project }) {
 
   if (!project) return null
 
-  const events = project.onboarding_events || []
+  const events = activityEvents || []
   const canPush = Boolean(project.onboarding_draft_id) && pushState !== 'running'
   const progress = readPlanProgress(project)
   const currentPlan = readCurrentPlan(project)

--- a/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
+++ b/src/ui/src/components/__tests__/BootstrapWizard.test.jsx
@@ -187,8 +187,89 @@ describe('BootstrapWizard', () => {
     fireEvent.click(screen.getByText('Next'))
     fireEvent.click(screen.getByTestId('materialize-project'))
 
-    await waitFor(() => expect(materializeOnboardingDraft).toHaveBeenCalledWith('draft-1', { output_dir: null }))
+    await waitFor(() => expect(materializeOnboardingDraft).toHaveBeenCalledWith(
+      'draft-1',
+      { output_dir: null },
+      expect.objectContaining({ onActivity: expect.any(Function) })
+    ))
     expect(selectRepo).toHaveBeenCalledWith('finance-tool')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('drives a third-domain project through the wizard without terminal input', async () => {
+    const createOnboardingDraft = vi.fn().mockImplementation(async (spec) => ({
+      ok: true,
+      draft: { id: 'draft-claims', spec, events: [{ level: 'info', message: 'draft created' }] },
+    }))
+    const draftOnboardingSpec = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-claims',
+        spec: { name: 'claims-ledger', owner: 'Acme' },
+        spec_draft: '# Acme claims-ledger',
+      },
+      spec_draft: '# Acme claims-ledger',
+    })
+    const saveOnboardingSpecDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-claims',
+        spec: { name: 'claims-ledger', owner: 'Acme' },
+        spec_draft: '# Acme claims-ledger',
+      },
+      spec_draft: '# Acme claims-ledger',
+    })
+    const draftOnboardingPlan = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-claims',
+        spec: { name: 'claims-ledger', owner: 'Acme' },
+        plan_draft: ['Create invariant kernel', 'Validate claims workflow'],
+      },
+      plan_draft: ['Create invariant kernel', 'Validate claims workflow'],
+    })
+    const materializeOnboardingDraft = vi.fn().mockResolvedValue({
+      ok: true,
+      draft: {
+        id: 'draft-claims',
+        spec: { name: 'claims-ledger', owner: 'Acme' },
+        events: [{ level: 'info', message: 'materialized invariant kernel' }],
+      },
+      materialized: { path: '/tmp/claims-ledger' },
+    })
+    const selectRepo = vi.fn()
+    const onClose = vi.fn()
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      createOnboardingDraft,
+      draftOnboardingSpec,
+      saveOnboardingSpecDraft,
+      draftOnboardingPlan,
+      materializeOnboardingDraft,
+      selectRepo,
+    }))
+
+    render(<BootstrapWizard isOpen onClose={onClose} />)
+    fireEvent.change(screen.getByDisplayValue('new-project'), { target: { value: 'claims-ledger' } })
+    fireEvent.change(screen.getByDisplayValue('T-rav'), { target: { value: 'Acme' } })
+    fireEvent.change(screen.getByDisplayValue('A HydraFlow-format project bootstrapped from the dashboard.'), {
+      target: { value: 'Claims workflow audit trail for a third-domain repo.' },
+    })
+    fireEvent.click(screen.getByText('Next'))
+    await screen.findByDisplayValue('# Acme claims-ledger')
+    fireEvent.click(screen.getByText('Next'))
+    await screen.findByText('Validate claims workflow')
+    fireEvent.click(screen.getByText('Next'))
+    fireEvent.click(screen.getByTestId('materialize-project'))
+
+    await waitFor(() => expect(createOnboardingDraft).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'claims-ledger', owner: 'Acme' })
+    ))
+    await waitFor(() => expect(materializeOnboardingDraft).toHaveBeenCalledWith(
+      'draft-claims',
+      { output_dir: null },
+      expect.objectContaining({ onActivity: expect.any(Function) })
+    ))
+    expect(selectRepo).toHaveBeenCalledWith('claims-ledger')
     expect(onClose).toHaveBeenCalled()
   })
 

--- a/src/ui/src/components/__tests__/ProjectView.test.jsx
+++ b/src/ui/src/components/__tests__/ProjectView.test.jsx
@@ -151,7 +151,10 @@ describe('ProjectView', () => {
     }} />)
 
     fireEvent.click(screen.getByText('Push to GitHub'))
-    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith('draft-1'))
+    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith(
+      'draft-1',
+      expect.objectContaining({ onActivity: expect.any(Function) })
+    ))
     expect(screen.getByText('Push failed')).toBeInTheDocument()
     expect(screen.getByText('Push endpoint unavailable')).toBeInTheDocument()
   })
@@ -168,7 +171,31 @@ describe('ProjectView', () => {
     }} />)
 
     fireEvent.click(screen.getByText('Push to GitHub'))
-    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith('draft-1'))
+    await waitFor(() => expect(pushOnboardingDraft).toHaveBeenCalledWith(
+      'draft-1',
+      expect.objectContaining({ onActivity: expect.any(Function) })
+    ))
     expect(screen.getByText('Pushed')).toBeInTheDocument()
+  })
+
+  it('streams push activity into the expanded log while running', async () => {
+    const pushOnboardingDraft = vi.fn().mockImplementation(async (_draftId, options) => {
+      options?.onActivity?.({ level: 'info', message: 'push started' })
+      options?.onActivity?.({ level: 'info', message: 'push succeeded' })
+      return { ok: true, repo_url: 'https://github.com/T-rav/finance-tool' }
+    })
+    mockUseHydraFlow.mockReturnValue({ pushOnboardingDraft })
+
+    render(<ProjectView project={{
+      slug: 'finance-tool',
+      local_only: true,
+      onboarding_draft_id: 'draft-1',
+      onboarding_events: [],
+    }} />)
+
+    fireEvent.click(screen.getByText('Activity down'))
+    fireEvent.click(screen.getByText('Push to GitHub'))
+    await waitFor(() => expect(screen.getByTestId('project-activity-log')).toHaveTextContent('push started'))
+    expect(screen.getByTestId('project-activity-log')).toHaveTextContent('push succeeded')
   })
 })

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -97,6 +97,44 @@ function addEvent(state, action) {
   }
 }
 
+async function readNdjsonStream(res, options = {}) {
+  if (!res.body?.getReader) return { ok: false, error: 'Streaming is unavailable' }
+  const reader = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let finalPayload = null
+  const handleLine = (line) => {
+    if (!line.trim()) return
+    const event = JSON.parse(line)
+    if (event.type === 'activity') {
+      options?.onActivity?.(event.event)
+    } else if (event.type === 'reply_delta') {
+      options?.onReplyDelta?.(event.text || '')
+    } else if (event.type === 'final') {
+      finalPayload = event
+    }
+  }
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const lines = buffer.split('\n')
+    buffer = lines.pop() || ''
+    lines.forEach(handleLine)
+  }
+  buffer += decoder.decode()
+  if (buffer.trim()) handleLine(buffer)
+  if (!finalPayload) return { ok: false, error: 'Stream ended without final payload' }
+  if (finalPayload.ok === false) {
+    return {
+      ok: false,
+      error: finalPayload.error || `Request failed (${finalPayload.status || 'stream'})`,
+      draft: finalPayload.draft,
+    }
+  }
+  return { ok: true, ...finalPayload }
+}
+
 function mergeStageIssues(existingIssues, incomingIssues) {
   // Server snapshot is authoritative: items absent from incoming are removed
   // (prevents ghost cards) and incoming fields (including status) override
@@ -1446,38 +1484,14 @@ export function HydraFlowProvider({ children }) {
         const data = await res.json().catch(() => ({}))
         return { ok: false, error: data?.error || `Design chat failed (${res.status})`, draft: data?.draft }
       }
-      if (!res.body?.getReader) return { ok: false, error: 'Design chat streaming is unavailable' }
-      const reader = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-      let finalPayload = null
-      while (true) {
-        const { value, done } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() || ''
-        for (const line of lines) {
-          if (!line.trim()) continue
-          const event = JSON.parse(line)
-          if (event.type === 'reply_delta') {
-            options?.onReplyDelta?.(event.text || '')
-          } else if (event.type === 'final') {
-            finalPayload = event
-          }
-        }
+      const streamed = await readNdjsonStream(res, options)
+      if (!streamed.ok && streamed.error === 'Stream ended without final payload') {
+        return { ok: false, error: 'Design chat stream ended without final payload' }
       }
-      buffer += decoder.decode()
-      if (buffer.trim()) {
-        const event = JSON.parse(buffer)
-        if (event.type === 'reply_delta') {
-          options?.onReplyDelta?.(event.text || '')
-        } else if (event.type === 'final') {
-          finalPayload = event
-        }
+      if (!streamed.ok && streamed.error === 'Streaming is unavailable') {
+        return { ok: false, error: 'Design chat streaming is unavailable' }
       }
-      if (!finalPayload) return { ok: false, error: 'Design chat stream ended without final payload' }
-      return { ok: true, ...finalPayload }
+      return streamed
     } catch (err) {
       return { ok: false, error: err?.message || 'Design chat failed' }
     }
@@ -1537,14 +1551,31 @@ export function HydraFlowProvider({ children }) {
     }
   }, [])
 
-  const materializeOnboardingDraft = useCallback(async (draftId, request = {}) => {
+  const materializeOnboardingDraft = useCallback(async (draftId, request = {}, options = {}) => {
     try {
-      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/materialize`, {
+      const basePath = `/api/onboarding/drafts/${encodeURIComponent(draftId)}`
+      const fetchOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(request),
-      })
-      const data = await res.json().catch(() => ({}))
+      }
+      let res
+      let data
+      if (typeof ReadableStream === 'undefined' || typeof TextDecoder === 'undefined') {
+        res = await fetch(`${basePath}/materialize`, fetchOptions)
+        data = await res.json().catch(() => ({}))
+      } else {
+        res = await fetch(`${basePath}/materialize/stream`, fetchOptions)
+        if (res.ok && res.body?.getReader) {
+          const streamed = await readNdjsonStream(res, options)
+          data = streamed
+          if (!streamed.ok) {
+            return { ok: false, error: streamed.error || 'Materialize failed', draft: streamed.draft }
+          }
+        } else {
+          data = await res.json().catch(() => ({}))
+        }
+      }
       if (!res.ok) {
         return { ok: false, error: data?.error || `Materialize failed (${res.status})`, draft: data?.draft }
       }
@@ -1575,13 +1606,27 @@ export function HydraFlowProvider({ children }) {
     }
   }, [addRepoByPath])
 
-  const pushOnboardingDraft = useCallback(async (draftId) => {
+  const pushOnboardingDraft = useCallback(async (draftId, options = {}) => {
     if (!draftId) return { ok: false, error: 'Draft id required' }
     try {
-      const res = await fetch(`/api/onboarding/drafts/${encodeURIComponent(draftId)}/push`, {
-        method: 'POST',
-      })
-      const data = await res.json().catch(() => ({}))
+      const basePath = `/api/onboarding/drafts/${encodeURIComponent(draftId)}`
+      let res
+      let data
+      if (typeof ReadableStream === 'undefined' || typeof TextDecoder === 'undefined') {
+        res = await fetch(`${basePath}/push`, { method: 'POST' })
+        data = await res.json().catch(() => ({}))
+      } else {
+        res = await fetch(`${basePath}/push/stream`, { method: 'POST' })
+        if (res.ok && res.body?.getReader) {
+          const streamed = await readNdjsonStream(res, options)
+          data = streamed
+          if (!streamed.ok) {
+            return { ok: false, error: streamed.error || 'Push failed', draft: streamed.draft }
+          }
+        } else {
+          data = await res.json().catch(() => ({}))
+        }
+      }
       if (!res.ok) {
         return { ok: false, error: data?.error || `Push failed (${res.status})`, draft: data?.draft }
       }

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -684,6 +684,145 @@ describe('HydraFlowProvider', () => {
     )
     expect(screen.getByText('Test Child')).toBeInTheDocument()
   })
+
+  it('materializeOnboardingDraft consumes streamed activity and final payload', async () => {
+    vi.resetModules()
+    const activity = []
+    const makeStream = (lines) => new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder()
+        lines.forEach(line => controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`)))
+        controller.close()
+      },
+    })
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/onboarding/drafts/draft-1/materialize/stream') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: makeStream([
+            { type: 'activity', event: { level: 'info', message: 'materialize started' } },
+            {
+              type: 'final',
+              ok: true,
+              status: 200,
+              draft: {
+                id: 'draft-1',
+                spec: { name: 'finance-tool' },
+                events: [{ level: 'info', message: 'materialize started' }],
+              },
+              materialized: { path: '/tmp/finance-tool' },
+            },
+          ]),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ repos: [] }),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    let result
+    await act(async () => {
+      result = await capturedState.materializeOnboardingDraft('draft-1', {}, {
+        onActivity: (event) => activity.push(event.message),
+      })
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/onboarding/drafts/draft-1/materialize/stream', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    })
+    expect(result.ok).toBe(true)
+    expect(activity).toEqual(['materialize started'])
+  })
+
+  it('pushOnboardingDraft consumes streamed activity and final payload', async () => {
+    vi.resetModules()
+    const activity = []
+    const makeStream = (lines) => new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder()
+        lines.forEach(line => controller.enqueue(encoder.encode(`${JSON.stringify(line)}\n`)))
+        controller.close()
+      },
+    })
+    const fetchSpy = vi.spyOn(global, 'fetch').mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : String(input)
+      if (url === '/api/onboarding/drafts/draft-1/push/stream') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: makeStream([
+            { type: 'activity', event: { level: 'info', message: 'push started' } },
+            {
+              type: 'final',
+              ok: true,
+              status: 200,
+              draft: {
+                id: 'draft-1',
+                status: 'pushed',
+                push_status: 'succeeded',
+                events: [{ level: 'info', message: 'push succeeded' }],
+              },
+              repo_url: 'https://github.com/T-rav/finance-tool',
+            },
+          ]),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ repos: [] }),
+      })
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let capturedState = null
+    function StateCapture() {
+      capturedState = useHydraFlow()
+      return <div>ready</div>
+    }
+
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <StateCapture />
+        </HydraFlowProvider>
+      )
+    })
+
+    let result
+    await act(async () => {
+      result = await capturedState.pushOnboardingDraft('draft-1', {
+        onActivity: (event) => activity.push(event.message),
+      })
+    })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/onboarding/drafts/draft-1/push/stream', {
+      method: 'POST',
+    })
+    expect(result.ok).toBe(true)
+    expect(activity).toEqual(['push started'])
+  })
 })
 
 describe('startRuntime compatibility flow', () => {

--- a/tests/test_onboarding_api.py
+++ b/tests/test_onboarding_api.py
@@ -71,7 +71,9 @@ class TestOnboardingDraftRoutes:
         assert "/api/onboarding/drafts/{draft_id}/continue-plan" in paths
         assert "/api/onboarding/drafts/{draft_id}/upgrade-format" in paths
         assert "/api/onboarding/drafts/{draft_id}/materialize" in paths
+        assert "/api/onboarding/drafts/{draft_id}/materialize/stream" in paths
         assert "/api/onboarding/drafts/{draft_id}/push" in paths
+        assert "/api/onboarding/drafts/{draft_id}/push/stream" in paths
 
     @pytest.mark.asyncio
     async def test_create_draft_persists_state(
@@ -178,6 +180,42 @@ class TestOnboardingDraftRoutes:
         assert persisted["materialized_path"].endswith("generated/finance-tool")
 
     @pytest.mark.asyncio
+    async def test_materialize_draft_streams_activity_then_final_payload(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="finance-tool"))
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/materialize/stream",
+            method="POST",
+        )
+
+        response = await endpoint(
+            draft.id,
+            MaterializeRequest(output_dir=str(tmp_path / "generated")),
+        )
+        chunks = [chunk async for chunk in response.body_iterator]
+        events = [json.loads(chunk) for chunk in chunks]
+
+        assert response.media_type == "application/x-ndjson"
+        assert events[0] == {
+            "type": "activity",
+            "event": {"level": "info", "message": "materialize queued"},
+        }
+        assert any(
+            event["type"] == "activity"
+            and event["event"]["message"] == "materialize started"
+            for event in events
+        )
+        assert events[-1]["type"] == "final"
+        assert events[-1]["ok"] is True
+        assert events[-1]["draft"]["materialize_status"] == "succeeded"
+
+    @pytest.mark.asyncio
     async def test_push_draft_requires_materialized_repo(
         self, config, event_bus, state, tmp_path
     ) -> None:
@@ -253,6 +291,55 @@ class TestOnboardingDraftRoutes:
         assert ("git", "push", "-u", "origin", "staging") in calls
         persisted = state.get_onboarding_draft(draft.id)
         assert persisted["repo_url"] == "https://github.com/T-rav/finance-tool"
+
+    @pytest.mark.asyncio
+    async def test_push_draft_streams_activity_then_final_payload(
+        self, config, event_bus, state, tmp_path, monkeypatch
+    ) -> None:
+        repo_dir = tmp_path / "generated" / "finance-tool"
+        repo_dir.mkdir(parents=True)
+        (repo_dir / "README.md").write_text("# finance-tool\n")
+        draft = BootstrapDraft(
+            spec=BootstrapSpec.model_validate(_spec_payload(name="finance-tool")),
+            status="materialized",
+            materialize_status="succeeded",
+            materialized_path=str(repo_dir),
+        )
+        state.set_onboarding_draft(draft.id, draft.model_dump(mode="json"))
+
+        class Proc:
+            returncode = 0
+
+            async def communicate(self):
+                return b"", b""
+
+            def kill(self) -> None:
+                return None
+
+        async def fake_exec(*_cmd, **_kwargs):
+            return Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+        endpoint = find_endpoint(
+            router,
+            "/api/onboarding/drafts/{draft_id}/push/stream",
+            method="POST",
+        )
+
+        response = await endpoint(draft.id)
+        chunks = [chunk async for chunk in response.body_iterator]
+        events = [json.loads(chunk) for chunk in chunks]
+
+        assert response.media_type == "application/x-ndjson"
+        assert events[0]["event"]["message"] == "push queued"
+        assert any(
+            event["type"] == "activity" and event["event"]["message"] == "push started"
+            for event in events
+        )
+        assert events[-1]["type"] == "final"
+        assert events[-1]["ok"] is True
+        assert events[-1]["repo_url"] == "https://github.com/T-rav/finance-tool"
 
     @pytest.mark.asyncio
     async def test_push_draft_records_cli_failure(


### PR DESCRIPTION
## Summary
- add NDJSON stream endpoints for onboarding materialize and push activity
- wire BootstrapWizard and ProjectView to stream activity into their logs with JSON fallback support
- add dashboard/context/backend coverage, including a no-terminal Acme/claims-ledger third-domain wizard flow

## Verification
- uv run pytest tests/test_onboarding_api.py -q
- npm test -- --run src/components/__tests__/BootstrapWizard.test.jsx src/components/__tests__/ProjectView.test.jsx src/context/__tests__/HydraFlowContext.test.jsx
- make quality

Fixes #8931