### PR TITLE
test: harden MockWorld side-effect coverage

### DIFF
--- a/docs/arch/area_review_mockworld_2026-05-12.md
+++ b/docs/arch/area_review_mockworld_2026-05-12.md
@@ -146,6 +146,34 @@ The gap is that ADR-0047 being "Proposed" means the contract testing pattern doe
 
 ---
 
+## 2026-05-30 Addendum — Production-Port Dry-Run Standard
+
+A follow-up senior review of the RC budget loop found a recurring MockWorld
+scenario weakness: several loop scenarios replaced GitHub side effects with raw
+`AsyncMock` objects even though `FakeGitHub` already implements the relevant
+PRPort surface. That proved that a loop attempted to file or comment, but did
+not prove the fake adapter accepted the call or preserved the production
+title/body/labels.
+
+The new standard is:
+
+- Use `FakeGitHub` for issue/comment/label side effects by default.
+- Assert on stored fake state: issue title, body, labels, comments, PR metadata,
+  or CI scripts.
+- Mock only the external boundary that MockWorld cannot model yet, such as
+  `gh run download`, `git bisect`, or an LLM corpus subprocess.
+- Add focused unit tests for parser/enrichment branches hidden behind those
+  mocked external boundaries.
+
+The RC budget loop is the reference implementation: its MockWorld scenario now
+files through `FakeGitHub`, while unit tests cover job breakdown parsing, JUnit
+artifact parsing, and regression issue-body enrichment. The same conversion was
+applied to high-signal loop scenarios for flake tracking, skill prompt eval,
+fake coverage auditing, staging bisect no-op/escalation paths, and ADR
+touchpoint rollups.
+
+---
+
 ## Files Examined
 
 - `src/mockworld/__init__.py`, `seed.py`, `sandbox_main.py`

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -1,6 +1,24 @@
 # Testing
 
 
+## Assert MockWorld side effects through fake adapters
+
+MockWorld loop scenarios should use production-facing fake adapters for side
+effects whenever an adapter exists. For GitHub actions, let `MockWorld` wire
+`FakeGitHub` and assert on created issues, labels, comments, PRs, and CI scripts
+instead of replacing `create_issue`, `post_comment`, or `add_labels` with raw
+`AsyncMock` call counters. Mock only the unmodeled external boundary, such as a
+`gh` subprocess, `git bisect`, or an LLM corpus runner. Cover parser and
+formatter branches that sit behind those boundaries with focused unit tests.
+**Why:** Adapter-backed assertions catch title/body/label drift and fake-contract
+regressions that call-count-only mocks hide.
+
+
+```json:entry
+{"id":"01JRC_MOCKWORLD_FAKE_PORT_ASSERTIONS","title":"Assert MockWorld side effects through fake adapters","topic":"mockworld","source_type":"manual","source_issue":"hydraflow-wgac","source_repo":"T-rav/hydraflow","created_at":"2026-05-30T21:15:00+00:00","updated_at":"2026-05-30T21:15:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
+```
+
+
 ## Enforce function structure limits for testability
 
 Limit handler functions to 50 lines and registration wiring to 30 lines. Extract nested closures into instance methods to flatten nesting to ≤3 levels. Example: move callback validation from nested closures to instance methods. **Why:** Deep nesting and long functions are difficult to test in isolation and encourage tight coupling.

--- a/tests/sandbox_scenarios/README.md
+++ b/tests/sandbox_scenarios/README.md
@@ -35,6 +35,23 @@ architecture, and the spec at
    Builds the compose stack, boots, runs your assertions, tears down.
    Returns 0 on PASS, 1 on scenario failure, 2 on infra failure.
 
+## MockWorld fidelity rules
+
+MockWorld scenarios should exercise production ports through fake adapters
+whenever the adapter exists. For GitHub side effects, prefer the default
+`FakeGitHub` wired into `MockWorld` and assert on stored issues, labels,
+comments, PRs, and CI scripts. Do not replace `pr_manager.create_issue`,
+`post_comment`, or `add_labels` with a raw `AsyncMock` just to count calls; that
+misses the fake-adapter contract and can hide title/body/label drift.
+
+Patch only the true external boundary that MockWorld cannot yet model, such as
+`gh run download`, `git bisect`, or an LLM/subprocess corpus runner. When a loop
+has enrichment logic behind that boundary, add focused unit coverage for the
+parser/formatter as well as the scenario. The RC budget loop is the reference
+pattern: the MockWorld scenario asserts issue creation through `FakeGitHub`,
+while unit tests cover job-breakdown parsing, JUnit parsing, and issue-body
+enrichment without creating live GitHub issues.
+
 ## Existing scenarios
 
 | Name | What it tests |

