### PR TITLE
fix(workspace): heal stale core.worktree before salvaging a worktree (WS-8)

### DIFF
--- a/src/workspace.py
+++ b/src/workspace.py
@@ -231,6 +231,42 @@ class WorkspaceManager:
         """
         await self._fetch_origin_with_retry(self._repo_root, self._config.base_branch())
 
+    async def _heal_worktree_config(self, wt_path: Path, gh_token: str) -> None:
+        """Clear a stale ``core.worktree`` from a worktree's git config.
+
+        A docker container that runs git inside the worktree can write
+        ``core.worktree=/workspace`` into ``<wt>/.git/config``. On the host that
+        path doesn't exist, and git then refuses to run *any* command in the
+        worktree — including ``git config --unset core.worktree`` itself —
+        failing with "fatal: Invalid path '/workspace'". So we can't heal from
+        inside the worktree.
+
+        Instead, edit the config file directly via ``git config --file <path>
+        --unset`` run from OUTSIDE the worktree (``cwd=wt_path.parent``), where
+        git won't auto-discover and validate the broken worktree. Workspaces
+        here are full local clones (see ``_create_unlocked``), so the config is
+        always ``<wt>/.git/config``. No-op when ``core.worktree`` is absent (git
+        exits non-zero, which we ignore) or the config file is missing.
+        """
+        config_path = wt_path / ".git" / "config"
+        if not config_path.exists():
+            return
+        # A non-zero exit just means core.worktree was not set — nothing to heal.
+        with contextlib.suppress(RuntimeError):
+            await run_subprocess(
+                "git",
+                "config",
+                "--file",
+                str(config_path),
+                "--unset",
+                "core.worktree",
+                # Run from outside the worktree: from inside, git auto-discovers
+                # the repo and re-validates the bogus core.worktree before it
+                # ever processes --file, re-triggering the same fatal error.
+                cwd=wt_path.parent,
+                gh_token=gh_token,
+            )
+
     async def _salvage_uncommitted(self, issue_number: int) -> None:
         """Commit and push any uncommitted changes in the worktree before destroying it.
 
@@ -243,6 +279,12 @@ class WorkspaceManager:
 
         gh = self._credentials.gh_token
         branch = self._config.branch_for_issue(issue_number)
+
+        # A container may have written a stale core.worktree into the worktree's
+        # git config during the run; heal it before the status check below, or
+        # that check fails with "not a work tree" and we silently skip the
+        # salvage — losing the uncommitted work this method exists to protect.
+        await self._heal_worktree_config(wt_path, gh)
 
         # Check for uncommitted changes
         try:

--- a/tests/test_integration_worktree.py
+++ b/tests/test_integration_worktree.py
@@ -48,6 +48,90 @@ def _make_repo(base: Path, name: str = "repo") -> Path:
 
 
 # ---------------------------------------------------------------------------
