### PR TITLE
feat(skill-eval): real FORMAT=json corpus producer so skill_prompt_eval does work (closes #9154)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,13 @@ scenario-browser: deps
 	@echo "$(GREEN)Browser scenario tests passed$(RESET)"
 
 trust-adversarial: deps
+ifeq ($(FORMAT),json)
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) python tests/trust/adversarial/corpus_runner.py --json
+else
 	@echo "$(BLUE)Running adversarial skill corpus...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/trust/adversarial/ -v
 	@echo "$(GREEN)Adversarial corpus passed$(RESET)"
+endif
 
 trust-contracts: deps
 	@echo "$(BLUE)Running fake contract tests...$(RESET)"

--- a/tests/test_adversarial_corpus_harness.py
+++ b/tests/test_adversarial_corpus_harness.py
@@ -1,9 +1,10 @@
-"""Unit tests for tests/trust/adversarial/test_adversarial_corpus.py.
+"""Unit tests for the adversarial corpus runner's per-case evaluation.
 
-Tests harness behavior against synthetic case directories — proves the
-harness parameterizes correctly, enforces keyword assertion, accepts the
-`none` sentinel, and rejects unknown catcher names. Does NOT run the
-real corpus (that's the RC gate's job).
+Tests behaviour against synthetic case directories — proves the runner
+synthesizes diffs, enforces the keyword assertion, accepts the `none`
+sentinel, and rejects unknown catcher names. Does NOT run the real corpus
+(that's the RC gate's job). Complements test_adversarial_corpus_runner.py,
+which covers the loop-facing JSON schema against the committed corpus.
 """
 
 from __future__ import annotations
@@ -13,11 +14,16 @@ from pathlib import Path
 
 import pytest
 
-TRUST_DIR = Path(__file__).resolve().parent / "trust" / "adversarial"
-sys.path.insert(0, str(TRUST_DIR))
+_ADV = Path(__file__).resolve().parent / "trust" / "adversarial"
+if str(_ADV) not in sys.path:
+    sys.path.insert(0, str(_ADV))
 
-# Import harness helpers under test.
-import test_adversarial_corpus as harness  # type: ignore[import-not-found]
+from corpus_runner import (  # noqa: E402
+    evaluate_case,
+    read_expected_catcher,
+    read_keyword,
+    synthesize_diff,
+)
 
 
 def _write_case(
@@ -51,36 +57,41 @@ def _write_case(
     return case
 
 
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
 def test_synthesize_diff_produces_git_headers(tmp_path: Path) -> None:
     (tmp_path / "before").mkdir()
     (tmp_path / "after").mkdir()
     (tmp_path / "before" / "x.py").write_text("old\n")
     (tmp_path / "after" / "x.py").write_text("new\n")
-    diff = harness._synthesize_diff(tmp_path / "before", tmp_path / "after")
+    diff = synthesize_diff(tmp_path / "before", tmp_path / "after")
     assert "diff --git a/x.py b/x.py" in diff
     assert "-old" in diff and "+new" in diff
 
 
 def test_read_keyword_extracts_line(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# title\n\nKeyword: scope creep\n\nmore\n")
-    assert harness._read_keyword(tmp_path / "README.md") == "scope creep"
+    assert read_keyword(tmp_path / "README.md") == "scope creep"
 
 
 def test_read_keyword_missing_raises(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# title\n\nno keyword line\n")
     with pytest.raises(AssertionError, match="missing 'Keyword:' line"):
-        harness._read_keyword(tmp_path / "README.md")
+        read_keyword(tmp_path / "README.md")
 
 
 def test_read_expected_catcher_rejects_unknown(tmp_path: Path) -> None:
     (tmp_path / "expected_catcher.txt").write_text("bogus-skill\n")
     with pytest.raises(AssertionError, match="must be one of"):
-        harness._read_expected_catcher(tmp_path)
+        read_expected_catcher(tmp_path)
 
 
 def test_read_expected_catcher_accepts_sentinel(tmp_path: Path) -> None:
     (tmp_path / "expected_catcher.txt").write_text("none\n")
-    assert harness._read_expected_catcher(tmp_path) == "none"
+    assert read_expected_catcher(tmp_path) == "none"
 
 
 def test_read_expected_catcher_accepts_registered_skills(tmp_path: Path) -> None:
@@ -89,16 +100,18 @@ def test_read_expected_catcher_accepts_registered_skills(tmp_path: Path) -> None
 
     name = BUILTIN_SKILLS[0].name
     (tmp_path / "expected_catcher.txt").write_text(name + "\n")
-    assert harness._read_expected_catcher(tmp_path) == name
+    assert read_expected_catcher(tmp_path) == name
 
 
-def test_test_case_happy_path_uses_transcript_fixture(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With a canned transcript, the expected_catcher must flag and keyword must match."""
-    cases = tmp_path / "cases"
+# ---------------------------------------------------------------------------
+# evaluate_case behaviour (synthetic cases + canned transcripts)
+# ---------------------------------------------------------------------------
+
+
+def test_catcher_flags_with_keyword_is_pass(tmp_path: Path) -> None:
+    """A transcript where the expected catcher flags + the keyword matches -> PASS."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-synthetic",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -111,16 +124,13 @@ def test_test_case_happy_path_uses_transcript_fixture(
             "FINDINGS:\n- src/unrelated.py — not in plan\n"
         ),
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    harness.test_case(case)  # must not raise
+    assert evaluate_case(case, strict=False)["status"] == "PASS"
 
 
-def test_test_case_raises_when_keyword_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
+def test_catcher_flags_without_keyword_is_fail(tmp_path: Path) -> None:
+    """Flagged but the required keyword is absent -> the catch regressed -> FAIL."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-no-keyword",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -133,17 +143,13 @@ def test_test_case_raises_when_keyword_missing(
             "FINDINGS:\n- src/unrelated.py — not in plan\n"
         ),
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    with pytest.raises(AssertionError, match="did not contain required keyword"):
-        harness.test_case(case)
+    assert evaluate_case(case, strict=False)["status"] == "FAIL"
 
 
-def test_test_case_raises_when_catcher_returns_ok(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
+def test_catcher_returns_ok_is_fail(tmp_path: Path) -> None:
+    """The expected catcher passed the case through (no flag) -> FAIL."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-ok-returned",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -152,25 +158,18 @@ def test_test_case_raises_when_catcher_returns_ok(
         plan="## Plan\n- Edit `src/foo.py`\n",
         transcript="SCOPE_CHECK_RESULT: OK\nSUMMARY: nothing unusual\n",
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    with pytest.raises(AssertionError, match="returned OK"):
-        harness.test_case(case)
+    assert evaluate_case(case, strict=False)["status"] == "FAIL"
 
 
-def test_test_case_sentinel_none_passes_when_all_skills_ok(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
-    # Transcript that every parser reads as OK (no RESULT marker).
-    benign = "No issues found.\n"
+def test_sentinel_none_passes_when_all_skills_ok(tmp_path: Path) -> None:
+    """A benign 'none' case no skill flags -> PASS."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "benign-noop",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 2\n"},
         catcher="none",
         keyword="ignored",
