### PR TITLE
fix(logging): never log empty exception messages (fall back to repr/type)

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
 from events import EventBus, EventType, HydraFlowEvent
-from exception_classify import is_likely_bug, reraise_on_credit_or_bug
+from exception_classify import exc_detail, is_likely_bug, reraise_on_credit_or_bug
 from models import LoopResult, Task, WorkerResult, WorkerStatus, WorkerUpdatePayload
 from plugin_skill_registry import (
     discover_plugin_skills,
@@ -300,7 +300,7 @@ Run through this checklist before your final commit:
             logger.exception(
                 "Agent failed for issue #%d: %s",
                 task.id,
-                exc,
+                exc_detail(exc),
                 extra={"issue": task.id},
             )
             await self._emit_status(task.id, worker_id, WorkerStatus.FAILED)

--- a/src/exception_classify.py
+++ b/src/exception_classify.py
@@ -38,6 +38,21 @@ def is_likely_bug(exc: BaseException) -> bool:
     return isinstance(exc, LIKELY_BUG_EXCEPTIONS)
 
 
+def exc_detail(exc: BaseException) -> str:
+    """Return a non-empty, human-readable detail string for *exc*.
+
+    Many exceptions carry an empty ``str()`` — e.g. a subprocess error raised
+    with empty stderr, or a bare ``RuntimeError()`` — which produces useless
+    log lines like ``"Review failed for PR #8672: "`` (nothing after the
+    colon). This helper guarantees a diagnostic remains by falling back to
+    ``repr(exc)`` and finally the exception's type name.
+
+    Use it anywhere ``str(exc)`` is interpolated into a log message without
+    ``exc_info=True`` to back-stop the empty-message case.
+    """
+    return str(exc).strip() or repr(exc).strip() or type(exc).__name__
+
+
 def capture_if_bug(
     exc: Exception,
     obs: ObservabilityPort | None = None,

--- a/src/planner.py
+++ b/src/planner.py
@@ -12,7 +12,7 @@ from typing import ClassVar
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
 from events import EventType, HydraFlowEvent
-from exception_classify import reraise_on_credit_or_bug
+from exception_classify import exc_detail, reraise_on_credit_or_bug
 from models import NewIssueSpec, PlannerStatus, PlannerUpdatePayload, PlanResult, Task
 from plan_constants import (
     LITE_BODY_THRESHOLD,
@@ -218,7 +218,7 @@ class PlannerRunner(BaseRunner):
             logger.exception(
                 "Planner failed for issue #%d: %s",
                 task.id,
-                exc,
+                exc_detail(exc),
                 extra={"issue": task.id},
             )
             await self._emit_status(task.id, worker_id, PlannerStatus.FAILED)

--- a/src/reviewer.py
+++ b/src/reviewer.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 from agent_cli import build_agent_command
 from base_runner import BaseRunner
 from events import EventType, HydraFlowEvent
-from exception_classify import reraise_on_credit_or_bug
+from exception_classify import exc_detail, reraise_on_credit_or_bug
 from models import (
     CICheckPayload,
     CodeScanningAlert,
@@ -240,8 +240,9 @@ class ReviewRunner(BaseRunner):
         except Exception as exc:
             reraise_on_credit_or_bug(exc)
             result.verdict = ReviewVerdict.COMMENT
-            result.summary = f"Review failed: {exc}"
-            logger.error("Review failed for PR #%d: %s", pr.number, exc)
+            detail = exc_detail(exc)
+            result.summary = f"Review failed: {detail}"
+            logger.error("Review failed for PR #%d: %s", pr.number, detail)
 
         result.duration_seconds = time.monotonic() - start
 
@@ -338,8 +339,9 @@ class ReviewRunner(BaseRunner):
         except Exception as exc:
             reraise_on_credit_or_bug(exc)
             result.verdict = ReviewVerdict.REQUEST_CHANGES
-            result.summary = f"CI fix failed: {exc}"
-            logger.error("CI fix failed for PR #%d: %s", pr.number, exc)
+            detail = exc_detail(exc)
+            result.summary = f"CI fix failed: {detail}"
+            logger.error("CI fix failed for PR #%d: %s", pr.number, detail)
 
         await self._bus.publish(
             HydraFlowEvent(
@@ -449,8 +451,9 @@ class ReviewRunner(BaseRunner):
         except Exception as exc:
             reraise_on_credit_or_bug(exc)
             result.verdict = ReviewVerdict.REQUEST_CHANGES
-            result.summary = f"Review fix failed: {exc}"
-            logger.error("Review fix failed for PR #%d: %s", pr.number, exc)
+            detail = exc_detail(exc)
+            result.summary = f"Review fix failed: {detail}"
+            logger.error("Review fix failed for PR #%d: %s", pr.number, detail)
 
         result.duration_seconds = time.monotonic() - start
 

--- a/tests/test_exception_classify.py
+++ b/tests/test_exception_classify.py
@@ -13,9 +13,38 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from exception_classify import (
     LIKELY_BUG_EXCEPTIONS,
     capture_if_bug,
+    exc_detail,
     is_likely_bug,
     reraise_on_credit_or_bug,
 )
+
+
+class TestExcDetail:
+    def test_returns_message_when_present(self) -> None:
+        assert exc_detail(RuntimeError("boom")) == "boom"
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        assert exc_detail(RuntimeError("  boom  ")) == "boom"
+
+    def test_falls_back_to_repr_when_str_empty(self) -> None:
+        detail = exc_detail(RuntimeError())
+        assert detail != ""
+        assert detail == "RuntimeError()"
+
+    def test_falls_back_to_repr_when_str_blank(self) -> None:
+        detail = exc_detail(RuntimeError("   "))
+        assert detail.strip() != ""
+        assert "RuntimeError" in detail
+
+    def test_falls_back_to_type_name_when_repr_blank(self) -> None:
+        class _SilentError(Exception):
+            def __str__(self) -> str:
+                return ""
+
+            def __repr__(self) -> str:
+                return "   "
+
+        assert exc_detail(_SilentError()) == "_SilentError"
 
 
 class TestIsLikelyBug:

--- a/tests/test_reviewer.py
+++ b/tests/test_reviewer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -523,6 +524,39 @@ async def test_review_failure_path_on_exception(
     assert result.verdict == ReviewVerdict.COMMENT
     assert "Review failed" in result.summary
     assert "subprocess crashed" in result.summary
+
+
+@pytest.mark.asyncio
+async def test_review_failure_logs_non_empty_detail_for_empty_str_exception(
+    config, event_bus, pr_info, task, tmp_path, caplog
+):
+    # A subprocess error with empty stderr / a bare exception has an empty
+    # str(), which previously produced a log line ending in a bare colon
+    # ("Review failed for PR #N: ") with zero diagnostic detail.
+    runner = _make_runner(config, event_bus)
+
+    mock_execute = AsyncMock(side_effect=RuntimeError())
+
+    with (
+        caplog.at_level(logging.ERROR, logger="hydraflow.reviewer"),
+        patch.object(runner, "_get_head_sha", AsyncMock(return_value="abc123")),
+        patch.object(runner, "_execute", mock_execute),
+    ):
+        result = await runner.review(pr_info, task, tmp_path, "some diff")
+
+    review_errors = [
+        rec.getMessage()
+        for rec in caplog.records
+        if rec.getMessage().startswith("Review failed for PR")
+    ]
+    assert review_errors, "expected a 'Review failed for PR' error log line"
+    message = review_errors[0]
+    # The message must carry a non-empty detail after the colon.
+    detail = message.split(":", 1)[1].strip()
+    assert detail, f"log message had empty detail: {message!r}"
+    assert "RuntimeError" in detail
+    # The result summary must also carry the detail (not a bare "Review failed:").
+    assert result.summary.split(":", 1)[1].strip()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Bug

Production logs showed error lines with **empty messages**, e.g.:

```
Review failed for PR #8672:
```

(nothing after the colon). When an exception's `str(exc)` is empty — a subprocess error with empty stderr, or a bare `RuntimeError()` — the interpolated `%s` detail vanished, leaving the log line (and the reviewer's `result.summary`) with zero diagnostic content. Failures became un-debuggable.

## Fix (logging-only, defensive, low-risk)

Add `exc_detail(exc)` in `src/exception_classify.py` (the existing cross-cutting home for `reraise_on_credit_or_bug`):

```python
return str(exc).strip() or repr(exc).strip() or type(exc).__name__
```

Applied at the four `exc`-interpolating error-log sites that could emit an empty message:

- `src/reviewer.py` — `"Review failed for PR #%d: %s"` (`logger.error`, no `exc_info`)
- `src/reviewer.py` — `"CI fix failed for PR #%d: %s"` (`logger.error`, no `exc_info`)
- `src/reviewer.py` — `"Review fix failed for PR #%d: %s"` (`logger.error`, no `exc_info`)
- `src/planner.py` / `src/agent.py` — `"<role> failed for issue #%d: %s"` (`logger.exception` — traceback already retained; the header `%s` is now also non-empty)

The reviewer `result.summary` strings now carry the same detail, so the empty `Review failed:` summary can't recur either.

**No control-flow or exception-handling changes** — only what gets logged/summarized.

## Tests

- `TestExcDetail` in `tests/test_exception_classify.py`: empty `str()`, blank `str()`, and blank-`repr()` → type-name fallback.
- `tests/test_reviewer.py`: a `caplog` assertion that a `RuntimeError()` with empty `str()` still produces a `"Review failed for PR ..."` line with a non-empty detail containing `RuntimeError`.

Verified: pytest (changed test files) + ruff + pyright all pass.

Autonomous overnight log-cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)