### PR TITLE
fix(viz): carry issue number on MERGE_UPDATE for real-time card move (WS-RT)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2628,6 +2628,10 @@ class MergeUpdatePayload(TypedDict, total=False):
     pr: int
     status: str
     title: str
+    # Issue the merged PR resolves. Required for the dashboard to move the card
+    # review -> merged in real time: the frontend's optimistic getPipelineAction
+    # returns null without it, so the move was dead code until WS-RT populated it.
+    issue: int
 
 
 class TriageUpdatePayload(TypedDict, total=False):

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1089,9 +1089,24 @@ class PRManager:
                     continue
                 return False
 
+            # Resolve the issue number from the PR title once, here, so it can
+            # both (a) ride the MERGE_UPDATE event — the dashboard needs it to
+            # move the card review -> merged in real time — and (b) feed the
+            # per-issue cost check below. Prefer a Fixes/Closes/Resolves-anchored
+            # match so an embedded reference like "Fixes #12: address #34" picks
+            # the issue the PR actually fixes (not the first bare "#N"); fall
+            # back to the first "#N" for keyword-less titles (e.g.
+            # "feat(x): do thing (#123)") so cost is still attributed.
+            issue_match = re.search(
+                r"(?:Fixes|Closes|Resolves)\s+#(\d+)", pr_title or "", re.IGNORECASE
+            ) or re.search(r"#(\d+)", pr_title or "")
+            issue_no = int(issue_match.group(1)) if issue_match else None
+
             payload = MergeUpdatePayload(pr=pr_number, status="merged")
             if pr_title:
                 payload["title"] = pr_title
+            if issue_no is not None:
+                payload["issue"] = issue_no
             await self._bus.publish(
                 HydraFlowEvent(
                     type=EventType.MERGE_UPDATE,
@@ -1105,8 +1120,6 @@ class PRManager:
             # helper method) so the hook site is self-contained and
             # easy to reason about from merge_pr alone.
             try:
-                issue_match = re.search(r"#(\d+)", pr_title or "")
-                issue_no = int(issue_match.group(1)) if issue_match else None
                 if issue_no is not None:
                     from dedup_store import DedupStore  # noqa: PLC0415
 

--- a/tests/regressions/test_merge_update_issue_number.py
+++ b/tests/regressions/test_merge_update_issue_number.py
@@ -1,0 +1,105 @@
+"""Regression: MERGE_UPDATE carries the issue number (WS-RT).
+
+The dashboard moves a card review -> merged via the frontend's optimistic
+``getPipelineAction``, which returns ``null`` unless ``event.data.issue`` is
+present. ``MergeUpdatePayload`` had no ``issue`` field and both publish sites
+omitted it, so that move was dead code in production — the card only moved on
+the next REST poll, visibly hanging in review. ``merge_pr`` now parses the
+issue from the canonical ``Fixes #N:`` title and includes it.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from events import EventType
+from tests.helpers import ConfigFactory, make_pr_manager
+
+
+def _make_pr_manager() -> Any:
+    config = ConfigFactory.create(repo="owner/repo")
+    return make_pr_manager(config=config, event_bus=AsyncMock())
+
+
+def _merge_update_events(pm: Any) -> list[Any]:
+    return [
+        call.args[0]
+        for call in pm._bus.publish.call_args_list
+        if call.args and getattr(call.args[0], "type", None) == EventType.MERGE_UPDATE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_includes_issue_number(monkeypatch: pytest.MonkeyPatch) -> None:
+    pm = _make_pr_manager()
+
+    async def _ok(*_cmd: str, **_kwargs: Any) -> str:
+        return ""
+
+    monkeypatch.setattr("pr_manager.run_subprocess", _ok)
+    monkeypatch.setattr(
+        pm,
+        "get_pr_title_and_body",
+        AsyncMock(return_value=("Fixes #321: do the thing", "body")),
+    )
+
+    ok = await pm.merge_pr(321)
+
+    assert ok is True
+    events = _merge_update_events(pm)
+    assert events, "merge_pr must publish a MERGE_UPDATE event"
+    data = events[-1].data
+    assert data["issue"] == 321, "MERGE_UPDATE must carry the issue number"
+    assert data["pr"] == 321
+    assert data["status"] == "merged"
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_omits_issue_when_title_has_no_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A non-canonical title (no "#N") must not fabricate an issue number.
+    pm = _make_pr_manager()
+
+    async def _ok(*_cmd: str, **_kwargs: Any) -> str:
+        return ""
+
+    monkeypatch.setattr("pr_manager.run_subprocess", _ok)
+    monkeypatch.setattr(
+        pm,
+        "get_pr_title_and_body",
+        AsyncMock(return_value=("chore: tidy up", "body")),
+    )
+
+    ok = await pm.merge_pr(7)
+
+    assert ok is True
+    data = _merge_update_events(pm)[-1].data
+    assert "issue" not in data
+
+
+@pytest.mark.asyncio
+async def test_merge_pr_picks_the_fixed_issue_not_an_embedded_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A title that embeds a second reference must resolve to the issue the PR
+    # FIXES (anchored on the keyword), never the first bare "#N".
+    pm = _make_pr_manager()
+
+    async def _ok(*_cmd: str, **_kwargs: Any) -> str:
+        return ""
+
+    monkeypatch.setattr("pr_manager.run_subprocess", _ok)
+    monkeypatch.setattr(
+        pm,
+        "get_pr_title_and_body",
+        AsyncMock(return_value=("Fixes #12: also touches #34", "body")),
+    )
+
+    ok = await pm.merge_pr(12)
+
+    assert ok is True
+    assert _merge_update_events(pm)[-1].data["issue"] == 12

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -52,6 +52,7 @@ class TestInitialization:
             "ci_monitor_settings",
             "ci_monitor_tracked_failures",
             "cost_budget_killed_workers",
+            "default_disabled_workers_seeded",
             "disabled_workers",
             "epic_states",
             "hitl_causes",


### PR DESCRIPTION
## What
`MergeUpdatePayload` now carries the resolved `issue` number, so the dashboard moves a card **review → merged in real time** instead of waiting for the next 5–10s REST poll.

## Why
The frontend's optimistic `getPipelineAction` returns `null` for a `merge_update` unless `event.data.issue` is present — and both publish sites omitted it, so the move was dead code (root cause A5/B3 from the WS-RT viz recon: cards visibly hang in review, then jump to merged on a poll).

## How
- `models.MergeUpdatePayload`: add `issue: int` (TypedDict, total=False).
- `pr_manager.merge_pr`: resolve the issue number from the canonical PR title, hoisted above the publish and **reusing** the extraction that already fed the per-issue cost-budget check (no duplicate regex). Anchored on the `Fixes/Closes/Resolves #N` keyword so an embedded reference resolves to the issue the PR fixes — not the first bare `#N` (closes #9099).
- Promotion-merge intentionally omits `issue` (RC PRs bundle many).

## Tests
`tests/regressions/test_merge_update_issue_number.py`: payload includes `issue`; omitted on non-canonical titles; multi-`#N` picks the fixed issue. Full `make quality` green.

Fixes #9099

🤖 Generated with [Claude Code](https://claude.com/claude-code)