### PR TITLE
fix(dependabot): cache all open PRs so DependabotMergeLoop can see bot PRs (s09)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-01T17:28:50.890337+00:00",
-  "commit_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921",
+  "regenerated_at": "2026-06-02T16:15:49.303634+00:00",
+  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ports.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "labels.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "modules.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "events.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "adr_xref.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "mockworld.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "changelog.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "functional_areas.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
+- `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
+- `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*
 - `85e9c95` — refactor(review): retire vestigial max_veto_retries; derive retry cap from authority (#9136) (#9136) *(2026-06-01)*
 - `650e8a9` — reconcile: staging-canonical resolution + onboarding re-integration *(2026-06-01)*
 - `d2dc597` — merge: reconcile main into staging (resolve onboarding divergence) *(2026-06-01)*

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -46,7 +46,11 @@ class DependabotMergeLoop(BaseBackgroundLoop):
         processed = self._state.get_dependabot_merge_processed()
         bot_authors = {a.lower() for a in settings.authors}
 
-        open_prs = self._cache.get_open_prs()
+        # Read the label-agnostic snapshot: bot PRs carry only GitHub-native
+        # labels (e.g. ``dependencies``) and are absent from the workflow-label
+        # filtered ``get_open_prs`` snapshot, so filtering that by author would
+        # always be empty in production (the s09 bug).
+        open_prs = self._cache.get_all_open_prs()
         bot_prs = [
             pr
             for pr in open_prs

--- a/src/github_cache_loop.py
+++ b/src/github_cache_loop.py
@@ -73,6 +73,7 @@ class GitHubDataCache:
 
         # In-memory snapshots
         self._open_prs = CacheSnapshot()
+        self._all_open_prs = CacheSnapshot()
         self._hitl_items = CacheSnapshot()
         self._label_counts = CacheSnapshot()
         self._collaborators = CacheSnapshot()
@@ -85,6 +86,16 @@ class GitHubDataCache:
     def get_open_prs(self) -> list[PRListItem]:
         """Return cached open PRs, or empty list if not yet fetched."""
         return self._open_prs.data or []
+
+    def get_all_open_prs(self) -> list[PRListItem]:
+        """Return ALL cached open PRs (label-agnostic), or empty if unfetched.
+
+        Distinct from :meth:`get_open_prs`, which is filtered to workflow
+        labels. ``DependabotMergeLoop`` reads this so it can see bot PRs that
+        carry only GitHub-native labels (e.g. ``dependencies``) and would
+        otherwise be excluded from the label-filtered snapshot.
+        """
+        return self._all_open_prs.data or []
 
     def get_hitl_items(self) -> list[HITLItem]:
         """Return cached HITL items, or empty list if not yet fetched."""
@@ -134,6 +145,19 @@ class GitHubDataCache:
                 reraise_on_credit_or_bug(exc)
                 logger.warning("Cache poll failed for open_prs", exc_info=True)
 
+            # All open PRs (label-agnostic) — consumed by DependabotMergeLoop,
+            # which filters by author. Bot PRs carry only GitHub-native labels
+            # (e.g. ``dependencies``) and are absent from the label-filtered
+            # ``open_prs`` snapshot above. Without this, dependabot_merge never
+            # sees a bot PR and merges nothing (the s09 production bug).
+            try:
+                all_open = await self._prs.list_all_open_prs()
+                self._all_open_prs = CacheSnapshot(data=all_open, fetched_at=now)
+                stats["all_open_prs"] = len(all_open)
+            except Exception as exc:
+                reraise_on_credit_or_bug(exc)
+                logger.warning("Cache poll failed for all_open_prs", exc_info=True)
+
             # HITL items
             try:
                 hitl_labels = list(
@@ -177,7 +201,13 @@ class GitHubDataCache:
         targets = (
             [f"_{dataset}"]
             if dataset
-            else ["_open_prs", "_hitl_items", "_label_counts", "_collaborators"]
+            else [
+                "_open_prs",
+                "_all_open_prs",
+                "_hitl_items",
+                "_label_counts",
+                "_collaborators",
+            ]
         )
         for attr in targets:
             snap = getattr(self, attr, None)
@@ -195,6 +225,11 @@ class GitHubDataCache:
                 data["open_prs"] = [
                     p.model_dump() if hasattr(p, "model_dump") else p
                     for p in self._open_prs.data
+                ]
+            if self._all_open_prs.data is not None:
+                data["all_open_prs"] = [
+                    p.model_dump() if hasattr(p, "model_dump") else p
+                    for p in self._all_open_prs.data
                 ]
             if self._hitl_items.data is not None:
                 data["hitl_items"] = [
@@ -229,6 +264,16 @@ class GitHubDataCache:
                     data=[
                         PRListItem.model_validate(p) if isinstance(p, dict) else p
                         for p in raw["open_prs"]
+                    ],
+                    fetched_at=fetched_at,
+                )
+            if "all_open_prs" in raw:
+                from models import PRListItem  # noqa: PLC0415
+
+                self._all_open_prs = CacheSnapshot(
+                    data=[
+                        PRListItem.model_validate(p) if isinstance(p, dict) else p
+                        for p in raw["all_open_prs"]
                     ],
                     fetched_at=fetched_at,
                 )

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -63,6 +63,9 @@ class FakePR:
     reviews: list[tuple[str, str]] = field(default_factory=list)
     checks: list[tuple[str, str]] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
+    # PR author login (e.g. "dependabot[bot]"). Drives DependabotMergeLoop's
+    # bot-PR eligibility (it matches pr.author against the configured bots).
+    author: str = "fake-author"
     # Commit count used by ``find_label_drift`` (ADR-0056) to distinguish
     # zero-commit PRs from real ones. Defaults to 1 so seeded PRs look
     # "real" without explicit setup.
@@ -119,6 +122,7 @@ class FakeGitHub:
                 branch=pr_dict["branch"],
                 ci_status=pr_dict.get("ci_status", "pass"),
                 merged=pr_dict.get("merged", False),
+                author=pr_dict.get("author", "fake-author"),
             )
             for label in pr_dict.get("labels", []):
                 gh.add_pr_label(pr_dict["number"], label)
@@ -152,6 +156,7 @@ class FakeGitHub:
         branch: str,
         ci_status: str = "pass",
         merged: bool = False,
+        author: str = "fake-author",
     ) -> None:
         """Directly insert a PR record (sync helper for test seeding).
 
@@ -165,6 +170,7 @@ class FakeGitHub:
             branch=branch,
             merged=merged,
             ci_status=ci_status,
+            author=author,
         )
 
     def add_pr_label(self, pr_number: int, label: str) -> None:
@@ -904,10 +910,37 @@ class FakeGitHub:
                     draft=pr.draft,
                     title="",
                     merged=pr.merged,
-                    author="fake-author",
+                    author=pr.author,
                 )
             )
         return out
+
+    async def list_all_open_prs(self) -> list[Any]:
+        """Return ALL open PRs regardless of label, including author login.
+
+        Mirrors ``PRManager.list_all_open_prs``. Used by ``GitHubCacheLoop``
+        to warm the all-open-PRs snapshot that ``DependabotMergeLoop`` reads
+        (it filters by author). Bot PRs carry only GitHub-native labels like
+        ``dependencies`` and are invisible to the label-filtered
+        ``list_open_prs`` cache — this method does not filter by label.
+        """
+        self._maybe_rate_limit()
+        from models import PRListItem
+
+        return [
+            PRListItem(
+                pr=pr.number,
+                issue=pr.issue_number,
+                branch=pr.branch,
+                url=pr.url or "",
+                draft=pr.draft,
+                title="",
+                merged=pr.merged,
+                author=pr.author,
+            )
+            for pr in self._prs.values()
+            if not pr.merged
+        ]
 
     async def _run_gh(self, *cmd: str, cwd: Any = None) -> str:
         """Generic ``gh`` CLI passthrough — returns minimal-shape JSON.

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2839,6 +2839,55 @@ class PRManager:
 
         return prs
 
+    async def list_all_open_prs(self) -> list[PRListItem]:
+        """Fetch ALL open PRs regardless of label, including author login.
+
+        Unlike :meth:`list_open_prs` (label-filtered for the dashboard/cache),
+        this returns the complete open-PR set so consumers that key on author
+        — notably :class:`DependabotMergeLoop` — can see bot PRs that carry
+        only GitHub-native labels (e.g. ``dependencies``) and would otherwise
+        be invisible to the label-filtered cache.
+
+        Returns ``[]`` in dry-run mode or when the ``gh`` query fails.
+        """
+        if self._config.dry_run:
+            return []
+        self._assert_repo()
+        try:
+            output = await self._run_gh(
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self._repo,
+                "--state",
+                "open",
+                "--json",
+                "number,headRefName,url,isDraft,title,author",
+                "--limit",
+                "200",
+            )
+            raw_items = json.loads(output)
+        except (RuntimeError, json.JSONDecodeError):
+            logger.warning("list_all_open_prs failed", exc_info=True)
+            return []
+
+        prs: list[PRListItem] = []
+        for item in raw_items:
+            branch = str(item.get("headRefName", ""))
+            prs.append(
+                PRListItem(
+                    pr=int(item.get("number", 0)),
+                    issue=self._issue_number_from_branch(branch),
+                    branch=branch,
+                    url=str(item.get("url", "")),
+                    draft=bool(item.get("isDraft", False)),
+                    title=str(item.get("title", "")),
+                    author=str((item.get("author") or {}).get("login", "")),
+                )
+            )
+        return prs
+
     async def _fetch_hitl_raw_issues(
         self, hitl_labels: list[str]
     ) -> list[dict[str, Any]]:

--- a/tests/regressions/test_issue_6534.py
+++ b/tests/regressions/test_issue_6534.py
@@ -38,6 +38,7 @@ def _make_cache(tmp_path: Path) -> GitHubDataCache:
 
     pr_manager = MagicMock()
     pr_manager.list_open_prs = AsyncMock(return_value=[])
+    pr_manager.list_all_open_prs = AsyncMock(return_value=[])
     pr_manager.list_hitl_items = AsyncMock(return_value=[])
     pr_manager.get_label_counts = AsyncMock(return_value=None)
 
@@ -64,6 +65,21 @@ class TestAuthenticationErrorNotSwallowed:
         """
         cache = _make_cache(tmp_path)
         cache._prs.list_open_prs = AsyncMock(
+            side_effect=AuthenticationError("Bad credentials"),
+        )
+
+        with pytest.raises(AuthenticationError, match="Bad credentials"):
+            await cache.poll()
+
+    @pytest.mark.asyncio
+    async def test_all_open_prs_auth_error_propagates(self, tmp_path: Path) -> None:
+        """When list_all_open_prs raises AuthenticationError, poll() must
+        re-raise it instead of logging a warning and continuing (same
+        guarantee as the other datasets — added with the label-agnostic
+        all-open-PRs snapshot).
+        """
+        cache = _make_cache(tmp_path)
+        cache._prs.list_all_open_prs = AsyncMock(
             side_effect=AuthenticationError("Bad credentials"),
         )
 

--- a/tests/sandbox_scenarios/scenarios/s09_dependabot_auto_merge.py
+++ b/tests/sandbox_scenarios/scenarios/s09_dependabot_auto_merge.py
@@ -18,21 +18,41 @@ def seed() -> MockWorldSeed:
                 "ci_status": "pass",
                 "merged": False,
                 "labels": ["dependencies"],
+                # DependabotMergeLoop only merges PRs authored by a configured
+                # bot (default authors include "dependabot[bot]"). Without this
+                # the loop skips the PR (not a bot author).
+                "author": "dependabot[bot]",
             }
         ],
-        loops_enabled=["dependabot_merge"],
+        # github_cache must run too: DependabotMergeLoop reads open PRs from the
+        # GitHubDataCache (cache.get_all_open_prs()), warmed only by the
+        # github_cache loop. The bot PR carries only the GitHub-native
+        # "dependencies" label, so it is absent from the workflow-label-filtered
+        # snapshot — get_all_open_prs (label-agnostic) is what surfaces it.
+        loops_enabled=["dependabot_merge", "github_cache"],
         cycles_to_run=3,
     )
 
 
 async def assert_outcome(api, page) -> None:
-    prs = await api.wait_until(
-        "/api/prs",
+    # /api/prs lists only OPEN PRs, and the workflow-label-filtered cache never
+    # carried this "dependencies"-labeled PR anyway, so a merged dependabot PR
+    # cannot be observed there. Verify the merge via the dependabot_merge
+    # worker-status event, whose details carry the merged count
+    # (DependabotMergeLoop._do_work → {"merged": N}).
+    # dependabot_merge reads the github_cache all-open-PRs snapshot, so it can
+    # only merge once that cache is warm. On the first orchestrator tick the
+    # two caretakers race and dependabot often polls just before github_cache's
+    # first poll (seeing an empty cache → merged=0). Sandbox caretakers poll on
+    # a 60s cadence, so the timeout must span at least one more dependabot poll
+    # after the cache is warm.
+    await api.wait_until(
+        "/api/events",
         lambda p: any(
-            item.get("number") == 100 and item.get("merged") is True
-            for item in p.get("prs", [])
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "dependabot_merge"
+            and e.get("data", {}).get("details", {}).get("merged", 0) >= 1
+            for e in (p if isinstance(p, list) else [])
         ),
-        timeout=45.0,
+        timeout=120.0,
     )
-    pr = next(p for p in prs["prs"] if p["number"] == 100)
-    assert pr["merged"] is True

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -269,7 +269,11 @@ class TestL7DependabotMergeAutoMerges:
 
         # Initialize loop to get cache/state mock refs, then configure
         await world.run_with_loops(["dependabot_merge"], cycles=1)
+        # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+        # bot PRs carry only the GitHub-native "dependencies" label and are absent
+        # from the workflow-label-filtered get_open_prs snapshot (s09).
         world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
         stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
 
@@ -308,7 +312,11 @@ class TestL8DependabotMergeSkipsOnFailure:
 
         # Initialize and configure
         await world.run_with_loops(["dependabot_merge"], cycles=1)
+        # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+        # bot PRs carry only the GitHub-native "dependencies" label and are absent
+        # from the workflow-label-filtered get_open_prs snapshot (s09).
         world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
         stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
 

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -67,7 +67,10 @@ def _make_loop(
     )
 
     cache = MagicMock()
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+    # get_open_prs is kept in sync for any incidental reads.
     cache.get_open_prs.return_value = open_prs or []
+    cache.get_all_open_prs.return_value = open_prs or []
 
     prs = MagicMock()
     prs.wait_for_ci = AsyncMock(return_value=ci_result)

--- a/tests/test_github_cache_loop.py
+++ b/tests/test_github_cache_loop.py
@@ -46,6 +46,7 @@ def _make_cache(
     tmp_path: Path,
     *,
     open_prs: list[PRListItem] | None = None,
+    all_open_prs: list[PRListItem] | None = None,
     hitl_items: list[HITLItem] | None = None,
     label_counts: LabelCounts | None = None,
     collaborators: set[str] | None = None,
@@ -65,11 +66,15 @@ def _make_cache(
     prs = MagicMock()
     if prs_error is not None:
         prs.list_open_prs = AsyncMock(side_effect=prs_error)
+        prs.list_all_open_prs = AsyncMock(side_effect=prs_error)
         prs.list_hitl_items = AsyncMock(side_effect=hitl_error or prs_error)
         prs.get_label_counts = AsyncMock(side_effect=label_error or prs_error)
     else:
         prs.list_open_prs = AsyncMock(
             return_value=open_prs if open_prs is not None else []
+        )
+        prs.list_all_open_prs = AsyncMock(
+            return_value=all_open_prs if all_open_prs is not None else []
         )
         prs.list_hitl_items = (
             AsyncMock(
@@ -262,6 +267,71 @@ class TestGitHubDataCachePoll:
         assert "hitl_items" in stats
         assert "label_counts" in stats
         assert "collaborators" in stats
+
+
+# ===========================================================================
+# GitHubDataCache — all-open-PRs snapshot (label-agnostic; s09)
+# ===========================================================================
+
+
+class TestGitHubDataCacheAllOpenPrs:
+    @pytest.mark.asyncio
+    async def test_get_all_open_prs_empty_before_poll(self, tmp_path: Path) -> None:
+        cache, _, _ = _make_cache(tmp_path)
+        assert cache.get_all_open_prs() == []
+
+    @pytest.mark.asyncio
+    async def test_poll_populates_all_open_prs(self, tmp_path: Path) -> None:
+        all_prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        cache, _, _ = _make_cache(tmp_path, all_open_prs=all_prs)
+
+        stats = await cache.poll()
+
+        assert cache.get_all_open_prs() == all_prs
+        assert stats["all_open_prs"] == 3
+
+    @pytest.mark.asyncio
+    async def test_all_open_prs_includes_bot_pr_excluded_from_label_filter(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (s09): a dependabot PR carries only the GitHub-native
+        ``dependencies`` label, so it is absent from the workflow-label-filtered
+        ``get_open_prs`` snapshot. DependabotMergeLoop reads ``get_all_open_prs``
+        and filters by author — that snapshot MUST include the bot PR, else the
+        loop never merges anything in production.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from mockworld.fakes.fake_github import FakeGitHub
+        from tests.helpers import ConfigFactory
+
+        gh = FakeGitHub()
+        gh.add_pr(
+            number=100,
+            issue_number=0,
+            branch="dependabot/npm/foo-1.2.3",
+            author="dependabot[bot]",
+        )
+        gh.add_pr_label(100, "dependencies")
+
+        fetcher = MagicMock()
+        fetcher._get_collaborators = AsyncMock(return_value=set())
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        cache = GitHubDataCache(
+            config=config,
+            pr_manager=gh,
+            fetcher=fetcher,
+            cache_dir=tmp_path / "cache",
+        )
+
+        await cache.poll()
+
+        # Label-filtered snapshot excludes the bot PR (documents the gap):
+        assert 100 not in [p.pr for p in cache.get_open_prs()]
+        # Label-agnostic snapshot includes it, with author preserved (the fix):
+        all_open = cache.get_all_open_prs()
+        assert [p.pr for p in all_open] == [100]
+        assert all_open[0].author == "dependabot[bot]"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary — production bug

`s09_dependabot_auto_merge` surfaced a **real production bug**, not just a test gap. `DependabotMergeLoop` reads open PRs from `GitHubDataCache.get_open_prs()` and filters by **author**, but the cache's open-PR snapshot is warmed via `list_open_prs([ready, review, hitl])` — only **workflow-labelled** PRs. Dependabot PRs carry the GitHub-native `dependencies` label (not a workflow label), so they were never cached → `bot_prs` was always empty → **the loop merged nothing in production.**

The unit tests passed because they injected a pre-populated mock cache, masking the integration gap. The sandbox e2e — running the real cache + loop together — caught it, the same way s24 caught an unregistered loop.

## Fix — label-agnostic all-open-PRs snapshot
- `PRManager.list_all_open_prs()` — `gh pr list --state open` (no label filter), carrying author; + `FakeGitHub` parity.
- `GitHubDataCache` gains an `_all_open_prs` snapshot (`poll` + `get_all_open_prs` + disk persistence + invalidate), **distinct** from the workflow-label-filtered `_open_prs` that the dashboard/pr-unsticker still read — zero blast radius on existing consumers.
- `DependabotMergeLoop` reads `get_all_open_prs()` and filters by author as before.

The docker event payload confirms the fix: `github_cache … 'all_open_prs': 1` (the bot PR is now cached) → dependabot merges it on its next poll.

## Tests
- New cache tests incl. a regression: a bot PR carrying only `dependencies` is **absent** from `get_open_prs()` but **present** in `get_all_open_prs()` with author preserved.
- `test_issue_6534` extended with `list_all_open_prs` auth-error-propagation coverage (the new poll dataset must not swallow `AuthenticationError`).
- s09 scenario seeds the bot author + enables `github_cache`, asserts the merge via the `dependabot_merge` worker-status event, and spans a second dependabot poll after the cache warms (60s caretaker cadence).
- **End-to-end: s09 sandbox scenario passes in docker (55s).** `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)