### PR TITLE
fix(staging-promotion): skip empty RC branch instead of erroring on PR create

### DIFF
--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -153,6 +153,20 @@ class StagingPromotionLoop(BaseBackgroundLoop):
             logger.exception("Failed to create RC branch %s", rc_branch)
             return {"status": "rc_branch_failed"}
 
+        # Pre-check: skip when staging is already identical to main. Opening a
+        # promotion PR with zero commits ahead hard-fails on GitHub with
+        # "GraphQL: No commits between main and <rc> (createPullRequest)" — a
+        # recurring ERROR on every cadence tick during quiet periods. Treat the
+        # empty-RC case as a clean no-op instead.
+        if not await self._prs.branch_has_diff_from_main(rc_branch):
+            self._record_last_rc(now)
+            logger.info(
+                "RC branch %s has no commits ahead of %s; skipping promotion PR",
+                rc_branch,
+                self._config.main_branch,
+            )
+            return {"status": "no_commits", "rc_branch": rc_branch}
+
         title = f"Promote {rc_branch} → {self._config.main_branch}"
         body = (
             f"Automated release-candidate promotion PR.\n\n"

--- a/tests/test_staging_promotion_loop.py
+++ b/tests/test_staging_promotion_loop.py
@@ -39,6 +39,7 @@ def _make_loop(
     open_promotion: PRInfo | None = None,
     ci_result: tuple[bool, str] = (True, "ok"),
     merge_result: bool = True,
+    rc_has_diff: bool = True,
 ) -> tuple[StagingPromotionLoop, MagicMock]:
     monkeypatch.setenv(
         "HYDRAFLOW_STAGING_ENABLED", "true" if staging_enabled else "false"
@@ -66,6 +67,7 @@ def _make_loop(
     prs.post_comment = AsyncMock()
     prs.close_issue = AsyncMock()
     prs.create_rc_branch = AsyncMock(return_value="sha123")
+    prs.branch_has_diff_from_main = AsyncMock(return_value=rc_has_diff)
     prs.create_promotion_pr = AsyncMock(return_value=42)
     prs.push_synthetic_commit = AsyncMock(return_value="synthetic-sha-rc")
     prs.create_issue = AsyncMock(return_value=1234)
@@ -172,6 +174,60 @@ class TestRecordOnCreate:
         result = await loop._do_work()
         assert result["status"] == "rc_branch_failed"
         assert not loop._cadence_path().exists()
+
+
+class TestEmptyRcNoOp:
+    @pytest.mark.asyncio
+    async def test_skips_pr_when_rc_has_no_commits_ahead(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs = _make_loop(tmp_path, monkeypatch, rc_has_diff=False)
+        result = await loop._do_work()
+        assert result["status"] == "no_commits"
+        assert result["rc_branch"].startswith("rc/")
+        prs.branch_has_diff_from_main.assert_called_once()
+        # No promotion PR is opened and no synthetic commit is pushed —
+        # avoids the "No commits between main and <rc>" GraphQL hard-fail.
+        prs.create_promotion_pr.assert_not_called()
+        prs.push_synthetic_commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_rc_logs_info_not_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        loop, _ = _make_loop(tmp_path, monkeypatch, rc_has_diff=False)
+        with caplog.at_level("INFO", logger="hydraflow.staging_promotion_loop"):
+            await loop._do_work()
+        assert not any(r.levelname == "ERROR" for r in caplog.records)
+        assert any(
+            "no commits ahead" in r.getMessage() and r.levelname == "INFO"
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_rc_records_cadence_to_avoid_immediate_recut(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, _ = _make_loop(tmp_path, monkeypatch, rc_has_diff=False)
+        assert not loop._cadence_path().exists()
+        await loop._do_work()
+        # Recording the timestamp prevents re-cutting an identical RC on the
+        # very next poll tick during quiet periods.
+        assert loop._cadence_path().exists()
+
+    @pytest.mark.asyncio
+    async def test_opens_pr_when_rc_has_commits_ahead(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs = _make_loop(tmp_path, monkeypatch, rc_has_diff=True)
+        result = await loop._do_work()
+        assert result["status"] == "opened"
+        assert result["pr"] == 42
+        prs.create_promotion_pr.assert_called_once()
+        prs.push_synthetic_commit.assert_called_once()
 
 
 class TestOpenPromotionPassing:


### PR DESCRIPTION
## Bug

`StagingPromotionLoop` cuts an `rc/*` snapshot from `staging` every cadence tick. During quiet periods `staging` is identical to `main`, so the snapshot has **zero commits ahead**. Opening a promotion PR for such a branch hard-fails on GitHub:

```
pull request create failed: GraphQL: No commits between main and rc/2026-06-04-0520 (createPullRequest)
```

This surfaced as **7 ERROR occurrences** in production logs from `src/staging_promotion_loop.py` (the create-promotion-PR path, ~line 164) — recurring log noise and wasted churn on every cadence cycle.

## Fix

Pre-check the freshly-cut RC branch with the existing `PRPort.branch_has_diff_from_main` before attempting the PR. When the branch has no commits ahead of `main`:

- record the cadence timestamp (so we don't re-cut an identical RC on the next poll tick),
- log at **INFO** (not ERROR),
- return a clean `{"status": "no_commits", "rc_branch": ...}` skip.

The real create-promotion-PR path is unchanged, so unrelated failures still raise — no errors are swallowed.

## Test

`tests/test_staging_promotion_loop.py` — new `TestEmptyRcNoOp`:
- empty-RC tick → `no_commits` status, no PR created, no synthetic commit pushed;
- empty-RC logs INFO, never ERROR;
- empty-RC records cadence timestamp (no immediate re-cut);
- non-empty RC → PR opened as before.

`FakeGitHub.branch_has_diff_from_main` already returns `True`, so existing MockWorld promotion scenarios continue to open PRs unchanged.

Local verification: `pytest tests/test_staging_promotion_loop.py` → 26 passed; `ruff check` on both files → clean.

Autonomous overnight log-cleanup (WS-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)