### PR TITLE
test(config): make test_config_otel_defaults hermetic against .env xdist leakage

### DIFF
--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -473,7 +473,21 @@ class TestEnvVarOverrideTable:
 
 
 class TestOtelConfigFields:
-    def test_config_otel_defaults(self, tmp_path: Path) -> None:
+    def test_config_otel_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Hermetic: the repo .env sets HF_ENV=dev and HYDRAFLOW_OTEL_ENABLED=true.
+        # Under pytest-xdist, a sibling test that loads .env into os.environ can
+        # leak those into this worker and flip the asserted defaults (the
+        # historical "assert 'dev' == 'local'" flake). Clear the backing env vars
+        # so we assert the true compile-time defaults regardless of leakage.
+        for _var in (
+            "HYDRAFLOW_OTEL_ENABLED",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_SERVICE_NAME",
+            "HF_ENV",
+        ):
+            monkeypatch.delenv(_var, raising=False)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",


### PR DESCRIPTION
## Problem
`tests/test_config_env.py::TestOtelConfigFields::test_config_otel_defaults` flakes ~1×/full `make quality` (and intermittently in the CI "Tests" job) with `assert 'dev' == 'local'`. It passes in isolation → a pytest-xdist test-isolation bug, not a config defect.

## Cause
The repo `.env` sets `HF_ENV=dev` and `HYDRAFLOW_OTEL_ENABLED=true`. A sibling test that loads `.env` into `os.environ` under xdist leaks those into the worker running this test, flipping the asserted defaults (`otel_environment` → "dev", `otel_enabled` → True).

## Fix
Make the test hermetic: clear the four backing env vars (`HYDRAFLOW_OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`, `HF_ENV`) via `monkeypatch.delenv(..., raising=False)` so it asserts the true compile-time defaults regardless of any leak source.

## Verification
The test now **passes even with `HF_ENV=dev HYDRAFLOW_OTEL_ENABLED=true OTEL_SERVICE_NAME=leaked` set** in the environment (it failed before). Full file: 697 passed.

Found while landing the worker-fleet audit PRs (#9153/#9156), where this flake repeatedly reddened the CI Tests job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)