### PR TITLE
fix(dashboard): idle factory loops show yellow "not running", not red "stopped"

### DIFF
--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -82,18 +82,20 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
   let dotColor, statusText, lastRun, details
 
   if (!orchRunning) {
-    // Orchestrator not running — system workers stopped, non-system show toggle state
+    // Orchestrator not running is an orchestrator-level fact, not a per-loop
+    // health signal: no loop is "errored" just because the factory is stopped.
+    // So nothing here is red — red is reserved for status === 'error' (a loop
+    // that actually ran and failed). Every loop (system and non-system alike)
+    // reads "not running"; only loops the operator explicitly toggled off show
+    // a neutral "off". This keeps a stopped factory from looking like an outage.
     lastRun = isPipelinePoller ? (pipelinePollerLastRun || null) : (state?.last_run || null)
     details = state?.details || {}
-    if (isSystem) {
-      dotColor = theme.red
-      statusText = 'stopped'
-    } else if (state?.enabled === false) {
-      dotColor = theme.red
+    if (state?.enabled === false) {
+      dotColor = theme.textInactive
       statusText = 'off'
     } else {
       dotColor = theme.yellow
-      statusText = 'idle'
+      statusText = 'not running'
     }
   } else if (isPipelinePoller) {
     // Pipeline poller is frontend-only — derive details from pipeline snapshot
@@ -155,7 +157,7 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
   const effectiveInterval = state?.interval_seconds ?? SYSTEM_WORKER_INTERVALS[def.key] ?? null
   const enabled = !isSystem && (state ? state.enabled !== false : true)
   const showToggle = onToggleBgWorker && !isSystem
-  const isError = statusText === 'error' || statusText === 'stopped'
+  const isError = statusText === 'error'
   const hasDetails = Object.keys(details).length > 0
   const description = state?.description || def.description || ''
   return (

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -113,22 +113,28 @@ describe('SystemPanel', () => {
       expect(dot.style.background).toBe('var(--red)')
     })
 
-    it('shows "idle" (yellow) for enabled non-system workers and "stopped" (red) for system workers when orchestrator not running', () => {
+    it('shows "not running" (yellow) for all loops — system and non-system — when orchestrator not running', () => {
       render(<SystemPanel backgroundWorkers={[]} />)
-      const nonSystem = BACKGROUND_WORKERS.filter(w => !w.system)
-      const systemWorkers = BACKGROUND_WORKERS.filter(w => w.system)
-      const idleTexts = screen.getAllByText('idle')
-      expect(idleTexts.length).toBe(nonSystem.length)
-      for (const def of nonSystem) {
+      // A stopped factory is not an outage: no loop is red just because the
+      // orchestrator is idle. Every loop reads "not running" in neutral yellow.
+      const notRunningTexts = screen.getAllByText('not running')
+      expect(notRunningTexts.length).toBe(BACKGROUND_WORKERS.length)
+      for (const def of BACKGROUND_WORKERS) {
         const dot = screen.getByTestId(`dot-${def.key}`)
         expect(dot.style.background).toBe('var(--yellow)')
       }
-      const stoppedTexts = screen.getAllByText('stopped')
-      expect(stoppedTexts.length).toBe(systemWorkers.length)
-      for (const def of systemWorkers) {
-        const dot = screen.getByTestId(`dot-${def.key}`)
-        expect(dot.style.background).toBe('var(--red)')
-      }
+      // Red is reserved for genuine errors — none should appear while idle.
+      expect(screen.queryByText('stopped')).toBeNull()
+    })
+
+    it('shows neutral "off" (never red) for explicitly disabled loops when orchestrator not running', () => {
+      const disabledWorkers = [
+        { name: 'retrospective', status: 'ok', enabled: false, last_run: null, details: {} },
+      ]
+      mockUseHydraFlow.mockReturnValue(defaultMockContext({ backgroundWorkers: disabledWorkers }))
+      render(<SystemPanel backgroundWorkers={disabledWorkers} />)
+      const dot = screen.getByTestId('dot-retrospective')
+      expect(dot.style.background).toBe('var(--text-inactive)')
     })
 
     it('shows ok/error status when orchestrator is running', () => {
@@ -332,20 +338,20 @@ describe('SystemPanel', () => {
       expect(dot.style.background).toBe('var(--green)')
     })
 
-    it('shows red stopped when orchestrator is not running even if poller has lastRun', () => {
+    it('shows "not running" (yellow, never red) when orchestrator is not running even if poller has lastRun', () => {
       mockUseHydraFlow.mockReturnValue(defaultMockContext({
         pipelinePollerLastRun: '2026-02-20T10:00:00Z',
         orchestratorStatus: 'idle',
       }))
       render(<SystemPanel backgroundWorkers={[]} />)
       const dot = screen.getByTestId('dot-pipeline_poller')
-      expect(dot.style.background).toBe('var(--red)')
+      expect(dot.style.background).toBe('var(--yellow)')
     })
 
-    it('shows red stopped when pipeline poller has not run', () => {
+    it('shows "not running" (yellow) when orchestrator not running and poller has not run', () => {
       render(<SystemPanel backgroundWorkers={[]} />)
       const dot = screen.getByTestId('dot-pipeline_poller')
-      expect(dot.style.background).toBe('var(--red)')
+      expect(dot.style.background).toBe('var(--yellow)')
     })
 
     it('does not show pipeline stage counts as details when orchestrator running (log stream only)', () => {


### PR DESCRIPTION
## Problem

When the orchestrator is idle/stopped, the System tab painted all **14 `system: true` loops red "stopped"** while non-system loops showed yellow "idle". Red reads as an outage, so a *deliberately* stopped factory looked like a fleet of errors. That mismatch was the operator's actual complaint — "lots of ops loops red, I thought they were fixed."

Root cause is purely presentational (`SystemPanel.jsx`, `!orchRunning` branch): the red was driven by `isSystem`, not by any real health signal. The backend `status: "disabled"` is *ignored* while the factory is idle, so the red was never about errors.

## Change

A stopped factory is an orchestrator-level fact, not a per-loop health signal — no loop has errored just because the factory is idle. So in the `!orchRunning` branch:

- **Every loop** (system + non-system) now reads **"not running"** in neutral **yellow**.
- Loops the operator **explicitly toggled off** show a neutral grey **"off"** (was red).
- **Red is reserved exclusively for `status === 'error'`** — a loop that actually ran and failed. `isError` no longer treats the (now-removed) `"stopped"` text as an error.

| State | Before | After |
|---|---|---|
| System loop, factory idle | 🔴 stopped | 🟡 not running |
| Non-system loop, factory idle | 🟡 idle | 🟡 not running |
| Explicitly toggled off, factory idle | 🔴 off | ⚪ off |
| Loop ran and failed (running) | 🔴 error | 🔴 error (unchanged) |

## Tests

- Replaced the test that encoded the old "system → red stopped" behavior with one asserting **all** loops show yellow "not running" when idle.
- Added coverage for the neutral grey "off" case.
- Updated the two pipeline-poller idle tests (red → yellow).
- **Full UI suite green: 61 files / 1078 tests**, plus `vite build`. No Python touched, so the Python `quality`/`scenario` CI jobs don't apply; the `ui-build` job (build + `npm test`) is the relevant gate and passes locally.

## Scope notes (deliberately *not* in this PR)

- When the factory **is** running, an explicitly-disabled loop still shows red "off" (running-branch, line ~127). The operator's ask was scoped to the not-running case; de-redding that is a reasonable follow-up.
- Two unrelated backend bugs surfaced while investigating, filed separately: `diagram_loop` heartbeat orphaned under the old hyphenated key `diagram-loop`, and stale orphan worker keys in `state.json` (`verify_monitor`, `manifest_refresh`, `worktree_gc`, `metrics`, `memory_sync`, `code_grooming`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)