### PR TITLE
fix: UI kill-switch integrity — DiagramLoop name mismatch + 4 env-only loops + completeness net

### DIFF
--- a/src/cost_budget_watcher_loop.py
+++ b/src/cost_budget_watcher_loop.py
@@ -108,6 +108,9 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
         return 300
 
     async def _do_work(self) -> WorkCycleResult:  # noqa: PLR0911
+        # ADR-0049 in-body kill-switch (UI toggle, System tab). Must be FIRST.
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         if not self._config.cost_budget_watcher_loop_enabled:
             return {"status": "config_disabled"}
         if os.environ.get(_KILL_SWITCH_ENV) == "1":

--- a/src/diagram_loop.py
+++ b/src/diagram_loop.py
@@ -59,7 +59,7 @@ class DiagramLoop(BaseBackgroundLoop):
         deps: LoopDeps,
     ) -> None:
         super().__init__(
-            worker_name="diagram-loop",
+            worker_name="diagram_loop",
             config=config,
             deps=deps,
         )
@@ -75,6 +75,9 @@ class DiagramLoop(BaseBackgroundLoop):
         return 14400
 
     async def _do_work(self) -> WorkCycleResult:
+        # ADR-0049 in-body kill-switch (UI toggle, System tab). Must be FIRST.
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         if not self._config.diagram_loop_enabled:
             return {"status": "config_disabled"}
         # Kill-switch (ADR-0049). Belt and suspenders.

--- a/src/entry_evidence_loop.py
+++ b/src/entry_evidence_loop.py
@@ -93,6 +93,9 @@ class EntryEvidenceLoop(BaseBackgroundLoop):
         return self._config.entry_evidence_interval
 
     async def _do_work(self) -> dict[str, Any] | None:
+        # ADR-0049 in-body kill-switch (UI toggle, System tab). Must be FIRST.
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         if not self._config.entry_evidence_enabled:
             return {"status": "disabled"}
 

--- a/src/pricing_refresh_loop.py
+++ b/src/pricing_refresh_loop.py
@@ -80,6 +80,9 @@ class PricingRefreshLoop(BaseBackgroundLoop):
         return 86400
 
     async def _do_work(self) -> WorkCycleResult:  # noqa: PLR0911 — linear gate checks, each with its own return path
+        # ADR-0049 in-body kill-switch (UI toggle, System tab). Must be FIRST.
+        if not self._enabled_cb(self._worker_name):
+            return {"status": "disabled"}
         if not self._config.pricing_refresh_loop_enabled:
             return {"status": "config_disabled"}
         # Kill-switch (ADR-0049). Belt and suspenders.

--- a/tests/regressions/test_canonical_killswitch.py
+++ b/tests/regressions/test_canonical_killswitch.py
@@ -1,11 +1,15 @@
-"""Regression: all 6 non-canonical kill-switch loops now respect _enabled_cb.
+"""Regression: every non-canonical kill-switch loop respects the _enabled_cb gate.
 
 Per ADR-0049, every loop's _do_work must check self._enabled_cb(self._worker_name)
-at the top. Before this fix the 6 loops below used raw env-var or static config
-checks instead, so the operator UI toggle could not disable them at runtime.
+as its FIRST statement. These loops previously used only a raw env-var or static
+config check, so the operator's UI toggle could not disable them at runtime — the
+WS-1 kill-switch-integrity fix added the in-body gate to cost_budget_watcher,
+diagram, pricing_refresh, and entry_evidence. The auto-discovery enforcer is
+tests/test_loop_kill_switch_completeness.py.
 
