### PR TITLE
fix(sandbox): repair s05 diagnose→HITL flow (fake fidelity + diagnostic runner bypass)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-01T17:28:50.890337+00:00",
-  "commit_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921",
+  "regenerated_at": "2026-06-02T16:04:47.393672+00:00",
+  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ports.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "labels.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "modules.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "events.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "adr_xref.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "mockworld.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "changelog.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "functional_areas.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
+- `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
+- `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*
 - `85e9c95` — refactor(review): retire vestigial max_veto_retries; derive retry cap from authority (#9136) (#9136) *(2026-06-01)*
 - `650e8a9` — reconcile: staging-canonical resolution + onboarding re-integration *(2026-06-01)*
 - `d2dc597` — merge: reconcile main into staging (resolve onboarding divergence) *(2026-06-01)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -19,7 +19,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `CorpusLearningLoop` | ✅ [0045] | ✅ [corpus-learning-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
 | `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ✅ [dependabot-merge-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ✅ in catalog | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ✅ [diagnostic-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
+| `DiagnosticLoop` | ✅ [0050] | ✅ [diagnostic-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `DiagramLoop` | ✅ [0001] | ✅ [diagram-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
 | `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ✅ [edge-proposer-loop.md, entry-evidence-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
 | `EntryEvidenceLoop` | ✅ [0062, 0078] | ✅ [edge-proposer-loop.md, entry-evidence-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
@@ -49,7 +49,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ❌ |
 | `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
+| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [bot-pr-port.md, entry-evidence-loop.md, task.md, term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
 | `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |

--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -102,6 +102,29 @@ class DiagnosticRunner(BaseRunner):
             model=self._config.model,
         )
 
+    def _mockworld_diagnosis(self) -> DiagnosisResult | None:
+        """MockWorld bypass for the air-gapped sandbox (ADR-0063 pattern).
+
+        When a ``_mockworld_fake_llm`` sentinel is attached (set by
+        ``sandbox_main`` on the diagnostic runner), Stage-1 diagnosis must
+        not spawn a real ``claude`` subprocess — the sandbox is
+        ``internal: true`` and the call would hang on api-retry backoff,
+        stranding the issue in ``hydraflow-diagnose`` until the scenario
+        times out (s05). Return a not-fixable diagnosis so the loop
+        escalates straight to HITL — the path s05 exercises. Returns
+        ``None`` in production so the real subprocess path runs.
+        """
+        fake_llm = getattr(self, "_mockworld_fake_llm", None)
+        if fake_llm is None or not getattr(fake_llm, "_is_fake_adapter", False):
+            return None
+        return DiagnosisResult(
+            root_cause="MockWorld sandbox diagnosis (no real agent)",
+            severity=Severity.P2_FUNCTIONAL,
+            fixable=False,
+            fix_plan="",
+            human_guidance="Sandbox diagnostic bypass — escalating to human review.",
+        )
+
     async def diagnose(
         self,
         issue_number: int,
@@ -110,6 +133,9 @@ class DiagnosticRunner(BaseRunner):
         context: EscalationContext,
     ) -> DiagnosisResult:
         """Stage 1: Read-only diagnosis against repo root. Returns structured result."""
+        bypass = self._mockworld_diagnosis()
+        if bypass is not None:
+            return bypass
         prompt = _build_diagnosis_prompt(issue_number, issue_title, issue_body, context)
         try:
             cmd = self._build_command()

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -283,6 +283,11 @@ class FakeGitHub:
             "review": "hydraflow-review",
             "done": "hydraflow-done",
             "hitl": "hydraflow-hitl",
+            # Mirrors PRManager.transition._STAGE_LABEL. Without this, a
+            # "diagnose" transition (review-fix-cap escalation) labels the
+            # issue bare "diagnose"; the DiagnosticLoop scans for
+            # "hydraflow-diagnose" and never sees it, so HITL never forms (s05).
+            "diagnose": "hydraflow-diagnose",
         }
         new_label = stage_label_map.get(new_stage, new_stage)
         if issue_number in self._issues:

--- a/src/mockworld/fakes/fake_issue_store.py
+++ b/src/mockworld/fakes/fake_issue_store.py
@@ -64,6 +64,7 @@ STAGE_READY = "ready"
 STAGE_REVIEW = "review"
 STAGE_HITL = "hitl"
 STAGE_MERGED = "merged"
+STAGE_DIAGNOSE = "diagnose"
 
 _LABEL_TO_STAGE: dict[str, str] = {
     "hydraflow-find": STAGE_FIND,
@@ -73,6 +74,11 @@ _LABEL_TO_STAGE: dict[str, str] = {
     "hydraflow-ready": STAGE_READY,
     "hydraflow-review": STAGE_REVIEW,
     "hydraflow-hitl": STAGE_HITL,
+    # Review-fix-cap escalation routes through the diagnostic loop:
+    # enqueue_transition(task, "diagnose") must map to hydraflow-diagnose,
+    # else the transition is silently dropped and the issue never reaches
+    # the DiagnosticLoop (which polls hydraflow-diagnose). See s05.
+    "hydraflow-diagnose": STAGE_DIAGNOSE,
 }
 
 

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -282,6 +282,12 @@ async def main() -> None:
     spec_reviewer = getattr(svc.implementer, "_spec_reviewer", None)
     if spec_reviewer is not None:
         spec_reviewer._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]
+    # DiagnosticRunner.diagnose spawns a real ``claude`` subprocess that hangs
+    # in the air-gapped sandbox; the sentinel routes it to a not-fixable
+    # diagnosis so review-fix-cap escalations reach HITL (s05).
+    diagnostic_runner = getattr(svc.diagnostic_loop, "_runner", None)
+    if diagnostic_runner is not None:
+        diagnostic_runner._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]
 
     orch = HydraFlowOrchestrator(
         config,

--- a/tests/sandbox_scenarios/scenarios/s05_hitl_after_review_exhaustion.py
+++ b/tests/sandbox_scenarios/scenarios/s05_hitl_after_review_exhaustion.py
@@ -24,6 +24,16 @@ def seed() -> MockWorldSeed:
                 ]
             },
         },
