### PR TITLE
fix(ui): render HITL issues in the workstream board (WS-RT)

### DIFF
--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -12,6 +12,19 @@ import {
   WORKSTREAM_SIDE_INSET_PX,
 } from '../styles/sectionStyles'
 
+// No-role stages (role: null) share the worker-less rendering branches, but each
+// carries its own semantics. 'merged' is success (green, "{N} merged"); 'hitl' is
+// an escalation bucket (yellow, "{N} needs human") and must NOT read as success.
+// Keyed by stage.key so adding a no-role stage is one map entry, not a conditional.
+const NO_ROLE_COUNT_LABELS = {
+  merged: 'merged',
+  hitl: 'needs human',
+}
+const NO_ROLE_DOT_COLORS = {
+  merged: theme.green,
+  hitl: theme.yellow,
+}
+
 function PendingIntentCard({ intent }) {
   return (
     <div style={styles.pendingCard}>
@@ -160,7 +173,7 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
               </span>
             </>
           ) : (
-            <span>{issues.length} merged</span>
+            <span>{issues.length} {NO_ROLE_COUNT_LABELS[stage.key] ?? 'merged'}</span>
           )}
         </span>
         <span
@@ -485,7 +498,7 @@ export function StreamView({ intents, expandedStages, onToggleStage, onRequestCh
         const workerCap = stage.role ? (stageStatus.workerCaps?.[stage.key] ?? null) : null
         let dotColor
         if (!stage.role) {
-          dotColor = theme.green
+          dotColor = NO_ROLE_DOT_COLORS[stage.key] ?? theme.green
         } else if (!enabled) {
           dotColor = theme.red
         } else if (workerCount > 0) {

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -59,6 +59,24 @@ const basePipeIssue = {
   url: 'https://github.com/test/42',
 }
 
+describe('HITL issues are rendered in the workstream (WS-RT)', () => {
+  it('renders a card for an issue escalated to the hitl bucket', () => {
+    // Before the fix PIPELINE_STAGES had no 'hitl' entry, so StreamView's
+    // `PIPELINE_STAGES.map(...)` never rendered the hitl bucket — an escalated
+    // issue vanished from the board entirely (present only in the HITL tab).
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: {
+        hitl: [{ issue_number: 77, title: 'Escalated issue', status: 'hitl' }],
+      },
+    }))
+    render(<StreamView {...defaultProps} />)
+
+    expect(screen.getByTestId('stage-section-hitl')).toBeTruthy()
+    expect(screen.getByTestId('stream-card-77')).toBeTruthy()
+    expect(screen.getByText('Escalated issue')).toBeTruthy()
+  })
+})
+
 describe('StreamView stage indicators', () => {
   it('keeps stream card horizontal inset aligned with its stage header', () => {
     mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -75,6 +75,26 @@ describe('HITL issues are rendered in the workstream (WS-RT)', () => {
     expect(screen.getByTestId('stream-card-77')).toBeTruthy()
     expect(screen.getByText('Escalated issue')).toBeTruthy()
   })
+
+  it('labels the hitl bucket as needs-human, not merged, with a yellow dot', () => {
+    // The hitl stage has role:null like merged, so it shares the worker-less
+    // rendering branches. Those branches must stay stage-aware: a "Needs Human"
+    // escalation bucket reading "merged" + green (success) is a mislabel.
+    mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
+      pipelineIssues: {
+        hitl: [{ issue_number: 77, title: 'Escalated issue', status: 'hitl' }],
+      },
+    }))
+    render(<StreamView {...defaultProps} />)
+
+    const header = screen.getByTestId('stage-header-hitl')
+    expect(header.textContent).not.toContain('merged')
+    expect(header.textContent).toContain('needs human')
+
+    const dot = screen.getByTestId('stage-dot-hitl')
+    expect(dot.style.background).not.toBe('var(--green)')
+    expect(dot.style.background).toBe('var(--yellow)')
+  })
 })
 
 describe('StreamView stage indicators', () => {

--- a/src/ui/src/components/__tests__/constants.test.js
+++ b/src/ui/src/components/__tests__/constants.test.js
@@ -34,17 +34,17 @@ describe('ACTIVE_STATUSES', () => {
 describe('PIPELINE_STAGES', () => {
   it('is an array with 7 stages', () => {
     expect(Array.isArray(PIPELINE_STAGES)).toBe(true)
-    expect(PIPELINE_STAGES).toHaveLength(7)
+    expect(PIPELINE_STAGES).toHaveLength(8)
   })
 
   it('contains all pipeline stage keys in order', () => {
     const keys = PIPELINE_STAGES.map(s => s.key)
-    expect(keys).toEqual(['triage', 'discover', 'shape', 'plan', 'implement', 'review', 'merged'])
+    expect(keys).toEqual(['triage', 'discover', 'shape', 'plan', 'implement', 'review', 'hitl', 'merged'])
   })
 
   it('has title-case labels for each stage', () => {
     const labels = PIPELINE_STAGES.map(s => s.label)
-    expect(labels).toEqual(['Triage', 'Discover', 'Shape', 'Plan', 'Implement', 'Review', 'Merged'])
+    expect(labels).toEqual(['Triage', 'Discover', 'Shape', 'Plan', 'Implement', 'Review', 'Needs Human', 'Merged'])
   })
 
   it('maps each stage to the correct theme color', () => {
@@ -56,6 +56,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purple,
       implement: theme.accent,
       review: theme.orange,
+      hitl: theme.yellow,
       merged: theme.green,
     })
   })
@@ -69,6 +70,7 @@ describe('PIPELINE_STAGES', () => {
       plan: 'planner',
       implement: 'implementer',
       review: 'reviewer',
+      hitl: null,
       merged: null,
     })
   })
@@ -82,6 +84,7 @@ describe('PIPELINE_STAGES', () => {
       plan: 'max_planners',
       implement: 'max_workers',
       review: 'max_reviewers',
+      hitl: null,
       merged: null,
     })
   })
