### PR TITLE
fix(escalation): route escalations to specialist playbooks + restore recursion-safety deny-list

### DIFF
--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -137,10 +137,25 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         sub_labels = sorted(labels - {"hitl-escalation"})
         sub_label = sub_labels[0] if sub_labels else "_default"
 
-        # Sub-label deny-list.
-        if sub_label in self._config.auto_agent_skip_sublabels:
+        # Sub-label deny-list (recursion safety, dark-factory §2.7). The skip-list
+        # is unprefixed (e.g. "principles-stuck") while escalation labels carry the
+        # `hydraflow-` prefix, so compare on the prefix-stripped form — otherwise
+        # the guard never matches and the auto-agent acts on the very escalations
+        # (principles/cultural) it must defer to a human. Check EVERY sub-label,
+        # not just sub_labels[0], so a deny-listed label can't slip through by
+        # losing the alphabetical sort.
+        denied = next(
+            (
+                s
+                for s in sub_labels
+                if s.removeprefix("hydraflow-")
+                in self._config.auto_agent_skip_sublabels
+            ),
+            None,
+        )
+        if denied is not None:
             await self._prs.add_labels(issue_number, ["human-required"])
-            self._audit_store.append(_skip_audit(issue_number, sub_label, "deny_list"))
+            self._audit_store.append(_skip_audit(issue_number, denied, "deny_list"))
             return {"status": "skipped_deny_list"}
 
         # Attempt-cap check.

--- a/src/preflight/playbooks/__init__.py
+++ b/src/preflight/playbooks/__init__.py
@@ -165,15 +165,23 @@ _REGISTRY: dict[str, PreflightPlaybook] = {
 }
 
 
+# Escalation sub-labels carry the HydraFlow label prefix (e.g.
+# ``hydraflow-plan-stuck``), but the registry keys / prompt-file stems are
+# unprefixed. ``removeprefix`` is a no-op for already-unprefixed labels.
+_LABEL_PREFIX = "hydraflow-"
+
+
 def get_playbook(sub_label: str) -> PreflightPlaybook:
     """Return the playbook for ``sub_label`` (falls back to ``_default``).
 
-    Backwards-compatible: any sub-label the registry doesn't specialise gets
-    the generic lead-engineer playbook, which renders the existing
-    ``prompts/auto_agent/_default.md`` (or a sub-label-specific prompt file
-    if one exists, via the runner's existing lookup) with the default persona.
+    The ``hydraflow-`` label prefix is stripped before lookup so a real
+    escalation label like ``hydraflow-plan-stuck`` routes to its specialist
+    playbook instead of silently falling back to ``_default`` (the entire
+    specialist registry was dead before this — every escalation got the generic
+    playbook). Backwards-compatible: any sub-label the registry doesn't
+    specialise still gets the generic lead-engineer playbook.
     """
-    return _REGISTRY.get(sub_label, _DEFAULT_PLAYBOOK)
+    return _REGISTRY.get(sub_label.removeprefix(_LABEL_PREFIX), _DEFAULT_PLAYBOOK)
 
 
 def iter_playbooks() -> tuple[PreflightPlaybook, ...]:

