### PR TITLE
fix(logging): downgrade benign HITL + term_proposer WARN spam to INFO

### DIFF
--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -585,9 +585,10 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             records = insight_store.load_recent(50)
             stale = verify_proposals(insight_store, records)
             for category in stale:
-                logger.warning(
-                    "HITL recommendation: stale review insight '%s'", category
-                )
+                # Informational HITL-recommendation status, not a warning — this
+                # line floods the WARNING channel in production (~195 occ.) with
+                # benign tuning-recommendation output (WS-05 log-hygiene).
+                logger.info("HITL recommendation: stale review insight '%s'", category)
         except ImportError:
             pass
         except Exception:  # noqa: BLE001
@@ -897,7 +898,10 @@ class HealthMonitorLoop(BaseBackgroundLoop):
                         rec_path.parent.mkdir(parents=True, exist_ok=True)
                         with rec_path.open("a") as f:
                             f.write(json.dumps(rec) + "\n")
-                        logger.warning("HITL recommendation: %s", title)
+                        # Informational status (a recommendation was filed), not a
+                        # warning — downgraded from WARNING to stop flooding the
+                        # production WARNING channel (WS-05 log-hygiene).
+                        logger.info("HITL recommendation: %s", title)
                     except OSError:
                         logger.debug(
                             "Failed to write HITL recommendation", exc_info=True

--- a/src/term_proposer_loop.py
+++ b/src/term_proposer_loop.py
@@ -199,7 +199,13 @@ class TermProposerLoop(BaseBackgroundLoop):
             except (ValueError, RuntimeError) as e:
                 # No dedup on failure — the candidate falls through to natural
                 # re-detection on the next tick (Fix C1; see ADR-0054 I2).
-                logger.warning(
+                #
+                # INFO, not WARNING: when the LLM client adapter is in its
+                # documented intentional-incomplete state (ADR-0054), draft()
+                # raises on every candidate, flooding the WARNING channel
+                # (~470 occ.). This is an expected pending-adapter signal, not an
+                # error, so it belongs at INFO (WS-05 log-hygiene).
+                logger.info(
                     "term_proposer: LLM draft failed for %s: %s", candidate.name, e
                 )
                 dropped_drafts += 1

--- a/tests/test_health_monitor_loop_primary_cycle.py
+++ b/tests/test_health_monitor_loop_primary_cycle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -376,6 +377,32 @@ class TestFileHitlRecommendations:
         rec = json.loads(lines[0])
         assert rec["type"] == "recommendation"
         assert "surprise_rate" in rec["title"]
+
+    async def test_recommendation_status_logs_at_info_not_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The 'HITL recommendation: ...' filed-status line is informational and
+        must emit at INFO, never WARNING — it floods the production WARNING
+        channel (~195 occ.) otherwise (WS-05 log-hygiene)."""
+        loop = _make_loop(tmp_path)
+        metrics = TrendMetrics(
+            first_pass_rate=0.5,
+            avg_memory_score=0.7,
+            surprise_rate=_SURPRISE_HIGH + 0.05,
+            hitl_escalation_rate=0.0,
+            stale_item_count=0,
+            total_outcomes=10,
+        )
+        with caplog.at_level(logging.INFO, logger="hydraflow.health_monitor_loop"):
+            await loop._file_hitl_recommendations(metrics)
+        rec_records = [
+            r
+            for r in caplog.records
+            if r.getMessage().startswith("HITL recommendation:")
+        ]
+        assert rec_records, "expected a 'HITL recommendation:' status log line"
+        assert all(r.levelno == logging.INFO for r in rec_records)
+        assert all(r.levelno != logging.WARNING for r in rec_records)
 
     async def test_high_hitl_rate_writes_recommendation(self, tmp_path: Path) -> None:
         loop = _make_loop(tmp_path)

--- a/tests/test_term_proposer_loop.py
+++ b/tests/test_term_proposer_loop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -123,7 +124,9 @@ class TestTermProposerLoopFlow:
         assert result["opened_pr"] is True
 
     @pytest.mark.asyncio
-    async def test_invalid_draft_from_llm_dropped(self, synthetic_repo: Path) -> None:
+    async def test_invalid_draft_from_llm_dropped(
+        self, synthetic_repo: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
         """LLM returns a payload with an out-of-vocabulary ``kind`` → Pydantic
         validation in ``TermDraft`` raises → counted under ``dropped_drafts``
         via the LLM-failure branch.
@@ -131,6 +134,10 @@ class TestTermProposerLoopFlow:
         This exercises the LLM-failure path (Pydantic enum coercion fails),
         NOT the F1 ``validate_draft`` path. For real F1 coverage see
         ``test_validation_rejects_unresolvable_depends_on``.
+
+        The draft-failed line must emit at INFO, not WARNING: when the client
+        adapter is in its documented intentional-incomplete state (ADR-0054) it
+        raises on every candidate and floods the WARNING channel (~470 occ.).
         """
         loop, _, port = _build_loop(
             synthetic_repo,
@@ -144,11 +151,21 @@ class TestTermProposerLoopFlow:
                 "depends_on_anchors": [],
             },
         )
-        result = await loop._do_work()
+        with caplog.at_level(logging.INFO, logger="hydraflow.term_proposer_loop"):
+            result = await loop._do_work()
         assert port.calls == []
         assert result["drafted"] == 0  # LLM call failed before counting
         assert result["validated"] == 0
         assert result["dropped_drafts"] >= 1
+
+        draft_failed = [
+            r
+            for r in caplog.records
+            if "term_proposer: LLM draft failed" in r.getMessage()
+        ]
+        assert draft_failed, "expected a draft-failed log line"
+        assert all(r.levelno == logging.INFO for r in draft_failed)
+        assert all(r.levelno != logging.WARNING for r in draft_failed)
 
     @pytest.mark.asyncio
     async def test_llm_skip_judgment_drops_candidate_with_no_pr(


### PR DESCRIPTION
## Bug (WS-05 log-hygiene)

Two known non-bug patterns flood the production WARNING channel:

1. **`src/health_monitor_loop.py`** — the `HITL recommendation: ...` filed-status lines (~195 occurrences) are informational tuning-recommendation status, not warnings.
2. **`src/term_proposer_loop.py`** — the `term_proposer: LLM draft failed for ...` line (~470 occurrences) fires on every candidate when the LLM client adapter is in its documented intentional-incomplete state per **ADR-0054**. This is an expected pending-adapter signal, not an error.

## Fix (log level only — no behavior change)

- `health_monitor_loop.py`: both informational `HITL recommendation:` emitters (stale-review-insight status and the filed-recommendation status) moved `logger.warning` → `logger.info`. Genuine failure warnings (`Failed to file ...`, `_file_hitl_recommendations failed`) are left untouched.
- `term_proposer_loop.py`: the draft-failed/pending-adapter `logger.warning` → `logger.info`.

No control flow or behavior changed — pure logging hygiene.

## Tests

Each loop's existing unit test is extended to assert via `caplog` that the message now emits at **INFO** and **NOT** at **WARNING**:
- `tests/test_health_monitor_loop_primary_cycle.py::TestFileHitlRecommendations::test_recommendation_status_logs_at_info_not_warning`
- `tests/test_term_proposer_loop.py::TestTermProposerLoopFlow::test_invalid_draft_from_llm_dropped` (extended)

Verified locally: `pytest` (41 passed) + `ruff check` + `pyright` (0 errors) all green.

Autonomous overnight log-cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)