### PR TITLE
perf(plan): run research pre-pass only for escalated or cycled issues

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1846,6 +1846,20 @@ class HydraFlowConfig(BaseModel):
         default=True,
         description="Run ResearchRunner before PlanPhase to inject codebase context",
     )
+    # The research pre-pass is a full extra codebase-exploration subprocess
+    # on top of the planner's own exploration — so it is gated, not run for
+    # every issue. With ``research_enabled`` on, research runs only for issues
+    # that need the depth: those carrying one of these escalation labels, and
+    # those that have cycled back to planning (route-back count > 0). The
+    # common first-pass issue skips research and lets the planner explore once.
+    research_escalation_labels: list[str] = Field(
+        default=["hydraflow-hitl-escalation"],
+        description=(
+            "Labels that force the research pre-pass before planning "
+            "(escalated issues). Cycled issues (route-back count > 0) also "
+            "trigger research regardless of label. OR logic."
+        ),
+    )
 
     # Transcript summarization
     transcript_summarization_enabled: bool = Field(

--- a/src/plan_phase.py
+++ b/src/plan_phase.py
@@ -380,11 +380,34 @@ class PlanPhase:
         )
         self._persist_adversarial_state(issue, adv)
 
-    def _should_research(self) -> bool:
-        """Return True if research should run before planning."""
+    def _should_research(self, issue: Task) -> bool:
+        """Return True if the research pre-pass should run before planning *issue*.
+
+        Research spawns a full extra codebase-exploration subprocess on top of
+        the planner's own exploration, so it is gated rather than run for every
+        issue. With ``research_enabled`` on and a runner wired, research runs
+        only for issues that need the depth:
+
+        - **Escalated** — the issue carries one of
+          ``config.research_escalation_labels``.
+        - **Cycled / failing to land** — the issue has been routed back to
+          planning at least once (route-back count > 0).
+
+        The common first-pass issue skips research and lets the planner explore
+        once.
+        """
         if not getattr(self._config, "research_enabled", True):
             return False
