### PR TITLE
fix(term-proposer): update retired model claude-sonnet-4-5 → claude-sonnet-4-6

### DIFF
--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -42,7 +42,7 @@ class ClaudeCLIClient:
         runner: SubprocessRunner,
         *,
         tool: AgentTool = "claude",
-        model: str = "claude-sonnet-4-5",
+        model: str = "claude-sonnet-4-6",
         timeout: int = 180,
     ) -> None:
         self._runner = runner

--- a/tests/regressions/test_term_proposer_model_id.py
+++ b/tests/regressions/test_term_proposer_model_id.py
@@ -1,0 +1,22 @@
+"""Regression: term_proposer_runtime used retired model claude-sonnet-4-5.
+
+ClaudeCLIClient hardcoded the stale model ID, causing every tick of
+TermProposerLoop to fail with a CLI error (issue #9223, tick_error_ratio=1.0).
+
+The default must always match the current active Sonnet model in the fleet.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+
+def test_claude_cli_client_default_model_is_current() -> None:
+    from term_proposer_runtime import ClaudeCLIClient
+
+    sig = inspect.signature(ClaudeCLIClient.__init__)
+    default_model = sig.parameters["model"].default
+    assert default_model == "claude-sonnet-4-6", (
+        f"ClaudeCLIClient default model is {default_model!r}; "
+        "update to the current active Sonnet model when models are retired"
+    )


### PR DESCRIPTION
## Summary

- `ClaudeCLIClient` in `term_proposer_runtime.py` hardcoded the retired model ID `claude-sonnet-4-5`, causing every `TermProposerLoop` tick to fail with a CLI error (`tick_error_ratio=1.0`, issue #9223)
- Updated to `claude-sonnet-4-6`, which is the current active Sonnet model used throughout the rest of the codebase
- Added a regression test in `tests/regressions/test_term_proposer_model_id.py` to catch future model drift

## Root cause

`src/term_proposer_runtime.py:45` — model default drifted when Sonnet 4.5 was retired but this file was not updated. All other LLM spawners (`adversarial_agent_runner.py`, `onboarding/design_ai.py`, test fixtures) already used the correct `claude-sonnet-4-6` / `claude-haiku-4-5-20251001` IDs.

## Test plan

- [x] `make quality` passes (15524 tests)
- [x] Regression test `tests/regressions/test_term_proposer_model_id.py` asserts default model is `claude-sonnet-4-6`
- [x] Pre-push quality-lite hook passes

Closes #9223

🤖 Generated with [Claude Code](https://claude.com/claude-code)