### PR TITLE
fix(workers): surface all 45 background loops in System tab + register github_cache

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-01T17:28:50.890337+00:00",
-  "commit_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921",
+  "regenerated_at": "2026-06-02T16:38:32.755932+00:00",
+  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ports.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "labels.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "modules.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "events.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "adr_xref.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "mockworld.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "changelog.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "functional_areas.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
+- `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
+- `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*
 - `85e9c95` — refactor(review): retire vestigial max_veto_retries; derive retry cap from authority (#9136) (#9136) *(2026-06-01)*
 - `650e8a9` — reconcile: staging-canonical resolution + onboarding re-integration *(2026-06-01)*
 - `d2dc597` — merge: reconcile main into staging (resolve onboarding divergence) *(2026-06-01)*

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -167,6 +167,159 @@ _bg_worker_defs = [
         "Cost Budget Watcher",
         "Polls rolling-24h LLM spend; disables caretaker loops when daily cap exceeded. Default unlimited.",
     ),
+    # --- Background loops surfaced in the System tab (parity with bg_loop_registry;
+    # enforced by tests/test_loop_wiring_completeness.py). Labels/descriptions mirror
+    # ui/src/constants.js BACKGROUND_WORKERS. ---
+    (
+        "adr_touchpoint_auditor",
+        "ADR Touchpoint Auditor",
+        "Scans recently-merged PRs for ADR drift — cited src/ modules changed without the ADR being updated. Replaces the synchronous touchpoint gate. See ADR-0056.",
+    ),
+    (
+        "auto_agent_preflight",
+        "Auto-Agent Pre-Flight",
+        "Intercepts hitl-escalation issues; runs an emulated-engineer subprocess to attempt autonomous resolution before the issue surfaces to a human (spec §1–§11; ADR-0050).",
+    ),
+    (
+        "branch_protection_auditor",
+        "Branch Protection Auditor",
+        "Audits live GitHub branch protection against the canonical rulesets generated from gates.toml; files an issue on drift. See ADR-0082.",
+    ),
+    (
+        "ci_monitor",
+        "CI Monitor",
+        "Detects failing CI on main and files/auto-closes issues.",
+    ),
+    (
+        "dependabot_merge",
+        "Dependabot Merge",
+        "Auto-merges dependency update PRs from configured bots after CI passes.",
+    ),
+    (
+        "diagnostic",
+        "Diagnostic Agent",
+        "Analyzes escalated issues, classifies severity, and attempts targeted fixes before HITL.",
+    ),
+    (
+        "diagram_loop",
+        "Diagram Loop (L24)",
+        "Self-documenting architecture caretaker. Walks src/, tests/, docs/adr/ every 4h; emits regenerated docs/arch/generated/ markdown + opens a PR when the live truth has drifted. Per ADR-0029 (caretaker pattern) and the Architecture Knowledge System spec.",
+    ),
+    (
+        "edge_proposer",
+        "Edge Proposer",
+        "Caretaker that proposes depends_on + implements edges between existing UL terms based on import graph + class inheritance. See ADR-0058.",
+    ),
+    (
+        "entry_evidence",
+        "Entry Evidence",
+        "Caretaker that links wiki entries to UL terms via LLM matching, populating Term.evidence so the Atlas Domain view can render entry leaves under their term parents. See ADR-0062.",
+    ),
+    (
+        "epic_monitor",
+        "Epic Monitor",
+        "Detects stale epics and refreshes progress cache so the dashboard shows accurate sub-issue rollups.",
+    ),
+    (
+        "epic_sweeper",
+        "Epic Sweeper",
+        "Periodically sweeps open epics and auto-closes those with all sub-issues resolved.",
+    ),
+    (
+        "gate_activator",
+        "Gate Activator",
+        "Proposes activating planned gates in gates.toml once the surface each protects exists (producing job + make target present, profile matches); files a reviewed issue. See ADR-0082.",
+    ),
+    (
+        "github_cache",
+        "GitHub Cache",
+        "Single-poller cache for GitHub data; serves all dashboard + loop consumers from one shared snapshot to avoid rate-limit fan-out.",
+    ),
+    (
+        "health_monitor",
+        "Health Monitor",
+        "Analyzes pipeline trends, auto-tunes parameters, detects knowledge gaps, and ingests log patterns.",
+    ),
+    (
+        "label_drift_watcher",
+        "Label Drift Watcher",
+        "Periodic scan for cross-entity issue/PR label drift (e.g., issue at hydraflow-ready while linked PR at hydraflow-review with commits); reconciles via per-entity swap_pipeline_labels. See ADR-0056.",
+    ),
+    (
+        "live_corpus_replay",
+        "Live Corpus Replay",
+        "Diffs fresh shadow-corpus samples against fake-adapter outputs to catch value-level drift between real and fake adapters; files one hydraflow-find issue per unique drift signature. See #8786 / ADR-0045.",
+    ),
+    (
+        "memory_backlog",
+        "Memory Backlog",
+        "Files hydraflow-find issues for pending entries in docs/wiki/memory-feedback/.",
+    ),
+    (
+        "merge_state_watcher",
+        "Merge State Watcher",
+        "Auto-rebases or HITL-escalates open PRs flagged mergeable=CONFLICTING (RC, dependabot, agent).",
+    ),
+    (
+        "repo_wiki",
+        "Repo Wiki",
+        "Lints and maintains per-repo knowledge wikis compiled from plan/implement/review cycles.",
+    ),
+    (
+        "runs_gc",
+        "Runs GC",
+        "Purges expired pipeline run artifacts per TTL and size-cap config; keeps the runs store from growing unbounded.",
+    ),
+    (
+        "sandbox_failure_fixer",
+        "Sandbox Failure Fixer",
+        "Auto-fixes promotion PRs failing sandbox CI by dispatching the auto-agent",
+    ),
+    (
+        "security_patch",
+        "Security Patch",
+        "Polls Dependabot alerts and files issues for fixable vulnerabilities.",
+    ),
+    (
+        "sentry_ingest",
+        "Sentry Ingest",
+        "Polls Sentry for unresolved errors and files them as GitHub issues for the pipeline.",
+    ),
+    (
+        "staging_promotion",
+        "Staging Promotion",
+        "Cuts release-candidate snapshots from staging and auto-promotes them to main on green CI. See ADR-0042.",
+    ),
+    (
+        "stale_issue",
+        "Stale General Issue Cleanup",
+        "Auto-closes stale general issues (excludes HydraFlow lifecycle labels). Per-tag thresholds, configurable. Distinct from Stale Issue GC, which handles HITL escalations.",
+    ),
+    (
+        "stale_issue_gc",
+        "Stale HITL Issue GC",
+        "Auto-closes stale HITL escalation issues — posts a farewell comment, capped at 10/cycle. Distinct from Stale General Issue Cleanup, which excludes HF lifecycle labels.",
+    ),
+    (
+        "term_proposer",
+        "Term Proposer",
+        "Caretaker that grows the ubiquitous-language glossary by detecting load-bearing classes without terms (S1+S2+S5 signals), drafting them via LLM, and opening auto-merging bot PRs as `confidence: proposed`. See ADR-0054.",
+    ),
+    (
+        "term_pruner",
+        "Term Pruner",
+        "Caretaker that deprecates UL terms whose code_anchor no longer resolves in src/. Companion to TermProposerLoop. See ADR-0057.",
+    ),
+    (
+        "triage_retry",
+        "Triage Retry",
+        "Re-runs parked-issue triage every 24h with the original parking reason as context. Caps at 3 retries before escalating to HITL with the triage-retry-exhausted sub-label. Closes the only factory phase with no autonomous re-entry path. See ADR-0063 W2.",
+    ),
+    (
+        "workspace_gc",
+        "Workspace GC",
+        "Garbage-collects stale workspaces and orphaned branches.",
+    ),
 ]
 
 # Workers that have independent configurable intervals

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -706,6 +706,15 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                     interval = 5
             elif name in _PIPELINE_WORKERS:
                 interval = _cfg.poll_interval
