### PR TITLE
ci: scope gates to relevant change areas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       python: ${{ steps.filter.outputs.python }}
+      core_python: ${{ steps.filter.outputs.core_python }}
+      arch: ${{ steps.filter.outputs.arch }}
+      scenario_tests: ${{ steps.filter.outputs.scenario_tests }}
+      regression_tests: ${{ steps.filter.outputs.regression_tests }}
       ui: ${{ steps.filter.outputs.ui }}
       ci: ${{ steps.filter.outputs.ci }}
       service_registry: ${{ steps.filter.outputs.service_registry }}
@@ -36,6 +40,28 @@ jobs:
               - 'tests/**'
               - 'pyproject.toml'
               - 'uv.lock'
+            core_python:
+              - 'src/**/*.py'
+              - '!src/arch/**'
+              - 'tests/**'
+              - '!tests/architecture/**'
+              - '!tests/regressions/**'
+              - '!tests/scenarios/**'
+              - '!tests/sandbox_scenarios/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+            arch:
+              - 'src/arch/**'
+              - 'tests/architecture/**'
+              - 'docs/arch/**'
+              - 'docs/adr/**'
+              - 'docs/wiki/**'
+              - 'Makefile'
+            scenario_tests:
+              - 'tests/scenarios/**'
+              - 'tests/sandbox_scenarios/**'
+            regression_tests:
+              - 'tests/regressions/**'
             ui:
               - 'src/ui/**'
             ci:
@@ -112,10 +138,36 @@ jobs:
       - name: Bandit security scan
         run: uv run bandit -c pyproject.toml -r . --severity-level medium
 
+  arch:
+    name: Architecture Check
+    needs: changes
+    if: needs.changes.outputs.arch == 'true' || needs.changes.outputs.ci == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: uv sync --all-extras
+      - name: Validate functional_areas.yml
+        run: |
+          uv run python -c "from arch._functional_areas_schema import load_functional_areas; from pathlib import Path; load_functional_areas(Path('docs/arch/functional_areas.yml')); print('functional_areas.yml: schema OK')"
+      - name: Drift check
+        run: make arch-check
+      - name: Architecture tests
+        run: uv run pytest tests/architecture -x --tb=short
+
   test:
     name: Tests
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.core_python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -143,7 +195,7 @@ jobs:
   smoke:
     name: Smoke Tests
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.core_python == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -170,7 +222,7 @@ jobs:
   scenario:
     name: Scenario Tests
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.core_python == 'true' || needs.changes.outputs.scenario_tests == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -191,7 +243,7 @@ jobs:
   regression:
     name: Regression Tests
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.core_python == 'true' || needs.changes.outputs.regression_tests == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -210,7 +262,7 @@ jobs:
   audit:
     name: Principles Audit
     needs: changes
-    if: needs.changes.outputs.python == 'true' || needs.changes.outputs.ci == 'true'
+    if: needs.changes.outputs.core_python == 'true' || needs.changes.outputs.ci == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -361,7 +413,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [changes, lint, typecheck, security, test, smoke, scenario, regression, audit, ui-build]
+    needs: [changes, lint, typecheck, security, arch, test, smoke, scenario, regression, audit, ui-build]
     if: always()
     steps:
       - name: Require all CI jobs to have passed or been skipped

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      full_quality: ${{ steps.filter.outputs.full_quality }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -25,6 +26,18 @@ jobs:
             code:
               - 'src/**'
               - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Makefile'
+              - '.github/workflows/**'
+            full_quality:
+              - 'src/**'
+              - '!src/arch/**'
+              - 'tests/**'
+              - '!tests/architecture/**'
+              - '!tests/regressions/**'
+              - '!tests/scenarios/**'
+              - '!tests/sandbox_scenarios/**'
               - 'pyproject.toml'
               - 'uv.lock'
               - 'Makefile'
@@ -155,7 +168,7 @@ jobs:
           fi
           echo "No Makefile in ${{ matrix.project_dir }}; skipping make quality-lite."
       - name: Quality Full
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.full_quality == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -166,7 +179,7 @@ jobs:
           fi
           echo "No Makefile in ${{ matrix.project_dir }}; skipping make quality."
       - name: Smoke
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.full_quality == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/src/arch/extractors/labels.py
+++ b/src/arch/extractors/labels.py
@@ -6,10 +6,9 @@ Looks for a top-level constant of the form
 
 For codebases where transitions are scattered across imperative
 `swap_pipeline_labels(...)` call-sites (HydraFlow as of v1) this returns an
-empty state machine. That's intentional: the matching ADR-0002 drift test
-is marked xfail in such cases per Plan A's escape hatch (Task 22 step 4),
-and a hydraflow-find issue documents the gap so the cleanup can introduce
-a declarative table later.
+empty state machine. That's intentional: the ADR-0002 drift guard asserts
+that generated labels documentation explicitly reports the empty extraction
+until a later cleanup introduces a declarative transition table.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- split CI path filters into core Python, architecture, scenario, and regression scopes
- add an Architecture Check job for arch-only changes so they run arch-check plus architecture tests without forcing the 20-minute coverage job
- make full Tests, Smoke, Scenario, Regression, and Principles Audit conditional on the relevant scope while keeping CI Gate as the aggregate check
- make quality.yml run quality-lite for code changes, but skip full quality/smoke for architecture-only/specialized test changes
- reconcile stale Architecture Knowledge Plan A labels-extractor wording

## Validation
- uv run python YAML parse for .github/workflows/ci.yml and quality.yml
- make arch-check
- uv run pytest tests/architecture/test_no_ignored_active_tests.py -q
- make quality-lite

Tracking: hydraflow-twwm