### PR TITLE
fix(dashboard): repo-scope action routes request-changes/intent (WS-8 multi-repo)

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1339,8 +1339,16 @@ def create_router(
         return JSONResponse(QueueStats().model_dump())
 
     @router.post("/api/request-changes")
-    async def request_changes(body: dict[str, Any]) -> JSONResponse:
-        """Escalate an issue to HITL with user feedback."""
+    async def request_changes(
+        body: dict[str, Any], repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Escalate an issue to HITL with user feedback (repo-scoped).
+
+        Resolves the per-repo runtime so the label swap, HITL cause/origin, and
+        escalation event all land on the SELECTED repo — not the default one —
+        in a multi-repo deployment.
+        """
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
         issue_number: int | None = body.get("issue_number")
         feedback = (body.get("feedback") or "").strip()
         stage: str = body.get("stage") or ""
@@ -1361,15 +1369,16 @@ def create_router(
                 status_code=400,
             )
 
-        stage_labels: list[str] = getattr(config, label_field, [])
+        stage_labels: list[str] = getattr(_cfg, label_field, [])
         origin_label: str = stage_labels[0]
 
-        await pr_manager.swap_pipeline_labels(issue_number, config.hitl_label[0])
+        manager = _pr_manager_for(_cfg, _bus)
+        await manager.swap_pipeline_labels(issue_number, _cfg.hitl_label[0])
 
-        state.set_hitl_cause(issue_number, feedback)
-        state.set_hitl_origin(issue_number, origin_label)
+        _state.set_hitl_cause(issue_number, feedback)
+        _state.set_hitl_origin(issue_number, origin_label)
 
-        await event_bus.publish(
+        await _bus.publish(
             HydraFlowEvent(
                 type=EventType.HITL_ESCALATION,
                 data=HITLEscalationPayload(
@@ -1824,20 +1833,26 @@ def create_router(
     _register_state(router, ctx)
 
     @router.post("/api/intent")
-    async def submit_intent(request: IntentRequest) -> JSONResponse:
-        """Create a GitHub issue from a user intent typed in the dashboard."""
+    async def submit_intent(
+        request: IntentRequest, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Create a GitHub issue from a user intent typed in the dashboard.
+
+        Repo-scoped: the issue is created in the SELECTED repo (and its URL
+        points there), not the default repo, in a multi-repo deployment.
+        """
+        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
         title = request.text[:120]
         body = request.text
-        labels = list(config.planner_label)
+        labels = list(_cfg.planner_label)
 
-        issue_number = await pr_manager.create_issue(
-            title=title, body=body, labels=labels
-        )
+        manager = _pr_manager_for(_cfg, _bus)
+        issue_number = await manager.create_issue(title=title, body=body, labels=labels)
 
         if issue_number == 0:
             return JSONResponse({"error": "Failed to create issue"}, status_code=500)
 
-        url = f"https://github.com/{config.repo}/issues/{issue_number}"
+        url = f"https://github.com/{_cfg.repo}/issues/{issue_number}"
         response = IntentResponse(issue_number=issue_number, title=title, url=url)
         return JSONResponse(response.model_dump())
 

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -354,6 +354,100 @@ class TestRequestChangesEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# Multi-repo ACTION route scoping (WS-8): /api/request-changes and /api/intent
+# must write to the SELECTED repo (its pr_manager / state / event bus), not the
+# closure-captured default — otherwise a HITL escalation or new issue lands in
+# the wrong repo in a multi-repo deployment.
+# ---------------------------------------------------------------------------
+
+
+class TestMultiRepoActionRouteScoping:
+    def _registry_for(self, repo_b_cfg, repo_b_state, repo_b_bus):
+        rt = SimpleNamespace(
+            config=repo_b_cfg,
+            state=repo_b_state,
+            event_bus=repo_b_bus,
+            orchestrator=None,
+        )
+        registry = MagicMock()
+        registry.get.return_value = rt
+        return registry
+
+    @pytest.mark.asyncio
+    async def test_request_changes_routes_write_to_selected_repo(
+        self, monkeypatch, config, event_bus, state, tmp_path
+    ) -> None:
+        from tests.helpers import ConfigFactory
+
+        repo_b_cfg = ConfigFactory.create(repo="owner/repo-b")
+        repo_b_state = MagicMock()
+        repo_b_bus = EventBus()
+        registry = self._registry_for(repo_b_cfg, repo_b_state, repo_b_bus)
+
+        router, default_pm = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=registry
+        )
+        default_pm.swap_pipeline_labels = AsyncMock()
+        # repo-b's pr_manager is constructed via PRManager(repo_b_cfg, repo_b_bus)
+        # (different config than default) — mock the class so no real gh runs.
+        repo_b_pm = AsyncMock()
+        monkeypatch.setattr(
+            "dashboard_routes._routes.PRManager", lambda cfg, bus: repo_b_pm
+        )
+
+        queue = repo_b_bus.subscribe()
+        endpoint = find_endpoint(router, "/api/request-changes")
+        resp = await endpoint(
+            {"issue_number": 5, "feedback": "redo it", "stage": "implement"},
+            repo="repo-b",
+        )
+        assert json.loads(resp.body)["status"] == "ok"
+
+        # Write went to repo-b's pr_manager + state + bus; default untouched.
+        repo_b_pm.swap_pipeline_labels.assert_awaited_once_with(
+            5, repo_b_cfg.hitl_label[0]
+        )
+        default_pm.swap_pipeline_labels.assert_not_called()
+        repo_b_state.set_hitl_cause.assert_called_once_with(5, "redo it")
+        event = queue.get_nowait()
+        assert event.type == "hitl_escalation"
+        assert event.data["issue"] == 5
+
+    @pytest.mark.asyncio
+    async def test_intent_creates_issue_in_selected_repo(
+        self, monkeypatch, config, event_bus, state, tmp_path
+    ) -> None:
+        from models import IntentRequest
+        from tests.helpers import ConfigFactory
+
+        repo_b_cfg = ConfigFactory.create(repo="owner/repo-b")
+        repo_b_state = MagicMock()
+        repo_b_bus = EventBus()
+        registry = self._registry_for(repo_b_cfg, repo_b_state, repo_b_bus)
+
+        router, default_pm = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=registry
+        )
+        default_pm.create_issue = AsyncMock(return_value=999)
+        repo_b_pm = AsyncMock()
+        repo_b_pm.create_issue = AsyncMock(return_value=314)
+        monkeypatch.setattr(
+            "dashboard_routes._routes.PRManager", lambda cfg, bus: repo_b_pm
+        )
+
+        endpoint = find_endpoint(router, "/api/intent")
+        resp = await endpoint(IntentRequest(text="add a thing"), repo="repo-b")
+        data = json.loads(resp.body)
+
+        # Issue created in repo-b (its create_issue, its repo in the URL); the
+        # default pr_manager was not touched.
+        repo_b_pm.create_issue.assert_awaited_once()
+        default_pm.create_issue.assert_not_called()
+        assert data["issue_number"] == 314
+        assert "owner/repo-b" in data["url"]
+
+
+# ---------------------------------------------------------------------------
 # /api/runs endpoints
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**Dark-factory hardening WS-8 — slice 4 (multi-repo action routes).** Standalone off `staging`. Completes WS-8 multi-repo bleed (read-only routes shipped in #9115).

## Problem (verified vs staging)
The two **write** routes used the closure-captured default `config`/`state`/`event_bus`/`pr_manager`, so in multi-repo mode a HITL escalation or a new issue landed in the **default** repo regardless of the selected one — **action bleed**, worse than the read bleed fixed in #9115:

| Route | Wrong-repo effect |
|---|---|
| `/api/request-changes` | `swap_pipeline_labels` + `set_hitl_cause/origin` + escalation event on the default repo |
| `/api/intent` | `create_issue` (+ returned URL) in the default repo |

## Fix
Each now takes `repo: RepoSlugParam = None`, resolves the per-repo runtime via `_resolve_runtime(repo)`, and gets the per-repo `pr_manager` via the existing `_pr_manager_for(_cfg, _bus)` helper. Both `swap_pipeline_labels` and `create_issue` are on `PRPort`, so no cast is needed (mirrors the `get_prs` route precedent). `repo=None` falls back to the default — single-repo behavior unchanged.

## Tests
`TestMultiRepoActionRouteScoping` mocks `PRManager` so repo-b's per-repo manager doesn't hit real `gh`, and asserts the label swap / issue creation, the HITL state write, and the escalation event all route to **repo-b** — not the default `pr_manager`. Existing request-changes tests pass unchanged. Full `make quality` green (**15231 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)