### PR TITLE
fix(repo-wiki): aggregate+downgrade malformed-entry warning storm (7,663 WARN/run)

### DIFF
--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -1374,6 +1374,7 @@ class RepoWikiStore:
         second directory walk.
         """
         pairs: list[tuple[WikiEntry, Path]] = []
+        skipped_ids: list[str] = []
         for raw in _load_tracked_active_entries(topic_dir):
             try:
                 corroborations_raw = raw.get("corroborations", "1")
@@ -1397,7 +1398,26 @@ class RepoWikiStore:
                 path = Path(path_raw) if path_raw else topic_dir / "unknown.md"
                 pairs.append((entry, path))
             except (ValueError, TypeError):
-                logger.warning("Skipping malformed tracked entry under %s", topic_dir)
+                # Per-entry skips log at DEBUG (with the offending id/path so the
+                # skip stays diagnosable) instead of WARNING. The parser re-reads
+                # the same malformed files on every loop tick, so a per-entry
+                # WARNING here produced a self-amplifying log storm (~7,663
+                # lines/run in prod, 85% of all warnings). The single aggregate
+                # WARNING below is the operator-actionable signal per dir per tick.
+                offender = raw.get("id") or raw.get("path") or "<unknown>"
+                skipped_ids.append(str(offender))
+                logger.debug(
+                    "repo_wiki: skipping malformed tracked entry %s under %s",
+                    offender,
+                    topic_dir,
+                )
+        if skipped_ids:
+            logger.warning(
+                "repo_wiki: skipped %d malformed entries under %s (ids: %s)",
+                len(skipped_ids),
+                topic_dir,
+                ", ".join(skipped_ids),
+            )
         return pairs
 
     def _load_topic_entries(self, topic_path: Path) -> list[WikiEntry]:

--- a/tests/test_compile_topic_tracked.py
+++ b/tests/test_compile_topic_tracked.py
@@ -12,6 +12,7 @@ real LLM backend.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -19,6 +20,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from repo_wiki import (
+    RepoWikiStore,
     WikiEntry,
     _load_tracked_active_entries,
     _mark_tracked_entry_superseded,
@@ -94,6 +96,96 @@ class TestLoadTrackedActiveEntries:
         topic_dir.mkdir()
         (topic_dir / "0001-issue-1-x.md").write_text("# no frontmatter\n")
         assert _load_tracked_active_entries(topic_dir) == []
+
+
+class TestMalformedTrackedEntryLogging:
+    """Malformed tracked entries must not produce a per-entry WARNING storm.
+
+    A non-numeric ``source_issue`` makes ``int(...)`` raise inside
+    ``_load_tracked_topic_entries_with_paths``. The parser re-reads the same
+    files every loop tick, so per-entry WARNINGs self-amplified to ~7,663
+    lines/run in prod. The fix downgrades each skip to DEBUG (with the
+    offending id) and emits exactly one aggregated WARNING per topic dir.
+    """
+
+    def _write_topic(self, tmp_path: Path) -> Path:
+        topic_dir = tmp_path / "patterns"
+        # One good entry plus two malformed (non-numeric source_issue).
+        _write_entry_file(
+            topic_dir / "0001-issue-1-good.md",
+            entry_id="0001",
+            topic="patterns",
+            source_issue=1,
+            title="Good",
+        )
+        _write_entry_file(
+            topic_dir / "0002-issue-bad-b.md",
+            entry_id="0002",
+            topic="patterns",
+            source_issue="not-a-number",
+            title="Bad B",
+        )
+        _write_entry_file(
+            topic_dir / "0003-issue-bad-c.md",
+            entry_id="0003",
+            topic="patterns",
+            source_issue="also-bad",
+            title="Bad C",
+        )
+        return topic_dir
+
+    def test_per_entry_skip_logs_at_debug_with_id(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        topic_dir = self._write_topic(tmp_path)
+        store = RepoWikiStore(tmp_path / "wikiroot")
+
+        with caplog.at_level(logging.DEBUG, logger="hydraflow.repo_wiki"):
+            pairs = store._load_tracked_topic_entries_with_paths(topic_dir)
+
+        # Good entry still parses; malformed ones are dropped (behavior intact).
+        assert [entry.id for entry, _ in pairs] == ["0001"]
+
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        debug_msgs = [r.getMessage() for r in debug_records]
+        assert any("0002" in m for m in debug_msgs)
+        assert any("0003" in m for m in debug_msgs)
+        assert all("malformed tracked entry" in m for m in debug_msgs)
+
+    def test_emits_exactly_one_aggregated_warning_with_count_and_ids(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        topic_dir = self._write_topic(tmp_path)
+        store = RepoWikiStore(tmp_path / "wikiroot")
+
+        with caplog.at_level(logging.DEBUG, logger="hydraflow.repo_wiki"):
+            store._load_tracked_topic_entries_with_paths(topic_dir)
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "skipped 2 malformed entries" in msg
+        assert str(topic_dir) in msg
+        assert "0002" in msg and "0003" in msg
+
+    def test_no_warning_when_all_entries_well_formed(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        topic_dir = tmp_path / "patterns"
+        _write_entry_file(
+            topic_dir / "0001-issue-1-good.md",
+            entry_id="0001",
+            topic="patterns",
+            source_issue=1,
+            title="Good",
+        )
+        store = RepoWikiStore(tmp_path / "wikiroot")
+
+        with caplog.at_level(logging.DEBUG, logger="hydraflow.repo_wiki"):
+            pairs = store._load_tracked_topic_entries_with_paths(topic_dir)
+
+        assert [entry.id for entry, _ in pairs] == ["0001"]
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
 
 
 class TestWriteTrackedSynthesisEntry:


### PR DESCRIPTION
## Bug (WS-04)

The repo_wiki tracked-entry parser (`RepoWikiStore._load_tracked_topic_entries_with_paths`) logged **one WARNING per malformed wiki entry**. Because the parser re-reads the same malformed `.md` files on **every** `RepoWikiLoop` tick, those per-entry WARNINGs self-amplified into a log storm: **~7,663 WARNING lines per run** in production — roughly **85% of all warnings** — drowning out every other operator signal in the log.

## Fix (logging hygiene only)

Parsing behavior is unchanged and **no wiki `.md` data files are touched** — fixing the underlying malformed markdown is a separate data-cleanup task, out of scope here.

1. **Downgrade** the per-entry "skipping malformed tracked entry" log from `WARNING` to `DEBUG`, and **include the offending entry id/path** so each skip stays diagnosable.
2. **Aggregate**: emit **exactly one** `WARNING` per topic dir, only when `count > 0`:
   `repo_wiki: skipped N malformed entries under <dir> (ids: ...)` — so operators still get a single actionable signal per dir per tick instead of thousands.

## Test

Extended `tests/test_compile_topic_tracked.py` (new `TestMalformedTrackedEntryLogging`). Using `caplog`, it feeds a mix of well-formed and malformed tracked entries (non-numeric `source_issue`) and asserts:
- each individual skip logs at **DEBUG** carrying its entry id,
- **exactly one** aggregated **WARNING** per dir with the correct count (`2`) and ids (`0002, 0003`),
- the good entry still parses (behavior intact),
- **no** WARNING when all entries are well-formed.

Local verification (pytest 14 passed · ruff clean · pyright 0 errors on `src/repo_wiki.py`).

_Autonomous overnight log-cleanup run._

🤖 Generated with [Claude Code](https://claude.com/claude-code)