### PR TITLE
fix(adr): bare paths in ADR-0069/0072 Enforced-by lines (preventive)

### DIFF
--- a/docs/adr/0069-workspace-gc-loop.md
+++ b/docs/adr/0069-workspace-gc-loop.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-05-19
-**Enforced by:** `tests/test_workspace_gc_loop.py`
+**Enforced by:** tests/test_workspace_gc_loop.py
 
 ## Context
 

--- a/docs/adr/0072-stale-issue-loop.md
+++ b/docs/adr/0072-stale-issue-loop.md
@@ -2,7 +2,7 @@
 
 **Status:** Proposed
 **Date:** 2026-05-19
-**Enforced by:** `tests/test_stale_issue_loop.py`
+**Enforced by:** tests/test_stale_issue_loop.py
 
 ## Context
 


### PR DESCRIPTION
## Why

`test_adr_enforcement.py::test_enforcement_test_files_exist` parses each Accepted ADR's `**Enforced by:**` field as comma-separated **bare paths** and does **not** strip markdown backticks. ADR-0069 and ADR-0072 wrap their path in backticks, so the file-existence check would resolve a path containing literal backticks and fail.

They pass today only because both ADRs are still `Proposed` (the test skips non-Accepted ADRs). The moment either flips to `Accepted`, CI breaks — exactly what happened to ADR-0071 in #9218.

## What

Strip the backticks on the `**Enforced by:**` line of both ADRs so they use bare paths, matching the convention every other ADR follows. Referenced test files (`tests/test_workspace_gc_loop.py`, `tests/test_stale_issue_loop.py`) exist. Pure doc hygiene — no code change.

After this, zero ADRs carry the backtick deviation.

## Verification

`pytest tests/test_adr_enforcement.py` green (64 cases). `grep` confirms no remaining `**Enforced by:** \`...\`` lines anywhere in `docs/adr/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)