### PR TITLE
feat(review-phase): stratify PostVerifyAdvisor retry budget by blast radius (R-2)

### DIFF
--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -88,6 +88,12 @@ class FakeGitHub:
         # Per-PR list of commit-diff strings for get_pr_recent_commit_diffs.
         # Each entry is a pre-rendered "## <sha> <title>\n<diff>" block.
         self._commit_diffs: dict[int, list[str]] = {}
+        # Per-PR full unified diff for get_pr_diff. Lets scenarios control the
+        # diff a review sees (e.g. its blast radius for retry-budget tests).
+        self._pr_diffs: dict[int, str] = {}
+        # Catch-all diff for PRs without a per-PR seed. PR numbers come from an
+        # opaque counter, so single-PR scenarios set this rather than guess.
+        self._default_pr_diff: str | None = None
         # Per-PR CI failure log text for fetch_ci_failure_logs.
         self._ci_failure_logs: dict[int, str] = {}
         # Mirrors PRManager._repo. Some loops (StaleIssueLoop) read this
@@ -187,6 +193,23 @@ class FakeGitHub:
         ``get_pr_recent_commit_diffs`` returns the last *n* of these.
         """
         self._commit_diffs[pr_number] = list(diffs)
+
+    def seed_pr_diff(self, pr_number: int, diff: str) -> None:
+        """Seed the full unified diff ``get_pr_diff`` returns for *pr_number*.
+
+        Lets a scenario control the diff a review sees — e.g. its blast radius
+        (critical paths / src line count), which drives the PostVerifyAdvisor
+        retry budget. Absent a seed, ``get_pr_diff`` returns the default stub.
+        """
+        self._pr_diffs[pr_number] = diff
+
+    def set_default_pr_diff(self, diff: str) -> None:
+        """Set the diff ``get_pr_diff`` returns for any PR lacking a per-PR seed.
+
+        Convenience for single-PR scenarios that want to control blast radius
+        without knowing the opaque PR number assigned by ``create_pr``.
+        """
+        self._default_pr_diff = diff
 
     def set_issue_updated_at(self, issue_number: int, updated_at: str) -> None:
         """Set the updated_at timestamp on a seeded issue."""
@@ -422,6 +445,10 @@ class FakeGitHub:
 
     async def get_pr_diff(self, pr_number: int) -> str:
         self._maybe_rate_limit()
+        if pr_number in self._pr_diffs:
+            return self._pr_diffs[pr_number]
+        if self._default_pr_diff is not None:
+            return self._default_pr_diff
         return "diff --git a/x b/x"
 
     async def get_pr_head_sha(self, pr_number: int) -> str:

--- a/src/review_advisor.py
+++ b/src/review_advisor.py
@@ -392,6 +392,32 @@ def min_review_passes_for_blast_radius(
     return BLAST_RADIUS_RETRIES[blast_radius]
 
 
+def post_verify_retry_budget(
+    blast_radius: Literal["low", "medium", "high"],
+    max_veto_retries: int,
+) -> int:
+    """Return the PostVerifyAdvisor veto-retry budget for a diff (refinement R-2).
+
+    For veto-authority surfaces (``max_veto_retries > 0``) the budget is
+    stratified by blast radius (``BLAST_RADIUS_RETRIES``) so high-blast changes
+    earn more automated fix attempts before escalating to a human and trivial
+    ones escalate sooner. Here ``max_veto_retries`` acts as a veto-authority
+    *enable flag*, not a numeric cap: a high-blast budget of 3 intentionally
+    exceeds a configured value of 2 — that "more retries for risky changes" is
+    the whole point of R-2.
+
+    ``max_veto_retries == 0`` is a HARD CAP returning 0 regardless of blast: an
+    advisory-only surface never retries and never blocks a merge, preserving
+    the zero-budget contract. (Only ``wiki_ingest`` is configured to 0 today,
+    and the advisory surfaces — visual_gate/adr_review/wiki_ingest — run their
+    own one-shot advisor path rather than the retry loop that consumes this
+    budget, so the cap is defensive.)
+    """
+    if max_veto_retries == 0:
+        return 0
+    return BLAST_RADIUS_RETRIES[blast_radius]
+
+
 def diff_stats_from_text(diff: str) -> DiffStats:
     """Compute a coarse :class:`DiffStats` from a raw unified-diff string.
 

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -1618,7 +1618,10 @@ class ReviewPhase:
         """
         from review_advisor import (  # noqa: PLC0415
             build_surface_config,
+            compute_blast_radius,
+            diff_stats_from_text,
             is_advisor_enabled,
+            post_verify_retry_budget,
         )
 
         surface_cfg = build_surface_config(surface)
@@ -1674,12 +1677,21 @@ class ReviewPhase:
                     )
                 return result, diff
 
-            # VETO — either retry or escalate, up to surface_cfg.max_veto_retries.
-            # (Blast-radius-stratified retry budgets — refinement R-2 — are
-            # deferred to a dedicated PR: they override the surface-config
-            # max_veto_retries model, which needs deliberate co-design with the
-            # advisory-mode surfaces and the veto→HITL escalation scenarios.)
-            if attempt_number >= surface_cfg.max_veto_retries:
+            # VETO — either retry or escalate. Refinement R-2: the retry budget
+            # is stratified by the diff's blast radius (low=1, medium=2, high=3)
+            # rather than a flat surface value, so high-blast changes earn more
+            # automated fix attempts before escalating to a human and trivial
+            # ones escalate sooner. This loop serves the veto-authority PR-review
+            # surfaces (pr_review, pre_merge_spec_check; max_veto_retries>0);
+            # advisory-only surfaces (visual_gate/adr_review/wiki_ingest) run
+            # their own one-shot advisor and never enter this loop. The
+            # max_veto_retries==0 branch in post_verify_retry_budget is a
+            # defensive hard-cap (a zero-budget surface never retries/blocks).
+            _blast = compute_blast_radius(diff_stats_from_text(diff))
+            _retry_budget = post_verify_retry_budget(
+                _blast, surface_cfg.max_veto_retries
+            )
+            if attempt_number >= _retry_budget:
                 _emit_advisor_loop_metric(_veto_exhausted_total, {"surface": surface})
                 _emit_advisor_loop_metric(
                     _veto_retries_total,

--- a/tests/scenarios/test_pr_review_advisor_post_verify_fails_blocks.py
+++ b/tests/scenarios/test_pr_review_advisor_post_verify_fails_blocks.py
@@ -4,9 +4,10 @@ when advisor errors, treat as VETO instead of degrading.
 T15 of the advisor-pattern feature. Validates the fail-closed mode of
 the advisor failure-mode envelope: each advisor invocation hits a
 parse-error path (no scripted result), ``_handle_failure`` returns VETO
-(because FAIL_AS_VETO=true), and the bounded retry loop exhausts after
-``max_veto_retries+1 == 3`` calls — escalating to HITL with the merge
-blocked.
+(because FAIL_AS_VETO=true), and the bounded retry loop exhausts —
+escalating to HITL with the merge blocked. The PR is seeded with a
+medium-blast diff so the R-2 blast-stratified budget is 2 (medium tier),
+i.e. initial + 2 retries = 3 calls before exhaustion.
 """
 
 from __future__ import annotations
