### PR TITLE
fix(loops): guard create_issue==0 sentinel so loops stop filing/committing phantom issue #0

### DIFF
--- a/src/adr_touchpoint_auditor_loop.py
+++ b/src/adr_touchpoint_auditor_loop.py
@@ -455,12 +455,24 @@ class AdrTouchpointAuditorLoop(BaseBackgroundLoop):
                 escalated += 1
             else:
                 issue_number = await self._file_drift_rollup(entry.adr, new_pr_entries)
-                if issue_number:
-                    self._state.set_adr_rollup(
+                if issue_number == 0:
+                    # create_issue's documented 0-sentinel: the gh call
+                    # failed. Don't record the rollup or add the dedup key —
+                    # that would suppress re-filing forever without a real
+                    # issue (next tick's `dedup_key in dedup` would skip).
+                    # Retry next cycle.
+                    logger.warning(
+                        "adr_touchpoint_auditor: create_issue returned 0 "
+                        "(sentinel) for %s rollup; skipping record/dedup, "
+                        "will retry next cycle",
                         rollup_key,
-                        issue_number=issue_number,
-                        pr_numbers=sorted(new_pr_numbers),
                     )
+                    continue
+                self._state.set_adr_rollup(
+                    rollup_key,
+                    issue_number=issue_number,
+                    pr_numbers=sorted(new_pr_numbers),
+                )
                 filed += 1
             dedup.add(dedup_key)
             self._dedup.set_all(dedup)

--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -611,6 +611,16 @@ class ContractRefreshLoop(BaseBackgroundLoop):
                 )
                 continue
             issue_num = await self._file_escalation_issue(adapter, attempts)
+            if issue_num == 0:
+                # create_issue's documented 0-sentinel: the gh call failed.
+                # Don't add the escalation-dedup key — that would suppress
+                # re-escalation forever without a real issue. Retry next tick.
+                logger.warning(
+                    "contract_refresh: create_issue returned 0 (sentinel) for "
+                    "%s escalation; skipping, will retry next cycle",
+                    adapter,
+                )
+                continue
             self._escalation_dedup.add(adapter)
             escalated[adapter] = issue_num
             logger.warning(

--- a/src/live_corpus_replay_loop.py
+++ b/src/live_corpus_replay_loop.py
@@ -165,8 +165,18 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
             seen = self._dedup.get()
             if dedup_key not in seen:
                 filed_issue = await self._file_drift_issue(drifted)
-                seen.add(dedup_key)
-                self._dedup.set_all(seen)
+                if filed_issue == 0:
+                    # create_issue's documented 0-sentinel: the gh call
+                    # failed. Don't add the dedup key — that would suppress
+                    # re-filing forever without a real issue. Retry next tick.
+                    logger.warning(
+                        "live_corpus_replay: create_issue returned 0 "
+                        "(sentinel) for drift issue; skipping dedup, will "
+                        "retry next cycle",
+                    )
+                else:
+                    seen.add(dedup_key)
+                    self._dedup.set_all(seen)
 
             # If any signature reached the threshold, file an escalation
             # issue routed to the auto-agent preflight loop via the

--- a/src/memory_backlog_loop.py
+++ b/src/memory_backlog_loop.py
@@ -97,10 +97,24 @@ class MemoryBacklogLoop(BaseBackgroundLoop):
             attempts = self._state.inc_memory_backlog_attempts(key)
             try:
                 if attempts >= _MAX_ATTEMPTS:
-                    await self._file_escalation(entry, attempts)
+                    issue_num = await self._file_escalation(entry, attempts)
+                    if issue_num == 0:
+                        logger.warning(
+                            "memory_backlog: create_issue returned 0 (sentinel) "
+                            "for escalation of %s; skipping, will retry next cycle",
+                            entry.slug,
+                        )
+                        continue
                     escalated += 1
                 else:
                     issue_num = await self._file_backlog_issue(entry)
+                    if issue_num == 0:
+                        logger.warning(
+                            "memory_backlog: create_issue returned 0 (sentinel) "
+                            "for %s; skipping record/commit, will retry next cycle",
+                            entry.slug,
+                        )
+                        continue
                     update_status(entry.path, status="issue-open", issue=issue_num)
                     filed += 1
                     filed_issue_numbers.append(issue_num)

--- a/src/prep.py
+++ b/src/prep.py
@@ -56,6 +56,16 @@ HYDRAFLOW_LABELS: tuple[tuple[str, str, str], ...] = (
         "b60205",
         "ADR drift unresolved after retries",
     ),
+    (
+        "memory_backlog_label",
+        "fef2c0",
+        "Session-memory feedback promoted to the find queue (MemoryBacklogLoop)",
+    ),
+    (
+        "memory_backlog_stuck_label",
+        "b60205",
+        "Memory-backlog entry unresolved after retries",
+    ),
 )
 
 

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -298,6 +298,19 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                 )
                 if attempts >= _MAX_ATTEMPTS:
                     issue_no = await self._file_anomaly(worker, kind, det)
