### PR TITLE
Promote rc/2026-06-03-0314 → main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,9 +237,13 @@ scenario-browser: deps
 	@echo "$(GREEN)Browser scenario tests passed$(RESET)"
 
 trust-adversarial: deps
+ifeq ($(FORMAT),json)
+	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) python tests/trust/adversarial/corpus_runner.py --json
+else
 	@echo "$(BLUE)Running adversarial skill corpus...$(RESET)"
 	@cd $(HYDRAFLOW_DIR) && PYTHONPATH=src $(UV) pytest tests/trust/adversarial/ -v
 	@echo "$(GREEN)Adversarial corpus passed$(RESET)"
+endif
 
 trust-contracts: deps
 	@echo "$(BLUE)Running fake contract tests...$(RESET)"

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-02T20:00:20.240473+00:00",
-  "commit_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594",
+  "regenerated_at": "2026-06-02T20:24:48.558525+00:00",
+  "commit_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135",
   "artifacts": {
     "loops.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "ports.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "labels.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "modules.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "events.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "adr_xref.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "mockworld.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "changelog.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "coverage_matrix.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "functional_areas.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "ubiquitous-language.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
+      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-02T16:38:32.755932+00:00",
-  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
+  "regenerated_at": "2026-06-02T20:00:20.240473+00:00",
+  "commit_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594",
   "artifacts": {
     "loops.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "ports.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "labels.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "modules.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "events.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "adr_xref.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "mockworld.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "changelog.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "coverage_matrix.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "functional_areas.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "ubiquitous-language.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
+      "source_sha": "27e956c3f852bf1f58da0804a4eb0d2db94f5594"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-01T17:28:50.890337+00:00",
-  "commit_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921",
+  "regenerated_at": "2026-06-02T16:38:32.755932+00:00",
+  "commit_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ports.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "labels.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "modules.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "events.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "adr_xref.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "mockworld.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "changelog.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "coverage_matrix.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "functional_areas.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ba038a6fe486c0abf4c3fce8e3148041bf1da921"
+      "source_sha": "bba9fda034127f710fcf469b4ae5c7d96c2f45ff"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-02T20:48:07.809183+00:00",
-  "commit_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed",
+  "regenerated_at": "2026-06-03T00:03:40.102567+00:00",
+  "commit_sha": "6c586f9407cdad08651c87e128a616922a77a9f7",
   "artifacts": {
     "loops.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "ports.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "labels.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "modules.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "events.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "adr_xref.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "mockworld.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "changelog.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "coverage_matrix.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "functional_areas.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "ubiquitous-language.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
+      "source_sha": "6c586f9407cdad08651c87e128a616922a77a9f7"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-02T20:24:48.558525+00:00",
-  "commit_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135",
+  "regenerated_at": "2026-06-02T20:48:07.809183+00:00",
+  "commit_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed",
   "artifacts": {
     "loops.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "ports.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "labels.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "modules.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "events.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "adr_xref.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "mockworld.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "changelog.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "coverage_matrix.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "functional_areas.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "ubiquitous-language.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "93266cb37eb1f34a39186fbd6a96885037ac1135"
+      "source_sha": "1e8d21c6fc62b2f27644ca5da1cf4f60ee95d7ed"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `27e956c` — fix(sandbox): repair s05 diagnose→HITL flow (fake fidelity + diagnostic runner bypass) *(2026-06-02)*
 - `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
 - `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
 - `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
-- `27e956c` — fix(sandbox): repair s05 diagnose→HITL flow (fake fidelity + diagnostic runner bypass) *(2026-06-02)*
+- `988b95b` — fix(dependabot): cache all open PRs so DependabotMergeLoop can see bot PRs (s09) *(2026-06-02)*
 - `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
 - `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
 - `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
-- `988b95b` — fix(dependabot): cache all open PRs so DependabotMergeLoop can see bot PRs (s09) *(2026-06-02)*
+- `1e8d21c` — chore(arch): regenerate changelog + meta after s30 fix *(2026-06-02)*
 - `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
 - `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
 - `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
-- `1e8d21c` — chore(arch): regenerate changelog + meta after s30 fix *(2026-06-02)*
+- `6c586f9` — chore(arch): regen generated artifacts for sandbox e2e batch 1 scenarios *(2026-06-02)*
+- `04dc3a6` — fix(workers): surface all 45 background loops in System tab + register github_cache (#9153) (#9153) *(2026-06-02)*
 - `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
 - `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
 - `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `7caa4bb` — docs(memory): add critical workflow feedback (#9140) (#9140) *(2026-06-01)*
+- `5f59fb2` — docs(adr): promote ADR-0049 + ADR-0045 to Accepted; fix stale port-conformance ref (WS-6) (#9112) (#9112) *(2026-06-01)*
+- `3639644` — feat(gates): GateActivatorLoop — propose activating planned gates as surfaces land (ADR-0082 Slice 4) (#9138) (#9138) *(2026-06-01)*
 - `85e9c95` — refactor(review): retire vestigial max_veto_retries; derive retry cap from authority (#9136) (#9136) *(2026-06-01)*
 - `650e8a9` — reconcile: staging-canonical resolution + onboarding re-integration *(2026-06-01)*
 - `d2dc597` — merge: reconcile main into staging (resolve onboarding divergence) *(2026-06-01)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -19,7 +19,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `CorpusLearningLoop` | ✅ [0045] | ✅ [corpus-learning-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_corpus_learning_loop.py` | ✅ in catalog | ✅ `s22_corpus_learning_no_escape_issues.py` |
 | `CostBudgetWatcherLoop` | ✅ [0054] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_cost_budget_watcher_loop.py` | ✅ in catalog | ✅ `s26_cost_budget_watcher_unlimited.py` |
 | `DependabotMergeLoop` | ✅ [0054, 0057, 0058] | ✅ [dependabot-merge-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_dependabot_merge_loop.py` | ✅ in catalog | ✅ `s09_dependabot_auto_merge.py` |
-| `DiagnosticLoop` | ✅ [0050] | ✅ [diagnostic-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s32_diagnostic_no_failures.py` |
+| `DiagnosticLoop` | ✅ [0050] | ✅ [diagnostic-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagnostic_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `DiagramLoop` | ✅ [0001] | ✅ [diagram-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_diagram_loop.py` | ✅ in catalog | ✅ `s34_diagram_loop_no_changes.py` |
 | `EdgeProposerLoop` | ✅ [0058, 0060, 0062] | ✅ [edge-proposer-loop.md, entry-evidence-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_edge_proposer_loop.py` | ✅ in catalog | ✅ `s28_edge_proposer_no_proposals.py` |
 | `EntryEvidenceLoop` | ✅ [0062, 0078] | ✅ [edge-proposer-loop.md, entry-evidence-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
@@ -49,7 +49,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `StagingBisectLoop` | ✅ [0045, 0048, 0063] | ✅ [architecture.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_bisect_loop.py` | ✅ in catalog | ❌ |
 | `StagingPromotionLoop` | ✅ [0042] | ✅ [patterns.md] | ✅ loops.md | ✅ README.md | ✅ `test_staging_promotion_loop.py` | ✅ in catalog | ❌ |
 | `StaleIssueGCLoop` | ✅ [0029, 0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_gc_loop.py` | ✅ in catalog | ❌ |
-| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s16_stale_issue_scan.py` |
+| `StaleIssueLoop` | ✅ [0072] | ✅ [gotchas.md, stale-issue-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_stale_issue_loop.py` | ✅ in catalog | ✅ `s05_hitl_after_review_exhaustion.py` |
 | `TermProposerLoop` | ✅ [0054, 0057, 0060, 0061, 0062, 0068] | ✅ [bot-pr-port.md, entry-evidence-loop.md, task.md, term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_proposer_loop.py` | ✅ in catalog | ❌ |
 | `TermPrunerLoop` | ✅ [0057, 0060, 0062, 0068] | ✅ [term-pruner-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_term_pruner_loop.py` | ✅ in catalog | ❌ |
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -29,11 +29,11 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ✅ [flake-tracker-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GateActivatorLoop` | ✅ [0082] | ❌ | ✅ loops.md | ❌ | ✅ `test_gate_activator_loop.py` | ✅ in catalog | ✅ `s45_gate_activator_no_proposals.py` |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_github_cache_loop.py` | ✅ in catalog | ✅ `s44_github_cache_idle_poll.py` |
-| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ❌ |
+| `HealthMonitorLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_health_monitor_loop_primary_cycle.py` | ✅ in catalog | ✅ `s48_health_monitor_idle_poll.py` |
 | `LabelDriftWatcherLoop` | ✅ [0056] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_label_drift_watcher_loop.py` | ✅ in catalog | ❌ |
 | `LiveCorpusReplayLoop` | ✅ [0086] | ✅ [live-corpus-replay-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_live_corpus_replay_loop.py` | ✅ in catalog | ✅ `s43_live_corpus_replay_idle.py` |
 | `MemoryBacklogLoop` | ✅ [0057] | ✅ [README.md] | ✅ loops.md | ✅ README.md | ✅ `test_memory_backlog_loop.py` | ✅ in catalog | ❌ |
-| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ❌ |
+| `MergeStateWatcherLoop` | ✅ [0075, 0077] | ✅ [merge-state-watcher-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_merge_state_watcher_loop.py` | ✅ in catalog | ✅ `s49_merge_state_watcher_idle_poll.py` |
 | `PRUnstickerLoop` | ✅ [0075, 0077] | ✅ [pr-unsticker-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pr_unsticker_loop.py` | ✅ in catalog | ✅ `s08_pr_unsticker_revives_stuck_pr.py` |
 | `PricingRefreshLoop` | ✅ [0078] | ✅ [pricing-refresh-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_pricing_refresh_loop_scenario.py` | ✅ in catalog | ❌ |
 | `PrinciplesAuditLoop` | ✅ [0045, 0056] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_principles_audit_loop.py` | ✅ in catalog | ❌ |
@@ -41,7 +41,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `RepoWikiLoop` | ✅ [0032, 0053, 0061, 0062, 0064] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_repo_wiki_loop.py` | ✅ in catalog | ❌ |
 | `ReportIssueLoop` | ✅ [0013, 0018, 0028] | ✅ [report-issue-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_report_issue_loop.py` | ✅ in catalog | ✅ `s19_report_issue_empty_queue.py` |
 | `RetrospectiveLoop` | ✅ [0074] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_retrospective_loop.py` | ✅ in catalog | ✅ `s18_retrospective_empty_queue.py` |
-| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ❌ |
+| `RunsGCLoop` | ✅ [0073] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_runs_gc_loop.py` | ✅ in catalog | ✅ `s47_runs_gc_idle_poll.py` |
 | `SandboxFailureFixerLoop` | ✅ [0052, 0063] | ✅ [dark-factory.md] | ✅ loops.md | ✅ README.md | ✅ `test_sandbox_failure_fixer_loop.py` | ✅ in catalog | ✅ `s38_sandbox_fixer_richer_context.py` |
 | `SecurityPatchLoop` | ✅ [0029, 0065] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_security_patch_loop.py` | ✅ in catalog | ✅ `s21_security_patch_no_alerts.py` |
 | `SentryLoop` | ✅ [0055] | ✅ [sentry-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_sentry_loop.py` | ✅ in catalog | ✅ `s42_sentry_ingest_no_credentials.py` |
@@ -55,7 +55,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `TriageRetryLoop` | ✅ [0063] | ❌ | ✅ loops.md | ✅ README.md | ✅ `test_triage_retry_loop.py` | ✅ in catalog | ❌ |
 | `TrustFleetSanityLoop` | ✅ [0045, 0046] | ✅ [testing.md] | ✅ loops.md | ✅ README.md | ✅ `test_trust_fleet_sanity_loop.py` | ✅ in catalog | ❌ |
 | `WikiRotDetectorLoop` | ✅ [0045, 0056, 0057] | ✅ [wiki-rot-detector-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_wiki_rot_detector_loop.py` | ✅ in catalog | ❌ |
-| `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ❌ |
+| `WorkspaceGCLoop` | ✅ [0069] | ✅ [workspace-gc-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_workspace_gc_loop.py` | ✅ in catalog | ✅ `s46_workspace_gc_idle_poll.py` |
 ## Section 2: Ports
 
 Cassette and Contract columns are N/A for all ports (ADR-0047 contracts are

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ exclude = ["ui*", "templates*", "tests*"]
 
 [project]
 name = "hydraflow"
-version = "0.9.3"
+version = "0.9.4"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "pydantic>=2.0.0",

--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from exception_classify import reraise_on_credit_or_bug
 
 logger = logging.getLogger("hydraflow.auto_agent_preflight")
 
@@ -281,6 +282,9 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
             created = await self._workspaces.create(issue_number, branch)
             return str(created)
         except Exception as exc:
+            # Credit-exhaustion / likely-bug signals must propagate, not be
+            # swallowed by the broad guard (ADR-0049 / dark-factory mandate).
+            reraise_on_credit_or_bug(exc)
             # Workspace creation can fail (concurrent worktree, branch
             # collision, disk pressure). Degrade to repo_root so the
             # agent still gets a valid cwd; the agent itself can handle

--- a/src/config.py
+++ b/src/config.py
@@ -2409,6 +2409,17 @@ class HydraFlowConfig(BaseModel):
             "(spec §8). Override if the sandbox org is renamed."
         ),
     )
+    contract_refresh_external_enabled: bool = Field(
+        default=True,
+        description=(
+            "Run ContractRefreshLoop's external recorders (github → "
+            "contracts-sandbox repo, claude → api.anthropic.com, docker → "
+            "alpine image pull). Disabling skips them so the loop completes "
+            "fast in the air-gapped sandbox (only the local git recorder "
+            "runs); each external recorder otherwise blocks up to the 120s "
+            "subprocess timeout. Production defaults to True."
+        ),
+    )
 
     # Trust fleet — TrustFleetSanityLoop (spec §12.1)
     trust_fleet_sanity_interval: int = Field(

--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -198,12 +198,26 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         """
         sandbox_dir = self._config.repo_root / _GIT_SANDBOX_RELPATH
 
+        # The git recorder is local (a fixture dir + local git) and always
+        # runs. The github/docker/claude recorders reach external services
+        # (contracts-sandbox repo, an alpine image pull, api.anthropic.com)
+        # and each blocks up to the 120s subprocess timeout when those are
+        # unreachable — e.g. the air-gapped sandbox. ``contract_refresh_
+        # external_enabled=False`` skips them so the loop still completes and
+        # emits its worker-status event promptly (s30). Skipped recorders
+        # report ``[]``, which the diff layer already treats as no-signal.
+        external = self._config.contract_refresh_external_enabled
+
         recorded: dict[str, list[Path]] = {}
-        recorded["github"] = await self._record_with_trace(
-            "contract_recording.record_github",
-            record_github,
-            _SANDBOX_GITHUB_REPO,
-            tmp_root / "github",
+        recorded["github"] = (
+            await self._record_with_trace(
+                "contract_recording.record_github",
+                record_github,
+                _SANDBOX_GITHUB_REPO,
+                tmp_root / "github",
+            )
+            if external
+            else []
         )
         recorded["git"] = await self._record_with_trace(
             "contract_recording.record_git",
@@ -211,15 +225,23 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             sandbox_dir,
             tmp_root / "git",
         )
-        recorded["docker"] = await self._record_with_trace(
-            "contract_recording.record_docker",
-            record_docker,
-            tmp_root / "docker",
+        recorded["docker"] = (
+            await self._record_with_trace(
+                "contract_recording.record_docker",
+                record_docker,
+                tmp_root / "docker",
+            )
+            if external
+            else []
         )
-        recorded["claude"] = await self._record_with_trace(
-            "contract_recording.record_claude_stream",
-            record_claude_stream,
-            tmp_root / "claude",
+        recorded["claude"] = (
+            await self._record_with_trace(
+                "contract_recording.record_claude_stream",
+                record_claude_stream,
+                tmp_root / "claude",
+            )
+            if external
+            else []
         )
         return recorded
 

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -167,6 +167,159 @@ _bg_worker_defs = [
         "Cost Budget Watcher",
         "Polls rolling-24h LLM spend; disables caretaker loops when daily cap exceeded. Default unlimited.",
     ),
+    # --- Background loops surfaced in the System tab (parity with bg_loop_registry;
+    # enforced by tests/test_loop_wiring_completeness.py). Labels/descriptions mirror
+    # ui/src/constants.js BACKGROUND_WORKERS. ---
+    (
+        "adr_touchpoint_auditor",
+        "ADR Touchpoint Auditor",
+        "Scans recently-merged PRs for ADR drift — cited src/ modules changed without the ADR being updated. Replaces the synchronous touchpoint gate. See ADR-0056.",
+    ),
+    (
+        "auto_agent_preflight",
+        "Auto-Agent Pre-Flight",
+        "Intercepts hitl-escalation issues; runs an emulated-engineer subprocess to attempt autonomous resolution before the issue surfaces to a human (spec §1–§11; ADR-0050).",
+    ),
+    (
+        "branch_protection_auditor",
+        "Branch Protection Auditor",
+        "Audits live GitHub branch protection against the canonical rulesets generated from gates.toml; files an issue on drift. See ADR-0082.",
+    ),
+    (
+        "ci_monitor",
+        "CI Monitor",
+        "Detects failing CI on main and files/auto-closes issues.",
+    ),
+    (
+        "dependabot_merge",
+        "Dependabot Merge",
+        "Auto-merges dependency update PRs from configured bots after CI passes.",
+    ),
+    (
+        "diagnostic",
+        "Diagnostic Agent",
+        "Analyzes escalated issues, classifies severity, and attempts targeted fixes before HITL.",
+    ),
+    (
+        "diagram_loop",
+        "Diagram Loop (L24)",
+        "Self-documenting architecture caretaker. Walks src/, tests/, docs/adr/ every 4h; emits regenerated docs/arch/generated/ markdown + opens a PR when the live truth has drifted. Per ADR-0029 (caretaker pattern) and the Architecture Knowledge System spec.",
+    ),
+    (
+        "edge_proposer",
+        "Edge Proposer",
+        "Caretaker that proposes depends_on + implements edges between existing UL terms based on import graph + class inheritance. See ADR-0058.",
+    ),
+    (
+        "entry_evidence",
+        "Entry Evidence",
+        "Caretaker that links wiki entries to UL terms via LLM matching, populating Term.evidence so the Atlas Domain view can render entry leaves under their term parents. See ADR-0062.",
+    ),
+    (
+        "epic_monitor",
+        "Epic Monitor",
+        "Detects stale epics and refreshes progress cache so the dashboard shows accurate sub-issue rollups.",
+    ),
+    (
+        "epic_sweeper",
+        "Epic Sweeper",
+        "Periodically sweeps open epics and auto-closes those with all sub-issues resolved.",
+    ),
+    (
+        "gate_activator",
+        "Gate Activator",
+        "Proposes activating planned gates in gates.toml once the surface each protects exists (producing job + make target present, profile matches); files a reviewed issue. See ADR-0082.",
+    ),
+    (
+        "github_cache",
+        "GitHub Cache",
+        "Single-poller cache for GitHub data; serves all dashboard + loop consumers from one shared snapshot to avoid rate-limit fan-out.",
+    ),
+    (
+        "health_monitor",
+        "Health Monitor",
+        "Analyzes pipeline trends, auto-tunes parameters, detects knowledge gaps, and ingests log patterns.",
+    ),
+    (
+        "label_drift_watcher",
+        "Label Drift Watcher",
+        "Periodic scan for cross-entity issue/PR label drift (e.g., issue at hydraflow-ready while linked PR at hydraflow-review with commits); reconciles via per-entity swap_pipeline_labels. See ADR-0056.",
+    ),
+    (
+        "live_corpus_replay",
+        "Live Corpus Replay",
+        "Diffs fresh shadow-corpus samples against fake-adapter outputs to catch value-level drift between real and fake adapters; files one hydraflow-find issue per unique drift signature. See #8786 / ADR-0045.",
+    ),
+    (
+        "memory_backlog",
+        "Memory Backlog",
+        "Files hydraflow-find issues for pending entries in docs/wiki/memory-feedback/.",
+    ),
+    (
+        "merge_state_watcher",
+        "Merge State Watcher",
+        "Auto-rebases or HITL-escalates open PRs flagged mergeable=CONFLICTING (RC, dependabot, agent).",
+    ),
+    (
+        "repo_wiki",
+        "Repo Wiki",
+        "Lints and maintains per-repo knowledge wikis compiled from plan/implement/review cycles.",
+    ),
+    (
+        "runs_gc",
+        "Runs GC",
+        "Purges expired pipeline run artifacts per TTL and size-cap config; keeps the runs store from growing unbounded.",
+    ),
+    (
+        "sandbox_failure_fixer",
+        "Sandbox Failure Fixer",
+        "Auto-fixes promotion PRs failing sandbox CI by dispatching the auto-agent",
+    ),
+    (
+        "security_patch",
+        "Security Patch",
+        "Polls Dependabot alerts and files issues for fixable vulnerabilities.",
+    ),
+    (
+        "sentry_ingest",
+        "Sentry Ingest",
+        "Polls Sentry for unresolved errors and files them as GitHub issues for the pipeline.",
+    ),
+    (
+        "staging_promotion",
+        "Staging Promotion",
+        "Cuts release-candidate snapshots from staging and auto-promotes them to main on green CI. See ADR-0042.",
+    ),
+    (
+        "stale_issue",
+        "Stale General Issue Cleanup",
+        "Auto-closes stale general issues (excludes HydraFlow lifecycle labels). Per-tag thresholds, configurable. Distinct from Stale Issue GC, which handles HITL escalations.",
+    ),
+    (
+        "stale_issue_gc",
+        "Stale HITL Issue GC",
+        "Auto-closes stale HITL escalation issues — posts a farewell comment, capped at 10/cycle. Distinct from Stale General Issue Cleanup, which excludes HF lifecycle labels.",
+    ),
+    (
+        "term_proposer",
+        "Term Proposer",
+        "Caretaker that grows the ubiquitous-language glossary by detecting load-bearing classes without terms (S1+S2+S5 signals), drafting them via LLM, and opening auto-merging bot PRs as `confidence: proposed`. See ADR-0054.",
+    ),
+    (
+        "term_pruner",
+        "Term Pruner",
+        "Caretaker that deprecates UL terms whose code_anchor no longer resolves in src/. Companion to TermProposerLoop. See ADR-0057.",
+    ),
+    (
+        "triage_retry",
+        "Triage Retry",
+        "Re-runs parked-issue triage every 24h with the original parking reason as context. Caps at 3 retries before escalating to HITL with the triage-retry-exhausted sub-label. Closes the only factory phase with no autonomous re-entry path. See ADR-0063 W2.",
+    ),
+    (
+        "workspace_gc",
+        "Workspace GC",
+        "Garbage-collects stale workspaces and orphaned branches.",
+    ),
 ]
 
 # Workers that have independent configurable intervals
@@ -553,6 +706,15 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                     interval = 5
             elif name in _PIPELINE_WORKERS:
                 interval = _cfg.poll_interval
+            elif orch and name in _INTERVAL_BOUNDS:
+                # Registry-backed loops surfaced in _bg_worker_defs but absent
+                # from the curated _INTERVAL_WORKERS set: resolve the live
+                # interval (incl. any operator override) straight from the
+                # orchestrator so the System tab shows a real cadence + next_run
+                # and interval edits round-trip. _INTERVAL_BOUNDS is the
+                # editable-interval set, so this covers exactly the controllable
+                # loops without inventing intervals for event-driven ones.
+                interval = orch.get_bg_worker_interval(name)
 
             entry = bg_states.get(name) or persisted_states.get(name)
             if entry:

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -46,7 +46,11 @@ class DependabotMergeLoop(BaseBackgroundLoop):
         processed = self._state.get_dependabot_merge_processed()
         bot_authors = {a.lower() for a in settings.authors}
 
-        open_prs = self._cache.get_open_prs()
+        # Read the label-agnostic snapshot: bot PRs carry only GitHub-native
+        # labels (e.g. ``dependencies``) and are absent from the workflow-label
+        # filtered ``get_open_prs`` snapshot, so filtering that by author would
+        # always be empty in production (the s09 bug).
+        open_prs = self._cache.get_all_open_prs()
         bot_prs = [
             pr
             for pr in open_prs

--- a/src/diagnostic_runner.py
+++ b/src/diagnostic_runner.py
@@ -102,6 +102,29 @@ class DiagnosticRunner(BaseRunner):
             model=self._config.model,
         )
 
+    def _mockworld_diagnosis(self) -> DiagnosisResult | None:
+        """MockWorld bypass for the air-gapped sandbox (ADR-0063 pattern).
+
+        When a ``_mockworld_fake_llm`` sentinel is attached (set by
+        ``sandbox_main`` on the diagnostic runner), Stage-1 diagnosis must
+        not spawn a real ``claude`` subprocess — the sandbox is
+        ``internal: true`` and the call would hang on api-retry backoff,
+        stranding the issue in ``hydraflow-diagnose`` until the scenario
+        times out (s05). Return a not-fixable diagnosis so the loop
+        escalates straight to HITL — the path s05 exercises. Returns
+        ``None`` in production so the real subprocess path runs.
+        """
+        fake_llm = getattr(self, "_mockworld_fake_llm", None)
+        if fake_llm is None or not getattr(fake_llm, "_is_fake_adapter", False):
+            return None
+        return DiagnosisResult(
+            root_cause="MockWorld sandbox diagnosis (no real agent)",
+            severity=Severity.P2_FUNCTIONAL,
+            fixable=False,
+            fix_plan="",
+            human_guidance="Sandbox diagnostic bypass — escalating to human review.",
+        )
+
     async def diagnose(
         self,
         issue_number: int,
@@ -110,6 +133,9 @@ class DiagnosticRunner(BaseRunner):
         context: EscalationContext,
     ) -> DiagnosisResult:
         """Stage 1: Read-only diagnosis against repo root. Returns structured result."""
+        bypass = self._mockworld_diagnosis()
+        if bypass is not None:
+            return bypass
         prompt = _build_diagnosis_prompt(issue_number, issue_title, issue_body, context)
         try:
             cmd = self._build_command()

--- a/src/github_cache_loop.py
+++ b/src/github_cache_loop.py
@@ -73,6 +73,7 @@ class GitHubDataCache:
 
         # In-memory snapshots
         self._open_prs = CacheSnapshot()
+        self._all_open_prs = CacheSnapshot()
         self._hitl_items = CacheSnapshot()
         self._label_counts = CacheSnapshot()
         self._collaborators = CacheSnapshot()
@@ -85,6 +86,16 @@ class GitHubDataCache:
     def get_open_prs(self) -> list[PRListItem]:
         """Return cached open PRs, or empty list if not yet fetched."""
         return self._open_prs.data or []
+
+    def get_all_open_prs(self) -> list[PRListItem]:
+        """Return ALL cached open PRs (label-agnostic), or empty if unfetched.
+
+        Distinct from :meth:`get_open_prs`, which is filtered to workflow
+        labels. ``DependabotMergeLoop`` reads this so it can see bot PRs that
+        carry only GitHub-native labels (e.g. ``dependencies``) and would
+        otherwise be excluded from the label-filtered snapshot.
+        """
+        return self._all_open_prs.data or []
 
     def get_hitl_items(self) -> list[HITLItem]:
         """Return cached HITL items, or empty list if not yet fetched."""
@@ -134,6 +145,19 @@ class GitHubDataCache:
                 reraise_on_credit_or_bug(exc)
                 logger.warning("Cache poll failed for open_prs", exc_info=True)
 
+            # All open PRs (label-agnostic) — consumed by DependabotMergeLoop,
+            # which filters by author. Bot PRs carry only GitHub-native labels
+            # (e.g. ``dependencies``) and are absent from the label-filtered
+            # ``open_prs`` snapshot above. Without this, dependabot_merge never
+            # sees a bot PR and merges nothing (the s09 production bug).
+            try:
+                all_open = await self._prs.list_all_open_prs()
+                self._all_open_prs = CacheSnapshot(data=all_open, fetched_at=now)
+                stats["all_open_prs"] = len(all_open)
+            except Exception as exc:
+                reraise_on_credit_or_bug(exc)
+                logger.warning("Cache poll failed for all_open_prs", exc_info=True)
+
             # HITL items
             try:
                 hitl_labels = list(
@@ -177,7 +201,13 @@ class GitHubDataCache:
         targets = (
             [f"_{dataset}"]
             if dataset
-            else ["_open_prs", "_hitl_items", "_label_counts", "_collaborators"]
+            else [
+                "_open_prs",
+                "_all_open_prs",
+                "_hitl_items",
+                "_label_counts",
+                "_collaborators",
+            ]
         )
         for attr in targets:
             snap = getattr(self, attr, None)
@@ -195,6 +225,11 @@ class GitHubDataCache:
                 data["open_prs"] = [
                     p.model_dump() if hasattr(p, "model_dump") else p
                     for p in self._open_prs.data
+                ]
+            if self._all_open_prs.data is not None:
+                data["all_open_prs"] = [
+                    p.model_dump() if hasattr(p, "model_dump") else p
+                    for p in self._all_open_prs.data
                 ]
             if self._hitl_items.data is not None:
                 data["hitl_items"] = [
@@ -229,6 +264,16 @@ class GitHubDataCache:
                     data=[
                         PRListItem.model_validate(p) if isinstance(p, dict) else p
                         for p in raw["open_prs"]
+                    ],
+                    fetched_at=fetched_at,
+                )
+            if "all_open_prs" in raw:
+                from models import PRListItem  # noqa: PLC0415
+
+                self._all_open_prs = CacheSnapshot(
+                    data=[
+                        PRListItem.model_validate(p) if isinstance(p, dict) else p
+                        for p in raw["all_open_prs"]
                     ],
                     fetched_at=fetched_at,
                 )

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -283,6 +283,11 @@ class FakeGitHub:
             "review": "hydraflow-review",
             "done": "hydraflow-done",
             "hitl": "hydraflow-hitl",
+            # Mirrors PRManager.transition._STAGE_LABEL. Without this, a
+            # "diagnose" transition (review-fix-cap escalation) labels the
+            # issue bare "diagnose"; the DiagnosticLoop scans for
+            # "hydraflow-diagnose" and never sees it, so HITL never forms (s05).
+            "diagnose": "hydraflow-diagnose",
         }
         new_label = stage_label_map.get(new_stage, new_stage)
         if issue_number in self._issues:

--- a/src/mockworld/fakes/fake_github.py
+++ b/src/mockworld/fakes/fake_github.py
@@ -63,6 +63,9 @@ class FakePR:
     reviews: list[tuple[str, str]] = field(default_factory=list)
     checks: list[tuple[str, str]] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
+    # PR author login (e.g. "dependabot[bot]"). Drives DependabotMergeLoop's
+    # bot-PR eligibility (it matches pr.author against the configured bots).
+    author: str = "fake-author"
     # Commit count used by ``find_label_drift`` (ADR-0056) to distinguish
     # zero-commit PRs from real ones. Defaults to 1 so seeded PRs look
     # "real" without explicit setup.
@@ -119,6 +122,7 @@ class FakeGitHub:
                 branch=pr_dict["branch"],
                 ci_status=pr_dict.get("ci_status", "pass"),
                 merged=pr_dict.get("merged", False),
+                author=pr_dict.get("author", "fake-author"),
             )
             for label in pr_dict.get("labels", []):
                 gh.add_pr_label(pr_dict["number"], label)
@@ -152,6 +156,7 @@ class FakeGitHub:
         branch: str,
         ci_status: str = "pass",
         merged: bool = False,
+        author: str = "fake-author",
     ) -> None:
         """Directly insert a PR record (sync helper for test seeding).
 
@@ -165,6 +170,7 @@ class FakeGitHub:
             branch=branch,
             merged=merged,
             ci_status=ci_status,
+            author=author,
         )
 
     def add_pr_label(self, pr_number: int, label: str) -> None:
@@ -909,10 +915,37 @@ class FakeGitHub:
                     draft=pr.draft,
                     title="",
                     merged=pr.merged,
-                    author="fake-author",
+                    author=pr.author,
                 )
             )
         return out
+
+    async def list_all_open_prs(self) -> list[Any]:
+        """Return ALL open PRs regardless of label, including author login.
+
+        Mirrors ``PRManager.list_all_open_prs``. Used by ``GitHubCacheLoop``
+        to warm the all-open-PRs snapshot that ``DependabotMergeLoop`` reads
+        (it filters by author). Bot PRs carry only GitHub-native labels like
+        ``dependencies`` and are invisible to the label-filtered
+        ``list_open_prs`` cache — this method does not filter by label.
+        """
+        self._maybe_rate_limit()
+        from models import PRListItem
+
+        return [
+            PRListItem(
+                pr=pr.number,
+                issue=pr.issue_number,
+                branch=pr.branch,
+                url=pr.url or "",
+                draft=pr.draft,
+                title="",
+                merged=pr.merged,
+                author=pr.author,
+            )
+            for pr in self._prs.values()
+            if not pr.merged
+        ]
 
     async def _run_gh(self, *cmd: str, cwd: Any = None) -> str:
         """Generic ``gh`` CLI passthrough — returns minimal-shape JSON.

--- a/src/mockworld/fakes/fake_issue_store.py
+++ b/src/mockworld/fakes/fake_issue_store.py
@@ -64,6 +64,7 @@ STAGE_READY = "ready"
 STAGE_REVIEW = "review"
 STAGE_HITL = "hitl"
 STAGE_MERGED = "merged"
+STAGE_DIAGNOSE = "diagnose"
 
 _LABEL_TO_STAGE: dict[str, str] = {
     "hydraflow-find": STAGE_FIND,
@@ -73,6 +74,11 @@ _LABEL_TO_STAGE: dict[str, str] = {
     "hydraflow-ready": STAGE_READY,
     "hydraflow-review": STAGE_REVIEW,
     "hydraflow-hitl": STAGE_HITL,
+    # Review-fix-cap escalation routes through the diagnostic loop:
+    # enqueue_transition(task, "diagnose") must map to hydraflow-diagnose,
+    # else the transition is silently dropped and the issue never reaches
+    # the DiagnosticLoop (which polls hydraflow-diagnose). See s05.
+    "hydraflow-diagnose": STAGE_DIAGNOSE,
 }
 
 

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -282,6 +282,12 @@ async def main() -> None:
     spec_reviewer = getattr(svc.implementer, "_spec_reviewer", None)
     if spec_reviewer is not None:
         spec_reviewer._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]
+    # DiagnosticRunner.diagnose spawns a real ``claude`` subprocess that hangs
+    # in the air-gapped sandbox; the sentinel routes it to a not-fixable
+    # diagnosis so review-fix-cap escalations reach HITL (s05).
+    diagnostic_runner = getattr(svc.diagnostic_loop, "_runner", None)
+    if diagnostic_runner is not None:
+        diagnostic_runner._mockworld_fake_llm = fake_llm  # type: ignore[attr-defined]
 
     orch = HydraFlowOrchestrator(
         config,

--- a/src/mockworld/sandbox_main.py
+++ b/src/mockworld/sandbox_main.py
@@ -159,6 +159,13 @@ async def main() -> None:
     #   this flag (see src/plan_phase.py).
     config.transcript_summarization_enabled = False  # type: ignore[misc]
     config.research_enabled = False  # type: ignore[misc]
+    # ContractRefreshLoop's github/claude/docker recorders reach external
+    # services (contracts-sandbox repo, api.anthropic.com, alpine pull) that
+    # are unreachable on the internal sandbox network; each blocks up to the
+    # 120s subprocess timeout, so the loop never emits its worker-status event
+    # within a scenario's window (s30). Skip them — only the local git
+    # recorder runs.
+    config.contract_refresh_external_enabled = False  # type: ignore[misc]
     seed = _load_seed()
     event_bus = EventBus()
     state = build_state_tracker(config)

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -170,6 +170,7 @@ class HydraFlowOrchestrator:
             "staging_bisect": svc.staging_bisect_loop,
             "stale_issue": svc.stale_issue_loop,
             "sentry_ingest": svc.sentry_loop,
+            "github_cache": svc.github_cache_loop,
             "stale_issue_gc": svc.stale_issue_gc_loop,
             "ci_monitor": svc.ci_monitor_loop,
             "branch_protection_auditor": svc.branch_protection_auditor_loop,

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -717,15 +717,30 @@ class HydraFlowOrchestrator:
         )
 
     async def _pipeline_stats_loop(self) -> None:
-        """Emit pipeline stats every ~10 seconds."""
-        interval = self.get_bg_worker_interval("pipeline_poller")
+        """Emit pipeline stats each cycle as the ``pipeline_poller`` worker.
+
+        Honors the System-tab worker controls the same way the other
+        background workers do: it skips a cycle when the worker is disabled,
+        re-reads its interval each cycle so operator edits take effect without
+        an orchestrator restart, and publishes a per-cycle heartbeat so the
+        dashboard renders an ``ok``/``error`` status instead of a permanently
+        stale row.
+        """
         stats_failures = 0
         while not self._stop_event.is_set():
+            if not self.is_bg_worker_enabled("pipeline_poller"):
+                await self._sleep_or_stop(
+                    self.get_bg_worker_interval("pipeline_poller")
+                )
+                continue
+            interval = self.get_bg_worker_interval("pipeline_poller")
             try:
                 await self.emit_pipeline_stats()
                 stats_failures = 0
+                self.update_bg_worker_status("pipeline_poller", "ok")
             except Exception as exc:
                 stats_failures += 1
+                self.update_bg_worker_status("pipeline_poller", "error")
                 if is_likely_bug(exc) or stats_failures >= 5:
                     logger.critical(
                         "Pipeline stats emission failed (%s, %d consecutive)",
@@ -999,7 +1014,7 @@ class HydraFlowOrchestrator:
             ("stale_issue", self._svc.stale_issue_loop.run),
             ("sentry_ingest", self._svc.sentry_loop.run),
             ("github_cache", self._svc.github_cache_loop.run),
-            ("pipeline_stats", self._pipeline_stats_loop),
+            ("pipeline_poller", self._pipeline_stats_loop),
             ("diagnostic", self._svc.diagnostic_loop.run),
             ("ci_monitor", self._svc.ci_monitor_loop.run),
             (

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2839,6 +2839,55 @@ class PRManager:
 
         return prs
 
+    async def list_all_open_prs(self) -> list[PRListItem]:
+        """Fetch ALL open PRs regardless of label, including author login.
+
+        Unlike :meth:`list_open_prs` (label-filtered for the dashboard/cache),
+        this returns the complete open-PR set so consumers that key on author
+        — notably :class:`DependabotMergeLoop` — can see bot PRs that carry
+        only GitHub-native labels (e.g. ``dependencies``) and would otherwise
+        be invisible to the label-filtered cache.
+
+        Returns ``[]`` in dry-run mode or when the ``gh`` query fails.
+        """
+        if self._config.dry_run:
+            return []
+        self._assert_repo()
+        try:
+            output = await self._run_gh(
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                self._repo,
+                "--state",
+                "open",
+                "--json",
+                "number,headRefName,url,isDraft,title,author",
+                "--limit",
+                "200",
+            )
+            raw_items = json.loads(output)
+        except (RuntimeError, json.JSONDecodeError):
+            logger.warning("list_all_open_prs failed", exc_info=True)
+            return []
+
+        prs: list[PRListItem] = []
+        for item in raw_items:
+            branch = str(item.get("headRefName", ""))
+            prs.append(
+                PRListItem(
+                    pr=int(item.get("number", 0)),
+                    issue=self._issue_number_from_branch(branch),
+                    branch=branch,
+                    url=str(item.get("url", "")),
+                    draft=bool(item.get("isDraft", False)),
+                    title=str(item.get("title", "")),
+                    author=str((item.get("author") or {}).get("login", "")),
+                )
+            )
+        return prs
+
     async def _fetch_hitl_raw_issues(
         self, hitl_labels: list[str]
     ) -> list[dict[str, Any]]:

--- a/src/sandbox_failure_fixer_loop.py
+++ b/src/sandbox_failure_fixer_loop.py
@@ -24,7 +24,7 @@ from config import HydraFlowConfig
 from exception_classify import reraise_on_credit_or_bug
 
 if TYPE_CHECKING:
-    from ports import PRPort
+    from ports import PRPort, WorkspacePort
     from preflight.auto_agent_runner import AutoAgentRunner
     from state import StateTracker
 
@@ -58,6 +58,7 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
         deps: LoopDeps,
         prs: PRPort | Any | None = None,
         runner: AutoAgentRunner | Any | None = None,
+        workspaces: WorkspacePort | Any | None = None,
     ) -> None:
         super().__init__(
             worker_name="sandbox_failure_fixer",
@@ -68,9 +69,43 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
         self._state = state
         self._prs = prs
         self._runner = runner
+        self._workspaces = workspaces
 
     def _get_default_interval(self) -> int:
         return self._config.sandbox_failure_fixer_interval
+
+    async def _resolve_worktree(self, pr: Any) -> str:
+        """Return a filesystem worktree path for *pr* (never its branch name).
+
+        The auto-agent runner uses ``worktree_path`` directly as the subprocess
+        cwd, so it must be a real directory. Mirrors AutoAgentPreflightLoop:
+        reuse the conventional per-issue workspace if present, otherwise create
+        one on the PR's branch (``WorkspacePort.create`` checks out an existing
+        branch so the fix resumes the PR's work). Falls back to ``repo_root``
+        when no ``WorkspacePort`` is wired (test fixtures / dry-run).
+        """
+        if self._workspaces is None:
+            return str(self._config.repo_root)
+        # NOTE: PR and issue numbers share one namespace, so a pre-existing
+        # workspace at this path could belong to an unrelated same-number issue.
+        # We reuse it as-is (matches AutoAgentPreflightLoop); WorkspacePort.create
+        # is only invoked when no workspace exists yet.
+        wt_path = self._config.workspace_path_for_issue(int(pr.number))
+        if wt_path.exists():
+            return str(wt_path)
+        branch = str(getattr(pr, "branch", "") or f"agent/sandbox-fix-{pr.number}")
+        try:
+            created = await self._workspaces.create(int(pr.number), branch)
+            return str(created)
+        except Exception as exc:
+            reraise_on_credit_or_bug(exc)
+            logger.warning(
+                "sandbox-fix worktree creation failed for PR #%d: %s — "
+                "falling back to repo_root",
+                pr.number,
+                exc,
+            )
+            return str(self._config.repo_root)
 
     async def _do_work(self) -> dict[str, Any] | None:
         # ADR-0049 in-body kill-switch (universal mandate).
@@ -132,7 +167,7 @@ class SandboxFailureFixerLoop(BaseBackgroundLoop):
             try:
                 outcome = await runner.run(
                     prompt=await self._build_prompt(pr),
-                    worktree_path=str(getattr(pr, "branch", "")),
+                    worktree_path=await self._resolve_worktree(pr),
                     issue_number=int(pr.number),
                 )
             except Exception as exc:

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1274,6 +1274,7 @@ def build_services(
         deps=loop_deps,
         prs=prs,
         runner=sandbox_failure_fixer_runner,
+        workspaces=workspaces,
     )
 
     # Term-Proposer (ADR-0054). Production adapters wire the loop to:

--- a/src/ui/src/components/HarnessInsightsPanel.jsx
+++ b/src/ui/src/components/HarnessInsightsPanel.jsx
@@ -16,7 +16,7 @@ const CATEGORY_COLORS = {
   quality_gate: theme.orange,
   review_rejection: theme.red,
   ci_failure: theme.red,
-  hitl_escalation: theme.yellow,
+  hitl_escalation: theme.red,
   implementation_error: theme.red,
 }
 

--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -62,7 +62,7 @@ function statusStyle(status) {
   }
   if (status === 'merged') return { ...common, background: theme.greenSubtle || theme.surface, color: theme.green }
   if (status === 'failed') return { ...common, background: theme.redSubtle || theme.surface, color: theme.red }
-  if (status === 'hitl') return { ...common, background: theme.yellowSubtle || theme.surface, color: theme.yellow }
+  if (status === 'hitl') return { ...common, background: theme.redSubtle || theme.surface, color: theme.red }
   if (status === 'active') return { ...common, background: theme.accentSubtle || theme.surface, color: theme.accent }
   return { ...common, background: theme.surfaceInset, color: theme.textMuted }
 }

--- a/src/ui/src/components/StreamCard.jsx
+++ b/src/ui/src/components/StreamCard.jsx
@@ -298,7 +298,7 @@ export const dotStyles = {
   },
   done: { fontSize: 11, fontWeight: 700, color: theme.green },
   failed: { fontSize: 11, fontWeight: 700, color: theme.red },
-  hitl: { fontSize: 11, fontWeight: 700, color: theme.yellow },
+  hitl: { fontSize: 11, fontWeight: 700, color: theme.red },
   queued: {
     display: 'inline-block',
     width: 8,
@@ -327,7 +327,7 @@ export const badgeStyleMap = {
   active: { ...badgeBase, background: theme.accentSubtle, color: theme.accent },
   done: { ...badgeBase, background: theme.greenSubtle, color: theme.green },
   failed: { ...badgeBase, background: theme.redSubtle, color: theme.red },
-  hitl: { ...badgeBase, background: theme.yellowSubtle, color: theme.yellow },
+  hitl: { ...badgeBase, background: theme.redSubtle, color: theme.red },
   pending: { ...badgeBase, background: theme.mutedSubtle, color: theme.textMuted },
 }
 

--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -14,7 +14,7 @@ import {
 
 // No-role stages (role: null) share the worker-less rendering branches, but each
 // carries its own semantics. 'merged' is success (green, "{N} merged"); 'hitl' is
-// an escalation bucket (yellow, "{N} needs human") and must NOT read as success.
+// an escalation bucket (red, "{N} needs human") and must NOT read as success.
 // Keyed by stage.key so adding a no-role stage is one map entry, not a conditional.
 const NO_ROLE_COUNT_LABELS = {
   merged: 'merged',
@@ -22,7 +22,7 @@ const NO_ROLE_COUNT_LABELS = {
 }
 const NO_ROLE_DOT_COLORS = {
   merged: theme.green,
-  hitl: theme.yellow,
+  hitl: theme.red,
 }
 
 function PendingIntentCard({ intent }) {
@@ -574,7 +574,7 @@ const flowDotFailedStyles = Object.fromEntries(
 )
 
 const flowDotHitlStyles = Object.fromEntries(
-  PIPELINE_STAGES.map(s => [s.key, { ...flowDotBase, background: theme.yellow }])
+  PIPELINE_STAGES.map(s => [s.key, { ...flowDotBase, background: theme.red }])
 )
 
 // Epic dot styles — 12px circles with centered "e" text
@@ -609,7 +609,7 @@ const epicFlowDotFailedStyles = Object.fromEntries(
   PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.red }])
 )
 const epicFlowDotHitlStyles = Object.fromEntries(
-  PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.yellow }])
+  PIPELINE_STAGES.map(s => [s.key, { ...epicDotBase, background: theme.red }])
 )
 
 // Grouped style maps for quick lookup in render

--- a/src/ui/src/components/__tests__/StreamView.test.jsx
+++ b/src/ui/src/components/__tests__/StreamView.test.jsx
@@ -76,7 +76,7 @@ describe('HITL issues are rendered in the workstream (WS-RT)', () => {
     expect(screen.getByText('Escalated issue')).toBeTruthy()
   })
 
-  it('labels the hitl bucket as needs-human, not merged, with a yellow dot', () => {
+  it('labels the hitl bucket as needs-human, not merged, with a red dot', () => {
     // The hitl stage has role:null like merged, so it shares the worker-less
     // rendering branches. Those branches must stay stage-aware: a "Needs Human"
     // escalation bucket reading "merged" + green (success) is a mislabel.
@@ -93,7 +93,7 @@ describe('HITL issues are rendered in the workstream (WS-RT)', () => {
 
     const dot = screen.getByTestId('stage-dot-hitl')
     expect(dot.style.background).not.toBe('var(--green)')
-    expect(dot.style.background).toBe('var(--yellow)')
+    expect(dot.style.background).toBe('var(--red)')
   })
 })
 
@@ -747,7 +747,7 @@ describe('PipelineFlow failed and hitl dots', () => {
     expect(dot.style.animation).toBe('')
   })
 
-  it('renders hitl dots with yellow background and no animation', () => {
+  it('renders hitl dots with red background and no animation', () => {
     mockUseHydraFlow.mockReturnValue(defaultHydraFlowContext({
       pipelineIssues: {
         triage: [],
@@ -761,7 +761,7 @@ describe('PipelineFlow failed and hitl dots', () => {
     render(<StreamView {...defaultProps} />)
     const dot = screen.getByTestId('flow-dot-2')
     expect(dot).toBeInTheDocument()
-    expect(dot.style.background).toBe('var(--yellow)')
+    expect(dot.style.background).toBe('var(--red)')
     expect(dot.style.animation).toBe('')
   })
 
@@ -805,9 +805,9 @@ describe('PipelineFlow failed and hitl dots', () => {
     const failedDot = screen.getByTestId('flow-dot-11')
     expect(failedDot.style.background).toBe('var(--red)')
     expect(failedDot.style.animation).toBe('')
-    // HITL: yellow, no animation
+    // HITL: red, no animation (shares Failed's hue in the glyph-less flow view)
     const hitlDot = screen.getByTestId('flow-dot-12')
-    expect(hitlDot.style.background).toBe('var(--yellow)')
+    expect(hitlDot.style.background).toBe('var(--red)')
     expect(hitlDot.style.animation).toBe('')
     // Queued: subtle stage color (accent), no animation
     const queuedDot = screen.getByTestId('flow-dot-13')

--- a/src/ui/src/components/__tests__/constants.test.js
+++ b/src/ui/src/components/__tests__/constants.test.js
@@ -56,7 +56,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purple,
       implement: theme.accent,
       review: theme.orange,
-      hitl: theme.yellow,
+      hitl: theme.red,
       merged: theme.green,
     })
   })
@@ -98,7 +98,7 @@ describe('PIPELINE_STAGES', () => {
       plan: theme.purpleSubtle,
       implement: theme.accentSubtle,
       review: theme.orangeSubtle,
-      hitl: theme.yellowSubtle,
+      hitl: theme.redSubtle,
       merged: theme.greenSubtle,
     })
   })

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -257,7 +257,7 @@ export const WORKER_PRESETS = {
 /**
  * Workers whose interval can be edited from the UI.
  */
-export const EDITABLE_INTERVAL_WORKERS = new Set(['pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'worktree_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
+export const EDITABLE_INTERVAL_WORKERS = new Set(['pr_unsticker', 'merge_state_watcher', 'pipeline_poller', 'report_issue', 'workspace_gc', 'adr_reviewer', 'epic_sweeper', 'epic_monitor', 'dependabot_merge', 'staging_promotion', 'staging_bisect', 'stale_issue', 'security_patch', 'ci_monitor', 'sentry_ingest', 'retrospective', 'principles_audit', 'flake_tracker', 'skill_prompt_eval', 'fake_coverage_auditor', 'adr_touchpoint_auditor', 'memory_backlog', 'rc_budget', 'wiki_rot_detector', 'trust_fleet_sanity', 'contract_refresh', 'corpus_learning', 'live_corpus_replay', 'auto_agent_preflight', 'diagram_loop', 'pricing_refresh', 'cost_budget_watcher', 'label_drift_watcher', 'github_cache', 'runs_gc', 'triage_retry'])
 
 /**
  * Default intervals (in seconds) for system workers.
@@ -269,7 +269,7 @@ export const SYSTEM_WORKER_INTERVALS = {
   pr_unsticker: 3600,
   merge_state_watcher: 600,
   report_issue: 30,
-  worktree_gc: 1800,
+  workspace_gc: 1800,
   adr_reviewer: 86400,
   epic_sweeper: 3600,
   dependabot_merge: 3600,

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -51,7 +51,7 @@ export const PIPELINE_STAGES = [
   { key: 'plan',      label: 'Plan',      color: theme.purple,      subtleColor: theme.purpleSubtle,  role: 'planner',     configKey: 'max_planners', track: 'junction' },
   { key: 'implement', label: 'Implement', color: theme.accent,      subtleColor: theme.accentSubtle,  role: 'implementer', configKey: 'max_workers',  track: 'engineering' },
   { key: 'review',    label: 'Review',    color: theme.orange,      subtleColor: theme.orangeSubtle,  role: 'reviewer',    configKey: 'max_reviewers', track: 'engineering' },
-  { key: 'hitl',      label: 'Needs Human', color: theme.yellow,    subtleColor: theme.yellowSubtle,  role: null,           configKey: null,           track: 'engineering' },
+  { key: 'hitl',      label: 'Needs Human', color: theme.red,       subtleColor: theme.redSubtle,     role: null,           configKey: null,           track: 'engineering' },
   { key: 'merged',    label: 'Merged',    color: theme.green,       subtleColor: theme.greenSubtle,   role: null,           configKey: null,           track: 'engineering' },
 ]
 

--- a/tests/orchestrator_integration_utils.py
+++ b/tests/orchestrator_integration_utils.py
@@ -481,6 +481,7 @@ def build_scripted_services(
     services.staging_bisect_loop = FakeBackgroundLoop()
     services.stale_issue_loop = FakeBackgroundLoop()
     services.sentry_loop = FakeBackgroundLoop()
+    services.github_cache_loop = FakeBackgroundLoop()
     services.stale_issue_gc_loop = FakeBackgroundLoop()
     services.ci_monitor_loop = FakeBackgroundLoop()
     services.branch_protection_auditor_loop = FakeBackgroundLoop()

--- a/tests/regressions/test_issue_6534.py
+++ b/tests/regressions/test_issue_6534.py
@@ -38,6 +38,7 @@ def _make_cache(tmp_path: Path) -> GitHubDataCache:
 
     pr_manager = MagicMock()
     pr_manager.list_open_prs = AsyncMock(return_value=[])
+    pr_manager.list_all_open_prs = AsyncMock(return_value=[])
     pr_manager.list_hitl_items = AsyncMock(return_value=[])
     pr_manager.get_label_counts = AsyncMock(return_value=None)
 
@@ -64,6 +65,21 @@ class TestAuthenticationErrorNotSwallowed:
         """
         cache = _make_cache(tmp_path)
         cache._prs.list_open_prs = AsyncMock(
+            side_effect=AuthenticationError("Bad credentials"),
+        )
+
+        with pytest.raises(AuthenticationError, match="Bad credentials"):
+            await cache.poll()
+
+    @pytest.mark.asyncio
+    async def test_all_open_prs_auth_error_propagates(self, tmp_path: Path) -> None:
+        """When list_all_open_prs raises AuthenticationError, poll() must
+        re-raise it instead of logging a warning and continuing (same
+        guarantee as the other datasets — added with the label-agnostic
+        all-open-PRs snapshot).
+        """
+        cache = _make_cache(tmp_path)
+        cache._prs.list_all_open_prs = AsyncMock(
             side_effect=AuthenticationError("Bad credentials"),
         )
 

--- a/tests/sandbox_scenarios/scenarios/s05_hitl_after_review_exhaustion.py
+++ b/tests/sandbox_scenarios/scenarios/s05_hitl_after_review_exhaustion.py
@@ -24,6 +24,16 @@ def seed() -> MockWorldSeed:
                 ]
             },
         },
+        # Review-fix-cap exhaustion routes the issue through the diagnostic
+        # loop (transition to hydraflow-diagnose), which — when it can't fix —
+        # escalates to hydraflow-hitl; github_cache then surfaces it on
+        # /api/hitl. Restricting to these two caretakers keeps stale_issue
+        # (and other caretakers) from closing the issue mid-flight: FakeGitHub
+        # issues carry an ancient default updated_at, so with all loops enabled
+        # StaleIssueLoop closes issue #1 before the diagnostic loop sees it.
+        # Phase orchestrators (triage/plan/implement/review) run regardless of
+        # loops_enabled (ADR-0049 — they gate on BGWorkerManager, not this cb).
+        loops_enabled=["diagnostic", "github_cache"],
         cycles_to_run=10,
     )
 
@@ -41,12 +51,18 @@ async def assert_outcome(api, page) -> None:
         )
         if not isinstance(items, list):
             return False
-        return any(isinstance(item, dict) and item.get("number") == 1 for item in items)
+        # HITLItem serializes the issue number under "issue" (its model field;
+        # to_camel leaves it unchanged), not "number".
+        return any(isinstance(item, dict) and item.get("issue") == 1 for item in items)
 
+    # Generous timeout: the flow is multi-hop (pipeline review-cycling →
+    # diagnose transition → DiagnosticLoop poll → escalate to hydraflow-hitl →
+    # github_cache poll → /api/hitl), and sandbox caretaker loops poll on a
+    # 60s cadence, so several aligned poll cycles are needed.
     await api.wait_until(
         "/api/hitl",
         _has_issue,
-        timeout=120.0,
+        timeout=240.0,
     )
 
     # UI assertions removed 2026-05-19 — the `hitl-row-1` data-testid no

--- a/tests/sandbox_scenarios/scenarios/s09_dependabot_auto_merge.py
+++ b/tests/sandbox_scenarios/scenarios/s09_dependabot_auto_merge.py
@@ -18,21 +18,41 @@ def seed() -> MockWorldSeed:
                 "ci_status": "pass",
                 "merged": False,
                 "labels": ["dependencies"],
+                # DependabotMergeLoop only merges PRs authored by a configured
+                # bot (default authors include "dependabot[bot]"). Without this
+                # the loop skips the PR (not a bot author).
+                "author": "dependabot[bot]",
             }
         ],
-        loops_enabled=["dependabot_merge"],
+        # github_cache must run too: DependabotMergeLoop reads open PRs from the
+        # GitHubDataCache (cache.get_all_open_prs()), warmed only by the
+        # github_cache loop. The bot PR carries only the GitHub-native
+        # "dependencies" label, so it is absent from the workflow-label-filtered
+        # snapshot — get_all_open_prs (label-agnostic) is what surfaces it.
+        loops_enabled=["dependabot_merge", "github_cache"],
         cycles_to_run=3,
     )
 
 
 async def assert_outcome(api, page) -> None:
-    prs = await api.wait_until(
-        "/api/prs",
+    # /api/prs lists only OPEN PRs, and the workflow-label-filtered cache never
+    # carried this "dependencies"-labeled PR anyway, so a merged dependabot PR
+    # cannot be observed there. Verify the merge via the dependabot_merge
+    # worker-status event, whose details carry the merged count
+    # (DependabotMergeLoop._do_work → {"merged": N}).
+    # dependabot_merge reads the github_cache all-open-PRs snapshot, so it can
+    # only merge once that cache is warm. On the first orchestrator tick the
+    # two caretakers race and dependabot often polls just before github_cache's
+    # first poll (seeing an empty cache → merged=0). Sandbox caretakers poll on
+    # a 60s cadence, so the timeout must span at least one more dependabot poll
+    # after the cache is warm.
+    await api.wait_until(
+        "/api/events",
         lambda p: any(
-            item.get("number") == 100 and item.get("merged") is True
-            for item in p.get("prs", [])
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "dependabot_merge"
+            and e.get("data", {}).get("details", {}).get("merged", 0) >= 1
+            for e in (p if isinstance(p, list) else [])
         ),
-        timeout=45.0,
+        timeout=120.0,
     )
-    pr = next(p for p in prs["prs"] if p["number"] == 100)
-    assert pr["merged"] is True

--- a/tests/sandbox_scenarios/scenarios/s46_workspace_gc_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s46_workspace_gc_idle_poll.py
@@ -1,0 +1,46 @@
+"""s46 - WorkspaceGCLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``WorkspaceGCLoop`` and a GC
+cycle completes (no stale worktrees/branches to collect) without error, proving
+the loop is registered, started, and heartbeating in the real Docker stack.
+Closes part of #9155 (worker-fleet e2e backfill).
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s46_workspace_gc_idle_poll"
+DESCRIPTION = "WorkspaceGCLoop performs an idle GC cycle and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["workspace_gc"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by WorkspaceGCLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "workspace_gc"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "workspace_gc"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one workspace_gc worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s47_runs_gc_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s47_runs_gc_idle_poll.py
@@ -1,0 +1,45 @@
+"""s47 - RunsGCLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``RunsGCLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s47_runs_gc_idle_poll"
+DESCRIPTION = "RunsGCLoop performs an idle purge cycle and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["runs_gc"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by RunsGCLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "runs_gc"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "runs_gc"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one runs_gc worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s48_health_monitor_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s48_health_monitor_idle_poll.py
@@ -1,0 +1,47 @@
+"""s48 - HealthMonitorLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``HealthMonitorLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s48_health_monitor_idle_poll"
+DESCRIPTION = (
+    "HealthMonitorLoop performs an idle analysis cycle and emits worker status."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["health_monitor"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by HealthMonitorLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "health_monitor"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "health_monitor"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one health_monitor worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/scenarios/s49_merge_state_watcher_idle_poll.py
+++ b/tests/sandbox_scenarios/scenarios/s49_merge_state_watcher_idle_poll.py
@@ -1,0 +1,45 @@
+"""s49 - MergeStateWatcherLoop emits worker status for an idle poll.
+
+Golden path: the sandbox runtime starts the real ``MergeStateWatcherLoop`` and an idle cycle
+completes without error, proving the loop is registered, started, and
+heartbeating in the real Docker stack. Closes part of #9155.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s49_merge_state_watcher_idle_poll"
+DESCRIPTION = "MergeStateWatcherLoop performs an idle scan and emits worker status."
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        loops_enabled=["merge_state_watcher"],
+        cycles_to_run=2,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    """Verify a BACKGROUND_WORKER_STATUS event was emitted by MergeStateWatcherLoop."""
+    events_payload = await api.wait_until(
+        "/api/events",
+        lambda payload: any(
+            isinstance(payload, list)
+            and event.get("type") == "background_worker_status"
+            and event.get("data", {}).get("worker") == "merge_state_watcher"
+            for event in (payload if isinstance(payload, list) else [])
+        ),
+        timeout=60.0,
+    )
+
+    worker_events = [
+        event
+        for event in events_payload
+        if event.get("type") == "background_worker_status"
+        and event.get("data", {}).get("worker") == "merge_state_watcher"
+    ]
+    assert len(worker_events) >= 1, (
+        "Expected at least one merge_state_watcher worker-status event; "
+        f"got none. All events: {events_payload!r}"
+    )

--- a/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
+++ b/tests/sandbox_scenarios/seeds/s05_hitl_after_review_exhaustion.json
@@ -1,0 +1,76 @@
+{
+  "repos": [],
+  "issues": [
+    {
+      "number": 1,
+      "title": "t",
+      "body": "b",
+      "labels": [
+        "hydraflow-ready"
+      ]
+    }
+  ],
+  "prs": [],
+  "scripts": {
+    "plan": {
+      "1": [
+        {
+          "success": true
+        }
+      ]
+    },
+    "implement": {
+      "1": [
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        },
+        {
+          "success": true,
+          "branch": "hf/issue-1"
+        }
+      ]
+    },
+    "review": {
+      "1": [
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 1"
+          ]
+        },
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 2"
+          ]
+        },
+        {
+          "verdict": "request-changes",
+          "comments": [
+            "bad 3"
+          ]
+        }
+      ]
+    }
+  },
+  "advisor_scripts": {},
+  "phase_scripts": {},
+  "cycles_to_run": 10,
+  "loops_enabled": [
+    "diagnostic",
+    "github_cache"
+  ],
+  "main_branch_ci_status": [
+    "success",
+    ""
+  ]
+}

--- a/tests/scenarios/browser/scenarios/test_loops_browser.py
+++ b/tests/scenarios/browser/scenarios/test_loops_browser.py
@@ -356,6 +356,10 @@ async def test_l7_dependabot_merge_merges_green_pr(world, page) -> None:
     # --- Step 2: first run to initialize loop cache/state mock refs ---
     await world.run_with_loops(["dependabot_merge"], cycles=1)
     world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs),
+    # not the workflow-label-filtered get_open_prs (s09 fix, #9151). Seed both so
+    # the loop's bot-PR scan finds the seeded PR.
+    world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
     # --- Step 3: second run with configured cache ---
     stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
@@ -406,6 +410,10 @@ async def test_l8_dependabot_merge_skips_red_pr(world, page) -> None:
     # --- Step 2: first run to initialize loop cache/state mock refs ---
     await world.run_with_loops(["dependabot_merge"], cycles=1)
     world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs),
+    # not the workflow-label-filtered get_open_prs (s09 fix, #9151). Seed both so
+    # the loop's bot-PR scan finds the seeded PR.
+    world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
     # --- Step 3: second run with configured cache ---
     stats = await world.run_with_loops(["dependabot_merge"], cycles=1)

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -106,7 +106,19 @@ def _build_workspace_gc(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 def _build_runs_gc(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from runs_gc_loop import RunsGCLoop  # noqa: PLC0415
 
-    run_recorder = ports.get("run_recorder") or MagicMock()
+    run_recorder = ports.get("run_recorder")
+    if run_recorder is None:
+        # Faithful idle fake: a bare MagicMock returns MagicMocks from the
+        # purge calls, which breaks RunsGCLoop's `total_purged > 0` arithmetic.
+        # Return real ints (nothing to purge) + empty storage stats.
+        run_recorder = MagicMock()
+        run_recorder.purge_expired.return_value = 0
+        run_recorder.purge_oversized.return_value = 0
+        run_recorder.get_storage_stats.return_value = {
+            "total_runs": 0,
+            "total_mb": 0.0,
+            "issues": [],
+        }
     ports.setdefault("run_recorder", run_recorder)
     return RunsGCLoop(config=config, run_recorder=run_recorder, deps=deps)
 

--- a/tests/scenarios/fakes/test_fake_github.py
+++ b/tests/scenarios/fakes/test_fake_github.py
@@ -69,6 +69,41 @@ class TestFakeGitHubMutations:
         await gh.transition(1, "plan")
         assert gh.issue(1).labels == ["hydraflow-plan"]
 
+    @pytest.mark.parametrize(
+        ("stage", "expected_label"),
+        [
+            ("find", "hydraflow-find"),
+            ("discover", "hydraflow-discover"),
+            ("shape", "hydraflow-shape"),
+            ("plan", "hydraflow-plan"),
+            ("ready", "hydraflow-ready"),
+            ("review", "hydraflow-review"),
+            ("hitl", "hydraflow-hitl"),
+            ("diagnose", "hydraflow-diagnose"),
+        ],
+    )
+    async def test_transition_applies_canonical_stage_label(
+        self, stage: str, expected_label: str
+    ) -> None:
+        # Mirrors PRManager.transition._STAGE_LABEL — the fake must route every
+        # production stage to its hydraflow-* label. A missing entry silently
+        # labels the issue with the bare stage name, stranding it from the loop
+        # that scans for the canonical label (the s05 diagnose-hop failure).
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-review"])
+        await gh.transition(1, stage)
+        assert gh.issue(1).labels == [expected_label]
+
+    async def test_transition_diagnose_visible_to_diagnostic_loop(self) -> None:
+        # The DiagnosticLoop polls list_issues_by_label("hydraflow-diagnose").
+        # Review-fix-cap escalation transitions the issue to "diagnose"; if the
+        # fake mislabels it, the loop never sees it and HITL never forms (s05).
+        gh = FakeGitHub()
+        gh.add_issue(1, "t", "b", labels=["hydraflow-review"])
+        await gh.transition(1, "diagnose")
+        found = await gh.list_issues_by_label("hydraflow-diagnose")
+        assert [issue["number"] for issue in found] == [1]
+
     async def test_swap_pipeline_labels_removes_existing(self):
         gh = FakeGitHub()
         gh.add_issue(1, "t", "b", labels=["hydraflow-find", "bug"])

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -269,7 +269,11 @@ class TestL7DependabotMergeAutoMerges:
 
         # Initialize loop to get cache/state mock refs, then configure
         await world.run_with_loops(["dependabot_merge"], cycles=1)
+        # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+        # bot PRs carry only the GitHub-native "dependencies" label and are absent
+        # from the workflow-label-filtered get_open_prs snapshot (s09).
         world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
         stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
 
@@ -308,7 +312,11 @@ class TestL8DependabotMergeSkipsOnFailure:
 
         # Initialize and configure
         await world.run_with_loops(["dependabot_merge"], cycles=1)
+        # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+        # bot PRs carry only the GitHub-native "dependencies" label and are absent
+        # from the workflow-label-filtered get_open_prs snapshot (s09).
         world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
         stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
 

--- a/tests/test_adversarial_corpus_harness.py
+++ b/tests/test_adversarial_corpus_harness.py
@@ -1,9 +1,10 @@
-"""Unit tests for tests/trust/adversarial/test_adversarial_corpus.py.
+"""Unit tests for the adversarial corpus runner's per-case evaluation.
 
-Tests harness behavior against synthetic case directories — proves the
-harness parameterizes correctly, enforces keyword assertion, accepts the
-`none` sentinel, and rejects unknown catcher names. Does NOT run the
-real corpus (that's the RC gate's job).
+Tests behaviour against synthetic case directories — proves the runner
+synthesizes diffs, enforces the keyword assertion, accepts the `none`
+sentinel, and rejects unknown catcher names. Does NOT run the real corpus
+(that's the RC gate's job). Complements test_adversarial_corpus_runner.py,
+which covers the loop-facing JSON schema against the committed corpus.
 """
 
 from __future__ import annotations
@@ -13,11 +14,16 @@ from pathlib import Path
 
 import pytest
 
-TRUST_DIR = Path(__file__).resolve().parent / "trust" / "adversarial"
-sys.path.insert(0, str(TRUST_DIR))
+_ADV = Path(__file__).resolve().parent / "trust" / "adversarial"
+if str(_ADV) not in sys.path:
+    sys.path.insert(0, str(_ADV))
 
-# Import harness helpers under test.
-import test_adversarial_corpus as harness  # type: ignore[import-not-found]
+from corpus_runner import (  # noqa: E402
+    evaluate_case,
+    read_expected_catcher,
+    read_keyword,
+    synthesize_diff,
+)
 
 
 def _write_case(
@@ -51,36 +57,41 @@ def _write_case(
     return case
 
 
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
 def test_synthesize_diff_produces_git_headers(tmp_path: Path) -> None:
     (tmp_path / "before").mkdir()
     (tmp_path / "after").mkdir()
     (tmp_path / "before" / "x.py").write_text("old\n")
     (tmp_path / "after" / "x.py").write_text("new\n")
-    diff = harness._synthesize_diff(tmp_path / "before", tmp_path / "after")
+    diff = synthesize_diff(tmp_path / "before", tmp_path / "after")
     assert "diff --git a/x.py b/x.py" in diff
     assert "-old" in diff and "+new" in diff
 
 
 def test_read_keyword_extracts_line(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# title\n\nKeyword: scope creep\n\nmore\n")
-    assert harness._read_keyword(tmp_path / "README.md") == "scope creep"
+    assert read_keyword(tmp_path / "README.md") == "scope creep"
 
 
 def test_read_keyword_missing_raises(tmp_path: Path) -> None:
     (tmp_path / "README.md").write_text("# title\n\nno keyword line\n")
     with pytest.raises(AssertionError, match="missing 'Keyword:' line"):
-        harness._read_keyword(tmp_path / "README.md")
+        read_keyword(tmp_path / "README.md")
 
 
 def test_read_expected_catcher_rejects_unknown(tmp_path: Path) -> None:
     (tmp_path / "expected_catcher.txt").write_text("bogus-skill\n")
     with pytest.raises(AssertionError, match="must be one of"):
-        harness._read_expected_catcher(tmp_path)
+        read_expected_catcher(tmp_path)
 
 
 def test_read_expected_catcher_accepts_sentinel(tmp_path: Path) -> None:
     (tmp_path / "expected_catcher.txt").write_text("none\n")
-    assert harness._read_expected_catcher(tmp_path) == "none"
+    assert read_expected_catcher(tmp_path) == "none"
 
 
 def test_read_expected_catcher_accepts_registered_skills(tmp_path: Path) -> None:
@@ -89,16 +100,18 @@ def test_read_expected_catcher_accepts_registered_skills(tmp_path: Path) -> None
 
     name = BUILTIN_SKILLS[0].name
     (tmp_path / "expected_catcher.txt").write_text(name + "\n")
-    assert harness._read_expected_catcher(tmp_path) == name
+    assert read_expected_catcher(tmp_path) == name
 
 
-def test_test_case_happy_path_uses_transcript_fixture(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """With a canned transcript, the expected_catcher must flag and keyword must match."""
-    cases = tmp_path / "cases"
+# ---------------------------------------------------------------------------
+# evaluate_case behaviour (synthetic cases + canned transcripts)
+# ---------------------------------------------------------------------------
+
+
+def test_catcher_flags_with_keyword_is_pass(tmp_path: Path) -> None:
+    """A transcript where the expected catcher flags + the keyword matches -> PASS."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-synthetic",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -111,16 +124,13 @@ def test_test_case_happy_path_uses_transcript_fixture(
             "FINDINGS:\n- src/unrelated.py — not in plan\n"
         ),
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    harness.test_case(case)  # must not raise
+    assert evaluate_case(case, strict=False)["status"] == "PASS"
 
 
-def test_test_case_raises_when_keyword_missing(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
+def test_catcher_flags_without_keyword_is_fail(tmp_path: Path) -> None:
+    """Flagged but the required keyword is absent -> the catch regressed -> FAIL."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-no-keyword",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -133,17 +143,13 @@ def test_test_case_raises_when_keyword_missing(
             "FINDINGS:\n- src/unrelated.py — not in plan\n"
         ),
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    with pytest.raises(AssertionError, match="did not contain required keyword"):
-        harness.test_case(case)
+    assert evaluate_case(case, strict=False)["status"] == "FAIL"
 
 
-def test_test_case_raises_when_catcher_returns_ok(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
+def test_catcher_returns_ok_is_fail(tmp_path: Path) -> None:
+    """The expected catcher passed the case through (no flag) -> FAIL."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "scope-creep-ok-returned",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 1\n", "src/unrelated.py": "y = 2\n"},
@@ -152,25 +158,18 @@ def test_test_case_raises_when_catcher_returns_ok(
         plan="## Plan\n- Edit `src/foo.py`\n",
         transcript="SCOPE_CHECK_RESULT: OK\nSUMMARY: nothing unusual\n",
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    with pytest.raises(AssertionError, match="returned OK"):
-        harness.test_case(case)
+    assert evaluate_case(case, strict=False)["status"] == "FAIL"
 
 
-def test_test_case_sentinel_none_passes_when_all_skills_ok(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    cases = tmp_path / "cases"
-    # Transcript that every parser reads as OK (no RESULT marker).
-    benign = "No issues found.\n"
+def test_sentinel_none_passes_when_all_skills_ok(tmp_path: Path) -> None:
+    """A benign 'none' case no skill flags -> PASS."""
     case = _write_case(
-        cases,
+        tmp_path / "cases",
         "benign-noop",
         before={"src/foo.py": "x = 1\n"},
         after={"src/foo.py": "x = 2\n"},
         catcher="none",
         keyword="ignored",
-        transcript=benign,
+        transcript="No issues found.\n",
     )
-    monkeypatch.setattr(harness, "CASES_DIR", cases)
-    harness.test_case(case)  # must not raise
+    assert evaluate_case(case, strict=False)["status"] == "PASS"

--- a/tests/test_adversarial_corpus_runner.py
+++ b/tests/test_adversarial_corpus_runner.py
@@ -1,0 +1,85 @@
+"""Unit tests for the adversarial corpus runner (the FORMAT=json producer).
+
+Guards the contract SkillPromptEvalLoop._run_corpus depends on: a JSON list of
+{case_id, skill, status, provenance, expected_catcher} dicts.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ADV = Path(__file__).resolve().parent / "trust" / "adversarial"
+if str(_ADV) not in sys.path:
+    sys.path.insert(0, str(_ADV))
+
+from corpus_runner import (  # noqa: E402
+    CASES_DIR,
+    MissingTranscriptError,
+    evaluate_case,
+    run_corpus,
+)
+
+_LOOP_KEYS = {"case_id", "skill", "status", "provenance", "expected_catcher"}
+_VALID_STATUS = {"PASS", "FAIL", "SKIPPED"}
+
+
+def test_run_corpus_returns_loop_schema() -> None:
+    """Every result carries exactly the keys the loop reads, with a valid status."""
+    results = run_corpus(strict=False)
+    assert results, "expected a non-empty committed adversarial corpus"
+    for r in results:
+        assert set(r) >= _LOOP_KEYS, f"missing loop keys: {_LOOP_KEYS - set(r)}"
+        assert r["status"] in _VALID_STATUS
+        assert r["case_id"]
+
+
+def test_committed_corpus_is_all_green() -> None:
+    """The committed fixtures must currently PASS (this is the loop's last-green
+    baseline); a FAIL here means a skill prompt regressed."""
+    failing = [r["case_id"] for r in run_corpus(strict=False) if r["status"] == "FAIL"]
+    assert not failing, f"corpus cases regressed to FAIL: {failing}"
+
+
+def test_evaluate_real_catcher_case() -> None:
+    # Committed corpus fixture — a catcher case the diff-sanity skill must flag.
+    case = CASES_DIR / "missing-import"
+    assert case.is_dir(), "committed corpus case 'missing-import' is missing"
+    result = evaluate_case(case, strict=False)
+    assert result["expected_catcher"] == "diff-sanity"
+    assert result["skill"] == "diff-sanity"
+    assert result["status"] == "PASS"
+
+
+def test_evaluate_real_sentinel_case() -> None:
+    # Committed corpus fixture — a benign 'none' sentinel no skill may flag.
+    case = CASES_DIR / "benign-rename-sentinel"
+    assert case.is_dir(), "committed corpus case 'benign-rename-sentinel' is missing"
+    result = evaluate_case(case, strict=False)
+    assert result["expected_catcher"] == "none"
+    assert result["status"] == "PASS"
+
+
+def _make_case_without_transcript(tmp_path: Path) -> Path:
+    case = tmp_path / "synthetic-case"
+    (case / "before").mkdir(parents=True)
+    (case / "after").mkdir(parents=True)
+    (case / "before" / "x.py").write_text("a = 1\n")
+    (case / "after" / "x.py").write_text("a = 2\n")
+    (case / "expected_catcher.txt").write_text("diff-sanity\n")
+    (case / "README.md").write_text("Keyword: something\n")
+    return case
+
+
+def test_missing_transcript_skipped_when_not_strict(tmp_path: Path) -> None:
+    case = _make_case_without_transcript(tmp_path)
+    result = evaluate_case(case, live=False, strict=False)
+    assert result["status"] == "SKIPPED"
+
+
+def test_missing_transcript_raises_when_strict(tmp_path: Path) -> None:
+    case = _make_case_without_transcript(tmp_path)
+    with pytest.raises(MissingTranscriptError):
+        evaluate_case(case, live=False, strict=True)

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -291,9 +291,9 @@ class TestSystemWorkersEndpoint:
 
         response = await endpoint()
         data = json.loads(response.body)
-        assert len(data["workers"]) == 22
         names = [w["name"] for w in data["workers"]]
-        assert names == [
+        # Stable pipeline-phase prefix.
+        assert names[:7] == [
             "triage",
             "plan",
             "implement",
@@ -301,24 +301,46 @@ class TestSystemWorkersEndpoint:
             "retrospective",
             "review_insights",
             "pipeline_poller",
-            "pr_unsticker",
-            "report_issue",
-            "adr_reviewer",
-            # Trust fleet (ADR-0045)
-            "corpus_learning",
-            "contract_refresh",
-            "staging_bisect",
-            "principles_audit",
-            "flake_tracker",
-            "skill_prompt_eval",
-            "fake_coverage_auditor",
-            "rc_budget",
-            "wiki_rot_detector",
-            "trust_fleet_sanity",
-            # Caretaking — daily upstream pricing refresh
-            "pricing_refresh",
-            "cost_budget_watcher",
         ]
+        # 2026-06-02 worker-fleet visibility audit: 30 background loops were absent
+        # from _bg_worker_defs and therefore invisible in the System tab even though
+        # they ran. Assert the full background fleet is now surfaced (not a frozen
+        # count — the wiring-completeness test enforces registry<->defs parity).
+        for worker in (
+            "github_cache",
+            "workspace_gc",
+            "runs_gc",
+            "epic_monitor",
+            "epic_sweeper",
+            "health_monitor",
+            "gate_activator",
+            "branch_protection_auditor",
+            "diagnostic",
+            "merge_state_watcher",
+            "ci_monitor",
+            "sentry_ingest",
+            "staging_promotion",
+            "stale_issue",
+            "stale_issue_gc",
+            "repo_wiki",
+            "security_patch",
+            "dependabot_merge",
+            "label_drift_watcher",
+            "memory_backlog",
+            "triage_retry",
+            "sandbox_failure_fixer",
+            "auto_agent_preflight",
+            "adr_touchpoint_auditor",
+            "term_proposer",
+            "term_pruner",
+            "edge_proposer",
+            "entry_evidence",
+            "live_corpus_replay",
+            "diagram_loop",
+        ):
+            assert worker in names, f"{worker} missing from System-tab worker catalog"
+        assert len(names) == len(set(names)), "duplicate worker names in catalog"
+        assert len(data["workers"]) >= 45
         assert all(
             isinstance(w["description"], str) and w["description"]
             for w in data["workers"]
@@ -623,11 +645,34 @@ class TestSystemWorkersEndpointIntervals:
         response = await endpoint()
         data = json.loads(response.body)
 
-        retro = next(w for w in data["workers"] if w["name"] == "retrospective")
-        assert retro["interval_seconds"] is None
-
+        # review_insights is a derived/event-driven worker — not a registry loop
+        # and not in _INTERVAL_BOUNDS — so it has no schedulable interval.
         ri = next(w for w in data["workers"] if w["name"] == "review_insights")
         assert ri["interval_seconds"] is None
+
+    @pytest.mark.asyncio
+    async def test_registry_loops_report_their_interval(
+        self, config, event_bus: EventBus, tmp_path: Path
+    ) -> None:
+        """Registry-backed loops surfaced in _bg_worker_defs and editable via
+        _INTERVAL_BOUNDS must report their live interval. Worker-fleet audit:
+        the System tab previously left interval/next_run blank for all of them
+        because the endpoint only resolved intervals for the curated
+        _INTERVAL_WORKERS set.
+        """
+        from orchestrator import HydraFlowOrchestrator
+
+        orch = HydraFlowOrchestrator(config, event_bus=event_bus)
+        router = self._make_router(config, event_bus, tmp_path, orch=orch)
+        endpoint = self._find_endpoint(router, "/api/system/workers")
+        response = await endpoint()
+        data = json.loads(response.body)
+
+        by_name = {w["name"]: w for w in data["workers"]}
+        for name in ("ci_monitor", "retrospective", "github_cache", "workspace_gc"):
+            assert by_name[name]["interval_seconds"] is not None, (
+                f"{name} should report a live interval (worker-fleet visibility)"
+            )
 
     @pytest.mark.asyncio
     async def test_next_run_none_when_no_last_run(

--- a/tests/test_config_env.py
+++ b/tests/test_config_env.py
@@ -473,7 +473,21 @@ class TestEnvVarOverrideTable:
 
 
 class TestOtelConfigFields:
-    def test_config_otel_defaults(self, tmp_path: Path) -> None:
+    def test_config_otel_defaults(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Hermetic: the repo .env sets HF_ENV=dev and HYDRAFLOW_OTEL_ENABLED=true.
+        # Under pytest-xdist, a sibling test that loads .env into os.environ can
+        # leak those into this worker and flip the asserted defaults (the
+        # historical "assert 'dev' == 'local'" flake). Clear the backing env vars
+        # so we assert the true compile-time defaults regardless of leakage.
+        for _var in (
+            "HYDRAFLOW_OTEL_ENABLED",
+            "OTEL_EXPORTER_OTLP_ENDPOINT",
+            "OTEL_SERVICE_NAME",
+            "HF_ENV",
+        ):
+            monkeypatch.delenv(_var, raising=False)
         cfg = HydraFlowConfig(
             repo_root=tmp_path,
             workspace_base=tmp_path / "wt",

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -818,3 +818,58 @@ async def test_escalation_resets_after_clean_tick(
     assert post_count == pre_count + 1, (
         "Escalation should re-fire after an adapter goes clean then drifts again"
     )
+
+
+# ---------------------------------------------------------------------------
+# External-recorder skip (s30 — air-gapped sandbox)
+# ---------------------------------------------------------------------------
+
+
+def _track_recorders(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace each ``record_*`` with a tracker that records its adapter name."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        crl_module, "record_github", lambda *_a, **_k: calls.append("github") or []
+    )
+    monkeypatch.setattr(
+        crl_module, "record_git", lambda *_a, **_k: calls.append("git") or []
+    )
+    monkeypatch.setattr(
+        crl_module, "record_docker", lambda *_a, **_k: calls.append("docker") or []
+    )
+    monkeypatch.setattr(
+        crl_module,
+        "record_claude_stream",
+        lambda *_a, **_k: calls.append("claude") or [],
+    )
+    return calls
+
+
+def test_record_all_skips_external_recorders_when_disabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # contract_refresh_external_enabled=False (the sandbox setting): the three
+    # network/daemon recorders must NOT run (they block on the air-gapped
+    # network up to the 120s subprocess timeout); only the local git recorder
+    # runs. Skipped adapters report [] (no-signal to the diff layer).
+    calls = _track_recorders(monkeypatch)
+    loop = _loop(tmp_path, contract_refresh_external_enabled=False)
+
+    recorded = asyncio.run(loop._record_all(tmp_path / "rec"))
+
+    assert calls == ["git"]
+    assert recorded["github"] == []
+    assert recorded["docker"] == []
+    assert recorded["claude"] == []
+
+
+def test_record_all_runs_all_recorders_when_enabled(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Production default (external_enabled=True): every adapter is recorded.
+    calls = _track_recorders(monkeypatch)
+    loop = _loop(tmp_path, contract_refresh_external_enabled=True)
+
+    asyncio.run(loop._record_all(tmp_path / "rec"))
+
+    assert set(calls) == {"github", "git", "docker", "claude"}

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -67,7 +67,10 @@ def _make_loop(
     )
 
     cache = MagicMock()
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs);
+    # get_open_prs is kept in sync for any incidental reads.
     cache.get_open_prs.return_value = open_prs or []
+    cache.get_all_open_prs.return_value = open_prs or []
 
     prs = MagicMock()
     prs.wait_for_ci = AsyncMock(return_value=ci_result)

--- a/tests/test_diagnostic_runner.py
+++ b/tests/test_diagnostic_runner.py
@@ -229,6 +229,30 @@ class TestDiagnosticRunner:
         assert result.affected_files == ["src/app.py"]
 
     @pytest.mark.asyncio
+    async def test_diagnose_mockworld_bypass_returns_unfixable_without_subprocess(
+        self, runner, monkeypatch
+    ) -> None:
+        # ADR-0063 sentinel: with a fake LLM attached (sandbox), diagnose must
+        # NOT spawn a real subprocess (it hangs air-gapped). It returns a
+        # not-fixable diagnosis so the diagnostic loop escalates to HITL (s05).
+        ctx = EscalationContext(cause="CI failed", origin_phase="review")
+
+        async def boom(*_a, **_kw):
+            raise AssertionError("_execute must not be called in MockWorld mode")
+
+        monkeypatch.setattr(runner, "_execute", boom)
+        fake_llm = MagicMock()
+        fake_llm._is_fake_adapter = True
+        runner._mockworld_fake_llm = fake_llm
+
+        result = await runner.diagnose(
+            issue_number=7, issue_title="t", issue_body="b", context=ctx
+        )
+
+        assert isinstance(result, DiagnosisResult)
+        assert result.fixable is False
+
+    @pytest.mark.asyncio
     async def test_diagnose_returns_unfixable_on_parse_error(
         self, runner, monkeypatch
     ) -> None:

--- a/tests/test_github_cache_loop.py
+++ b/tests/test_github_cache_loop.py
@@ -46,6 +46,7 @@ def _make_cache(
     tmp_path: Path,
     *,
     open_prs: list[PRListItem] | None = None,
+    all_open_prs: list[PRListItem] | None = None,
     hitl_items: list[HITLItem] | None = None,
     label_counts: LabelCounts | None = None,
     collaborators: set[str] | None = None,
@@ -65,11 +66,15 @@ def _make_cache(
     prs = MagicMock()
     if prs_error is not None:
         prs.list_open_prs = AsyncMock(side_effect=prs_error)
+        prs.list_all_open_prs = AsyncMock(side_effect=prs_error)
         prs.list_hitl_items = AsyncMock(side_effect=hitl_error or prs_error)
         prs.get_label_counts = AsyncMock(side_effect=label_error or prs_error)
     else:
         prs.list_open_prs = AsyncMock(
             return_value=open_prs if open_prs is not None else []
+        )
+        prs.list_all_open_prs = AsyncMock(
+            return_value=all_open_prs if all_open_prs is not None else []
         )
         prs.list_hitl_items = (
             AsyncMock(
@@ -262,6 +267,71 @@ class TestGitHubDataCachePoll:
         assert "hitl_items" in stats
         assert "label_counts" in stats
         assert "collaborators" in stats
+
+
+# ===========================================================================
+# GitHubDataCache — all-open-PRs snapshot (label-agnostic; s09)
+# ===========================================================================
+
+
+class TestGitHubDataCacheAllOpenPrs:
+    @pytest.mark.asyncio
+    async def test_get_all_open_prs_empty_before_poll(self, tmp_path: Path) -> None:
+        cache, _, _ = _make_cache(tmp_path)
+        assert cache.get_all_open_prs() == []
+
+    @pytest.mark.asyncio
+    async def test_poll_populates_all_open_prs(self, tmp_path: Path) -> None:
+        all_prs = [_make_pr(1), _make_pr(2), _make_pr(3)]
+        cache, _, _ = _make_cache(tmp_path, all_open_prs=all_prs)
+
+        stats = await cache.poll()
+
+        assert cache.get_all_open_prs() == all_prs
+        assert stats["all_open_prs"] == 3
+
+    @pytest.mark.asyncio
+    async def test_all_open_prs_includes_bot_pr_excluded_from_label_filter(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (s09): a dependabot PR carries only the GitHub-native
+        ``dependencies`` label, so it is absent from the workflow-label-filtered
+        ``get_open_prs`` snapshot. DependabotMergeLoop reads ``get_all_open_prs``
+        and filters by author — that snapshot MUST include the bot PR, else the
+        loop never merges anything in production.
+        """
+        from unittest.mock import AsyncMock, MagicMock
+
+        from mockworld.fakes.fake_github import FakeGitHub
+        from tests.helpers import ConfigFactory
+
+        gh = FakeGitHub()
+        gh.add_pr(
+            number=100,
+            issue_number=0,
+            branch="dependabot/npm/foo-1.2.3",
+            author="dependabot[bot]",
+        )
+        gh.add_pr_label(100, "dependencies")
+
+        fetcher = MagicMock()
+        fetcher._get_collaborators = AsyncMock(return_value=set())
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        cache = GitHubDataCache(
+            config=config,
+            pr_manager=gh,
+            fetcher=fetcher,
+            cache_dir=tmp_path / "cache",
+        )
+
+        await cache.poll()
+
+        # Label-filtered snapshot excludes the bot PR (documents the gap):
+        assert 100 not in [p.pr for p in cache.get_open_prs()]
+        # Label-agnostic snapshot includes it, with author preserved (the fix):
+        all_open = cache.get_all_open_prs()
+        assert [p.pr for p in all_open] == [100]
+        assert all_open[0].author == "dependabot[bot]"
 
 
 # ===========================================================================

--- a/tests/test_loop_wiring_completeness.py
+++ b/tests/test_loop_wiring_completeness.py
@@ -27,23 +27,18 @@ SRC = Path(__file__).resolve().parent.parent / "src"
 # These are either non-caretaker pipeline workers, or workers whose intervals
 # are managed through a different mechanism (e.g. not dashboard-editable).
 # ---------------------------------------------------------------------------
-_INTERVAL_BOUNDS_SKIP: set[str] = {
-    "github_cache",
-}
+# NOTE (2026-06-02, worker-fleet visibility audit): these skip-lists previously
+# whitelisted github_cache / epic_monitor / runs_gc — the exact loops operators
+# reported as "not running" because they were absent from the dashboard catalogs.
+# They are now fully wired, so the skips are removed and the guard enforces parity.
+_INTERVAL_BOUNDS_SKIP: set[str] = set()
 
-# Loops that intentionally aren't in the orchestrator bg_loop_registry
-# (e.g. GitHubCacheLoop is started separately).
-_ORCHESTRATOR_SKIP: set[str] = {
-    "github_cache",
-}
+# Loops that intentionally aren't in the orchestrator bg_loop_registry.
+_ORCHESTRATOR_SKIP: set[str] = set()
 
 # Loops that intentionally aren't in BACKGROUND_WORKERS in constants.js
 # (e.g. internal loops not shown in the dashboard).
-_CONSTANTS_JS_SKIP: set[str] = {
-    "github_cache",
-    "epic_monitor",
-    "runs_gc",
-}
+_CONSTANTS_JS_SKIP: set[str] = set()
 
 
 def _discover_loops() -> dict[str, str]:
@@ -82,6 +77,21 @@ def _parse_bg_loop_registry() -> set[str]:
     text = (SRC / "orchestrator.py").read_text()
     # Match lines like:  "memory_sync": svc.memory_sync_bg,
     return set(re.findall(r'"(\w+)"\s*:\s*svc\.', text))
+
+
+def _parse_bg_worker_defs() -> set[str]:
+    """Extract worker names from _bg_worker_defs in dashboard_routes/_control_routes.py.
+
+    ``_bg_worker_defs`` is the *sole* iteration source of the
+    ``GET /api/system/workers`` REST response (``_control_routes.py`` builds the
+    System-tab worker list by walking only this list). A registry loop missing
+    from it renders no row / a permanently-blank row in the dashboard even though
+    the loop runs and heartbeats — the "not running" symptom this guard prevents.
+    """
+    text = (SRC / "dashboard_routes" / "_control_routes.py").read_text()
+    block = re.search(r"_bg_worker_defs\s*=\s*\[(.*?)\n\]", text, re.S)
+    assert block, "_bg_worker_defs list not found in _control_routes.py"
+    return set(re.findall(r'\(\s*"(\w+)"', block.group(1)))
 
 
 def _parse_service_registry_fields() -> set[str]:
@@ -138,6 +148,53 @@ class TestOrchestratorRegistry:
         }
         assert not missing, (
             f"Loops missing from orchestrator bg_loop_registry: {sorted(missing)}"
+        )
+
+
+class TestBgWorkerDefsParity:
+    """Every bg_loop_registry loop must appear in the dashboard's _bg_worker_defs.
+
+    The System tab's ``GET /api/system/workers`` endpoint enumerates *only*
+    ``_bg_worker_defs`` (``_control_routes.py``). A loop registered + started but
+    missing from this catalog runs headless and is invisible/uncontrollable in the
+    dashboard. This is the exact regression class behind the 2026-06-02 worker-fleet
+    audit, where 30 of 45 loops were absent from ``_bg_worker_defs``.
+    """
+
+    def test_all_registry_loops_in_bg_worker_defs(self) -> None:
+        registry_keys = _parse_bg_loop_registry()
+        defs_keys = _parse_bg_worker_defs()
+        missing = registry_keys - defs_keys
+        assert not missing, (
+            "Loops in bg_loop_registry but missing from _bg_worker_defs "
+            "(invisible in the System tab even though they run): "
+            f"{sorted(missing)}"
+        )
+
+    def test_no_orphan_bg_worker_defs(self) -> None:
+        """Reverse parity: every _bg_worker_defs entry is either a registry loop
+        or one of the explicit pipeline/non-loop UI workers.
+
+        Without this, a typo'd def key (e.g. ``github_cahce``) would render a
+        dead System-tab row pointing at a non-existent worker, and the
+        forward parity test above would stay green.
+        """
+        # Pipeline phases + the non-loop UI workers that legitimately appear in
+        # _bg_worker_defs without a BaseBackgroundLoop behind them.
+        allowed_non_registry = {
+            "triage",
+            "plan",
+            "implement",
+            "review",
+            "review_insights",
+            "pipeline_poller",
+        }
+        orphans = (
+            _parse_bg_worker_defs() - _parse_bg_loop_registry() - allowed_non_registry
+        )
+        assert not orphans, (
+            "_bg_worker_defs entries that are neither a registry loop nor a known "
+            f"pipeline/non-loop worker (typo'd or stale def?): {sorted(orphans)}"
         )
 
 
@@ -215,7 +272,7 @@ class TestLoopFactories:
     hydraflow-diagnose (gh-TBD).
     """
 
-    def test_all_registry_loops_in_factories(self, loops: dict[str, str]) -> None:
+    def test_all_registry_loops_in_factories(self) -> None:
         registry_keys = _parse_bg_loop_registry()
         factory_keys = _parse_loop_factories()
         missing = {

--- a/tests/test_orchestrator_hooks.py
+++ b/tests/test_orchestrator_hooks.py
@@ -1308,13 +1308,86 @@ class TestPipelineStatsEmission:
         json_str = json.dumps(data)
         assert isinstance(json_str, str)
 
-    def test_pipeline_stats_loop_in_supervise_factories(
+    def test_pipeline_poller_registered_in_loop_factories(
         self, config: HydraFlowConfig
     ) -> None:
-        """pipeline_stats loop is registered in _supervise_loops."""
+        """The stats loop is started under the 'pipeline_poller' task name.
+
+        The supervised task name must match the worker identity used by the
+        interval/UI/enable controls (``pipeline_poller``); a divergent task
+        name (the old ``pipeline_stats``) breaks the disabled-flag prune and
+        the trigger/control routes.
+        """
+        import inspect
+
         from orchestrator import HydraFlowOrchestrator
 
         orch = HydraFlowOrchestrator(config)
-        # Verify the method exists
-        assert hasattr(orch, "_pipeline_stats_loop")
         assert callable(orch._pipeline_stats_loop)
+        src = inspect.getsource(HydraFlowOrchestrator._supervise_loops)
+        assert '("pipeline_poller", self._pipeline_stats_loop)' in src
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_publishes_heartbeat(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Each cycle records an 'ok' heartbeat under the 'pipeline_poller' worker."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+
+        async def _emit_then_stop() -> None:
+            orch._stop_event.set()
+
+        orch.emit_pipeline_stats = _emit_then_stop  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        states = orch.get_bg_worker_states()
+        assert "pipeline_poller" in states, "no heartbeat published for pipeline_poller"
+        assert states["pipeline_poller"]["status"] == "ok"
+        assert states["pipeline_poller"]["last_run"] is not None
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_skips_emit_when_disabled(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """A disabled pipeline_poller does not emit stats (toggle is honored)."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+        orch.set_bg_worker_enabled("pipeline_poller", False)
+
+        emit = AsyncMock()
+        orch.emit_pipeline_stats = emit  # type: ignore[method-assign]
+
+        async def _sleep_then_stop(_seconds: float) -> None:
+            orch._stop_event.set()
+
+        orch._sleep_or_stop = _sleep_then_stop  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        emit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pipeline_poller_rereads_interval_each_cycle(
+        self, config: HydraFlowConfig
+    ) -> None:
+        """Interval edits take effect live (re-read each cycle, not once at start)."""
+        orch = HydraFlowOrchestrator(config, event_bus=EventBus())
+        orch.set_bg_worker_interval("pipeline_poller", 99)
+        slept: list[float] = []
+        cycles = {"n": 0}
+
+        async def _emit() -> None:
+            cycles["n"] += 1
+            if cycles["n"] == 1:
+                orch.set_bg_worker_interval("pipeline_poller", 7)
+            if cycles["n"] >= 2:
+                orch._stop_event.set()
+
+        async def _capture_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        orch.emit_pipeline_stats = _emit  # type: ignore[method-assign]
+        orch._sleep_or_stop = _capture_sleep  # type: ignore[method-assign]
+        await orch._pipeline_stats_loop()
+
+        # First cycle slept 99; after the mid-run edit the second cycle slept 7.
+        assert slept[0] == 99
+        assert slept[1] == 7

--- a/tests/test_sandbox_failure_fixer_loop.py
+++ b/tests/test_sandbox_failure_fixer_loop.py
@@ -26,6 +26,7 @@ def _make_loop(
     prs: object | None = None,
     runner: object | None = None,
     state: object | None = None,
+    workspaces: object | None = None,
     **config_overrides,
 ):
     # Default to static-config-enabled here so each behavioral test exercises
@@ -39,6 +40,7 @@ def _make_loop(
         prs=prs,
         runner=runner,
         deps=deps.loop_deps,
+        workspaces=workspaces,
     )
     return loop, state
 
@@ -327,3 +329,69 @@ async def test_build_prompt_degrades_gracefully_on_fetch_error(
     # Template placeholders must not leak into the prompt.
     assert "{CI_FAILURE_LOG}" not in prompt_used
     assert "{RECENT_COMMIT_DIFFS}" not in prompt_used
+
+
+@pytest.mark.asyncio
+async def test_dispatch_resolves_worktree_path_not_branch_name(
+    tmp_path: Path,
+) -> None:
+    """runner.run must receive a real worktree PATH (subprocess cwd), not the
+    PR's git branch name. Regression for the dispatch that passed pr.branch."""
+    pr_port = MagicMock()
+    pr_port.list_prs_by_label = AsyncMock(
+        return_value=[
+            SimpleNamespace(number=100, branch="rc/2026-04-26", labels=[]),
+        ]
+    )
+    pr_port.add_pr_labels = AsyncMock()
+    pr_port.remove_pr_label = AsyncMock()
+    runner = MagicMock()
+    runner.run = AsyncMock(
+        return_value=SimpleNamespace(crashed=False, output_text="OK")
+    )
+    state = _make_state_with_attempts()
+
+    resolved = tmp_path / "worktrees" / "issue-100"
+    resolved.mkdir(parents=True)
+    workspaces = MagicMock()
+    workspaces.create = AsyncMock(return_value=resolved)
+
+    loop, _ = _make_loop(
+        tmp_path, prs=pr_port, runner=runner, state=state, workspaces=workspaces
+    )
+    await loop._do_work()
+
+    runner.run.assert_called_once()
+    kwargs = runner.run.call_args.kwargs
+    assert kwargs["worktree_path"] == str(resolved)
+    assert kwargs["worktree_path"] != "rc/2026-04-26"
+    workspaces.create.assert_awaited_once_with(100, "rc/2026-04-26")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_falls_back_to_repo_root_without_workspace_port(
+    tmp_path: Path,
+) -> None:
+    """With no WorkspacePort wired the cwd degrades to repo_root — still a real
+    directory, never the branch name."""
+    pr_port = MagicMock()
+    pr_port.list_prs_by_label = AsyncMock(
+        return_value=[
+            SimpleNamespace(number=100, branch="rc/2026-04-26", labels=[]),
+        ]
+    )
+    pr_port.add_pr_labels = AsyncMock()
+    pr_port.remove_pr_label = AsyncMock()
+    runner = MagicMock()
+    runner.run = AsyncMock(
+        return_value=SimpleNamespace(crashed=False, output_text="OK")
+    )
+    state = _make_state_with_attempts()
+
+    loop, _ = _make_loop(tmp_path, prs=pr_port, runner=runner, state=state)
+    await loop._do_work()
+
+    runner.run.assert_called_once()
+    kwargs = runner.run.call_args.kwargs
+    assert kwargs["worktree_path"] == str(loop._config.repo_root)
+    assert kwargs["worktree_path"] != "rc/2026-04-26"

--- a/tests/trust/adversarial/corpus_runner.py
+++ b/tests/trust/adversarial/corpus_runner.py
@@ -1,0 +1,280 @@
+"""Adversarial corpus runner — shared eval logic for the pytest harness and the
+``FORMAT=json`` producer consumed by ``SkillPromptEvalLoop._run_corpus``.
+
+A *case* lives at ``tests/trust/adversarial/cases/<name>/``:
+
+  - ``before/`` / ``after/``     minimal pre/post-diff repo subset
+  - ``expected_catcher.txt``     a registered skill name, or ``"none"``
+  - ``README.md``                describes the bug + a ``Keyword:`` line
+  - ``expected_transcript.txt``  (optional) canned LLM transcript fixture
+  - ``plan.md`` / ``provenance.txt``  (optional)
+
+``evaluate_case`` synthesizes a unified diff from ``before/`` vs ``after/``,
+feeds it to every skill's ``prompt_builder``, parses the transcript with each
+skill's ``result_parser``, and decides a per-case ``status``:
+
+  - ``PASS``  — expected behaviour holds (the expected catcher flags the case
+                with its keyword; or, for ``none`` cases, no skill flags it).
+  - ``FAIL``  — a regression: the catcher no longer flags it (or a ``none``
+                case is now flagged).
+  - ``SKIPPED`` — no transcript fixture and live mode off (non-strict only).
+
+The pytest harness asserts on this; the loop diffs ``PASS -> FAIL`` per case to
+detect skill-prompt drift. Run ``python corpus_runner.py --json`` to emit the
+loop-facing result list (``[{case_id, skill, status, provenance,
+expected_catcher}, ...]``) on stdout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+CASES_DIR = HERE / "cases"
+REPO_ROOT = HERE.parent.parent.parent
+SRC = REPO_ROOT / "src"
+
+# Mirror the conftest sys.path setup: bare imports (skill_registry) resolve via
+# src/, while modules that self-reference as ``src.X`` (e.g. models.py) need the
+# repo root on the path too.
+for _path in (REPO_ROOT, SRC):
+    if str(_path) not in sys.path:
+        sys.path.insert(0, str(_path))
+
+from skill_registry import BUILTIN_SKILLS  # noqa: E402
+
+_SKILLS_BY_NAME = {s.name: s for s in BUILTIN_SKILLS}
+_VALID_CATCHERS: frozenset[str] = frozenset({*_SKILLS_BY_NAME.keys(), "none"})
+
+
+class MissingTranscriptError(RuntimeError):
+    """Raised in strict mode when a case has no transcript fixture and live is off."""
+
+
+def discover_cases(cases_dir: Path = CASES_DIR) -> list[Path]:
+    if not cases_dir.is_dir():
+        return []
+    return sorted(
+        p for p in cases_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
+    )
+
+
+def _read_case_files(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            rel = path.relative_to(root).as_posix()
+            try:
+                out[rel] = path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                out[rel] = ""
+    return out
+
+
+def synthesize_diff(before_dir: Path, after_dir: Path) -> str:
+    """Build a unified diff from before/ -> after/ with git-style headers."""
+    before = _read_case_files(before_dir)
+    after = _read_case_files(after_dir)
+    chunks: list[str] = []
+    for rel in sorted(set(before) | set(after)):
+        b = before.get(rel, "")
+        a = after.get(rel, "")
+        if b == a:
+            continue
+        diff = difflib.unified_diff(
+            b.splitlines(keepends=True),
+            a.splitlines(keepends=True),
+            fromfile=f"a/{rel}",
+            tofile=f"b/{rel}",
+        )
+        chunks.append(f"diff --git a/{rel} b/{rel}\n")
+        chunks.extend(diff)
+    return "".join(chunks)
+
+
+def load_transcript(case_dir: Path, prompt: str, *, live: bool) -> str | None:
+    """Return the canned transcript for *case_dir*, invoke live claude, or None.
+
+    Returns ``None`` when no ``expected_transcript.txt`` exists and *live* is
+    off — callers decide whether that is a skip or an error.
+    """
+    fixture = case_dir / "expected_transcript.txt"
+    if fixture.exists():
+        return fixture.read_text(encoding="utf-8")
+    if not live:
+        return None
+    result = subprocess.run(  # noqa: S603
+        ["claude", "-p", prompt, "--output-format", "text"],  # noqa: S607
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=True,
+    )
+    return result.stdout
+
+
+def read_keyword(readme_path: Path) -> str:
+    """Extract the required ``Keyword:`` from a case README (case-insensitive)."""
+    text = readme_path.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        if line.strip().lower().startswith("keyword:"):
+            return line.split(":", 1)[1].strip()
+    raise AssertionError(f"README.md {readme_path} missing 'Keyword:' line")
+
+
+def read_expected_catcher(case_dir: Path) -> str:
+    catcher = (case_dir / "expected_catcher.txt").read_text(encoding="utf-8").strip()
+    if catcher not in _VALID_CATCHERS:
+        raise AssertionError(
+            f"{case_dir.name}/expected_catcher.txt = {catcher!r}; must be one of "
+            f"{sorted(_VALID_CATCHERS)} (from live skill_registry.BUILTIN_SKILLS)"
+        )
+    return catcher
+
+
+def load_plan_text(case_dir: Path) -> str:
+    plan = case_dir / "plan.md"
+    return plan.read_text(encoding="utf-8") if plan.exists() else ""
+
+
+def read_provenance(case_dir: Path) -> str:
+    """Return the case provenance (``provenance.txt``), defaulting to hand-crafted."""
+    prov = case_dir / "provenance.txt"
+    if prov.exists():
+        text = prov.read_text(encoding="utf-8").strip()
+        if text:
+            return text
+    return "hand-crafted"
+
+
+def evaluate_case(
+    case_dir: Path, *, live: bool = False, strict: bool = True
+) -> dict[str, Any]:
+    """Evaluate one case and return its loop-facing result dict.
+
+    Keys: ``case_id, skill, expected_catcher, provenance, status`` plus
+    ``summary`` and ``findings`` for the pytest assertions. ``status`` is one of
+    ``PASS`` / ``FAIL`` / ``SKIPPED``.
+
+    In *strict* mode a missing transcript raises :class:`MissingTranscriptError`
+    (the pytest harness requires a fixture or live mode); otherwise the case is
+    reported ``SKIPPED`` so the loop simply ignores it.
+    """
+    case_id = case_dir.name
+    before_dir = case_dir / "before"
+    after_dir = case_dir / "after"
+    if not before_dir.is_dir() or not after_dir.is_dir():
+        raise AssertionError(f"{case_id}: missing before/ or after/")
+
+    diff = synthesize_diff(before_dir, after_dir)
+    if not diff.strip():
+        raise AssertionError(f"{case_id}: before/ and after/ produced empty diff")
+
+    catcher = read_expected_catcher(case_dir)
+    provenance = read_provenance(case_dir)
+    plan_text = load_plan_text(case_dir)
+
+    # One transcript per case, fed to every skill's parser (the prompt arg only
+    # matters for the live-claude path).
+    sample_prompt = ""
+    if BUILTIN_SKILLS:
+        sample_prompt = BUILTIN_SKILLS[0].prompt_builder(
+            issue_number=0,
+            issue_title=f"adversarial-corpus::{case_id}",
+            diff=diff,
+            plan_text=plan_text,
+        )
+    transcript = load_transcript(case_dir, sample_prompt, live=live)
+    if transcript is None:
+        if strict:
+            raise MissingTranscriptError(
+                f"No expected_transcript.txt for {case_id}; set "
+                "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE=1 to invoke the real claude CLI."
+            )
+        return {
+            "case_id": case_id,
+            "skill": catcher,
+            "expected_catcher": catcher,
+            "provenance": provenance,
+            "status": "SKIPPED",
+            "summary": "",
+            "findings": [],
+        }
+
+    results: dict[str, tuple[bool, str, list[str]]] = {}
+    for skill in BUILTIN_SKILLS:
+        results[skill.name] = skill.result_parser(transcript)
+
+    if catcher == "none":
+        failing = [name for name, (passed, _, _) in results.items() if not passed]
+        status = "PASS" if not failing else "FAIL"
+        return {
+            "case_id": case_id,
+            "skill": "none",
+            "expected_catcher": "none",
+            "provenance": provenance,
+            "status": status,
+            "summary": "" if status == "PASS" else f"flagged by {failing}",
+            "findings": failing,
+        }
+
+    passed, summary, findings = results[catcher]
+    keyword = read_keyword(case_dir / "README.md")
+    haystack = (summary + "\n" + "\n".join(findings)).lower()
+    caught = (not passed) and (keyword.lower() in haystack)
+    return {
+        "case_id": case_id,
+        "skill": catcher,
+        "expected_catcher": catcher,
+        "provenance": provenance,
+        "status": "PASS" if caught else "FAIL",
+        "summary": summary,
+        "findings": findings,
+    }
+
+
+def run_corpus(
+    *, cases_dir: Path = CASES_DIR, live: bool = False, strict: bool = False
+) -> list[dict[str, Any]]:
+    """Evaluate every discovered case and return the loop-facing result list."""
+    return [
+        evaluate_case(case_dir, live=live, strict=strict)
+        for case_dir in discover_cases(cases_dir)
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Adversarial corpus runner")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit the loop-facing result list as JSON on stdout",
+    )
+    args = parser.parse_args(argv)
+    live = os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1"
+    results = run_corpus(live=live, strict=False)
+    if args.json:
+        # Only the loop-facing keys belong on stdout (the loop json.loads it).
+        slim = [
+            {
+                "case_id": r["case_id"],
+                "skill": r["skill"],
+                "status": r["status"],
+                "provenance": r["provenance"],
+                "expected_catcher": r["expected_catcher"],
+            }
+            for r in results
+        ]
+        print(json.dumps(slim))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/trust/adversarial/test_adversarial_corpus.py
+++ b/tests/trust/adversarial/test_adversarial_corpus.py
@@ -1,195 +1,51 @@
 """Adversarial corpus harness — iterates tests/trust/adversarial/cases/*.
 
 Each case directory contains:
-  - before/                 minimal pre-diff repo subset
-  - after/                  minimal post-diff repo subset
-  - expected_catcher.txt    one of the registered skills' names, or "none"
-  - README.md               describes the bug + names a required keyword
+  - before/ / after/        minimal pre/post-diff repo subset
+  - expected_catcher.txt     one of the registered skills' names, or "none"
+  - README.md                describes the bug + names a required `Keyword:`
+  - expected_transcript.txt  (optional) canned LLM transcript fixture
 
-The harness synthesizes a unified diff from before/ vs after/, feeds it to
-every skill's registered prompt_builder, records what the corresponding
-result_parser would return when given a canned "RETRY+summary" transcript
-from a captured fixture at cases/<name>/expected_transcript.txt (if present)
-or produced on demand from an LLM call against the prompt. The "pass"
-assertion is: the expected_catcher skill's parser reports passed=False AND
-the keyword from the README appears (case-insensitive substring) in the
-parser's summary field.
-
-The `none` sentinel asserts that NO skill reports passed=False on the
-case — i.e. a deliberately benign diff must not trip any catcher.
+The per-case evaluation logic lives in :mod:`corpus_runner` so it is shared
+with the ``FORMAT=json`` producer consumed by ``SkillPromptEvalLoop``. This
+harness asserts the expected catcher still flags each case (status ``PASS``);
+the loop diffs ``PASS -> FAIL`` over time to detect skill-prompt drift.
 """
 
 from __future__ import annotations
 
-import difflib
 import os
-import subprocess
 import sys
 from pathlib import Path
 
 import pytest
 
 HERE = Path(__file__).resolve().parent
-CASES_DIR = HERE / "cases"
-REPO_ROOT = HERE.parent.parent.parent
-SRC = REPO_ROOT / "src"
+if str(HERE) not in sys.path:
+    sys.path.insert(0, str(HERE))
 
-sys.path.insert(0, str(SRC))
-
-from skill_registry import BUILTIN_SKILLS, AgentSkill  # noqa: E402
-
-# Map skill.name -> AgentSkill, resolved at module import from the live
-# registry. If a new post-impl skill is added to BUILTIN_SKILLS, the
-# corpus automatically accepts expected_catcher.txt values naming it.
-_SKILLS_BY_NAME: dict[str, AgentSkill] = {s.name: s for s in BUILTIN_SKILLS}
-_VALID_CATCHERS: frozenset[str] = frozenset({*_SKILLS_BY_NAME.keys(), "none"})
-
-
-def _discover_cases() -> list[Path]:
-    if not CASES_DIR.is_dir():
-        return []
-    return sorted(
-        p for p in CASES_DIR.iterdir() if p.is_dir() and not p.name.startswith(".")
-    )
-
-
-def _read_case_files(root: Path) -> dict[str, str]:
-    """Return {relative_path: file_text} under *root*."""
-    out: dict[str, str] = {}
-    for path in sorted(root.rglob("*")):
-        if path.is_file():
-            rel = path.relative_to(root).as_posix()
-            try:
-                out[rel] = path.read_text(encoding="utf-8")
-            except UnicodeDecodeError:
-                out[rel] = ""
-    return out
-
-
-def _synthesize_diff(before_dir: Path, after_dir: Path) -> str:
-    """Build a unified diff from before/ -> after/ with git-style headers."""
-    before = _read_case_files(before_dir)
-    after = _read_case_files(after_dir)
-    chunks: list[str] = []
-    for rel in sorted(set(before) | set(after)):
-        b = before.get(rel, "")
-        a = after.get(rel, "")
-        if b == a:
-            continue
-        diff = difflib.unified_diff(
-            b.splitlines(keepends=True),
-            a.splitlines(keepends=True),
-            fromfile=f"a/{rel}",
-            tofile=f"b/{rel}",
-        )
-        chunks.append(f"diff --git a/{rel} b/{rel}\n")
-        chunks.extend(diff)
-    return "".join(chunks)
-
-
-def _load_transcript(case_dir: Path, prompt: str) -> str:
-    """Return the canned LLM transcript for *case_dir*, or invoke live claude."""
-    fixture = case_dir / "expected_transcript.txt"
-    if fixture.exists():
-        return fixture.read_text(encoding="utf-8")
-    assert os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1", (
-        f"No expected_transcript.txt for {case_dir.name}; set "
-        "HYDRAFLOW_TRUST_ADVERSARIAL_LIVE=1 to invoke the real claude CLI."
-    )
-    try:
-        result = subprocess.run(  # noqa: S603
-            ["claude", "-p", prompt, "--output-format", "text"],
-            capture_output=True,
-            text=True,
-            timeout=180,
-            check=True,
-        )
-    except (
-        subprocess.CalledProcessError,
-        subprocess.TimeoutExpired,
-        FileNotFoundError,
-    ) as exc:
-        pytest.fail(f"Live claude invocation failed for {case_dir.name}: {exc}")
-    return result.stdout
-
-
-def _read_keyword(readme_path: Path) -> str:
-    """Extract the required keyword from a case README.
-
-    Convention: one line of the README reads `Keyword: <word-or-phrase>`.
-    The match is case-insensitive substring against the parser's summary.
-    """
-    text = readme_path.read_text(encoding="utf-8")
-    for line in text.splitlines():
-        if line.strip().lower().startswith("keyword:"):
-            return line.split(":", 1)[1].strip()
-    raise AssertionError(f"README.md {readme_path} missing 'Keyword:' line")
-
-
-def _read_expected_catcher(case_dir: Path) -> str:
-    catcher = (case_dir / "expected_catcher.txt").read_text(encoding="utf-8").strip()
-    if catcher not in _VALID_CATCHERS:
-        raise AssertionError(
-            f"{case_dir.name}/expected_catcher.txt = {catcher!r}; must be one of "
-            f"{sorted(_VALID_CATCHERS)} (from live skill_registry.BUILTIN_SKILLS)"
-        )
-    return catcher
-
-
-def _load_plan_text(case_dir: Path) -> str:
-    """Return plan_text for plan-compliance / scope-check cases, or empty."""
-    plan = case_dir / "plan.md"
-    return plan.read_text(encoding="utf-8") if plan.exists() else ""
+from corpus_runner import (  # noqa: E402
+    MissingTranscriptError,
+    discover_cases,
+    evaluate_case,
+)
 
 
 @pytest.mark.parametrize(
     "case_dir",
-    _discover_cases(),
+    discover_cases(),
     ids=lambda p: p.name,
 )
 def test_case(case_dir: Path) -> None:
-    """For each case, assert the expected catcher flags it."""
-    before_dir = case_dir / "before"
-    after_dir = case_dir / "after"
-    assert before_dir.is_dir(), f"{case_dir.name}: missing before/"
-    assert after_dir.is_dir(), f"{case_dir.name}: missing after/"
+    """Each case's expected catcher must still flag it (no PASS->FAIL drift)."""
+    live = os.environ.get("HYDRAFLOW_TRUST_ADVERSARIAL_LIVE") == "1"
+    try:
+        result = evaluate_case(case_dir, live=live, strict=True)
+    except MissingTranscriptError as exc:
+        pytest.fail(str(exc))
 
-    diff = _synthesize_diff(before_dir, after_dir)
-    assert diff.strip(), f"{case_dir.name}: before/ and after/ produced empty diff"
-
-    catcher = _read_expected_catcher(case_dir)
-    plan_text = _load_plan_text(case_dir)
-
-    # For every skill, build its prompt and parse the transcript.
-    results: dict[str, tuple[bool, str, list[str]]] = {}
-    for skill in BUILTIN_SKILLS:
-        prompt = skill.prompt_builder(
-            issue_number=0,
-            issue_title=f"adversarial-corpus::{case_dir.name}",
-            diff=diff,
-            plan_text=plan_text,
-        )
-        transcript = _load_transcript(case_dir, prompt)
-        results[skill.name] = skill.result_parser(transcript)
-
-    if catcher == "none":
-        failing = [name for name, (passed, _, _) in results.items() if not passed]
-        assert not failing, (
-            f"{case_dir.name}: sentinel 'none' case was flagged by {failing} "
-            "but should pass every skill"
-        )
-        return
-
-    passed, summary, findings = results[catcher]
-    assert not passed, (
-        f"{case_dir.name}: expected_catcher '{catcher}' returned OK; "
-        f"summary={summary!r} findings={findings!r}"
-    )
-
-    keyword = _read_keyword(case_dir / "README.md")
-    haystack = (summary + "\n" + "\n".join(findings)).lower()
-    assert keyword.lower() in haystack, (
-        f"{case_dir.name}: expected_catcher '{catcher}' returned RETRY but "
-        f"summary/findings did not contain required keyword {keyword!r}. "
-        f"summary={summary!r}, findings={findings!r}"
+    assert result["status"] == "PASS", (
+        f"{case_dir.name}: expected_catcher {result['expected_catcher']!r} "
+        f"regressed (status={result['status']}); summary={result['summary']!r}, "
+        f"findings={result['findings']!r}"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -327,7 +327,7 @@ wheels = [
 
 [[package]]
 name = "hydraflow"
-version = "0.9.3"
+version = "0.9.4"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Release-candidate promotion PR (ADR-0042). Snapshot of `staging` → `main`. Manually cut in dark-factory mode; mirrors StagingPromotionLoop conventions (rc/* head, base main, **merge-commit** not squash).

## Promoting 9 commits

**Worker-fleet audit + remediation:**
- #9153 — surface all 45 background loops in System tab + register github_cache + live interval/next_run + hardened wiring guard
- #9156 — pipeline_poller heartbeat/enable/interval + sandbox_failure_fixer worktree dispatch + preflight reraise
- #9157 — test_config_otel_defaults hermetic (xdist .env flake)
- #9158 — skill_prompt_eval real FORMAT=json corpus producer (28 cases)
- #9159 — sandbox e2e backfill batch 1 (workspace_gc, runs_gc, health_monitor, merge_state_watcher) + fake-fidelity fix

**Sandbox/dependabot fixes (already on staging):**
- #9150 s05 diagnose→HITL · #9151 s09 dependabot cache · #9152 s30 ContractRefresh air-gap · #9160 hitl tile color

## Gate
Full RC CI incl. `Sandbox (rc/* promotion PR full suite)`. Merge to main with `--merge` (merge commit) on green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)