### PR TITLE
feat(impl): lint-strip warning + serialize-lint + worktree extras (factory refinements)

### DIFF
--- a/.claude/hooks/hf.auto-lint-after-edit.sh
+++ b/.claude/hooks/hf.auto-lint-after-edit.sh
@@ -28,10 +28,19 @@ if [ ! -f "$FILE_PATH" ]; then
   exit 0
 fi
 
-# Auto-fix then check remaining (2 ruff calls, not 3 — skip detection pass)
+# Auto-fix then check remaining (2 ruff calls, not 3 — skip detection pass).
+# Snapshot the line count before/after the fix pass so we can warn when ruff
+# silently deletes lines (unused imports/vars), which is a frequent mid-edit
+# footgun. The warning is exit-0/stderr-only — visibility, not blocking.
 if command -v ruff &>/dev/null; then
+  BEFORE_LINES=$(wc -l < "$FILE_PATH")
   ruff check --fix --unsafe-fixes "$FILE_PATH" > /dev/null 2>&1 || true
   ruff format "$FILE_PATH" > /dev/null 2>&1 || true
+  AFTER_LINES=$(wc -l < "$FILE_PATH")
+  REMOVED=$(( BEFORE_LINES - AFTER_LINES ))
+  if [ "$REMOVED" -gt 0 ]; then
+    echo "LINT-STRIP: ruff removed ${REMOVED} line(s) from $(basename "$FILE_PATH") (unused-import/unused-variable). If these were mid-edit placeholders, re-add them before the next write." >&2
+  fi
   REMAINING=$(ruff check "$FILE_PATH" 2>/dev/null || true)
   if [ -n "$REMAINING" ]; then
     echo "LINT: Auto-fixed some issues in $(basename "$FILE_PATH"), but these remain:" >&2
@@ -39,8 +48,14 @@ if command -v ruff &>/dev/null; then
     echo "Fix these manually before committing." >&2
   fi
 elif command -v uv &>/dev/null; then
+  BEFORE_LINES=$(wc -l < "$FILE_PATH")
   uv run ruff check --fix --unsafe-fixes "$FILE_PATH" > /dev/null 2>&1 || true
   uv run ruff format "$FILE_PATH" > /dev/null 2>&1 || true
+  AFTER_LINES=$(wc -l < "$FILE_PATH")
+  REMOVED=$(( BEFORE_LINES - AFTER_LINES ))
+  if [ "$REMOVED" -gt 0 ]; then
+    echo "LINT-STRIP: ruff removed ${REMOVED} line(s) from $(basename "$FILE_PATH") (unused-import/unused-variable). If these were mid-edit placeholders, re-add them before the next write." >&2
+  fi
   REMAINING=$(uv run ruff check "$FILE_PATH" 2>/dev/null || true)
   if [ -n "$REMAINING" ]; then
     echo "LINT: Auto-fixed some issues in $(basename "$FILE_PATH"), but these remain:" >&2

--- a/Makefile
+++ b/Makefile
@@ -332,10 +332,13 @@ init:
 		$(ARGS)
 
 
+# Lint runs first, serially — ensures a failing lint aborts quality before
+# spending time on tests, and guarantees the same verdict as `make lint-check`.
+# pyright, bandit, and pytest are parallelised after lint passes.
 quality: deps lint-ul
 	@echo "$(BLUE)Running quality checks in parallel...$(RESET)"
