### PR TITLE
fix(auto-agent): use durable audit as floor for the daily-budget gate (WS-5)

### DIFF
--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -62,7 +62,16 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         cap = self._config.auto_agent_daily_budget_usd
         if cap is not None:
             today = datetime.now(UTC).date().isoformat()
-            spend = self._state.get_auto_agent_daily_spend(today)
+            # Use the durable audit log as a floor for today's spend. The state
+            # cache (add_auto_agent_daily_spend) is updated only AFTER the costly
+            # run_preflight returns, so a crash in between loses the increment and
+            # the gate would undercount → overspend past the cap. The audit entry
+            # is appended BEFORE that cache update, so it never loses a completed
+            # attempt; max() tolerates either being momentarily ahead.
+            spend = max(
+                self._state.get_auto_agent_daily_spend(today),
+                self._audit_store.daily_spend(today),
+            )
             if spend >= cap:
                 return {"status": "budget_exceeded", "spend_usd": spend, "cap_usd": cap}
 

--- a/src/preflight/audit.py
+++ b/src/preflight/audit.py
@@ -91,6 +91,19 @@ class PreflightAuditStore:
     def entries_for_issue(self, issue: int) -> list[PreflightAuditEntry]:
         return [e for e in self._read_all() if e.issue == issue]
 
+    def daily_spend(self, date_iso: str) -> float:
+        """Total cost (USD) recorded for the given UTC calendar date (YYYY-MM-DD).
+
+        Computed from this durable append-only log so the daily-budget gate can't
+        undercount: the separate state spend cache is updated only AFTER the
+        costly ``run_preflight`` returns, so a crash in between loses the
+        increment. Each audit entry carries the same ``cost_usd`` and is appended
+        BEFORE that cache update, so it is the reliable source of truth. Entry
+        timestamps are UTC ISO (``...Z``), so the ``YYYY-MM-DD`` prefix is the
+        UTC date — no parsing needed.
+        """
+        return sum(e.cost_usd for e in self._read_all() if e.ts[:10] == date_iso)
+
 
 def _percentile(sorted_values: list[float], p: float) -> float:
     if not sorted_values:

--- a/tests/test_auto_agent_preflight_loop.py
+++ b/tests/test_auto_agent_preflight_loop.py
@@ -19,6 +19,7 @@ def _make_loop(tmp_path: Path, *, enabled: bool = True, **config_overrides):
     pr = AsyncMock()
     pr.list_closed_issues_by_label = AsyncMock(return_value=[])
     audit = MagicMock()
+    audit.daily_spend = MagicMock(return_value=0.0)
     loop = AutoAgentPreflightLoop(
         config=deps.config,
         state=state,
@@ -71,6 +72,23 @@ async def test_daily_budget_gate(
     result = await loop._do_work()
     assert result["status"] == "budget_exceeded"
     assert result["cap_usd"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_daily_budget_gate_uses_audit_floor_when_cache_lost_increment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The state spend cache (add_auto_agent_daily_spend) is written only after
+    # run_preflight returns, so a crash can lose the increment — the cache then
+    # reads 0 even though real spend exceeds the cap. The durable audit log still
+    # has the cost, so the gate must use it (max of cache + audit) and still trip.
+    monkeypatch.setenv("HYDRAFLOW_AUTO_AGENT_DAILY_BUDGET_USD", "50.0")
+    loop, state = _make_loop(tmp_path)
+    state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)  # cache lost it
+    loop._audit_store.daily_spend = MagicMock(return_value=51.0)  # durable truth
+    result = await loop._do_work()
+    assert result["status"] == "budget_exceeded"
+    assert result["spend_usd"] == 51.0
 
 
 @pytest.mark.asyncio
@@ -230,6 +248,7 @@ async def test_resolve_worktree_uses_existing_path(tmp_path: Path) -> None:
     state = MagicMock()
     state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
     audit = MagicMock()
+    audit.daily_spend = MagicMock(return_value=0.0)
     loop = AutoAgentPreflightLoop(
         config=deps.config,
         state=state,
@@ -257,6 +276,7 @@ async def test_resolve_worktree_creates_when_missing(tmp_path: Path) -> None:
     state = MagicMock()
     state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
     audit = MagicMock()
+    audit.daily_spend = MagicMock(return_value=0.0)
     loop = AutoAgentPreflightLoop(
         config=deps.config,
         state=state,
@@ -284,6 +304,7 @@ async def test_resolve_worktree_falls_back_on_create_failure(
     state = MagicMock()
     state.get_auto_agent_daily_spend = MagicMock(return_value=0.0)
     audit = MagicMock()
+    audit.daily_spend = MagicMock(return_value=0.0)
     loop = AutoAgentPreflightLoop(
         config=deps.config,
         state=state,

--- a/tests/test_preflight_audit_store.py
+++ b/tests/test_preflight_audit_store.py
@@ -40,6 +40,16 @@ def test_append_and_query_for_issue(tmp_path: Path) -> None:
     assert len(store.entries_for_issue(2)) == 1
 
 
+def test_daily_spend_sums_only_the_given_utc_date(tmp_path: Path) -> None:
+    store = PreflightAuditStore(tmp_path)
+    store.append(_entry(ts="2026-04-25T08:00:00Z", cost=1.5))
+    store.append(_entry(ts="2026-04-25T20:00:00Z", cost=0.75))
+    store.append(_entry(ts="2026-04-26T01:00:00Z", cost=9.0))  # different day
+    assert store.daily_spend("2026-04-25") == 2.25
+    assert store.daily_spend("2026-04-26") == 9.0
+    assert store.daily_spend("2026-04-27") == 0.0
+
+
 def test_query_window_filters_by_ts(tmp_path: Path) -> None:
     store = PreflightAuditStore(tmp_path)
     old = datetime.now(UTC) - timedelta(hours=48)


### PR DESCRIPTION
**Dark-factory hardening WS-5 #3 (spend undercount).** Standalone off `staging`.

## Problem (verified vs staging)
`AutoAgentPreflightLoop`'s daily-budget gate reads `state.get_auto_agent_daily_spend(today)` — a cache updated only **after** the costly `run_preflight` returns (the `add_auto_agent_daily_spend` call). A crash between `run_preflight` and that update loses the increment, so the cache undercounts and the gate keeps spending past the configured cap.

## Fix
The audit log (`PreflightAuditStore`, append-only JSONL) records the same `cost_usd` and is appended **before** the cache update, so it never loses a completed attempt. The gate now uses:
```python
spend = max(state.get_auto_agent_daily_spend(today),
            audit_store.daily_spend(today))
```
The audit is a floor a crash can't erase; `max()` tolerates either being momentarily ahead and keeps the cache as a fast path. (Kept the cache rather than ripping out the tested state methods — low ripple.)

- New `PreflightAuditStore.daily_spend(date_iso)`: sums `cost_usd` for entries whose UTC ISO timestamp falls on that calendar date (`ts[:10]` prefix — no parsing).
- Tests: `daily_spend` sums only the given UTC date; the gate trips when the cache reads 0 but the audit shows spend over cap (the crash-undercount regression). Existing budget tests pass unchanged.

Full `make quality` green (**15232 passed**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)