### PR TITLE
fix(runner): guard proc.kill() against ProcessLookupError on dead process

### DIFF
--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -192,7 +192,10 @@ async def _stream_and_collect(
             and config.on_output(accumulated_text)
         ):
             early_killed = True
-            proc.kill()
+            # The process may have already exited between the last read and
+            # this kill; suppress ProcessLookupError so it does not escape.
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.kill()
             break
 
         # Emit structured activity event (additive — does not replace TRANSCRIPT_LINE)
@@ -212,7 +215,10 @@ async def _stream_and_collect(
 
     # --- Post-stream validation and result assembly ---
     stderr_bytes = await stderr_task
-    await proc.wait()
+    # After an early kill the process may already be reaped, so waiting on it can
+    # raise ProcessLookupError; suppress it so cleanup never escapes.
+    with contextlib.suppress(ProcessLookupError, OSError):
+        await proc.wait()
     stderr_text = stderr_bytes.decode(errors="replace").strip()
 
     return _post_stream_result(
@@ -321,11 +327,18 @@ async def stream_claude_process(
             timeout=config.timeout,
         )
     except TimeoutError as exc:
-        proc.kill()
-        await proc.wait()
+        # The process may already be dead/reaped; killing/waiting on a gone
+        # process raises ProcessLookupError out of the cleanup path. Mirror the
+        # guard in terminate_processes().
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
+            await proc.wait()
         raise RuntimeError(f"Agent process timed out after {config.timeout}s") from exc
     except asyncio.CancelledError:
-        proc.kill()
+        # On cancellation the process may already have exited; suppress
+        # ProcessLookupError so it does not escape the cancel path.
+        with contextlib.suppress(ProcessLookupError, OSError):
+            proc.kill()
         raise
     finally:
         if stderr_task is not None and not stderr_task.done():

--- a/tests/test_runner_utils.py
+++ b/tests/test_runner_utils.py
@@ -606,6 +606,93 @@ class TestStreamClaudeProcessLifecycle:
         mock_proc.kill.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_timeout_suppresses_process_lookup_error_on_kill(
+        self, event_bus
+    ) -> None:
+        """A dead process on the timeout path must not leak ProcessLookupError.
+
+        If the agent process already exited/was reaped, ``proc.kill()`` raises
+        ProcessLookupError. The timeout handler must swallow it and still raise
+        the timeout RuntimeError, not the bare ProcessLookupError.
+        """
+
+        class HangingIter:
+            def __aiter__(self):  # noqa: ANN204
+                return self
+
+            async def __anext__(self) -> bytes:
+                await asyncio.sleep(3600)
+                return b""
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdin.drain = AsyncMock()
+        mock_proc.stdout = HangingIter()
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"")
+        mock_proc.kill = MagicMock(side_effect=ProcessLookupError)
+        mock_proc.wait = AsyncMock(side_effect=ProcessLookupError)
+
+        mock_create = AsyncMock(return_value=mock_proc)
+        active_procs: set[asyncio.subprocess.Process] = set()
+
+        with (
+            patch("asyncio.create_subprocess_exec", mock_create),
+            pytest.raises(RuntimeError, match="timed out"),
+        ):
+            await stream_claude_process(
+                **_default_kwargs(event_bus, active_procs=active_procs),
+                config=StreamConfig(timeout=0.01),
+            )
+
+        mock_proc.kill.assert_called_once()
+        assert mock_proc not in active_procs
+
+    @pytest.mark.asyncio
+    async def test_cancellation_suppresses_process_lookup_error_on_kill(
+        self, event_bus
+    ) -> None:
+        """A dead process on the cancel path must not leak ProcessLookupError.
+
+        Reproduces the production crash: ``ProcessLookupError`` at
+        base_subprocess.py:142 during ``proc.kill()`` in runner_utils.py after
+        ``asyncio.CancelledError``. The handler must re-raise CancelledError,
+        never the bare ProcessLookupError.
+        """
+
+        class CancellingIter:
+            def __aiter__(self):  # noqa: ANN204
+                return self
+
+            async def __anext__(self) -> bytes:
+                raise asyncio.CancelledError
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdin.drain = AsyncMock()
+        mock_proc.stdout = CancellingIter()
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.read = AsyncMock(return_value=b"")
+        mock_proc.kill = MagicMock(side_effect=ProcessLookupError)
+        mock_proc.wait = AsyncMock()
+
+        mock_create = AsyncMock(return_value=mock_proc)
+        active_procs: set[asyncio.subprocess.Process] = set()
+
+        with (
+            patch("asyncio.create_subprocess_exec", mock_create),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await stream_claude_process(
+                **_default_kwargs(event_bus, active_procs=active_procs)
+            )
+
+        mock_proc.kill.assert_called_once()
+        assert mock_proc not in active_procs
+
+    @pytest.mark.asyncio
     async def test_tracks_process_in_active_set(self, event_bus) -> None:
         """Process should be in active_procs during execution and removed after."""
         active_procs: set[asyncio.subprocess.Process] = set()


### PR DESCRIPTION
## Bug (WS-01)

Bare `proc.kill()` / `proc.wait()` calls in `src/runner_utils.py` run after a `TimeoutError`, after `asyncio.CancelledError`, and on the early-kill path inside `_stream_and_collect`. If the agent subprocess has already exited / been reaped, `proc.kill()` raises `ProcessLookupError` (and a stale `proc.wait()` can too), which then escapes the cleanup/cancel path.

Production logs show **2 occurrences**: `ProcessLookupError` at `base_subprocess.py:142` during `proc.kill()` in `runner_utils.py` after `asyncio.CancelledError`.

The same file already had the correct guard in `terminate_processes()` — this PR mirrors it.

## Fix

Wrap each bare `proc.kill()` (and adjacent `proc.wait()` / `await proc.wait()` that can also raise on a dead proc) in `contextlib.suppress(ProcessLookupError, OSError)`, matching the existing `terminate_processes()` guard. `contextlib` was already imported. Control flow is otherwise unchanged:
- timeout path still raises `RuntimeError`
- cancel path still re-raises `CancelledError`

Sites guarded: early-kill `proc.kill()`, post-stream `await proc.wait()`, the `TimeoutError` handler (`proc.kill()` + `await proc.wait()`), and the `CancelledError` handler (`proc.kill()`).

## Test

Extended `tests/test_runner_utils.py` with two regression tests proving the **timeout path** and the **cancel path** do not propagate `ProcessLookupError` when `proc.kill()` raises it (mock proc whose `kill()` raises `ProcessLookupError`). Both were verified failing before the fix and passing after. Full file: 50 passed; `ruff check` clean.

Part of autonomous overnight log-cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)