### PR TITLE
fix(workers): pipeline_poller controllability + sandbox_failure_fixer worktree dispatch

### DIFF
--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from exception_classify import reraise_on_credit_or_bug
 
 logger = logging.getLogger("hydraflow.auto_agent_preflight")
 
@@ -281,6 +282,9 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
             created = await self._workspaces.create(issue_number, branch)
             return str(created)
         except Exception as exc:
+            # Credit-exhaustion / likely-bug signals must propagate, not be
+            # swallowed by the broad guard (ADR-0049 / dark-factory mandate).
+            reraise_on_credit_or_bug(exc)
             # Workspace creation can fail (concurrent worktree, branch
             # collision, disk pressure). Degrade to repo_root so the
             # agent still gets a valid cwd; the agent itself can handle

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -716,15 +716,30 @@ class HydraFlowOrchestrator:
         )
 
     async def _pipeline_stats_loop(self) -> None:
-        """Emit pipeline stats every ~10 seconds."""
-        interval = self.get_bg_worker_interval("pipeline_poller")
+        """Emit pipeline stats each cycle as the ``pipeline_poller`` worker.
+
+        Honors the System-tab worker controls the same way the other
+        background workers do: it skips a cycle when the worker is disabled,
+        re-reads its interval each cycle so operator edits take effect without
+        an orchestrator restart, and publishes a per-cycle heartbeat so the
+        dashboard renders an ``ok``/``error`` status instead of a permanently
+        stale row.
+        """
         stats_failures = 0
         while not self._stop_event.is_set():
+            if not self.is_bg_worker_enabled("pipeline_poller"):
+                await self._sleep_or_stop(
+                    self.get_bg_worker_interval("pipeline_poller")
+                )
+                continue
+            interval = self.get_bg_worker_interval("pipeline_poller")
             try:
                 await self.emit_pipeline_stats()
                 stats_failures = 0
+                self.update_bg_worker_status("pipeline_poller", "ok")
             except Exception as exc:
                 stats_failures += 1
