### PR TITLE
feat(planning): empirical spike-check + kill-switch principle + dup-test gate (factory refinements)

### DIFF
--- a/src/assumption_surfacer.py
+++ b/src/assumption_surfacer.py
@@ -43,6 +43,15 @@ return empty lists. Severity guide:
   HIGH: assumption affects buildability or test design and is unverified.
   MEDIUM: assumption is plausible but worth documenting.
   LOW: assumption is minor.
+
+Mechanism assumption rule (ALWAYS apply):
+  Any assumption about a specific subprocess command, external tool exit code,
+  OS path behavior, or git command flag (e.g. "git config --unset succeeds
+  when core.worktree is set", "gh api returns 404 for missing resources")
+  MUST be marked severity HIGH with must_address_by set to "planner" and a
+  note: "validate in a scratch repo or minimal spike before committing to
+  this mechanism in the plan." These assumptions are load-bearing and
+  frequently wrong — do not mark them MEDIUM or LOW.
 """
 
 

--- a/src/plan_council_prompts.py
+++ b/src/plan_council_prompts.py
@@ -44,6 +44,11 @@ Ask:
   - Is the motivating assumption verifiable?
   - Is this scope-creep beyond the issue?
   - Is there a cheaper way to test the hypothesis before building this?
+  - If the plan assumes a specific git, gh, or subprocess behavior (exit code,
+    command flag, path manipulation, tool return value), flag HIGH unless the
+    plan includes empirical validation for that behavior: a scratch-repo test
+    result, a cited documentation reference, or a named spike outcome. Untested
+    mechanism assumptions are a top-3 source of implementation failures.
 
 You do NOT critique buildability or test coverage. You critique whether this plan should exist as written. YAGNI is your default.
 

--- a/src/plan_validation.py
+++ b/src/plan_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from plan_constants import (
@@ -277,6 +278,62 @@ def run_phase_gates(
                     )
         except OSError:
             logger.warning("Could not read constitution.md")
+
+    # --- Kill-switch gate: block new loops/runners without ADR-0049 kill-switch ---
+    _NEW_LOOP_RE = re.compile(
+        r"BaseBackgroundLoop|(\b\w+Loop\b.*create\b|\bcreate\b.*\b\w+Loop\b)",
+        re.IGNORECASE,
+    )
+    _KILLSWITCH_PRESENT_RE = re.compile(
+        r"(ADR-0049|kill.?switch|HYDRAFLOW_DISABLE_\w+|enabled_cb)",
+        re.IGNORECASE,
+    )
+    # Search Task Graph Files: lines for new loop class introductions
+    task_graph_section = re.search(
+        r"## Task Graph\s*\n(.*?)(?=\n## |\Z)", plan, re.DOTALL | re.IGNORECASE
+    )
+    if task_graph_section:
+        tg_body = task_graph_section.group(1)
+        if _NEW_LOOP_RE.search(tg_body) and not _KILLSWITCH_PRESENT_RE.search(plan):
+            blocking.append(
+                "Kill-switch gate: plan introduces a new loop or subprocess-spawning "
+                "runner but includes no ADR-0049 kill-switch "
+                "(HYDRAFLOW_DISABLE_<WORKER>_LOOP=1 env + enabled_cb body check). "
+                "Add the kill-switch before this plan advances to implementation."
+            )
+
+    # --- Duplicate enforcement-test gate: warn if proposed test file matches a known invariant ---
+    _ENFORCEMENT_INVENTORY = {
+        "test_loop_wiring_completeness": "loop registry/service/UI/interval parity",
+        "test_config_consistency": "config field/env-override/interval-bounds parity",
+        "test_event_type_reducer_parity": "EventType↔JSX reducer parity",
+        "test_mock_spec_discipline": "AsyncMock spec= ratchet",
+        "test_audit_prompts": "prompt structure",
+    }
+    _ENFORCEMENT_KEYWORDS = {"wiring", "parity", "consistency", "discipline"}
+    proposed_test_files = re.findall(r"tests/test_[\w_]+\.py", plan)
+    for proposed in proposed_test_files:
+        stem = Path(proposed).stem  # e.g. "test_loop_wiring_completeness_v2"
+        # Check against known inventory names
+        for canonical, description in _ENFORCEMENT_INVENTORY.items():
+            if canonical in stem:
+                warnings.append(
+                    f"Duplicate enforcement-test gate: proposed {proposed!r} overlaps "
+                    f"with existing {canonical}.py ({description}). "
+                    f"Extend the existing file rather than creating a new one."
+                )
+                break
+        else:
+            # Check for keyword overlap
+            stem_lower = stem.lower()
+            matched_kw = _ENFORCEMENT_KEYWORDS & set(stem_lower.split("_"))
+            if matched_kw:
+                warnings.append(
+                    f"Duplicate enforcement-test gate: proposed {proposed!r} contains "
+                    f"enforcement keyword(s) {matched_kw}. Verify no existing "
+                    f"enforcement test already covers this invariant "
+                    f"(see: {', '.join(sorted(_ENFORCEMENT_INVENTORY))}). "
+                )
 
     # Log warnings
     for w in warnings:

--- a/src/planner.py
+++ b/src/planner.py
@@ -488,6 +488,10 @@ Use semantic tools first (before grep):
    - **Hexagonal Ports:** new GitHub / git / worktree / subprocess calls must go through `PRPort`, `IssueStorePort`, or `WorkspacePort`. If your plan introduces a direct `subprocess.run`, `gh`, or `git` call in a non-adapter file, route it through the existing Port (or extend the Port) instead.
    - **One responsibility per file:** if you're adding ≥~200 lines to an already-big file, split by responsibility in the plan. Don't bolt unrelated concerns onto a mega-file just because the imports are handy.
    - **3As tests:** every test in the plan's test specs should map cleanly to Arrange / Act / Assert with one logical assertion per test. List tests in the plan at the behaviour level — the implementer will write each one red-first.
+   - **ADR-0049 kill-switch (new loops/runners only):** a plan adding a new
+     `BaseBackgroundLoop` subclass or subprocess-spawning runner MUST include the
+     ADR-0049 kill-switch (`HYDRAFLOW_DISABLE_<WORKER>_LOOP` env + in-body
+     `enabled_cb` gate); `run_phase_gates` rejects plans that omit it.
 9. **Audit the plan against `docs/wiki/gotchas.md`.** Every code snippet,
    test fixture, and cross-module import in your plan must avoid the anti-patterns
    listed there. Specifically check: symbols imported across modules do not start

--- a/tests/test_assumption_surfacer.py
+++ b/tests/test_assumption_surfacer.py
@@ -148,3 +148,25 @@ async def test_concerns_set_raised_in_phase_and_stage():
     assert len(out.concerns) == 1
     assert out.concerns[0].raised_in_phase == "discover"
     assert out.concerns[0].raised_in_stage == "assumption_surfacer"
+
+
+class TestSurfacerMechanismSpikeCheck:
+    def test_system_prompt_escalates_mechanism_assumptions(self):
+        """_SYSTEM_PROMPT must instruct HIGH severity for subprocess/OS assumptions."""
+        from src.assumption_surfacer import _SYSTEM_PROMPT
+
+        lower = _SYSTEM_PROMPT.lower()
+        assert "subprocess" in lower or "git" in lower, (
+            "_SYSTEM_PROMPT must mention subprocess/git/OS mechanism assumptions"
+        )
+        assert "must_address_by" in _SYSTEM_PROMPT or "spike" in lower, (
+            "_SYSTEM_PROMPT must require spike validation for mechanism assumptions"
+        )
+
+    def test_risk_skeptic_prompt_requires_empirical_validation_for_mechanisms(self):
+        from src.plan_council_prompts import RISK_SKEPTIC_PROMPT
+
+        lower = RISK_SKEPTIC_PROMPT.lower()
+        assert "empirical" in lower or "spike" in lower or "scratch repo" in lower, (
+            "RISK_SKEPTIC_PROMPT must require empirical validation for mechanism assumptions"
+        )

--- a/tests/test_plan_validation.py
+++ b/tests/test_plan_validation.py
@@ -187,3 +187,79 @@ class TestRunPhaseGates:
         )
         blocking, warnings = run_phase_gates(plan, config)
         assert any("new files" in w.lower() for w in warnings)
+
+
+class TestKillSwitchGate:
+    def _loop_plan(self, *, with_killswitch: bool) -> str:
+        """Plan that introduces a new BaseBackgroundLoop subclass.
+
+        The new-loop marker is placed in a Task Graph phase's ``**Files:**``
+        line \u2014 that is where ``run_phase_gates`` scans for it (the gate is
+        deliberately scoped to the Task Graph to avoid prose false positives).
+        """
+        ks = (
+            "\nADR-0049 kill-switch: HYDRAFLOW_DISABLE_FOO_LOOP=1 with enabled_cb\n"
+            if with_killswitch
+            else ""
+        )
+        return (
+            _valid_plan().replace(
+                "**Files:** src/models.py (modify)",
+                "**Files:** src/foo_loop.py (create) \u2014 new BaseBackgroundLoop subclass",
+            )
+            + ks
+        )
+
+    def test_new_loop_without_killswitch_blocks(self):
+        config = _make_config()
+        blocking, _ = run_phase_gates(self._loop_plan(with_killswitch=False), config)
+        assert any(
+            "kill-switch" in e.lower() or "adr-0049" in e.lower() for e in blocking
+        ), f"Expected kill-switch blocking error, got: {blocking}"
+
+    def test_new_loop_with_killswitch_passes(self):
+        config = _make_config()
+        blocking, _ = run_phase_gates(self._loop_plan(with_killswitch=True), config)
+        ks_errors = [
+            e for e in blocking if "kill-switch" in e.lower() or "adr-0049" in e.lower()
+        ]
+        assert not ks_errors, f"Unexpected kill-switch error: {ks_errors}"
+
+    def test_non_loop_plan_no_killswitch_error(self):
+        """Plans not introducing loops are not subject to the kill-switch gate."""
+        config = _make_config()
+        blocking, _ = run_phase_gates(_valid_plan(), config)
+        assert not any("kill-switch" in e.lower() for e in blocking)
+
+
+class TestDuplicateEnforcementTestGate:
+    def _plan_with_test(self, proposed_test: str) -> str:
+        return _valid_plan().replace(
+            "- src/models.py \u2014 add new data model",
+            f"- {proposed_test} (create)",
+        )
+
+    def test_exact_wiring_completeness_duplicate_warns(self):
+        config = _make_config()
+        plan = self._plan_with_test("tests/test_loop_wiring_completeness_v2.py")
+        _, warnings = run_phase_gates(plan, config)
+        assert any(
+            "wiring" in w.lower()
+            or "duplicate" in w.lower()
+            or "test_loop_wiring_completeness" in w
+            for w in warnings
+        ), f"Expected duplicate enforcement warning, got: {warnings}"
+
+    def test_parity_keyword_warns(self):
+        config = _make_config()
+        plan = self._plan_with_test("tests/test_event_reducer_parity_new.py")
+        _, warnings = run_phase_gates(plan, config)
+        assert any(
+            "parity" in w.lower() or "duplicate" in w.lower() for w in warnings
+        ), f"Expected parity-enforcement warning, got: {warnings}"
+
+    def test_unrelated_new_test_no_warn(self):
+        config = _make_config()
+        plan = self._plan_with_test("tests/test_widget_service.py")
+        _, warnings = run_phase_gates(plan, config)
+        assert not any("duplicate enforcement" in w.lower() for w in warnings)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -235,6 +235,18 @@ async def test_build_prompt_includes_principles_checklist(config, event_bus, iss
 
 
 @pytest.mark.asyncio
+async def test_step8_includes_killswitch_principle(config, event_bus, issue):
+    """Planner step-8 principles must name the ADR-0049 kill-switch so plans
+    that introduce new loops/runners carry the disable env + enabled_cb check
+    before they reach the run_phase_gates kill-switch gate."""
+    runner = _make_runner(config, event_bus)
+    task = issue.to_task()
+    prompt, _ = await runner._build_prompt_with_stats(task)
+    assert "ADR-0049" in prompt
+    assert "kill-switch" in prompt.lower() or "HYDRAFLOW_DISABLE" in prompt
+
+
+@pytest.mark.asyncio
 async def test_build_prompt_includes_comments_when_present(config, event_bus):
     task = TaskFactory.create(
         body="It is broken.",


### PR DESCRIPTION
**Factory-process refinement — PLANNING** (from the 2026-05-31 retro). The "obvious fix" was wrong on the highest-blast items this run (the `git config --unset` mechanism doesn't work; counting all gh failures would halt the factory) — only empirical validation caught it. And two planned enforcement tests already existed (near-reinvention).

- **P3:** `AssumptionSurfacer` flags assumptions about subprocess commands / exit codes / OS-git behavior as **HIGH** with a "validate in a scratch repo / spike before committing" note; Risk-Skeptic requires empirical evidence (scratch-repo result, doc link, or spike outcome) for mechanism assumptions.
- **P4:** planner step-8 **ADR-0049 kill-switch** as a required principle for new loops/runners + a `run_phase_gates` new-loop detector. (Bullet trimmed to stay under the 15.5k prompt-budget guard.)
- **P5:** `run_phase_gates` warns on a **duplicate enforcement-test filename** (stops reinventing `test_loop_wiring_completeness` / `test_config_consistency`).

Full `make quality` green: **15275 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)