### PR TITLE
fix(dashboard): repo-scope read-only history/timeline routes (WS-8 multi-repo)

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1646,16 +1646,18 @@ def create_router(
         status: str | None = None,
         query: str | None = None,
         limit: int = 300,
+        repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return issue lifecycle history with inference rollups."""
+        """Return issue lifecycle history with inference rollups (repo-scoped)."""
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
         since_dt = _parse_iso_or_none(since)
         until_dt = _parse_iso_or_none(until)
         requested_status = (status or "").strip().lower()
         query_text = (query or "").strip().lower()
         clamped_limit = max(1, min(limit, 1000))
 
-        telemetry = PromptTelemetry(config)
-        all_events = event_bus.get_history()
+        telemetry = PromptTelemetry(_cfg)
+        all_events = _bus.get_history()
 
         # Check if we can reuse cached aggregation for the unfiltered case.
         use_unfiltered = since_dt is None and until_dt is None
@@ -1664,6 +1666,7 @@ def create_router(
         now = time.monotonic()
         cache_hit = (
             use_unfiltered
+            and repo is None
             and _history_cache["issue_rows"] is not None
             and _history_cache["event_count"] == event_count
             and _history_cache["telemetry_mtime"] == telem_mtime
@@ -1740,8 +1743,11 @@ def create_router(
                 all_events, issue_rows, pr_to_issue, since_dt, until_dt
             )
 
-            # Store in cache if this was an unfiltered aggregation.
-            if use_unfiltered:
+            # Store in cache if this was an unfiltered aggregation. Only the
+            # default-repo view is cached: _history_cache is not repo-keyed, so
+            # a per-repo request must never read (see cache_hit above) or write
+            # it, or one repo's rollups would bleed into another's view.
+            if use_unfiltered and repo is None:
                 _history_cache["issue_rows"] = copy.deepcopy(issue_rows)
                 _history_cache["pr_to_issue"] = dict(pr_to_issue)
                 _history_cache["event_count"] = event_count
@@ -1793,29 +1799,34 @@ def create_router(
         )
 
     @router.get("/api/timeline")
-    async def get_timeline() -> JSONResponse:
-        """Return timelines for all tracked issues."""
-        builder = TimelineBuilder(event_bus)
+    async def get_timeline(repo: RepoSlugParam = None) -> JSONResponse:
+        """Return timelines for all tracked issues (repo-scoped)."""
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
+        builder = TimelineBuilder(_bus)
         timelines = builder.build_all()
         return JSONResponse([t.model_dump() for t in timelines])
 
     @router.get("/api/timeline/issue/{issue_number}")
-    async def get_timeline_issue(issue_number: int) -> JSONResponse:
-        """Return the event timeline for a single issue."""
-        builder = TimelineBuilder(event_bus)
+    async def get_timeline_issue(
+        issue_number: int, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Return the event timeline for a single issue (repo-scoped)."""
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
+        builder = TimelineBuilder(_bus)
         timeline = builder.build_for_issue(issue_number)
         if timeline is None:
             return JSONResponse({"error": "Issue not found"}, status_code=404)
         return JSONResponse(timeline.model_dump())
 
     @router.get("/api/timeline/completed")
-    async def get_completed_timelines() -> JSONResponse:
-        """Return persisted timelines for completed (merged) issues.
+    async def get_completed_timelines(repo: RepoSlugParam = None) -> JSONResponse:
+        """Return persisted timelines for completed (merged) issues (repo-scoped).
 
         Unlike /api/timeline which derives from ephemeral events,
         these survive event log rotation.
         """
-        timelines = state.get_all_completed_timelines()
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
+        timelines = _state.get_all_completed_timelines()
         return JSONResponse([t.model_dump() for t in timelines.values()])
 
     # --- State/runtimes/repos/filesystem routes (extracted to _state_routes.py) ---

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -653,6 +653,53 @@ class TestGetEventsEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Multi-repo route scoping (WS-8): read-only routes must resolve the per-repo
+# runtime via _resolve_runtime(repo), not the closure-captured default bus, so
+# one repo's data never bleeds into another's view in a multi-repo deployment.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRepoReadOnlyRouteScoping:
+    @pytest.mark.asyncio
+    async def test_timeline_scoped_to_requested_repo_bus(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        from events import EventType
+        from tests.conftest import EventFactory
+
+        # repo-b carries issue #42's lifecycle on its OWN bus; the default
+        # (closure) bus the router was built with is empty.
+        repo_b_bus = EventBus()
+        await repo_b_bus.publish(
+            EventFactory.create(
+                type=EventType.TRIAGE_UPDATE,
+                data={"issue": 42, "status": "done"},
+            )
+        )
+        rt = MagicMock()
+        rt.config = config
+        rt.state = state
+        rt.event_bus = repo_b_bus
+        rt.orchestrator = None
+        registry = MagicMock()
+        registry.get.return_value = rt
+
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=registry
+        )
+        endpoint = find_endpoint(router, "/api/timeline")
+
+        # repo-scoped request resolves repo-b's bus → sees issue #42.
+        scoped = json.loads((await endpoint(repo="repo-b")).body)
+        registry.get.assert_called_with("repo-b")
+        assert any(t["issue_number"] == 42 for t in scoped)
+
+        # no repo → the default empty bus, NOT repo-b's: no #42 bleed.
+        default = json.loads((await endpoint(repo=None)).body)
+        assert not any(t.get("issue_number") == 42 for t in default)
+
+
+# ---------------------------------------------------------------------------
 # GET /api/prs
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**Dark-factory hardening WS-8 — slice 2 (multi-repo read-only routes).** Standalone off `staging`.

## Problem (verified vs staging)
The dashboard resolves a per-repo runtime via `_resolve_runtime(repo) → (config, state, event_bus, get_orchestrator)`. Four **read-only** routes ignored that and used the closure-captured default bus/state/config, so in multi-repo mode they showed the **default** repo's data regardless of the selected repo (read bleed):

| Route | Was using |
|---|---|
| `/api/issues/history` | closure `event_bus` + `config` |
| `/api/timeline` | `TimelineBuilder(event_bus)` |
| `/api/timeline/issue/{n}` | `TimelineBuilder(event_bus)` |
| `/api/timeline/completed` | closure `state` |

## Fix
Each now takes `repo: RepoSlugParam = None` and uses `_resolve_runtime(repo)`'s `_bus`/`_cfg`/`_state` — the same pattern the operational routes already use. `repo=None` falls back to the default, so single-repo behavior is unchanged.

`/api/issues/history` additionally guards its in-memory `_history_cache` on `repo is None`: the cache is keyed by `event_count`+`telemetry_mtime`, **not** by repo, so a per-repo request must never read or write it — otherwise one repo's rollups could bleed into another's view on a key collision. Only the default-repo view is cached.

## Test
`TestMultiRepoReadOnlyRouteScoping` publishes issue #42's lifecycle to a `repo-b` bus via a registry and asserts `/api/timeline?repo=repo-b` sees #42 while the default (empty closure bus) does not. Full `make quality` green (**15230 passed**).

## Follow-up
The **action** routes (`/api/request-changes`, `/api/intent`) also write to the wrong repo — scoped in the next PR (they need a per-repo `pr_manager` via `ctx.pr_manager_for`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)