### PR TITLE
fix(report): make in-progress->in-progress report transition idempotent (no-op)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -2224,8 +2224,17 @@ class TrackedReport(BaseModel):
 
         Appends a :class:`ReportHistoryEntry` and updates ``updated_at``.
 
-        Raises :class:`ValueError` if the transition is not allowed.
+        A self-transition (``new_status == self.status``) is a semantic no-op:
+        it leaves the report unchanged and returns without raising.  This keeps
+        idempotent re-marks (e.g. ``report_issue_loop`` re-marking an already
+        ``in-progress`` report every tick) from raising ``ValueError`` — the
+        highest-volume production ERROR before this fix.
+
+        Raises :class:`ValueError` if the transition is to a *distinct*,
+        disallowed state.
         """
+        if new_status == self.status:
+            return
         allowed = self._VALID_TRANSITIONS.get(self.status, set())
         if new_status not in allowed:
             msg = f"Invalid transition: {self.status} -> {new_status}"

--- a/tests/test_report_issue_loop.py
+++ b/tests/test_report_issue_loop.py
@@ -458,6 +458,41 @@ class TestReportStatusTransitions:
 
         assert "in-progress" in captured_status
 
+    @pytest.mark.asyncio
+    async def test_already_in_progress_report_remark_does_not_raise(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-marking an already 'in-progress' report is idempotent.
+
+        Regression for the highest-volume production ERROR (31 occurrences):
+        ``ValueError: Invalid transition: in-progress -> in-progress`` raised
+        every tick because the report was already in-progress.  The self-
+        transition is now a no-op.
+        """
+        loop, _stop, state, _pr = _make_loop(tmp_path)
+        report = PendingReport(description="Loop re-mark", reporter_id="u1")
+        state.enqueue_report(report)
+        state.add_tracked_report(
+            TrackedReport(
+                id=report.id,
+                reporter_id="u1",
+                description=report.description,
+                status="in-progress",
+            )
+        )
+
+        with patch(
+            "runner_utils.stream_claude_process", new_callable=AsyncMock
+        ) as mock_stream:
+            mock_stream.return_value = "https://github.com/acme/repo/issues/77"
+            result = await loop._do_work()
+
+        assert result is not None
+        assert result["processed"] == 1
+        tracked = state.get_tracked_report(report.id)
+        assert tracked is not None
+        assert tracked.status == "filed"
+
 
 class TestReportRetryAndEscalation:
     @pytest.mark.asyncio

--- a/tests/test_rich_models.py
+++ b/tests/test_rich_models.py
@@ -184,6 +184,27 @@ class TestTrackedReportTransition:
         report.transition("in-progress", action="processing")
         assert report.history[0].detail == ""
 
+    def test_self_transition_is_noop(self) -> None:
+        report = self._make_report("in-progress")
+        old_updated = report.updated_at
+        report.transition("in-progress", action="processing", detail="again")
+        assert report.status == "in-progress"
+        assert report.history == []
+        assert report.updated_at == old_updated
+
+    def test_self_transition_terminal_state_is_noop(self) -> None:
+        report = self._make_report("closed")
+        report.transition("closed", action="confirm_fixed")
+        assert report.status == "closed"
+        assert report.history == []
+
+    def test_invalid_distinct_transition_still_raises_after_noop_guard(self) -> None:
+        report = self._make_report("in-progress")
+        with pytest.raises(
+            ValueError, match="Invalid transition: in-progress -> fixed"
+        ):
+            report.transition("fixed", action="fixed")
+
 
 # ---------------------------------------------------------------------------
 # StateTracker.record_successful_merge


### PR DESCRIPTION
## Bug

Highest-volume ERROR in production logs (**31 occurrences**):

```
ValueError: Invalid transition: in-progress -> in-progress
```

Raised from `TrackedReport.transition` (`src/models.py`) and triggered by `report_issue_loop.py` re-marking an already-in-progress report as `"in-progress"` every tick. The report state machine rejected same-state (idempotent) transitions, so the loop errored on every pass over a report that was already being processed.

A self-transition is semantically a **no-op**, not an error.

## Fix (model-level, so all callers benefit)

`TrackedReport.transition` now early-returns when `new_status == self.status`, leaving `status`, `updated_at`, and `history` untouched. Genuinely-invalid (distinct-state) transitions are still rejected with the same `ValueError` as before.

## Tests

- `tests/test_rich_models.py` — self-transition is a no-op (no raise; status and history unchanged) for both a normal and a terminal state; a distinct invalid transition still raises.
- `tests/test_report_issue_loop.py` — re-marking an already-in-progress report during `_do_work` processes cleanly through to `"filed"` without error.

Local: `109 passed`; `ruff` clean on touched files.

_Autonomous overnight log-cleanup (WS-02): targets the top recurring production ERROR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)