### PR TITLE
fix(dashboard): color "Needs Human" stage red to end Triage color clash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["ui*", "templates*", "tests*"]
 
 [project]
 name = "hydraflow"
-version = "0.9.3"
+version = "0.9.4"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "pydantic>=2.0.0",

--- a/src/ui/src/components/HarnessInsightsPanel.jsx
+++ b/src/ui/src/components/HarnessInsightsPanel.jsx
@@ -16,7 +16,7 @@ const CATEGORY_COLORS = {
   quality_gate: theme.orange,
   review_rejection: theme.red,
   ci_failure: theme.red,
-  hitl_escalation: theme.yellow,
+  hitl_escalation: theme.red,
   implementation_error: theme.red,
 }
 

--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -62,7 +62,7 @@ function statusStyle(status) {
   }
   if (status === 'merged') return { ...common, background: theme.greenSubtle || theme.surface, color: theme.green }
   if (status === 'failed') return { ...common, background: theme.redSubtle || theme.surface, color: theme.red }
-  if (status === 'hitl') return { ...common, background: theme.yellowSubtle || theme.surface, color: theme.yellow }
+  if (status === 'hitl') return { ...common, background: theme.redSubtle || theme.surface, color: theme.red }
   if (status === 'active') return { ...common, background: theme.accentSubtle || theme.surface, color: theme.accent }
   return { ...common, background: theme.surfaceInset, color: theme.textMuted }
 }

--- a/src/ui/src/components/StreamCard.jsx
+++ b/src/ui/src/components/StreamCard.jsx
@@ -298,7 +298,7 @@ export const dotStyles = {
   },
   done: { fontSize: 11, fontWeight: 700, color: theme.green },
   failed: { fontSize: 11, fontWeight: 700, color: theme.red },
-  hitl: { fontSize: 11, fontWeight: 700, color: theme.yellow },
+  hitl: { fontSize: 11, fontWeight: 700, color: theme.red },
   queued: {
     display: 'inline-block',
     width: 8,
@@ -327,7 +327,7 @@ export const badgeStyleMap = {
   active: { ...badgeBase, background: theme.accentSubtle, color: theme.accent },
   done: { ...badgeBase, background: theme.greenSubtle, color: theme.green },
   failed: { ...badgeBase, background: theme.redSubtle, color: theme.red },
-  hitl: { ...badgeBase, background: theme.yellowSubtle, color: theme.yellow },
+  hitl: { ...badgeBase, background: theme.redSubtle, color: theme.red },
   pending: { ...badgeBase, background: theme.mutedSubtle, color: theme.textMuted },
 }
 

--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -14,7 +14,7 @@ import {
 
 // No-role stages (role: null) share the worker-less rendering branches, but each
 // carries its own semantics. 'merged' is success (green, "{N} merged"); 'hitl' is
-// an escalation bucket (yellow, "{N} needs human") and must NOT read as success.
+// an escalation bucket (red, "{N} needs human") and must NOT read as success.
 // Keyed by stage.key so adding a no-role stage is one map entry, not a conditional.
 const NO_ROLE_COUNT_LABELS = {
   merged: 'merged',
@@ -22,7 +22,7 @@ const NO_ROLE_COUNT_LABELS = {
 }
 const NO_ROLE_DOT_COLORS = {
   merged: theme.green,
-  hitl: theme.yellow,
+  hitl: theme.red,
 }
 
 function PendingIntentCard({ intent }) {
@@ -574,7 +574,7 @@ const flowDotFailedStyles = Object.fromEntries(
 )
 
 const flowDotHitlStyles = Object.fromEntries(
-  PIPELINE_STAGES.map(s => [s.key, { ...flowDotBase, background: theme.yellow }])
+  PIPELINE_STAGES.map(s => [s.key, { ...flowDotBase, background: theme.red }])
 )
 
 // Epic dot styles — 12px circles with centered "e" text
@@ -609,7 +609,7 @@ const epicFlowDotFailedStyles = Object.fromEntries(
   PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.red }])
 )
 const epicFlowDotHitlStyles = Object.fromEntries(
-  PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.yellow }])
+  PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.red }])
 )
 
 // Grouped style maps for quick lookup in render

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -76,7 +76,7 @@ describe('HITL issues are rendered in the workstream (WS-RT)', () => {
     expect(screen.getByText('Escalated issue')).toBeTruthy()
   })
 
