### PR TITLE
docs(memory): add critical workflow feedback

### DIFF
--- a/docs/wiki/memory-feedback/feedback-make-audit-separate-from-quality.md
+++ b/docs/wiki/memory-feedback/feedback-make-audit-separate-from-quality.md
@@ -1,0 +1,18 @@
+---
+source: feedback_make_audit_separate_from_quality.md
+name: feedback_make_audit_separate_from_quality
+description: CI's "Principles Audit" runs `make audit` — NOT part of `make quality`; run it on convention/CI/workflow-touching PRs
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: '2026-05-31'
+---
+
+CI's **"Principles Audit"** job runs `make audit` (`scripts/hydraflow_audit`), which is **NOT** part of `make quality`. A PR can pass full `make quality` (lint/typecheck/security/~15k tests) and still fail CI on Principles Audit.
+
+**Why:** `make audit` checks repo-wide conventions (P1–P10) against the live tree — e.g. P5.2 "a workflow runs `make quality-lite` or equivalent", P5.3 coverage gate, layer-check, etc. These are policy checks, not in the quality pipeline.
+
+**How to apply:** any PR that touches `.github/workflows/`, `Makefile` targets, hooks, or repo conventions MUST run `make audit` locally before pushing — `make quality` alone will miss it. Caught on PR #9131 (factory CI refinements): C-3 unified CI onto `make quality` (replacing `quality-lite` in quality.yml), which made P5.2 fail because the check literally grepped for `quality-lite`. Fix was to teach P5.2 that `make quality` (a superset) satisfies the principle's own "or equivalent" clause + a unit test — NOT to revert the unification. (Updating a too-literal audit check to honor its documented principle is not loosening; see [[feedback_plans_are_flexible]].)
+
+Related discipline: [[feedback_cleanup_prs_need_full_suite]], [[feedback_make_quality_pipe_exit_code]].

--- a/docs/wiki/memory-feedback/feedback-squash-stack-cascade.md
+++ b/docs/wiki/memory-feedback/feedback-squash-stack-cascade.md
@@ -1,0 +1,24 @@
+---
+source: feedback_squash_stack_cascade.md
+name: feedback_squash_stack_cascade
+description: How to land a stacked-PR chain onto staging when force-push (rebase --onto) is hook-blocked
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: '2026-05-31'
+---
+
+Landing a stacked-PR chain (#A→#B→#C→#D, each cut from its parent's branch) onto staging when `git push --force` is hook-blocked — so the `git rebase --onto origin/staging <old-parent-tip> <child>` recipe is unavailable.
+
+**Why:** rebase rewrites history → needs force-push → blocked. Auto-merge is also not enabled on this repo ([[feedback_auto_merge_not_enabled]]), so each PR is merged manually.
+
+**How to apply (bottom-up, NON-destructive):**
+1. Merge the lowest PR to staging: `gh pr merge <A> --squash`.
+2. GitHub auto-retargets the next child's base → staging.
+3. For each child bottom-up: `cd` its worktree, `git merge origin/staging`, resolve conflicts, commit (merge commit), push (pre-push gate runs), wait CI green, `gh pr merge --squash`.
+4. **Squash-merge naturally drops the duplicated parent commits** — squash diffs the branch against staging *at merge time*, so already-merged ancestor content is excluded. No `--onto` needed.
+
+**The conflict shape to expect:** the squash-merge of each parent *breaks git ancestry* (the squash is a fresh commit), so when you `git merge origin/staging` into a child, ALL the ancestor commits' content re-enters as "incoming" and conflicts with the child's own copies of them. The merge-base goes ancient (pre-stack). Resolve by taking **HEAD (--ours)** for files the child owns — HEAD already = (staging's ancestor content) + (this child's unique delta). VERIFY per file that `--ours` drops nothing staging gained independently: `git diff origin/staging HEAD -- <file>` and check the `-` (staging-only) lines are only ancestor code the PR deliberately rewrote, not an unrelated staging change (e.g. a factory commit, or a fix applied to a parent *after* this child was cut — see [[feedback_waitfor_flake_fix]] for the waitFor case where staging had a fix the child lacked → take --theirs or re-apply). Arch conflicts: always `make arch-regen` + `git add docs/arch/` ([[feedback_cleanup_prs_need_full_suite]] discipline: verify with real tests + build before pushing).
+
+Used 2026-06-01 to land WS-RT #9108–#9111 onto staging after C-1's arch-stamp fix removed the per-file arch-conflict noise. Linked: [[feedback_stacked_pr_rebase]] (the --onto recipe, when force-push IS allowed).

--- a/docs/wiki/memory-feedback/feedback-waitfor-flake-fix.md
+++ b/docs/wiki/memory-feedback/feedback-waitfor-flake-fix.md
@@ -1,0 +1,18 @@
+---
+source: feedback_waitfor_flake_fix.md
+name: feedback_waitfor_flake_fix
+description: Fix the recurring vitest "assert right after act(async render)" timing-race flake with waitFor, not CI re-runs
+status: pending
+issue: null
+promoted_in: null
+wontfix_reason: null
+created: '2026-05-31'
+---
+
+A vitest test that asserts state **synchronously right after** `await act(async () => render(...))`, when the trigger fires on a **macrotask** (e.g. a MockWebSocket whose `constructor` does `setTimeout(() => this.onopen(), 0)`), is a timing race: `act()` flushes microtasks + effects but does NOT await `setTimeout(0)`. CI (slower/loaded runners) loses the race intermittently; local full-suite often wins it → looks like a flake that "passes locally."
+
+**Why:** the assertion runs before the async onopen → setState → re-render lands.
+
+**How to apply:** wrap the assertion in `waitFor(() => { ... })` (import from `@testing-library/react`) so it polls until the condition holds or times out. This is NOT loosening — same assertion, just correctly awaited. Fix the ROOT, don't gamble on `gh run rerun --failed` — the flake recurs across the whole stack and on staging.
+
+Seen 2026-06-01 on `HydraFlowContext.test.jsx > sets data-connected on body when websocket connects` (WS-RT #9109). Verified stable 5/5 after the fix. Verify CI's real runner with `node ./scripts/run-vitest.cjs run <file>` (the wrapper isolates differently than raw `npx vitest run <file>`, which can itself flake). NOTE for stacked PRs: a fix applied to a parent branch *after* a child was cut lives only in staging (via the parent's squash) — when cascading the child, take `--theirs` for that file (or re-apply the fix) so you don't drop it. See [[feedback_squash_stack_cascade]].


### PR DESCRIPTION
## Summary
- add memory feedback that Principles Audit runs `make audit` separately from `make quality`
- add stacked-PR squash cascade guidance for force-push-blocked branches
- add Vitest waitFor guidance for macrotask timing flakes

## Verification
- pre-push hook ran `make arch-check`
- pre-push hook ran `make quality-lite`