@@ -95,6 +98,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purpleSubtle,
       implement: theme.accentSubtle,
       review: theme.orangeSubtle,
+      hitl: theme.yellowSubtle,
       merged: theme.greenSubtle,
     })
   })
@@ -117,8 +121,10 @@ describe('PIPELINE_STAGES', () => {
 })
 
 describe('PIPELINE_LOOPS', () => {
-  it('has entries for all non-merged pipeline stages', () => {
-    const stageKeys = PIPELINE_STAGES.filter(s => s.key !== 'merged').map(s => s.key)
+  it('has entries for all worker-bearing pipeline stages (excludes terminal/no-role stages)', () => {
+    // PIPELINE_LOOPS are the stages that run workers — i.e. stages with a role.
+    // Terminal/no-role stages (merged, hitl) have no loop.
+    const stageKeys = PIPELINE_STAGES.filter(s => s.role !== null).map(s => s.key)
     expect(PIPELINE_LOOPS.map(l => l.key)).toEqual(stageKeys)
   })
 

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -33,6 +33,7 @@ export const PIPELINE_STAGES = [
   { key: 'plan',      label: 'Plan',      color: theme.purple,      subtleColor: theme.purpleSubtle,  role: 'planner',     configKey: 'max_planners', track: 'junction' },
   { key: 'implement', label: 'Implement', color: theme.accent,      subtleColor: theme.accentSubtle,  role: 'implementer', configKey: 'max_workers',  track: 'engineering' },
   { key: 'review',    label: 'Review',    color: theme.orange,      subtleColor: theme.orangeSubtle,  role: 'reviewer',    configKey: 'max_reviewers', track: 'engineering' },
+  { key: 'hitl',      label: 'Needs Human', color: theme.yellow,    subtleColor: theme.yellowSubtle,  role: null,           configKey: null,           track: 'engineering' },
   { key: 'merged',    label: 'Merged',    color: theme.green,       subtleColor: theme.greenSubtle,   role: null,           configKey: null,           track: 'engineering' },
 ]
 

--- a/src/ui/src/hooks/__tests__/useTimeline.test.js
+++ b/src/ui/src/hooks/__tests__/useTimeline.test.js
@@ -13,7 +13,7 @@ import {
 
 describe('STAGE_KEYS', () => {
   it('contains all pipeline stages in order', () => {
-    expect(STAGE_KEYS).toEqual(['triage', 'discover', 'shape', 'plan', 'implement', 'review', 'merged'])
+    expect(STAGE_KEYS).toEqual(['triage', 'discover', 'shape', 'plan', 'implement', 'review', 'hitl', 'merged'])
   })
 })
 

--- a/src/ui/src/hooks/__tests__/useTimeline.test.js
+++ b/src/ui/src/hooks/__tests__/useTimeline.test.js
@@ -326,6 +326,21 @@ describe('deriveIssueTimelines', () => {
     // Should NOT be 'done' — merge hasn't happened yet
     expect(result[0].overallStatus).toBe('active')
   })
+
+  it('advances a review-completed merge-pending issue to merged, skipping hitl', () => {
+    const events = [
+      { type: 'triage_update', timestamp: '2026-01-15T10:00:00Z', data: { issue: 13, status: 'done' } },
+      { type: 'planner_update', timestamp: '2026-01-15T10:01:00Z', data: { issue: 13, status: 'done' } },
+      { type: 'worker_update', timestamp: '2026-01-15T10:02:00Z', data: { issue: 13, status: 'done' } },
+      { type: 'review_update', timestamp: '2026-01-15T10:03:00Z', data: { issue: 13, pr: 70, status: 'done' } },
+    ]
+    const result = deriveIssueTimelines(events, {}, [])
+
+    expect(result[0].stages.review.status).toBe('done')
+    expect(result[0].stages.merged.status).toBe('pending')
+    // Natural next stage after review is merged, not hitl (a terminal/no-role stage)
+    expect(result[0].currentStage).toBe('merged')
+  })
 })
 
 // ── applyFiltersAndSort ──────────────────────────────────────────────

--- a/src/ui/src/hooks/useTimeline.js
+++ b/src/ui/src/hooks/useTimeline.js
@@ -4,9 +4,9 @@ import { PIPELINE_STAGES } from '../constants'
 /** Canonical stage keys in lifecycle order. */
 export const STAGE_KEYS = PIPELINE_STAGES.map(s => s.key)
 
-/** Map stage key → { color, subtleColor, label }. */
+/** Map stage key → { color, subtleColor, label, role }. */
 export const STAGE_META = Object.fromEntries(
-  PIPELINE_STAGES.map(s => [s.key, { color: s.color, subtleColor: s.subtleColor, label: s.label }])
+  PIPELINE_STAGES.map(s => [s.key, { color: s.color, subtleColor: s.subtleColor, label: s.label, role: s.role }])
 )
 
 /**
@@ -273,13 +273,23 @@ export function deriveIssueTimelines(events, workers, prs) {
     }
 
     // Current stage: prefer the actively running stage, otherwise
-    // advance to the next stage after the last completed one
+    // advance to the next *processing* stage after the last completed one.
+    // Skip terminal/no-role stages (role === null, e.g. 'hitl') when
+    // computing the natural next stage — 'hitl' is only the currentStage
+    // when the issue is genuinely escalated (handled via overallStatus/the
+    // hitl bucket), never as the implicit successor of 'review'.
     if (activeStage) {
       entry.currentStage = activeStage
-    } else if (lastDoneIndex >= 0 && lastDoneIndex < STAGE_KEYS.length - 1) {
-      entry.currentStage = STAGE_KEYS[lastDoneIndex + 1]
-    } else if (lastDoneIndex === STAGE_KEYS.length - 1) {
-      entry.currentStage = STAGE_KEYS[lastDoneIndex] // merged
+    } else if (lastDoneIndex >= 0) {
+      let nextIndex = lastDoneIndex + 1
+      // Advance past any no-role stage (e.g. 'hitl') so 'review' → 'merged'.
+      while (
+        nextIndex < STAGE_KEYS.length - 1 &&
+        STAGE_META[STAGE_KEYS[nextIndex]]?.role == null
+      ) {
+        nextIndex += 1
+      }
+      entry.currentStage = STAGE_KEYS[Math.min(nextIndex, STAGE_KEYS.length - 1)]
     } else {
       entry.currentStage = 'triage'
     }


### PR DESCRIPTION
## What
Issues escalated to human-in-the-loop now appear as a **"Needs Human"** column on the workstream board, instead of vanishing from it.

## Why
Escalated issues land in `pipelineIssues.hitl` (backend `get_pipeline_snapshot`), but `PIPELINE_STAGES` had no `hitl` entry — and `StreamView` builds its columns via `PIPELINE_STAGES.map(...)` — so an escalated issue disappeared from the board entirely, surfacing only in the separate HITL tab. This is the cleanest "issues go missing on handoff" instance from the WS-RT viz recon (visualization-only; no work was lost).

## How
- Add a terminal `hitl` stage (`role:null`/`configKey:null`, like `merged`) to `PIPELINE_STAGES`, so every per-stage style map (`Object.fromEntries(PIPELINE_STAGES.map(...))`) auto-populates and the board renders the column. Worker-count controls iterate `PIPELINE_LOOPS` (unchanged), so no bogus control appears.
- Convergence-review follow-ups: the worker-less render branches are now stage-aware — hitl shows **"{N} needs human" + a yellow dot** (not "{N} merged" + green). `useTimeline` currentStage advancement skips terminal/no-role stages (review→merged, not review→hitl).

## Tests
New StreamView RTL tests (card renders in the hitl bucket; header says "needs human" not "merged"; dot is yellow not green); updated `constants.test.js`/`useTimeline.test.js` stage lists; corrected the `PIPELINE_LOOPS` invariant to worker-bearing stages. Full UI vitest suite green (1 unrelated pre-existing `data-connected` flake).

## Follow-ups
Deeper real-time fixes (WS snapshot push, reconnect resilience) are separate WS-RT PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)