+                    if issue_no == 0:
+                        # create_issue's documented 0-sentinel: the gh call
+                        # failed. Don't record a phantom anomaly or add the
+                        # dedup key — that would suppress re-filing forever
+                        # without a real issue. Retry next cycle.
+                        logger.warning(
+                            "trust_fleet_sanity: create_issue returned 0 "
+                            "(sentinel) for %s/%s; skipping, will retry next "
+                            "cycle",
+                            worker,
+                            kind,
+                        )
+                        continue
                     anomalies.append(
                         {
                             "worker": worker,

--- a/tests/regressions/test_issue_9241_create_issue_zero_sentinel.py
+++ b/tests/regressions/test_issue_9241_create_issue_zero_sentinel.py
@@ -1,0 +1,221 @@
+"""Regression for issue #9241 — loops must not file/commit phantom ``issue #0``.
+
+``PRManager.create_issue`` returns ``0`` on failure — a documented sentinel
+("Callers MUST check for 0 before storing or referencing the returned value").
+``MemoryBacklogLoop`` previously recorded ``issue=0`` into mirror frontmatter,
+git-committed a ``chore(memory-backlog): file issue #0`` entry, AND added the
+dedup key (suppressing all future re-filing) whenever ``create_issue`` returned
+the sentinel. The live instance committed ``file issues #0, #0, #0...`` to git.
+
+The contract guarded here:
+
+1. ``create_issue`` returns 0 → NO git commit, NO frontmatter record, NO dedup
+   add — the entry stays ``pending`` so it re-files next cycle.
+2. ``create_issue`` returns a real number → frontmatter records it and a git
+   commit lands (positive control — proves the guard didn't break the happy
+   path).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from events import EventBus
+from memory_backlog_loop import MemoryBacklogLoop
+from memory_backlog_mirror import load_mirror_entry
+
+
+def _deps(stop: asyncio.Event) -> LoopDeps:
+    return LoopDeps(
+        event_bus=EventBus(),
+        stop_event=stop,
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+
+
+def _write_mirror_entry(dir_: Path, slug: str) -> Path:
+    front = {
+        "source": f"feedback_{slug.replace('-', '_')}.md",
+        "name": f"Test rule {slug}",
+        "description": f"desc for {slug}",
+        "status": "pending",
+        "issue": None,
+        "promoted_in": None,
+        "wontfix_reason": None,
+        "created": "2026-06-04",
+    }
+    p = dir_ / f"{slug}.md"
+    p.write_text(
+        f"---\n{yaml.safe_dump(front, sort_keys=False).rstrip()}\n---\n\n"
+        f"Rule: do the thing.\n\n**Why:** because.\n"
+    )
+    return p
+
+
+def _git_repo(repo_root: Path, mirror_dir: Path, slug: str) -> tuple[Path, str]:
+    """Init a real git repo with one committed mirror entry. Return (path, sha)."""
+    subprocess.run(["git", "init", "-q"], cwd=repo_root, check=True)
+    entry_path = _write_mirror_entry(mirror_dir, slug)
+    subprocess.run(["git", "add", "-A"], cwd=repo_root, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@e.st", "-c", "user.name=t", "commit", "-q", "-m", "init"],
+        cwd=repo_root,
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return entry_path, base_sha
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    repo_root = tmp_path
+    mirror_dir = repo_root / "docs" / "wiki" / "memory-feedback"
+    mirror_dir.mkdir(parents=True)
+    cfg = HydraFlowConfig(
+        data_root=tmp_path / ".hydraflow",
+        repo="hydra/hydraflow",
+        repo_root=repo_root,
+        git_user_email="t@e.st",
+        git_user_name="t",
+    )
+    state = MagicMock()
+    state.get_memory_backlog_attempts.return_value = 0
+    state.inc_memory_backlog_attempts.return_value = 1
+    pr = AsyncMock()
+    dedup = MagicMock()
+    dedup.get.return_value = set()
+    return cfg, state, pr, dedup, mirror_dir
+
+
+def _make_loop(env) -> MemoryBacklogLoop:
+    cfg, state, pr, dedup, _ = env
+    loop = MemoryBacklogLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        deps=_deps(asyncio.Event()),
+    )
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_zero_sentinel_does_not_commit_record_or_dedup(env) -> None:
+    """create_issue returns 0 → no commit, no frontmatter record, no dedup add."""
+    cfg, _state, pr, dedup, mirror_dir = env
+    entry_path, base_sha = _git_repo(cfg.repo_root, mirror_dir, "fb-sentinel")
+    pr.create_issue = AsyncMock(return_value=0)
+    loop = _make_loop(env)
+
+    result = await loop._do_work()
+
+    # Nothing was filed — the sentinel was caught.
+    assert result == {
+        "status": "ok",
+        "filed": 0,
+        "skipped": 0,
+        "escalated": 0,
+    }
+    pr.create_issue.assert_awaited_once()
+
+    # Frontmatter is untouched: still pending, no phantom issue=0.
+    after = load_mirror_entry(entry_path)
+    assert after.status == "pending"
+    assert after.issue is None
+
+    # No git commit was made for a phantom #0.
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head_sha == base_sha, "loop committed a phantom issue #0"
+
+    # Dedup key was NOT added — the entry re-files next cycle.
+    dedup.set_all.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_real_number_commits_and_records(env) -> None:
+    """Positive control: a real issue number records frontmatter and commits."""
+    cfg, _state, pr, dedup, mirror_dir = env
+    entry_path, base_sha = _git_repo(cfg.repo_root, mirror_dir, "fb-real")
+    pr.create_issue = AsyncMock(return_value=4321)
+    loop = _make_loop(env)
+
+    result = await loop._do_work()
+
+    assert result == {
+        "status": "ok",
+        "filed": 1,
+        "skipped": 0,
+        "escalated": 0,
+    }
+    after = load_mirror_entry(entry_path)
+    assert after.status == "issue-open"
+    assert after.issue == 4321
+
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert head_sha != base_sha, "loop did not commit the real issue"
+
+    title = subprocess.run(
+        ["git", "log", "-1", "--format=%s"],
+        cwd=cfg.repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert "#4321" in title
+    assert "#0" not in title
+
+    dedup.set_all.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_escalation_zero_sentinel_does_not_dedup(env) -> None:
+    """At escalation (>= max attempts), a 0 sentinel skips counting + dedup."""
+    cfg, state, pr, dedup, mirror_dir = env
+    _write_mirror_entry(mirror_dir, "fb-escalate")
+    state.inc_memory_backlog_attempts.return_value = 3  # >= _MAX_ATTEMPTS
+    pr.create_issue = AsyncMock(return_value=0)
+    loop = _make_loop(env)
+    loop._commit_mirror_updates = AsyncMock(return_value=None)
+
+    result = await loop._do_work()
+
+    assert result == {
+        "status": "ok",
+        "filed": 0,
+        "skipped": 0,
+        "escalated": 0,
+    }
+    pr.create_issue.assert_awaited_once()
+    # No dedup add — escalation retries next cycle once gh recovers.
+    dedup.set_all.assert_not_called()

--- a/tests/test_adr_touchpoint_auditor_loop.py
+++ b/tests/test_adr_touchpoint_auditor_loop.py
@@ -160,6 +160,51 @@ async def test_drift_files_one_rollup_per_adr(loop_env, monkeypatch) -> None:
     assert call_kwargs["issue_number"] == 42
 
 
+async def test_rollup_zero_sentinel_does_not_record_or_dedup(
+    loop_env, monkeypatch
+) -> None:
+    """create_issue's 0 sentinel must not record a rollup or add the dedup key.
+
+    Regression for issue #9241: a failed gh call returns 0; recording
+    ``issue_number=0`` or adding the dedup key would suppress re-filing
+    forever (next tick's ``dedup_key in dedup`` skips) without a real issue.
+    """
+    cfg, state, pr, dedup, idx = loop_env
+    pr.create_issue = AsyncMock(return_value=0)  # gh failed → sentinel
+    stop = asyncio.Event()
+    loop = AdrTouchpointAuditorLoop(
+        config=cfg,
+        state=state,
+        pr_manager=pr,
+        dedup=dedup,
+        adr_index=idx,
+        deps=_deps(stop),
+    )
+
+    async def fake_list(_cursor):
+        return [
+            {
+                "number": 8473,
+                "mergedAt": "2026-05-06T20:00:00Z",
+                "title": "feat: tweak",
+                "files": [{"path": "src/agent.py"}],
+            }
+        ]
+
+    async def fake_reconcile():
+        return None
+
+    monkeypatch.setattr(loop, "_list_recent_merged_prs", fake_list)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+
+    stats = await loop._do_work()
+
+    pr.create_issue.assert_awaited()  # it tried
+    assert stats["filed"] == 0  # but recorded nothing
+    state.set_adr_rollup.assert_not_called()
+    dedup.set_all.assert_not_called()  # no dedup add — retries next cycle
+
+
 async def test_one_pr_drifting_8_adrs_files_8_issues(loop_env, monkeypatch) -> None:
     """A single PR drifting 8 ADRs files 8 issues (one per ADR)."""
     cfg, state, pr, dedup, idx = loop_env

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -750,6 +750,51 @@ async def test_escalation_is_deduped_across_ticks(
 
 
 @pytest.mark.asyncio
+async def test_escalation_zero_sentinel_does_not_dedup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """create_issue's 0 sentinel must not add the escalation dedup key.
+
+    Regression for issue #9241: a failed gh call returns 0; adding the
+    adapter to the escalation dedup would suppress re-escalation forever
+    without a real issue. The next stuck tick must re-attempt.
+    """
+    _stub_recording(monkeypatch)
+    rec = _seed_recorded_cassette(tmp_path / "rec" / "git", "git", "commit")
+    monkeypatch.setattr(crl_module, "record_git", lambda *_a, **_k: [rec])
+    monkeypatch.setattr(
+        crl_module,
+        "detect_fleet_drift",
+        lambda *_a, **_k: _drift_fleet_for("git", rec),
+    )
+    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    _stub_make_trust_contracts_ok(monkeypatch)
+
+    state = _FakeState()
+    state.inc_contract_refresh_attempts("git")
+    state.inc_contract_refresh_attempts("git")
+
+    prs = AsyncMock()
+    prs.create_issue = AsyncMock(return_value=0)  # gh failed → sentinel
+    loop = _loop(tmp_path, prs=prs, state=state)
+
+    # Tick 3: escalation attempted but create_issue returns 0.
+    await loop._do_work()
+    # Dedup key must NOT be set — adapter can re-escalate.
+    assert "git" not in loop._escalation_dedup.get()
+
+    # Tick 4: still stuck → re-attempts (would be deduped if sentinel had
+    # been recorded).
+    await loop._do_work()
+    escalations = [
+        c
+        for c in prs.create_issue.await_args_list
+        if "hitl-escalation" in (c.kwargs.get("labels") or [])
+    ]
+    assert len(escalations) == 2, escalations
+
+
+@pytest.mark.asyncio
 async def test_escalation_resets_after_clean_tick(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_live_corpus_replay_loop.py
+++ b/tests/test_live_corpus_replay_loop.py
@@ -203,6 +203,40 @@ async def test_identical_drift_dedups_across_ticks(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_issue_zero_sentinel_does_not_dedup(tmp_path: Path) -> None:
+    """create_issue's 0 sentinel must not add the dedup key.
+
+    Regression for issue #9241: a failed gh call returns 0; adding the
+    dedup key would suppress re-filing forever without a real issue. The
+    next tick must re-attempt (create_issue awaited twice).
+    """
+    pr = MagicMock()
+    pr.create_issue = AsyncMock(return_value=0)
+    loop, corpus, _pr, _state = _build_loop(tmp_path, pr_manager=pr)
+    corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "42"],
+        stdout='{"state":"MERGED"}\n',
+        stderr="",
+        exit_code=0,
+    )
+
+    async def stale_fake(_sample):  # noqa: ANN001
+        return {"state": "OPEN"}
+
+    loop.register("github", "gh", stale_fake)
+    first = await loop._do_work()
+    second = await loop._do_work()
+
+    assert first["drifted"] == 1
+    assert first["filed_issue"] == 0  # sentinel surfaced in status, not tracked
+    # Second tick re-attempts because the dedup key was never added.
+    assert second["drifted"] == 1
+    assert pr.create_issue.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_dispatcher_raising_is_caught(tmp_path: Path) -> None:
     loop, corpus, pr, _state = _build_loop(tmp_path)
     corpus.record(

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1731,6 +1731,8 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "hydraflow-fake-coverage-stuck",
         "hydraflow-adr-drift",
         "hydraflow-adr-drift-stuck",
+        "hydraflow-memory-backlog",
+        "hydraflow-memory-backlog-stuck",
     }
 
 

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -291,6 +291,30 @@ class TestEnsureLabels:
         assert len(result.existed) == len(HYDRAFLOW_LABELS)
         assert len(result.failed) == 0
 
+    @pytest.mark.asyncio
+    async def test_provisions_memory_backlog_labels(self) -> None:
+        """MemoryBacklogLoop's labels are provisioned by ensure_labels.
+
+        Root-cause for the recurring `create_issue`-returns-0 / phantom
+        `issue #0` filings: `gh issue create --label <X>` fails when label
+        X is absent from the repo, so create_issue's except returns the
+        0 sentinel every cycle. The memory-backlog labels were missing
+        from HYDRAFLOW_LABELS, so ensure_labels never created them.
+        """
+        config = ConfigFactory.create()
+        created: list[str] = []
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_label_side_effect("[]", capture=created),
+        ):
+            await ensure_labels(config)
+
+        for name in config.memory_backlog_label:
+            assert name in created
+        for name in config.memory_backlog_stuck_label:
+            assert name in created
+
 
 # ---------------------------------------------------------------------------
 # AuditResult model tests

--- a/tests/test_trust_fleet_sanity_loop.py
+++ b/tests/test_trust_fleet_sanity_loop.py
@@ -211,6 +211,30 @@ async def test_do_work_skips_filing_when_dedup_key_present(loop_env) -> None:
     pr.create_issue.assert_not_awaited()
 
 
+async def test_do_work_create_issue_zero_sentinel_not_tracked(loop_env) -> None:
+    """create_issue's 0 sentinel must not record a phantom anomaly or dedup.
+
+    Regression for issue #9241: a failed gh call returns 0; tracking it
+    permanently suppresses re-filing without a real issue ever existing.
+    """
+    cfg, state, bg_workers, pr, dedup, bus = loop_env
+    pr.create_issue = AsyncMock(return_value=0)
+
+    async def fake_load(since):  # noqa: ARG001
+        return [_make_status_event("ci_monitor", "ok", ago_s=600, filed=20)]
+
+    bus.load_events_since = fake_load  # type: ignore[method-assign]
+    loop = _loop(loop_env)
+    loop._reconcile_closed_escalations = AsyncMock(return_value=None)
+    loop._load_cost_reader = MagicMock(return_value=None)
+    stats = await loop._do_work()
+
+    pr.create_issue.assert_awaited()  # it tried
+    assert stats["anomalies"] == 0  # but recorded nothing
+    assert stats["filed"] == 0
+    dedup.set_all.assert_not_called()  # no dedup add — retries next cycle
+
+
 async def test_do_work_staleness_detector_uses_bg_worker_state(loop_env) -> None:
     cfg, state, bg_workers, pr, dedup, bus = loop_env
     old = (datetime.now(UTC) - timedelta(seconds=99_999)).isoformat()


### PR DESCRIPTION
## Bug

`PRManager.create_issue` (src/pr_manager.py:1888) returns `0` on failure — a **documented sentinel** (docstring: "Callers MUST check for `0` before storing or referencing the returned value"). Several caretaker loops captured the return and **persisted / tracked / dedup'd / git-committed** it WITHOUT checking 0, creating phantom **"issue #0"** records. The live instance committed `chore(memory-backlog): file issues #0, #0, #0...` to git — `memory_backlog` recorded `issue=0` in mirror frontmatter, committed a mirror entry for it, and added the dedup key so the entry **never re-filed**.

## Audit — every `create_issue(` consumer in `src/`

### Guarded in this PR (captured + persisted/dedup'd a phantom #0)

| Loop | Call site | Defect | Fix |
|---|---|---|---|
| `memory_backlog_loop` | `_file_backlog_issue` / `_file_escalation` | recorded `issue=0` frontmatter, git-committed a `#0` entry, added dedup key → entry never re-filed | skip record/commit, `continue` before dedup, WARN, retry next cycle |
| `trust_fleet_sanity_loop` | `_file_anomaly` | recorded a phantom anomaly + added dedup key on 0 | skip + WARN, retry |
| `contract_refresh_loop` | `_maybe_escalate` | added escalation-dedup key on 0 → suppressed re-escalation forever | `continue` before dedup add |
| `live_corpus_replay_loop` | `_do_work` (`_file_drift_issue`) | added fleet dedup key on 0 → suppressed re-filing forever | only dedup on a real number |
| `adr_touchpoint_auditor_loop` | `_file_drift_rollup` | persist was already guarded (`if issue_number:`) but `dedup.add(dedup_key)` ran unconditionally on 0 → next tick's `dedup_key in dedup` skipped forever | `continue` before the dedup add on 0 |

### Already safe (no change)

- `branch_protection_auditor_loop` — explicit `if issue == 0:` guard (the reference pattern this PR mirrors).
- `gate_activator_loop` — explicit `if issue == 0:` guard.
- `staging_bisect_loop` — all issue numbers flow into transient `_do_work` status dicts (`escalation_issue` / `retry_issue`); never persisted/dedup'd/commented/committed, and the revert-PR body already guards `if retry_issue_number`.
- `corpus_learning_loop` — fire-and-forget (return not captured).
- `contract_refresh` `fake_drift_issue` / `live_corpus` `escalated_issue` — status dict only, not persisted/dedup'd.
- All other consumers (diagram, pricing_refresh, health_monitor, security_patch, report_issue, retrospective, wiki_rot_detector, cost_budget_watcher, triage_retry, principles_audit §353) — return not captured → SAFE.

## Root cause note

`create_issue`'s `except` (pr_manager.py:1951) catches gh failures and returns 0. The recurring live failure is `gh issue create --label <X>` where label X is **absent from the repo**. `prep.ensure_labels` (`HYDRAFLOW_LABELS`) provisions lifecycle labels but was **missing `memory_backlog_label` / `memory_backlog_stuck_label`** — so `gh issue create --label hydraflow-memory-backlog` failed every cycle → 0 sentinel → the phantom `#0` commits.

**Clean code-level mitigation applied:** added those two config-driven labels to `HYDRAFLOW_LABELS` so `ensure_labels` provisions them at startup (directly stops the memory_backlog `#0`).

Other ad-hoc **string-literal** labels (`trust-loop-anomaly`, `shadow-drift`, `rc-red-*`, `revert-conflict`, ...) are not config-field-backed, so `ensure_labels` can't provision them without scope creep. If those recur on the live instance it is **operational** — run `prep` / create the missing labels / check `gh auth` + rate-limit. `create_issue`'s 0-return contract is intentionally unchanged (a signature change across ~20 call sites is out of scope).

## Tests

- `tests/regressions/test_issue_9241_create_issue_zero_sentinel.py` — memory_backlog does NOT commit/record/dedup on 0, DOES on a real number (real git-repo harness), plus the escalation path.
- Unit tests for each newly-guarded consumer (trust_fleet, contract_refresh, live_corpus_replay, adr_touchpoint) assert no dedup add on 0 + re-attempt next cycle.
- `tests/test_prep.py::test_provisions_memory_backlog_labels` — the memory-backlog labels are now provisioned.

## Verification (local, all pass)

- `pytest` (5 changed loop test files + test_prep + regression): pass
- `ruff check` (changed src + tests): All checks passed
- `pyright` (changed src): 0 errors
- `pytest tests/scenarios/ -m scenario_loops -k "memory_backlog|staging_bisect|gate_activator|trust_fleet|contract_refresh|live_corpus|adr_touchpoint"`: pass

Closes #9241

🤖 Generated with [Claude Code](https://claude.com/claude-code)
