### PR TITLE
fix(ci): repair arch-regen.yml startup_failure (invalid YAML in run scalar)

### DIFF
--- a/.github/workflows/arch-regen.yml
+++ b/.github/workflows/arch-regen.yml
@@ -39,7 +39,8 @@ jobs:
         run: uv sync --all-extras
       - name: Validate functional_areas.yml
         if: steps.skip_check.outputs.pure_regen != 'true'
-        run: uv run python -c "from arch._functional_areas_schema import load_functional_areas; from pathlib import Path; load_functional_areas(Path('docs/arch/functional_areas.yml')); print('functional_areas.yml: schema OK')"
+        run: |
+          uv run python -c "from arch._functional_areas_schema import load_functional_areas; from pathlib import Path; load_functional_areas(Path('docs/arch/functional_areas.yml')); print('functional_areas.yml: schema OK')"
       - name: Regenerate ubiquitous language views
         if: steps.skip_check.outputs.pure_regen != 'true'
         run: uv run python scripts/lint_ubiquitous_language.py


### PR DESCRIPTION
## What

The `arch-regen` workflow has been **dead since #8435 (2026-04-25)** — it produces a 0s `startup_failure` ("This run likely failed because of a workflow file issue") on **every push and pull_request**, on both `main` and `staging`.

## Root cause

Line 42's `Validate functional_areas.yml` step used an **unquoted (plain) YAML scalar** for `run:` whose value contained `: ` (colon-space) inside the Python literal `print('functional_areas.yml: schema OK')`. In YAML block context, `: ` is a mapping-value indicator, so the parser fails with:

```
mapping values are not allowed here
  in "...arch-regen.yml", line 42, column 213
```

GitHub's workflow parser rejects the whole file, so the workflow never ran. Drift coverage was unaffected only because the real gate, **"Architecture Check", lives in `ci.yml`** (and is green) — `arch-regen.yml` was redundant-but-broken noise the whole time.

## Fix

Convert the step to a literal block scalar (`run: |`) so the embedded `: ` is harmless. One line, no behavior change to the step's command.

## Validation

- Strict YAML parse of all 10 workflow files: **all parse clean** (only `arch-regen.yml` was broken).
- `make arch-check` is **green** on current `staging` HEAD — confirms there was never any arch-artifact drift; the redness was purely this parse error.
- This is a CI-workflow-only change; no Python/JS surface. PR CI will exercise the repaired workflow on this very PR (first successful run in over a month).

## Notes for human review

- Pre-existing condition, unrelated to the declarative-gate-contract work stream (#9091) or the back-merge reconciliation (#9135). Surfaced while verifying staging CI health after the reconciliation.
- After merge, the `arch-regen` workflow will actually execute on PRs again; if it surfaces any latent drift it was previously unable to report, that's the workflow doing its job (treat as follow-up, not a regression from this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)