### PR TITLE
test(sandbox): seed get_all_open_prs in browser L7/L8 dependabot scenarios

### DIFF
--- a/tests/scenarios/browser/scenarios/test_loops_browser.py
+++ b/tests/scenarios/browser/scenarios/test_loops_browser.py
@@ -356,6 +356,10 @@ async def test_l7_dependabot_merge_merges_green_pr(world, page) -> None:
     # --- Step 2: first run to initialize loop cache/state mock refs ---
     await world.run_with_loops(["dependabot_merge"], cycles=1)
     world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs),
+    # not the workflow-label-filtered get_open_prs (s09 fix, #9151). Seed both so
+    # the loop's bot-PR scan finds the seeded PR.
+    world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
     # --- Step 3: second run with configured cache ---
     stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
@@ -406,6 +410,10 @@ async def test_l8_dependabot_merge_skips_red_pr(world, page) -> None:
     # --- Step 2: first run to initialize loop cache/state mock refs ---
     await world.run_with_loops(["dependabot_merge"], cycles=1)
     world._dependabot_cache.get_open_prs.return_value = [bot_pr]
+    # DependabotMergeLoop reads the label-agnostic snapshot (get_all_open_prs),
+    # not the workflow-label-filtered get_open_prs (s09 fix, #9151). Seed both so
+    # the loop's bot-PR scan finds the seeded PR.
+    world._dependabot_cache.get_all_open_prs.return_value = [bot_pr]
 
     # --- Step 3: second run with configured cache ---
     stats = await world.run_with_loops(["dependabot_merge"], cycles=1)


### PR DESCRIPTION
RC #9161 caught this: #9151 switched `DependabotMergeLoop` to `get_all_open_prs()` and updated the MockWorld scenario, but the **browser** scenarios (`test_loops_browser.py` L7/L8) still seeded only `get_open_prs` → loop reads unconfigured `get_all_open_prs` → 0 merges → `assert 0 == 1`. Browser scenarios run only on the `rc/*` promotion gate, so it slipped past per-PR staging CI.

Seed `get_all_open_prs.return_value = [bot_pr]` in both L7/L8, mirroring the already-fixed `test_loops.py`. Verified both pass locally with the real browser stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)