### PR TITLE
feat(triage): verify findings against current code before routing (factory refinements)

### DIFF
--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -169,6 +169,8 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
                 "audit trail).",
                 "",
                 "_Filed by `adr_touchpoint_auditor` per ADR-0056 (per-ADR rollup, #8987)._",
+                "",
+                "<!-- [hydraflow-auditor: source=ADRTouchpointAuditorLoop] -->",
             ]
         )
         return "\n".join(lines)

--- a/src/bug_reproducer.py
+++ b/src/bug_reproducer.py
@@ -47,7 +47,7 @@ REPRO_END = "REPRO_END"
 
 # Each transcript carries one Outcome line plus optional payload lines.
 _OUTCOME_RE = re.compile(
-    r"^\s*Outcome\s*:\s*(?P<outcome>success|partial|unable)\s*$",
+    r"^\s*Outcome\s*:\s*(?P<outcome>success|partial|unable|not_present)\s*$",
     re.IGNORECASE,
 )
 _TEST_PATH_RE = re.compile(
@@ -218,12 +218,16 @@ class BugReproducer(BaseRunner):
             f"- **partial**: agent could reproduce manually but not "
             f"automate — produce a `repro.sh`-style script\n"
             f"- **unable**: could not reproduce at all — escalate to "
-            f"a human\n\n"
+            f"a human\n"
+            f"- **not_present**: the described symptom does not exist in the "
+            f"current codebase — state this explicitly with evidence (file "
+            f"path, line number) rather than attempting to write a test for a "
+            f"non-existent problem\n\n"
             f"## Output format\n\n"
             f"Emit your result between {REPRO_START} and {REPRO_END} "
             f"markers using these key/value lines (one per line):\n"
             f"```\n"
-            f"Outcome: success | partial | unable\n"
+            f"Outcome: success | partial | unable | not_present\n"
             f"Test_path: tests/regressions/test_issue_{task.id}.py\n"
             f"Confidence: 0.0..1.0\n"
             f"Failing_output: <one-line summary of the failing assertion>\n"

--- a/src/config.py
+++ b/src/config.py
@@ -212,6 +212,8 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("health_monitor_interval", "HYDRAFLOW_HEALTH_MONITOR_INTERVAL", 7200),
     ("wiki_freshness_stale_days", "HYDRAFLOW_WIKI_FRESHNESS_STALE_DAYS", 7),
     ("stale_issue_interval", "HYDRAFLOW_STALE_ISSUE_INTERVAL", 86400),
+    ("auditor_finding_max_age_days", "HYDRAFLOW_AUDITOR_FINDING_MAX_AGE_DAYS", 14),
+    ("triage_max_turns", "HYDRAFLOW_TRIAGE_MAX_TURNS", 3),
     ("triage_retry_interval", "HYDRAFLOW_TRIAGE_RETRY_INTERVAL", 86400),
     ("triage_retry_max_attempts", "HYDRAFLOW_TRIAGE_RETRY_MAX_ATTEMPTS", 3),
     ("sentry_poll_interval", "SENTRY_POLL_INTERVAL", 600),
@@ -1092,6 +1094,23 @@ class HydraFlowConfig(BaseModel):
     triage_model: str = Field(
         default="gemini-3.1-pro-preview",
         description="Model for triage evaluation (fast/cheap)",
+    )
+    triage_max_turns: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description=(
+            "Max LLM turns for triage evaluation. Increase from 1 to allow "
+            "Read/Grep tool calls to verify currency and falsifiable claims."
+        ),
+    )
+    auditor_finding_max_age_days: int = Field(
+        default=14,
+        ge=0,
+        description=(
+            "Auto-close auditor-filed findings older than this many days. "
+            "0 = disabled. Auditor loops re-file findings on their next cycle."
+        ),
     )
     min_plan_words: int = Field(
         default=200,

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -264,6 +264,8 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 "**Repair:** record a cassette exercising each real-adapter "
                 "counterpart and commit. Spec §4.7; filed by "
                 "`fake_coverage_auditor` (#8986 rollup).",
+                "",
+                "<!-- [hydraflow-auditor: source=FakeCoverageAuditorLoop] -->",
             ]
         )
         return "\n".join(lines)
