### PR TITLE
test(mockworld): assert scenario side effects through fakes

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-05-31T05:14:40.623239+00:00",
-  "commit_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9",
+  "regenerated_at": "2026-05-31T06:11:22.210076+00:00",
+  "commit_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb",
   "artifacts": {
     "loops.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "ports.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "labels.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "modules.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "events.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "adr_xref.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "mockworld.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "changelog.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "coverage_matrix.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "functional_areas.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "ubiquitous-language.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "347cc9ed2d20ebfc7a1dce0ad074f95340a826c9"
+      "source_sha": "23d41c7d8e29cfed81ca688d85fd38cc0a9a66eb"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -252,4 +252,4 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.workspace_gc_loop` | ADR-0069 |
 | `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W22
 
+- `1e5ce26` — test(mockworld): count real scenario key invocations (#9121) (#9121) *(2026-05-30)*
 - `347cc9e` — test(mockworld): close loop coverage matrix gaps (#9119) (#9119) *(2026-05-30)*
 - `932dc1d` — fix(mockworld): include FakeHoneycomb in generated map (#9116) (#9116) *(2026-05-30)*
 - `5ada680` — test: harden MockWorld side-effect coverage (#9104) (#9104) *(2026-05-30)*
@@ -381,4 +382,4 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `ac0ecda` — Fixes #1883: [Bug Report] remove the processes tab too, and related... (#1906) (#1906) *(2026-03-04)*
 
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -78,4 +78,4 @@ HITL trigger). It is not regenerable from source and is maintained in
 `docs/arch/coverage_matrix.md` (the hand-curated baseline document).
 
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/events.md
+++ b/docs/arch/generated/events.md
@@ -52,4 +52,4 @@ Every `EventType` published or subscribed in `src/`. Events with no subscribers 
 | **VISUAL_GATE** ⚠️ | `src.post_merge_handler:PostMergeHandler._run_visual_gate`<br>`src.review_phase._phase:ReviewPhase._emit_visual_gate_telemetry`<br>`src.review_phase._phase:ReviewPhase.check_visual_gate` | — |
 | **WORKER_UPDATE** ⚠️ | `src.agent:AgentRunner._emit_status` | — |
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/functional_areas.md
+++ b/docs/arch/generated/functional_areas.md
@@ -279,4 +279,4 @@ The plan→implement→review pipeline driving each issue from hydraflow-ready t
 **Related ADRs:** `ADR-0001`, `ADR-0004`, `ADR-0011`, `ADR-0012`, `ADR-0029`
 
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/labels.md
+++ b/docs/arch/generated/labels.md
@@ -7,4 +7,4 @@ Live transitions extracted from source. Compared against the Mermaid block in AD
 _(no transitions discovered)_
 
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/loops.md
+++ b/docs/arch/generated/loops.md
@@ -52,4 +52,4 @@ All `BaseBackgroundLoop` subclasses discovered in `src/`. Generated from AST (no
 | **WikiRotDetectorLoop** | `src.wiki_rot_detector_loop` | 604800 | — | — | — |
 | **WorkspaceGCLoop** | `src.workspace_gc_loop` | 1800 | — | — | — |
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/mockworld.md
+++ b/docs/arch/generated/mockworld.md
@@ -14,8 +14,8 @@ All Fake adapters under `src/mockworld/fakes/` (classes with ``_is_fake_adapter 
 | **FakeClock** | `ClockPort` | `tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/fakes/test_fake_clock.py`<br>`tests/scenarios/fakes/test_supporting_fakes.py`<br>`tests/scenarios/test_fidelity.py` |
 | **FakeDocker** | `DockerPort` | `tests/scenarios/fakes/test_fake_docker.py`<br>`tests/scenarios/fakes/test_fake_subprocess_runner.py` |
 | **FakeFS** | `FSPort` | `tests/scenarios/fakes/test_fake_fs.py` |
-| **FakeGit** | `GitPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_git.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
-| **FakeGitHub** | `GitHubPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py` |
+| **FakeGit** | `GitPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_git.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py`<br>`tests/scenarios/test_memory_backlog_scenario.py` |
+| **FakeGitHub** | `GitHubPort` | `tests/scenarios/behaviors/test_eventual_consistency.py`<br>`tests/scenarios/behaviors/test_flaky.py`<br>`tests/scenarios/behaviors/test_latency.py`<br>`tests/scenarios/behaviors/test_rate_limit.py`<br>`tests/scenarios/browser/scenarios/test_loops_browser.py`<br>`tests/scenarios/fakes/test_fake_github.py`<br>`tests/scenarios/fakes/test_mock_world.py`<br>`tests/scenarios/fuzz/test_invariants.py`<br>`tests/scenarios/test_fidelity.py`<br>`tests/scenarios/test_loops.py`<br>`tests/scenarios/test_memory_backlog_scenario.py` |
 | **FakeHTTP** | `HTTPPort` | `tests/scenarios/fakes/test_fake_http.py` |
 | **FakeHoneycomb** | `HoneycombPort` | — |
 | **FakeIssueFetcher** | `IssueFetcherPort` | — |
@@ -76,4 +76,4 @@ graph LR
     tests_scenarios_fakes_test_supporting_fakes_py([tests/scenarios/fakes/test_supporting_fakes.py]) --> FakeWorkspace
 ```
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -44,4 +44,4 @@ graph LR
     src_state -- "1" --> src
 ```
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/arch/generated/ports.md
+++ b/docs/arch/generated/ports.md
@@ -100,4 +100,4 @@ graph LR
   - `WorkspaceManager` (`src.workspace`)
 - Fake: `FakeWorkspace` (`mockworld.fakes.fake_workspace`)
 
-_Regenerated from commit `347cc9e` on 2026-05-31 05:14 UTC. Source last changed at `347cc9e`. Status: 🟢 fresh._
+_Regenerated from commit `23d41c7` on 2026-05-31 06:11 UTC. Source last changed at `23d41c7`. Status: 🟢 fresh._

--- a/docs/standards/testing/README.md
+++ b/docs/standards/testing/README.md
@@ -66,6 +66,7 @@ A feature merges into `staging` when ALL three layers exist for it. Specifically
   - **Pattern A (full MockWorld):** import `MockWorld`, set up via builder methods (`add_repo`, `add_issue`, `set_phase_result`, `fail_service`), drive a phase or loop tick, assert against `world.<fake>`. Use this when the test exercises orchestration + multiple ports.
   - **Pattern B (direct instantiation):** build the loop directly with `LoopDeps` + a `MagicMock(spec=PRPort)` whose methods are scripted. Use this when the test exercises a single loop's reaction to specific port outcomes (e.g. `prs.merge_promotion_pr` returns False → loop files find-issue). Existing example: `tests/scenarios/test_caretaker_loops_part2.py::TestL22StagingPromotionLoop`.
 - The choice is governed by what's being asserted. Pattern A asserts cross-cutting outcomes ("after the phase ran, the dashboard reflects X"). Pattern B asserts a loop's reaction surface ("when the port returns Y, the loop does Z").
+- **Do not replace FakeGitHub side effects with raw mocks in MockWorld scenarios.** If a Pattern A test expects `create_issue`, `post_comment`, `add_labels`, `close_issue`, or related PR/issue mutations, let `MockWorld` wire `FakeGitHub` and assert `world.github.issue(...)`, labels, comments, PR records, or issue state. Keep raw `AsyncMock`/`MagicMock` PR ports only in documented Pattern B direct-instantiation tests or for boundaries FakeGitHub cannot model yet. `tests/architecture/test_mockworld_scenario_fake_boundaries.py` enforces this.
 
 ### Sandbox e2e scenarios
 - Live in `tests/sandbox_scenarios/scenarios/sNN_<feature>.py`
@@ -125,6 +126,11 @@ wrong. Canonicalised here so the generator slice and future audits agree.
   keep a green scenario file without a load-bearing assertion.
 
 - **Scenario tests that just unit-test through a fake.** Pattern B is fine when the loop's reaction surface is what matters — but if the test could equivalently be written as a unit test of one method, it's not really a scenario test.
+
+- **MockWorld scenarios that assert GitHub call counts instead of fake state.**
+  `create_issue.assert_awaited_once()` proves the call happened, not that
+  HydraFlow filed the right issue, labels, body, or state transition. Assert
+  the `FakeGitHub` state unless the test is explicitly documented as Pattern B.
 
 - **Screenshot or pixel-baseline regression tests.** They are noisy and
   low-signal for HydraFlow's UI. Prefer role/text/state/API assertions that

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -10,6 +10,10 @@ instead of replacing `create_issue`, `post_comment`, or `add_labels` with raw
 `AsyncMock` call counters. Mock only the unmodeled external boundary, such as a
 `gh` subprocess, `git bisect`, or an LLM corpus runner. Cover parser and
 formatter branches that sit behind those boundaries with focused unit tests.
+`tests/architecture/test_mockworld_scenario_fake_boundaries.py` guards this for
+MockWorld scenario files; documented Pattern B direct-instantiation tests may
+still script a PR port when the assertion is the loop's reaction to a specific
+port return value.
 **Why:** Adapter-backed assertions catch title/body/label drift and fake-contract
 regressions that call-count-only mocks hide.
 

--- a/tests/architecture/test_mockworld_scenario_fake_boundaries.py
+++ b/tests/architecture/test_mockworld_scenario_fake_boundaries.py
@@ -1,0 +1,104 @@
+"""Guard MockWorld scenarios against bypassing stateful fake adapters."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SCENARIO_ROOT = Path("tests/scenarios")
+WATCHED_GITHUB_METHODS = {
+    "add_labels",
+    "add_pr_labels",
+    "close_issue",
+    "create_issue",
+    "post_comment",
+    "post_pr_comment",
+    "remove_label",
+    "swap_pipeline_labels",
+    "update_issue_body",
+}
+MOCK_CONSTRUCTORS = {"AsyncMock", "MagicMock", "Mock"}
+
+
+def _is_mockworld_scenario(tree: ast.AST, source: str) -> bool:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.endswith("fakes.mock_world")
+        ):
+            return True
+        if isinstance(node, ast.Import) and any(
+            alias.name.endswith("fakes.mock_world") for alias in node.names
+        ):
+            return True
+    return "MockWorld(" in source or "run_with_loops(" in source
+
+
+def _mock_constructor_name(node: ast.AST) -> str | None:
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _find_raw_github_side_effect_mocks(path: Path) -> list[str]:
+    source = path.read_text()
+    tree = ast.parse(source, filename=str(path))
+    if not _is_mockworld_scenario(tree, source):
+        return []
+
+    parents: dict[ast.AST, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+
+        constructor = _mock_constructor_name(node.value)
+        if constructor not in MOCK_CONSTRUCTORS:
+            continue
+
+        for target in targets:
+            if (
+                isinstance(target, ast.Attribute)
+                and target.attr in WATCHED_GITHUB_METHODS
+            ):
+                if _is_documented_pattern_b(node, parents):
+                    continue
+                violations.append(
+                    f"{path}:{node.lineno} assigns {target.attr} to {constructor}"
+                )
+
+    return violations
+
+
+def _is_documented_pattern_b(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            doc = ast.get_docstring(current) or ""
+            if "Pattern B" in doc or "direct instantiation" in doc:
+                return True
+        current = parents.get(current)
+    return False
+
+
+def test_mockworld_scenarios_assert_github_side_effects_through_fake_state() -> None:
+    """MockWorld scenarios must use FakeGitHub for stateful GitHub side effects."""
+    violations: list[str] = []
+    for path in sorted(SCENARIO_ROOT.rglob("test*.py")):
+        violations.extend(_find_raw_github_side_effect_mocks(path))
+
+    assert violations == []

--- a/tests/scenarios/test_diagram_loop_mockworld.py
+++ b/tests/scenarios/test_diagram_loop_mockworld.py
@@ -27,11 +27,7 @@ class TestL24DiagramLoop:
         """Clean source → emit() runs, git status empty, no PR opened."""
         world = MockWorld(tmp_path)
 
-        github = AsyncMock(
-            find_existing_issue=AsyncMock(return_value=0),
-            create_issue=AsyncMock(return_value=0),
-        )
-        _seed_ports(world, github=github)
+        _seed_ports(world, github=world.github)
 
         pr_helper = AsyncMock()
         with (
@@ -46,17 +42,13 @@ class TestL24DiagramLoop:
         assert result == {"drift": False}
         mock_emit.assert_called_once()
         pr_helper.assert_not_awaited()
-        github.find_existing_issue.assert_not_awaited()
+        assert world.github._issues == {}
 
     async def test_drift_opens_regen_pr_via_auto_pr(self, tmp_path) -> None:
         """Source drifted → auto_pr opens PR with arch-regen-auto branch."""
         world = MockWorld(tmp_path)
 
-        github = AsyncMock(
-            find_existing_issue=AsyncMock(return_value=0),
-            create_issue=AsyncMock(return_value=0),
-        )
-        _seed_ports(world, github=github)
+        _seed_ports(world, github=world.github)
 
         pr_result = MagicMock(status="opened", pr_url="https://github.com/x/y/pull/1")
         pr_helper = AsyncMock(return_value=pr_result)

--- a/tests/scenarios/test_live_corpus_replay_scenario.py
+++ b/tests/scenarios/test_live_corpus_replay_scenario.py
@@ -20,6 +20,7 @@ from contracts.shadow import ShadowCorpus
 from dedup_store import DedupStore
 from events import EventBus
 from live_corpus_replay_loop import LiveCorpusReplayLoop
+from tests.scenarios.fakes.mock_world import MockWorld
 
 pytestmark = pytest.mark.scenario_loops
 
@@ -29,6 +30,7 @@ class TestLiveCorpusReplayScenario:
         """End-to-end: a shadow sample diverging from the fake fires a
         ``hydraflow-find`` + ``shadow-drift`` issue via PRManager.create_issue.
         No HITL label, no human in the loop."""
+        world = MockWorld(tmp_path)
         config = HydraFlowConfig(
             data_root=tmp_path / "data",
             repo_root=tmp_path / "repo",
@@ -48,8 +50,6 @@ class TestLiveCorpusReplayScenario:
             "live_corpus_replay",
             config.data_root / "dedup" / "live_corpus_replay.json",
         )
-        pr = MagicMock()
-        pr.create_issue = AsyncMock(return_value=7777)
         stop = asyncio.Event()
         deps = LoopDeps(
             event_bus=EventBus(),
@@ -61,7 +61,7 @@ class TestLiveCorpusReplayScenario:
         loop = LiveCorpusReplayLoop(
             config=config,
             corpus=corpus,
-            pr_manager=pr,
+            pr_manager=world.github,
             dedup=dedup,
             deps=deps,
         )
@@ -75,14 +75,9 @@ class TestLiveCorpusReplayScenario:
         result = await loop._do_work()
 
         assert result["drifted"] == 1
-        assert result["filed_issue"] == 7777
-        pr.create_issue.assert_awaited_once()
-        call_args = pr.create_issue.await_args
-        labels = (
-            call_args.kwargs.get("labels")
-            if "labels" in call_args.kwargs
-            else call_args.args[2]
-        )
+        assert result["filed_issue"] == 9001
+        issue = world.github.issue(9001)
+        labels = issue.labels
         assert "hydraflow-find" in labels
         assert "shadow-drift" in labels
         # Critically: the issue must NOT carry hitl-escalation or

--- a/tests/scenarios/test_memory_backlog_scenario.py
+++ b/tests/scenarios/test_memory_backlog_scenario.py
@@ -73,11 +73,12 @@ def _write_entry(
 
 
 def _make_loop(repo_root: Path):
-    """Build a MemoryBacklogLoop with a real config + mocked PRManager."""
+    """Build a MemoryBacklogLoop with a real config + FakeGitHub PRManager."""
     from base_background_loop import LoopDeps  # noqa: PLC0415
     from dedup_store import DedupStore  # noqa: PLC0415
     from events import EventBus  # noqa: PLC0415
     from memory_backlog_loop import MemoryBacklogLoop  # noqa: PLC0415
+    from mockworld.fakes.fake_github import FakeGitHub  # noqa: PLC0415
     from tests.helpers import ConfigFactory  # noqa: PLC0415
 
     config = ConfigFactory.create(repo_root=repo_root)
@@ -100,13 +101,12 @@ def _make_loop(repo_root: Path):
     dedup_path.parent.mkdir(parents=True, exist_ok=True)
     dedup = DedupStore("memory_backlog", dedup_path)
 
-    pr_manager = MagicMock()
-    pr_manager.create_issue = AsyncMock(return_value=4242)
+    github = FakeGitHub()
 
     loop = MemoryBacklogLoop(
-        config=config, state=state, pr_manager=pr_manager, dedup=dedup, deps=deps
+        config=config, state=state, pr_manager=github, dedup=dedup, deps=deps
     )
-    return loop, pr_manager
+    return loop, github
 
 
 class TestMemoryBacklogScenario:
@@ -114,12 +114,14 @@ class TestMemoryBacklogScenario:
         """Happy path: a single pending entry yields one create_issue call."""
         repo = _make_repo_with_mirror(tmp_path)
         _write_entry(repo / "docs" / "wiki" / "memory-feedback", "feedback-alpha")
-        loop, pr_manager = _make_loop(repo)
+        loop, github = _make_loop(repo)
 
         result = await loop._do_work()
 
         assert result == {"status": "ok", "filed": 1, "skipped": 0, "escalated": 0}
-        pr_manager.create_issue.assert_awaited_once()
+        assert len(github._issues) == 1
+        issue = next(iter(github._issues.values()))
+        assert "feedback-alpha" in issue.title
 
     async def test_malformed_yaml_does_not_crash_loop(self, tmp_path: Path) -> None:
         """A malformed mirror entry must not crash the loop — the good entries
@@ -139,10 +141,10 @@ class TestMemoryBacklogScenario:
             "status: pending\n"
             "---\n\nbody\n"
         )
-        loop, pr_manager = _make_loop(repo)
+        loop, github = _make_loop(repo)
 
         result = await loop._do_work()
 
         assert result["status"] == "ok"
         assert result["filed"] == 1
-        pr_manager.create_issue.assert_awaited_once()
+        assert len(github._issues) == 1

--- a/tests/scenarios/test_pricing_refresh_loop_mockworld.py
+++ b/tests/scenarios/test_pricing_refresh_loop_mockworld.py
@@ -68,11 +68,7 @@ class TestPricingRefreshLoop:
         world = MockWorld(tmp_path)
         _seed_pricing_file(tmp_path)
 
-        github = AsyncMock(
-            find_existing_issue=AsyncMock(return_value=0),
-            create_issue=AsyncMock(return_value=0),
-        )
-        _seed_ports(world, github=github, repo_root=tmp_path)
+        _seed_ports(world, github=world.github, repo_root=tmp_path)
 
         upstream_payload = {
             "claude-haiku-4-5-20251001": {
@@ -102,18 +98,14 @@ class TestPricingRefreshLoop:
 
         assert stats["pricing_refresh"] == {"drift": False}
         pr_helper.assert_not_awaited()
-        github.create_issue.assert_not_awaited()
+        assert world.github._issues == {}
 
     async def test_drift_opens_pr(self, tmp_path) -> None:
         """Upstream price changed → PR opens with pricing-refresh-auto branch."""
         world = MockWorld(tmp_path)
         _seed_pricing_file(tmp_path)
 
-        github = AsyncMock(
-            find_existing_issue=AsyncMock(return_value=0),
-            create_issue=AsyncMock(return_value=0),
-        )
-        _seed_ports(world, github=github, repo_root=tmp_path)
+        _seed_ports(world, github=world.github, repo_root=tmp_path)
 
         # Bump haiku's input cost: 1.0/M → 1.5/M (within bounds).
         upstream_payload = {

--- a/tests/scenarios/test_trust_fleet_sanity_scenario.py
+++ b/tests/scenarios/test_trust_fleet_sanity_scenario.py
@@ -25,7 +25,7 @@ stubbed via pre-seeded port keys.
 from __future__ import annotations
 
 import datetime as _dt
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -64,8 +64,6 @@ class TestTrustFleetSanityScenario:
     async def test_no_anomaly_no_file(self, tmp_path) -> None:
         """Healthy fleet → loop runs, finds nothing, files nothing."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=0)
 
         now = _dt.datetime.now(_dt.UTC)
         state = MagicMock()
@@ -76,7 +74,6 @@ class TestTrustFleetSanityScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
             event_bus=EventBus(),
         )
@@ -85,13 +82,11 @@ class TestTrustFleetSanityScenario:
 
         assert stats["trust_fleet_sanity"]["status"] == "ok", stats
         assert stats["trust_fleet_sanity"].get("filed", 0) == 0, stats
-        fake_pr.create_issue.assert_not_awaited()
+        assert world.github._issues == {}
 
     async def test_staleness_breach_files_escalation(self, tmp_path) -> None:
         """One watched loop silent far beyond its interval → escalation filed."""
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=4242)
 
         now = _dt.datetime.now(_dt.UTC)
         heartbeats = _healthy_heartbeats(now)
@@ -117,7 +112,6 @@ class TestTrustFleetSanityScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
             trust_fleet_sanity_bg_workers=bg_workers,
             event_bus=EventBus(),
@@ -127,9 +121,9 @@ class TestTrustFleetSanityScenario:
 
         assert stats["trust_fleet_sanity"]["status"] == "ok", stats
         assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
-        assert fake_pr.create_issue.await_count >= 1
 
-        labels = fake_pr.create_issue.await_args.args[2]
+        issue = next(iter(world.github._issues.values()))
+        labels = issue.labels
         assert "hitl-escalation" in labels
         assert "trust-loop-anomaly" in labels
 
@@ -155,8 +149,6 @@ class TestTrustFleetSanityBreachScenario:
         dedup set update.
         """
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=9001)
 
         now = _dt.datetime.now(_dt.UTC)
 
@@ -188,7 +180,6 @@ class TestTrustFleetSanityBreachScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
             event_bus=seeded_bus,
         )
@@ -197,13 +188,12 @@ class TestTrustFleetSanityBreachScenario:
 
         assert stats["trust_fleet_sanity"]["status"] == "ok", stats
         assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
-        assert fake_pr.create_issue.await_count >= 1
 
-        title = fake_pr.create_issue.await_args.args[0]
-        assert "rc_budget" in title
-        assert "issues_per_hour" in title
+        issue = next(iter(world.github._issues.values()))
+        assert "rc_budget" in issue.title
+        assert "issues_per_hour" in issue.title
 
-        labels = fake_pr.create_issue.await_args.args[2]
+        labels = issue.labels
         assert "hitl-escalation" in labels
         assert "trust-loop-anomaly" in labels
 
@@ -214,8 +204,6 @@ class TestTrustFleetSanityBreachScenario:
         Verifies a second distinct breach kind reaches the issue-filing path.
         """
         world = MockWorld(tmp_path)
-        fake_pr = AsyncMock()
-        fake_pr.create_issue = AsyncMock(return_value=9002)
 
         now = _dt.datetime.now(_dt.UTC)
         seeded_bus = EventBus()
@@ -249,7 +237,6 @@ class TestTrustFleetSanityBreachScenario:
 
         _seed_ports(
             world,
-            pr_manager=fake_pr,
             trust_fleet_sanity_state=state,
             event_bus=seeded_bus,
         )
@@ -258,7 +245,6 @@ class TestTrustFleetSanityBreachScenario:
 
         assert stats["trust_fleet_sanity"]["status"] == "ok", stats
         assert stats["trust_fleet_sanity"].get("filed", 0) >= 1, stats
-        assert fake_pr.create_issue.await_count >= 1
 
-        titles = [call.args[0] for call in fake_pr.create_issue.await_args_list]
+        titles = [issue.title for issue in world.github._issues.values()]
         assert any("tick_error_ratio" in t and "corpus_learning" in t for t in titles)


### PR DESCRIPTION
## Summary
- convert MockWorld scenario GitHub side-effect assertions from raw AsyncMock PR ports to FakeGitHub state
- add an architecture guard against raw GitHub side-effect mocks in MockWorld scenarios, while allowing documented Pattern B direct-instantiation seams
- document the MockWorld fake-state assertion rule and regenerate architecture docs

## Verification
- uv run pytest -m scenario_loops tests/scenarios/test_trust_fleet_sanity_scenario.py tests/scenarios/test_live_corpus_replay_scenario.py tests/scenarios/test_pricing_refresh_loop_mockworld.py tests/scenarios/test_diagram_loop_mockworld.py tests/scenarios/test_memory_backlog_scenario.py -q
- uv run pytest tests/architecture/test_mockworld_scenario_fake_boundaries.py -q
- make arch-check
- make quality-lite

Closes hydraflow-39j8
Closes hydraflow-t36c