### PR TITLE
fix(test): seed branch_has_diff_from_main AsyncMock in L22 promotion scenario (regression from #9231)

### DIFF
--- a/tests/scenarios/test_caretaker_loops_part2.py
+++ b/tests/scenarios/test_caretaker_loops_part2.py
@@ -429,6 +429,11 @@ class TestL22StagingPromotionLoop:
         prs.create_promotion_pr = AsyncMock(return_value=42)
         prs.push_synthetic_commit = AsyncMock(return_value="synthetic-sha")
         prs.wait_for_ci = AsyncMock(return_value=(True, "all green"))
+        # Empty-RC guard added in #9231: the loop awaits this before opening the
+        # promotion PR. Default True = RC has commits ahead of main, so the cut
+        # path proceeds. Without an explicit AsyncMock the bare MagicMock raises
+        # "object MagicMock can't be used in 'await' expression".
+        prs.branch_has_diff_from_main = AsyncMock(return_value=True)
 
         return StagingPromotionLoop(config=config, prs=prs, deps=deps), prs, config
 


### PR DESCRIPTION
## Regression fix

PR #9231 added an empty-RC guard to `StagingPromotionLoop` that `await`s `prs.branch_has_diff_from_main(...)` before opening the promotion PR. The L22 `scenario_loops` tests in `test_caretaker_loops_part2.py` build `prs` as a bare `MagicMock` and only seed the AsyncMocks they knew about, so the new `await` raised:

```
TypeError: object MagicMock can't be used in 'await' expression
FAILED tests/scenarios/test_caretaker_loops_part2.py::TestL22StagingPromotionLoop::test_staging_enabled_cadence_elapsed_cuts_new_rc
```

This surfaced in CI's `make scenario-loops` step (the `Scenario Tests` job runs both `make scenario` **and** `make scenario-loops`). #9231's unit suite + `make scenario` didn't cover this hand-mocked `scenario_loops` test, so it went green to the required checks and the regression landed on `staging`, contaminating every subsequent PR's `Scenario Tests`.

## Fix

Seed `prs.branch_has_diff_from_main = AsyncMock(return_value=True)` in the shared `_make_staging_loop` helper so the cut-RC path proceeds. **Test-only**, no production change.

Verified: `pytest tests/scenarios/test_caretaker_loops_part2.py -m scenario_loops` → 21 passed; ruff clean; pre-commit lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)