@@ -30,6 +31,13 @@ class TestPRReviewAdvisorPostVerifyFailsBlocks:
 
         world = mock_world
         IssueBuilder().numbered(24).titled("docs").bodied("docs").at(world)
+        # Seed a medium-blast diff (>200 changed lines on a non-critical src
+        # file → blast=medium → budget 2) so the assertion below is exactly
+        # initial + 2 retries = 3 calls before exhaustion.
+        medium_diff = "+++ b/src/feature.py\n" + "\n".join(
+            f"+    field_{i} = {i}" for i in range(220)
+        )
+        world.github.set_default_pr_diff(medium_diff)
 
         # No advisor result scripted → JSON parse error on each retry attempt
         # → all attempts return VETO under FAIL_AS_VETO=true →
@@ -37,6 +45,6 @@ class TestPRReviewAdvisorPostVerifyFailsBlocks:
 
         result = await world.run_pipeline()
         outcome = result.issue(24)
-        # Advisor was invoked max_veto_retries+1 times = 3 times
+        # Medium-blast budget+1 = 3 advisor invocations before exhaustion.
         assert world._llm.advisor_call_count_for("post_verify") == 3
         assert outcome.merged is False

--- a/tests/scenarios/test_pr_review_advisor_veto_exhausted_escalates_hitl.py
+++ b/tests/scenarios/test_pr_review_advisor_veto_exhausted_escalates_hitl.py
@@ -1,11 +1,20 @@
-"""Tier-1 scenario: 3 vetoes exhaust the retry budget and escalate to HITL.
+"""Tier-1 scenario: vetoes exhaust the blast-stratified retry budget → HITL.
 