+# Worktree core.worktree corruption healing (WS-8)
+# ---------------------------------------------------------------------------
+
+
+class TestWorktreeConfigHealing:
+    """WS-8: a docker container can write a stale ``core.worktree`` into a
+    worktree's git config; host-side git then fails with "not a work tree".
+    The salvage path must heal that before its status check, or it silently
+    aborts and loses the uncommitted work it exists to protect."""
+
+    def _make_manager(self, tmp_path: Path, repo: Path):
+        from tests.helpers import ConfigFactory
+        from workspace import WorkspaceManager
+
+        config = ConfigFactory.create(
+            repo_root=repo,
+            workspace_base=tmp_path / "worktrees",
+            execution_mode="host",
+        )
+        return WorkspaceManager(config)
+
+    @pytest.mark.asyncio
+    async def test_heal_unsets_stale_core_worktree(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "repo")
+        config_file = repo / ".git" / "config"
+        # Simulate a container having corrupted the worktree config. Setting the
+        # key works; reading it back via git does NOT (see below), so assert on
+        # the config file contents directly.
+        _git(repo, "config", "core.worktree", "/nonexistent/workspace")
+        assert "/nonexistent/workspace" in config_file.read_text()
+        # The corruption makes host git refuse to run in the worktree at all.
+        broken = subprocess.run(
+            ["git", "status", "--porcelain"],
+            check=False,
+            cwd=repo,
+            capture_output=True,
+            text=True,
+        )
+        assert broken.returncode != 0
+
+        mgr = self._make_manager(tmp_path, repo)
+        await mgr._heal_worktree_config(repo, "")
+
+        # Healed: the stale path is gone from the config and host git works.
+        assert "/nonexistent/workspace" not in config_file.read_text()
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_heal_is_noop_when_core_worktree_absent(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "repo")
+        mgr = self._make_manager(tmp_path, repo)
+        # Must not raise when there is nothing to unset; git still works.
+        await mgr._heal_worktree_config(repo, "")
+        assert _git(repo, "status", "--porcelain") == ""
+
+    @pytest.mark.asyncio
+    async def test_salvage_heals_corruption_then_commits(self, tmp_path: Path) -> None:
+        repo = _make_repo(tmp_path, "repo")
+        mgr = self._make_manager(tmp_path, repo)
+
+        # Build a worktree-like clone at the issue's workspace path with
+        # committed history + an uncommitted change.
+        wt = mgr._config.workspace_path_for_issue(7)
+        _make_repo(wt.parent, wt.name)
+        # run_subprocess uses a clean env (no global git identity in CI), so
+        # persist a repo-local identity for the salvage commit to succeed.
+        _git(wt, "config", "user.email", "test@test.com")
+        _git(wt, "config", "user.name", "Test")
+        (wt / "work.txt").write_text("uncommitted work\n")
+
+        # A container corrupted the worktree config.
+        _git(wt, "config", "core.worktree", "/nonexistent/workspace")
+
+        # Salvage must heal first; the push fails (no origin) and is caught,
+        # but the local commit — which a "not a work tree" abort would have
+        # skipped, silently losing the work — must have happened.
+        await mgr._salvage_uncommitted(7)
+
+        assert "/nonexistent/workspace" not in (wt / ".git" / "config").read_text()
+        log = _git(wt, "log", "--oneline")
+        assert "salvage uncommitted changes for issue #7" in log
+
+
+# ---------------------------------------------------------------------------
 # Setup helpers (_setup_dotenv, _setup_claude_settings, _setup_node_modules)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**Dark-factory hardening WS-8 — slice 3 (worktree corruption healing).** Standalone off `staging`.

## Problem (verified vs staging)
A docker container that runs git inside a worktree can write `core.worktree=/workspace` into `<wt>/.git/config`. On the host that path doesn't exist, so `_salvage_uncommitted`'s `git status` fails and its broad `except RuntimeError: return` **silently aborts — losing the uncommitted work the method exists to protect.** (PR #2238 added a heal for this, but it lived in the old `_force_commit_uncommitted`; the refactor to `_salvage_uncommitted` dropped it. There is currently **no** `core.worktree` healing anywhere on staging.)

## The trap
The obvious fix — `git config --unset core.worktree` inside the worktree — **does not work.** When `core.worktree` points to a nonexistent path, git refuses *every* command in that repo, **including the unset itself**:
```
$ git config --unset core.worktree
fatal: Invalid path '/workspace': No such file or directory
```

## Fix
`WorkspaceManager._heal_worktree_config` edits the config file directly via `git config --file <wt>/.git/config --unset core.worktree`, run from a cwd **outside** the worktree (`wt_path.parent`) so git can't auto-discover and re-validate the broken worktree before processing `--file`. Workspaces are full local clones (`_create_unlocked` does `git clone --local`), so the config is always `<wt>/.git/config`. Called at the top of `_salvage_uncommitted`; no-op when the key is absent or the config is missing.

## Tests (real-git integration)
- `_heal_worktree_config` clears a stale `core.worktree` and restores host git;
- heal is a no-op when the key is absent;
- `_salvage_uncommitted` heals corruption **then commits** the uncommitted work locally (a "not a work tree" abort would have skipped it — the regression this fixes).

Full `make quality` green (**15232 passed**). Memory's prior (wrong) `git config --unset` recipe corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)