-        return self._research_runner is not None
+        if self._research_runner is None:
+            return False
+        # Cycled / failing to land: routed back from a later stage at least once.
+        if self._state.get_route_back_count(issue.id) > 0:
+            return True
+        # Escalated: operator/loop flagged the issue for deeper handling.
+        escalation_labels = {
+            lbl.lower() for lbl in self._config.research_escalation_labels
+        }
+        return any(tag.lower() in escalation_labels for tag in issue.tags)
 
     async def _handle_already_satisfied(self, issue: Task, result: PlanResult) -> bool:
         """Validate evidence and close issue as already-satisfied.
@@ -1179,7 +1202,7 @@ class PlanPhase:
             with _sentry_transaction("pipeline.plan", f"plan:#{issue.id}"):
                 async with store_lifecycle(self._store, issue.id, "plan"):
                     research_context = ""
-                    if self._should_research():
+                    if self._should_research(issue):
                         research_result = await self._research_runner.research(issue)  # type: ignore[union-attr]
                         if research_result.success:
                             research_context = research_result.research

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -1050,20 +1050,54 @@ class TestPlanPhaseBatchScaling:
 
 
 class TestPlanPhaseResearch:
-    def test_should_research_true_when_runner_present(self, config):
-        """Research runs when runner is wired."""
+    """Research pre-pass gating.
+
+    The research pre-pass is a full extra codebase-exploration subprocess, so
+    it is reserved for issues that need the depth: escalated issues (carrying a
+    ``research_escalation_labels`` label) and cycled issues that have failed to
+    land (route-back count > 0). A plain first-pass issue skips research even
+    when a runner is wired, and the planner explores once.
+    """
+
+    def test_should_research_false_for_plain_first_pass_issue(self, config):
+        """A plain issue skips research even with a runner wired."""
         phase, *_ = make_plan_phase(config)
         phase._research_runner = AsyncMock()
-        assert phase._should_research() is True
+        issue = TaskFactory.create(id=1)  # default tags=["ready"], no route-back
+        assert phase._should_research(issue) is False
+
+    def test_should_research_true_for_escalated_label(self, config):
+        """An issue carrying an escalation label triggers research."""
+        phase, *_ = make_plan_phase(config)
+        phase._research_runner = AsyncMock()
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
+        assert phase._should_research(issue) is True
+
+    def test_should_research_true_for_cycled_issue(self, config):
+        """An issue that has cycled back (route-back > 0) triggers research."""
+        phase, state, *_ = make_plan_phase(config)
+        phase._research_runner = AsyncMock()
+        issue = TaskFactory.create(id=7)
+        state.increment_route_back_count(issue.id)
+        assert phase._should_research(issue) is True
 
     def test_should_research_false_when_no_runner(self, config):
-        """No research_runner means no research."""
+        """No research_runner means no research, even for escalated issues."""
         phase, *_ = make_plan_phase(config)
         # phase._research_runner is None by default
-        assert phase._should_research() is False
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
+        assert phase._should_research(issue) is False
+
+    def test_should_research_false_when_disabled(self, config):
+        """research_enabled=False disables research even for escalated issues."""
+        config.research_enabled = False  # type: ignore[assignment]
+        phase, *_ = make_plan_phase(config)
+        phase._research_runner = AsyncMock()
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
+        assert phase._should_research(issue) is False
 
     @pytest.mark.asyncio
-    async def test_plan_one_calls_research_for_complex_issue(self, config):
+    async def test_plan_one_calls_research_for_escalated_issue(self, config):
         """When research is triggered, result context is passed to planner."""
         phase, _state, planners, prs, store, _stop = make_plan_phase(config)
 
@@ -1075,7 +1109,7 @@ class TestPlanPhaseResearch:
         )
         phase._research_runner = research_mock
 
-        issue = TaskFactory.create(id=1)
+        issue = TaskFactory.create(id=1, tags=[config.research_escalation_labels[0]])
         plan_result = PlanResultFactory.create(
             issue_number=1,
             success=True,
@@ -1092,6 +1126,36 @@ class TestPlanPhaseResearch:
         # Verify research_context was passed
         call_kwargs = planners.plan.call_args
         assert call_kwargs.kwargs.get("research_context") == "Found relevant files"
+
+    @pytest.mark.asyncio
+    async def test_plan_one_skips_research_for_plain_issue(self, config):
+        """A plain first-pass issue skips research even when a runner is wired."""
+        phase, _state, planners, prs, store, _stop = make_plan_phase(config)
+
+        research_mock = AsyncMock()
+        research_mock.research = AsyncMock(
+            return_value=ResearchResult(
+                issue_number=1, success=True, research="Found relevant files"
+            )
+        )
+        phase._research_runner = research_mock
+
+        issue = TaskFactory.create(id=1)  # plain: no escalation label, no route-back
+        plan_result = PlanResultFactory.create(
+            issue_number=1,
+            success=True,
+            plan="## Files to Modify\n- src/main.py\n## Testing Strategy\n- tests/test.py",
+            summary="Plan summary",
+        )
+        planners.plan = AsyncMock(return_value=plan_result)
+        store.get_plannable = supply_once([issue])
+
+        await phase.plan_issues()
+
+        research_mock.research.assert_not_awaited()
+        # Planner still called, with empty research_context
+        call_kwargs = planners.plan.call_args
+        assert call_kwargs.kwargs.get("research_context") == ""
 
     @pytest.mark.asyncio
     async def test_plan_one_skips_research_when_no_runner(self, config):


### PR DESCRIPTION
## Why

The planning phase ran a full `ResearchRunner` subprocess before **every** issue — a second codebase-exploration pass on top of the planner's own exploration. For the common first-pass issue that double-exploration is the dominant per-plan cost and rarely changes the resulting plan. This is the "heavy planning for older, dumber models" pattern: shorten the cycle, keep the depth only where it earns its keep.

## What

Gate the research pre-pass in `PlanPhase._should_research(issue)`. With `research_enabled` on and a runner wired, research now runs **only** when the issue needs the depth:

- **Escalated** — the issue carries one of `config.research_escalation_labels` (new knob, default `["hydraflow-hitl-escalation"]`).
- **Cycled / failing to land** — route-back count > 0 (it has bounced back to planning at least once).

Plain first-pass issues skip research and let the planner explore once. The rest of the planning pipeline (assumption surfacer, plan council, plan review, spec-AC/judge, touchpoint expander) is **unchanged**.

## Config

New tunable field `research_escalation_labels: list[str]` (default `["hydraflow-hitl-escalation"]`) — surfaced in the System tab, OR logic. Operators can broaden what counts as "escalated" without a code change. Master switch `research_enabled` is unchanged (off ⇒ never research).

## Tests

`TestPlanPhaseResearch` (8 cases): plain-issue-skips, escalated-label-triggers, cycled-route-back-triggers, no-runner, research-disabled, plus the two `plan_one` integration paths (escalated ⇒ context passed to planner; plain ⇒ research not awaited, planner gets empty context).

Full local gate green: `ruff check` + `ruff format --check` + `pyright` (0 errors) + `bandit` (medium+) + full `pytest tests/`. No scenario tests reference research, so no scenario blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)