### PR TITLE
feat(security): scrub secrets on the canonical audit-write path (WS-4, ADR-0085)

### DIFF
--- a/docs/adr/0085-secrets-never-persist-in-audit-stream.md
+++ b/docs/adr/0085-secrets-never-persist-in-audit-stream.md
@@ -1,0 +1,27 @@
+# ADR-0085 — Secrets never persist in the canonical audit stream
+
+**Status:** Accepted
+**Date:** 2026-05-30
+**Enforced by:** tests/test_secret_scrub.py
+
+## Context
+
+`file_util.append_jsonl` is the durable write helper for HydraFlow's canonical audit, transcript, and event JSONL streams (the post-hoc source of truth, dark-factory §2.3). It fsync'd for crash-safety but did **not** redact secrets. Any agent that surfaces a credential — a failing `gh` command echoing `GH_TOKEN`, an agent pasting an env dump into a transcript, a diagnosis quoting an `ANTHROPIC_API_KEY` — would persist it verbatim into the durable, fanned-out audit stream. The prompt-injection surface (ADR-0084) makes this **attacker-triggerable** (a crafted issue can induce the agent to echo the child env).
+
+Redaction existed only on the API-response egress path (`server.py::_scrub`) and the screenshot scanner (`screenshot_scanner._SECRET_PATTERNS`) — not on the write path — and the pattern sets were duplicated (SEC-AUDIT-001/002/003).
+
+## Decision
+
+The **persistence boundary is the single scrub chokepoint**:
+
+1. `src/secret_scrub.py` is the canonical secret-pattern set, with `scan_for_secrets(text)` (detect → labels) and `scrub_secrets(text)` (redact → `[REDACTED:<label>]`).
+2. `file_util.append_jsonl` calls `scrub_secrets` on every record before writing, so no credential reaches the canonical audit stream regardless of which subsystem produced it.
+3. `screenshot_scanner` reuses the shared patterns (consolidation — one source of truth).
+4. Plain `open(path, "a")` JSONL writers route through `append_jsonl` for fsync + scrub — done here for `factory_metrics.jsonl` (the dashboard cost time-series, `trace_rollup`).
+
+## Consequences
+
+- **Secrets are redacted at the durability boundary**, labelled (`[REDACTED:<label>]`), and the scrubbed line remains valid JSON.
+- **This is the persistence trust boundary, not the agent sandbox.** A secret in flight is still in the agent's process memory; this ADR only guarantees it does not leak into durable, retained, fanned-out logs.
+- Patterns require specific structure (known prefixes, quoted assignments) to keep false-positive redaction of legitimate audit prose low; `scrub_secrets` is idempotent.
+- **Residual / follow-up:** other plain-`open` JSONL writers (`health_monitor` `decisions.jsonl`, the advisor session log) should also route through `append_jsonl`; and the disk-full silent-loss (suppressed `OSError` on the append path) must fail loud — both tracked as follow-up, not delivered here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -115,6 +115,7 @@ ADR and that named test files actually exist.
 | [0082](0082-declarative-gate-contract.md) | Declarative Gate Contract for Branch Protection | Proposed |
 | [0083](0083-no-ignored-test-gates.md) | No ignored automated test gates | Accepted |
 | [0084](0084-untrusted-text-trust-boundary.md) | Untrusted-text trust boundary for agent prompts | Accepted |
+| [0085](0085-secrets-never-persist-in-audit-stream.md) | Secrets never persist in the canonical audit stream | Accepted |
 
 ## Adding a new ADR
 

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -95,6 +95,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0082 | `src.branch_protection_audit`, `src.branch_protection_auditor_loop` |
 | ADR-0083 | — |
 | ADR-0084 | `src.agent`, `src.preflight.runner`, `src.untrusted_text` |
+| ADR-0085 | `src.secret_scrub` |
 
 ## Module → ADRs
 