--- a/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
+++ b/tests/scenarios/test_adr_touchpoint_auditor_scenario.py
@@ -55,10 +55,6 @@ class TestAdrTouchpointAuditor:
         from adr_index import ADRIndex  # noqa: PLC0415
 
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=2001)
-        fake_pr.update_issue_body = AsyncMock(return_value=None)
-        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -87,7 +83,6 @@ class TestAdrTouchpointAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             adr_touchpoint_state=state,
             adr_touchpoint_index=adr_index,
             adr_touchpoint_list_merged_prs=list_merged_prs,
@@ -96,23 +91,20 @@ class TestAdrTouchpointAuditor:
 
         await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        title, body, labels = fake_pr.create_issue.await_args.args
-        assert "ADR-0024" in title
-        assert "1 PR" in title
-        assert "#8473" in body
-        assert "hydraflow-find" in labels
-        assert "hydraflow-adr-drift" in labels
+        issues = await world.github.list_issues_by_label("hydraflow-adr-drift")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "ADR-0024" in issue.title
+        assert "1 PR" in issue.title
+        assert "#8473" in issue.body
+        assert "hydraflow-find" in issue.labels
+        assert "hydraflow-adr-drift" in issue.labels
 
     async def test_three_prs_drifting_same_adr_one_rollup(self, tmp_path) -> None:
         """3 PRs drifting the same ADR file ONE rollup with all PRs in body."""
         from adr_index import ADRIndex  # noqa: PLC0415
 
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=2010)
-        fake_pr.update_issue_body = AsyncMock(return_value=None)
-        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -149,7 +141,6 @@ class TestAdrTouchpointAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             adr_touchpoint_state=state,
             adr_touchpoint_index=adr_index,
             adr_touchpoint_list_merged_prs=list_merged_prs,
@@ -158,8 +149,9 @@ class TestAdrTouchpointAuditor:
 
         await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        body = fake_pr.create_issue.await_args.args[1]
+        issues = await world.github.list_issues_by_label("hydraflow-adr-drift")
+        assert len(issues) == 1
+        body = world.github.issue(issues[0]["number"]).body
         for n in (8501, 8502, 8503):
             assert f"#{n}" in body
 
@@ -168,10 +160,6 @@ class TestAdrTouchpointAuditor:
         from adr_index import ADRIndex  # noqa: PLC0415
 
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=2002)
-        fake_pr.update_issue_body = AsyncMock(return_value=None)
-        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -201,7 +189,6 @@ class TestAdrTouchpointAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             adr_touchpoint_state=state,
             adr_touchpoint_index=adr_index,
             adr_touchpoint_list_merged_prs=list_merged_prs,