+            elif orch and name in _INTERVAL_BOUNDS:
+                # Registry-backed loops surfaced in _bg_worker_defs but absent
+                # from the curated _INTERVAL_WORKERS set: resolve the live
+                # interval (incl. any operator override) straight from the
+                # orchestrator so the System tab shows a real cadence + next_run
+                # and interval edits round-trip. _INTERVAL_BOUNDS is the
+                # editable-interval set, so this covers exactly the controllable
+                # loops without inventing intervals for event-driven ones.
+                interval = orch.get_bg_worker_interval(name)
 
             entry = bg_states.get(name) or persisted_states.get(name)
             if entry:

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -170,6 +170,7 @@ class HydraFlowOrchestrator:
             "staging_bisect": svc.staging_bisect_loop,
             "stale_issue": svc.stale_issue_loop,
             "sentry_ingest": svc.sentry_loop,
+            "github_cache": svc.github_cache_loop,
             "stale_issue_gc": svc.stale_issue_gc_loop,
             "ci_monitor": svc.ci_monitor_loop,
             "branch_protection_auditor": svc.branch_protection_auditor_loop,

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -257,7 +257,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'workspace_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -269,7 +269,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   pr_unsticker: 3600,
   merge_state_watcher: 600,
   report_issue: 30,
-  worktree_gc: 1800,
+  workspace_gc: 1800,
   adr_reviewer: 86400,
   epic_sweeper: 3600,
   dependabot_merge: 3600,

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -481,6 +481,7 @@ def build_scripted_services(
     services.staging_bisect_loop = FakeBackgroundLoop()
     services.stale_issue_loop = FakeBackgroundLoop()
     services.sentry_loop = FakeBackgroundLoop()
+    services.github_cache_loop = FakeBackgroundLoop()
     services.stale_issue_gc_loop = FakeBackgroundLoop()
     services.ci_monitor_loop = FakeBackgroundLoop()
     services.branch_protection_auditor_loop = FakeBackgroundLoop()

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -645,11 +645,34 @@ class TestSystemWorkersEndpointIntervals:
         response = await endpoint()
         data = json.loads(response.body)
 
-        retro = next(w for w in data["workers"] if w["name"] == "retrospective")
-        assert retro["interval_seconds"] is None
-
+        # review_insights is a derived/event-driven worker — not a registry loop
+        # and not in _INTERVAL_BOUNDS — so it has no schedulable interval.
         ri = next(w for w in data["workers"] if w["name"] == "review_insights")
         assert ri["interval_seconds"] is None
+
+    @pytest.mark.asyncio
+    async def test_registry_loops_report_their_interval(
+        self, config, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """Registry-backed loops surfaced in _bg_worker_defs and editable via
+        _INTERVAL_BOUNDS must report their live interval. Worker-fleet audit:
+        the System tab previously left interval/next_run blank for all of them
+        because the endpoint only resolved intervals for the curated
+        _INTERVAL_WORKERS set.
+        """
+        from orchestrator import HydraFlowOrchestrator
+
+        orch = HydraFlowOrchestrator(config, event_bus=event_bus)
+        router = self._make_router(config, event_bus, tmp_path, orch=orch)
+        endpoint = self._find_endpoint(router, "/api/system/workers")
+        response = await endpoint()
+        data = json.loads(response.body)
+
+        by_name = {w["name"]: w for w in data["workers"]}
+        for name in ("ci_monitor", "retrospective", "github_cache", "workspace_gc"):
+            assert by_name[name]["interval_seconds"] is not None, (
+                f"{name} should report a live interval (worker-fleet visibility)"
+            )
 
     @pytest.mark.asyncio
     async def test_next_run_none_when_no_last_run(

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -291,9 +291,9 @@ class TestSystemWorkersEndpoint:
 
         response = await endpoint()
         data = json.loads(response.body)
-        assert len(data["workers"]) == 22
         names = [w["name"] for w in data["workers"]]
-        assert names == [
+        # Stable pipeline-phase prefix.
+        assert names[:7] == [
             "triage",
             "plan",
             "implement",
@@ -301,24 +301,46 @@ class TestSystemWorkersEndpoint:
             "retrospective",
             "review_insights",
             "pipeline_poller",
-            "pr_unsticker",
-            "report_issue",
-            "adr_reviewer",
-            # Trust fleet (ADR-0045)
-            "corpus_learning",
-            "contract_refresh",
-            "staging_bisect",
-            "principles_audit",
-            "flake_tracker",
-            "skill_prompt_eval",
-            "fake_coverage_auditor",
-            "rc_budget",
-            "wiki_rot_detector",
-            "trust_fleet_sanity",
-            # Caretaking — daily upstream pricing refresh
-            "pricing_refresh",
-            "cost_budget_watcher",
         ]
+        # 2026-06-02 worker-fleet visibility audit: 30 background loops were absent
+        # from _bg_worker_defs and therefore invisible in the System tab even though
+        # they ran. Assert the full background fleet is now surfaced (not a frozen
+        # count — the wiring-completeness test enforces registry<->defs parity).
+        for worker in (
+            "github_cache",
+            "workspace_gc",
+            "runs_gc",
+            "epic_monitor",
+            "epic_sweeper",
+            "health_monitor",
+            "gate_activator",
+            "branch_protection_auditor",
+            "diagnostic",
+            "merge_state_watcher",
+            "ci_monitor",
+            "sentry_ingest",
+            "staging_promotion",
+            "stale_issue",
+            "stale_issue_gc",
+            "repo_wiki",
+            "security_patch",
+            "dependabot_merge",
+            "label_drift_watcher",
+            "memory_backlog",
+            "triage_retry",
+            "sandbox_failure_fixer",
+            "auto_agent_preflight",
+            "adr_touchpoint_auditor",
+            "term_proposer",
+            "term_pruner",
+            "edge_proposer",
+            "entry_evidence",
+            "live_corpus_replay",
+            "diagram_loop",
+        ):
+            assert worker in names, f"{worker} missing from System-tab worker catalog"
+        assert len(names) == len(set(names)), "duplicate worker names in catalog"
+        assert len(data["workers"]) >= 45
         assert all(
             isinstance(w["description"], str) and w["description"]
             for w in data["workers"]

--- a/tests/test_loop_wiring_completeness.py
+++ b/tests/test_loop_wiring_completeness.py
@@ -171,6 +171,32 @@ class TestBgWorkerDefsParity:
             f"{sorted(missing)}"
         )
 
+    def test_no_orphan_bg_worker_defs(self) -> None:
+        """Reverse parity: every _bg_worker_defs entry is either a registry loop
+        or one of the explicit pipeline/non-loop UI workers.
+
+        Without this, a typo'd def key (e.g. ``github_cahce``) would render a
+        dead System-tab row pointing at a non-existent worker, and the
+        forward parity test above would stay green.
+        """
+        # Pipeline phases + the non-loop UI workers that legitimately appear in
+        # _bg_worker_defs without a BaseBackgroundLoop behind them.
+        allowed_non_registry = {
+            "triage",
+            "plan",
+            "implement",
+            "review",
+            "review_insights",
+            "pipeline_poller",
+        }
+        orphans = (
+            _parse_bg_worker_defs() - _parse_bg_loop_registry() - allowed_non_registry
+        )
+        assert not orphans, (
+            "_bg_worker_defs entries that are neither a registry loop nor a known "
+            f"pipeline/non-loop worker (typo'd or stale def?): {sorted(orphans)}"
+        )
+
 
 class TestServiceRegistryFields:
     """Each loop class must be declared as a field in ServiceRegistry."""

--- a/tests/test_loop_wiring_completeness.py
+++ b/tests/test_loop_wiring_completeness.py
@@ -27,23 +27,18 @@ SRC = Path(__file__).resolve().parent.parent / "src"
 # These are either non-caretaker pipeline workers, or workers whose intervals
 # are managed through a different mechanism (e.g. not dashboard-editable).
 # ---------------------------------------------------------------------------
-_INTERVAL_BOUNDS_SKIP: set[str] = {
-    "github_cache",
-}
+# NOTE (2026-06-02, worker-fleet visibility audit): these skip-lists previously
+# whitelisted github_cache / epic_monitor / runs_gc — the exact loops operators
+# reported as "not running" because they were absent from the dashboard catalogs.
+# They are now fully wired, so the skips are removed and the guard enforces parity.
+_INTERVAL_BOUNDS_SKIP: set[str] = set()
 
-# Loops that intentionally aren't in the orchestrator bg_loop_registry
-# (e.g. GitHubCacheLoop is started separately).
-_ORCHESTRATOR_SKIP: set[str] = {
-    "github_cache",
-}
+# Loops that intentionally aren't in the orchestrator bg_loop_registry.
+_ORCHESTRATOR_SKIP: set[str] = set()
 
 # Loops that intentionally aren't in BACKGROUND_WORKERS in constants.js
 # (e.g. internal loops not shown in the dashboard).
-_CONSTANTS_JS_SKIP: set[str] = {
-    "github_cache",
-    "epic_monitor",
-    "runs_gc",
-}
+_CONSTANTS_JS_SKIP: set[str] = set()
 
 
 def _discover_loops() -> dict[str, str]:
@@ -82,6 +77,21 @@ def _parse_bg_loop_registry() -> set[str]:
     text = (SRC / "orchestrator.py").read_text()
     # Match lines like:  "memory_sync": svc.memory_sync_bg,
     return set(re.findall(r'"(\w+)"\s*:\s*svc\.', text))
+
+
+def _parse_bg_worker_defs() -> set[str]:
+    """Extract worker names from _bg_worker_defs in dashboard_routes/_control_routes.py.
+
+    ``_bg_worker_defs`` is the *sole* iteration source of the
+    ``GET /api/system/workers`` REST response (``_control_routes.py`` builds the
+    System-tab worker list by walking only this list). A registry loop missing
+    from it renders no row / a permanently-blank row in the dashboard even though
+    the loop runs and heartbeats — the "not running" symptom this guard prevents.
+    """
+    text = (SRC / "dashboard_routes" / "_control_routes.py").read_text()
+    block = re.search(r"_bg_worker_defs\s*=\s*\[(.*?)\n\]", text, re.S)
+    assert block, "_bg_worker_defs list not found in _control_routes.py"
+    return set(re.findall(r'\(\s*"(\w+)"', block.group(1)))
 
 
 def _parse_service_registry_fields() -> set[str]:
@@ -138,6 +148,27 @@ class TestOrchestratorRegistry:
         }
         assert not missing, (
             f"Loops missing from orchestrator bg_loop_registry: {sorted(missing)}"
+        )
+
+
+class TestBgWorkerDefsParity:
+    """Every bg_loop_registry loop must appear in the dashboard's _bg_worker_defs.
+
+    The System tab's ``GET /api/system/workers`` endpoint enumerates *only*
+    ``_bg_worker_defs`` (``_control_routes.py``). A loop registered + started but
+    missing from this catalog runs headless and is invisible/uncontrollable in the
+    dashboard. This is the exact regression class behind the 2026-06-02 worker-fleet
+    audit, where 30 of 45 loops were absent from ``_bg_worker_defs``.
+    """
+
+    def test_all_registry_loops_in_bg_worker_defs(self) -> None:
+        registry_keys = _parse_bg_loop_registry()
+        defs_keys = _parse_bg_worker_defs()
+        missing = registry_keys - defs_keys
+        assert not missing, (
+            "Loops in bg_loop_registry but missing from _bg_worker_defs "
+            "(invisible in the System tab even though they run): "
+            f"{sorted(missing)}"
         )
 
 
@@ -215,7 +246,7 @@ class TestLoopFactories:
     hydraflow-diagnose (gh-TBD).
     """
 
-    def test_all_registry_loops_in_factories(self, loops: dict[str, str]) -> None:
+    def test_all_registry_loops_in_factories(self) -> None:
         registry_keys = _parse_bg_loop_registry()
         factory_keys = _parse_loop_factories()
         missing = {


### PR DESCRIPTION
## Problem

Operator reported many "system workers" appearing **not running / broken / duplicate** in the dashboard System tab (`workspace_gc`, `runs_gc`, `gate_activator`, `branch_protection_auditor`, `health_monitor`, `epic_monitor`, `epic_sweeper`, `diagnostic`, `merge_state_watcher`, `github_cache`, …).

## Root cause (from a 73-agent read-only fleet audit)

The loops were **running and heartbeating** — they were invisible due to **catalog drift** between the 6 worker source-of-truth lists:

- `GET /api/system/workers` iterates **only** `_bg_worker_defs` (`_control_routes.py:538`, no fallback over live heartbeat states). That list contained just **15 of 45** background loops → the other **30 ran headless with no System-tab row**.
- `github_cache` was started in `loop_factories` but **missing from `bg_loop_registry`** → `trigger()` returned `False` (Run-Now no-op) and its interval was uninspectable.
- `tests/test_loop_wiring_completeness.py` had **no `registry → _bg_worker_defs` check**, and its skip-lists whitelisted `github_cache`/`epic_monitor`/`runs_gc` — the exact loops reported missing. The guard stayed green through the bug.

## Fix

- **Add all 30 missing loops to `_bg_worker_defs`** (labels/descriptions mirror `ui/src/constants.js` `BACKGROUND_WORKERS` so the catalogs agree).
- **Register `github_cache` in `bg_loop_registry`** → Run-Now + interval control now resolve.
- **Harden the wiring guard:** new `TestBgWorkerDefsParity` asserts every `bg_loop_registry` key appears in `_bg_worker_defs`; removed the 3 stale skip-list entries. Any future loop that isn't fully wired now fails CI.
- Rewrote `test_returns_all_workers` to assert the **full fleet is surfaced** (not a frozen 22-entry list) and added `github_cache_loop` to the integration fixture's fake `ServiceRegistry`.

## Verification

- `make quality`: lint + pyright + bandit clean; **15466 passed**. (One unrelated pre-existing flake — `test_config_otel_defaults`, an xdist env-leakage issue — passes in isolation and touches no code in this PR.)
- Wiring-completeness + worker-status + dashboard-control + orchestrator-integration suites green.

## Follow-ups (tracked separately, not in this PR)

- `pipeline_poller` heartbeat/enable/live-interval + `sandbox_failure_fixer` worktree-path/`WorkspacePort` dispatch fix (functional bugs).
- `skill_prompt_eval` JSON-corpus harness ("Plan 1", unbuilt — loop no-ops safely on the empty corpus today).
- Sandbox e2e backfill for ~13 loops missing that pyramid layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)