-Each test: instantiate with an enabled_cb that returns False, assert _do_work
-returns {"status": "disabled"} without entering the loop body.
+Each test: instantiate with an enabled_cb that returns False while leaving the
+static config gate OPEN, then assert _do_work returns {"status": "disabled"} —
+proving the cb gate (not the config gate) is what disabled the loop.
 """
 
 from __future__ import annotations
@@ -37,12 +41,13 @@ def _disabled_deps() -> LoopDeps:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="needs AsyncMock conversion in deps setup (staging-level test fixture drift)", strict=False)
 async def test_cost_budget_watcher_disabled_by_enabled_cb() -> None:
     from cost_budget_watcher_loop import CostBudgetWatcherLoop
 
+    config = MagicMock()
+    config.cost_budget_watcher_loop_enabled = True  # static gate open; cb gate closed
     loop = CostBudgetWatcherLoop(
-        config=MagicMock(),
+        config=config,
         pr_manager=MagicMock(),
         state=MagicMock(),
         deps=_disabled_deps(),
@@ -57,12 +62,13 @@ async def test_cost_budget_watcher_disabled_by_enabled_cb() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="needs AsyncMock conversion in deps setup (staging-level test fixture drift)", strict=False)
 async def test_diagram_loop_disabled_by_enabled_cb() -> None:
     from diagram_loop import DiagramLoop
 
+    config = MagicMock()
+    config.diagram_loop_enabled = True  # static gate open; cb gate closed
     loop = DiagramLoop(
-        config=MagicMock(),
+        config=config,
         pr_manager=MagicMock(),
         deps=_disabled_deps(),
     )
@@ -76,14 +82,38 @@ async def test_diagram_loop_disabled_by_enabled_cb() -> None:
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="needs AsyncMock conversion in deps setup (staging-level test fixture drift)", strict=False)
 async def test_pricing_refresh_loop_disabled_by_enabled_cb() -> None:
     from pricing_refresh_loop import PricingRefreshLoop
 
+    config = MagicMock()
+    config.pricing_refresh_loop_enabled = True  # static gate open; cb gate closed
     loop = PricingRefreshLoop(
-        config=MagicMock(),
+        config=config,
         pr_manager=MagicMock(),
         deps=_disabled_deps(),
+    )
+    result = await loop._do_work()
+    assert result == {"status": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# EntryEvidenceLoop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_entry_evidence_loop_disabled_by_enabled_cb(tmp_path: Path) -> None:
+    from entry_evidence_loop import EntryEvidenceLoop
+
+    config = MagicMock()
+    config.entry_evidence_enabled = True  # static gate is open; cb gate is closed
+    loop = EntryEvidenceLoop(
+        config=config,
+        deps=_disabled_deps(),
+        llm=MagicMock(),
+        pr_port=MagicMock(),
+        repo_root=tmp_path,
+        dedup_path=tmp_path / "dedup.json",
     )
     result = await loop._do_work()
     assert result == {"status": "disabled"}

--- a/tests/sandbox_scenarios/scenarios/s34_diagram_loop_no_changes.py
+++ b/tests/sandbox_scenarios/scenarios/s34_diagram_loop_no_changes.py
@@ -2,7 +2,7 @@
 
 Golden path: the loop checks for module-graph changes since the last
 architecture regen, finds none, and emits a BACKGROUND_WORKER_STATUS event
-for ``diagram-loop``, proving caretaker-registry wiring is intact.
+for ``diagram_loop``, proving caretaker-registry wiring is intact.
 """
 
 from __future__ import annotations
@@ -24,13 +24,13 @@ def seed() -> MockWorldSeed:
 
 
 async def assert_outcome(api, page) -> None:
