### PR TITLE
fix(security): GitHub-side backstop dedup for the security-patch loop (WS-5)

### DIFF
--- a/src/security_patch_loop.py
+++ b/src/security_patch_loop.py
@@ -89,6 +89,7 @@ class SecurityPatchLoop(BaseBackgroundLoop):
 
         filed = 0
         skipped_dedup = 0
+        skipped_existing = 0
         skipped_unfixable = 0
         skipped_severity = 0
 
@@ -123,6 +124,24 @@ class SecurityPatchLoop(BaseBackgroundLoop):
                 f"A patched version is available. Please update the dependency.\n"
             )
 
+            # GitHub-side backstop: the local dedup file can lose an entry if a
+            # prior tick crashed between create_issue and dedup.add, which would
+            # otherwise re-file a duplicate security issue. GitHub is the durable
+            # source of truth — if an open issue with this exact title already
+            # exists, skip the create and heal the local dedup. find_existing_issue
+            # returns 0 when none is found (the common path), so creation proceeds.
+            existing = await self._pr_manager.find_existing_issue(title)
+            if existing:
+                self._dedup.add(alert_key)
+                skipped_existing += 1
+                logger.info(
+                    "Security issue for alert #%s already open as #%s; "
+                    "skipping duplicate and healing local dedup",
+                    alert_key,
+                    existing,
+                )
+                continue
+
             await self._pr_manager.create_issue(title, body, labels=["security"])
             self._dedup.add(alert_key)
             filed += 1
@@ -139,6 +158,7 @@ class SecurityPatchLoop(BaseBackgroundLoop):
             "total_alerts": len(alerts),
             "filed": filed,
             "skipped_dedup": skipped_dedup,
+            "skipped_existing": skipped_existing,
             "skipped_unfixable": skipped_unfixable,
             "skipped_severity": skipped_severity,
         }

--- a/tests/test_security_patch_loop.py
+++ b/tests/test_security_patch_loop.py
@@ -54,6 +54,7 @@ def _make_loop(
     security_patch_interval: int = 3600,
     alerts: list[dict] | None = None,
     existing_dedup: list[str] | None = None,
+    existing_issue_number: int = 0,
 ) -> tuple[SecurityPatchLoop, AsyncMock, asyncio.Event]:
     """Build a SecurityPatchLoop with test-friendly defaults."""
     deps = make_bg_loop_deps(
@@ -66,6 +67,11 @@ def _make_loop(
     pr_manager = AsyncMock()
     pr_manager.get_dependabot_alerts = AsyncMock(return_value=alerts or [])
     pr_manager.create_issue = AsyncMock(return_value=42)
+    # The GitHub-side backstop: 0 = no existing open issue with that title
+    # (the common case, so create proceeds). A positive number simulates an
+    # issue already filed on GitHub — e.g. the local dedup file lost the entry
+    # to a crash between create_issue and dedup.add on a prior tick.
+    pr_manager.find_existing_issue = AsyncMock(return_value=existing_issue_number)
 
     # Seed dedup store file if needed
     dedup_path = deps.config.data_root / "memory" / "security_patch_dedup.json"
@@ -146,6 +152,26 @@ class TestSecurityPatchLoopWork:
         assert result["filed"] == 0
         assert result["skipped_dedup"] == 1
         pm.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backstop_skips_create_when_issue_exists_on_github(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression: the alert is NOT in the local dedup file — simulating a
+        # crash between create_issue and dedup.add on a prior tick, which filed
+        # the issue on GitHub but lost the local dedup entry. Relying solely on
+        # the local file would re-file (duplicate). The GitHub-side backstop
+        # (find_existing_issue) must catch it: no second create_issue, and the
+        # local dedup is healed so later ticks skip it without the gh query.
+        alert = _make_alert(1)
+        loop, pm, _stop = _make_loop(tmp_path, alerts=[alert], existing_issue_number=99)
+        result = await loop._do_work()
+        assert result is not None
+        pm.find_existing_issue.assert_awaited_once()
+        pm.create_issue.assert_not_called()
+        assert result["filed"] == 0
+        assert result["skipped_existing"] == 1
+        assert "1" in loop._dedup.get(), "local dedup must be healed by the backstop"
 
     @pytest.mark.asyncio
     async def test_severity_below_threshold_skipped(self, tmp_path: Path) -> None:


### PR DESCRIPTION
**Dark-factory hardening WS-5 (resilience/idempotency) — slice 1 of N.** Standalone off `staging`.

## Problem (re-verified against current staging — finding `security-patch-no-backstop-dedup`, HIGH)

`SecurityPatchLoop._do_work` adds the alert key to its local `DedupStore` **after** `create_issue`:

```python
await self._pr_manager.create_issue(title, body, labels=["security"])
self._dedup.add(alert_key)   # <- a crash here re-files next tick
```

A process crash between the two leaves the issue filed on GitHub but the local dedup file never updated, so the next tick **re-files a duplicate** security issue. The loop relied solely on the local file — no durable backstop.

## Fix

Add a **GitHub-side backstop** using the existing `pr_manager.find_existing_issue(title) -> int` (returns `0` when none): before creating, skip if an open issue with that exact title already exists, and **heal** the local dedup so later ticks skip it without the `gh` query.

```python
existing = await self._pr_manager.find_existing_issue(title)
if existing:
    self._dedup.add(alert_key)   # heal local dedup
    skipped_existing += 1
    continue
await self._pr_manager.create_issue(...)
```

**Why a backstop and not just reordering `dedup.add` before `create_issue`?** A reorder prevents the duplicate but would risk **permanently dropping a security alert** if a crash landed between the dedup persist and the create. The backstop never drops *and* never duplicates — GitHub is the durable source of truth.

## Tests
- New regression `test_backstop_skips_create_when_issue_exists_on_github`: alert absent from the local dedup file but present open on GitHub (`find_existing_issue -> 99`) must skip `create_issue`, count `skipped_existing`, and heal the local dedup.
- `_make_loop` defaults `find_existing_issue -> 0`, so the common create path (existing tests) is unchanged.
- Added a `skipped_existing` counter to the `_do_work` result for observability.
- Full `make quality` green: **15230 passed, 18 skipped, 165 xfailed, 55 xpassed**.

## Remaining WS-5 (separate PRs / decisions)
- **#3** `auto-agent-daily-spend-undercount-on-crash` (LOW) — spend recorded after the spawn; fix is a design choice (reserve-then-reconcile vs recompute-from-audit).
- **#4** `circuit-breaker-defined-unused` (LOW) — `CircuitBreaker` is tested but wired nowhere. Roadmap D2 says wire it into `subprocess_util.run_subprocess`, but that's **high blast-radius** (a wrongly-opened breaker would halt all `gh` calls factory-wide), so holding for a maintainer decision before wiring.
- `report-loop-double-spawn-on-crash` — verified **already fixed** (report loop marks in-progress before spawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)