+	@cd $(HYDRAFLOW_DIR) && $(UV) ruff check . && $(UV) ruff format . --check && echo "[lint OK]"
 	@cd $(HYDRAFLOW_DIR) && ( \
-		$(UV) ruff check . && $(UV) ruff format . --check && echo "[lint OK]" & \
 		$(UV) pyright && echo "[typecheck OK]" & \
 		$(UV) bandit -c pyproject.toml -r . --severity-level medium && echo "[security OK]" & \
 		PYTHONPATH=src $(UV) pytest tests/ && echo "[tests OK]" & \

--- a/src/workspace.py
+++ b/src/workspace.py
@@ -836,11 +836,22 @@ class WorkspaceManager:
             logger.warning("git identity config failed in %s: %s", wt_path, exc)
 
     async def _create_venv(self, wt_path: Path) -> None:
-        """Create an independent venv in the worktree via ``uv sync``."""
+        """Create an independent venv in the worktree via ``uv sync --all-extras``.
+
+        ``--all-extras`` ensures test and dev extras (pytest, hypothesis, ulid, etc.)
+        are installed, matching the ``make deps`` behaviour in the main repo. Without
+        it, fresh worktree venvs miss test-only deps and route/scenario tests fail to
+        import.
+        """
         try:
             await run_subprocess(
-                "uv", "sync", cwd=wt_path, gh_token=self._credentials.gh_token
+                "uv",
+                "sync",
+                "--all-extras",
+                cwd=wt_path,
+                gh_token=self._credentials.gh_token,
             )
+            logger.info("uv sync --all-extras complete in %s", wt_path)
         except (RuntimeError, FileNotFoundError) as exc:
             logger.warning("uv sync failed in %s: %s", wt_path, exc)
 

--- a/tests/hooks/test_auto_lint_strip_warning.sh
+++ b/tests/hooks/test_auto_lint_strip_warning.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Regression: the auto-lint hook must emit a LINT-STRIP warning to stderr when
+# ruff silently deletes lines (e.g. an unused import) during the --fix pass.
+set -euo pipefail
+HOOK="$(git rev-parse --show-toplevel)/.claude/hooks/hf.auto-lint-after-edit.sh"
+TMP=$(mktemp /tmp/test_strip_XXXXXX.py)
+echo "import os  # unused" > "$TMP"
+STDERR=$( echo "{\"tool_input\":{\"file_path\":\"$TMP\"}}" | bash "$HOOK" 2>&1 >/dev/null || true )
+rm -f "$TMP"
+echo "$STDERR" | grep -q "LINT-STRIP" || { echo "FAIL: no LINT-STRIP warning emitted"; exit 1; }
+echo "PASS"

--- a/tests/test_makefile_quality_order.py
+++ b/tests/test_makefile_quality_order.py
@@ -1,0 +1,25 @@
+"""Regression: make quality must run lint serially before the parallel block."""
+
+from pathlib import Path
+
+MAKEFILE = Path(__file__).parent.parent / "Makefile"
+
+
+def test_lint_runs_before_parallel_block() -> None:
+    text = MAKEFILE.read_text()
+    quality_start = text.index("quality: deps lint-ul")
+    quality_end = text.index("\nquality-lite:", quality_start)
+    recipe = text[quality_start:quality_end]
+
+    # Lint preamble must appear before the parallel-job block opener
+    lint_pos = recipe.index("ruff check .")
+    parallel_pos = recipe.index("& \\")
+    assert lint_pos < parallel_pos, (
+        "make quality: lint must execute serially before the & parallel block"
+    )
+
+    # Lint line must NOT end with ' &' (i.e., it is not a background job)
+    lint_line = next(ln for ln in recipe.splitlines() if "ruff check ." in ln)
+    assert not lint_line.rstrip().endswith("&"), (
+        "make quality: lint preamble line must not be a background job"
+    )

--- a/tests/test_workspace_env.py
+++ b/tests/test_workspace_env.py
@@ -535,7 +535,11 @@ class TestCreateVenv:
             await manager._create_venv(tmp_path)
 
         mock_exec.assert_called_once()
-        assert mock_exec.call_args.args[:2] == ("uv", "sync")
+        call_args = mock_exec.call_args.args
+        assert call_args[:2] == ("uv", "sync")
+        assert "--all-extras" in call_args, (
+            "_create_venv must pass --all-extras so test extras (pytest, ulid, etc.) install"
+        )
 
     @pytest.mark.asyncio
     async def test_create_venv_swallows_errors(self, config, tmp_path: Path) -> None:


### PR DESCRIPTION
**Factory-process refinement — IMPLEMENTATION** (from the 2026-05-31 retro). Three recurring toolchain footguns from the hardening run:

- **I-1:** the auto-lint hook now **warns when ruff silently deletes** import/name lines (the momentarily-unused-symbol strip that bit me twice — a counter init and a `TYPE_CHECKING` import).
- **I-2:** `make quality` runs **lint serially first**, so a lint failure can't be masked by the parallel race (the SIM105 false-green).
- **I-3:** worktree `_create_venv` uses `uv sync --all-extras`, so fresh worktrees have `ulid`/test extras (route/scenario imports stop failing).

Full `make quality` green: **15268 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)