@@ -303,6 +305,8 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
                 "**Repair:** add a scenario that calls each helper so it is "
                 "part of the working contract. Spec §4.7; filed by "
                 "`fake_coverage_auditor` (#8986 rollup).",
+                "",
+                "<!-- [hydraflow-auditor: source=FakeCoverageAuditorLoop] -->",
             ]
         )
         return "\n".join(lines)

--- a/src/mockworld/fakes/_factories.py
+++ b/src/mockworld/fakes/_factories.py
@@ -372,6 +372,8 @@ class TriageResultFactory:
         enrichment: str = "",
         clarity_score: int = 10,
         needs_discovery: bool = False,
+        already_addressed: bool = False,
+        claim_verified: bool | None = None,
     ) -> TriageResult:
         from models import IssueType
         from models import TriageResult as TR
@@ -387,6 +389,8 @@ class TriageResultFactory:
             enrichment=enrichment,
             clarity_score=clarity_score,
             needs_discovery=needs_discovery,
+            already_addressed=already_addressed,
+            claim_verified=claim_verified,
         )
 
 

--- a/src/models.py
+++ b/src/models.py
@@ -363,6 +363,21 @@ class TriageResult(BaseModel):
         default=False,
         description="Whether the issue needs product discovery before planning",
     )
+    already_addressed: bool = Field(
+        default=False,
+        description=(
+            "Whether the LLM determined the described problem no longer exists "
+            "at HEAD. Triggers auto-close routing in triage_phase."
+        ),
+    )
+    claim_verified: bool | None = Field(
+        default=None,
+        description=(
+            "Whether the LLM verified a falsifiable claim against the codebase. "
+            "None = no falsifiable claim present; True = claim confirmed; "
+            "False = claim was false (problem doesn't exist)."
+        ),
+    )
 
     @field_validator("issue_type", mode="before")
     @classmethod
@@ -633,6 +648,7 @@ class ReproductionOutcome(StrEnum):
     SUCCESS = "success"  # failing test written and confirmed red
     PARTIAL = "partial"  # repro script produced but no automated test
     UNABLE = "unable"  # could not reproduce — escalate to HITL
+    NOT_PRESENT = "not_present"  # described symptom does not exist at HEAD
 
 
 class ReproductionResult(BaseModel):

--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -41,6 +41,11 @@ _STUCK_TITLE_RE = re.compile(
 )
 
 
+def _audit_iso_now() -> str:
+    """Return the current UTC time as a second-precision ISO-8601 string."""
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
 class PrinciplesAuditLoop(BaseBackgroundLoop):
     """Weekly audit against ADR-0044 + onboarding trigger (spec §4.4)."""
 
@@ -300,7 +305,9 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             f"**Last-green status:** {last_status}\n"
             f"**Current status:** {finding.get('status', 'FAIL')}\n"
             f"**Audit message:** {finding.get('message', '')}\n\n"
