### PR TITLE
fix(gh): treat HTTP 429 as a rate limit, not fast-retry/failure (WS-8)

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -147,9 +147,19 @@ def _get_gh_semaphore() -> asyncio.Semaphore:
 
 
 def _is_rate_limited(stderr: str) -> bool:
-    """Check if stderr indicates a GitHub API rate limit (403)."""
+    """Check if stderr indicates a GitHub API rate limit (HTTP 403 or 429).
+
+    GitHub signals rate limiting two ways: HTTP 403 for the secondary/abuse
+    limit ("You have exceeded a secondary rate limit") and HTTP 429 for the
+    primary limit. Both must route to the global cooldown in ``run_subprocess``
+    rather than the per-call retry path — a 429 that slips through would either
+    fail outright (429 is not in ``_RETRYABLE_PATTERNS``) or retry too fast,
+    amplifying the limit across concurrent agents instead of pausing.
+    """
     lower = stderr.lower()
-    return "rate limit" in lower and ("403" in lower or "http 403" in lower)
+    if "rate limit" not in lower:
+        return False
+    return any(code in lower for code in ("403", "http 403", "429", "http 429"))
 
 
 def _trigger_rate_limit_cooldown() -> None:

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -926,6 +926,36 @@ class TestRateLimitCooldown:
         assert subprocess_util._rate_limit_until is not None
 
     @pytest.mark.asyncio
+    async def test_rate_limit_429_triggers_global_cooldown(self) -> None:
+        """An HTTP 429 rate-limit response should set _rate_limit_until too.
+
+        GitHub returns 429 for the primary/abuse limit (vs 403 for the
+        secondary limit). Without the 429 case in _is_rate_limited, a 429
+        skips the global cooldown and falls to the per-call retry path, which
+        either fails outright or retries too fast — amplifying the limit
+        across concurrent agents instead of pausing.
+        """
+        import subprocess_util
+        from execution import SimpleResult
+
+        configure_gh_concurrency(5)
+
+        async def rate_limit_429(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            return SimpleResult(
+                stdout="",
+                stderr="gh: API rate limit exceeded (HTTP 429)",
+                returncode=1,
+            )
+
+        runner = MagicMock()
+        runner.run_simple = rate_limit_429
+
+        with pytest.raises(RuntimeError, match="rate limit"):
+            await run_subprocess("gh", "api", "test", runner=runner)
+
+        assert subprocess_util._rate_limit_until is not None
+
+    @pytest.mark.asyncio
     async def test_cooldown_delays_subsequent_calls(self) -> None:
         """When cooldown is active, gh calls should wait before executing."""
         from datetime import UTC, datetime, timedelta


### PR DESCRIPTION
**Dark-factory hardening WS-8 — slice 1 (429 classifier).** Standalone off `staging`.

## Problem (verified vs staging)
`subprocess_util._is_rate_limited` matched only HTTP **403** (GitHub's secondary/abuse limit):
```python
return "rate limit" in lower and ("403" in lower or "http 403" in lower)
```
So an HTTP **429** (GitHub's primary rate limit) bypassed the global cooldown in `run_subprocess` (line 559). It then fell to the per-call retry path, where 429 is **not** in `_RETRYABLE_PATTERNS` (could fail outright) and isn't backed off — and any retry races other concurrent agents straight back into the limit.

## Fix
`_is_rate_limited` now matches `429` / `http 429` in addition to 403, so both the secondary (403) and primary (429) limits route to `_trigger_rate_limit_cooldown`, pausing all `gh`/`git` calls factory-wide instead of hammering the API.

## Test
End-to-end test mirroring the existing 403 cooldown case: a 429 response sets `_rate_limit_until`. Full `make quality` green (**15230 passed**).

Part of the WS-8 series (multi-repo route scoping + worktree healing land in follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)