-T11 of the advisor-pattern feature. With ``max_veto_retries=2`` (the
-``pr_review`` surface default), three consecutive VETOs (initial attempt
-+ 2 retries) trip the exhaustion branch in
-``ReviewPhase._run_post_verify_advisor`` and route the PR to HITL via
-``_escalate_to_hitl`` with the full disagreement transcript. The
-exhausted run must NOT merge.
+T11 of the advisor-pattern feature, extended for refinement R-2. The
+PostVerifyAdvisor retry budget is stratified by the diff's blast radius
+(``BLAST_RADIUS_RETRIES`` = low:1, medium:2, high:3) rather than a flat
+surface value, so the number of advisor calls before exhaustion scales
+with risk:
+
+- low blast  → 1 retry  → 2 calls then escalate
+- medium     → 2 retries → 3 calls then escalate
+- high blast → 3 retries → 4 calls then escalate
+
+At *every* tier the safety invariant holds: once the budget is exhausted,
+``ReviewPhase._run_post_verify_advisor`` routes the PR to HITL via
+``_escalate_to_hitl`` (one ``HITL_ESCALATION`` event, cause
+``advisor_post_verify_veto``) and the run does NOT merge. Blast radius is
+driven by the seeded PR diff (``FakeGitHub.set_default_pr_diff``).
 """
 
 from __future__ import annotations
@@ -19,65 +28,137 @@ from tests.scenarios.builders import IssueBuilder
 pytestmark = pytest.mark.scenario
 
 
-class TestPRReviewVetoExhaustedEscalatesHITL:
-    """3 vetoes (max_veto_retries=2 + the initial attempt) -> HITL, no merge."""
+def _veto_payload() -> str:
+    """A blocking-severity VETO the advisor returns on every attempt."""
+    return json.dumps(
+        {
+            "verdict": "VETO",
+            "reasoning": "missed regression in module Y",
+            "disagreements": [
+                {
+                    "executor_claim": "addressed",
+                    "advisor_assessment": "still missing Y test",
+                    "severity": "blocking",
+                }
+            ],
+            "suggested_fix_direction": "add a regression test for Y",
+        }
+    )
 
-    async def test_three_vetoes_escalate_hitl(self, mock_world, monkeypatch) -> None:
-        # Enable the advisor master and the pr_review surface kill-switches
-        # explicitly so the retry loop is reachable regardless of test-suite
-        # default overrides.
+
+def _blast_diff(tier: str) -> str:
+    """Build a unified diff whose ``compute_blast_radius`` classifies as *tier*.
+
+    ``low`` is the default stub (no src path), so callers just omit the seed.
+    """
+    if tier == "high":
+        # src/orchestrator.py is a CRITICAL_PATHS_EXACT entry → blast=high.
+        return (
+            "diff --git a/src/orchestrator.py b/src/orchestrator.py\n"
+            "+++ b/src/orchestrator.py\n"
+            "+    _changed = True\n"
+        )
+    if tier == "medium":
+        # >200 changed lines on a non-critical src file → blast=medium.
+        body = "\n".join(f"+    field_{i} = {i}" for i in range(220))
+        return (
+            "diff --git a/src/feature_under_review.py "
+            "b/src/feature_under_review.py\n"
+            "+++ b/src/feature_under_review.py\n"
+            f"{body}\n"
+        )
+    raise ValueError(f"unsupported tier: {tier}")
+
+
+def _veto_escalations(result, issue_number: int) -> list:
+    """The advisor-post-verify-veto HITL escalation events for *issue_number*.
+
+    Asserting on the event (not label state) is durable across post-escalation
+    phases: after the exhaustion branch flips the verdict to REQUEST_CHANGES,
+    the caller's normal REQUEST_CHANGES handling re-queues to ready and would
+    otherwise overwrite a diagnose label.
+    """
+    events = result.pipeline_results[0].events
+    return [
+        e
+        for e in events
+        if e.type.value == "hitl_escalation"
+        and e.data.get("cause") == "advisor_post_verify_veto"
+        and e.data.get("issue") == issue_number
+    ]
+
+
+class TestPRReviewVetoExhaustedEscalatesHITL:
+    """Blast-stratified budget exhaustion routes to HITL with no merge."""
+
+    @staticmethod
+    def _enable_advisor(monkeypatch) -> None:
+        # Enable the advisor master + pr_review surface kill-switches explicitly
+        # so the retry loop is reachable regardless of test-suite defaults.
         monkeypatch.setenv("HYDRAFLOW_REVIEW_ADVISOR_ENABLED", "true")
         monkeypatch.setenv("HYDRAFLOW_PR_REVIEW_ADVISOR_ENABLED", "true")
         monkeypatch.setenv("HYDRAFLOW_REVIEW_POSTVERIFY_ENABLED", "true")
 
+    async def test_medium_blast_escalates_after_three_calls(
+        self, mock_world, monkeypatch
+    ) -> None:
+        """Medium blast → budget 2 → initial + 2 retries = 3 calls → HITL."""
+        self._enable_advisor(monkeypatch)
         world = mock_world
         IssueBuilder().numbered(13).titled("Stuck change").bodied(
             "Persistently disputed by advisor"
         ).at(world)
-
-        veto_payload = json.dumps(
-            {
-                "verdict": "VETO",
-                "reasoning": "missed regression in module Y",
-                "disagreements": [
-                    {
-                        "executor_claim": "addressed",
-                        "advisor_assessment": "still missing Y test",
-                        "severity": "blocking",
-                    }
-                ],
-                "suggested_fix_direction": "add a regression test for Y",
-            }
-        )
-        # max_veto_retries=2 -> initial + 2 retries = 3 advisor calls all VETO.
-        world._llm.script_advisor(13, "post_verify", [veto_payload] * 3)
+        world.github.set_default_pr_diff(_blast_diff("medium"))
+        world._llm.script_advisor(13, "post_verify", [_veto_payload()] * 3)
 
         result = await world.run_pipeline()
 
         outcome = result.issue(13)
         assert outcome.review_result is not None
         assert outcome.merged is False, "PR must not merge after veto exhaustion"
-        # The advisor was popped exactly three times — once for the initial
-        # VETO and once per retry — before the budget tripped exhaustion.
         assert world._llm.advisor_call_count_for("post_verify") == 3, (
-            "advisor should fire 3 times (initial + 2 retries) then escalate"
+            "medium blast: advisor fires 3 times (initial + 2 retries) then escalates"
         )
-        # Exhaustion routes through ``_escalate_to_hitl``, which publishes a
-        # ``HITL_ESCALATION`` event with cause ``advisor_post_verify_veto``.
-        # Asserting on the event (rather than label state) is durable across
-        # post-escalation pipeline phases that may re-label the issue: after
-        # T10's exhaustion branch flips the verdict to REQUEST_CHANGES, the
-        # caller's normal REQUEST_CHANGES handling re-queues to ready and
-        # would otherwise overwrite the diagnose label.
-        events = result.pipeline_results[0].events
-        veto_escalations = [
-            e
-            for e in events
-            if e.type.value == "hitl_escalation"
-            and e.data.get("cause") == "advisor_post_verify_veto"
-            and e.data.get("issue") == 13
-        ]
-        assert len(veto_escalations) == 1, (
-            f"expected exactly one advisor_post_verify_veto HITL_ESCALATION "
-            f"event for issue 13, got {[(e.type.value, e.data) for e in events if e.type.value == 'hitl_escalation']!r}"
+        assert len(_veto_escalations(result, 13)) == 1
+
+    async def test_low_blast_escalates_after_two_calls(
+        self, mock_world, monkeypatch
+    ) -> None:
+        """Low blast (default stub diff) → budget 1 → 2 calls → HITL sooner."""
+        self._enable_advisor(monkeypatch)
+        world = mock_world
+        IssueBuilder().numbered(14).titled("Trivial dispute").bodied(
+            "Small change the advisor keeps vetoing"
+        ).at(world)
+        # No diff seed → default stub has no src path → blast=low → budget 1.
+        world._llm.script_advisor(14, "post_verify", [_veto_payload()] * 2)
+
+        result = await world.run_pipeline()
+
+        outcome = result.issue(14)
+        assert outcome.merged is False, "PR must not merge after veto exhaustion"
+        assert world._llm.advisor_call_count_for("post_verify") == 2, (
+            "low blast: advisor fires 2 times (initial + 1 retry) then escalates"
         )
+        assert len(_veto_escalations(result, 14)) == 1
+
+    async def test_high_blast_escalates_after_four_calls(
+        self, mock_world, monkeypatch
+    ) -> None:
+        """High blast (critical path) → budget 3 → 4 calls before HITL."""
+        self._enable_advisor(monkeypatch)
+        world = mock_world
+        IssueBuilder().numbered(15).titled("Risky core change").bodied(
+            "Critical-path change the advisor keeps vetoing"
+        ).at(world)
+        world.github.set_default_pr_diff(_blast_diff("high"))
+        world._llm.script_advisor(15, "post_verify", [_veto_payload()] * 4)
+
+        result = await world.run_pipeline()
+
+        outcome = result.issue(15)
+        assert outcome.merged is False, "PR must not merge after veto exhaustion"
+        assert world._llm.advisor_call_count_for("post_verify") == 4, (
+            "high blast: advisor fires 4 times (initial + 3 retries) then escalates"
+        )
+        assert len(_veto_escalations(result, 15)) == 1

--- a/tests/test_review_advisor.py
+++ b/tests/test_review_advisor.py
@@ -27,6 +27,7 @@ from review_advisor import (
     compute_blast_radius,
     is_advisor_enabled,
     min_review_passes_for_blast_radius,
+    post_verify_retry_budget,
     resolve_model,
     should_pre_flight,
 )
@@ -1938,6 +1939,27 @@ class TestBlastRadius:
 class TestBlastRadiusRetryBudget:
     def test_BLAST_RADIUS_RETRIES_table_covers_all_tiers(self):
         assert BLAST_RADIUS_RETRIES == {"low": 1, "medium": 2, "high": 3}
+
+    def test_budget_matches_tier_when_surface_allows_retries(self):
+        # pr_review-style surface (max_veto_retries=2): budget == the blast tier.
+        assert post_verify_retry_budget("low", 2) == 1
+        assert post_verify_retry_budget("medium", 2) == 2
+        assert post_verify_retry_budget("high", 2) == 3
+
+    def test_zero_max_veto_retries_hard_caps_every_tier_to_zero(self):
+        # Advisory-only surfaces (wiki_ingest, max_veto_retries=0) must NEVER
+        # gain a retry budget from blast radius — they stay at 0 and never
+        # block a merge, regardless of how risky the diff is.
+        assert post_verify_retry_budget("low", 0) == 0
+        assert post_verify_retry_budget("medium", 0) == 0
+        assert post_verify_retry_budget("high", 0) == 0
+
+    def test_nonzero_max_veto_retries_is_an_enable_flag_not_a_cap(self):
+        # For veto-authority surfaces the numeric max_veto_retries only gates
+        # retries on/off; the count is blast-driven and intentionally exceeds
+        # the configured value for high blast (3 > 1). No zero-vs-one off-by-one.
+        assert post_verify_retry_budget("low", 1) == 1
+        assert post_verify_retry_budget("high", 1) == 3
 
 
 class TestSecondOrderFailureProbe:


### PR DESCRIPTION
The deferred **R-2** follow-up from the factory-process refinements (the helper shipped in #9130; the stratification was split out because the naive override broke the veto→HITL escalation scenarios). Now implemented with the scenario co-design those scenarios needed.

## What it does
The PostVerifyAdvisor veto-retry budget is now stratified by the diff's blast radius instead of a flat per-surface value:

| blast | budget | advisor calls before HITL |
|-------|--------|---------------------------|
| low   | 1      | 2 |
| medium| 2      | 3 |
| high  | 3      | 4 |

So high-blast (critical-path / large) changes earn **more** automated fix attempts before escalating to a human, and trivial changes escalate **sooner**. `max_veto_retries == 0` is a **hard cap** → 0 (advisory surfaces never retry/block). For veto-authority surfaces the numeric `max_veto_retries` is an enable-flag, not a cap — a high-blast budget of 3 intentionally exceeds a configured 2 (that's the point of R-2).

## Implementation
- `post_verify_retry_budget(blast, max_veto_retries)` helper in `review_advisor.py` (single source of truth, unit-tested).
- `_run_post_verify_advisor` consumes it (replaces the flat `attempt_number >= surface_cfg.max_veto_retries`).
- `FakeGitHub.seed_pr_diff` / `set_default_pr_diff` — per-PR / default diff control so scenarios drive a known blast radius.
- The two escalation scenarios rebuilt into low/medium/high tier tests; unit tests lock the budget table, the **zero-budget hard-cap**, and the enable-flag (not cap) semantics.

## Why it's safe
Adversarially reviewed — **all four safety invariants confirmed**:
1. A budget-exhausted VETO can't reach merge (verdict flips to REQUEST_CHANGES before the merge gate).
2. `max_veto_retries==0` hard-caps to 0 retries regardless of blast.
3. The loop stays bounded at every tier.
4. The zero-case is byte-identical to the prior behavior.

Only `pr_review` / `pre_merge_spec_check` reach this retry loop; `visual_gate`/`adr_review`/`wiki_ingest` use their own one-shot advisor path. Full `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)