### PR TITLE
Accept ADR-0071: route back counter port

### DIFF
--- a/docs/adr/0071-route-back-counter-port.md
+++ b/docs/adr/0071-route-back-counter-port.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-05-19
-**Enforced by:** `tests/test_route_back.py`
+**Enforced by:** tests/test_route_back.py
 
 ## Context
 

--- a/docs/adr/0071-route-back-counter-port.md
+++ b/docs/adr/0071-route-back-counter-port.md
@@ -1,6 +1,6 @@
 # ADR-0071 — RouteBackCounterPort: Testable Counter for Precondition Route-Backs
 
-**Status:** Proposed
+**Status:** Accepted
 **Date:** 2026-05-19
 **Enforced by:** `tests/test_route_back.py`
 


### PR DESCRIPTION
## ADR Council Review

The ADR review council has voted to **accept** ADR-0071.

**Final decision:** ACCEPT
**Rounds needed:** 1

### Final Votes
- **Architect:** approve — The ADR codifies a pattern already fully implemented and tested, with correct co-location rationale grounded in ADR-0068 precedent and a tight, non-speculative port surface. The only gap is that the enforcement story does not explain how StateTracker-to-port structural conformance is verified given the port lives outside ports.py, but this is a documentation omission rather than an architectural defect, and the shipped test suite already covers the rollback invariant that is the primary risk being managed.
- **Pragmatist:** approve — The implementation is demonstrably real — the port, coordinator wiring, and rollback invariant tests all exist and match the ADR's claims. The rollback no-op-at-zero invariant is a non-trivial behavioral contract that justifies a dedicated record rather than a code comment, and it is not captured in any ancestor ADR. The significance threshold is borderline given the narrow scope, but the rollback semantics diverge from sibling ports in a load-bearing way, making the record earn its place.
- **Editor:** request_changes — The ADR is clear, well-motivated, and non-duplicate, but it is missing the explicit note present in all peer Port ADRs (0066–0070) that a structural subtype check confirming StateTracker satisfies RouteBackCounterPort is planned for tests/test_ports.py as a follow-up. The appended "Relevant ADR context" block also breaks the canonical format of the wave and should be integrated into the Related section or removed.

### Minority Note

Editor flagged two advisory issues: (1) unlike peer Port ADRs 0066–0070, this ADR omits an explicit statement that the StateTracker→RouteBackCounterPort structural conformance check is planned for tests/test_ports.py; (2) the appended "Relevant ADR context" block is not part of the canonical Port ADR format and clutters the document as a living artifact. Neither concern is blocking, but both should be patched before the ADR is marked Accepted.

### Summary

The council accepts ADR-0071 with a 2-1 vote; the port is real, the rollback invariant is load-bearing and novel across the Port wave, and co-location follows ADR-0068 precedent. The Editor's minority concern — missing structural-subtype enforcement note and non-canonical appended context block — is advisory and can be addressed in a follow-up editorial pass without blocking acceptance.

---
Generated by HydraFlow ADR Council