### PR TITLE
fix(sandbox): s15 predicate matches lowercase event type (unblocks RC promotion gate)

### DIFF
--- a/tests/sandbox_scenarios/scenarios/s15_ci_monitor_main_branch_red.py
+++ b/tests/sandbox_scenarios/scenarios/s15_ci_monitor_main_branch_red.py
@@ -38,7 +38,7 @@ async def assert_outcome(api, page) -> None:
         "/api/events",
         lambda payload: any(
             isinstance(payload, list)
-            and e.get("type") == "BACKGROUND_WORKER_STATUS"
+            and e.get("type") == "background_worker_status"
             and e.get("data", {}).get("worker") == "ci_monitor"
             and e.get("data", {}).get("details", {}).get("status") == "red"
             and "issue_created" in e.get("data", {}).get("details", {})
@@ -51,7 +51,7 @@ async def assert_outcome(api, page) -> None:
     ci_events = [
         e
         for e in events_payload
-        if e.get("type") == "BACKGROUND_WORKER_STATUS"
+        if e.get("type") == "background_worker_status"
         and e.get("data", {}).get("worker") == "ci_monitor"
     ]
 


### PR DESCRIPTION
The `Sandbox (rc/* promotion PR full suite)` gate was red on RC promotion PR #9142 because **s15_ci_monitor_main_branch_red** times out. Root-caused by reproducing the scenario in the docker sandbox locally.

## Root cause
s15's predicate asserted `e.get("type") == "BACKGROUND_WORKER_STATUS"` (the uppercase EventType **name**), but events serialize to `/api/events` as the lowercase enum **value** `"background_worker_status"`. The predicate never matched → 180s timeout.

It was masked for a long time because s15 was effectively ignored until #8642f7b4 ("enforce non-ignored sandbox coverage", ADR-0083) made the rc/* full suite actually run it — surfacing the bug and turning the promotion gate red.

## Evidence the product code is fine
From the local sandbox run, the ci_monitor loop works correctly — `/api/events` contained `{'worker': 'ci_monitor', ..., 'details': {'status': 'red', 'issue_created': 9001}}` plus a deduped second-tick event. The seed→FakeGitHub→loop→event→API chain is correct; only s15's predicate case was wrong. Siblings s16/s17/s18 already use the lowercase value.

## Fix
Both s15 predicates → `"background_worker_status"` (lowercase). **Test-only** change.

## Verification
Reproduced + fixed in the **actual docker sandbox** locally: s15 went from 180s-timeout → `1 passed` / `PASSED s15_ci_monitor_main_branch_red`. ruff + pyright clean; ci_monitor tier-2 tests green.

Once merged, I'll re-cut the RC so its Sandbox gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)