### PR TITLE
fix(state): prune orphaned bg_worker_states keys on startup

### DIFF
--- a/src/bg_worker_manager.py
+++ b/src/bg_worker_manager.py
@@ -133,6 +133,10 @@ class BGWorkerManager:
         """Return the set of worker names that have heartbeat state."""
         return set(self._bg_worker_states)
 
+    def _remove_worker_state_entry(self, name: str) -> None:
+        """Remove an in-memory heartbeat entry entirely (for stale worker pruning)."""
+        self._bg_worker_states.pop(name, None)
+
     def set_interval(self, name: str, seconds: int) -> None:
         """Set a dynamic interval override for a background worker."""
         self._bg_worker_intervals[name] = seconds

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -1053,9 +1053,9 @@ class HydraFlowOrchestrator:
 
         # Hindsight WAL replay loop removed in Phase 3 cutover — the wiki
         # pipeline doesn't need a replay loop.
-        self._state_restorer.prune_stale_disabled_workers(
-            {n for n, _ in loop_factories}
-        )
+        known_worker_names = {n for n, _ in loop_factories}
+        self._state_restorer.prune_stale_disabled_workers(known_worker_names)
+        self._state_restorer.prune_stale_worker_states(known_worker_names)
         tasks: dict[str, asyncio.Task[None]] = {}
         for name, factory in loop_factories:
             tasks[name] = asyncio.create_task(factory(), name=f"hydraflow-{name}")

--- a/src/state_restorer.py
+++ b/src/state_restorer.py
@@ -128,6 +128,36 @@ class StateRestorer:
             self._bg_workers._remove_enabled_entry(name)
         self._state.set_disabled_workers(disabled - stale)
 
+    def prune_stale_worker_states(self, known_names: set[str]) -> None:
+        """Remove persisted heartbeat entries for workers that no longer exist.
+
+        Mirror of :meth:`prune_stale_disabled_workers` but for the
+        ``bg_worker_states`` heartbeat cache.  Orphan keys accumulate when a
+        worker is renamed (e.g. ``diagram-loop`` -> ``diagram_loop``) or removed
+        between releases (``verify_monitor``, ``manifest_refresh``,
+        ``worktree_gc``, ``metrics``, ``memory_sync``, ``code_grooming``); the
+        old key lingers in ``state.json`` forever and can confuse the dashboard.
+
+        Called after loop factories are defined so we know the full set of valid
+        worker names.  Only entries whose name is not in *known_names* are
+        dropped — a live worker's heartbeat is never removed.
+        """
+        if not known_names:
+            return
+        persisted = set(self._state.get_bg_worker_states())
+        stale = persisted - known_names
+        if not stale:
+            return
+        logger.info(
+            "Pruning %d stale bg_worker_state heartbeat entr%s from state: %s",
+            len(stale),
+            "ies" if len(stale) != 1 else "y",
+            sorted(stale),
+        )
+        for name in stale:
+            self._bg_workers._remove_worker_state_entry(name)
+            self._state.remove_bg_worker_state(name)
+
     def _restore_bg_worker_states(self) -> None:
         """Hydrate background worker heartbeat cache from persisted state."""
         persisted = self._state.get_bg_worker_states()

--- a/tests/test_state_restorer.py
+++ b/tests/test_state_restorer.py
@@ -134,6 +134,59 @@ class TestPruneStaleDisabledWorkers:
         assert bg_workers.worker_enabled == {}
 
 
+class TestPruneStaleWorkerStates:
+    @staticmethod
+    def _seed(state: Any, name: str) -> None:
+        state.set_bg_worker_state(
+            name,
+            {
+                "name": name,
+                "status": "ok",
+                "last_run": "2026-01-01T00:00:00Z",
+                "details": {},
+            },
+        )
+
+    def test_prunes_orphan_heartbeats(
+        self,
+        restorer: StateRestorer,
+        state: Any,
+        bg_workers: BGWorkerManager,
+    ) -> None:
+        # Orphan keys: renamed (diagram-loop) and removed (verify_monitor) workers
+        self._seed(state, "diagram-loop")
+        self._seed(state, "verify_monitor")
+        # Valid keys for live workers
+        self._seed(state, "triage")
+        self._seed(state, "review")
+        # Hydrate the in-memory cache the way startup recovery would
+        restorer.restore_all(set(), set(), set(), set())
+
+        restorer.prune_stale_worker_states({"triage", "review"})
+
+        # Only live workers survive in persisted state...
+        persisted = set(state.get_bg_worker_states())
+        assert persisted == {"triage", "review"}
+        # ...and in the in-memory heartbeat cache.
+        assert "diagram-loop" not in bg_workers.worker_states
+        assert "verify_monitor" not in bg_workers.worker_states
+        assert "triage" in bg_workers.worker_states
+        assert "review" in bg_workers.worker_states
+
+    def test_noop_when_no_stale(self, restorer: StateRestorer, state: Any) -> None:
+        self._seed(state, "triage")
+        restorer.restore_all(set(), set(), set(), set())
+        restorer.prune_stale_worker_states({"triage", "review"})
+        assert set(state.get_bg_worker_states()) == {"triage"}
+
+    def test_noop_when_no_known(self, restorer: StateRestorer, state: Any) -> None:
+        self._seed(state, "diagram-loop")
+        restorer.restore_all(set(), set(), set(), set())
+        # Empty known set must never drop a live worker's state defensively
+        restorer.prune_stale_worker_states(set())
+        assert set(state.get_bg_worker_states()) == {"diagram-loop"}
+
+
 class TestBackfillFromEvents:
     @pytest.mark.asyncio
     async def test_backfills_from_event_history(


### PR DESCRIPTION
## Bug (WS-07)

The persisted `bg_worker_states` heartbeat cache in `state.json` accumulated orphan keys for workers that no longer exist under their current name:

- `diagram_loop`'s heartbeat was stored under the OLD hyphenated key `diagram-loop` (the loop was renamed underscore → hyphen drift).
- Stale keys from removed/renamed workers: `verify_monitor`, `manifest_refresh`, `worktree_gc`, `metrics`, `memory_sync`, `code_grooming`.

These linger forever, clutter state, and can confuse the dashboard.

## Fix

Mirrors the existing `StateRestorer.prune_stale_disabled_workers(known_names)` precedent (which prunes stale disabled-worker flags):

- Add `StateRestorer.prune_stale_worker_states(known_names)` — drops any `bg_worker_states` entry whose name is not in the known-worker set, from both the in-memory heartbeat cache (new `BGWorkerManager._remove_worker_state_entry`) and the persisted store (existing `StateTracker.remove_bg_worker_state`, which clears `bg_worker_states` + `worker_heartbeats` and saves).
- Wire it into `orchestrator._supervise_loops` right next to the existing `prune_stale_disabled_workers(...)` call, using the SAME `{n for n, _ in loop_factories}` known-names set.
- Only names **not** in `known_names` are pruned — a live worker's heartbeat is never dropped (empty known-set is a no-op guard).

## Test

`tests/test_state_restorer.py::TestPruneStaleWorkerStates` mirrors the disabled-workers prune test: seeds persisted states with orphan keys (`diagram-loop`, `verify_monitor`) plus valid keys (`triage`, `review`); after prune only the valid keys remain in both persisted state and the in-memory cache. Plus no-op-when-no-stale and no-op-when-no-known (defensive) cases.

Verified: `pytest tests/test_state_restorer.py` (14 passed), `ruff check`, `pyright` (0 errors), and the `test_caretaker_loops_part2.py` scenario_loops sanity (orchestrator startup wiring) all green.

Autonomous overnight cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)