### PR TITLE
feat(resilience): wire gh circuit breaker into the subprocess boundary (WS-5)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -125,6 +125,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("max_review_diff_chars", "HYDRAFLOW_MAX_REVIEW_DIFF_CHARS", 15_000),
     ("gh_max_retries", "HYDRAFLOW_GH_MAX_RETRIES", 3),
     ("gh_api_concurrency", "HYDRAFLOW_GH_API_CONCURRENCY", 5),
+    (
+        "gh_circuit_breaker_max_failures",
+        "HYDRAFLOW_GH_CIRCUIT_BREAKER_MAX_FAILURES",
+        10,
+    ),
     ("max_issue_attempts", "HYDRAFLOW_MAX_ISSUE_ATTEMPTS", 3),
     ("memory_sync_interval", "HYDRAFLOW_MEMORY_SYNC_INTERVAL", 3600),
     ("max_merge_conflict_fix_attempts", "HYDRAFLOW_MAX_MERGE_CONFLICT_FIX_ATTEMPTS", 3),
@@ -310,6 +315,11 @@ _ENV_FLOAT_OVERRIDES: list[tuple[str, str, float]] = [
         2.0,
     ),
     ("loop_anomaly_cost_spike_ratio", "HYDRAFLOW_LOOP_ANOMALY_COST_SPIKE_RATIO", 5.0),
+    (
+        "gh_circuit_breaker_reset_timeout_s",
+        "HYDRAFLOW_GH_CIRCUIT_BREAKER_RESET_TIMEOUT_S",
+        60.0,
+    ),
 ]
 
 # Optional floats — `None` when env var is missing/empty/invalid.
