### PR TITLE
fix(sandbox): skip ContractRefreshLoop external recorders in the air-gapped sandbox (s30)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-01T17:28:50.890337+00:00",
-  "commit_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921",
+  "regenerated_at": "2026-06-02T16:27:16.281342+00:00",
+  "commit_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "ports.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "labels.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "modules.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "events.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "adr_xref.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "mockworld.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "changelog.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "functional_areas.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "9bdf3987fb0043fe13369acda98523f3e39e479e"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
+- `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
+- `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*
 - `85e9c95` — refactor(review): retire vestigial max_veto_retries; derive retry cap from authority (#9136) (#9136) *(2026-06-01)*
 - `650e8a9` — reconcile: staging-canonical resolution + onboarding re-integration *(2026-06-01)*
 - `d2dc597` — merge: reconcile main into staging (resolve onboarding divergence) *(2026-06-01)*

--- a/src/config.py
+++ b/src/config.py
@@ -2409,6 +2409,17 @@ class HydraFlowConfig(BaseModel):
             "(spec §8). Override if the sandbox org is renamed."
         ),
     )
+    contract_refresh_external_enabled: bool = Field(
+        default=True,
+        description=(
+            "Run ContractRefreshLoop's external recorders (github → "
+            "contracts-sandbox repo, claude → api.anthropic.com, docker → "
+            "alpine image pull). Disabling skips them so the loop completes "
+            "fast in the air-gapped sandbox (only the local git recorder "
+            "runs); each external recorder otherwise blocks up to the 120s "
+            "subprocess timeout. Production defaults to True."
+        ),
+    )
 
     # Trust fleet — TrustFleetSanityLoop (spec §12.1)
     trust_fleet_sanity_interval: int = Field(

--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -198,12 +198,26 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         """
         sandbox_dir = self._config.repo_root / _GIT_SANDBOX_RELPATH
 
+        # The git recorder is local (a fixture dir + local git) and always
+        # runs. The github/docker/claude recorders reach external services
+        # (contracts-sandbox repo, an alpine image pull, api.anthropic.com)
+        # and each blocks up to the 120s subprocess timeout when those are
+        # unreachable — e.g. the air-gapped sandbox. ``contract_refresh_
+        # external_enabled=False`` skips them so the loop still completes and
+        # emits its worker-status event promptly (s30). Skipped recorders
+        # report ``[]``, which the diff layer already treats as no-signal.
+        external = self._config.contract_refresh_external_enabled
+
         recorded: dict[str, list[Path]] = {}
-        recorded["github"] = await self._record_with_trace(
-            "contract_recording.record_github",
-            record_github,
-            _SANDBOX_GITHUB_REPO,
-            tmp_root / "github",
+        recorded["github"] = (
+            await self._record_with_trace(
+                "contract_recording.record_github",
+                record_github,
+                _SANDBOX_GITHUB_REPO,
+                tmp_root / "github",
+            )
+            if external
+            else []
         )
         recorded["git"] = await self._record_with_trace(
             "contract_recording.record_git",
@@ -211,15 +225,23 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             sandbox_dir,
             tmp_root / "git",
         )
-        recorded["docker"] = await self._record_with_trace(
-            "contract_recording.record_docker",
-            record_docker,
-            tmp_root / "docker",
+        recorded["docker"] = (
+            await self._record_with_trace(
+                "contract_recording.record_docker",
+                record_docker,
+                tmp_root / "docker",
+            )
+            if external
+            else []
         )
-        recorded["claude"] = await self._record_with_trace(
-            "contract_recording.record_claude_stream",
-            record_claude_stream,
-            tmp_root / "claude",
+        recorded["claude"] = (
+            await self._record_with_trace(
+                "contract_recording.record_claude_stream",
+                record_claude_stream,
+                tmp_root / "claude",
+            )
+            if external
+            else []
         )
         return recorded
 

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -159,6 +159,13 @@ async def main() -> None:
     #   this flag (see src/plan_phase.py).
     config.transcript_summarization_enabled = False  # type: ignore[misc]
     config.research_enabled = False  # type: ignore[misc]
+    # ContractRefreshLoop's github/claude/docker recorders reach external
+    # services (contracts-sandbox repo, api.anthropic.com, alpine pull) that
+    # are unreachable on the internal sandbox network; each blocks up to the
+    # 120s subprocess timeout, so the loop never emits its worker-status event
+    # within a scenario's window (s30). Skip them — only the local git
+    # recorder runs.
+    config.contract_refresh_external_enabled = False  # type: ignore[misc]
     seed = _load_seed()
     event_bus = EventBus()
     state = build_state_tracker(config)

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -818,3 +818,58 @@ async def test_escalation_resets_after_clean_tick(
     assert post_count == pre_count + 1, (
         "Escalation should re-fire after an adapter goes clean then drifts again"
     )
+
+
+# ---------------------------------------------------------------------------
+# External-recorder skip (s30 — air-gapped sandbox)
+# ---------------------------------------------------------------------------
+
+
+def _track_recorders(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace each ``record_*`` with a tracker that records its adapter name."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        crl_module, "record_github", lambda *_a, **_k: calls.append("github") or []
+    )
+    monkeypatch.setattr(
+        crl_module, "record_git", lambda *_a, **_k: calls.append("git") or []
+    )
+    monkeypatch.setattr(
+        crl_module, "record_docker", lambda *_a, **_k: calls.append("docker") or []
+    )
+    monkeypatch.setattr(
+        crl_module,
+        "record_claude_stream",
+        lambda *_a, **_k: calls.append("claude") or [],
+    )
+    return calls
+
+
+def test_record_all_skips_external_recorders_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # contract_refresh_external_enabled=False (the sandbox setting): the three
+    # network/daemon recorders must NOT run (they block on the air-gapped
+    # network up to the 120s subprocess timeout); only the local git recorder
+    # runs. Skipped adapters report [] (no-signal to the diff layer).
+    calls = _track_recorders(monkeypatch)
+    loop = _loop(tmp_path, contract_refresh_external_enabled=False)
+
+    recorded = asyncio.run(loop._record_all(tmp_path / "rec"))
+
+    assert calls == ["git"]
+    assert recorded["github"] == []
+    assert recorded["docker"] == []
+    assert recorded["claude"] == []
+
+
+def test_record_all_runs_all_recorders_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Production default (external_enabled=True): every adapter is recorded.
+    calls = _track_recorders(monkeypatch)
+    loop = _loop(tmp_path, contract_refresh_external_enabled=True)
+
+    asyncio.run(loop._record_all(tmp_path / "rec"))
+
+    assert set(calls) == {"github", "git", "docker", "claude"}


### PR DESCRIPTION
## Summary

`s30_contract_refresh_clean` timed out: `ContractRefreshLoop` runs four recorders sequentially, and three reach external services unreachable on the sandbox's internal network — **github** (contracts-sandbox repo), **claude** (`api.anthropic.com`), and **docker** (alpine image pull). Each blocks up to the 120s recorder subprocess timeout, so the loop never emits its `BACKGROUND_WORKER_STATUS` event within the scenario's 60s window.

## Fix

Add a `contract_refresh_external_enabled` config flag (production default `True`, mirroring `research_enabled`). When `False` — set by `sandbox_main` — the loop skips the three external recorders and runs only the local **git** recorder (a fixture dir + local git), completing in milliseconds. Skipped adapters report `[]`, which the diff layer already treats as no-signal. The s30 scenario is unchanged.

## Tests
- `_record_all` skips the external recorders when disabled (only git runs); runs all four when enabled.
- **End-to-end: s30 sandbox scenario passes in docker (0.4s, was a 60s timeout).** `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)