### PR TITLE
fix(sandbox): register entry_evidence loop (real bug) + s08/s12 scenario fixes

### DIFF
--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -200,6 +200,7 @@ class HydraFlowOrchestrator:
             "edge_proposer": svc.edge_proposer_loop,
             "live_corpus_replay": svc.live_corpus_replay_loop,
             "triage_retry": svc.triage_retry_loop,
+            "entry_evidence": svc.entry_evidence_loop,
         }
         self._bg_workers = BGWorkerManager(config, self._state, bg_loop_registry)
         # Loops that need a reference to BGWorkerManager cannot take one
@@ -1031,6 +1032,7 @@ class HydraFlowOrchestrator:
             ("edge_proposer", self._svc.edge_proposer_loop.run),
             ("live_corpus_replay", self._svc.live_corpus_replay_loop.run),
             ("triage_retry", self._svc.triage_retry_loop.run),
+            ("entry_evidence", self._svc.entry_evidence_loop.run),
         ]
 
         # Hindsight WAL replay loop removed in Phase 3 cutover — the wiki

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -512,6 +512,7 @@ def build_scripted_services(
     services.edge_proposer_loop = FakeBackgroundLoop()
     services.live_corpus_replay_loop = None
     services.triage_retry_loop = FakeBackgroundLoop()
+    services.entry_evidence_loop = FakeBackgroundLoop()
     services.repo_wiki_store = SimpleNamespace(
         is_ingested=MagicMock(return_value=False),
         mark_ingested=MagicMock(),

--- a/tests/sandbox_scenarios/scenarios/s08_pr_unsticker_revives_stuck_pr.py
+++ b/tests/sandbox_scenarios/scenarios/s08_pr_unsticker_revives_stuck_pr.py
@@ -15,7 +15,10 @@ def seed() -> MockWorldSeed:
                 "number": 1,
                 "title": "t",
                 "body": "b",
-                "labels": ["hydraflow-implementing"],
+                # HITL-escalated: PRUnstickerLoop only processes issues carrying
+                # the hitl_label (it calls list_hitl_items(hitl_label) and unsticks
+                # those with a linked PR). The stuck PR #100 links to this issue.
+                "labels": ["hydraflow-hitl"],
             }
         ],
         prs=[
@@ -35,10 +38,16 @@ def seed() -> MockWorldSeed:
 
 async def assert_outcome(api, page) -> None:
     history = await api.wait_until(
-        "/api/timeline/issue/1",
+        "/api/events",
         lambda p: any(
-            e.get("event") == "pr_unsticker_resync" for e in p.get("events", [])
+            e.get("type") == "hitl_update"
+            and e.get("data", {}).get("action") == "unstick_resolved"
+            for e in p
         ),
         timeout=180.0,
     )
-    assert any(e.get("event") == "pr_unsticker_resync" for e in history["events"])
+    assert any(
+        e.get("type") == "hitl_update"
+        and e.get("data", {}).get("action") == "unstick_resolved"
+        for e in history
+    )

--- a/tests/sandbox_scenarios/scenarios/s12_trust_fleet_three_repos_independent.py
+++ b/tests/sandbox_scenarios/scenarios/s12_trust_fleet_three_repos_independent.py
@@ -35,15 +35,36 @@ def seed() -> MockWorldSeed:
 
 async def assert_outcome(api, page) -> None:
     for n in (1, 2, 3):
-        timeline = await api.wait_until(
-            f"/api/timeline/issue/{n}",
-            lambda p: p.get("outcome") == "merged",
+
+        def _has_merged_outcome(payload: dict, _n: int = n) -> bool:
+            items = payload.get("items") if isinstance(payload, dict) else None
+            if not isinstance(items, list):
+                return False
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("issue_number") != _n:
+                    continue
+                outcome = item.get("outcome") or {}
+                if isinstance(outcome, dict) and outcome.get("outcome") == "merged":
+                    return True
+            return False
+
+        history = await api.wait_until(
+            "/api/issues/history?limit=500",
+            _has_merged_outcome,
             timeout=180.0,
         )
-        assert timeline["outcome"] == "merged"
-
-    await page.goto("/")
-    await page.click("text=Wiki")
-    # All three repos surface in the Wiki tab.
-    for slug in ("repo-a", "repo-b", "repo-c"):
-        await page.wait_for_selector(f"text=acme/{slug}", timeout=10_000)
+        items = history.get("items") if isinstance(history, dict) else None
+        assert isinstance(items, list), f"history payload missing items: {history!r}"
+        matching = [
+            i for i in items if isinstance(i, dict) and i.get("issue_number") == n
+        ]
+        assert matching, f"no issue_number={n} entry in history: {history!r}"
+        outcome = matching[0].get("outcome") or {}
+        assert outcome.get("outcome") == "merged", f"got {matching[0]!r}"
+    # UI assertion removed: the trust-fleet independence is fully verified above
+    # via /api/issues/history (all three repos' issues reach a merged outcome).
+    # The prior `page.click("text=Wiki")` was ambiguous (multiple "Wiki"/"Repo
+    # Wiki" labels render → Playwright strict-mode violation) and the Wiki tab
+    # is not the surface that lists per-repo slugs.


### PR DESCRIPTION
Continues the sandbox-suite cleanup (after s15 in #9144). Lands **4 fixes**, including a genuine product bug the sandbox e2e caught.

## Fixes
- **s24 — PRODUCT BUG.** `EntryEvidenceLoop` was constructed in `ServiceRegistry` but never added to the orchestrator's `bg_loop_registry` or run-list → it never started (dead code). Registered in both + updated the scripted-services test fixture. All 8 orchestrator integration tests green; full `make quality` green; s24 passes in docker.
- **s08.** PRUnstickerLoop only processes issues with the `hitl_label` (calls `list_hitl_items(hitl_label)`). The seed labeled the issue `hydraflow-implementing` → no HITL item to unstick. Labeled it `hydraflow-hitl`. Verified in docker.
- **s12.** Replaced the `/api/timeline` `outcome` assertion (IssueTimeline has no `outcome` field) with the `/api/issues/history` pattern (matches s01/s04), and removed the ambiguous `page.click("text=Wiki")` UI step (multiple "Wiki"/"Repo Wiki" labels → strict-mode violation). Trust-fleet independence is fully verified via the per-repo merged outcomes. Verified in docker.

(s15 — lowercase event-type predicate — already merged in #9144.)

## Verification
Each fix reproduced + confirmed PASSING in the docker sandbox locally. Full `make quality` green.

## Remaining (filed separately)
Three sandbox scenarios remain failing — all **pre-existing** (unchanged in the staging→main delta), deep multi-layer issues, not quick predicate fixes: **s09** (dependabot merge — needs per-PR bot-author plumbing + a warmed PR cache), **s05** (review-exhaustion→HITL flow), **s30** (contract_refresh's github/claude recorders hang on the air-gapped sandbox network). Tracking issue with root causes to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)