### PR TITLE
fix(escalation): preserve routing cleanup

### DIFF
--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -137,13 +137,14 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         sub_labels = sorted(labels - {"hitl-escalation"})
         sub_label = sub_labels[0] if sub_labels else "_default"
 
-        # Sub-label deny-list (recursion safety, dark-factory §2.7). The skip-list
-        # is unprefixed (e.g. "principles-stuck") while escalation labels carry the
-        # `hydraflow-` prefix, so compare on the prefix-stripped form — otherwise
-        # the guard never matches and the auto-agent acts on the very escalations
-        # (principles/cultural) it must defer to a human. Check EVERY sub-label,
-        # not just sub_labels[0], so a deny-listed label can't slip through by
-        # losing the alphabetical sort.
+        # Sub-label deny-list (recursion safety, dark-factory §2.7). The real gap:
+        # producers file the deny-listed label ALONGSIDE others — e.g.
+        # principles_audit_loop files ["principles-stuck", "check-<id>"], and
+        # "check-<id>" sorts first, so the old sub_labels[0]-only check missed the
+        # deny-listed label and the auto-agent acted on a principles escalation it
+        # must defer to a human. Check EVERY sub-label. removeprefix is defensive
+        # for the config-default labels that carry the `hydraflow-` prefix (the
+        # skip-list is unprefixed); it's a no-op for the unprefixed producers.
         denied = next(
             (
                 s

--- a/src/preflight/playbooks/__init__.py
+++ b/src/preflight/playbooks/__init__.py
@@ -165,21 +165,24 @@ _REGISTRY: dict[str, PreflightPlaybook] = {
 }
 
 
-# Escalation sub-labels carry the HydraFlow label prefix (e.g.
-# ``hydraflow-plan-stuck``), but the registry keys / prompt-file stems are
-# unprefixed. ``removeprefix`` is a no-op for already-unprefixed labels.
+# Escalation sub-labels are a MIX: most producer loops file *unprefixed*
+# sub-labels (e.g. ``principles-stuck``, ``discover-stuck`` — strip is a no-op),
+# but the config-default escalation labels (``fake_coverage_stuck_label`` =
+# ``hydraflow-fake-coverage-stuck``, ``adr_drift_stuck_label``,
+# ``memory_backlog_stuck_label``) carry the prefix.
 _LABEL_PREFIX = "hydraflow-"
 
 
 def get_playbook(sub_label: str) -> PreflightPlaybook:
     """Return the playbook for ``sub_label`` (falls back to ``_default``).
 
-    The ``hydraflow-`` label prefix is stripped before lookup so a real
-    escalation label like ``hydraflow-plan-stuck`` routes to its specialist
-    playbook instead of silently falling back to ``_default`` (the entire
-    specialist registry was dead before this — every escalation got the generic
-    playbook). Backwards-compatible: any sub-label the registry doesn't
-    specialise still gets the generic lead-engineer playbook.
+    The ``hydraflow-`` prefix is stripped before lookup so a prefixed
+    config-default escalation label can still match an (unprefixed) registry
+    key. This is defensive today — no currently-prefixed escalation label has a
+    registry specialist, so the live prefix benefit is in ``render_prompt``'s
+    file fallback — but it keeps the registry path correct if one is added.
+    Backwards-compatible: any sub-label the registry doesn't specialise still
+    gets the generic lead-engineer playbook.
     """
     return _REGISTRY.get(sub_label.removeprefix(_LABEL_PREFIX), _DEFAULT_PLAYBOOK)
 

--- a/src/preflight/runner.py
+++ b/src/preflight/runner.py
@@ -41,10 +41,13 @@ def render_prompt(
             file route to a specialist persona + the ``_default`` template,
             or vice versa.
     """
-    # Strip the `hydraflow-` label prefix from the file-fallback stem: the prompt
-    # files (flaky-test-stuck.md, wiki-rot-stuck.md, ...) are unprefixed, but the
-    # sub-label arrives prefixed, so without this every unregistered specialist
-    # fell through to _default.md — ADR-0063's file-fallback was dead for them.
+    # Strip the `hydraflow-` label prefix from the file-fallback stem. The
+    # config-default escalation labels (fake_coverage_stuck_label =
+    # `hydraflow-fake-coverage-stuck`, adr_drift_stuck_label,
+    # memory_backlog_stuck_label) are prefixed, but their prompt files
+    # (fake-coverage-stuck.md, ...) are unprefixed — so without this strip a
+    # prefixed label falls through to _default.md instead of its specialist
+    # file. Unprefixed producer labels are a no-op here.
     template_stem = (
         prompt_template
         if prompt_template is not None

--- a/tests/test_auto_agent_preflight_loop.py
+++ b/tests/test_auto_agent_preflight_loop.py
@@ -155,6 +155,35 @@ async def test_deny_list_bypasses_agent_with_prefixed_label(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_deny_list_skips_when_denied_label_not_sorted_first(
+    tmp_path: Path,
+) -> None:
+    # The real producer pattern (principles_audit_loop): the deny-listed
+    # "principles-stuck" is filed ALONGSIDE a "check-<id>" label that sorts first.
+    # The old sub_labels[0]-only check looked at "check-some-id", missed the
+    # deny-listed label, and ran the auto-agent on a principles escalation it must
+    # defer to a human. Checking EVERY sub-label closes the recursion-safety hole.
+    loop, state = _make_loop(tmp_path)
+    state.get_auto_agent_attempts = MagicMock(return_value=0)
+    loop._prs.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 1,
+                "body": "x",
+                "labels": [
+                    {"name": "hitl-escalation"},
+                    {"name": "check-some-id"},  # sorts before "principles-stuck"
+                    {"name": "principles-stuck"},
+                ],
+            },
+        ]
+    )
+    result = await loop._do_work()
+    loop._prs.add_labels.assert_awaited_with(1, ["human-required"])
+    assert result["result_status"] == "skipped_deny_list"
+
+
+@pytest.mark.asyncio
 async def test_attempt_cap_marks_exhausted(tmp_path: Path) -> None:
     loop, state = _make_loop(tmp_path)
     state.get_auto_agent_attempts = MagicMock(return_value=3)

--- a/tests/test_preflight_playbooks.py
+++ b/tests/test_preflight_playbooks.py
@@ -41,11 +41,10 @@ def test_plan_stuck_playbook_specialises() -> None:
 
 
 def test_prefixed_escalation_label_routes_to_specialist() -> None:
-    # Real escalation labels carry the `hydraflow-` prefix (e.g.
-    # `hydraflow-plan-stuck`), but the registry keys are unprefixed. Before the
-    # prefix-strip fix every prefixed label fell through to `_default`, so the
-    # entire specialist registry was dead. removeprefix must route the prefixed
-    # label to the same specialist as the bare key.
+    # Mechanism check: removeprefix routes a `hydraflow-`-prefixed label to its
+    # (unprefixed) registry specialist. plan-stuck is produced UNPREFIXED in
+    # practice; this guards the defensive prefix-strip so a prefixed config-default
+    # label (or a future prefixed producer) does not silently fall to `_default`.
     assert get_playbook("hydraflow-plan-stuck").name == "plan-stuck"
     assert get_playbook("hydraflow-plan-stuck").name == get_playbook("plan-stuck").name
     assert get_playbook("hydraflow-plan-stuck").persona != DEFAULT_PERSONA

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -76,6 +76,29 @@ def test_prefixed_sublabel_routes_to_specialist_file() -> None:
     assert "Default Playbook" in unknown
 
 
+def test_prefixed_config_default_label_routes_to_specialist_file() -> None:
+    # The real production case this PR fixes: ``fake_coverage_stuck_label``
+    # defaults to the PREFIXED ``hydraflow-fake-coverage-stuck`` (config.py) and
+    # ``fake-coverage-stuck.md`` exists. The file-fallback prefix-strip routes it
+    # to that specialist file; before the fix it fell through to ``_default.md``.
+    fields = {
+        "persona": "x",
+        "issue_number": 1,
+        "repo_slug": "r/s",
+        "worktree_path": "/tmp",
+        "issue_body": "b",
+        "issue_comments_block": "x",
+        "escalation_context_block": "x",
+        "wiki_excerpts_block": "x",
+        "sentry_events_block": "x",
+        "recent_commits_block": "x",
+        "prior_attempts_block": "x",
+    }
+    out = render_prompt(sub_label="hydraflow-fake-coverage-stuck", **fields)
+    assert "Default Playbook" not in out
+    assert "fake-coverage" in out
+
+
 def test_explicit_prompt_template_overrides_sub_label_lookup() -> None:
     """ADR-0063 W1: PreflightPlaybook.prompt_template lets the registry pick
     a prompt file independent of the sub-label string. Sub-label


### PR DESCRIPTION
## Summary
- preserve the corrected escalation-routing comments on current staging
- add regressions for deny-list labels that do not sort first and prefixed config-default prompt file routing
- keep ADR-0084 untrusted-text fencing intact from staging

## Tests
- rg no pytest skip/xfail markers in changed files
- git diff --check
- uv run ruff check src/auto_agent_preflight_loop.py src/preflight/playbooks/__init__.py src/preflight/runner.py tests/test_auto_agent_preflight_loop.py tests/test_preflight_playbooks.py tests/test_preflight_runner.py
- uv run pyright src/auto_agent_preflight_loop.py src/preflight/playbooks/__init__.py src/preflight/runner.py tests/test_auto_agent_preflight_loop.py tests/test_preflight_playbooks.py tests/test_preflight_runner.py
- PYTHONPATH=src uv run pytest tests/test_auto_agent_preflight_loop.py tests/test_preflight_playbooks.py tests/test_preflight_runner.py -q
- make arch-check
- pre-push make quality-lite