-    """Verify a BACKGROUND_WORKER_STATUS event was emitted by diagram-loop."""
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by diagram_loop."""
     events_payload = await api.wait_until(
         "/api/events",
         lambda payload: any(
             isinstance(payload, list)
             and e.get("type") == "background_worker_status"
-            and e.get("data", {}).get("worker") == "diagram-loop"
+            and e.get("data", {}).get("worker") == "diagram_loop"
             for e in (payload if isinstance(payload, list) else [])
         ),
         timeout=60.0,
@@ -40,9 +40,9 @@ async def assert_outcome(api, page) -> None:
         e
         for e in events_payload
         if e.get("type") == "background_worker_status"
-        and e.get("data", {}).get("worker") == "diagram-loop"
+        and e.get("data", {}).get("worker") == "diagram_loop"
     ]
     assert len(dl_events) >= 1, (
-        f"Expected at least one diagram-loop worker-status event; got none. "
+        f"Expected at least one diagram_loop worker-status event; got none. "
         f"All events: {events_payload!r}"
     )

--- a/tests/test_diagram_loop.py
+++ b/tests/test_diagram_loop.py
@@ -28,7 +28,7 @@ def test_constructor_sets_worker_name(loop_deps):
     config = MagicMock()
     pr_manager = MagicMock()
     loop = DiagramLoop(config=config, pr_manager=pr_manager, deps=loop_deps)
-    assert loop._worker_name == "diagram-loop"
+    assert loop._worker_name == "diagram_loop"
 
 
 def test_default_interval_is_four_hours(loop_deps):

--- a/tests/test_loop_kill_switch_completeness.py
+++ b/tests/test_loop_kill_switch_completeness.py
@@ -1,0 +1,119 @@
+"""Factory validation: every background loop has the ADR-0049 in-body kill-switch gate.
+
+Auto-discovers ``BaseBackgroundLoop`` subclasses from ``src/*_loop.py`` (reusing the
+same regex discovery as ``test_loop_wiring_completeness.py``) and asserts each one's
+``_do_work`` begins with the universal kill-switch gate::
+
+    if not self._enabled_cb(self._worker_name):
+        return {"status": "disabled"}
+
+This is the enforcement net ``docs/wiki/dark-factory.md`` §5 advertises but which was
+never actually committed. It is a *ratchet*: ``_GRANDFATHERED`` must stay empty. A new
+loop that gates only on an env/config flag (the deprecated mechanism — operator intent
+is a UI toggle, not env vars) fails this test instead of silently shipping an inert
+System-tab toggle.
+
+Ref: dark-factory hands-off audit (findings: no-killswitch-completeness-net,
+four-env-only-loops-no-inbody-gate, diagram-loop-uncontrollable-from-ui).
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+
+# Ratchet allow-list. MUST stay empty — every loop is UI-kill-switchable, no exceptions
+# (dark-factory.md §2.1.2). If a loop genuinely cannot host the gate, fixing the loop is
+# the answer, not adding it here.
+_GRANDFATHERED: frozenset[str] = frozenset()
+
+_GATE_CALL = "self._enabled_cb(self._worker_name)"
+
+_CLASS_RE = re.compile(r"class\s+(\w+)\s*\(.*BaseBackgroundLoop.*\)")
+
+
+def _loops_missing_inbody_gate() -> list[str]:
+    """Return loop file stems whose loop class lacks the in-body kill-switch gate."""
+    missing: list[str] = []
+    for path in sorted(SRC.glob("*_loop.py")):
+        text = path.read_text()
+        if not _CLASS_RE.search(text):
+            continue  # file has no BaseBackgroundLoop subclass
+        tree = ast.parse(text)
+        loop_classes = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef)
+            and any(
+                base_id == "BaseBackgroundLoop"
+                for base_id in (
+                    getattr(b, "id", None) or getattr(b, "attr", None)
+                    for b in node.bases
+                )
+            )
+        ]
+        for cls in loop_classes:
+            dowork = next(
+                (
+                    n
+                    for n in cls.body
+                    if isinstance(n, ast.AsyncFunctionDef | ast.FunctionDef)
+                    and n.name == "_do_work"
+                ),
+                None,
+            )
+            if dowork is None:
+                # No _do_work in this class: it does not define a work cycle here.
+                continue
+            method_src = ast.get_source_segment(text, dowork) or ""
+            if _GATE_CALL not in method_src:
+                missing.append(path.stem)
+    return [m for m in missing if m not in _GRANDFATHERED]
+
+
+def test_every_loop_has_inbody_kill_switch_gate() -> None:
+    missing = _loops_missing_inbody_gate()
+    assert not missing, (
+        "Loops missing the ADR-0049 in-body kill-switch gate "
+        f"`if not {_GATE_CALL}: return {{'status': 'disabled'}}` in _do_work: "
+        f"{sorted(set(missing))}. The UI toggle is inert for these loops — add the gate "
+        "as the FIRST statement of _do_work (keep any env/config gate below as deploy-time "
+        "defense-in-depth)."
+    )
+
+
+def test_grandfather_list_is_empty() -> None:
+    """The ratchet only works if nobody quietly adds exemptions."""
+    assert frozenset() == _GRANDFATHERED, (
+        "_GRANDFATHERED must stay empty: every loop is UI-kill-switchable (no exceptions). "
+        f"Found exemptions: {sorted(_GRANDFATHERED)}"
+    )
+
+
+def test_worker_names_are_underscore_canonical() -> None:
+    """worker_name must be underscore-canonical (no hyphens).
+
+    The kill-switch gate calls ``self._enabled_cb(self._worker_name)``, and the UI
+    toggle / BGWorkerManager / orchestrator registry / worker_catalog / constants.js
+    all key the loop by an *underscore* name. A hyphenated worker_name (the historical
+    ``diagram-loop`` bug) silently never matches that key, so flipping the System-tab
+    toggle is a no-op — ``is_enabled('diagram-loop')`` returns the True default forever.
+    This guards the regression at its source for every loop.
+    """
+    offenders: dict[str, str] = {}
+    worker_re = re.compile(r"""worker_name\s*=\s*["']([\w-]+)["']""")
+    for path in sorted(SRC.glob("*_loop.py")):
+        text = path.read_text()
+        if not _CLASS_RE.search(text):
+            continue
+        for match in worker_re.finditer(text):
+            name = match.group(1)
+            if "-" in name:
+                offenders[path.stem] = name
+    assert not offenders, (
+        "worker_name values must be underscore-canonical to match the registry/UI keys "
+        f"the kill-switch toggle uses (hyphens make the toggle inert): {offenders}"
+    )


### PR DESCRIPTION
**WS-1 of the dark-factory hands-off hardening program** (52 audit findings → 7 workstreams). This is the CRITICAL one: the operator's #1 promise — kill any loop from the UI — was broken.

## What was broken
- **`DiagramLoop` UI kill-switch was a silent no-op.** `worker_name="diagram-loop"` (hyphen) while the orchestrator registry, `worker_catalog`, `constants.js`, and `BGWorkerManager` all key `diagram_loop` (underscore). `is_enabled('diagram-loop')` hit the `.get(name, True)` default forever — the System-tab toggle, the dashboard heartbeat, **and** CostBudgetWatcher's emergency budget kill were all no-ops for the highest-autonomy loop (opens arch-regen PRs every 4h). Even its status events were mis-keyed.
- **4 loops never called the in-body `_enabled_cb` gate** (`cost_budget_watcher`, `diagram`, `entry_evidence`, `pricing_refresh`) — they gated only on an env/config `*_enabled` flag, so the UI toggle was rendered but inert on the startup-catchup and manual-trigger paths.
- **The one regression test lied.** `test_canonical_killswitch.py` `xfail(strict=False)`'d the 3 genuinely-broken loops behind a fabricated "AsyncMock fixture drift" reason and its docstring claimed all 6 respected `_enabled_cb`. The auto-discovery enforcer `dark-factory.md §5` advertises (`test_loop_kill_switch_completeness.py`) was never committed.

## Fix
- Canonicalize `DiagramLoop.worker_name` to `diagram_loop`.
- Add the ADR-0049 in-body gate as the FIRST `_do_work` statement in all 4 loops (env/config gate kept below as deploy-time defense-in-depth).
- New **`tests/test_loop_kill_switch_completeness.py`** ratchet (empty grandfather list) + a `worker_names_are_underscore_canonical` guard that catches the hyphen class of bug at the source for every loop.
- Un-muzzle `test_canonical_killswitch.py`: remove the 3 false xfails, add the omitted `entry_evidence` case, fix the docstring.

## Verification
- `make quality` green: **13700 passed, 18 skipped, 193 xfailed** in 10m26s (this PR *removes* 3 false xfails).
- New completeness test was RED (flagged exactly the 4 loops), now GREEN.

Findings closed: diagram-loop-uncontrollable-from-ui, diagram-loop-killswitch-name-mismatch, four-env-only-loops-no-inbody-gate, env-only-killswitch-gaps, no-killswitch-completeness-net, canonical-killswitch-regression-net-muzzled, canonical-killswitch-test-xfails-the-real-violators, kill-switch-completeness-test-never-existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)