+        # Review-fix-cap exhaustion routes the issue through the diagnostic
+        # loop (transition to hydraflow-diagnose), which — when it can't fix —
+        # escalates to hydraflow-hitl; github_cache then surfaces it on
+        # /api/hitl. Restricting to these two caretakers keeps stale_issue
+        # (and other caretakers) from closing the issue mid-flight: FakeGitHub
+        # issues carry an ancient default updated_at, so with all loops enabled
+        # StaleIssueLoop closes issue #1 before the diagnostic loop sees it.
+        # Phase orchestrators (triage/plan/implement/review) run regardless of
+        # loops_enabled (ADR-0049 — they gate on BGWorkerManager, not this cb).
+        loops_enabled=["diagnostic", "github_cache"],
         cycles_to_run=10,
     )
 
@@ -41,12 +51,18 @@ async def assert_outcome(api, page) -> None:
         )
         if not isinstance(items, list):
             return False
-        return any(isinstance(item, dict) and item.get("number") == 1 for item in items)
+        # HITLItem serializes the issue number under "issue" (its model field;
+        # to_camel leaves it unchanged), not "number".
+        return any(isinstance(item, dict) and item.get("issue") == 1 for item in items)
 
+    # Generous timeout: the flow is multi-hop (pipeline review-cycling →
+    # diagnose transition → DiagnosticLoop poll → escalate to hydraflow-hitl →
+    # github_cache poll → /api/hitl), and sandbox caretaker loops poll on a
+    # 60s cadence, so several aligned poll cycles are needed.
     await api.wait_until(
         "/api/hitl",
         _has_issue,
-        timeout=120.0,
+        timeout=240.0,
     )
 
     # UI assertions removed 2026-05-19 — the `hitl-row-1` data-testid no

--- a/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
+++ b/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
@@ -1,0 +1,76 @@
+{
+  "repos": [],
+  "issues": [
+    {
+      "number": 1,
+      "title": "t",
+      "body": "b",
+      "labels": [
+        "hydraflow-ready"
+      ]
+    }
+  ],
+  "prs": [],
+  "scripts": {
+    "plan": {
+      "1": [
+        {
+          "success": true
+        }
+      ]
+    },
+    "implement": {
+      "1": [
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        }
+      ]
+    },
+    "review": {
+      "1": [
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 1"
+          ]
+        },
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 2"
+          ]
+        },
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 3"
+          ]
+        }
+      ]
+    }
+  },
+  "advisor_scripts": {},
+  "phase_scripts": {},
+  "cycles_to_run": 10,
+  "loops_enabled": [
+    "diagnostic",
+    "github_cache"
+  ],
+  "main_branch_ci_status": [
+    "success",
+    ""
+  ]
+}

--- a/tests/scenarios/fakes/test_fake_github.py
+++ b/tests/scenarios/fakes/test_fake_github.py
@@ -69,6 +69,41 @@ class TestFakeGitHubMutations:
         await gh.transition(1, "plan")
         assert gh.issue(1).labels == ["hydraflow-plan"]
 