@@ -210,7 +197,7 @@ class TestAdrTouchpointAuditor:
 
         await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
 
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("hydraflow-adr-drift") == []
 
     async def test_third_strike_files_hitl_escalation(self, tmp_path) -> None:
         """Third consecutive drift tick against an open rollup triggers HITL escalation.
@@ -233,11 +220,6 @@ class TestAdrTouchpointAuditor:
         from config import HydraFlowConfig  # noqa: PLC0415
 
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        # The escalation issue gets number 3001.
-        fake_pr.create_issue = AsyncMock(return_value=3001)
-        fake_pr.update_issue_body = AsyncMock(return_value=None)
-        fake_pr.close_issue = AsyncMock(return_value=None)
 
         repo = tmp_path / "repo"
         adr_dir = repo / "docs" / "adr"
@@ -246,6 +228,12 @@ class TestAdrTouchpointAuditor:
         adr_index = ADRIndex(adr_dir)
 
         # Open rollup from two prior ticks.
+        world.github.add_issue(
+            2999,
+            "ADR drift rollup: ADR-0024",
+            "prior rollup",
+            labels=["hydraflow-adr-drift"],
+        )
         state = MagicMock()
         state.get_adr_audit_cursor.return_value = "2026-05-01T00:00:00Z"
         state.get_adr_rollup.return_value = {
@@ -267,7 +255,6 @@ class TestAdrTouchpointAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             adr_touchpoint_state=state,
             adr_touchpoint_index=adr_index,
             adr_touchpoint_list_merged_prs=list_merged_prs,
@@ -277,20 +264,21 @@ class TestAdrTouchpointAuditor:
         await world.run_with_loops(["adr_touchpoint_auditor"], cycles=1)
 
         # Exactly one issue filed — the HITL escalation (no new rollup).
-        assert fake_pr.create_issue.await_count == 1
-        title, body, labels = fake_pr.create_issue.await_args.args
+        issues = await world.github.list_issues_by_label("hydraflow-adr-drift-stuck")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
 
         # Title identifies the rollup key and attempt count.
-        assert "HITL" in title
-        assert "ADR-0024" in title
-        assert "3" in title
+        assert "HITL" in issue.title
+        assert "ADR-0024" in issue.title
+        assert "3" in issue.title
 
         # Body mentions the dedup key so a human can correlate with the rollup.
-        assert "ADR-0024" in body
+        assert "ADR-0024" in issue.body
 
         # Required labels: hitl-escalation + adr-drift-stuck.
-        assert "hydraflow-hitl-escalation" in labels
-        assert "hydraflow-adr-drift-stuck" in labels
+        assert "hydraflow-hitl-escalation" in issue.labels
+        assert "hydraflow-adr-drift-stuck" in issue.labels
 
         # ADR-0050 preflight reachability: hydraflow-adr-drift-stuck must NOT
         # be in the auto-agent deny list, so AutoAgentPreflightLoop can pick

--- a/tests/scenarios/test_branch_protection_auditor_scenario.py
+++ b/tests/scenarios/test_branch_protection_auditor_scenario.py
@@ -21,8 +21,6 @@ pytestmark = pytest.mark.scenario_loops
 class TestBranchProtectionAuditor:
     async def test_drift_files_one_issue(self, tmp_path) -> None:
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=5001)
         auditor = AsyncMock(
             return_value=AuditReport(
                 repo="o/r",
@@ -30,26 +28,29 @@ class TestBranchProtectionAuditor:
             )
         )
 
-        _seed_ports(world, pr_manager=fake_pr, branch_protection_audit=auditor)
+        _seed_ports(world, branch_protection_audit=auditor)
 
         await world.run_with_loops(["branch_protection_auditor"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        title, body = fake_pr.create_issue.await_args.args[:2]
-        labels = fake_pr.create_issue.await_args.kwargs.get("labels", [])
-        assert "branch-protection" in title
-        assert "make gen-gates" in body
-        assert "hydraflow-find" in labels
-        assert "hydraflow-branch-protection-drift" in labels
+        issues = await world.github.list_issues_by_label(
+            "hydraflow-branch-protection-drift"
+        )
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "branch-protection" in issue.title
+        assert "make gen-gates" in issue.body
+        assert "hydraflow-find" in issue.labels
+        assert "hydraflow-branch-protection-drift" in issue.labels
 
     async def test_clean_audit_files_no_issue(self, tmp_path) -> None:
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=5002)
         auditor = AsyncMock(return_value=AuditReport(repo="o/r", drifts=[]))
 
-        _seed_ports(world, pr_manager=fake_pr, branch_protection_audit=auditor)
+        _seed_ports(world, branch_protection_audit=auditor)
 
         await world.run_with_loops(["branch_protection_auditor"], cycles=1)
 
-        fake_pr.create_issue.assert_not_awaited()
+        assert (
+            await world.github.list_issues_by_label("hydraflow-branch-protection-drift")
+            == []
+        )

--- a/tests/scenarios/test_fake_coverage_auditor_scenario.py
+++ b/tests/scenarios/test_fake_coverage_auditor_scenario.py
@@ -45,8 +45,6 @@ class TestFakeCoverageAuditor:
     async def test_uncassetted_surface_files_adapter_gap(self, tmp_path) -> None:
         """Public fake method w/o cassette → one adapter-surface gap filed."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=501)
 
         # Seed under config.repo_root (= tmp_path / "repo" per make_bg_loop_deps).
         repo = tmp_path / "repo"
@@ -68,7 +66,6 @@ class TestFakeCoverageAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             fake_coverage_reconcile_closed=AsyncMock(return_value=None),
             # Helpers (none present in this fake) — trivially True to short-circuit.
             fake_coverage_grep=AsyncMock(return_value=True),
