### PR TITLE
refactor(review): retire vestigial max_veto_retries; derive retry cap from authority

### DIFF
--- a/docs/adr/0059-advisor-pattern-self-repairing-review.md
+++ b/docs/adr/0059-advisor-pattern-self-repairing-review.md
@@ -29,15 +29,18 @@ Implement the advisor pattern as **three role-based advisors** layered onto `Rev
 
 ### Per-surface tiering
 
-The matrix below matches `_SURFACE_DEFAULTS` in `src/review_advisor.py`:
+The matrix below matches `_SURFACE_DEFAULTS` in `src/review_advisor.py`. The
+post-verify retry budget is **derived** from blast radius + authority since R-2
+(`post_verify_retry_budget`), not a stored `max_veto_retries` field (retired in
+favour of the single-source-of-truth `post_verify_authority`):
 
-| Surface | Pre-flight | Mid-flight | Post-verify | Authority | `max_veto_retries` |
+| Surface | Pre-flight | Mid-flight | Post-verify | Authority | Post-verify retry budget |
 |---|---|---|---|---|---|
-| `pr_review` | conditional (`CompositeTrigger`: LOC + critical paths + prior fix attempts) | yes | yes | `veto` | 2 |
-| `pre_merge_spec_check` | piggyback (reuses `pr_review`'s plan) | yes | yes | `veto` | 2 (binary gate) |
-| `adr_review` | always (`AlwaysTrigger`) | n/a | yes | `veto` | 2 |
-| `visual_gate` | n/a | n/a | yes | `veto` | 1 |
-| `wiki_ingest` | n/a | n/a | yes | `advisory`* | 0 |
+| `pr_review` | conditional (`CompositeTrigger`: LOC + critical paths + prior fix attempts) | yes | yes | `veto` | blast-stratified (low 1 / med 2 / high 3) |
+| `pre_merge_spec_check` | piggyback (reuses `pr_review`'s plan) | yes | yes | `veto` | blast-stratified (low 1 / med 2 / high 3) |
+| `adr_review` | always (`AlwaysTrigger`) | n/a | yes | `veto` | one-shot (no retry loop) |
+| `visual_gate` | n/a | n/a | yes | `veto` | one-shot (no retry loop) |
+| `wiki_ingest` | n/a | n/a | yes | `advisory`* | n/a (advisory — never retries/blocks) |
 
 \* `wiki_ingest`'s advisory authority is upgraded to `veto` when the diff modifies advisor's own implementation (T29 self-modification guard).
 
@@ -55,7 +58,7 @@ The matrix below matches `_SURFACE_DEFAULTS` in `src/review_advisor.py`:
    - Mid-flight failure → executor proceeds with own judgment.
    - Post-verify failure → APPROVE by default; `HYDRAFLOW_REVIEW_POSTVERIFY_FAIL_AS_VETO=true` flips to VETO for high-trust environments.
 5. **Credit/bug error propagation** — every advisor runner calls `reraise_on_credit_or_bug(exc)` in its broad `except` block, per `docs/wiki/dark-factory.md` §2.2. Without this, `CreditExhaustedError` is silently eaten and the review burns retry budget against an exhausted billing signal.
-6. **Veto bounded retry** — post-verify VETO hands back the **full advisor transcript** (not just verdict reasoning) to the executor for re-attempt. After `max_veto_retries` exhausted, escalate to HITL with the disagreement transcript attached.
+6. **Veto bounded retry** — post-verify VETO hands back the **full advisor transcript** (not just verdict reasoning) to the executor for re-attempt. After the blast-radius-stratified retry budget is exhausted (R-2; `post_verify_retry_budget` — low 1 / med 2 / high 3 for veto-authority surfaces, 0 for advisory), escalate to HITL with the disagreement transcript attached.
 7. **Cross-review state isolation** — `_advisor_attempt`, `_advisor_results`, and `_advisor_pre_flight_plan` reset per review entry. HITL-escalated PRs that come back through review get a fresh budget; nothing leaks across re-reviews.
 8. **Explicit `role` Protocol parameter, not substring detection** — initial prototypes inferred role from prompt-text substrings; this misrouted on meta-PRs whose body legitimately quoted role markers. Replaced with an explicit `role` parameter on the advisor Protocol plus a HTML-comment sentinel marker for mid-flight. (T24.5 fix; see Risks below.)
 

--- a/src/review_advisor.py
+++ b/src/review_advisor.py
@@ -246,7 +246,6 @@ class SurfaceAdvisorConfig:
     post_verify_authority: Literal["advisory", "veto"]
     executor_model: str
     advisor_model: str
-    max_veto_retries: int
 
 
 @dataclass(frozen=True)
@@ -394,26 +393,23 @@ def min_review_passes_for_blast_radius(
 
 def post_verify_retry_budget(
     blast_radius: Literal["low", "medium", "high"],
-    max_veto_retries: int,
+    post_verify_authority: Literal["advisory", "veto"],
 ) -> int:
     """Return the PostVerifyAdvisor veto-retry budget for a diff (refinement R-2).
 
-    For veto-authority surfaces (``max_veto_retries > 0``) the budget is
-    stratified by blast radius (``BLAST_RADIUS_RETRIES``) so high-blast changes
-    earn more automated fix attempts before escalating to a human and trivial
-    ones escalate sooner. Here ``max_veto_retries`` acts as a veto-authority
-    *enable flag*, not a numeric cap: a high-blast budget of 3 intentionally
-    exceeds a configured value of 2 — that "more retries for risky changes" is
-    the whole point of R-2.
+    For veto-authority surfaces the budget is stratified by blast radius
+    (``BLAST_RADIUS_RETRIES``) so high-blast changes earn more automated fix
+    attempts before escalating to a human and trivial ones escalate sooner.
 
-    ``max_veto_retries == 0`` is a HARD CAP returning 0 regardless of blast: an
-    advisory-only surface never retries and never blocks a merge, preserving
-    the zero-budget contract. (Only ``wiki_ingest`` is configured to 0 today,
-    and the advisory surfaces — visual_gate/adr_review/wiki_ingest — run their
-    own one-shot advisor path rather than the retry loop that consumes this
-    budget, so the cap is defensive.)
+    Advisory surfaces (``post_verify_authority == "advisory"``) are HARD-CAPPED
+    to 0: they never retry and never block a merge, preserving the zero-budget
+    contract. The cap derives from the authority — the single source of truth
+    for advisory-vs-veto — rather than a separate retry-count field. It is
+    defensive for the retry loop, which only the veto-authority PR-review
+    surfaces (pr_review, pre_merge_spec_check) reach; the advisory wiki_ingest
+    surface and the one-shot visual_gate/adr_review surfaces never enter it.
     """
-    if max_veto_retries == 0:
+    if post_verify_authority == "advisory":
         return 0
     return BLAST_RADIUS_RETRIES[blast_radius]
 
@@ -473,7 +469,6 @@ _SURFACE_DEFAULTS: dict[str, dict[str, object]] = {
         "mid_flight_enabled": True,
         "post_verify_enabled": True,
         "post_verify_authority": "veto",
-        "max_veto_retries": 2,
     },
     "pre_merge_spec_check": {
         "pre_flight_enabled": False,
@@ -481,7 +476,6 @@ _SURFACE_DEFAULTS: dict[str, dict[str, object]] = {
         "mid_flight_enabled": True,
         "post_verify_enabled": True,
         "post_verify_authority": "veto",
-        "max_veto_retries": 2,
     },
     "adr_review": {
         "pre_flight_enabled": True,
@@ -489,7 +483,6 @@ _SURFACE_DEFAULTS: dict[str, dict[str, object]] = {
         "mid_flight_enabled": False,
         "post_verify_enabled": True,
         "post_verify_authority": "veto",
-        "max_veto_retries": 2,
     },
     "visual_gate": {
         "pre_flight_enabled": False,
@@ -497,7 +490,6 @@ _SURFACE_DEFAULTS: dict[str, dict[str, object]] = {
         "mid_flight_enabled": False,
         "post_verify_enabled": True,
         "post_verify_authority": "veto",
-        "max_veto_retries": 1,
     },
     "wiki_ingest": {
         "pre_flight_enabled": False,
@@ -505,7 +497,6 @@ _SURFACE_DEFAULTS: dict[str, dict[str, object]] = {
         "mid_flight_enabled": False,
         "post_verify_enabled": True,
         "post_verify_authority": "advisory",
-        "max_veto_retries": 0,
     },
 }
 
@@ -521,7 +512,6 @@ def build_surface_config(surface: str) -> SurfaceAdvisorConfig:
     mid_flight_enabled = base["mid_flight_enabled"]
     post_verify_enabled = base["post_verify_enabled"]
     post_verify_authority = base["post_verify_authority"]
-    max_veto_retries = base["max_veto_retries"]
     assert isinstance(pre_flight_enabled, bool)
     assert pre_flight_trigger is None or isinstance(
         pre_flight_trigger, PreFlightTrigger
@@ -529,7 +519,6 @@ def build_surface_config(surface: str) -> SurfaceAdvisorConfig:
     assert isinstance(mid_flight_enabled, bool)
     assert isinstance(post_verify_enabled, bool)
     assert post_verify_authority in ("advisory", "veto")
-    assert isinstance(max_veto_retries, int)
     return SurfaceAdvisorConfig(
         surface=surface,
         pre_flight_enabled=pre_flight_enabled,
@@ -539,7 +528,6 @@ def build_surface_config(surface: str) -> SurfaceAdvisorConfig:
         post_verify_authority=post_verify_authority,
         executor_model=resolve_model(surface, "executor", default="sonnet"),
         advisor_model=resolve_model(surface, "advisor", default="opus"),
-        max_veto_retries=max_veto_retries,
     )
 
 

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -211,8 +211,9 @@ class ReviewPhase:
 
             self._visual_validator = VisualValidator(config)
 
-        # Per-PR advisor retry counter — incremented on VETO. Bounded by
-        # surface_cfg.max_veto_retries.
+        # Per-PR advisor retry counter — incremented on VETO. Bounded by the
+        # blast-radius-stratified post-verify retry budget (R-2; see
+        # review_advisor.post_verify_retry_budget).
         self._advisor_attempt: dict[int, int] = {}
         # Per-PR list of advisor PostVerifyResults collected this run. The
         # transcript hand-back to the executor (on VETO) is rendered from
@@ -358,8 +359,8 @@ class ReviewPhase:
         main host's legacy wiki path.
 
         T28: PostVerifyAdvisor (surface=``wiki_ingest``) is consulted
-        in advisory mode (``post_verify_authority="advisory"``,
-        ``max_veto_retries=0``) before content is written. In advisory
+        in advisory mode (``post_verify_authority="advisory"``) before
+        content is written. In advisory
         mode the advisor's VETO is downgraded to APPROVE inside
         :class:`PostVerifyAdvisor.run` — disagreements are still logged
         for telemetry/calibration but ingestion proceeds. EXCEPTION:
@@ -456,7 +457,7 @@ class ReviewPhase:
         the kill-switch off path, and degraded advisor failures.
 
         Per spec tiering, ``wiki_ingest`` has ``post_verify_authority="advisory"``
-        and ``max_veto_retries=0`` — so the advisor is consulted purely for
+        — so the advisor is consulted purely for
         calibration: disagreements feed
         ``review_advisor_disagreement_total`` (T16.5) and the
         ``review_advisor_disagreement_validated_total`` KPI (T22), and every
@@ -1313,7 +1314,7 @@ class ReviewPhase:
 
         # PostVerifyAdvisor — second-opinion gate on APPROVE verdicts.
         # On VETO, the advisor hands the disagreement back to the executor
-        # for up to ``surface_cfg.max_veto_retries`` retries. After the
+        # for up to a blast-radius-stratified retry budget (R-2). After the
         # retry budget is exhausted, the disagreement is escalated to HITL.
         if result.verdict == ReviewVerdict.APPROVE and pr.number > 0:
             result, diff = await self._run_post_verify_advisor(
@@ -1601,8 +1602,9 @@ class ReviewPhase:
 
         On VETO, hands the full advisor transcript back to ``_attempt_review_fix``
         so the executor can address the disagreement, then re-runs the advisor.
-        Repeats up to ``surface_cfg.max_veto_retries`` retries. Once the
-        retry budget is exhausted, escalates to HITL with the full
+        Repeats up to a blast-radius-stratified retry budget (R-2;
+        ``post_verify_retry_budget``). Once the budget is exhausted,
+        escalates to HITL with the full
         disagreement transcript and returns ``(result, diff)`` flipped to
         REQUEST_CHANGES so the caller skips the merge branch.
 
@@ -1681,15 +1683,14 @@ class ReviewPhase:
             # is stratified by the diff's blast radius (low=1, medium=2, high=3)
             # rather than a flat surface value, so high-blast changes earn more
             # automated fix attempts before escalating to a human and trivial
-            # ones escalate sooner. This loop serves the veto-authority PR-review
-            # surfaces (pr_review, pre_merge_spec_check; max_veto_retries>0);
-            # advisory-only surfaces (visual_gate/adr_review/wiki_ingest) run
-            # their own one-shot advisor and never enter this loop. The
-            # max_veto_retries==0 branch in post_verify_retry_budget is a
-            # defensive hard-cap (a zero-budget surface never retries/blocks).
+            # ones escalate sooner. Only the veto-authority PR-review surfaces
+            # (pr_review, pre_merge_spec_check) reach this loop; the advisory
+            # wiki_ingest surface and the one-shot visual_gate/adr_review
+            # surfaces never enter it. post_verify_retry_budget derives the
+            # advisory hard-cap (budget 0) from post_verify_authority.
             _blast = compute_blast_radius(diff_stats_from_text(diff))
             _retry_budget = post_verify_retry_budget(
-                _blast, surface_cfg.max_veto_retries
+                _blast, surface_cfg.post_verify_authority
             )
             if attempt_number >= _retry_budget:
                 _emit_advisor_loop_metric(_veto_exhausted_total, {"surface": surface})
@@ -2756,8 +2757,8 @@ class ReviewPhase:
 
         T27: PostVerifyAdvisor (surface=``visual_gate``) wraps the visual
         pipeline's PASS verdict. The visual_gate surface is post-verify
-        only (no pre-flight, no mid-flight, ``max_veto_retries=1``) so this
-        is a one-shot binary gate — VETO blocks the merge and routes
+        only (no pre-flight, no mid-flight) so this is a one-shot binary
+        gate — VETO blocks the merge and routes
         through the existing failure/escalation path with the advisor's
         reasoning attached. APPROVE / disabled / degraded all fall through
         to the existing PASS sign-off behaviour.
@@ -2848,8 +2849,8 @@ class ReviewPhase:
         visual diff (verdict, pipeline reason, artifact links/count) — not
         a unified text diff. Visual gate has ``mid_flight_enabled=False``
         and ``pre_flight_enabled=False``, so this is a one-shot binary gate
-        with a tighter retry budget (``max_veto_retries=1`` per spec) — no
-        plan threading, no fix-and-iterate loop. ``reraise_on_credit_or_bug``
+        — a single advisor call, no retry budget, no plan threading, no
+        fix-and-iterate loop. ``reraise_on_credit_or_bug``
         discipline is preserved inside :meth:`_run_post_verify_for_surface`
         per ``docs/wiki/dark-factory.md`` §2.2.
 

--- a/tests/test_review_advisor.py
+++ b/tests/test_review_advisor.py
@@ -241,7 +241,6 @@ class TestSurfaceConfigs:
         assert c.mid_flight_enabled is True
         assert c.post_verify_enabled is True
         assert c.post_verify_authority == "veto"
-        assert c.max_veto_retries == 2
         assert isinstance(c.pre_flight_trigger, CompositeTrigger)
 
     def test_pre_merge_spec_check_no_preflight(self):
@@ -266,7 +265,6 @@ class TestSurfaceConfigs:
         assert c.mid_flight_enabled is False
         assert c.post_verify_enabled is True
         assert c.post_verify_authority == "veto"
-        assert c.max_veto_retries == 1
 
     def test_wiki_ingest_advisory_only(self):
         c = SURFACE_ADVISOR_CONFIGS["wiki_ingest"]
@@ -274,7 +272,6 @@ class TestSurfaceConfigs:
         assert c.mid_flight_enabled is False
         assert c.post_verify_enabled is True
         assert c.post_verify_authority == "advisory"
-        assert c.max_veto_retries == 0
 
     def test_build_resolves_models_from_env(self, monkeypatch):
         monkeypatch.setenv("HYDRAFLOW_PR_REVIEW_EXECUTOR_MODEL", "haiku")
@@ -1940,26 +1937,20 @@ class TestBlastRadiusRetryBudget:
     def test_BLAST_RADIUS_RETRIES_table_covers_all_tiers(self):
         assert BLAST_RADIUS_RETRIES == {"low": 1, "medium": 2, "high": 3}
 
-    def test_budget_matches_tier_when_surface_allows_retries(self):
-        # pr_review-style surface (max_veto_retries=2): budget == the blast tier.
-        assert post_verify_retry_budget("low", 2) == 1
-        assert post_verify_retry_budget("medium", 2) == 2
-        assert post_verify_retry_budget("high", 2) == 3
+    def test_veto_authority_budget_matches_blast_tier(self):
+        # Veto-authority surfaces (pr_review, pre_merge_spec_check): budget is
+        # purely blast-driven (low=1/medium=2/high=3) — no separate cap.
+        assert post_verify_retry_budget("low", "veto") == 1
+        assert post_verify_retry_budget("medium", "veto") == 2
+        assert post_verify_retry_budget("high", "veto") == 3
 
-    def test_zero_max_veto_retries_hard_caps_every_tier_to_zero(self):
-        # Advisory-only surfaces (wiki_ingest, max_veto_retries=0) must NEVER
-        # gain a retry budget from blast radius — they stay at 0 and never
-        # block a merge, regardless of how risky the diff is.
-        assert post_verify_retry_budget("low", 0) == 0
-        assert post_verify_retry_budget("medium", 0) == 0
-        assert post_verify_retry_budget("high", 0) == 0
-
-    def test_nonzero_max_veto_retries_is_an_enable_flag_not_a_cap(self):
-        # For veto-authority surfaces the numeric max_veto_retries only gates
-        # retries on/off; the count is blast-driven and intentionally exceeds
-        # the configured value for high blast (3 > 1). No zero-vs-one off-by-one.
-        assert post_verify_retry_budget("low", 1) == 1
-        assert post_verify_retry_budget("high", 1) == 3
+    def test_advisory_authority_hard_caps_every_tier_to_zero(self):
+        # Advisory surfaces (wiki_ingest) must NEVER gain a retry budget from
+        # blast radius — they stay at 0 and never block a merge, regardless of
+        # how risky the diff is. The cap derives from post_verify_authority.
+        assert post_verify_retry_budget("low", "advisory") == 0
+        assert post_verify_retry_budget("medium", "advisory") == 0
+        assert post_verify_retry_budget("high", "advisory") == 0
 
 
 class TestSecondOrderFailureProbe:

--- a/tests/test_review_phase_core.py
+++ b/tests/test_review_phase_core.py
@@ -3441,7 +3441,7 @@ class TestPreMergeSpecCheckAdvisor:
 class TestVisualGateAdvisor:
     """T27 — PostVerifyAdvisor wired into ``check_visual_gate`` for the
     ``visual_gate`` surface (post-only; pre_flight=False, mid_flight=False;
-    ``max_veto_retries=1``).
+    one-shot binary gate — no retry budget).
 
     The visual gate is a binary post-verify gate: when the visual pipeline
     returns ``"pass"``, the advisor gets a chance to second-opinion the
@@ -3687,7 +3687,7 @@ class TestVisualGateAdvisor:
 class TestWikiIngestAdvisor:
     """T28 — PostVerifyAdvisor wired into ``_wiki_ingest_review`` for the
     ``wiki_ingest`` surface (post-only; pre_flight=False, mid_flight=False;
-    ``post_verify_authority="advisory"``; ``max_veto_retries=0``).
+    ``post_verify_authority="advisory"``).
 
     Advisory mode means the advisor's VETO is downgraded to APPROVE in
     :meth:`PostVerifyAdvisor.run` — disagreements are still logged via the


### PR DESCRIPTION
Follow-up to **R-2 (#9134)** — resolves the design smell an adversarial review of that PR flagged.

## The problem
After R-2 made the post-verify retry budget blast-radius-driven, the surface-config `max_veto_retries: int` field became **numerically vestigial**: only its `0`-vs-nonzero distinction still mattered, and that correlates *exactly* with the existing `post_verify_authority` field (`"advisory"` ⟺ the sole zero-budget surface, `wiki_ingest`). The one-shot surfaces (`visual_gate`/`adr_review`) never consumed the value at all. So the repo carried a config int that looked like a retry cap but no longer was one — misleading for maintainers.

## The fix
- `post_verify_retry_budget(blast, post_verify_authority)` derives the advisory hard-cap (budget 0) from **`post_verify_authority`** — the single source of truth for advisory-vs-veto — instead of a separate retry-count field.
- Removes `max_veto_retries` from `SurfaceAdvisorConfig`, all 5 `_SURFACE_DEFAULTS` entries, and `build_surface_config`.
- Corrects now-stale comments/docstrings (several wrongly implied `visual_gate`/`adr_review` were advisory or had a retry budget — they're veto-authority **one-shot** gates).
- Updates **ADR-0059**'s surface table + rule 6 (both already stale after R-2's blast-stratification) to reflect the derived budget.

## Safety / behavior
**Behavior-preserving:** `authority=="advisory"` is equivalent to the old `max_veto_retries==0` across *every* surface, so the advisory hard-cap is unchanged; veto-authority surfaces keep the blast-stratified budget (low 1 / med 2 / high 3). The veto→HITL escalation invariant is untouched (covered by the tier scenarios from #9134).

Fresh pyright clean; full `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)