### PR TITLE
fix(dashboard): toggled-off loop shows neutral grey when running too (sibling to #9221)

### DIFF
--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -127,7 +127,7 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
     lastRun = null
     details = {}
   } else if (state.enabled === false) {
-    dotColor = theme.red
+    dotColor = theme.textInactive
     statusText = 'off'
     lastRun = state.last_run || null
     details = state.details || {}

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -148,7 +148,7 @@ describe('SystemPanel', () => {
       const errDot = screen.getByTestId('dot-retrospective')
       expect(errDot.style.background).toBe('var(--red)')
       const offDot = screen.getByTestId('dot-dependabot_merge')
-      expect(offDot.style.background).toBe('var(--red)')
+      expect(offDot.style.background).toBe('var(--text-inactive)')
     })
 
     it('shows last run time when available', () => {


### PR DESCRIPTION
## Context

Sibling to #9221, which made idle-factory loops show yellow "not running" and de-redded the toggled-off case in the \`!orchRunning\` branch of \`SystemPanel.jsx\` to neutral grey. The principle established there: **RED is reserved exclusively for \`status === 'error'\`.**

One inconsistency remained: when the orchestrator **is** running (\`orchRunning === true\`), a loop that is explicitly toggled OFF still rendered RED. So the same toggled-off loop looked grey while the factory was idle but red while it was running — confusing and inconsistent with the #9221 principle.

## Change

In the running branch's \`else if (state.enabled === false)\` case, changed \`dotColor = theme.red\` → \`dotColor = theme.textInactive\` (neutral grey). \`statusText\` stays \`'off'\`. A toggled-off loop is now neutral grey whether or not the factory is running. The \`status === 'error'\` red is untouched.

## Test

Updated the running-branch test "shows ok/error status when orchestrator is running" to expect \`var(--text-inactive)\` for the toggled-off \`dependabot_merge\` dot. The error-state (\`retrospective\`, \`status: 'error'\`) red assertion is unchanged.

Autonomous overnight UI-consistency cleanup. Vitest (83 passed) + \`npm run build\` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)