+    @pytest.mark.parametrize(
+        ("stage", "expected_label"),
+        [
+            ("find", "hydraflow-find"),
+            ("discover", "hydraflow-discover"),
+            ("shape", "hydraflow-shape"),
+            ("plan", "hydraflow-plan"),
+            ("ready", "hydraflow-ready"),
+            ("review", "hydraflow-review"),
+            ("hitl", "hydraflow-hitl"),
+            ("diagnose", "hydraflow-diagnose"),
+        ],
+    )
+    async def test_transition_applies_canonical_stage_label(
+        self, stage: str, expected_label: str
+    ) -> None:
+        # Mirrors PRManager.transition._STAGE_LABEL — the fake must route every
+        # production stage to its hydraflow-* label. A missing entry silently
+        # labels the issue with the bare stage name, stranding it from the loop
+        # that scans for the canonical label (the s05 diagnose-hop failure).
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-review"])
+        await gh.transition(1, stage)
+        assert gh.issue(1).labels == [expected_label]
+
+    async def test_transition_diagnose_visible_to_diagnostic_loop(self) -> None:
+        # The DiagnosticLoop polls list_issues_by_label("hydraflow-diagnose").
+        # Review-fix-cap escalation transitions the issue to "diagnose"; if the
+        # fake mislabels it, the loop never sees it and HITL never forms (s05).
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-review"])
+        await gh.transition(1, "diagnose")
+        found = await gh.list_issues_by_label("hydraflow-diagnose")
+        assert [issue["number"] for issue in found] == [1]
+
     async def test_swap_pipeline_labels_removes_existing(self):
         gh = FakeGitHub()
         gh.add_issue(1, "t", "b", labels=["hydraflow-find", "bug"])

--- a/tests/test_diagnostic_runner.py
+++ b/tests/test_diagnostic_runner.py
@@ -229,6 +229,30 @@ class TestDiagnosticRunner:
         assert result.affected_files == ["src/app.py"]
 
     @pytest.mark.asyncio
+    async def test_diagnose_mockworld_bypass_returns_unfixable_without_subprocess(
+        self, runner, monkeypatch
+    ) -> None:
+        # ADR-0063 sentinel: with a fake LLM attached (sandbox), diagnose must
+        # NOT spawn a real subprocess (it hangs air-gapped). It returns a
+        # not-fixable diagnosis so the diagnostic loop escalates to HITL (s05).
+        ctx = EscalationContext(cause="CI failed", origin_phase="review")
+
+        async def boom(*_a, **_kw):
+            raise AssertionError("_execute must not be called in MockWorld mode")
+
+        monkeypatch.setattr(runner, "_execute", boom)
+        fake_llm = MagicMock()
+        fake_llm._is_fake_adapter = True
+        runner._mockworld_fake_llm = fake_llm
+
+        result = await runner.diagnose(
+            issue_number=7, issue_title="t", issue_body="b", context=ctx
+        )
+
+        assert isinstance(result, DiagnosisResult)
+        assert result.fixable is False
+
+    @pytest.mark.asyncio
     async def test_diagnose_returns_unfixable_on_parse_error(
         self, runner, monkeypatch
     ) -> None:


### PR DESCRIPTION
## Summary

`s05_hitl_after_review_exhaustion` was one of the pre-existing sandbox failures the ADR-0083 no-ignored-gates change surfaced on the rc/* full suite. Review-fix-cap exhaustion routes an issue **through the diagnostic loop** (transition to `hydraflow-diagnose`), not straight to HITL — and four sandbox-fidelity gaps stranded the issue before it could surface on `/api/hitl`:

1. **`FakeGitHub.transition`** omitted `diagnose` from its stage→label map → the issue was labelled bare `diagnose` while `DiagnosticLoop` scans for `hydraflow-diagnose`. Now mirrors `PRManager.transition._STAGE_LABEL`.
2. **`FakeIssueStore.enqueue_transition`** silently dropped the `diagnose` stage (missing from `_LABEL_TO_STAGE`) → added `STAGE_DIAGNOSE`.
3. **`StaleIssueLoop`** closed the lingering issue (FakeGitHub issues carry an ancient default `updated_at`) before `DiagnosticLoop` saw it. The scenario now enables only the two caretakers the flow needs (`diagnostic`, `github_cache`); phase orchestrators run regardless of `loops_enabled` per ADR-0049.
4. **`DiagnosticRunner.diagnose`** spawned a real `claude` subprocess that hangs on the air-gapped sandbox network — it was the only LLM-backed runner left unfaked. Added the ADR-0063 `_mockworld_fake_llm` sentinel bypass (returns a not-fixable diagnosis so the loop escalates to HITL) and wired the sentinel onto the diagnostic runner in `sandbox_main`.

Also corrected the assertion field (`HITLItem` serializes the issue number under `issue`, not `number`) and widened the timeout (the flow is multi-hop across 60s-cadence caretaker polls).

## Tests
- Parametrized `FakeGitHub.transition` stage→label drift guard + a `diagnose`-visible-to-`DiagnosticLoop` test.
- `DiagnosticRunner` MockWorld-bypass unit test (asserts no subprocess + not-fixable result).
- **End-to-end: `s05` sandbox scenario passes in docker** (175s).
- `make quality` green (one flaky `test_curated_drift` parallelism hit — passes in isolation, arch-check clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)