### PR TITLE
feat(ul): entry-evidence — 4 new entry links across 2 terms

### DIFF
--- a/docs/wiki/terms/base-background-loop.md
+++ b/docs/wiki/terms/base-background-loop.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/base_background_loop.py:BaseBackgroundLoop"
 aliases: ["base background loop", "loop base class"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}]
-evidence: []
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668776+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-04T05:06:42.396716+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/event-bus.md
+++ b/docs/wiki/terms/event-bus.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/events.py:EventBus"
 aliases: ["pub/sub bus", "hydraflow event bus"]
 related: []
-evidence: []
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ268"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668765+00:00"
-updated_at: "2026-05-05T03:35:36.668766+00:00"
+updated_at: "2026-06-04T05:06:42.396716+00:00"
 ---
 
 ## Definition


### PR DESCRIPTION
Auto-generated batch from `EntryEvidenceLoop` (ADR-0062).

Entry → term backlinks added:
- `BaseBackgroundLoop` ← entry `01KQP0XFBGMB32VFGNPV8GZ268`
- `BaseBackgroundLoop` ← entry `01KQP0XFBGMB32VFGNPV8GZ26F`
- `BaseBackgroundLoop` ← entry `01KQP0XFBGMB32VFGNPV8GZ26P`
- `EventBus` ← entry `01KQP0XFBGMB32VFGNPV8GZ268`

Matches are LLM-validated (one call per uncached entry) against the
live `TermStore`. Idempotent: re-runs skip entries already linked.

Auto-merge on CI green via `DependabotMergeLoop`.

Generated by `EntryEvidenceLoop`