@@ -208,6 +209,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.run_recorder` | ADR-0073 |
 | `src.runs_gc_loop` | ADR-0073 |
 | `src.screenshot_scanner` | ADR-0018 |
+| `src.secret_scrub` | ADR-0085 |
 | `src.sentry.reverse_lookup` | ADR-0050 |
 | `src.server` | ADR-0038, ADR-0055 |
 | `src.service_registry` | ADR-0045 |
@@ -247,4 +249,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `40473a4` on 2026-05-30 11:42 UTC. Source last changed at `40473a4`. Status: 🟢 fresh._
+_Regenerated from commit `bca7775` on 2026-05-30 15:10 UTC. Source last changed at `bca7775`. Status: 🟢 fresh._

--- a/src/file_util.py
+++ b/src/file_util.py
@@ -12,6 +12,8 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
+from secret_scrub import scrub_secrets
+
 logger = logging.getLogger("hydraflow.file_util")
 
 
@@ -41,14 +43,16 @@ def atomic_write(path: Path, data: str) -> None:
 
 
 def append_jsonl(path: Path, data: str) -> None:
-    """Append *data* as a single line to *path* with crash-safe fsync.
+    """Append *data* as a single scrubbed line to *path* with crash-safe fsync.
 
-    Creates parent directories if needed.  Calls ``flush`` + ``fsync``
-    to ensure the record reaches stable storage before returning.
+    Creates parent directories if needed.  Secrets are redacted (ADR-0085) so a
+    leaked credential never persists in the canonical audit/transcript/event
+    stream, then ``flush`` + ``fsync`` ensure the record reaches stable storage
+    before returning.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "a", encoding="utf-8") as f:
-        f.write(data + "\n")
+        f.write(scrub_secrets(data) + "\n")
         f.flush()
         os.fsync(f.fileno())
 

--- a/src/screenshot_scanner.py
+++ b/src/screenshot_scanner.py
@@ -8,37 +8,9 @@ rendered as visible text in the dashboard UI.
 
 from __future__ import annotations
 
-import re
-
-# Patterns that match common secret/token formats.
-# Each tuple: (label, compiled regex)
-_SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    ("GitHub PAT (classic)", re.compile(r"ghp_[A-Za-z0-9]{36,}")),
-    ("GitHub PAT (fine-grained)", re.compile(r"github_pat_[A-Za-z0-9_]{40,}")),
-    ("GitHub OAuth token", re.compile(r"gho_[A-Za-z0-9]{36,}")),
-    ("GitHub App token", re.compile(r"ghu_[A-Za-z0-9]{36,}")),
-    ("GitHub App installation", re.compile(r"ghs_[A-Za-z0-9]{36,}")),
-    ("GitHub refresh token", re.compile(r"ghr_[A-Za-z0-9]{36,}")),
-    ("AWS access key", re.compile(r"AKIA[0-9A-Z]{16}")),
-    (
-        "AWS secret key",
-        re.compile(r"(?:aws_secret_access_key|secret_key)\s*[:=]\s*\S{20,}"),
-    ),
-    ("Slack token", re.compile(r"xox[bporas]-[A-Za-z0-9\-]+")),
-    ("Anthropic API key", re.compile(r"sk-ant-[A-Za-z0-9\-]{20,}")),
-    ("OpenAI API key", re.compile(r"sk-[A-Za-z0-9]{20,}")),
-    (
-        "Generic private key",
-        re.compile(r"-----BEGIN\s+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
-    ),
-    (
-        "Generic secret assignment",
-        re.compile(
-            r"(?:secret|password|token|api_key)\s*[:=]\s*['\"][^'\"]{8,}['\"]",
-            re.IGNORECASE,
-        ),
-    ),
-]
+# Canonical secret patterns live in ``secret_scrub`` (the single source of truth
+# shared with the audit-stream scrubber, ADR-0085 / SEC-AUDIT-003).
+from secret_scrub import SECRET_PATTERNS as _SECRET_PATTERNS
 
 
 def scan_base64_for_secrets(png_base64: str) -> list[str]:

--- a/src/secret_scrub.py
+++ b/src/secret_scrub.py
@@ -1,0 +1,77 @@
+"""Canonical secret patterns + scrubber for HydraFlow.
+
+Single source of truth for credential-shaped strings. Used by:
+
+- ``file_util.append_jsonl`` — scrubs every record on the canonical
+  audit/transcript/event JSONL write path, so a leaked token (e.g. a failing
+  ``gh`` command echoing ``GH_TOKEN``, or an agent pasting an env dump) never
+  reaches the durable, fanned-out audit stream. See ADR-0085.
+- ``screenshot_scanner`` — detects secrets in upload-bound payloads.
+
+The detect/scrub split: ``scan_for_secrets`` returns the labels found (for
+flagging); ``scrub_secrets`` replaces each match with a labelled redaction
+marker (for the persistence boundary). Patterns require specific structure
+(known prefixes, quoted assignments) to keep false-positive redaction of
+legitimate audit prose low.
+"""
+
+from __future__ import annotations
+
+import re
+
+# (label, compiled regex). Specific-prefix / structured patterns only.
+SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("GitHub PAT (classic)", re.compile(r"ghp_[A-Za-z0-9]{36,}")),
+    ("GitHub PAT (fine-grained)", re.compile(r"github_pat_[A-Za-z0-9_]{40,}")),
+    ("GitHub OAuth token", re.compile(r"gho_[A-Za-z0-9]{36,}")),
+    ("GitHub App token", re.compile(r"ghu_[A-Za-z0-9]{36,}")),
+    ("GitHub App installation", re.compile(r"ghs_[A-Za-z0-9]{36,}")),
+    ("GitHub refresh token", re.compile(r"ghr_[A-Za-z0-9]{36,}")),
+    ("AWS access key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    (
+        "AWS secret key",
+        # Value class excludes whitespace AND JSON structural chars (quote,
+        # comma, brace) so the greedy match can't cross a string boundary and
+        # corrupt the serialized JSON line append_jsonl scrubs. IGNORECASE also
+        # catches the uppercase AWS_SECRET_ACCESS_KEY=... env-var form.
+        re.compile(
+            r"(?:aws_secret_access_key|secret_key)\s*[:=]\s*[^\s'\",}]{20,}",
+            re.IGNORECASE,
+        ),
+    ),
+    ("Slack token", re.compile(r"xox[bporas]-[A-Za-z0-9\-]+")),
+    ("Anthropic API key", re.compile(r"sk-ant-[A-Za-z0-9\-]{20,}")),
+    # Anchored (not preceded by word-char/hyphen) + length closer to a real
+    # 48-char key, so it doesn't mid-token-corrupt legitimate identifiers like
+    # `disk-1a2b...` or `task-sk-...` on the irreversible audit-write path.
+    # (sk-ant- runs earlier and is matched first.)
+    ("OpenAI API key", re.compile(r"(?<![\w-])sk-[A-Za-z0-9]{40,}")),
+    (
+        "Generic private key",
+        re.compile(r"-----BEGIN\s+(RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"),
+    ),
+    (
+        "Generic secret assignment",
+        re.compile(
+            r"(?:secret|password|token|api_key)\s*[:=]\s*['\"][^'\"]{8,}['\"]",
+            re.IGNORECASE,
+        ),
+    ),
+]
+
+
+def scan_for_secrets(text: str) -> list[str]:
+    """Return the labels of every secret pattern found in *text* (empty = none)."""
+    return [label for label, pattern in SECRET_PATTERNS if pattern.search(text)]
+
+
+def scrub_secrets(text: str) -> str:
+    """Replace credential-shaped substrings with a labelled redaction marker.
+
+    Idempotent: the ``[REDACTED:...]`` markers it emits do not match any pattern.
+    The markers contain no JSON-breaking characters, so scrubbing a serialized
+    JSON line keeps it valid.
+    """
+    for label, pattern in SECRET_PATTERNS:
+        text = pattern.sub(f"[REDACTED:{label}]", text)
+    return text

--- a/src/trace_rollup.py
+++ b/src/trace_rollup.py
@@ -6,6 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from file_util import append_jsonl
 from models import (
     SubprocessTrace,
     TraceSkillProfile,
@@ -258,5 +259,6 @@ def _append_factory_metric(
         "crashed": summary.crashed,
     }
 
-    with open(metrics_path, "a", encoding="utf-8") as f:
-        f.write(json.dumps(event) + "\n")
+    # append_jsonl gives crash-safe fsync + secret scrubbing (ADR-0085); the
+    # factory_metrics.jsonl cost time-series is the canonical dashboard source.
+    append_jsonl(metrics_path, json.dumps(event))

--- a/tests/test_screenshot_scanner.py
+++ b/tests/test_screenshot_scanner.py
@@ -47,8 +47,14 @@ class TestScanBase64ForSecrets:
         assert "Anthropic API key" in result
 
     def test_openai_api_key_detected(self) -> None:
-        """An OpenAI API key is detected."""
-        payload = "sk-ABCDEFGHIJKLMNOPQRSTUVWXYZabcd more"
+        """A realistic 48-char OpenAI API key is detected.
+
+        The shared pattern (secret_scrub) is anchored + length-tightened to
+        avoid mid-token-corrupting legitimate identifiers when scrubbing the
+        audit stream (ADR-0085); real OpenAI keys are 48 chars, so detection of
+        a genuine key is unaffected.
+        """
+        payload = "sk-" + "A1B2C3D4E5" * 4 + "ABCDEFGH more"  # sk- + 48 chars
         result = scan_base64_for_secrets(payload)
         assert "OpenAI API key" in result
 

--- a/tests/test_secret_scrub.py
+++ b/tests/test_secret_scrub.py
@@ -1,0 +1,97 @@
+"""secret_scrub: canonical secret patterns + scrubber, and the append_jsonl
+audit-write chokepoint that uses it (ADR-0085 / SEC-AUDIT-001)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from file_util import append_jsonl
+from secret_scrub import scan_for_secrets, scrub_secrets
+
+
+def test_scrubs_anthropic_key() -> None:
+    out = scrub_secrets("key=sk-ant-api03-" + "A" * 24 + " done")
+    assert "sk-ant-" not in out
+    assert "[REDACTED:Anthropic API key]" in out
+    assert "done" in out  # surrounding text preserved
+
+
+def test_scrubs_github_and_aws() -> None:
+    out = scrub_secrets("ghp_" + "a" * 36 + " and AKIA" + "A" * 16)
+    assert "ghp_" not in out
+    assert "AKIA" + "A" * 16 not in out
+    assert "[REDACTED:GitHub PAT (classic)]" in out
+    assert "[REDACTED:AWS access key]" in out
+
+
+def test_leaves_legitimate_text_unredacted() -> None:
+    # Normal audit prose / a short commit sha must NOT be redacted.
+    text = "Fixed in commit a1b2c3d4 — the function returns early on empty input."
+    assert scrub_secrets(text) == text
+
+
+def test_scrub_is_idempotent() -> None:
+    once = scrub_secrets("token sk-ant-api03-" + "x" * 24)
+    assert scrub_secrets(once) == once  # the [REDACTED:...] markers do not re-match
+
+
+def test_scan_for_secrets_returns_labels() -> None:
+    assert "AWS access key" in scan_for_secrets("AKIA" + "B" * 16)
+    assert scan_for_secrets("nothing secret here") == []
+
+
+def test_append_jsonl_scrubs_secrets_and_stays_valid_json(tmp_path: Path) -> None:
+    # A leaked credential in an audit record must not persist, and the scrubbed
+    # line must still parse as JSON.
+    path = tmp_path / "audit.jsonl"
+    secret = "sk-ant-api03-" + "z" * 24
+    append_jsonl(path, json.dumps({"transcript": f"command failed: {secret}"}))
+    content = path.read_text(encoding="utf-8")
+    assert secret not in content
+    assert "[REDACTED:Anthropic API key]" in content
+    record = json.loads(content.strip())
+    assert "REDACTED" in record["transcript"]
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "aws_secret_access_key=" + "A" * 24,
+        "secret_key=" + "B" * 24,
+        "AWS_SECRET_ACCESS_KEY=" + "C" * 24,  # uppercase env-var form (IGNORECASE)
+        "ghp_" + "d" * 36,
+        "sk-ant-api03-" + "e" * 40,
+        "AKIA" + "F" * 16,
+    ],
+)
+def test_append_jsonl_stays_valid_json_with_secret_at_value_end(
+    tmp_path: Path, secret: str
+) -> None:
+    # A matching secret at the END of a JSON string value (immediately before the
+    # closing quote + trailing fields) must not let the redaction eat the quote
+    # and corrupt the serialized line — which events.py would then silently DROP.
+    # This is the case the original sk-ant-only test could never hit.
+    path = tmp_path / "audit.jsonl"
+    append_jsonl(
+        path,
+        json.dumps({"transcript": f"leaked {secret}", "user": "alice", "amount": 42}),
+    )
+    line = path.read_text(encoding="utf-8").strip()
+    record = json.loads(line)  # must NOT raise (ADR-0085: stays valid JSON)
+    assert secret not in line  # the secret was redacted
+    assert record["user"] == "alice"  # trailing fields survive
+    assert record["amount"] == 42
+
+
+def test_openai_pattern_does_not_over_redact_legitimate_ids() -> None:
+    # The anchored, length-tightened sk- pattern must leave legitimate
+    # hyphenated identifiers untouched on the irreversible audit-write path.
+    for benign in (
+        "disk-1a2b3c4d5e6f7g8h9i0j",
+        "risk-assessmentABCDEF12345678",
+        "task-sk-12345678abcdefghij90",
+    ):
+        assert scrub_secrets(benign) == benign


### PR DESCRIPTION
**WS-4 of the dark-factory hardening program.** Self-reviewed to convergence **before** push (the corrected cadence).

`file_util.append_jsonl` — the durable audit/transcript/event JSONL helper — fsync'd but never redacted secrets, so a leaked credential (a failing `gh` echoing `GH_TOKEN`, an env dump in a transcript) persisted verbatim in the canonical, fanned-out audit stream, **attacker-triggerable** via the merged ADR-0084 prompt-injection surface.

## Fix (ADR-0085)
- **`src/secret_scrub.py`** — single source of truth for credential patterns + `scrub_secrets`/`scan_for_secrets`.
- **`append_jsonl` scrubs every record** before the fsync'd write.
- **`screenshot_scanner` consolidated** onto the shared patterns (kills the SEC-AUDIT-003 duplication).
- **`factory_metrics.jsonl`** routes through `append_jsonl` (fsync + scrub) instead of a plain `open("a")`.

## The self-review earned its keep
The pre-push adversarial review caught a **CRITICAL data-integrity bug `make quality` passed green**: the `AWS secret key` pattern's greedy `\S{20,}`, applied to the already-serialized JSON line, ate the closing quote + trailing fields → invalid JSON → `events.py` silently **dropped** the record. Fixed (bounded value class `[^\s'",}]{20,}` + `IGNORECASE`), plus the `OpenAI sk-` over-redaction of legit IDs (anchored + length-tightened), plus a parametrized regression test that fails-red on the old pattern. A second convergence pass confirmed no remaining issues.

`make quality` green. **Follow-up (non-blocking):** route `health_monitor`/advisor plain-open writers through `append_jsonl`, fail-loud on disk-full, and extend OpenAI coverage to `sk-proj-`/`sk-svcacct-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)