### PR TITLE
test(circuit-breaker): de-flake OPEN→HALF_OPEN timeout tests (drop global time patch)

### DIFF
--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -45,11 +45,13 @@ class TestOpenToHalfOpen:
         cb.record_failure()
         assert cb.state == CircuitBreaker.OPEN
 
-        # Simulate time passing beyond reset_timeout
-        with patch(
-            "circuit_breaker.time.monotonic", return_value=cb._last_failure_time + 10.0
-        ):
-            assert cb.state == CircuitBreaker.HALF_OPEN
+        # Backdate the failure beyond reset_timeout so the elapsed-time check
+        # passes against the *real* monotonic clock — no time-module patch.
+        # Patching circuit_breaker.time.monotonic (which IS the global time
+        # module) to the exact boundary was flaky on CI under coverage/xdist;
+        # backdating is patch-free and deterministic.
+        cb._last_failure_time -= cb.reset_timeout + 1.0
+        assert cb.state == CircuitBreaker.HALF_OPEN
 
     def test_stays_open_before_timeout(self) -> None:
         cb = CircuitBreaker("test", max_failures=1, reset_timeout=10.0)
@@ -113,11 +115,11 @@ class TestAllowRequest:
         cb.record_failure()
         assert cb.allow_request() is False
 
-        with patch(
-            "circuit_breaker.time.monotonic", return_value=cb._last_failure_time + 5.0
-        ):
-            assert cb.allow_request() is True
-            assert cb.state == CircuitBreaker.HALF_OPEN
+        # Backdate beyond reset_timeout (patch-free, real clock) — see
+        # test_transitions_after_timeout for why the time-module patch was flaky.
+        cb._last_failure_time -= cb.reset_timeout + 1.0
+        assert cb.allow_request() is True
+        assert cb.state == CircuitBreaker.HALF_OPEN
 
 
 class TestReset:


### PR DESCRIPTION
Fixes the recurring circuit-breaker timeout-transition flake that blocked PR #9156 and RC #9161 (intermittent `'open' == 'half_open'` on the full CI Tests job).

## Root cause
`TestOpenToHalfOpen::test_transitions_after_timeout` and `TestAllowRequest::test_allows_after_timeout_triggers_half_open` patched `circuit_breaker.time.monotonic` — which **is the shared global `time` module** — to exactly `_last_failure_time + reset_timeout`. The arithmetic is deterministic (`(M+T)-M == T` by Sterbenz for realistic monotonic values), so it wasn't a float-boundary issue. The most plausible cause is the **process-wide time-module patch not applying cleanly under coverage/xdist**, leaving the real clock (~0 elapsed) so the breaker stayed OPEN.

## Fix
Drop the time patch entirely; **backdate `_last_failure_time`** past `reset_timeout` so the elapsed check passes against the real monotonic clock — patch-free and deterministic. Mirrors the existing in-test state manipulation pattern (`_make_half_open` sets `_state` directly). Non-flaky `test_stays_open_before_timeout` left as-is.

## Verification
8× full-file runs green (incl. both formerly-flaky tests). Recorded in memory as the 2nd of the two known CI flakes (the OTel `.env` one is already fixed on main via #9157).

Lands on staging; reaches main via the next RC promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)