-  it('labels the hitl bucket as needs-human, not merged, with a yellow dot', () => {
+  it('labels the hitl bucket as needs-human, not merged, with a red dot', () => {
     // The hitl stage has role:null like merged, so it shares the worker-less
     // rendering branches. Those branches must stay stage-aware: a "Needs Human"
     // escalation bucket reading "merged" + green (success) is a mislabel.
@@ -93,7 +93,7 @@ describe('HITL issues are rendered in the workstream (WS-RT)', () => {
 
     const dot = screen.getByTestId('stage-dot-hitl')
     expect(dot.style.background).not.toBe('var(--green)')
-    expect(dot.style.background).toBe('var(--yellow)')
+    expect(dot.style.background).toBe('var(--red)')
   })
 })
 
@@ -747,7 +747,7 @@ describe('PipelineFlow failed and hitl dots', () => {
     expect(dot.style.animation).toBe('')
   })
 
-  it('renders hitl dots with yellow background and no animation', () => {
+  it('renders hitl dots with red background and no animation', () => {
     mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
       pipelineIssues: {
         triage: [],
@@ -761,7 +761,7 @@ describe('PipelineFlow failed and hitl dots', () => {
     render(<StreamView {...defaultProps} />)
     const dot = screen.getByTestId('flow-dot-2')
     expect(dot).toBeInTheDocument()
-    expect(dot.style.background).toBe('var(--yellow)')
+    expect(dot.style.background).toBe('var(--red)')
     expect(dot.style.animation).toBe('')
   })
 
@@ -805,9 +805,9 @@ describe('PipelineFlow failed and hitl dots', () => {
     const failedDot = screen.getByTestId('flow-dot-11')
     expect(failedDot.style.background).toBe('var(--red)')
     expect(failedDot.style.animation).toBe('')
-    // HITL: yellow, no animation
+    // HITL: red, no animation (shares Failed's hue in the glyph-less flow view)
     const hitlDot = screen.getByTestId('flow-dot-12')
-    expect(hitlDot.style.background).toBe('var(--yellow)')
+    expect(hitlDot.style.background).toBe('var(--red)')
     expect(hitlDot.style.animation).toBe('')
     // Queued: subtle stage color (accent), no animation
     const queuedDot = screen.getByTestId('flow-dot-13')

--- a/src/ui/src/components/__tests__/constants.test.js
+++ b/src/ui/src/components/__tests__/constants.test.js
@@ -56,7 +56,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purple,
       implement: theme.accent,
       review: theme.orange,
-      hitl: theme.yellow,
+      hitl: theme.red,
       merged: theme.green,
     })
   })
@@ -98,7 +98,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purpleSubtle,
       implement: theme.accentSubtle,
       review: theme.orangeSubtle,
-      hitl: theme.yellowSubtle,
+      hitl: theme.redSubtle,
       merged: theme.greenSubtle,
     })
   })

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -51,7 +51,7 @@ export const PIPELINE_STAGES = [
   { key: 'plan',      label: 'Plan',      color: theme.purple,      subtleColor: theme.purpleSubtle,  role: 'planner',     configKey: 'max_planners', track: 'junction' },
   { key: 'implement', label: 'Implement', color: theme.accent,      subtleColor: theme.accentSubtle,  role: 'implementer', configKey: 'max_workers',  track: 'engineering' },
   { key: 'review',    label: 'Review',    color: theme.orange,      subtleColor: theme.orangeSubtle,  role: 'reviewer',    configKey: 'max_reviewers', track: 'engineering' },
-  { key: 'hitl',      label: 'Needs Human', color: theme.yellow,    subtleColor: theme.yellowSubtle,  role: null,           configKey: null,           track: 'engineering' },
+  { key: 'hitl',      label: 'Needs Human', color: theme.red,       subtleColor: theme.redSubtle,     role: null,           configKey: null,           track: 'engineering' },
   { key: 'merged',    label: 'Merged',    color: theme.green,       subtleColor: theme.greenSubtle,   role: null,           configKey: null,           track: 'engineering' },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "hydraflow"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## What

The dashboard's **"Needs Human" (hitl)** pipeline stage shared `theme.yellow` with **Triage**, making the two indistinguishable in the stage legend. This recolors every *active* HITL/escalation surface to `theme.red`.

### Changed (yellow → red)
- `constants.js` — canonical `PIPELINE_STAGES` hitl stage (`color` + `subtleColor`)
- `StreamView.jsx` — `NO_ROLE_DOT_COLORS`, `flowDotHitlStyles`, `epicFlowDotHitlStyles` (+ comment)
- `StreamCard.jsx` — `dotStyles.hitl` (the `!` dot) + `badgeStyleMap.hitl`
- `IssueHistoryPanel.jsx` — hitl status badge
- `HarnessInsightsPanel.jsx` — `hitl_escalation` category (was the lone yellow holdout; `EventLog` already had it red)

### Deliberately left alone
The **resolved-outcome** palette stays distinct: `hitl_approved`=green, `hitl_closed`=orange, `hitl_skipped`=yellow. These render only in the outcomes/metrics views and recoloring `hitl_skipped` red would re-introduce a clash with `failed`=red and wrongly signal failure for a benign dismissal.

### Known tradeoff
In the glyph-less StreamView *flow dots*, "Needs Human" and "Failed" now share red. Everywhere with a glyph/label (StreamCard `!` vs `✗`, badges, legend) they remain distinct.

## Version
`0.9.3 → 0.9.4` (`pyproject.toml` + `uv.lock`).

## Tests
Test assertions moved with the behavior (`StreamView.test.jsx`, `constants.test.js`). Full UI suite green: **61 files, 1077 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)