### PR TITLE
test(sandbox): e2e backfill batch 1 — workspace_gc, runs_gc, health_monitor, merge_state_watcher

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-02T16:38:32.755932+00:00",
-  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
+  "regenerated_at": "2026-06-02T20:46:02.197162+00:00",
+  "commit_sha": "30297ce40525c2e2b720a29249b30333b1ea1374",
   "artifacts": {
     "loops.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "ports.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "labels.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "modules.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "events.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "adr_xref.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "mockworld.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "changelog.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "coverage_matrix.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "functional_areas.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "ubiquitous-language.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "30297ce40525c2e2b720a29249b30333b1ea1374"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `04dc3a6` — fix(workers): surface all 45 background loops in System tab + register github_cache (#9153) (#9153) *(2026-06-02)*
 - `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
 - `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
 - `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -29,11 +29,11 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ✅ [flake-tracker-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GateActivatorLoop` | ✅ [0082] | ❌ | ✅ loops.md | ❌ | ✅ `test_gate_activator_loop.py` | ✅ in catalog | ✅ `s45_gate_activator_no_proposals.py` |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_github_cache_loop.py` | ✅ in catalog | ✅ `s44_github_cache_idle_poll.py` |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ✅ `s48_health_monitor_idle_poll.py` |
 | `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ✅ in catalog | ❌ |
 | `LiveCorpusReplayLoop` | ✅ [0086] | ✅ [live-corpus-replay-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_live_corpus_replay_loop.py` | ✅ in catalog | ✅ `s43_live_corpus_replay_idle.py` |
 | `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ✅ loops.md | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ✅ `s49_merge_state_watcher_idle_poll.py` |
 | `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ✅ in catalog | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
 | `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
 | `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
@@ -41,7 +41,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
 | `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
 | `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
-| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ✅ `s47_runs_gc_idle_poll.py` |
 | `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ✅ `s38_sandbox_fixer_richer_context.py` |
 | `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
 | `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_sentry_loop.py` | ✅ in catalog | ✅ `s42_sentry_ingest_no_credentials.py` |
@@ -55,7 +55,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ✅ [wiki-rot-detector-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ✅ `s46_workspace_gc_idle_poll.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are

--- a/tests/sandbox_scenarios/scenarios/s46_workspace_gc_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s46_workspace_gc_idle_poll.py
@@ -1,0 +1,46 @@
+"""s46 - WorkspaceGCLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``WorkspaceGCLoop`` and a GC
+cycle completes (no stale worktrees/branches to collect) without error, proving
+the loop is registered, started, and heartbeating in the real Docker stack.
+Closes part of #9155 (worker-fleet e2e backfill).
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s46_workspace_gc_idle_poll"
+DESCRIPTION = "WorkspaceGCLoop performs an idle GC cycle and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["workspace_gc"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by WorkspaceGCLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "workspace_gc"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "workspace_gc"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one workspace_gc worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s47_runs_gc_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s47_runs_gc_idle_poll.py
@@ -1,0 +1,45 @@
+"""s47 - RunsGCLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``RunsGCLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s47_runs_gc_idle_poll"
+DESCRIPTION = "RunsGCLoop performs an idle purge cycle and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["runs_gc"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by RunsGCLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "runs_gc"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "runs_gc"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one runs_gc worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s48_health_monitor_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s48_health_monitor_idle_poll.py
@@ -1,0 +1,47 @@
+"""s48 - HealthMonitorLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``HealthMonitorLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s48_health_monitor_idle_poll"
+DESCRIPTION = (
+    "HealthMonitorLoop performs an idle analysis cycle and emits worker status."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["health_monitor"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by HealthMonitorLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "health_monitor"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "health_monitor"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one health_monitor worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s49_merge_state_watcher_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s49_merge_state_watcher_idle_poll.py
@@ -1,0 +1,45 @@
+"""s49 - MergeStateWatcherLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``MergeStateWatcherLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s49_merge_state_watcher_idle_poll"
+DESCRIPTION = "MergeStateWatcherLoop performs an idle scan and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["merge_state_watcher"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by MergeStateWatcherLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "merge_state_watcher"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "merge_state_watcher"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one merge_state_watcher worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -106,7 +106,19 @@ def _build_workspace_gc(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 def _build_runs_gc(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from runs_gc_loop import RunsGCLoop  # noqa: PLC0415
 
-    run_recorder = ports.get("run_recorder") or MagicMock()
+    run_recorder = ports.get("run_recorder")
+    if run_recorder is None:
+        # Faithful idle fake: a bare MagicMock returns MagicMocks from the
+        # purge calls, which breaks RunsGCLoop's `total_purged > 0` arithmetic.
+        # Return real ints (nothing to purge) + empty storage stats.
+        run_recorder = MagicMock()
+        run_recorder.purge_expired.return_value = 0
+        run_recorder.purge_oversized.return_value = 0
+        run_recorder.get_storage_stats.return_value = {
+            "total_runs": 0,
+            "total_mb": 0.0,
+            "issues": [],
+        }
     ports.setdefault("run_recorder", run_recorder)
     return RunsGCLoop(config=config, run_recorder=run_recorder, deps=deps)
 


### PR DESCRIPTION
First batch of the worker-fleet sandbox e2e backfill (part of #9155).

## What
Idle-poll e2e scenarios (the established s23–s45 pattern) that boot the real loop in the sandbox Docker stack and assert it emits a `background_worker_status` heartbeat — covering the docker/wiring/registration layer that unit + MockWorld tests can't reach:
- **s46** `workspace_gc` (leak prevention)
- **s47** `runs_gc` (leak prevention)
- **s48** `health_monitor` (meta-observability)
- **s49** `merge_state_watcher` (recovery)

## Fake-fidelity fix surfaced by s47
The `LoopCatalog` `runs_gc` builder injected a bare `MagicMock` `run_recorder`, whose `purge_*` calls returned `MagicMock`s and broke `RunsGCLoop`'s `total_purged > 0` arithmetic in-process. Gave it a faithful idle stub (`purge_*`→0, empty storage stats). This is exactly the kind of gap the e2e layer is meant to expose.

## Audit correction
4 of the 13 loops #9155 listed **already** had scenarios (branch_protection_auditor s41, gate_activator s45, epic_monitor s27, epic_sweeper s23) — the per-worker audit agents grepped only scenario *bodies* and false-negatived. Genuinely-missing remainder for a follow-up batch: `trust_fleet_sanity`, `wiki_rot_detector`, `label_drift_watcher`, `stale_issue_gc`, `pipeline_poller`.

## Verification
Host-side parity test (`tests/scenarios/test_sandbox_parity.py`) 46/46 green; scenario contract test green. Full Docker e2e runs in CI / via `scripts/sandbox_scenario.py`.

Part of #9155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)