### PR TITLE
fix(ci): skip project quality steps on docs-only PRs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           go-version: '1.22'
       - name: Quality Full
-        if: needs.changes.outputs.full_quality == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs.full_quality == 'true' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -168,7 +168,7 @@ jobs:
           fi
           echo "No Makefile in ${{ matrix.project_dir }}; skipping make quality."
       - name: Smoke
-        if: needs.changes.outputs.full_quality == 'true'
+        if: ${{ needs.changes.outputs.code == 'true' && needs.changes.outputs.full_quality == 'true' }}
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- require both `code == true` and `full_quality == true` before running matrix project quality/smoke steps
- prevents docs-only PRs from skipping checkout and then failing at `cd src/ui`

## Verification
- `make audit`
- `make quality-lite`
- pre-push `make arch-check`
- pre-push `make quality-lite`

Tracks bd: hydraflow-4lvx