### PR TITLE
Remove MockWorld xfailed scenario placeholders

### DIFF
--- a/tests/scenarios/browser/scenarios/test_loops_browser.py
+++ b/tests/scenarios/browser/scenarios/test_loops_browser.py
@@ -20,11 +20,13 @@ from __future__ import annotations
 import asyncio
 import json
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from playwright.async_api import expect
 
 from tests.scenarios.builders import IssueBuilder, PRBuilder
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
 
 pytestmark = pytest.mark.scenario_browser
 
@@ -130,15 +132,6 @@ async def test_l1_health_monitor_config_bump(world, page) -> None:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "workspace_gc state mock returns empty active_workspaces (Phase 1 no-ops) and "
-        "_is_safe_to_gc calls `gh api` via run_subprocess which is not stubbed in the "
-        "scenario harness. Same xfail as the reference test_loops.py::TestL2. "
-        "Remove when the workspace_gc Phase 3B track lands."
-    ),
-    strict=False,
-)
 async def test_l2_workspace_gc_cleans_stale(world, page) -> None:
     """L2: workspace_gc destroys stale (closed-issue) worktrees, preserves active.
 
@@ -156,8 +149,23 @@ async def test_l2_workspace_gc_cleans_stale(world, page) -> None:
     await world._workspace.create(100, "agent/issue-100")
     await world._workspace.create(200, "agent/issue-200")
 
+    state = MagicMock()
+    state.get_active_workspaces.return_value = {
+        100: "agent/issue-100",
+        200: "agent/issue-200",
+    }
+    state.get_active_issue_numbers.return_value = {200}
+    state.get_active_branches.return_value = {}
+    state.get_hitl_cause.return_value = None
+    state.get_issue_attempts.return_value = 0
+    _seed_ports(world, workspace_gc_state=state)
+
+    run_subprocess = AsyncMock(return_value="")
+    run_subprocess.side_effect = ["closed", ""]
+
     # --- Step 2: run loop ---
-    await world.run_with_loops(["workspace_gc"], cycles=1)
+    with patch("workspace_gc_loop.run_subprocess", run_subprocess):
+        await world.run_with_loops(["workspace_gc"], cycles=1)
 
     # --- Step 3: Python-side assertions ---
     assert 100 in world._workspace.destroyed, (

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -7,11 +7,13 @@ subclasses via ``run_with_loops()``, and asserts on the world's final state.
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from tests.scenarios.builders import IssueBuilder, PRBuilder
 from tests.scenarios.fakes.mock_world import MockWorld
+from tests.scenarios.helpers.loop_port_seeding import seed_ports as _seed_ports
 
 pytestmark = pytest.mark.scenario_loops
 
@@ -69,17 +71,6 @@ class TestL1HealthMonitorConfigAdjustment:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(
-    reason=(
-        "workspace_gc state mock returns empty active_workspaces (Phase 1 no-ops) and "
-        "_is_safe_to_gc calls `gh api` via run_subprocess which is not stubbed in the "
-        "scenario harness. Full GC coverage deferred to the per-loop scenarios track "
-        "documented in the Phase 3B plan's 'out of scope' section; remove this xfail "
-        "when that track lands and the workspace_gc registration feeds realistic "
-        "active-issue state to the loop."
-    ),
-    strict=False,
-)
 class TestL2WorkspaceGCCleansStale:
     """L2: workspace_gc destroys stale (closed-issue) worktrees, preserves active."""
 
@@ -95,8 +86,23 @@ class TestL2WorkspaceGCCleansStale:
         await world._workspace.create(100, "agent/issue-100")
         await world._workspace.create(200, "agent/issue-200")
 
+        state = MagicMock()
+        state.get_active_workspaces.return_value = {
+            100: "agent/issue-100",
+            200: "agent/issue-200",
+        }
+        state.get_active_issue_numbers.return_value = {200}
+        state.get_active_branches.return_value = {}
+        state.get_hitl_cause.return_value = None
+        state.get_issue_attempts.return_value = 0
+        _seed_ports(world, workspace_gc_state=state)
+
+        run_subprocess = AsyncMock(return_value="")
+        run_subprocess.side_effect = ["closed", ""]
+
         # Run workspace_gc — it should GC issue 100's worktree but not 200's
-        await world.run_with_loops(["workspace_gc"], cycles=1)
+        with patch("workspace_gc_loop.run_subprocess", run_subprocess):
+            await world.run_with_loops(["workspace_gc"], cycles=1)
 
         # After GC: issue 100 destroyed, 200 still active
         assert 100 in world._workspace.destroyed, (

--- a/tests/scenarios/test_trust_fleet_sanity_scenario.py
+++ b/tests/scenarios/test_trust_fleet_sanity_scenario.py
@@ -58,10 +58,6 @@ def _healthy_heartbeats(now: _dt.datetime) -> dict[str, dict[str, object]]:
     }
 
 
-@pytest.mark.xfail(
-    reason="bg_workers MagicMock doesn't support await; needs AsyncMock conversion (staging-level test bug)",
-    strict=False,
-)
 class TestTrustFleetSanityScenario:
     """§12.1 — meta-observability MockWorld scenarios."""
 
@@ -82,6 +78,7 @@ class TestTrustFleetSanityScenario:
             world,
             pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
+            event_bus=EventBus(),
         )
 
         stats = await world.run_with_loops(["trust_fleet_sanity"], cycles=1)
@@ -123,6 +120,7 @@ class TestTrustFleetSanityScenario:
             pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
             trust_fleet_sanity_bg_workers=bg_workers,
+            event_bus=EventBus(),
         )
 
         stats = await world.run_with_loops(["trust_fleet_sanity"], cycles=1)


### PR DESCRIPTION
## Summary
- Remove xfail markers from TrustFleetSanity MockWorld scenarios by seeding a real async EventBus.
- Remove WorkspaceGC scenario/browser xfails by seeding realistic GC state and stubbing only the subprocess boundary.
- Verify there are no remaining pytest xfail markers under tests/scenarios or tests/sandbox_scenarios.

## Verification
- uv run pytest -m scenario_loops tests/scenarios/test_trust_fleet_sanity_scenario.py tests/scenarios/test_loops.py -q
- uv run pytest -m scenario_browser tests/scenarios/browser/scenarios/test_loops_browser.py::test_l2_workspace_gc_cleans_stale -q
- rg -n "pytest\.mark\.xfail|@pytest\.mark\.xfail|xfail\(" tests/scenarios tests/sandbox_scenarios -S
- make quality-lite

Bead: hydraflow-a1rd