@@ -76,23 +73,21 @@ class TestFakeCoverageAuditor:
 
         await world.run_with_loops(["fake_coverage_auditor"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        args = fake_pr.create_issue.await_args.args
-        title, body, labels = args[0], args[1], args[2]
+        issues = await world.github.list_issues_by_label("hydraflow-adapter-surface")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
         # #8986 — rollup shape: title names the (fake, kind) pair; the
         # uncovered method names live in the body.
-        assert "FakeGitHub" in title
-        assert "adapter surface" in title
-        assert "close_issue" in body
-        assert "hydraflow-adapter-surface" in labels
-        assert "hydraflow-fake-coverage-gap" in labels
-        assert "hydraflow-find" in labels
+        assert "FakeGitHub" in issue.title
+        assert "adapter surface" in issue.title
+        assert "close_issue" in issue.body
+        assert "hydraflow-adapter-surface" in issue.labels
+        assert "hydraflow-fake-coverage-gap" in issue.labels
+        assert "hydraflow-find" in issue.labels
 
     async def test_unused_test_helper_files_helper_gap(self, tmp_path) -> None:
         """Fake ``script_*`` helper with no scenario caller → one test-helper gap."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=502)
 
         repo = tmp_path / "repo"
         # Seed at the new canonical Fake location (post-Task-1.1 of the
@@ -110,21 +105,20 @@ class TestFakeCoverageAuditor:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             fake_coverage_reconcile_closed=AsyncMock(return_value=None),
             fake_coverage_grep=AsyncMock(return_value=False),  # helper uncalled
         )
 
         await world.run_with_loops(["fake_coverage_auditor"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        args = fake_pr.create_issue.await_args.args
-        title, body, labels = args[0], args[1], args[2]
+        issues = await world.github.list_issues_by_label("hydraflow-test-helper")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
         # #8986 — rollup shape: title names the (fake, kind) pair; the
         # uncovered helper names live in the body.
-        assert "FakeDocker" in title
-        assert "test helpers" in title
-        assert "script_run" in body
-        assert "hydraflow-test-helper" in labels
-        assert "hydraflow-fake-coverage-gap" in labels
-        assert "hydraflow-find" in labels
+        assert "FakeDocker" in issue.title
+        assert "test helpers" in issue.title
+        assert "script_run" in issue.body
+        assert "hydraflow-test-helper" in issue.labels
+        assert "hydraflow-fake-coverage-gap" in issue.labels
+        assert "hydraflow-find" in issue.labels

--- a/tests/scenarios/test_flake_tracker_scenario.py
+++ b/tests/scenarios/test_flake_tracker_scenario.py
@@ -35,8 +35,6 @@ class TestFlakeTracker:
     async def test_files_issue_when_threshold_crossed(self, tmp_path) -> None:
         """20 RC runs with one test failing on 4 → one flaky-test issue filed."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=101)
 
         # 20 runs; test_flaky fails on runs 0, 3, 7, 14 → flake count = 4.
         def make_run_results(i: int) -> dict[str, str]:
@@ -62,7 +60,6 @@ class TestFlakeTracker:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             flake_fetch_runs=fake_fetch,
             flake_download_junit=fake_download,
             flake_reconcile_closed=fake_reconcile,
@@ -70,13 +67,13 @@ class TestFlakeTracker:
 
         await world.run_with_loops(["flake_tracker"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        args = fake_pr.create_issue.await_args.args
-        title, _body, labels = args[0], args[1], args[2]
-        assert "test_flaky" in title
-        assert "flake rate: 4/20" in title
-        assert "flaky-test" in labels
-        assert "hydraflow-find" in labels
+        issues = await world.github.list_issues_by_label("flaky-test")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "test_flaky" in issue.title
+        assert "flake rate: 4/20" in issue.title
+        assert "flaky-test" in issue.labels
+        assert "hydraflow-find" in issue.labels
         fake_fetch.assert_awaited_once()
         # _download_junit called once per run
         assert fake_download.await_count == 20
@@ -85,8 +82,6 @@ class TestFlakeTracker:
     async def test_no_file_below_threshold(self, tmp_path) -> None:
         """20 RC runs with 2 failures (< threshold=3) → no issue filed."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         # Only 2 fails — below default threshold 3.
         def make_run_results(i: int) -> dict[str, str]:
@@ -101,7 +96,6 @@ class TestFlakeTracker:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             flake_fetch_runs=AsyncMock(return_value=fake_runs),
             flake_download_junit=AsyncMock(
                 side_effect=lambda r: make_run_results(r["databaseId"])
@@ -110,4 +104,4 @@ class TestFlakeTracker:
         )
 
         await world.run_with_loops(["flake_tracker"], cycles=1)
-        assert fake_pr.create_issue.await_count == 0
+        assert await world.github.list_issues_by_label("flaky-test") == []

--- a/tests/scenarios/test_principles_audit_scenario.py
+++ b/tests/scenarios/test_principles_audit_scenario.py
@@ -87,9 +87,6 @@ class TestPrinciplesAuditScenario:
 
         world = MockWorld(tmp_path)
 
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=101)
-
         # Current audit: one P1 FAIL + one passing hydraflow-self check.
         failing_report = {
             "findings": [
@@ -111,7 +108,6 @@ class TestPrinciplesAuditScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             principles_audit_state=state,
             principles_audit_run_audit=run_audit,
             principles_audit_refresh_checkout=refresh_checkout,
@@ -126,26 +122,15 @@ class TestPrinciplesAuditScenario:
         assert state._store.get("acme/widget") == "blocked"
 
         # The loop filed at least the onboarding issue. Find it by label.
-        assert fake_pr.create_issue.await_count >= 1
-        onboarding_calls = [
-            call
-            for call in fake_pr.create_issue.await_args_list
-            if "onboarding-blocked" in (call.kwargs.get("labels") or [])
-        ]
-        assert len(onboarding_calls) == 1, (
-            "expected exactly one onboarding-blocked issue, got "
-            f"{[c.kwargs for c in fake_pr.create_issue.await_args_list]}"
-        )
-        labels = onboarding_calls[0].kwargs["labels"]
+        issues = await world.github.list_issues_by_label("onboarding-blocked")
+        assert len(issues) == 1
+        labels = world.github.issue(issues[0]["number"]).labels
         assert "hydraflow-find" in labels
         assert "onboarding-blocked" in labels
 
     async def test_drift_regression_files_find_issue(self, tmp_path) -> None:
         """Hydraflow-self was green; current audit fails one check → drift issue filed."""
         world = MockWorld(tmp_path)
-
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=202)
 
         # State: hydraflow-self was all-green last tick.
         state = MagicMock()
@@ -170,7 +155,6 @@ class TestPrinciplesAuditScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             principles_audit_state=state,
             principles_audit_run_audit=run_audit,
             # No managed_repos → only hydraflow-self audits.
@@ -186,14 +170,14 @@ class TestPrinciplesAuditScenario:
         assert stats["principles_audit"]["escalations_filed"] == 0, stats
 
         # Exactly one issue filed with the drift label set.
-        assert fake_pr.create_issue.await_count == 1
-        call = fake_pr.create_issue.await_args
-        title, _body, labels = call.args[:3]
-        assert "P1.1" in title
-        assert "hydraflow-self" in title
-        assert "hydraflow-find" in labels
-        assert "principles-drift" in labels
-        assert "check-P1.1" in labels
+        issues = await world.github.list_issues_by_label("principles-drift")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "P1.1" in issue.title
+        assert "hydraflow-self" in issue.title
+        assert "hydraflow-find" in issue.labels
+        assert "principles-drift" in issue.labels
+        assert "check-P1.1" in issue.labels
 
     async def test_reconcile_closed_escalations_via_pr_port(self, tmp_path) -> None:
         """Closing a principles-stuck issue clears the attempt counter via PRPort.
@@ -204,14 +188,14 @@ class TestPrinciplesAuditScenario:
         """
         world = MockWorld(tmp_path)
 
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
         # One closed principles-stuck issue whose title encodes (slug, check_id).
-        fake_pr.list_closed_issues_by_label = AsyncMock(
-            return_value=[
-                {"title": "Principles drift stuck: P3.2 in acme/widget"},
-            ]
+        world.github.add_issue(
+            77,
+            "Principles drift stuck: P3.2 in acme/widget",
+            "",
+            labels=["principles-stuck"],
         )
+        await world.github.close_issue(77)
 
         state = _stateful_onboarding_mock()
         # Simulate that the escalation counter was previously incremented.
@@ -226,7 +210,6 @@ class TestPrinciplesAuditScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             principles_audit_state=state,
             principles_audit_run_audit=run_audit,
             principles_audit_managed_repos=[],
@@ -234,9 +217,5 @@ class TestPrinciplesAuditScenario:
 
         await world.run_with_loops(["principles_audit"], cycles=1)
 
-        # Port was called with the correct label — no subprocess spawned.
-        fake_pr.list_closed_issues_by_label.assert_awaited_once_with(
-            "principles-stuck", limit=100
-        )
         # Counter reset for the parsed (slug, check_id) pair.
         state.reset_drift_attempts.assert_called_once_with("acme/widget", "P3.2")

--- a/tests/scenarios/test_rc_budget_scenario.py
+++ b/tests/scenarios/test_rc_budget_scenario.py
@@ -64,14 +64,11 @@ class TestRCBudgetScenario:
     async def test_files_issue_on_spike(self, tmp_path) -> None:
         """Current run at 900s vs ~300s history → spike signal fires."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=4242)
 
         runs = _make_runs(current_duration_s=900)
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             rc_budget_fetch_runs=AsyncMock(return_value=runs),
             rc_budget_fetch_jobs=AsyncMock(return_value=[]),
             rc_budget_fetch_junit=AsyncMock(return_value=[]),
@@ -82,24 +79,21 @@ class TestRCBudgetScenario:
 
         assert stats["rc_budget"]["status"] == "ok", stats
         assert stats["rc_budget"]["filed"] >= 1, stats
-        assert fake_pr.create_issue.await_count >= 1
-        title = fake_pr.create_issue.await_args.args[0]
-        labels = fake_pr.create_issue.await_args.args[2]
-        assert "RC gate duration regression" in title
-        assert "hydraflow-find" in labels
-        assert "rc-duration-regression" in labels
+        issues = await world.github.list_issues_by_label("rc-duration-regression")
+        assert len(issues) >= 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "RC gate duration regression" in issue.title
+        assert "hydraflow-find" in issue.labels
+        assert "rc-duration-regression" in issue.labels
 
     async def test_no_file_when_within_budget(self, tmp_path) -> None:
         """Current run matches history baseline → no signal, no file."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         runs = _make_runs(current_duration_s=300)
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             rc_budget_fetch_runs=AsyncMock(return_value=runs),
             rc_budget_fetch_jobs=AsyncMock(return_value=[]),
             rc_budget_fetch_junit=AsyncMock(return_value=[]),
@@ -111,4 +105,4 @@ class TestRCBudgetScenario:
         assert stats["rc_budget"]["status"] == "ok", stats
         assert stats["rc_budget"]["filed"] == 0, stats
         assert stats["rc_budget"]["escalated"] == 0, stats
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("rc-duration-regression") == []

--- a/tests/scenarios/test_skill_prompt_eval_scenario.py
+++ b/tests/scenarios/test_skill_prompt_eval_scenario.py
@@ -35,8 +35,6 @@ class TestSkillPromptEval:
     async def test_drift_regression_files_issue(self, tmp_path) -> None:
         """One hand-crafted case regressed PASS→FAIL → one drift issue filed."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=301)
 
         # Seed a state mock whose last-green snapshot pre-declares both
         # cases as PASS; the corpus below flips case_shrink_001 to FAIL.
@@ -67,7 +65,6 @@ class TestSkillPromptEval:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             skill_prompt_state=fake_state,
             skill_corpus_runner=AsyncMock(return_value=corpus_result),
             skill_reconcile_closed=AsyncMock(return_value=None),
@@ -75,19 +72,17 @@ class TestSkillPromptEval:
 
         await world.run_with_loops(["skill_prompt_eval"], cycles=1)
 
-        assert fake_pr.create_issue.await_count == 1
-        args = fake_pr.create_issue.await_args.args
-        title, _body, labels = args[0], args[1], args[2]
-        assert "diff_sanity" in title
-        assert "case_shrink_001" in title
-        assert "skill-prompt-drift" in labels
-        assert "hydraflow-find" in labels
+        issues = await world.github.list_issues_by_label("skill-prompt-drift")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert "diff_sanity" in issue.title
+        assert "case_shrink_001" in issue.title
+        assert "skill-prompt-drift" in issue.labels
+        assert "hydraflow-find" in issue.labels
 
     async def test_weak_case_sampling_files_issue(self, tmp_path) -> None:
         """10 learning-loop cases all PASS — sampled 10% surface a weak-case issue."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=302)
 
         fake_state = MagicMock()
         fake_state.get_skill_prompt_last_green.return_value = {}
@@ -107,7 +102,6 @@ class TestSkillPromptEval:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             skill_prompt_state=fake_state,
             skill_corpus_runner=AsyncMock(return_value=corpus_result),
             skill_reconcile_closed=AsyncMock(return_value=None),
@@ -115,9 +109,5 @@ class TestSkillPromptEval:
 
         await world.run_with_loops(["skill_prompt_eval"], cycles=1)
 
-        weak_calls = [
-            c
-            for c in fake_pr.create_issue.await_args_list
-            if len(c.args) > 2 and "corpus-case-weak" in c.args[2]
-        ]
-        assert len(weak_calls) >= 1
+        weak_issues = await world.github.list_issues_by_label("corpus-case-weak")
+        assert len(weak_issues) >= 1

--- a/tests/scenarios/test_staging_bisect_scenario.py
+++ b/tests/scenarios/test_staging_bisect_scenario.py
@@ -34,8 +34,6 @@ class TestStagingBisectScenario:
     async def test_no_red_sha(self, tmp_path) -> None:
         """No red SHA → no-op, no PR call."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = ""
@@ -43,20 +41,17 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
         )
 
         stats = await world.run_with_loops(["staging_bisect"], cycles=1)
 
         assert stats["staging_bisect"]["status"] == "no_red", stats
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("hitl-escalation") == []
 
     async def test_flake_dismissed(self, tmp_path) -> None:
         """Red SHA seeded, probe passes on retry → flake-dismissed, no file."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = "redshaflake"
@@ -68,7 +63,6 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_run_probe=probe,
         )
@@ -79,13 +73,11 @@ class TestStagingBisectScenario:
         assert stats["staging_bisect"]["sha"] == "redshaflake"
         probe.assert_awaited_once_with("redshaflake")
         state.increment_flake_reruns_total.assert_called_once()
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("hitl-escalation") == []
 
     async def test_already_processed(self, tmp_path) -> None:
         """Red SHA already in dedup → skip without running the probe."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = "redshadup1234"
@@ -97,7 +89,6 @@ class TestStagingBisectScenario:
         probe_prime = AsyncMock(return_value=(True, ""))
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_run_probe=probe_prime,
         )
@@ -112,14 +103,12 @@ class TestStagingBisectScenario:
 
         assert stats["staging_bisect"]["status"] == "already_processed", stats
         probe_after.assert_not_awaited()
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("hitl-escalation") == []
 
     async def test_guardrail_escalation(self, tmp_path) -> None:
         """Red SHA seeded, bisect pipeline returns guardrail_escalated → no
         revert PR, hitl-escalation issue filed with rc-red-attribution-unsafe."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=777)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = "redguardr4il"
@@ -134,7 +123,6 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_run_probe=probe,
             staging_bisect_run_pipeline=pipeline,
@@ -149,8 +137,6 @@ class TestStagingBisectScenario:
         """Red SHA, bisect pipeline returns reverted → revert PR recorded
         and the pipeline short-circuits the flake + already-processed paths."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = "redrevert01"
@@ -168,7 +154,6 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_run_probe=probe,
             staging_bisect_run_pipeline=pipeline,
@@ -183,8 +168,6 @@ class TestStagingBisectScenario:
     async def test_no_green_anchor(self, tmp_path) -> None:
         """Red SHA seeded but no last_green_rc_sha → pipeline refuses to bisect."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         state = MagicMock()
         state.get_last_rc_red_sha.return_value = "redorphan1"
@@ -197,7 +180,6 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_run_probe=probe,
             staging_bisect_run_pipeline=pipeline,
@@ -207,7 +189,7 @@ class TestStagingBisectScenario:
 
         assert stats["staging_bisect"]["status"] == "no_green_anchor", stats
         pipeline.assert_awaited_once()
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("hitl-escalation") == []
 
     async def test_watchdog_escalates_after_stuck_bisect(self, tmp_path) -> None:
         """Watchdog fires with 'still_red' when a new red arrives in a later cycle
@@ -220,8 +202,6 @@ class TestStagingBisectScenario:
         hitl-escalation issue tagged 'rc-red-post-revert-red'.
         """
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=911)
 
         state = MagicMock()
         # Simulate: auto-revert was filed during cycle 2 for red_A.
@@ -233,7 +213,6 @@ class TestStagingBisectScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             staging_bisect_state=state,
             staging_bisect_pending_watchdog={
                 "red_sha_at_revert": "red_A_original",
@@ -245,8 +224,9 @@ class TestStagingBisectScenario:
         stats = await world.run_with_loops(["staging_bisect"], cycles=1)
 
         assert stats["staging_bisect"]["status"] == "watchdog_still_red", stats
-        assert stats["staging_bisect"]["escalation_issue"] == 911
-        fake_pr.create_issue.assert_awaited_once()
-        labels = fake_pr.create_issue.await_args.args[2]
-        assert "hitl-escalation" in labels
-        assert "rc-red-post-revert-red" in labels
+        issues = await world.github.list_issues_by_label("rc-red-post-revert-red")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
+        assert stats["staging_bisect"]["escalation_issue"] == issue.number
+        assert "hitl-escalation" in issue.labels
+        assert "rc-red-post-revert-red" in issue.labels

--- a/tests/scenarios/test_wiki_rot_detector_scenario.py
+++ b/tests/scenarios/test_wiki_rot_detector_scenario.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio as _asyncio
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -100,13 +100,8 @@ class TestWikiRotDetectorScenario:
         fake_wiki_store.list_repos.return_value = [_SLUG]
         fake_wiki_store.repo_dir.return_value = wiki_dir
 
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=42)
-
         _seed_ports(
             world,
-            github=fake_pr,
-            pr_manager=fake_pr,
             wiki_rot_state=fake_state,
             wiki_rot_dedup=fake_dedup,
             wiki_store=fake_wiki_store,
@@ -125,17 +120,16 @@ class TestWikiRotDetectorScenario:
         assert stats["wiki_rot_detector"]["issues_filed"] >= 1, stats
         assert stats["wiki_rot_detector"]["escalations"] == 0, stats
 
-        fake_pr.create_issue.assert_awaited()
-        title = fake_pr.create_issue.await_args.args[0]
-        body = fake_pr.create_issue.await_args.args[1]
-        labels = fake_pr.create_issue.await_args.args[2]
+        issues = await world.github.list_issues_by_label("wiki-rot")
+        assert len(issues) == 1
+        issue = world.github.issue(issues[0]["number"])
 
-        assert "src/foo.py:bar" in title
-        assert "hydraflow-find" in labels
-        assert "wiki-rot" in labels
+        assert "src/foo.py:bar" in issue.title
+        assert "hydraflow-find" in issue.labels
+        assert "wiki-rot" in issue.labels
         # Fuzzy suggestion surfaces — ``bar`` ↔ ``other`` via difflib 0.6 cutoff
         # OR the loop's first-symbol fallback when no close match clears.
-        assert "Did you mean" in body
+        assert "Did you mean" in issue.body
 
     async def test_no_fire_when_cite_resolves(
         self,
@@ -163,13 +157,8 @@ class TestWikiRotDetectorScenario:
         fake_wiki_store.list_repos.return_value = [_SLUG]
         fake_wiki_store.repo_dir.return_value = wiki_dir
 
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
-
         _seed_ports(
             world,
-            github=fake_pr,
-            pr_manager=fake_pr,
             wiki_rot_state=fake_state,
             wiki_rot_dedup=fake_dedup,
             wiki_store=fake_wiki_store,
@@ -184,4 +173,4 @@ class TestWikiRotDetectorScenario:
 
         assert stats["wiki_rot_detector"]["status"] == "noop", stats
         assert stats["wiki_rot_detector"]["issues_filed"] == 0, stats
-        fake_pr.create_issue.assert_not_awaited()
+        assert await world.github.list_issues_by_label("wiki-rot") == []

--- a/tests/test_rc_budget_loop.py
+++ b/tests/test_rc_budget_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -234,6 +235,109 @@ async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) 
     assert "rc_budget:median" not in remaining
     assert "rc_budget:spike" in remaining
     state.clear_rc_budget_attempts.assert_called_once_with("median")
+
+
+async def test_fetch_job_breakdown_sorts_and_caps_slowest_jobs(
+    loop_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _loop(loop_env)
+    jobs = [
+        {
+            "name": f"job-{idx}",
+            "startedAt": "2026-04-20T00:00:00Z",
+            "completedAt": f"2026-04-20T00:{idx:02d}:00Z",
+        }
+        for idx in range(1, 13)
+    ]
+
+    class _Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return (json.dumps({"jobs": jobs}).encode(), b"")
+
+    async def fake_subproc(*args, **kwargs):
+        assert args[:4] == ("gh", "run", "view", "123")
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+
+    result = await loop._fetch_job_breakdown({"databaseId": 123})
+
+    assert [job["name"] for job in result[:3]] == ["job-12", "job-11", "job-10"]
+    assert len(result) == 10
+    assert result[0]["duration_s"] == 720
+
+
+async def test_fetch_junit_tests_parses_and_caps_slowest_tests(
+    loop_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    loop = _loop(loop_env)
+
+    class _Proc:
+        returncode = 0
+
+        async def communicate(self):
+            return (b"", b"")
+
+    async def fake_subproc(*args, **kwargs):
+        assert args[:4] == ("gh", "run", "download", "123")
+        out_dir = Path(args[args.index("--dir") + 1])
+        out_dir.mkdir(parents=True, exist_ok=True)
+        cases = "\n".join(
+            f'<testcase classname="pkg.TestSuite" name="test_{idx}" time="{idx / 10}" />'
+            for idx in range(1, 13)
+        )
+        (out_dir / "junit.xml").write_text(f"<testsuite>{cases}</testsuite>")
+        return _Proc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_subproc)
+
+    result = await loop._fetch_junit_tests({"databaseId": 123})
+
+    assert result[:3] == [
+        ("pkg.TestSuite.test_12", 1.2),
+        ("pkg.TestSuite.test_11", 1.1),
+        ("pkg.TestSuite.test_10", 1.0),
+    ]
+    assert len(result) == 10
+
+
+async def test_regression_issue_body_includes_enrichment(loop_env) -> None:
+    loop = _loop(loop_env)
+    current = {
+        "databaseId": 99,
+        "duration_s": 900,
+        "createdAt": "2026-04-20T00:00:00Z",
+        "conclusion": "success",
+        "url": "https://example/run/99",
+    }
+    previous_5 = [
+        {
+            "databaseId": 90,
+            "duration_s": 300,
+            "createdAt": "2026-04-19T00:00:00Z",
+        }
+    ]
+
+    await loop._file_regression_issue(
+        kind="spike",
+        current=current,
+        baseline_s=300,
+        baselines={"rolling_median": 300, "recent_max": 300},
+        previous_5=previous_5,
+        jobs=[{"name": "scenario-loop", "duration_s": 420}],
+        junit_tests=[("tests.scenarios.test_rc_budget.test_spike", 12.345)],
+    )
+
+    _, _, pr, _ = loop_env
+    title, body, labels = pr.create_issue.await_args.args
+    assert title == "RC gate duration regression: 900s vs 300s (spike)"
+    assert labels == ["hydraflow-find", "rc-duration-regression"]
+    assert "Run [99](https://example/run/99) took **900s**" in body
+    assert "- `scenario-loop` — 420s" in body
+    assert "- `tests.scenarios.test_rc_budget.test_spike` — 12.35s" in body
+    assert "- run 90 (2026-04-19T00:00:00Z) — 300s" in body
 
 
 async def test_kill_switch_short_circuits_run(loop_env) -> None:


### PR DESCRIPTION
## Summary
- document MockWorld fake-adapter side-effect standard
- convert high-signal loop scenarios to assert through FakeGitHub stored state instead of raw create_issue mocks
- add RC budget job/JUnit enrichment parser coverage

## Verification
- uv run ruff check changed test files
- uv run pytest tests/scenarios/ -m scenario_loops -q
- uv run pytest tests/scenarios/test_sandbox_parity.py -q
- pre-push make quality-lite passed

Bead: hydraflow-wgac