-        transcript=benign,
+        transcript="No issues found.\n",
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    harness.test_case(case)  # must not raise
+    assert evaluate_case(case, strict=False)["status"] == "PASS"

--- a/tests/test_adversarial_corpus_runner.py
+++ b/tests/test_adversarial_corpus_runner.py
@@ -1,0 +1,85 @@
+"""Unit tests for the adversarial corpus runner (the FORMAT=json producer).
+
+Guards the contract SkillPromptEvalLoop._run_corpus depends on: a JSON list of
+{case_id, skill, status, provenance, expected_catcher} dicts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ADV = Path(__file__).resolve().parent / "trust" / "adversarial"
+if str(_ADV) not in sys.path:
+    sys.path.insert(0, str(_ADV))
+
+from corpus_runner import (  # noqa: E402
+    CASES_DIR,
+    MissingTranscriptError,
+    evaluate_case,
+    run_corpus,
+)
+
+_LOOP_KEYS = {"case_id", "skill", "status", "provenance", "expected_catcher"}
+_VALID_STATUS = {"PASS", "FAIL", "SKIPPED"}
+
+
+def test_run_corpus_returns_loop_schema() -> None:
+    """Every result carries exactly the keys the loop reads, with a valid status."""
+    results = run_corpus(strict=False)
+    assert results, "expected a non-empty committed adversarial corpus"
+    for r in results:
+        assert set(r) >= _LOOP_KEYS, f"missing loop keys: {_LOOP_KEYS - set(r)}"
+        assert r["status"] in _VALID_STATUS
+        assert r["case_id"]
+
+
+def test_committed_corpus_is_all_green() -> None:
+    """The committed fixtures must currently PASS (this is the loop's last-green
+    baseline); a FAIL here means a skill prompt regressed."""
+    failing = [r["case_id"] for r in run_corpus(strict=False) if r["status"] == "FAIL"]
+    assert not failing, f"corpus cases regressed to FAIL: {failing}"
+
+
+def test_evaluate_real_catcher_case() -> None:
+    case = CASES_DIR / "missing-import"
+    if not case.is_dir():
+        pytest.skip("missing-import case not present")
+    result = evaluate_case(case, strict=False)
+    assert result["expected_catcher"] == "diff-sanity"
+    assert result["skill"] == "diff-sanity"
+    assert result["status"] == "PASS"
+
+
+def test_evaluate_real_sentinel_case() -> None:
+    case = CASES_DIR / "benign-rename-sentinel"
+    if not case.is_dir():
+        pytest.skip("benign-rename-sentinel case not present")
+    result = evaluate_case(case, strict=False)
+    assert result["expected_catcher"] == "none"
+    assert result["status"] == "PASS"
+
+
+def _make_case_without_transcript(tmp_path: Path) -> Path:
+    case = tmp_path / "synthetic-case"
+    (case / "before").mkdir(parents=True)
+    (case / "after").mkdir(parents=True)
+    (case / "before" / "x.py").write_text("a = 1\n")
+    (case / "after" / "x.py").write_text("a = 2\n")
+    (case / "expected_catcher.txt").write_text("diff-sanity\n")
+    (case / "README.md").write_text("Keyword: something\n")
+    return case
+
+
+def test_missing_transcript_skipped_when_not_strict(tmp_path: Path) -> None:
+    case = _make_case_without_transcript(tmp_path)
+    result = evaluate_case(case, live=False, strict=False)
+    assert result["status"] == "SKIPPED"
+
+
+def test_missing_transcript_raises_when_strict(tmp_path: Path) -> None:
+    case = _make_case_without_transcript(tmp_path)
+    with pytest.raises(MissingTranscriptError):
+        evaluate_case(case, live=False, strict=True)

--- a/tests/test_adversarial_corpus_runner.py
+++ b/tests/test_adversarial_corpus_runner.py
@@ -44,9 +44,9 @@ def test_committed_corpus_is_all_green() -> None:
 
 
 def test_evaluate_real_catcher_case() -> None:
+    # Committed corpus fixture — a catcher case the diff-sanity skill must flag.
     case = CASES_DIR / "missing-import"
-    if not case.is_dir():
-        pytest.skip("missing-import case not present")
+    assert case.is_dir(), "committed corpus case 'missing-import' is missing"
     result = evaluate_case(case, strict=False)
     assert result["expected_catcher"] == "diff-sanity"
     assert result["skill"] == "diff-sanity"
@@ -54,9 +54,9 @@ def test_evaluate_real_catcher_case() -> None:
 
 
 def test_evaluate_real_sentinel_case() -> None:
+    # Committed corpus fixture — a benign 'none' sentinel no skill may flag.
     case = CASES_DIR / "benign-rename-sentinel"
-    if not case.is_dir():
-        pytest.skip("benign-rename-sentinel case not present")
+    assert case.is_dir(), "committed corpus case 'benign-rename-sentinel' is missing"
     result = evaluate_case(case, strict=False)
     assert result["expected_catcher"] == "none"
     assert result["status"] == "PASS"

--- a/tests/trust/adversarial/corpus_runner.py
+++ b/tests/trust/adversarial/corpus_runner.py
@@ -1,0 +1,280 @@
+"""Adversarial corpus runner — shared eval logic for the pytest harness and the
+``FORMAT=json`` producer consumed by ``SkillPromptEvalLoop._run_corpus``.
+
+A *case* lives at ``tests/trust/adversarial/cases/<name>/``:
+
+  - ``before/`` / ``after/``     minimal pre/post-diff repo subset
+  - ``expected_catcher.txt``     a registered skill name, or ``"none"``
+  - ``README.md``                describes the bug + a ``Keyword:`` line
+  - ``expected_transcript.txt``  (optional) canned LLM transcript fixture
+  - ``plan.md`` / ``provenance.txt``  (optional)
+
+``evaluate_case`` synthesizes a unified diff from ``before/`` vs ``after/``,
+feeds it to every skill's ``prompt_builder``, parses the transcript with each
+skill's ``result_parser``, and decides a per-case ``status``:
+
+  - ``PASS``  — expected behaviour holds (the expected catcher flags the case
+                with its keyword; or, for ``none`` cases, no skill flags it).
+  - ``FAIL``  — a regression: the catcher no longer flags it (or a ``none``
+                case is now flagged).
+  - ``SKIPPED`` — no transcript fixture and live mode off (non-strict only).
+
+The pytest harness asserts on this; the loop diffs ``PASS -> FAIL`` per case to
+detect skill-prompt drift. Run ``python corpus_runner.py --json`` to emit the
+loop-facing result list (``[{case_id, skill, status, provenance,
+expected_catcher}, ...]``) on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+CASES_DIR = HERE / "cases"
+REPO_ROOT = HERE.parent.parent.parent
+SRC = REPO_ROOT / "src"
+
+# Mirror the conftest sys.path setup: bare imports (skill_registry) resolve via
+# src/, while modules that self-reference as ``src.X`` (e.g. models.py) need the
+# repo root on the path too.
+for _path in (REPO_ROOT, SRC):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from skill_registry import BUILTIN_SKILLS  # noqa: E402
+
+_SKILLS_BY_NAME = {s.name: s for s in BUILTIN_SKILLS}
+_VALID_CATCHERS: frozenset[str] = frozenset({*_SKILLS_BY_NAME.keys(), "none"})
+
+
+class MissingTranscriptError(RuntimeError):
+    """Raised in strict mode when a case has no transcript fixture and live is off."""
+
+
+def discover_cases(cases_dir: Path = CASES_DIR) -> list[Path]:
+    if not cases_dir.is_dir():
+        return []
+    return sorted(
+        p for p in cases_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
+    )
+
+
+def _read_case_files(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(root).as_posix()
+            try:
+                out[rel] = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                out[rel] = ""
+    return out
+
+
+def synthesize_diff(before_dir: Path, after_dir: Path) -> str:
+    """Build a unified diff from before/ -> after/ with git-style headers."""
+    before = _read_case_files(before_dir)
+    after = _read_case_files(after_dir)
+    chunks: list[str] = []
+    for rel in sorted(set(before) | set(after)):
+        b = before.get(rel, "")
+        a = after.get(rel, "")
+        if b == a:
+            continue
+        diff = difflib.unified_diff(
+            b.splitlines(keepends=True),
+            a.splitlines(keepends=True),
+            fromfile=f"a/{rel}",
+            tofile=f"b/{rel}",
+        )
+        chunks.append(f"diff --git a/{rel} b/{rel}\n")
+        chunks.extend(diff)
+    return "".join(chunks)
+
+
+def load_transcript(case_dir: Path, prompt: str, *, live: bool) -> str | None:
+    """Return the canned transcript for *case_dir*, invoke live claude, or None.
+
+    Returns ``None`` when no ``expected_transcript.txt`` exists and *live* is
+    off — callers decide whether that is a skip or an error.
+    """
+    fixture = case_dir / "expected_transcript.txt"
+    if fixture.exists():
+        return fixture.read_text(encoding="utf-8")
+    if not live:
+        return None
+    result = subprocess.run(  # noqa: S603
+        ["claude", "-p", prompt, "--output-format", "text"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=True,
+    )
+    return result.stdout
+
+
+def read_keyword(readme_path: Path) -> str:
+    """Extract the required ``Keyword:`` from a case README (case-insensitive)."""
+    text = readme_path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if line.strip().lower().startswith("keyword:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"README.md {readme_path} missing 'Keyword:' line")
+
+
+def read_expected_catcher(case_dir: Path) -> str:
+    catcher = (case_dir / "expected_catcher.txt").read_text(encoding="utf-8").strip()
+    if catcher not in _VALID_CATCHERS:
+        raise AssertionError(
+            f"{case_dir.name}/expected_catcher.txt = {catcher!r}; must be one of "
+            f"{sorted(_VALID_CATCHERS)} (from live skill_registry.BUILTIN_SKILLS)"
+        )
+    return catcher
+
+
+def load_plan_text(case_dir: Path) -> str:
+    plan = case_dir / "plan.md"
+    return plan.read_text(encoding="utf-8") if plan.exists() else ""
+
+
+def read_provenance(case_dir: Path) -> str:
+    """Return the case provenance (``provenance.txt``), defaulting to hand-crafted."""
+    prov = case_dir / "provenance.txt"
+    if prov.exists():
+        text = prov.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+    return "hand-crafted"
+
+
+def evaluate_case(
+    case_dir: Path, *, live: bool = False, strict: bool = True
+) -> dict[str, Any]:
+    """Evaluate one case and return its loop-facing result dict.
+
+    Keys: ``case_id, skill, expected_catcher, provenance, status`` plus
+    ``summary`` and ``findings`` for the pytest assertions. ``status`` is one of
+    ``PASS`` / ``FAIL`` / ``SKIPPED``.
+
+    In *strict* mode a missing transcript raises :class:`MissingTranscriptError`
+    (the pytest harness requires a fixture or live mode); otherwise the case is
+    reported ``SKIPPED`` so the loop simply ignores it.
+    """
+    case_id = case_dir.name
+    before_dir = case_dir / "before"
+    after_dir = case_dir / "after"
+    if not before_dir.is_dir() or not after_dir.is_dir():
+        raise AssertionError(f"{case_id}: missing before/ or after/")
+
+    diff = synthesize_diff(before_dir, after_dir)
+    if not diff.strip():
+        raise AssertionError(f"{case_id}: before/ and after/ produced empty diff")
+
+    catcher = read_expected_catcher(case_dir)
+    provenance = read_provenance(case_dir)
+    plan_text = load_plan_text(case_dir)
+
+    # One transcript per case, fed to every skill's parser (the prompt arg only
+    # matters for the live-claude path).
+    sample_prompt = ""
+    if BUILTIN_SKILLS:
+        sample_prompt = BUILTIN_SKILLS[0].prompt_builder(
+            issue_number=0,
+            issue_title=f"adversarial-corpus::{case_id}",
+            diff=diff,
+            plan_text=plan_text,
+        )
+    transcript = load_transcript(case_dir, sample_prompt, live=live)
+    if transcript is None:
+        if strict:
+            raise MissingTranscriptError(
+                f"No expected_transcript.txt for {case_id}; set "
+                "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE=1 to invoke the real claude CLI."
+            )
+        return {
+            "case_id": case_id,
+            "skill": catcher,
+            "expected_catcher": catcher,
+            "provenance": provenance,
+            "status": "SKIPPED",
+            "summary": "",
+            "findings": [],
+        }
+
+    results: dict[str, tuple[bool, str, list[str]]] = {}
+    for skill in BUILTIN_SKILLS:
+        results[skill.name] = skill.result_parser(transcript)
+
+    if catcher == "none":
+        failing = [name for name, (passed, _, _) in results.items() if not passed]
+        status = "PASS" if not failing else "FAIL"
+        return {
+            "case_id": case_id,
+            "skill": "none",
+            "expected_catcher": "none",
+            "provenance": provenance,
+            "status": status,
+            "summary": "" if status == "PASS" else f"flagged by {failing}",
+            "findings": failing,
+        }
+
+    passed, summary, findings = results[catcher]
+    keyword = read_keyword(case_dir / "README.md")
+    haystack = (summary + "\n" + "\n".join(findings)).lower()
+    caught = (not passed) and (keyword.lower() in haystack)
+    return {
+        "case_id": case_id,
+        "skill": catcher,
+        "expected_catcher": catcher,
+        "provenance": provenance,
+        "status": "PASS" if caught else "FAIL",
+        "summary": summary,
+        "findings": findings,
+    }
+
+
+def run_corpus(
+    *, cases_dir: Path = CASES_DIR, live: bool = False, strict: bool = False
+) -> list[dict[str, Any]]:
+    """Evaluate every discovered case and return the loop-facing result list."""
+    return [
+        evaluate_case(case_dir, live=live, strict=strict)
+        for case_dir in discover_cases(cases_dir)
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Adversarial corpus runner")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the loop-facing result list as JSON on stdout",
+    )
+    args = parser.parse_args(argv)
+    live = os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1"
+    results = run_corpus(live=live, strict=False)
+    if args.json:
+        # Only the loop-facing keys belong on stdout (the loop json.loads it).
+        slim = [
+            {
+                "case_id": r["case_id"],
+                "skill": r["skill"],
+                "status": r["status"],
+                "provenance": r["provenance"],
+                "expected_catcher": r["expected_catcher"],
+            }
+            for r in results
+        ]
+        print(json.dumps(slim))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/trust/adversarial/test_adversarial_corpus.py
+++ b/tests/trust/adversarial/test_adversarial_corpus.py
@@ -1,195 +1,51 @@
 """Adversarial corpus harness — iterates tests/trust/adversarial/cases/*.
 
 Each case directory contains:
-  - before/                 minimal pre-diff repo subset
-  - after/                  minimal post-diff repo subset
-  - expected_catcher.txt    one of the registered skills' names, or "none"
-  - README.md               describes the bug + names a required keyword
+  - before/ / after/        minimal pre/post-diff repo subset
+  - expected_catcher.txt     one of the registered skills' names, or "none"
+  - README.md                describes the bug + names a required `Keyword:`
+  - expected_transcript.txt  (optional) canned LLM transcript fixture
 
-The harness synthesizes a unified diff from before/ vs after/, feeds it to
-every skill's registered prompt_builder, records what the corresponding
-result_parser would return when given a canned "RETRY+summary" transcript
-from a captured fixture at cases/<name>/expected_transcript.txt (if present)
-or produced on demand from an LLM call against the prompt. The "pass"
-assertion is: the expected_catcher skill's parser reports passed=False AND
-the keyword from the README appears (case-insensitive substring) in the
-parser's summary field.
-
-The `none` sentinel asserts that NO skill reports passed=False on the
-case — i.e. a deliberately benign diff must not trip any catcher.
+The per-case evaluation logic lives in :mod:`corpus_runner` so it is shared
+with the ``FORMAT=json`` producer consumed by ``SkillPromptEvalLoop``. This
+harness asserts the expected catcher still flags each case (status ``PASS``);
+the loop diffs ``PASS -> FAIL`` over time to detect skill-prompt drift.
 """
 
 from __future__ import annotations
 
-import difflib
 import os
-import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
 HERE = Path(__file__).resolve().parent
-CASES_DIR = HERE / "cases"
-REPO_ROOT = HERE.parent.parent.parent
-SRC = REPO_ROOT / "src"
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
 
-sys.path.insert(0, str(SRC))
-
-from skill_registry import BUILTIN_SKILLS, AgentSkill  # noqa: E402
-
-# Map skill.name -> AgentSkill, resolved at module import from the live
-# registry. If a new post-impl skill is added to BUILTIN_SKILLS, the
-# corpus automatically accepts expected_catcher.txt values naming it.
-_SKILLS_BY_NAME: dict[str, AgentSkill] = {s.name: s for s in BUILTIN_SKILLS}
-_VALID_CATCHERS: frozenset[str] = frozenset({*_SKILLS_BY_NAME.keys(), "none"})
-
-
-def _discover_cases() -> list[Path]:
-    if not CASES_DIR.is_dir():
-        return []
-    return sorted(
-        p for p in CASES_DIR.iterdir() if p.is_dir() and not p.name.startswith(".")
-    )
-
-
-def _read_case_files(root: Path) -> dict[str, str]:
-    """Return {relative_path: file_text} under *root*."""
-    out: dict[str, str] = {}
-    for path in sorted(root.rglob("*")):
-        if path.is_file():
-            rel = path.relative_to(root).as_posix()
-            try:
-                out[rel] = path.read_text(encoding="utf-8")
-            except UnicodeDecodeError:
-                out[rel] = ""
-    return out
-
-
-def _synthesize_diff(before_dir: Path, after_dir: Path) -> str:
-    """Build a unified diff from before/ -> after/ with git-style headers."""
-    before = _read_case_files(before_dir)
-    after = _read_case_files(after_dir)
-    chunks: list[str] = []
-    for rel in sorted(set(before) | set(after)):
-        b = before.get(rel, "")
-        a = after.get(rel, "")
-        if b == a:
-            continue
-        diff = difflib.unified_diff(
-            b.splitlines(keepends=True),
-            a.splitlines(keepends=True),
-            fromfile=f"a/{rel}",
-            tofile=f"b/{rel}",
-        )
-        chunks.append(f"diff --git a/{rel} b/{rel}\n")
-        chunks.extend(diff)
-    return "".join(chunks)
-
-
-def _load_transcript(case_dir: Path, prompt: str) -> str:
-    """Return the canned LLM transcript for *case_dir*, or invoke live claude."""
-    fixture = case_dir / "expected_transcript.txt"
-    if fixture.exists():
-        return fixture.read_text(encoding="utf-8")
-    assert os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1", (
-        f"No expected_transcript.txt for {case_dir.name}; set "
-        "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE=1 to invoke the real claude CLI."
-    )
-    try:
-        result = subprocess.run(  # noqa: S603
-            ["claude", "-p", prompt, "--output-format", "text"],
-            capture_output=True,
-            text=True,
-            timeout=180,
-            check=True,
-        )
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-    ) as exc:
-        pytest.fail(f"Live claude invocation failed for {case_dir.name}: {exc}")
-    return result.stdout
-
-
-def _read_keyword(readme_path: Path) -> str:
-    """Extract the required keyword from a case README.
-
-    Convention: one line of the README reads `Keyword: <word-or-phrase>`.
-    The match is case-insensitive substring against the parser's summary.
-    """
-    text = readme_path.read_text(encoding="utf-8")
-    for line in text.splitlines():
-        if line.strip().lower().startswith("keyword:"):
-            return line.split(":", 1)[1].strip()
-    raise AssertionError(f"README.md {readme_path} missing 'Keyword:' line")
-
-
-def _read_expected_catcher(case_dir: Path) -> str:
-    catcher = (case_dir / "expected_catcher.txt").read_text(encoding="utf-8").strip()
-    if catcher not in _VALID_CATCHERS:
-        raise AssertionError(
-            f"{case_dir.name}/expected_catcher.txt = {catcher!r}; must be one of "
-            f"{sorted(_VALID_CATCHERS)} (from live skill_registry.BUILTIN_SKILLS)"
-        )
-    return catcher
-
-
-def _load_plan_text(case_dir: Path) -> str:
-    """Return plan_text for plan-compliance / scope-check cases, or empty."""
-    plan = case_dir / "plan.md"
-    return plan.read_text(encoding="utf-8") if plan.exists() else ""
+from corpus_runner import (  # noqa: E402
+    MissingTranscriptError,
+    discover_cases,
+    evaluate_case,
+)
 
 
 @pytest.mark.parametrize(
     "case_dir",
-    _discover_cases(),
+    discover_cases(),
     ids=lambda p: p.name,
 )
 def test_case(case_dir: Path) -> None:
-    """For each case, assert the expected catcher flags it."""
-    before_dir = case_dir / "before"
-    after_dir = case_dir / "after"
-    assert before_dir.is_dir(), f"{case_dir.name}: missing before/"
-    assert after_dir.is_dir(), f"{case_dir.name}: missing after/"
+    """Each case's expected catcher must still flag it (no PASS->FAIL drift)."""
+    live = os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1"
+    try:
+        result = evaluate_case(case_dir, live=live, strict=True)
+    except MissingTranscriptError as exc:
+        pytest.fail(str(exc))
 
-    diff = _synthesize_diff(before_dir, after_dir)
-    assert diff.strip(), f"{case_dir.name}: before/ and after/ produced empty diff"
-
-    catcher = _read_expected_catcher(case_dir)
-    plan_text = _load_plan_text(case_dir)
-
-    # For every skill, build its prompt and parse the transcript.
-    results: dict[str, tuple[bool, str, list[str]]] = {}
-    for skill in BUILTIN_SKILLS:
-        prompt = skill.prompt_builder(
-            issue_number=0,
-            issue_title=f"adversarial-corpus::{case_dir.name}",
-            diff=diff,
-            plan_text=plan_text,
-        )
-        transcript = _load_transcript(case_dir, prompt)
-        results[skill.name] = skill.result_parser(transcript)
-
-    if catcher == "none":
-        failing = [name for name, (passed, _, _) in results.items() if not passed]
-        assert not failing, (
-            f"{case_dir.name}: sentinel 'none' case was flagged by {failing} "
-            "but should pass every skill"
-        )
-        return
-
-    passed, summary, findings = results[catcher]
-    assert not passed, (
-        f"{case_dir.name}: expected_catcher '{catcher}' returned OK; "
-        f"summary={summary!r} findings={findings!r}"
-    )
-
-    keyword = _read_keyword(case_dir / "README.md")
-    haystack = (summary + "\n" + "\n".join(findings)).lower()
-    assert keyword.lower() in haystack, (
-        f"{case_dir.name}: expected_catcher '{catcher}' returned RETRY but "
-        f"summary/findings did not contain required keyword {keyword!r}. "
-        f"summary={summary!r}, findings={findings!r}"
+    assert result["status"] == "PASS", (
+        f"{case_dir.name}: expected_catcher {result['expected_catcher']!r} "
+        f"regressed (status={result['status']}); summary={result['summary']!r}, "
+        f"findings={result['findings']!r}"
     )


### PR DESCRIPTION
## Problem (worker-fleet audit finding F4, CRITICAL)
`SkillPromptEvalLoop._run_corpus` runs `make trust-adversarial FORMAT=json` and `json.loads` the stdout, expecting `[{case_id, skill, status, provenance, expected_catcher}, ...]`. But the Makefile target **ignored `FORMAT`** and ran `pytest -v` (text) → `JSONDecodeError` → `[]` every cycle. So the weekly skill-prompt-drift gate did **no work** — despite **28 committed corpus cases**.

## Fix
- Extract the per-case eval logic into `tests/trust/adversarial/corpus_runner.py` (single source of truth): synthesize the diff from `before/`/`after/`, parse the transcript fixture with each skill's `result_parser`, decide `status` = `PASS` (catcher flags it with its keyword / sentinel `none` case stays clean) / `FAIL` (regression) / `SKIPPED` (no fixture, non-strict).
- The pytest harness now asserts on `evaluate_case()`; a `--json` entrypoint emits the loop-facing list on stdout.
- Add a `FORMAT=json` branch to the Makefile target. **Default path (no FORMAT) is unchanged** — still `pytest -v` for CI.

## Verification
- `make trust-adversarial FORMAT=json` → valid JSON for all **28 cases** (all PASS — the loop's last-green baseline); clean stdout (loop can `json.loads` it).
- `make trust-adversarial` (default) → 28 passed (CI path intact).
- New `corpus_runner` unit tests: loop schema, all-green baseline, real catcher + sentinel cases, SKIPPED-vs-strict. Refactored harness 28/28; `skill_prompt_eval` loop tests green.
- `make audit`: PASS 90 / WARN 0 / FAIL 0.

Closes #9154.

🤖 Generated with [Claude Code](https://claude.com/claude-code)