@@ -334,6 +344,7 @@ _ENV_FLOAT_RATIO_OVERRIDES: list[tuple[str, str, float]] = [
 _ENV_BOOL_OVERRIDES: list[tuple[str, str, bool]] = [
     ("dry_run", "HYDRAFLOW_DRY_RUN", False),
     ("sensor_enrichment_enabled", "HYDRAFLOW_SENSOR_ENRICHMENT_ENABLED", True),
+    ("gh_circuit_breaker_enabled", "HYDRAFLOW_GH_CIRCUIT_BREAKER_ENABLED", True),
     ("issue_cache_enabled", "HYDRAFLOW_ISSUE_CACHE_ENABLED", True),
     (
         "caching_issue_store_enabled",
@@ -795,6 +806,31 @@ class HydraFlowConfig(BaseModel):
         ge=1,
         le=50,
         description="Max concurrent gh/git subprocess calls (prevents API rate limiting)",
+    )
+    gh_circuit_breaker_enabled: bool = Field(
+        default=True,
+        description=(
+            "Enable the gh/git circuit breaker (fails fast when GitHub is down). "
+            "Runtime-tunable via PATCH /api/config — the live kill-switch."
+        ),
+    )
+    gh_circuit_breaker_max_failures: int = Field(
+        default=10,
+        ge=1,
+        le=1000,
+        description=(
+            "Consecutive gh/git failures before the circuit breaker OPENs "
+            "(conservative — only trips on a sustained outage)"
+        ),
+    )
+    gh_circuit_breaker_reset_timeout_s: float = Field(
+        default=60.0,
+        ge=1.0,
+        le=3600.0,
+        description=(
+            "Seconds the gh/git circuit breaker stays OPEN before probing "
+            "(HALF_OPEN); it auto-recovers so it can't halt the factory forever"
+        ),
     )
 
     # Task source

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -204,6 +204,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     # Mutable fields that can be changed at runtime via PATCH
     _MUTABLE_FIELDS = {
+        "gh_circuit_breaker_enabled",
         "max_triagers",
         "max_workers",
         "max_planners",
@@ -493,6 +494,16 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             validated_value = getattr(validated, key)
             object.__setattr__(_cfg, key, validated_value)
             applied[key] = validated_value
+
+        # The circuit breaker lives in the process-global subprocess layer, so
+        # apply its enable/disable toggle live (the kill-switch). patch_config
+        # otherwise only mutates the config object, which the breaker can't see.
+        if "gh_circuit_breaker_enabled" in applied:
+            from subprocess_util import (  # noqa: PLC0415
+                set_gh_circuit_breaker_enabled,
+            )
+
+            set_gh_circuit_breaker_enabled(bool(applied["gh_circuit_breaker_enabled"]))
 
         if applied:
             if repo and ctx.repo_store is not None:

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -298,9 +298,14 @@ def build_services(
 
     # Configure global GitHub API concurrency limiter (startup config
     # belongs in the composition root, not the orchestrator).
-    from subprocess_util import configure_gh_concurrency
+    from subprocess_util import configure_gh_circuit_breaker, configure_gh_concurrency
 
     configure_gh_concurrency(config.gh_api_concurrency)
+    configure_gh_circuit_breaker(
+        enabled=config.gh_circuit_breaker_enabled,
+        max_failures=config.gh_circuit_breaker_max_failures,
+        reset_timeout=config.gh_circuit_breaker_reset_timeout_s,
+    )
 
     # Shadow corpus (#8786). Every gh/git/docker/claude subprocess call
     # feeds the bounded, normalized, PII-scrubbed corpus that

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
+    from circuit_breaker import CircuitBreaker
     from execution import SubprocessRunner
 
 logger = logging.getLogger("hydraflow.subprocess")
@@ -119,6 +120,49 @@ _RATE_LIMIT_POLL_INTERVAL: float = 1.0
 # and _rate_limit_until so concurrent callers cannot corrupt the backoff.
 _rate_limit_lock: threading.Lock = threading.Lock()
 
+# Global circuit breaker for the gh/git subprocess boundary. Opens after
+# ``max_failures`` consecutive non-rate-limit failures (GitHub/network down) so
+# callers fail fast instead of hammering a dead API; it auto-probes (HALF_OPEN)
+# after ``reset_timeout`` so it can never halt the factory permanently. When
+# disabled, every call is allowed — the live kill-switch, toggled via
+# ``PATCH /api/config`` → ``set_gh_circuit_breaker_enabled``. The breaker's
+# methods are synchronous and never await, so the single asyncio loop runs each
+# atomically; no extra lock is needed (unlike the cross-thread rate-limit state).
+_gh_circuit_breaker: CircuitBreaker | None = None
+_gh_circuit_breaker_enabled: bool = False
+
+
+def configure_gh_circuit_breaker(
+    enabled: bool, max_failures: int = 10, reset_timeout: float = 60.0
+) -> None:
+    """Configure the gh/git circuit breaker. Call once during startup."""
+    global _gh_circuit_breaker, _gh_circuit_breaker_enabled  # noqa: PLW0603
+    from circuit_breaker import CircuitBreaker  # noqa: PLC0415
+
+    _gh_circuit_breaker = CircuitBreaker(
+        "gh-subprocess", max_failures=max_failures, reset_timeout=reset_timeout
+    )
+    _gh_circuit_breaker_enabled = enabled
+    logger.info(
+        "gh circuit breaker configured (enabled=%s, max_failures=%d, "
+        "reset_timeout=%.0fs)",
+        enabled,
+        max_failures,
+        reset_timeout,
+    )
+
+
+def set_gh_circuit_breaker_enabled(enabled: bool) -> None:
+    """Enable/disable the gh circuit breaker at runtime — the live kill-switch.
+
+    Toggled via ``PATCH /api/config`` (``gh_circuit_breaker_enabled``) so an
+    operator can disable a misbehaving breaker without a restart. When disabled
+    the breaker never blocks a call (outcomes are simply not consulted).
+    """
+    global _gh_circuit_breaker_enabled  # noqa: PLW0603
+    _gh_circuit_breaker_enabled = enabled
+    logger.info("gh circuit breaker enabled=%s (runtime toggle)", enabled)
+
 
 def configure_gh_concurrency(limit: int) -> None:
     """Set the global GitHub API concurrency limit.
@@ -150,6 +194,41 @@ def _is_rate_limited(stderr: str) -> bool:
     """Check if stderr indicates a GitHub API rate limit (403)."""
     lower = stderr.lower()
     return "rate limit" in lower and ("403" in lower or "http 403" in lower)
+
+
+# Infrastructure/outage failure signatures — GitHub or the network is unhealthy.
+# ONLY these count toward the circuit breaker. A 4xx (404 "not found", 422,
+# "label does not exist", "cannot approve your own pull request", etc.) means
+# GitHub is UP and answered with a client error — that's normal control flow,
+# not an outage, and must never trip the process-global breaker.
+_GH_OUTAGE_PATTERNS = (
+    "http 5",  # any 5xx
+    "internal server error",
+    "bad gateway",
+    "service unavailable",
+    "gateway timeout",
+    "could not resolve",
+    "could not connect",
+    "connection refused",
+    "connection reset",
+    "network is unreachable",
+    "timed out",
+    "timeout",
+    "i/o timeout",
+    "tls handshake",
+)
+
+
+def _is_gh_outage_error(stderr: str) -> bool:
+    """True when a failed gh call looks like a GitHub/network outage.
+
+    Used to decide whether a failure counts toward the circuit breaker. Client
+    errors (4xx) and business-logic non-zero exits are excluded — they are not
+    outage signals, so they must not accumulate toward an OPEN that would halt
+    all gh calls factory-wide.
+    """
+    low = stderr.lower()
+    return any(p in low for p in _GH_OUTAGE_PATTERNS)
 
 
 def _trigger_rate_limit_cooldown() -> None:
@@ -209,6 +288,16 @@ class AuthenticationError(RuntimeError):
 
 class SubprocessTimeoutError(RuntimeError):
     """Raised when a subprocess exceeds its allowed execution time."""
+
+
+class CircuitBreakerOpenError(RuntimeError):
+    """Raised when the gh/git circuit breaker is OPEN and short-circuits a call.
+
+    Distinct from a transient failure: recent gh/git calls failed repeatedly
+    (likely GitHub or the network is down), so we fail fast instead of piling
+    on. The message contains none of ``_RETRYABLE_PATTERNS`` so
+    ``run_subprocess_with_retry`` will not retry it.
+    """
 
 
 class CreditExhaustedError(RuntimeError):
@@ -529,6 +618,18 @@ async def run_subprocess(
     resolved_runner = runner if runner is not None else get_default_runner()
 
     use_semaphore = bool(cmd) and cmd[0] in _GH_COMMANDS
+    # The circuit breaker guards the GitHub API (``gh``) specifically — NOT local
+    # ``git``. A repeated ``git`` failure (merge conflict, "nothing to commit", a
+    # corrupted worktree) is not a GitHub-down signal, and counting it could trip
+    # this PROCESS-GLOBAL breaker and halt all gh/git factory-wide on a purely
+    # local problem. ``gh`` failures are the clean outage signal. Enabled state
+    # (the live kill-switch) is re-read here each call, so a runtime toggle takes
+    # effect on the next subprocess.
+    breaker = (
+        _gh_circuit_breaker
+        if bool(cmd) and cmd[0] == "gh" and _gh_circuit_breaker_enabled
+        else None
+    )
 
     async def _exec() -> str:
         try:
@@ -539,6 +640,8 @@ async def run_subprocess(
                 timeout=timeout,
             )
         except TimeoutError as exc:
+            if breaker is not None:
+                breaker.record_failure()
             raise SubprocessTimeoutError(
                 f"Command {cmd!r} timed out after {timeout}s"
             ) from exc
@@ -555,15 +658,38 @@ async def run_subprocess(
                 stderr=result.stderr,
             )
             if _is_auth_error(result.stderr):
+                # Auth failure = bad/again-rejected credentials, not an outage;
+                # opening the breaker wouldn't help (the token is still bad after
+                # the reset window), so it must not count toward it.
                 raise AuthenticationError(msg) from cause
             if _is_rate_limited(result.stderr):
                 _trigger_rate_limit_cooldown()
+                # A rate limit has its own global cooldown and is not a
+                # GitHub-down signal, so it must NOT count toward the breaker.
+                raise RuntimeError(msg) from cause
+            # Count toward the breaker ONLY genuine GitHub/network outages — a
+            # 4xx / business-logic non-zero exit (404, "label does not exist",
+            # "cannot approve your own pull request", …) is normal control flow
+            # and must not accumulate toward an OPEN that halts the factory.
+            if breaker is not None and _is_gh_outage_error(result.stderr):
+                breaker.record_failure()
             raise RuntimeError(msg) from cause
         _reset_rate_limit_backoff()
+        if breaker is not None:
+            breaker.record_success()
         _maybe_sample_shadow(cmd, result.returncode, result.stdout, result.stderr)
         return result.stdout
 
     if use_semaphore:
+        if breaker is not None and not breaker.allow_request():
+            # Fail fast: recent gh/git calls failed repeatedly (likely GitHub or
+            # the network is down). The message intentionally avoids retryable
+            # keywords so run_subprocess_with_retry won't retry it.
+            raise CircuitBreakerOpenError(
+                f"gh/git circuit breaker OPEN ({breaker.max_failures}+ "
+                "consecutive failures); failing fast instead of hammering a "
+                "likely-down GitHub. Recovers after the reset window."
+            )
         await _wait_for_rate_limit_cooldown()
         async with _get_gh_semaphore():
             return await _exec()
@@ -620,7 +746,10 @@ async def run_subprocess_with_retry(
                 *cmd, cwd=cwd, gh_token=gh_token, timeout=timeout, runner=runner
             )
         except RuntimeError as exc:
-            if isinstance(exc, AuthenticationError | CreditExhaustedError):
+            if isinstance(
+                exc,
+                AuthenticationError | CreditExhaustedError | CircuitBreakerOpenError,
+            ):
                 raise
             last_error = exc
             error_msg = str(exc)

--- a/tests/test_config_persist_endpoint.py
+++ b/tests/test_config_persist_endpoint.py
@@ -73,6 +73,29 @@ class TestPatchConfigEndpoint:
         assert config.model == "opus"
 
     @pytest.mark.asyncio
+    async def test_patch_config_toggles_gh_circuit_breaker_live(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        """The gh circuit breaker kill-switch must take effect without a restart.
+
+        The breaker lives in the process-global subprocess layer, so patch_config
+        re-applies the toggle to that global — not just the config object.
+        """
+        import subprocess_util
+
+        subprocess_util._gh_circuit_breaker_enabled = True  # as configured at startup
+        router = _make_router(config, event_bus, state, tmp_path)
+        endpoint = _find_endpoint(router, "/api/control/config")
+
+        response = await endpoint({"gh_circuit_breaker_enabled": False})
+        data = json.loads(response.body)
+
+        assert data["updated"]["gh_circuit_breaker_enabled"] is False
+        # Live kill-switch: the module global flipped, not just config.
+        assert subprocess_util._gh_circuit_breaker_enabled is False
+        assert config.gh_circuit_breaker_enabled is False
+
+    @pytest.mark.asyncio
     async def test_patch_config_with_persist_writes_file(
         self, event_bus: EventBus, state, tmp_path: Path
     ) -> None:

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -985,6 +985,152 @@ class TestRateLimitCooldown:
         assert subprocess_util._rate_limit_until is None
 
 
+class TestGhCircuitBreaker:
+    @pytest.fixture(autouse=True)
+    def _reset_state(self) -> None:
+        import subprocess_util
+
+        subprocess_util._gh_semaphore = None
+        subprocess_util._rate_limit_until = None
+        subprocess_util._gh_circuit_breaker = None
+        subprocess_util._gh_circuit_breaker_enabled = False
+
+    @staticmethod
+    def _runner(stderr: str = "", returncode: int = 0, stdout: str = "done"):
+        from execution import SimpleResult
+
+        async def _run(cmd: list[str], **_kwargs: object) -> SimpleResult:
+            return SimpleResult(stdout=stdout, stderr=stderr, returncode=returncode)
+
+        runner = MagicMock()
+        runner.run_simple = _run
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_opens_after_max_consecutive_failures_then_fails_fast(self) -> None:
+        from subprocess_util import (
+            CircuitBreakerOpenError,
+            configure_gh_circuit_breaker,
+        )
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=3, reset_timeout=60.0)
+        fail = self._runner(stderr="fatal: unable to access (HTTP 500)", returncode=1)
+
+        # Three real command failures trip the breaker.
+        for _ in range(3):
+            with pytest.raises(RuntimeError) as ei:
+                await run_subprocess("gh", "api", "x", runner=fail)
+            assert not isinstance(ei.value, CircuitBreakerOpenError)
+
+        # Now OPEN: the next call short-circuits without running the command.
+        with pytest.raises(CircuitBreakerOpenError):
+            await run_subprocess("gh", "api", "x", runner=fail)
+
+    @pytest.mark.asyncio
+    async def test_half_open_probe_success_closes_breaker(self) -> None:
+        import subprocess_util
+        from subprocess_util import configure_gh_circuit_breaker
+
+        configure_gh_concurrency(5)
+        # reset_timeout=0 → OPEN transitions to HALF_OPEN immediately on next check.
+        configure_gh_circuit_breaker(enabled=True, max_failures=2, reset_timeout=0.0)
+        fail = self._runner(stderr="fatal: unable to access (HTTP 500)", returncode=1)
+        for _ in range(2):
+            with pytest.raises(RuntimeError):
+                await run_subprocess("gh", "api", "x", runner=fail)
+
+        # HALF_OPEN allows a probe; a success closes the breaker.
+        out = await run_subprocess("gh", "api", "x", runner=self._runner())
+        assert out == "done"
+        assert subprocess_util._gh_circuit_breaker.state == "closed"
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_failure_does_not_count_toward_breaker(self) -> None:
+        import subprocess_util
+        from subprocess_util import configure_gh_circuit_breaker
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=3, reset_timeout=60.0)
+
+        rl = self._runner(stderr="API rate limit exceeded (HTTP 403)", returncode=1)
+        with pytest.raises(RuntimeError):
+            await run_subprocess("gh", "api", "x", runner=rl)
+        # Rate-limit has its own cooldown — it must NOT increment the breaker.
+        assert subprocess_util._gh_circuit_breaker._failure_count == 0
+
+        # A genuine outage failure DOES count. (Clear the cooldown the rl call
+        # set so this call doesn't wait on it.)
+        subprocess_util._rate_limit_until = None
+        with pytest.raises(RuntimeError):
+            await run_subprocess(
+                "gh",
+                "api",
+                "x",
+                runner=self._runner(
+                    stderr="HTTP 503 Service Unavailable", returncode=1
+                ),
+            )
+        assert subprocess_util._gh_circuit_breaker._failure_count == 1
+
+    @pytest.mark.asyncio
+    async def test_benign_4xx_gh_failures_do_not_count_toward_breaker(self) -> None:
+        import subprocess_util
+        from subprocess_util import (
+            CircuitBreakerOpenError,
+            configure_gh_circuit_breaker,
+        )
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=3, reset_timeout=60.0)
+        # GitHub is UP and answering with client errors — normal control flow
+        # (e.g. removing a label that isn't present). These must NOT trip the
+        # outage breaker no matter how many occur in a row.
+        benign = self._runner(
+            stderr="HTTP 404: Not Found (label does not exist)", returncode=1
+        )
+        for _ in range(10):
+            with pytest.raises(RuntimeError) as ei:
+                await run_subprocess("gh", "api", "x", runner=benign)
+            assert not isinstance(ei.value, CircuitBreakerOpenError)
+        assert subprocess_util._gh_circuit_breaker._failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_local_git_failures_do_not_count_toward_breaker(self) -> None:
+        import subprocess_util
+        from subprocess_util import (
+            CircuitBreakerOpenError,
+            configure_gh_circuit_breaker,
+        )
+
+        configure_gh_concurrency(5)
+        configure_gh_circuit_breaker(enabled=True, max_failures=2, reset_timeout=60.0)
+        # Local git failures (e.g. a corrupted worktree) must not trip the
+        # process-global breaker — it guards the GitHub API (gh), not local git.
+        git_fail = self._runner(stderr="fatal: not a work tree", returncode=1)
+        for _ in range(5):
+            with pytest.raises(RuntimeError) as ei:
+                await run_subprocess("git", "status", runner=git_fail)
+            assert not isinstance(ei.value, CircuitBreakerOpenError)
+        assert subprocess_util._gh_circuit_breaker._failure_count == 0
+
+    @pytest.mark.asyncio
+    async def test_disabled_breaker_never_blocks(self) -> None:
+        from subprocess_util import (
+            CircuitBreakerOpenError,
+            configure_gh_circuit_breaker,
+        )
+
+        configure_gh_concurrency(5)
+        # The live kill-switch: disabled => never short-circuits, even past cap.
+        configure_gh_circuit_breaker(enabled=False, max_failures=1, reset_timeout=60.0)
+        fail = self._runner(stderr="fatal: unable to access (HTTP 500)", returncode=1)
+        for _ in range(5):
+            with pytest.raises(RuntimeError) as ei:
+                await run_subprocess("gh", "api", "x", runner=fail)
+            assert not isinstance(ei.value, CircuitBreakerOpenError)
+
+
 # ---------------------------------------------------------------------------
 # Credit exhaustion detection — Anthropic API spend-cap rejections
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Dark-factory hardening WS-5 #4 (circuit breaker).** Standalone off `staging`. Completes WS-5 (spend floor shipped in #9120).

Wires the tested-but-unused `CircuitBreaker` into `subprocess_util.run_subprocess` at the GitHub-API boundary, so the factory **fails fast** (instead of hammering a dead API) during a GitHub outage and **auto-recovers** when it returns.

> This guards **every** `gh` call, so a false-open would halt the factory. The design is deliberately conservative.

## Scope + safety
- **`gh` only, not local `git`.** A repeated `git` failure (merge conflict, "nothing to commit", a corrupted worktree) is not a GitHub-down signal and must not trip a process-global breaker.
- **Counts outage-class failures only**: timeouts + 5xx / connection / DNS / TLS (`_is_gh_outage_error`). **Benign 4xx / business-logic** nonzero exits (`404 "label does not exist"`, `"cannot approve your own pull request"`, …), **auth errors**, and **rate limits** do **not** count — they aren't outages, and counting them could open the breaker on normal control flow (e.g. a label sweep) and halt all `gh` factory-wide. *(This was caught in review pass 1 and fixed.)*
- **Conservative**: `max_failures=10` consecutive (any success resets); auto-probes `HALF_OPEN` after `reset_timeout` (default 60s) so it can never halt permanently.
- **Live kill-switch**: `gh_circuit_breaker_enabled` is in `_MUTABLE_FIELDS`; `patch_config` re-applies it to the process-global via `set_gh_circuit_breaker_enabled`, so an operator can disable a misbehaving breaker via `PATCH /api/control/config` **without a restart**.
- `CircuitBreakerOpenError` is in `run_subprocess_with_retry`'s isinstance fast-exit (explicit no-retry); its message avoids retryable keywords.

## Config (all env-tunable)
`gh_circuit_breaker_enabled` (bool, True) · `gh_circuit_breaker_max_failures` (int, 10) · `gh_circuit_breaker_reset_timeout_s` (float, 60). Wired at startup in `service_registry` beside `configure_gh_concurrency`.

## Tests
`TestGhCircuitBreaker`: opens after N consecutive outage failures then fails fast; `HALF_OPEN` probe success closes it; rate-limit / benign-4xx / local-`git` failures do **not** count; disabled never blocks; `PATCH /api/control/config` toggles it live. Full `make quality` green (**15273 passed**). **Two adversarial review passes** — pass 1 caught + fixed the benign-nonzero false-open risk, pass 2 converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)