-            f"Filed by PrinciplesAuditLoop (spec §4.4)."
+            f"Filed by PrinciplesAuditLoop (spec §4.4).\n\n"
+            f"<!-- [hydraflow-auditor: source=PrinciplesAuditLoop, "
+            f"check_id={check_id}, filed_at={_audit_iso_now()}, slug={slug}] -->"
         )
         labels = [
             "hydraflow-find",

--- a/src/triage.py
+++ b/src/triage.py
@@ -197,7 +197,7 @@ class TriageRunner(BaseRunner):
         return build_agent_command(
             tool=self._config.triage_tool,
             model=self._config.triage_model,
-            max_turns=1,
+            max_turns=self._config.triage_max_turns,
         )
 
     def _build_prompt_with_stats(
@@ -217,12 +217,14 @@ class TriageRunner(BaseRunner):
 
 ## Evaluation Criteria
 
-Evaluate the issue against these four criteria:
+Evaluate the issue against these six criteria:
 
 1. **Clarity**: Is the issue clearly written? Can an engineer understand what needs to happen?
 2. **Specificity**: Does it describe a concrete problem or feature, not a vague wish?
 3. **Actionability**: Is there enough context to start planning? (expected behavior, affected area, reproduction steps for bugs)
 4. **Scope**: Is it a single, bounded unit of work? (not an unstructured epic or multiple unrelated requests)
+5. **Currency**: For findings or bug reports that cite specific files, functions, or code patterns, verify the cited symptom still exists in the current codebase. Use Read or Grep tools to check. If the issue claims X is broken/missing/wrong, confirm X is actually broken/missing/wrong now. Set `already_addressed: true` if the described problem no longer exists.
+6. **Verifiable claim**: If the issue asserts that a specific thing is missing, broken, or not implemented, and that assertion is falsifiable by reading the source code, verify it. If the claim is demonstrably false (e.g., the function described as missing is present), return `ready: false` with `reasons: ["Claim not reproducible: <evidence>"]` and set `claim_verified: false`.
 
 ## Issue Type Classification
 
@@ -252,7 +254,7 @@ for competitive research and direction shaping before planning.
 Return ONLY a JSON object in this exact format, with no other text:
 
 ```json
-{{"ready": true, "reasons": [], "issue_type": "feature", "clarity_score": 9, "needs_discovery": false, "enrichment": "## Triage Enrichment\\n\\n**Interpreted intent:** ...\\n**Affected area:** ...\\n**Acceptance criteria:**\\n- ..."}}
+{{"ready": true, "reasons": [], "issue_type": "feature", "clarity_score": 9, "needs_discovery": false, "enrichment": "## Triage Enrichment\\n\\n**Interpreted intent:** ...\\n**Affected area:** ...\\n**Acceptance criteria:**\\n- ...", "already_addressed": false, "claim_verified": null}}
 ```
 
 or for vague product ideas needing discovery:
@@ -264,7 +266,13 @@ or for vague product ideas needing discovery:
 or for truly insufficient issues:
 
 ```json
-{{"ready": false, "reasons": ["Specific reason why this cannot proceed"], "issue_type": "bug", "clarity_score": 0, "needs_discovery": false, "enrichment": ""}}
+{{"ready": false, "reasons": ["Specific reason why this cannot proceed"], "issue_type": "bug", "clarity_score": 0, "needs_discovery": false, "enrichment": "", "already_addressed": false, "claim_verified": null}}
+```
+
+or for a claim that is demonstrably false / already implemented (the described problem no longer exists at HEAD):
+
+```json
+{{"ready": false, "reasons": ["Claim not reproducible: <evidence>"], "issue_type": "bug", "clarity_score": 5, "needs_discovery": false, "enrichment": "", "already_addressed": true, "claim_verified": false}}
 ```
 """
         plugin_skills_section = format_plugin_skills_for_prompt(
@@ -374,6 +382,11 @@ or for truly insufficient issues:
         clarity_raw = data.get("clarity_score", 10)
         clarity = int(clarity_raw) if isinstance(clarity_raw, int | float) else 10
         needs_discovery = bool(data.get("needs_discovery", False))
+        already_addressed = bool(data.get("already_addressed", False))
+        claim_verified_raw = data.get("claim_verified")
+        claim_verified = (
+            bool(claim_verified_raw) if claim_verified_raw is not None else None
+        )
         return TriageResult(
             issue_number=issue_number,
             ready=_coerce_ready(data["ready"]),
@@ -383,6 +396,8 @@ or for truly insufficient issues:
             enrichment=enrichment,
             clarity_score=max(0, min(clarity, 10)),
             needs_discovery=needs_discovery,
+            already_addressed=already_addressed,
+            claim_verified=claim_verified,
         )
 
     @staticmethod

--- a/src/triage_phase.py
+++ b/src/triage_phase.py
@@ -34,11 +34,33 @@ if TYPE_CHECKING:
 logger = logging.getLogger("hydraflow.triage_phase")
 
 _SENTRY_MARKER = "<!-- [sentry:"
+_AUDITOR_MARKER = "<!-- [hydraflow-auditor:"
 
 
 def _is_sentry_issue(issue: Task) -> bool:
     """Return True if the issue was filed by the Sentry ingest loop."""
     return _SENTRY_MARKER in (issue.body or "")
+
+
+def _is_auditor_issue(issue: Task) -> bool:
+    """Return True if the issue was filed by a HydraFlow auditor loop."""
+    return _AUDITOR_MARKER in (issue.body or "")
+
+
+def _is_auditor_finding_stale(issue: Task, max_age_days: int) -> bool:
+    """Return True if the auditor finding is older than *max_age_days*."""
+    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
+
+    created_raw = issue.created_at
+    if not created_raw:
+        return False
+    try:
+        created = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=UTC)
+        return datetime.now(UTC) - created > timedelta(days=max_age_days)
+    except (ValueError, AttributeError):
+        return False
 
 
 class TriagePhase:
@@ -196,6 +218,32 @@ class TriagePhase:
                 await self._triage_adr(issue)
             return 1
 
+        if (
+            not self._config.dry_run
+            and self._config.auditor_finding_max_age_days > 0
+            and _is_auditor_issue(issue)
+            and _is_auditor_finding_stale(
+                issue, self._config.auditor_finding_max_age_days
+            )
+        ):
+            await self._prs.post_comment(
+                issue.id,
+                "## Auto-closed: Stale Auditor Finding\n\n"
+                f"This auditor-filed finding is older than "
+                f"{self._config.auditor_finding_max_age_days} days. "
+                "The auditor loop will re-file it on its next cycle if the "
+                "issue persists.\n\n"
+                "*Closed by HydraFlow Triage.*",
+            )
+            await self._transitioner.close_task(issue.id)
+            self._state.mark_issue(issue.id, "completed")
+            logger.info(
+                "Issue #%d auditor finding auto-closed (stale > %d days)",
+                issue.id,
+                self._config.auditor_finding_max_age_days,
+            )
+            return 1
+
         from trace_rollup import write_phase_rollup  # noqa: PLC0415
         from tracing_context import (  # noqa: PLC0415
             TracingContext,
@@ -306,6 +354,27 @@ class TriagePhase:
                 issue.id,
                 "; ".join(result.reasons),
             )
+        elif result.already_addressed:
+            # LLM verified the claim does not exist at HEAD — auto-close
+            evidence = (
+                "; ".join(result.reasons) if result.reasons else "See triage evaluation"
+            )
+            await self._prs.post_comment(
+                issue.id,
+                "## Auto-closed: Already Addressed\n\n"
+                "The triage LLM verified that the described problem no longer "
+                "exists in the current codebase.\n\n"
+                f"**Evidence:** {evidence}\n\n"
+                "*Closed by HydraFlow Triage. Re-file if the problem reappears.*",
+            )
+            await self._transitioner.close_task(issue.id)
+            self._state.mark_issue(issue.id, "completed")
+            routing_outcome = "already_addressed"
+            logger.info(
+                "Issue #%d auto-closed as already-addressed: %s",
+                issue.id,
+                evidence,
+            )
         else:
             # Park the issue instead of escalating to HITL — author needs
             # to provide more detail before the system can act on it.
@@ -376,6 +445,28 @@ class TriagePhase:
                     test_path=repro.test_path,
                     details=repro.investigation or repro.failing_output,
                 )
+                if str(repro.outcome) == "not_present":
+                    evidence = (
+                        repro.investigation or "No evidence found in current codebase"
+                    )
+                    await self._prs.post_comment(
+                        issue.id,
+                        "## Auto-closed: Bug Not Present\n\n"
+                        "The bug reproducer could not find evidence of the "
+                        "described symptom in the current codebase.\n\n"
+                        f"**Evidence:** {evidence}\n\n"
+                        "*Closed by HydraFlow Triage. Re-file if the symptom "
+                        "reappears.*",
+                    )
+                    await self._transitioner.close_task(issue.id)
+                    self._state.mark_issue(issue.id, "completed")
+                    routing_outcome = "bug_not_present"
+                    logger.info(
+                        "Issue #%d bug not-present — auto-closed: %s",
+                        issue.id,
+                        evidence,
+                    )
+                    return 1
                 if str(repro.outcome) == "unable":
                     logger.warning(
                         "Bug reproduction unable for issue #%d — READY "

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -247,6 +247,8 @@ class ConfigFactory:
         planner_model: str = "opus",
         triage_tool: Literal["claude", "codex", "pi"] = "claude",
         triage_model: str = "haiku",
+        triage_max_turns: int = 3,
+        auditor_finding_max_age_days: int = 14,
         min_plan_words: int = 200,
         max_new_files_warning: int = 5,
         lite_plan_labels: list[str] | None = None,
@@ -473,6 +475,8 @@ class ConfigFactory:
                 planner_model=planner_model,
                 triage_tool=triage_tool,
                 triage_model=triage_model,
+                triage_max_turns=triage_max_turns,
+                auditor_finding_max_age_days=auditor_finding_max_age_days,
                 min_plan_words=min_plan_words,
                 max_new_files_warning=max_new_files_warning,
                 lite_plan_labels=lite_plan_labels

--- a/tests/test_bug_reproducer.py
+++ b/tests/test_bug_reproducer.py
@@ -370,3 +370,21 @@ class TestReproduceOrchestration:
         assert callback("partial reproducer output") is False
         # END marker present → terminate.
         assert callback(f"some output\n{REPRO_END}\n") is True
+
+
+class TestNotPresentOutcome:
+    def test_parse_outcome_recognises_not_present(self) -> None:
+        transcript = (
+            f"{REPRO_START}\n"
+            "Outcome: not_present\n"
+            "Investigation: The function described as broken does not exist in src/\n"
+            f"{REPRO_END}"
+        )
+        result = BugReproducer._parse_outcome(transcript)
+        assert result.outcome == ReproductionOutcome.NOT_PRESENT
+        assert "does not exist" in result.investigation
+
+    def test_build_prompt_instructs_not_present_outcome(self) -> None:
+        task = Task(id=99, title="Bug in foo", body="foo is broken")
+        prompt = BugReproducer._build_prompt(task)
+        assert "not_present" in prompt

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -519,12 +519,12 @@ class TestBuildCommand:
         assert cmd[model_idx + 1] == "sonnet"
 
     def test_command_includes_max_turns(self, event_bus: EventBus) -> None:
-        config = ConfigFactory.create()
+        config = ConfigFactory.create(triage_max_turns=3)
         runner = TriageRunner(config, event_bus)
         cmd = runner._build_command()
         assert "--max-turns" in cmd
         turns_idx = cmd.index("--max-turns")
-        assert cmd[turns_idx + 1] == "1"
+        assert cmd[turns_idx + 1] == "3"
 
     def test_command_includes_bypass_permissions(self, event_bus: EventBus) -> None:
         config = ConfigFactory.create()
@@ -871,3 +871,73 @@ class TestTriageSentryBreadcrumbs:
             b for b in fake_obs.breadcrumbs if b["category"] == "triage.parse_failed"
         ]
         assert len(parse_bcs) == 1
+
+
+class TestCurrencyPromptCriteria:
+    def test_prompt_contains_currency_criterion(self, config, event_bus) -> None:
+        issue = TaskFactory.create(id=1)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
+        assert "Currency" in prompt
+
+    def test_prompt_contains_verifiable_claim_criterion(
+        self, config, event_bus
+    ) -> None:
+        issue = TaskFactory.create(id=1)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
+        assert "Verifiable claim" in prompt or "already implemented" in prompt.lower()
+
+    def test_prompt_response_schema_includes_already_addressed(
+        self, config, event_bus
+    ) -> None:
+        issue = TaskFactory.create(id=1)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
+        assert "already_addressed" in prompt
+
+    def test_prompt_response_schema_includes_claim_verified(
+        self, config, event_bus
+    ) -> None:
+        issue = TaskFactory.create(id=1)
+        runner = TriageRunner(config, event_bus)
+        prompt, _ = runner._build_prompt_with_stats(issue)
+        assert "claim_verified" in prompt
+
+
+class TestAlreadyAddressedVerdict:
+    def test_parse_verdict_extracts_already_addressed_true(self) -> None:
+        transcript = json.dumps(
+            {
+                "ready": False,
+                "reasons": [
+                    "Claim not reproducible: function is present at src/foo.py:42"
+                ],
+                "issue_type": "feature",
+                "clarity_score": 8,
+                "needs_discovery": False,
+                "enrichment": "",
+                "already_addressed": True,
+                "claim_verified": False,
+            }
+        )
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is not None
+        assert result.already_addressed is True
+        assert result.claim_verified is False
+
+    def test_parse_verdict_already_addressed_defaults_false(self) -> None:
+        transcript = json.dumps(
+            {
+                "ready": True,
+                "reasons": [],
+                "issue_type": "feature",
+                "clarity_score": 9,
+                "needs_discovery": False,
+                "enrichment": "",
+            }
+        )
+        result = TriageRunner._parse_verdict(transcript, 1)
+        assert result is not None
+        assert result.already_addressed is False
+        assert result.claim_verified is None

--- a/tests/test_triage_phase.py
+++ b/tests/test_triage_phase.py
@@ -459,3 +459,204 @@ class TestComplexityRank:
         assert phase._complexity_rank(6) == "high"
         assert phase._complexity_rank(7) == "high"
         assert phase._complexity_rank(5) == "medium"
+
+
+class TestAuditorMarker:
+    def test_is_auditor_issue_true_when_marker_present(self) -> None:
+        from triage_phase import _is_auditor_issue
+
+        issue = TaskFactory.create(
+            id=1,
+            body="Some finding.\n<!-- [hydraflow-auditor: source=PrinciplesAuditLoop] -->",
+        )
+        assert _is_auditor_issue(issue) is True
+
+    def test_is_auditor_issue_false_when_marker_absent(self) -> None:
+        from triage_phase import _is_auditor_issue
+
+        issue = TaskFactory.create(id=2, body="Regular human-filed issue.")
+        assert _is_auditor_issue(issue) is False
+
+    def test_is_auditor_issue_false_for_sentry_issue(self) -> None:
+        from triage_phase import _is_auditor_issue
+
+        issue = TaskFactory.create(
+            id=3, body="Error spike\n<!-- [sentry: project=backend] -->"
+        )
+        assert _is_auditor_issue(issue) is False
+
+
+class TestAuditorAgeGate:
+    @pytest.mark.asyncio
+    async def test_auditor_issue_within_max_age_proceeds_to_llm(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        config.auditor_finding_max_age_days = 14
+        phase, _state, triage, prs, store, _stop = make_triage_phase(config)
+        body = (
+            "Finding detail.\n<!-- [hydraflow-auditor: source=PrinciplesAuditLoop] -->"
+        )
+        issue = TaskFactory.create(
+            id=10,
+            title="Principles drift: check_id regressed in slug",
+            body=body,
+            created_at=(datetime.now(UTC) - timedelta(days=3)).isoformat(),
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(issue_number=10, ready=True)
+        )
+        store.get_triageable = supply_once([issue])
+        await phase.triage_issues()
+        triage.evaluate.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stale_auditor_issue_is_closed_before_llm(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from datetime import UTC, datetime, timedelta
+
+        config.auditor_finding_max_age_days = 14
+        phase, _state, triage, prs, store, _stop = make_triage_phase(config)
+        body = (
+            "Finding detail.\n<!-- [hydraflow-auditor: source=PrinciplesAuditLoop] -->"
+        )
+        issue = TaskFactory.create(
+            id=11,
+            title="Principles drift: old finding",
+            body=body,
+            created_at=(datetime.now(UTC) - timedelta(days=20)).isoformat(),
+        )
+        store.get_triageable = supply_once([issue])
+        await phase.triage_issues()
+        triage.evaluate.assert_not_awaited()
+        prs.close_task.assert_called_once_with(11)
+        comment = prs.post_comment.call_args.args[1]
+        assert "stale" in comment.lower() or "auto-closed" in comment.lower()
+
+    @pytest.mark.asyncio
+    async def test_age_gate_respects_max_age_zero_disables_gate(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """auditor_finding_max_age_days=0 means no gate — all auditor issues proceed."""
+        from datetime import UTC, datetime, timedelta
+
+        config.auditor_finding_max_age_days = 0
+        phase, _state, triage, prs, store, _stop = make_triage_phase(config)
+        body = "Finding.\n<!-- [hydraflow-auditor: source=PrinciplesAuditLoop] -->"
+        issue = TaskFactory.create(
+            id=12,
+            title="Principles drift: should not be gated",
+            body=body,
+            created_at=(datetime.now(UTC) - timedelta(days=100)).isoformat(),
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(issue_number=12, ready=True)
+        )
+        store.get_triageable = supply_once([issue])
+        await phase.triage_issues()
+        triage.evaluate.assert_awaited_once()
+        prs.close_task.assert_not_called()
+
+
+class TestAlreadyAddressedRouting:
+    @pytest.mark.asyncio
+    async def test_already_addressed_verdict_auto_closes_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(
+            id=55, title="visual_validation is a noop stub", body="A" * 100
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=55,
+                ready=False,
+                already_addressed=True,
+                reasons=[
+                    "Claim not reproducible: function has real logic at "
+                    "src/visual.py:88"
+                ],
+            )
+        )
+        store.get_triageable = supply_once([issue])
+        await phase.triage_issues()
+        prs.close_task.assert_called_once_with(55)
+        comment = prs.post_comment.call_args.args[1]
+        assert "already" in comment.lower() or "implemented" in comment.lower()
+        prs.swap_pipeline_labels.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_already_addressed_does_not_park(
+        self, config: HydraFlowConfig
+    ) -> None:
+        phase, _state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(
+            id=56, title="Missing kill-switch in loop", body="A" * 100
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=56,
+                ready=False,
+                already_addressed=True,
+                reasons=["Kill-switch present at src/loop.py:15"],
+            )
+        )
+        store.get_triageable = supply_once([issue])
+        await phase.triage_issues()
+        prs.swap_pipeline_labels.assert_not_called()
+        prs.close_task.assert_called_once_with(56)
+
+
+class TestBugReproducerNotPresentRouting:
+    @pytest.mark.asyncio
+    async def test_not_present_repro_auto_closes_issue(
+        self, config: HydraFlowConfig
+    ) -> None:
+        from models import ReproductionOutcome, ReproductionResult
+
+        phase, state, triage, prs, store, _stop = make_triage_phase(config)
+        issue = TaskFactory.create(
+            id=70,
+            title="Crash in validate_config",
+            body="A" * 100,
+        )
+        triage.evaluate = AsyncMock(
+            return_value=TriageResultFactory.create(
+                issue_number=70, ready=True, issue_type="bug"
+            )
+        )
+        fake_repro = AsyncMock(
+            return_value=ReproductionResult(
+                issue_number=70,
+                outcome=ReproductionOutcome.NOT_PRESENT,
+                confidence=0.0,
+                investigation=(
+                    "validate_config does not exist in src/; function was renamed"
+                ),
+            )
+        )
+        store.get_triageable = supply_once([issue])
+
+        from unittest.mock import MagicMock
+
+        from bug_reproducer import BugReproducer
+
+        mock_reproducer = MagicMock(spec=BugReproducer)
+        mock_reproducer.reproduce = fake_repro
+        phase._bug_reproducer = mock_reproducer
+
+        from issue_cache import IssueCache
+
+        mock_cache = MagicMock(spec=IssueCache)
+        mock_cache.record_classification = MagicMock()
+        mock_cache.record_reproduction_stored = MagicMock()
+        phase._issue_cache = mock_cache
+
+        await phase.triage_issues()
+
+        prs.close_task.assert_called_once_with(70)
+        comment = prs.post_comment.call_args.args[1]
+        assert "not present" in comment.lower() or "does not exist" in comment.lower()
+        prs.transition.assert_not_called()


### PR DESCRIPTION
**Factory-process refinement — TRIAGE** (from the 2026-05-31 retro). Triage scored only issue *wording* (clarity/specificity/actionability/scope) with `max_turns=1` and no tools, so it couldn't tell whether a cited symptom still exists — letting stale audit findings waste plan/implement cycles (observed every workstream of the hardening run).

- **T-1:** `_AUDITOR_MARKER` on auditor-filed issues (mirrors `_SENTRY_MARKER`) + `auditor_finding_max_age_days` (default 14) staleness gate that auto-closes findings older than one audit cycle before spending LLM budget.
- **T-2:** "Currency"/"Verifiable-claim" triage criteria + `triage_max_turns` (default 3 → triage can grep/read to verify) + `already_addressed`/`claim_verified` `TriageResult` fields + an already-addressed close-with-evidence route.
- **T-3:** `ReproductionOutcome.NOT_PRESENT` + BugReproducer "symptom not present" → auto-close (don't route a non-reproducing bug to plan).

Full `make quality` green: **15289 passed**. Part of the 5-PR factory-refinements set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)