### PR TITLE
fix(proposers): regenerate arch artifacts before commit so PRs can push

### DIFF
--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -88,6 +88,61 @@ class ClaudeCLIClient:
         return json.loads(match.group(0))
 
 
+# Generated arch artifacts that derive from docs/wiki/terms/ (ADR-0053).
+# When a proposer adds/edits a term file, these two views go stale and the
+# pre-push `make arch-check` drift guard rejects the push — so they MUST be
+# regenerated and staged into the same bot-PR commit. See ADR-0053 / ADR-0058.
+_TERMS_REL_DIR = "docs/wiki/terms"
+_UL_GLOSSARY_REL = "docs/arch/generated/ubiquitous-language.md"
+_UL_CONTEXT_MAP_REL = "docs/arch/generated/ubiquitous-language-context-map.md"
+
+
+def regenerate_ubiquitous_language_artifacts(repo_root: Path) -> list[Path]:
+    """Re-render the term-derived arch artifacts from on-disk term files.
+
+    Term-proposer / edge-proposer bot-PRs mutate ``docs/wiki/terms/`` but the
+    generated ubiquitous-language views in ``docs/arch/generated/`` derive from
+    those term files. Committing the term change without refreshing the views
+    leaves ``make arch-check`` (run by the pre-push hook) detecting drift, which
+    rejects the push and the proposer PR never lands. Regenerating here — after
+    the new term files are written under ``repo_root`` — keeps the views in sync
+    so the same commit passes the drift guard.
+
+    Returns the absolute paths of the regenerated artifacts (for staging). When
+    no terms directory exists, returns an empty list (nothing to regenerate).
+    """
+    from ubiquitous_language import (  # noqa: PLC0415
+        TermStore,
+        render_context_map,
+        render_glossary,
+    )
+
+    terms_dir = repo_root / _TERMS_REL_DIR
+    if not terms_dir.is_dir():
+        return []
+
+    try:
+        terms = TermStore(terms_dir).list()
+    except (ValueError, OSError) as exc:
+        # A malformed term file shouldn't crash the PR-open. Degrade to the
+        # prior behavior (no regen) — the pre-push arch-check still guards
+        # correctness; we just don't pre-stage the refreshed views.
+        logger.warning(
+            "ubiquitous-language regen skipped — could not load terms: %s", exc
+        )
+        return []
+    regenerated: list[Path] = []
+    for rel_path, body in (
+        (_UL_GLOSSARY_REL, render_glossary(terms)),
+        (_UL_CONTEXT_MAP_REL, render_context_map(terms)),
+    ):
+        abs_path = repo_root / rel_path
+        abs_path.parent.mkdir(parents=True, exist_ok=True)
+        abs_path.write_text(body, encoding="utf-8")
+        regenerated.append(abs_path)
+    return regenerated
+
+
 class OpenAutoPRBotPRPort:
     """BotPRPort adapter wrapping auto_pr.open_automated_pr_async.
 
@@ -114,11 +169,22 @@ class OpenAutoPRBotPRPort:
         from auto_pr import open_automated_pr_async  # noqa: PLC0415
 
         written_paths: list[Path] = []
+        wrote_term_file = False
         for rel_path, content in files.items():
             abs_path = self._repo_root / rel_path
             abs_path.parent.mkdir(parents=True, exist_ok=True)
             abs_path.write_text(content, encoding="utf-8")
             written_paths.append(abs_path)
+            if Path(rel_path).is_relative_to(_TERMS_REL_DIR):
+                wrote_term_file = True
+
+        # Term changes make the generated ubiquitous-language views stale; the
+        # pre-push arch-check drift guard rejects the push unless the refreshed
+        # views ride along in the SAME commit. Regenerate + stage them here.
+        if wrote_term_file:
+            written_paths.extend(
+                regenerate_ubiquitous_language_artifacts(self._repo_root)
+            )
 
         result = await open_automated_pr_async(
             repo_root=self._repo_root,

--- a/tests/test_term_proposer_runtime.py
+++ b/tests/test_term_proposer_runtime.py
@@ -7,7 +7,26 @@ from pathlib import Path
 
 import pytest
 
-from term_proposer_runtime import ClaudeCLIClient, OpenAutoPRBotPRPort
+from term_proposer_runtime import (
+    ClaudeCLIClient,
+    OpenAutoPRBotPRPort,
+    regenerate_ubiquitous_language_artifacts,
+)
+
+
+def _term_file_str(name: str) -> str:
+    """Render one minimal Term to its canonical on-disk markdown form."""
+    from term_proposer_loop import _render_term_file_str
+    from ubiquitous_language import BoundedContext, Term, TermKind
+
+    term = Term(
+        name=name,
+        kind=TermKind.LOOP,
+        bounded_context=BoundedContext.CARETAKER,
+        code_anchor=f"src/{name.lower()}.py:{name}",
+        definition=f"{name} does a thing.",
+    )
+    return _render_term_file_str(term)
 
 
 class FakeRunner:
@@ -80,8 +99,8 @@ class TestOpenAutoPRBotPRPort:
 
         port = OpenAutoPRBotPRPort(repo_root=tmp_path, gh_token="ghs_x")
         files = {
-            "docs/wiki/terms/foo-loop.md": "---\nname: FooLoop\n---\n# def\n",
-            "docs/wiki/terms/bar-runner.md": "---\nname: BarRunner\n---\n# def\n",
+            "docs/wiki/terms/foo-loop.md": _term_file_str("FooLoop"),
+            "docs/wiki/terms/bar-runner.md": _term_file_str("BarRunner"),
         }
         pr_number = await port.open_bot_pr(
             branch="ul-proposer/abc123",
@@ -101,7 +120,8 @@ class TestOpenAutoPRBotPRPort:
         assert captured["labels"] == ["hydraflow-ul-proposed"]
         assert captured["auto_merge"] is False  # DependabotMergeLoop handles merge
         assert captured["base"] == "main"
-        assert len(captured["files"]) == 2
+        # 2 term files + the 2 regenerated ubiquitous-language views ride along.
+        assert len(captured["files"]) == 4
 
     @pytest.mark.asyncio
     async def test_raises_on_open_failure(self, tmp_path: Path, monkeypatch) -> None:
@@ -121,3 +141,109 @@ class TestOpenAutoPRBotPRPort:
             await port.open_bot_pr(
                 branch="x", title="x", body="x", labels=[], files={"foo.md": "x"}
             )
+
+    @pytest.mark.asyncio
+    async def test_stages_regenerated_ul_artifacts_with_term_change(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # A term-proposer PR mutates docs/wiki/terms/ — the generated
+        # ubiquitous-language views derive from those files, so the commit MUST
+        # also carry the regenerated views or the pre-push arch-check drift
+        # guard rejects the push.
+        from auto_pr import AutoPrResult
+
+        captured: dict = {}
+
+        async def fake_open_automated_pr_async(**kwargs):
+            captured.update(kwargs)
+            return AutoPrResult(
+                status="opened",
+                pr_url="https://github.com/T-rav/hydraflow/pull/77",
+                branch=kwargs["branch"],
+            )
+
+        monkeypatch.setattr(
+            "auto_pr.open_automated_pr_async", fake_open_automated_pr_async
+        )
+
+        port = OpenAutoPRBotPRPort(repo_root=tmp_path)
+        await port.open_bot_pr(
+            branch="ul-proposer/abc123",
+            title="feat(ul): batch",
+            body="body",
+            labels=["hydraflow-ul-proposed"],
+            files={"docs/wiki/terms/widget-maker.md": _term_file_str("WidgetMaker")},
+        )
+
+        staged = {p.relative_to(tmp_path).as_posix() for p in captured["files"]}
+        assert "docs/wiki/terms/widget-maker.md" in staged
+        assert "docs/arch/generated/ubiquitous-language.md" in staged
+        assert "docs/arch/generated/ubiquitous-language-context-map.md" in staged
+        # The regenerated views are actually written to disk so the worktree
+        # copy step has real content to stage.
+        assert (tmp_path / "docs/arch/generated/ubiquitous-language.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_skips_regen_when_no_term_files_change(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Non-term bot PRs (no docs/wiki/terms/ file) must not trigger UL regen.
+        from auto_pr import AutoPrResult
+
+        captured: dict = {}
+
+        async def fake_open_automated_pr_async(**kwargs):
+            captured.update(kwargs)
+            return AutoPrResult(
+                status="opened",
+                pr_url="https://github.com/T-rav/hydraflow/pull/88",
+                branch=kwargs["branch"],
+            )
+
+        monkeypatch.setattr(
+            "auto_pr.open_automated_pr_async", fake_open_automated_pr_async
+        )
+
+        port = OpenAutoPRBotPRPort(repo_root=tmp_path)
+        await port.open_bot_pr(
+            branch="x", title="x", body="x", labels=[], files={"docs/other.md": "x"}
+        )
+
+        staged = {p.relative_to(tmp_path).as_posix() for p in captured["files"]}
+        assert staged == {"docs/other.md"}
+        assert not (tmp_path / "docs/arch/generated").exists()
+
+
+class TestRegenerateUbiquitousLanguageArtifacts:
+    def test_renders_views_matching_canonical_generators(self, tmp_path: Path) -> None:
+        from ubiquitous_language import (
+            TermStore,
+            render_context_map,
+            render_glossary,
+        )
+
+        terms_dir = tmp_path / "docs" / "wiki" / "terms"
+        terms_dir.mkdir(parents=True)
+        (terms_dir / "widget-maker.md").write_text(
+            _term_file_str("WidgetMaker"), encoding="utf-8"
+        )
+        (terms_dir / "gadget-runner.md").write_text(
+            _term_file_str("GadgetRunner"), encoding="utf-8"
+        )
+
+        written = regenerate_ubiquitous_language_artifacts(tmp_path)
+
+        terms = TermStore(terms_dir).list()
+        glossary = tmp_path / "docs/arch/generated/ubiquitous-language.md"
+        context_map = (
+            tmp_path / "docs/arch/generated/ubiquitous-language-context-map.md"
+        )
+        assert set(written) == {glossary, context_map}
+        # Byte-for-byte equal to the canonical generators — this is exactly what
+        # `make arch-check` compares against, so a mismatch would re-trigger the
+        # drift guard the fix exists to silence.
+        assert glossary.read_text(encoding="utf-8") == render_glossary(terms)
+        assert context_map.read_text(encoding="utf-8") == render_context_map(terms)
+
+    def test_returns_empty_when_no_terms_dir(self, tmp_path: Path) -> None:
+        assert regenerate_ubiquitous_language_artifacts(tmp_path) == []


### PR DESCRIPTION
## Bug

Production logs showed ~3 git-push failures from `edge_proposer_loop` / `term_proposer_loop`, each:

> ❌ `docs/arch/generated/` is out of sync with source. Run: `make arch-regen-stage && git commit --amend --no-edit`

The proposer loops generate source changes (new terms / edges → `docs/wiki/terms/*.md`) that affect generated arch artifacts, but they committed WITHOUT regenerating those artifacts. The pre-push drift guard (`.githooks/pre-push` → `make arch-check`) then rejected the push, so the proposer PR never landed. (3 occurrences across the two proposer loops.)

## Investigation

- `EdgeProposerLoop._do_work` and `TermProposerLoop._do_work` / `open_proposer_pr` build a `files: dict[str, str]` of term-file content and hand it to `BotPRPort.open_bot_pr`.
- The single production `BotPRPort` is `OpenAutoPRBotPRPort.open_bot_pr` in `src/term_proposer_runtime.py` (shared by `TermProposerLoop`, `EdgeProposerLoop`, and `TermPrunerLoop`). It writes the term files under `repo_root`, then delegates to `auto_pr.open_automated_pr_async` for the worktree → copy → stage → commit → push → `gh pr create` flow.
- `make arch-check` (`src/arch/runner.py`) regenerates `ubiquitous-language.md` and `ubiquitous-language-context-map.md` from `docs/wiki/terms/` via `TermStore(...).list()` → `render_glossary` / `render_context_map`. These are the ONLY term-derived generated artifacts (`coverage_matrix.md`'s "terms" are name/alias match strings, not UL terms — confirmed it doesn't drift on a term-file change).
- `.githooks/pre-push` runs `make arch-check` with NO path filter, so any commit touching `docs/wiki/terms/` without refreshed views fails the push.

## Scoped fix

In `OpenAutoPRBotPRPort.open_bot_pr` (the proposer-specific bot-PR adapter — NOT shared PRManager/`auto_pr` core): after writing the new term files, when any staged file is under `docs/wiki/terms/`, regenerate the two ubiquitous-language views from `repo_root/docs/wiki/terms/` and append them to the staged path set. They then ride along in the SAME commit `open_automated_pr_async` produces, clearing the drift guard.

- New helper `regenerate_ubiquitous_language_artifacts(repo_root)` reproduces the `arch.runner` output **byte-for-byte** (it calls the same `render_glossary` / `render_context_map` that `make arch-check` compares against — verified equal in tests and against the live committed artifacts).
- A malformed term file degrades to the prior no-regen behavior (warn + skip) rather than crashing the PR-open; the pre-push guard still protects correctness.
- Static module graph unchanged: the `ubiquitous_language` import is function-local, so `arch-check` stays green.

## Shared-logic flags (for human review)

- **No shared-infra change made.** `auto_pr.open_automated_pr_async` (PRManager-adjacent core, used by many loops) is untouched — it already stages whatever paths it's handed, so the regen lives entirely in the proposer adapter.
- The regen reads `repo_root/docs/wiki/terms/`, which (post-write) equals the proposer's view of existing terms + the new files. This matches the existing trust model: the main checkout tracks the base branch and the worktree is built from `origin/<base>` + only the explicitly-staged files. If the main checkout's terms dir ever drifted ahead of base, the regenerated views would reflect that drift — same risk profile that already applies to the term files themselves. Flagging for awareness; no change recommended.

## Tests

- `regenerate_ubiquitous_language_artifacts`: byte-parity with `render_glossary` / `render_context_map`; empty-list when no terms dir.
- `OpenAutoPRBotPRPort.open_bot_pr`: stages the two regenerated views on a term change; skips regen (and writes no `docs/arch/generated/`) for a non-term PR; existing plumbing test updated for the +2 ride-along files.

Verification: `pytest` (10 runtime + 32 proposer-related + 10 `scenario_loops`), `ruff check`, `ruff format --check`, `pyright` (0 errors) all pass; pre-commit (lint + arch-check) and pre-push (arch-check + quality-lite) green.

Autonomous overnight log-cleanup run; do not merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)