### PR TITLE
docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6)

### DIFF
--- a/docs/adr/0045-trust-architecture-hardening.md
+++ b/docs/adr/0045-trust-architecture-hardening.md
@@ -1,9 +1,11 @@
 # ADR-0045: Trust Architecture Hardening — Lights-Off Trust Fleet
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-23
+- **Accepted:** 2026-05-30
 - **Supersedes:** none
 - **Superseded by:** none
+- **Enforced by:** tests/test_trust_fleet_sanity_loop.py, tests/test_loop_wiring_completeness.py, tests/test_trust_fleet_anomaly_detectors.py
 - **Spec:** [docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md](../superpowers/specs/2026-04-22-trust-architecture-hardening-design.md)
 - **Implementation plans:** 11 plans under [docs/superpowers/plans/2026-04-22-*.md](../superpowers/plans/) — one per trust loop and subsystem.
 
@@ -98,6 +100,15 @@ The following files carry this ADR's decisions and must be kept in sync with any
 
 ## Update Log
 
+- **2026-05-30: Promoted Proposed → Accepted.** The trust fleet shipped and is
+  running fleet-wide: all nine watched trust loops (`CorpusLearningLoop`,
+  `ContractRefreshLoop`, `StagingBisectLoop`, `PrinciplesAuditLoop`,
+  `FlakeTrackerLoop`, `SkillPromptEvalLoop`, `FakeCoverageAuditorLoop`,
+  `RCBudgetLoop`, `WikiRotDetectorLoop`) plus `TrustFleetSanityLoop` (meta-observer)
+  and `HealthMonitorLoop` (dead-man switch) appear in the generated loop registry
+  and operate in production. The `Proposed` label was the only drift; the decisions
+  it records (nine watched loops, the meta-observability spine, the kill-switch
+  convention per [ADR-0049](0049-trust-loop-kill-switch-convention.md)) are live.
 - **2026-05-19 (#8986):** `FakeCoverageAuditorLoop` issue shape changed from
   one-issue-per-`(fake, method)` to a **rollup** issue per `(fake, gap_kind)`
   with the uncovered-method list in the body. Subsequent ticks update the

--- a/docs/adr/0049-trust-loop-kill-switch-convention.md
+++ b/docs/adr/0049-trust-loop-kill-switch-convention.md
@@ -1,11 +1,12 @@
 # ADR-0049: Trust-loop kill-switch convention (`enabled_cb` only, no config-only)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-04-23
+- **Accepted:** 2026-05-30
 - **Supersedes:** none
 - **Superseded by:** none
 - **Related:** [ADR-0045](0045-trust-architecture-hardening.md) §12.2 (spec reference); [ADR-0048](0048-auto-revert-on-rc-red.md) (relies on live kill for StagingBisectLoop).
-- **Enforced by:** Convention-check in code review; `_do_work` body in every `BaseBackgroundLoop` subclass must call `self._enabled_cb(self._worker_name)` at the top; dark-factory review dispatched on every large background-loop PR.
+- **Enforced by:** tests/test_loop_kill_switch_completeness.py, tests/regressions/test_canonical_killswitch.py
 
 ## Context
 
@@ -52,9 +53,11 @@ The `enabled_cb` is wired by `LoopDeps` to the System-tab worker-enable state (`
 
 ## Verifying compliance
 
-Run `grep -l "async def _do_work" src/*_loop.py | xargs grep -L "self._enabled_cb"` in a review — any loop listed in the output is violating this ADR. (This is a simple grep, not a hard CI gate, because we don't want to dictate the exact line of the check — only that it's present.)
+`tests/test_loop_kill_switch_completeness.py` is the hard CI gate: it AST-discovers every `BaseBackgroundLoop` subclass in `src/*_loop.py` and fails closed if any `_do_work` omits the `self._enabled_cb(self._worker_name)` gate, with an empty grandfather list so the gap cannot silently reopen. For a quick manual spot-check, `grep -l "async def _do_work" src/*_loop.py | xargs grep -L "self._enabled_cb"` lists any violators.
 
-The dark-factory review agent dispatched for any PR >500 lines touching `src/*_loop.py` should flag violations as blockers.
+(The original convention deliberately stopped at a code-review grep "not a hard CI gate" so as not to dictate the exact line of the check. The kill-switch-integrity work — see Update Log — replaced that stance with the completeness ratchet above, which asserts presence of the gate without dictating its exact placement.)
+
+The dark-factory review agent dispatched for any PR >500 lines touching `src/*_loop.py` should also flag violations as blockers.
 
 ## When to supersede this ADR
 
@@ -67,3 +70,7 @@ The dark-factory review agent dispatched for any PR >500 lines touching `src/*_l
 - `src/bg_worker_manager.py::BGWorkerManager.is_enabled` — the backing implementation.
 - `src/ui/src/constants.js::EDITABLE_INTERVAL_WORKERS` — the list of loops the System tab exposes for toggling.
 - `tests/test_*_loop.py` — test fixtures that stub `enabled_cb` to exercise the disabled branch.
+
+## Update Log
+
+- **2026-05-30: Promoted Proposed → Accepted.** The convention shipped fleet-wide and is now hard-enforced. The kill-switch-integrity work fixed the `DiagramLoop` `worker_name` hyphen/underscore mismatch, added the in-body `_enabled_cb` gate to the four env-only loops (`cost_budget_watcher`, `diagram`, `entry_evidence`, `pricing_refresh`), and landed `tests/test_loop_kill_switch_completeness.py` — an AST-discovery ratchet with an empty grandfather list that fails CI if any `BaseBackgroundLoop` subclass omits the gate. This supersedes the original "simple grep in code review, not a hard CI gate" enforcement stance recorded above under *Verifying compliance*: the gate is now a CI hard-stop, so the decision is no longer aspirational.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,11 +76,11 @@ ADR and that named test files actually exist.
 | [0042](0042-two-tier-branch-release-promotion.md) | Two-tier branch model with automated release-candidate promotion | Accepted |
 | [0043](0043-prompt-structure-standard.md) | Prompt structure standard (XML tags, 8-criterion rubric, mechanical scoring) | Proposed |
 | [0044](0044-hydraflow-principles.md) | HydraFlow Principles — the audit contract for new and existing repos | Proposed |
-| [0045](0045-trust-architecture-hardening.md) | Trust Architecture Hardening — Lights-Off Trust Fleet (10 loops + 2 non-loop subsystems) | Proposed |
+| [0045](0045-trust-architecture-hardening.md) | Trust Architecture Hardening — Lights-Off Trust Fleet (10 loops + 2 non-loop subsystems) | Accepted |
 | [0046](0046-meta-observability-bounded-recursion.md) | Meta-observability with bounded recursion — one layer of meta, no more | Proposed |
 | [0047](0047-fake-adapter-contract-testing-cassettes.md) | Fake-adapter contract testing via cassette record/replay | Proposed |
 | [0048](0048-auto-revert-on-rc-red.md) | Auto-revert on RC red (extends ADR-0042) | Proposed |
-| [0049](0049-trust-loop-kill-switch-convention.md) | Trust-loop kill-switch convention (`enabled_cb` only, no config-only) | Proposed |
+| [0049](0049-trust-loop-kill-switch-convention.md) | Trust-loop kill-switch convention (`enabled_cb` only, no config-only) | Accepted |
 | [0050](0050-auto-agent-hitl-preflight.md) | Auto-Agent HITL Pre-Flight Loop | Accepted |
 | [0051](0051-iterative-production-readiness-review.md) | Iterative production-readiness review | Accepted |
 | [0052](0052-sandbox-tier-scenarios.md) | Sandbox-tier scenario testing | Accepted |

--- a/docs/wiki/dark-factory.md
+++ b/docs/wiki/dark-factory.md
@@ -207,10 +207,13 @@ and T13 close-reconciliation tasks).
 Tests that use `AsyncMock(pr)` auto-create any attribute name on access,
 so a typo like `pr.remove_labels(...)` (plural) when the real method is
 `remove_label` (singular) passes the test but crashes in production. The
-`tests/scenarios/fakes/test_port_conformance.py` is the safety net —
-make sure any new method on a real Port is also added to the corresponding
-Fake AND the conformance test runs. The C2/C3 critical findings on PR
-#8439 were exactly this class of break.
+`tests/test_ports.py` structural conformance suite is the safety net (it
+checks each adapter against its Port protocol via `runtime_checkable`
+isinstance AND `inspect.signature` comparison; per-Fake conformance lives
+in `tests/scenarios/fakes/test_fake_*.py` since the Fakes moved to
+`src/mockworld/fakes/`) — make sure any new method on a real Port is also
+added to the corresponding Fake AND the conformance suite runs. The C2/C3
+critical findings on PR #8439 were exactly this class of break.
 
 ### 4.3 Pyright IDE noise on Pydantic dynamic attrs
 
@@ -261,7 +264,7 @@ Auto-discovery tests that fail when a load-bearing convention is broken:
 | `tests/test_loop_wiring_completeness.py` | Loop missing one of the five checkpoints |
 | `tests/architecture/test_functional_area_coverage.py` | New loop or port unassigned in `functional_areas.yml` |
 | `tests/architecture/test_curated_drift.py` | Generated docs out of sync after a source-file change |
-| `tests/scenarios/fakes/test_port_conformance.py` | Fake adapter drifts from Port protocol |
+| `tests/test_ports.py` | Adapter/Fake drifts from its Port protocol signature |
 | `tests/test_loop_kill_switch_completeness.py` | Loop without ADR-0049 in-body gate |
 | `tests/test_config_consistency.py` | `*_interval` config field without matching `_INTERVAL_BOUNDS` entry |
 


### PR DESCRIPTION
**Dark-factory hardening WS-6 — doc & registry truth.** Standalone off `staging` (independent of the WS-RT stack #9108–#9111).

All WS-6 audit findings were **re-verified against current `staging` first** — the source audit was largely stale, so this lands only the confirmed-real, **doc-only** fixes. The WRONG/stale findings were dropped (loops.md kill-switch column is actually correct; ADR-0009's supervisor IS implemented; `visual_validation` is not a noop stub; etc.), and two code-touching items (worker-registry parity test, interval-default consolidation) are deferred as they need design judgment.

## Changes

**ADR-0049 (trust-loop kill-switch convention) `Proposed` → `Accepted`**
The convention is now hard-enforced fleet-wide: the kill-switch-integrity work fixed the `DiagramLoop` `worker_name` hyphen/underscore mismatch, added the in-body `_enabled_cb` gate to the four env-only loops, and landed `tests/test_loop_kill_switch_completeness.py` (AST-discovery ratchet, empty grandfather list). Updated `Enforced by` to name that ratchet + `tests/regressions/test_canonical_killswitch.py`, rewrote the now-false *"simple grep, not a hard CI gate"* compliance note, added an Update Log.

**ADR-0045 (trust architecture hardening) `Proposed` → `Accepted`**
The trust fleet shipped and runs fleet-wide (nine watched loops + `TrustFleetSanityLoop` + `HealthMonitorLoop`, all in the generated loop registry). The `Proposed` label was the only drift. Added an `Enforced by` line (real trust-fleet tests) + Update Log.

**`docs/adr/README.md`** — both index rows → Accepted.

**`docs/wiki/dark-factory.md`** — the Port↔Fake conformance tests were relocated when the Fakes moved to `src/mockworld/fakes/`. Fixed two stale references to the non-existent `tests/scenarios/fakes/test_port_conformance.py` → `tests/test_ports.py` (structural conformance; per-Fake conformance now in `tests/scenarios/fakes/test_fake_*.py`).

## Verification
- `tests/test_adr_enforcement.py` + `tests/architecture/test_curated_drift.py` pass (the enforcement parser accepts the clean comma-separated `Enforced by` paths; generated docs in sync).
- Full `make quality` green: **15229 passed, 18 skipped, 165 xfailed, 55 xpassed** (`[tests OK]`).

## Deferred (follow-up)
- Worker-registry drift-guard test (React `constants.js BACKGROUND_WORKERS` ↔ Python source-of-truth).
- Interval-default consolidation (`config.py` / `constants.js` / `_common.py`) — note `tests/test_config_consistency.py` already guards `*_interval` ↔ `_INTERVAL_BOUNDS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)