+                self.update_bg_worker_status("pipeline_poller", "error")
                 if is_likely_bug(exc) or stats_failures >= 5:
                     logger.critical(
                         "Pipeline stats emission failed (%s, %d consecutive)",
@@ -998,7 +1013,7 @@ class HydraFlowOrchestrator:
             ("stale_issue", self._svc.stale_issue_loop.run),
             ("sentry_ingest", self._svc.sentry_loop.run),
             ("github_cache", self._svc.github_cache_loop.run),
-            ("pipeline_stats", self._pipeline_stats_loop),
+            ("pipeline_poller", self._pipeline_stats_loop),
             ("diagnostic", self._svc.diagnostic_loop.run),
             ("ci_monitor", self._svc.ci_monitor_loop.run),
             (

--- a/src/sandbox_failure_fixer_loop.py
+++ b/src/sandbox_failure_fixer_loop.py
@@ -86,6 +86,10 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
         """
         if self._workspaces is None:
             return str(self._config.repo_root)
+        # NOTE: PR and issue numbers share one namespace, so a pre-existing
+        # workspace at this path could belong to an unrelated same-number issue.
+        # We reuse it as-is (matches AutoAgentPreflightLoop); WorkspacePort.create
+        # is only invoked when no workspace exists yet.
         wt_path = self._config.workspace_path_for_issue(int(pr.number))
         if wt_path.exists():
             return str(wt_path)

--- a/src/sandbox_failure_fixer_loop.py
+++ b/src/sandbox_failure_fixer_loop.py
@@ -24,7 +24,7 @@ from config import HydraFlowConfig
 from exception_classify import reraise_on_credit_or_bug
 
 if TYPE_CHECKING:
-    from ports import PRPort
+    from ports import PRPort, WorkspacePort
     from preflight.auto_agent_runner import AutoAgentRunner
     from state import StateTracker
 
@@ -58,6 +58,7 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
         deps: LoopDeps,
         prs: PRPort | Any | None = None,
         runner: AutoAgentRunner | Any | None = None,
+        workspaces: WorkspacePort | Any | None = None,
     ) -> None:
         super().__init__(
             worker_name="sandbox_failure_fixer",
@@ -68,9 +69,39 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
         self._state = state
         self._prs = prs
         self._runner = runner
+        self._workspaces = workspaces
 
     def _get_default_interval(self) -> int:
         return self._config.sandbox_failure_fixer_interval
+
+    async def _resolve_worktree(self, pr: Any) -> str:
+        """Return a filesystem worktree path for *pr* (never its branch name).
+
+        The auto-agent runner uses ``worktree_path`` directly as the subprocess
+        cwd, so it must be a real directory. Mirrors AutoAgentPreflightLoop:
+        reuse the conventional per-issue workspace if present, otherwise create
+        one on the PR's branch (``WorkspacePort.create`` checks out an existing
+        branch so the fix resumes the PR's work). Falls back to ``repo_root``
+        when no ``WorkspacePort`` is wired (test fixtures / dry-run).
+        """
+        if self._workspaces is None:
+            return str(self._config.repo_root)
+        wt_path = self._config.workspace_path_for_issue(int(pr.number))
+        if wt_path.exists():
+            return str(wt_path)
+        branch = str(getattr(pr, "branch", "") or f"agent/sandbox-fix-{pr.number}")
+        try:
+            created = await self._workspaces.create(int(pr.number), branch)
+            return str(created)
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
+            logger.warning(
+                "sandbox-fix worktree creation failed for PR #%d: %s — "
+                "falling back to repo_root",
+                pr.number,
+                exc,
+            )
+            return str(self._config.repo_root)
 
     async def _do_work(self) -> dict[str, Any] | None:
         # ADR-0049 in-body kill-switch (universal mandate).
@@ -132,7 +163,7 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
             try:
                 outcome = await runner.run(
                     prompt=await self._build_prompt(pr),
-                    worktree_path=str(getattr(pr, "branch", "")),
+                    worktree_path=await self._resolve_worktree(pr),
                     issue_number=int(pr.number),
                 )
             except Exception as exc:

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1274,6 +1274,7 @@ def build_services(
         deps=loop_deps,
         prs=prs,
         runner=sandbox_failure_fixer_runner,
+        workspaces=workspaces,
     )
 
     # Term-Proposer (ADR-0054). Production adapters wire the loop to:

--- a/tests/test_orchestrator_hooks.py
+++ b/tests/test_orchestrator_hooks.py
@@ -1308,13 +1308,85 @@ class TestPipelineStatsEmission:
         json_str = json.dumps(data)
         assert isinstance(json_str, str)
 
-    def test_pipeline_stats_loop_in_supervise_factories(
+    def test_pipeline_poller_registered_in_loop_factories(
         self, config: HydraFlowConfig
     ) -> None:
-        """pipeline_stats loop is registered in _supervise_loops."""
+        """The stats loop is started under the 'pipeline_poller' task name.
+
+        The supervised task name must match the worker identity used by the
+        interval/UI/enable controls (``pipeline_poller``); a divergent task
+        name (the old ``pipeline_stats``) breaks the disabled-flag prune and
+        the trigger/control routes.
+        """
+        import inspect
+
         from orchestrator import HydraFlowOrchestrator
 
         orch = HydraFlowOrchestrator(config)
-        # Verify the method exists
-        assert hasattr(orch, "_pipeline_stats_loop")
         assert callable(orch._pipeline_stats_loop)
+        src = inspect.getsource(HydraFlowOrchestrator._supervise_loops)
+        assert '("pipeline_poller", self._pipeline_stats_loop)' in src
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_publishes_heartbeat(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Each cycle records an 'ok' heartbeat under the 'pipeline_poller' worker."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+
+        async def _emit_then_stop() -> None:
+            orch._stop_event.set()
+
+        orch.emit_pipeline_stats = _emit_then_stop  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        states = orch.get_bg_worker_states()
+        assert states["pipeline_poller"]["status"] == "ok"
+        assert states["pipeline_poller"]["last_run"] is not None
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_skips_emit_when_disabled(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """A disabled pipeline_poller does not emit stats (toggle is honored)."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+        orch.set_bg_worker_enabled("pipeline_poller", False)
+
+        emit = AsyncMock()
+        orch.emit_pipeline_stats = emit  # type: ignore[method-assign]
+
+        async def _sleep_then_stop(_seconds: float) -> None:
+            orch._stop_event.set()
+
+        orch._sleep_or_stop = _sleep_then_stop  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_rereads_interval_each_cycle(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Interval edits take effect live (re-read each cycle, not once at start)."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+        orch.set_bg_worker_interval("pipeline_poller", 99)
+        slept: list[float] = []
+        cycles = {"n": 0}
+
+        async def _emit() -> None:
+            cycles["n"] += 1
+            if cycles["n"] == 1:
+                orch.set_bg_worker_interval("pipeline_poller", 7)
+            if cycles["n"] >= 2:
+                orch._stop_event.set()
+
+        async def _capture_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        orch.emit_pipeline_stats = _emit  # type: ignore[method-assign]
+        orch._sleep_or_stop = _capture_sleep  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        # First cycle slept 99; after the mid-run edit the second cycle slept 7.
+        assert slept[0] == 99
+        assert slept[1] == 7

--- a/tests/test_orchestrator_hooks.py
+++ b/tests/test_orchestrator_hooks.py
@@ -1341,6 +1341,7 @@ class TestPipelineStatsEmission:
         await orch._pipeline_stats_loop()
 
         states = orch.get_bg_worker_states()
+        assert "pipeline_poller" in states, "no heartbeat published for pipeline_poller"
         assert states["pipeline_poller"]["status"] == "ok"
         assert states["pipeline_poller"]["last_run"] is not None
 

--- a/tests/test_sandbox_failure_fixer_loop.py
+++ b/tests/test_sandbox_failure_fixer_loop.py
@@ -26,6 +26,7 @@ def _make_loop(
     prs: object | None = None,
     runner: object | None = None,
     state: object | None = None,
+    workspaces: object | None = None,
     **config_overrides,
 ):
     # Default to static-config-enabled here so each behavioral test exercises
@@ -39,6 +40,7 @@ def _make_loop(
         prs=prs,
         runner=runner,
         deps=deps.loop_deps,
+        workspaces=workspaces,
     )
     return loop, state
 
@@ -327,3 +329,69 @@ async def test_build_prompt_degrades_gracefully_on_fetch_error(
     # Template placeholders must not leak into the prompt.
     assert "{CI_FAILURE_LOG}" not in prompt_used
     assert "{RECENT_COMMIT_DIFFS}" not in prompt_used
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_worktree_path_not_branch_name(
+    tmp_path: Path,
+) -> None:
+    """runner.run must receive a real worktree PATH (subprocess cwd), not the
+    PR's git branch name. Regression for the dispatch that passed pr.branch."""
+    pr_port = MagicMock()
+    pr_port.list_prs_by_label = AsyncMock(
+        return_value=[
+            SimpleNamespace(number=100, branch="rc/2026-04-26", labels=[]),
+        ]
+    )
+    pr_port.add_pr_labels = AsyncMock()
+    pr_port.remove_pr_label = AsyncMock()
+    runner = MagicMock()
+    runner.run = AsyncMock(
+        return_value=SimpleNamespace(crashed=False, output_text="OK")
+    )
+    state = _make_state_with_attempts()
+
+    resolved = tmp_path / "worktrees" / "issue-100"
+    resolved.mkdir(parents=True)
+    workspaces = MagicMock()
+    workspaces.create = AsyncMock(return_value=resolved)
+
+    loop, _ = _make_loop(
+        tmp_path, prs=pr_port, runner=runner, state=state, workspaces=workspaces
+    )
+    await loop._do_work()
+
+    runner.run.assert_called_once()
+    kwargs = runner.run.call_args.kwargs
+    assert kwargs["worktree_path"] == str(resolved)
+    assert kwargs["worktree_path"] != "rc/2026-04-26"
+    workspaces.create.assert_awaited_once_with(100, "rc/2026-04-26")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_falls_back_to_repo_root_without_workspace_port(
+    tmp_path: Path,
+) -> None:
+    """With no WorkspacePort wired the cwd degrades to repo_root — still a real
+    directory, never the branch name."""
+    pr_port = MagicMock()
+    pr_port.list_prs_by_label = AsyncMock(
+        return_value=[
+            SimpleNamespace(number=100, branch="rc/2026-04-26", labels=[]),
+        ]
+    )
+    pr_port.add_pr_labels = AsyncMock()
+    pr_port.remove_pr_label = AsyncMock()
+    runner = MagicMock()
+    runner.run = AsyncMock(
+        return_value=SimpleNamespace(crashed=False, output_text="OK")
+    )
+    state = _make_state_with_attempts()
+
+    loop, _ = _make_loop(tmp_path, prs=pr_port, runner=runner, state=state)
+    await loop._do_work()
+
+    runner.run.assert_called_once()
+    kwargs = runner.run.call_args.kwargs
+    assert kwargs["worktree_path"] == str(loop._config.repo_root)
+    assert kwargs["worktree_path"] != "rc/2026-04-26"


### PR DESCRIPTION
Functional follow-ups to the worker-fleet audit (companion to #9153). Each commit is an independent fix.

## 1. `pipeline_poller` honors enable/interval + publishes a heartbeat
`_pipeline_stats_loop` (UI worker `pipeline_poller`) ran but was unmanageable and showed stale:
- **No heartbeat** → the System tab rendered a permanently DISABLED/never-ran row even though it emits `PIPELINE_STATS` every cycle. Now calls `update_bg_worker_status("pipeline_poller", ok|error)` each cycle.
- **Disable toggle was a no-op** (no enabled gate). Now skips the cycle when disabled.
- **Interval read once** before the loop → edits only applied after restart. Now re-read each cycle.
- Supervised task was named `pipeline_stats` while every control surface keys it `pipeline_poller` → renamed the `loop_factories` task so trigger/prune/restart resolve the same worker (the old divergence made `prune_stale_disabled_workers` drop an operator's disable as "stale" on restart).

## 2. `sandbox_failure_fixer` dispatches to a real worktree, not a branch name
When enabled, it passed `worktree_path=str(pr.branch)` to the runner — but the runner uses that as the subprocess **cwd**. A branch name is not a directory. Injected a `WorkspacePort` and added `_resolve_worktree(pr)` (mirrors `AutoAgentPreflightLoop`): reuse the per-issue workspace or `WorkspacePort.create(pr.number, pr.branch)` (checks out the PR branch to resume), falling back to `repo_root`.

## 3. Review-iteration fixes
- `AutoAgentPreflightLoop._resolve_worktree` swallowed `CreditExhaustedError`/likely-bug on its fallback — added the mandated `reraise_on_credit_or_bug(exc)` (the new sandbox copy already had it; the original was the buggy one).
- Doc'd the PR/issue number-namespace collision in the workspace-reuse branch.

## Tests
New regression tests (all fail against the old code): heartbeat published, disable stops emission, interval re-read live, task-name guard; runner receives the resolved worktree path (not `rc/...`) with a `WorkspacePort` and degrades to `repo_root` without one.

`make quality`: 15470 passed (only the unrelated pre-existing `test_config_otel_defaults` xdist env-leak flake failed — passes in isolation; tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)