--- a/src/preflight/runner.py
+++ b/src/preflight/runner.py
@@ -39,7 +39,15 @@ def render_prompt(
             file route to a specialist persona + the ``_default`` template,
             or vice versa.
     """
-    template_stem = prompt_template if prompt_template is not None else sub_label
+    # Strip the `hydraflow-` label prefix from the file-fallback stem: the prompt
+    # files (flaky-test-stuck.md, wiki-rot-stuck.md, ...) are unprefixed, but the
+    # sub-label arrives prefixed, so without this every unregistered specialist
+    # fell through to _default.md — ADR-0063's file-fallback was dead for them.
+    template_stem = (
+        prompt_template
+        if prompt_template is not None
+        else sub_label.removeprefix("hydraflow-")
+    )
     prompt_path = _PROMPT_DIR / f"{template_stem}.md"
     if not prompt_path.exists():
         prompt_path = _PROMPT_DIR / "_default.md"

--- a/tests/test_auto_agent_preflight_loop.py
+++ b/tests/test_auto_agent_preflight_loop.py
@@ -130,6 +130,31 @@ async def test_deny_list_bypasses_agent(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_deny_list_bypasses_agent_with_prefixed_label(tmp_path: Path) -> None:
+    # Recursion-safety regression (dark-factory §2.7): real escalation labels carry
+    # the `hydraflow-` prefix while the skip-list is unprefixed. Before the fix the
+    # deny-list never matched a prefixed label, so the auto-agent would act on the
+    # principles/cultural-check escalations it must defer to a human.
+    loop, state = _make_loop(tmp_path)
+    state.get_auto_agent_attempts = MagicMock(return_value=0)
+    loop._prs.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 1,
+                "body": "x",
+                "labels": [
+                    {"name": "hitl-escalation"},
+                    {"name": "hydraflow-principles-stuck"},
+                ],
+            },
+        ]
+    )
+    result = await loop._do_work()
+    loop._prs.add_labels.assert_awaited_with(1, ["human-required"])
+    assert result["result_status"] == "skipped_deny_list"
+
+
+@pytest.mark.asyncio
 async def test_attempt_cap_marks_exhausted(tmp_path: Path) -> None:
     loop, state = _make_loop(tmp_path)
     state.get_auto_agent_attempts = MagicMock(return_value=3)

--- a/tests/test_preflight_playbooks.py
+++ b/tests/test_preflight_playbooks.py
@@ -40,6 +40,17 @@ def test_plan_stuck_playbook_specialises() -> None:
     assert "touchpoint" in pb.persona.lower() or "adr" in pb.persona.lower()
 
 
+def test_prefixed_escalation_label_routes_to_specialist() -> None:
+    # Real escalation labels carry the `hydraflow-` prefix (e.g.
+    # `hydraflow-plan-stuck`), but the registry keys are unprefixed. Before the
+    # prefix-strip fix every prefixed label fell through to `_default`, so the
+    # entire specialist registry was dead. removeprefix must route the prefixed
+    # label to the same specialist as the bare key.
+    assert get_playbook("hydraflow-plan-stuck").name == "plan-stuck"
+    assert get_playbook("hydraflow-plan-stuck").name == get_playbook("plan-stuck").name
+    assert get_playbook("hydraflow-plan-stuck").persona != DEFAULT_PERSONA
+
+
 def test_implement_stuck_playbook_specialises() -> None:
     pb = get_playbook("implement-stuck")
     assert pb.name == "implement-stuck"

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -49,6 +49,33 @@ def test_default_fallback_for_unknown_sub_label() -> None:
     assert "Default Playbook" in out
 
 
+def test_prefixed_sublabel_routes_to_specialist_file() -> None:
+    # Real escalation labels are prefixed (e.g. ``hydraflow-flaky-test-stuck``)
+    # but the prompt files are unprefixed. Before the fix the prefixed label
+    # missed ``flaky-test-stuck.md`` and fell through to ``_default.md``, silently
+    # killing every file-based specialist playbook.
+    fields = {
+        "persona": "x",
+        "issue_number": 1,
+        "repo_slug": "r/s",
+        "worktree_path": "/tmp",
+        "issue_body": "b",
+        "issue_comments_block": "x",
+        "escalation_context_block": "x",
+        "wiki_excerpts_block": "x",
+        "sentry_events_block": "x",
+        "recent_commits_block": "x",
+        "prior_attempts_block": "x",
+    }
+    prefixed = render_prompt(sub_label="hydraflow-flaky-test-stuck", **fields)
+    # Routed to flaky-test-stuck.md, NOT the generic default playbook (the
+    # "Default Playbook" marker lives only in _default.md).
+    assert "Default Playbook" not in prefixed
+    # And a genuinely unknown prefixed label still falls through to _default.
+    unknown = render_prompt(sub_label="hydraflow-no-such-playbook", **fields)
+    assert "Default Playbook" in unknown
+
+
 def test_explicit_prompt_template_overrides_sub_label_lookup() -> None:
     """ADR-0063 W1: PreflightPlaybook.prompt_template lets the registry pick
     a prompt file independent of the sub-label string. Sub-label


### PR DESCRIPTION
**WS-3 of the dark-factory hardening program. HIGH** — escalation integrity.

One `hydraflow-` prefix gap broke escalation routing three ways (verified on live staging; the audit only caught the first):
1. **Registry routing dead** — `get_playbook` did a bare `_REGISTRY.get(prefixed_label, _default)` against unprefixed keys → all 5 registered specialists fell to `_default`.
2. **File-fallback dead** — `render_prompt`'s design-intended fallback to `<sub_label>.md` used the prefixed label → the ~11 file-based playbooks (`flaky-test-stuck.md`, `wiki-rot-stuck.md`, …) also fell to `_default.md`.
3. **Recursion-safety deny-list inert (safety)** — `auto_agent_skip_sublabels = ["principles-stuck","cultural-check"]` (unprefixed) was checked against the prefixed label and never matched, so the auto-agent would act on the principles/cultural escalations it must defer to a human (dark-factory §2.7).

**Fix:** strip the prefix at all three lookup boundaries; check *every* sub-label against the deny-list (closes the F6 `sorted()[0]`-only gap); keep the raw label for `apply_decision`'s label removal. Regression tests use the realistic **prefixed** labels the existing tests all omitted (which is why this shipped untested). `make quality` green.

Follow-up (not this PR): only 5 of ~16 escalation types have *registry* specialists; the other 11 now route via file-fallback — registering richer specialists for them is separate work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)