### PR TITLE
review: enforce test value standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,6 +217,7 @@ completeness / quality, optionally applies fixes, and returns a verdict.
 7. **Review instructions** — evaluate 3 dimensions; must find ≥`min_review_findings` issues or emit `THOROUGH_REVIEW_COMPLETE` block.
 8. **Verification step** — either "do NOT run tests (CI handles it)" or "run `make lint` + test cmd", depending on `max_ci_fix_attempts`.
 9. **Project audits** — SRP, type hints, naming, complexity, test 3As structure, security (injection, crypto, auth).
+   Includes the HydraFlow test-value standard: no skipped/xfail/commented-out or placeholder tests in active coverage, unit tests use documented factories/world-building helpers, integration tests keep real business logic wired and mock only external boundaries, and MockWorld scenarios assert fake-adapter state instead of raw mock call counts.
 10. **UI-specific checks** (when `"ui/" in diff`) — DRY, responsive, style consistency, component reuse.
 11. **Fix instructions** — make direct fixes and commit if issues are found.
 12. **Findings format** — `[SEVERITY] file[:line] - issue - expected fix`.

--- a/docs/standards/testing/README.md
+++ b/docs/standards/testing/README.md
@@ -114,6 +114,12 @@ wrong. Canonicalised here so the generator slice and future audits agree.
 
 - **"My feature is too small to need scenario / sandbox tests."** This is the rationalisation that ships features which pass unit tests but break in real conditions. If the feature has any observable runtime path through a loop or the orchestrator, both higher layers apply. Real-API behavior (e.g. GitHub's update-branch endpoint, OAuth flows, third-party rate limits) is invisible to unit tests.
 
+- **Skipped, xfailed, commented-out, or placeholder tests in active coverage.**
+  A skipped or expected-failing test is not a test; it is deferred work. If the
+  behavior is required, make the test active and fix the code. If the behavior is
+  not ready to implement, file the work in `bd` and keep the placeholder out of
+  the runnable suite.
+
 - **Asserting against state shapes that don't exist.** Scenarios authored against fields that aren't in `StateData` will pass at write-time (Python dicts are tolerant) but fail in CI when the missing key raises `KeyError`. Always `grep` the source-of-truth model file for the field name before asserting on it.
 
 - **Importing pytest or skipping at runtime in sandbox scenarios.** The sandbox
@@ -145,3 +151,13 @@ This standard lives at three load-bearing surfaces in any HydraFlow-format repo:
 - `CLAUDE.md` Quick Rules — one-line directive that all features ship with the full pyramid
 
 Drift detection: a future audit (extension of `principles_audit_loop`) should check that every PR landing on the integration branch adds at least one test in `tests/test_*.py`, one in `tests/scenarios/test_*.py`, and one in `tests/sandbox_scenarios/scenarios/sNN_*.py` — exempting docs-only and pure-refactor PRs.
+
+## Review enforcement
+
+Reviewers must treat this standard as a merge gate, not guidance. A PR review
+should request changes when it adds or preserves ignored tests (`skip`, `xfail`,
+commented-out tests/assertions, or placeholder smoke tests), labels mock-backed
+tests as integration, bypasses documented unit factories/world-building helpers,
+or asserts MockWorld side effects through raw mock call counts where a stateful
+fake adapter exists. New exceptions must be tracked in `bd` and removed from the
+active runnable suite until they can assert real behavior.

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -53,6 +53,23 @@ Only mark tests that exercise real external dependencies (Docker, network, files
 ```
 
 
+## Enforce test-value standards during review
+
+Review must request changes for skipped, xfailed, commented-out, or placeholder
+tests in active coverage. Unit tests should use the documented factories and
+world-building helpers instead of ad hoc setup. Integration tests should keep
+real business logic wired and mock only external boundaries whose real effects
+cannot run in the test environment. MockWorld scenarios should assert side
+effects through fake-adapter state, not raw mock call counts. **Why:** Test
+counts are meaningless when the runnable suite contains ignored tests or mocks
+that decide the outcome being asserted.
+
+
+```json:entry
+{"id":"01JRC_TEST_VALUE_REVIEW_GATE","title":"Enforce test-value standards during review","topic":"testing","source_type":"manual","source_issue":"hydraflow-1x87","source_repo":"T-rav/hydraflow","created_at":"2026-05-31T23:45:00+00:00","updated_at":"2026-05-31T23:45:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
+```
+
+
 ## Test async patterns with AsyncMock and fire-and-forget cleanup
 
 Use `AsyncMock` with explicit `assert_called_with()`. For fire-and-forget tasks via `create_task()`, call `await asyncio.sleep(0)` before assertions. Test async context managers: idempotent close, context manager triggers close on exit, returns self. **Why:** Async fire-and-forget races without yield points; explicit sleep ensures task completion.

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -890,6 +890,11 @@ Quality: No issues — <justification>
 7. Run project audits on changed code:
    - Review code quality patterns (SRP, type hints, naming, complexity)
    - Review test quality (3As structure, factories, edge cases)
+   - **Test-value standards (merge gate)** — request changes for:
+     - Skipped, xfailed, commented-out, or placeholder tests in active coverage; file deferred work in bd instead of keeping green placeholders.
+     - Unit tests that bypass documented factories or world-building helpers when the repo provides them (for HydraFlow, use `ConfigFactory`, `TaskFactory`, `make_pr_manager`, and MockWorld helpers as applicable).
+     - Integration tests that mock behavior-changing collaborators or assert only mock call shape. Integration tests should wire real business logic and mock only external boundaries that cannot run in the test environment.
+     - MockWorld scenarios that replace FakeGitHub/Fake* side effects with raw `AsyncMock`/`MagicMock` call-count assertions instead of asserting state through `world.<fake>`.
    - **Test coverage audit** — verify:
      - Tests cover the specific issue requirements, not just helper/utility functions
      - Failure and error paths have explicit tests, not only happy paths

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -1643,6 +1643,21 @@ async def test_build_review_prompt_includes_test_coverage_audit(
 
 
 @pytest.mark.asyncio
+async def test_build_review_prompt_enforces_test_value_standards(
+    config, event_bus, pr_info, task
+):
+    """Reviewer prompt should enforce the documented test-value standard."""
+    runner = _make_runner(config, event_bus)
+    prompt, _ = await runner._build_review_prompt_with_stats(pr_info, task, "diff")
+
+    assert "Test-value standards" in prompt
+    assert "Skipped, xfailed, commented-out, or placeholder tests" in prompt
+    assert "world-building helpers" in prompt
+    assert "Integration tests should wire real business logic" in prompt
+    assert "world.<fake>" in prompt
+
+
+@pytest.mark.asyncio
 async def test_build_review_prompt_includes_redundant_guard_audit(
     config, event_bus, pr_info, task
 ):


### PR DESCRIPTION
## Summary
- document ignored-test and test-value standards as review gates
- add reviewer prompt enforcement for skip/xfail/placeholders, unit world-building patterns, integration mock boundaries, and MockWorld fake-state assertions
- add reviewer prompt regression coverage

## Verification
- uv run pytest tests/test_reviewer.py::test_build_review_prompt_enforces_test_value_standards tests/test_reviewer.py::test_build_review_prompt_includes_test_coverage_audit tests/test_reviewer.py::test_build_review_prompt_includes_hydraflow_principles_checks -q
- make lint
- git diff --check
- pre-push make quality-lite

## Notes
- Full make test currently stops on existing unrelated failure: tests/test_config_env.py::TestOtelConfigFields::test_config_otel_defaults expects otel_environment local but observed dev.

Closes hydraflow-1x87