### PR TITLE
fix(labels): ensure_labels creates ad-hoc loop labels so create_issue stops returning 0

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -37,7 +37,7 @@ from models import (
     PRListItem,
     ReviewVerdict,
 )
-from prep import HYDRAFLOW_LABELS
+from prep import HYDRAFLOW_LABELS, HYDRAFLOW_LITERAL_LABELS
 from subprocess_util import run_subprocess, run_subprocess_with_retry
 from telemetry.spans import port_span  # noqa: E402
 
@@ -96,6 +96,7 @@ class PRManager:
 
     # Re-export from prep module for backward compatibility
     _HYDRAFLOW_LABELS = HYDRAFLOW_LABELS
+    _HYDRAFLOW_LITERAL_LABELS = HYDRAFLOW_LITERAL_LABELS
 
     _REPO_SLUG_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -73,6 +73,85 @@ HYDRAFLOW_LABELS: tuple[tuple[str, str, str], ...] = (
     ),
 )
 
+# Ad-hoc string-literal labels that loops pass directly to ``create_issue`` /
+# ``add_labels`` without going through a ``HydraFlowConfig`` field. They are NOT
+# resolvable via ``getattr(config, ...)``, so ``ensure_labels`` must create them
+# from these literal ``(label_name, color, description)`` rows. Without this, the
+# first ``gh issue create --label <X>`` for an uncreated label fails and the
+# consumer falls back to the ``0`` sentinel (PR #9242 guards that path; this row
+# table is what makes the labels actually exist). Colors are grouped by family:
+#   b60205/d93f0b reddish  -> escalation / rc-red / revert (operator-urgent)
+#   e99695 amber           -> ``*-stuck`` exhausted-retry escalations
+#   5319e7 purple          -> ``*-drift`` / ``*-anomaly`` detector findings
+#   e4e669 yellow          -> find-queue ad-hoc signal labels
+HYDRAFLOW_LITERAL_LABELS: tuple[tuple[str, str, str], ...] = (
+    # --- escalation root (bare literal; config field resolves to the
+    #     hydraflow-prefixed variant, so this bare name is never created by it) ---
+    ("hitl-escalation", "b60205", "Stuck-loop HITL escalation (bare literal label)"),
+    # --- rc-red / RC-duration / revert family (operator-urgent, reddish) ---
+    ("rc-red-attribution", "b60205", "Auto-revert culprit attribution for a red RC"),
+    ("rc-red-bisect-exhausted", "b60205", "RC bisect exhausted without a culprit"),
+    ("rc-red-post-revert-red", "b60205", "RC still red after auto-revert landed"),
+    ("rc-red-retry", "d93f0b", "RC red — retry the staging-bisect attempt"),
+    ("rc-red-verify-timeout", "b60205", "RC red verify step timed out"),
+    ("rc-duration-stuck", "e99695", "RC gate duration regression unresolved"),
+    ("rc-duration-regression", "d93f0b", "RC gate duration regressed past budget"),
+    ("revert-conflict", "d93f0b", "Auto-revert hit a merge conflict — needs a human"),
+    ("retry-lineage-exhausted", "d93f0b", "Retry lineage exhausted on a red RC"),
+    ("auto-revert", "d93f0b", "Issue/PR tied to an automated revert"),
+    # --- *-stuck exhausted-retry escalations (amber) ---
+    ("shadow-drift-stuck", "e99695", "Shadow drift unresolved after retries"),
+    ("fake-repair-stuck", "e99695", "Fake-adapter repair unresolved after retries"),
+    ("flaky-test-stuck", "e99695", "Flaky test unresolved after repair attempts"),
+    ("principles-stuck", "e99695", "Principles drift unresolved after retries"),
+    (
+        "corpus-learning-stuck",
+        "e99695",
+        "Corpus-learning case unresolved after retries",
+    ),
+    ("skill-prompt-stuck", "e99695", "Skill-prompt drift unresolved after retries"),
+    ("wiki-rot-stuck", "e99695", "Wiki rot unresolved after retries"),
+    ("triage-retry-exhausted", "e99695", "Triage retry budget exhausted for an issue"),
+    ("auto-agent-exhausted", "e99695", "Auto-agent attempt budget exhausted"),
+    # --- *-drift / *-anomaly detector findings (purple) ---
+    ("trust-loop-anomaly", "5319e7", "Trust-fleet sanity loop detected an anomaly"),
+    ("shadow-drift", "5319e7", "Shadow drift between fake output and live samples"),
+    ("fake-drift", "5319e7", "Fake-adapter output drifted from contract"),
+    ("principles-drift", "5319e7", "Principles/ADR-0044 cultural drift detected"),
+    ("skill-prompt-drift", "5319e7", "Skill-prompt eval drift detected"),
+    ("wiki-rot", "5319e7", "Repo wiki entry has rotted / gone stale"),
+    # --- find-queue ad-hoc signal labels (yellow) ---
+    ("flaky-test", "e4e669", "Flaky test detected by the flake_tracker loop"),
+    ("corpus-case-weak", "e4e669", "Weak corpus case bypassed its expected catcher"),
+    ("cost-budget", "e4e669", "Cost-budget watcher finding"),
+    ("cost-budget-exceeded", "e4e669", "Daily cost budget exceeded"),
+    ("issue-cost-spike", "e4e669", "Per-issue cost spike detected"),
+    ("arch-knowledge", "e4e669", "Architecture-knowledge coverage gap"),
+    ("sanity-loop-stalled", "e4e669", "Sanity loop stalled (dead-man switch)"),
+    ("wiki-stale", "e4e669", "Wiki freshness dead-man switch fired"),
+    ("onboarding-blocked", "e4e669", "Onboarding/auto-agent preflight blocked"),
+    ("cultural-check", "e4e669", "Principles cultural-check audit label"),
+    ("pricing-refresh", "e4e669", "Pricing-refresh loop signal"),
+    ("security", "d93f0b", "Security patch loop finding"),
+    ("adr-draft", "c5def5", "ADR draft opened for review"),
+    ("hydraflow-ci-failure", "d93f0b", "CI failure issue filed by ci_monitor"),
+    (
+        "hydraflow-branch-protection-drift",
+        "5319e7",
+        "Branch-protection ruleset drift detected",
+    ),
+    (
+        "hydraflow-gate-activation",
+        "e4e669",
+        "Planned gates ready to activate (gate_activator)",
+    ),
+    (
+        "human-required",
+        "d93f0b",
+        "Autonomous attempts exhausted — human action required",
+    ),
+)
+
 
 def _label_names(value: object) -> list[str]:
     """Normalise a label config field to a list of label names.
@@ -151,40 +230,50 @@ async def ensure_labels(
         for cfg_field, _color, _desc in HYDRAFLOW_LABELS:
             for name in _label_names(getattr(config, cfg_field)):
                 result.created.append(name)
+        for literal_name, _color, _desc in HYDRAFLOW_LITERAL_LABELS:
+            result.created.append(literal_name)
         logger.info("[dry-run] Would create labels: %s", result.created)
         return result
 
     existing = await _list_existing_labels(config, credentials=credentials)
 
+    # Config-field-backed lifecycle labels: name resolved via getattr(config, ...).
+    config_label_rows: list[tuple[str, str, str]] = []
     for cfg_field, color, description in HYDRAFLOW_LABELS:
-        label_names: list[str] = _label_names(getattr(config, cfg_field))
-        for label_name in label_names:
-            try:
-                await run_subprocess_with_retry(
-                    "gh",
-                    "label",
-                    "create",
-                    label_name,
-                    "--repo",
-                    config.repo,
-                    "--color",
-                    color,
-                    "--description",
-                    description,
-                    "--force",
-                    cwd=config.repo_root,
-                    gh_token=credentials.gh_token,
-                    max_retries=config.gh_max_retries,
-                )
-                if label_name in existing:
-                    result.existed.append(label_name)
-                    logger.debug("Label %r already existed (updated)", label_name)
-                else:
-                    result.created.append(label_name)
-                    logger.info("Created label %r", label_name)
-            except RuntimeError as exc:
-                result.failed.append(label_name)
-                logger.warning("Could not create label %r: %s", label_name, exc)
+        for label_name in _label_names(getattr(config, cfg_field)):
+            config_label_rows.append((label_name, color, description))
+
+    # Config-backed rows + ad-hoc literal rows (already literal names — no getattr).
+    for label_name, color, description in (
+        *config_label_rows,
+        *HYDRAFLOW_LITERAL_LABELS,
+    ):
+        try:
+            await run_subprocess_with_retry(
+                "gh",
+                "label",
+                "create",
+                label_name,
+                "--repo",
+                config.repo,
+                "--color",
+                color,
+                "--description",
+                description,
+                "--force",
+                cwd=config.repo_root,
+                gh_token=credentials.gh_token,
+                max_retries=config.gh_max_retries,
+            )
+            if label_name in existing:
+                result.existed.append(label_name)
+                logger.debug("Label %r already existed (updated)", label_name)
+            else:
+                result.created.append(label_name)
+                logger.info("Created label %r", label_name)
+        except RuntimeError as exc:
+            result.failed.append(label_name)
+            logger.warning("Could not create label %r: %s", label_name, exc)
 
     return result
 

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1649,12 +1649,15 @@ async def test_ensure_labels_exist_creates_all_hydraflow_labels(config, event_bu
     with patch("asyncio.create_subprocess_exec", mock_create):
         await mgr.ensure_labels_exist()
 
-    # 1 list call + 1 create per label
-    assert mock_create.call_count == 1 + len(PRManager._HYDRAFLOW_LABELS)
+    # 1 list call + 1 create per config-backed label + 1 per literal label
+    expected_creates = len(PRManager._HYDRAFLOW_LABELS) + len(
+        PRManager._HYDRAFLOW_LITERAL_LABELS
+    )
+    assert mock_create.call_count == 1 + expected_creates
 
     # Verify create calls use gh label create --force
     create_calls = [c for c in mock_create.call_args_list if "create" in c[0]]
-    assert len(create_calls) == len(PRManager._HYDRAFLOW_LABELS)
+    assert len(create_calls) == expected_creates
     for call in create_calls:
         args = call[0]
         assert args[0] == "gh"
@@ -1734,7 +1737,63 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "hydraflow-log-ingest",
         "hydraflow-memory-backlog",
         "hydraflow-memory-backlog-stuck",
+        # Ad-hoc literal labels loops pass to create_issue / add_labels — these
+        # are NOT config-field-backed and are created from HYDRAFLOW_LITERAL_LABELS.
+        # escalation root
+        "hitl-escalation",
+        # rc-red / RC-duration / revert family
+        "rc-red-attribution",
+        "rc-red-bisect-exhausted",
+        "rc-red-post-revert-red",
+        "rc-red-retry",
+        "rc-red-verify-timeout",
+        "rc-duration-stuck",
+        "rc-duration-regression",
+        "revert-conflict",
+        "retry-lineage-exhausted",
+        "auto-revert",
+        # *-stuck exhausted-retry escalations
+        "shadow-drift-stuck",
+        "fake-repair-stuck",
+        "flaky-test-stuck",
+        "principles-stuck",
+        "corpus-learning-stuck",
+        "skill-prompt-stuck",
+        "wiki-rot-stuck",
+        "triage-retry-exhausted",
+        "auto-agent-exhausted",
+        # *-drift / *-anomaly detector findings
+        "trust-loop-anomaly",
+        "shadow-drift",
+        "fake-drift",
+        "principles-drift",
+        "skill-prompt-drift",
+        "wiki-rot",
+        # find-queue ad-hoc signal labels
+        "flaky-test",
+        "corpus-case-weak",
+        "cost-budget",
+        "cost-budget-exceeded",
+        "issue-cost-spike",
+        "arch-knowledge",
+        "sanity-loop-stalled",
+        "wiki-stale",
+        "onboarding-blocked",
+        "cultural-check",
+        "pricing-refresh",
+        "security",
+        "adr-draft",
+        "hydraflow-ci-failure",
+        "hydraflow-branch-protection-drift",
+        "hydraflow-gate-activation",
+        "human-required",
     }
+    # The literal-label set must be a subset of what ensure_labels created,
+    # so every ad-hoc label a loop passes to create_issue / add_labels exists.
+    literal_names = {
+        name for name, _color, _desc in PRManager._HYDRAFLOW_LITERAL_LABELS
+    }
+    assert literal_names <= created_labels
 
 
 @pytest.mark.asyncio
@@ -1781,7 +1840,9 @@ async def test_ensure_labels_exist_handles_individual_failures(config, event_bus
         await mgr.ensure_labels_exist()
 
     # All labels should be attempted even though first one failed
-    assert create_count == len(PRManager._HYDRAFLOW_LABELS)
+    assert create_count == len(PRManager._HYDRAFLOW_LABELS) + len(
+        PRManager._HYDRAFLOW_LITERAL_LABELS
+    )
 
 
 def test_makefile_ensure_labels_calls_dedicated_task() -> None:

--- a/tests/test_pr_manager_queries.py
+++ b/tests/test_pr_manager_queries.py
@@ -422,8 +422,10 @@ class TestRetryWrapperUsage:
             mock_retry.return_value = "[]"
             await mgr.ensure_labels_exist()
 
-        # 1 list call + 12 create calls = 13
-        assert mock_retry.await_count == 1 + len(PRManager._HYDRAFLOW_LABELS)
+        # 1 list call + 1 create per config-backed label + 1 per literal label
+        assert mock_retry.await_count == 1 + len(PRManager._HYDRAFLOW_LABELS) + len(
+            PRManager._HYDRAFLOW_LITERAL_LABELS
+        )
 
     @pytest.mark.asyncio
     async def test_pull_main_uses_retry(self, config, event_bus):

--- a/tests/test_prep.py
+++ b/tests/test_prep.py
@@ -15,6 +15,7 @@ from admin_tasks import _seed_context_assets
 from models import AuditCheckStatus
 from prep import (
     HYDRAFLOW_LABELS,
+    HYDRAFLOW_LITERAL_LABELS,
     PrepResult,
     _label_names,
     _list_existing_labels,
@@ -168,6 +169,15 @@ class TestListExistingLabels:
 # ---------------------------------------------------------------------------
 
 
+def _expected_label_count(config: Any) -> int:
+    """Total labels ensure_labels creates: config-resolved + ad-hoc literals."""
+    config_count = sum(
+        len(_label_names(getattr(config, cfg_field)))
+        for cfg_field, _color, _desc in HYDRAFLOW_LABELS
+    )
+    return config_count + len(HYDRAFLOW_LITERAL_LABELS)
+
+
 class TestEnsureLabels:
     @pytest.mark.asyncio
     async def test_creates_all_labels(self) -> None:
@@ -182,9 +192,42 @@ class TestEnsureLabels:
             result = await ensure_labels(config)
 
         # All labels should be created (none existed)
-        assert len(result.created) == len(HYDRAFLOW_LABELS)
+        assert len(result.created) == _expected_label_count(config)
         assert len(result.existed) == 0
         assert len(result.failed) == 0
+
+    @pytest.mark.asyncio
+    async def test_creates_ad_hoc_literal_labels(self) -> None:
+        """Ad-hoc string-literal labels loops pass to create_issue are created.
+
+        Root-cause completion for the recurring `create_issue`-returns-0
+        sentinel: loops pass bare labels like ``hitl-escalation``,
+        ``rc-red-retry``, ``trust-loop-anomaly`` straight to
+        ``gh issue create --label`` without a backing config field, so they
+        were never created and the first filing failed. ensure_labels now
+        creates every row in HYDRAFLOW_LITERAL_LABELS.
+        """
+        config = ConfigFactory.create()
+        created: list[str] = []
+
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=_make_label_side_effect("[]", capture=created),
+        ):
+            result = await ensure_labels(config)
+
+        literal_names = {name for name, _c, _d in HYDRAFLOW_LITERAL_LABELS}
+        assert literal_names <= set(created)
+        assert literal_names <= set(result.created)
+        # Spot-check representatives of each color family.
+        for name in (
+            "hitl-escalation",
+            "rc-red-retry",
+            "flaky-test-stuck",
+            "trust-loop-anomaly",
+            "human-required",
+        ):
+            assert name in created
 
     @pytest.mark.asyncio
     async def test_reports_already_existing_labels_in_existed_list(self) -> None:
@@ -206,7 +249,9 @@ class TestEnsureLabels:
             result = await ensure_labels(config)
 
         assert set(result.existed) == set(existing)
-        assert len(result.created) + len(result.existed) == len(HYDRAFLOW_LABELS)
+        assert len(result.created) + len(result.existed) == _expected_label_count(
+            config
+        )
         assert len(result.failed) == 0
 
     @pytest.mark.asyncio
@@ -243,7 +288,7 @@ class TestEnsureLabels:
         # No subprocess calls at all
         mock.assert_not_called()
         # But result should list what would be created
-        assert len(result.created) == len(HYDRAFLOW_LABELS)
+        assert len(result.created) == _expected_label_count(config)
         assert len(result.existed) == 0
 
     @pytest.mark.asyncio
@@ -259,7 +304,7 @@ class TestEnsureLabels:
             result = await ensure_labels(config)
 
         assert fail_label in result.failed
-        assert len(result.created) == len(HYDRAFLOW_LABELS) - 1
+        assert len(result.created) == _expected_label_count(config) - 1
         assert len(result.failed) == 1
 
     @pytest.mark.asyncio
@@ -274,17 +319,18 @@ class TestEnsureLabels:
             result = await ensure_labels(config)
 
         # All should be "created" since list failed (empty existing set)
-        assert len(result.created) == len(HYDRAFLOW_LABELS)
+        assert len(result.created) == _expected_label_count(config)
         assert len(result.existed) == 0
 
     @pytest.mark.asyncio
     async def test_all_already_exist(self) -> None:
         """All labels already present are classified as 'existed'."""
         config = ConfigFactory.create()
-        # Build the list of all default label names
+        # Build the list of all default label names (config-backed + literals)
         all_names = []
         for cfg_field, _, _ in HYDRAFLOW_LABELS:
             all_names.extend(_label_names(getattr(config, cfg_field)))
+        all_names.extend(name for name, _c, _d in HYDRAFLOW_LITERAL_LABELS)
         existing_json = json.dumps([{"name": n} for n in all_names])
 
         with patch(
@@ -294,7 +340,7 @@ class TestEnsureLabels:
             result = await ensure_labels(config)
 
         assert len(result.created) == 0
-        assert len(result.existed) == len(HYDRAFLOW_LABELS)
+        assert len(result.existed) == _expected_label_count(config)
         assert len(result.failed) == 0
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Loops file issues by passing **bare string-literal labels** straight to `create_issue` / `add_labels` (e.g. `"hitl-escalation"`, `"rc-red-retry"`, `"trust-loop-anomaly"`). These labels are **not** backed by a `HydraFlowConfig` field, so `prep.ensure_labels` — which only resolved label names via `getattr(config, cfg_field)` over `HYDRAFLOW_LABELS` — never created them.

When `gh issue create --label <X>` runs against a repo where label `X` doesn't exist, gh fails, `create_issue`'s `except` returns the `0` sentinel, and the loop re-fires phantom "issue #0" filings every cycle. PR #9242 guarded the consumers of that sentinel; **this PR makes the labels actually exist**, finishing the root-cause work for ad-hoc-label loops.

Notably, `config.hitl_escalation_label` resolves to `hydraflow-hitl-escalation`, a **different** name from the bare `"hitl-escalation"` literal that ~11 caretaker loops actually pass — so the most widely-used escalation label was silently uncreated.

## Audit (literal labels added → loops that pass them)

**Already config-field-backed (left alone):** the `hydraflow-*` lifecycle labels resolved via `getattr(config, ...)` over `HYDRAFLOW_LABELS` (find/plan/ready/review/hitl/.../memory-backlog).

**Added (NOT config-field-backed, now created from `HYDRAFLOW_LITERAL_LABELS`):**

| Label | Loop(s) |
|---|---|
| `hitl-escalation` | trust_fleet_sanity, live_corpus_replay, contract_refresh, flake_tracker, rc_budget, skill_prompt_eval, corpus_learning, wiki_rot_detector, staging_bisect, memory_backlog, principles_audit |
| `rc-red-attribution`, `rc-red-bisect-exhausted`, `rc-red-post-revert-red`, `rc-red-retry`, `rc-red-verify-timeout`, `retry-lineage-exhausted`, `revert-conflict`, `auto-revert` | staging_bisect_loop |
| `rc-duration-stuck`, `rc-duration-regression` | rc_budget_loop |
| `shadow-drift`, `shadow-drift-stuck` | live_corpus_replay_loop |
| `fake-drift`, `fake-repair-stuck` | contract_refresh_loop |
| `flaky-test`, `flaky-test-stuck` | flake_tracker_loop |
| `principles-drift`, `principles-stuck`, `cultural-check`, `onboarding-blocked` | principles_audit_loop |
| `corpus-learning-stuck` | corpus_learning_loop |
| `skill-prompt-drift`, `skill-prompt-stuck`, `corpus-case-weak` | skill_prompt_eval_loop |
| `wiki-rot`, `wiki-rot-stuck` | wiki_rot_detector_loop |
| `trust-loop-anomaly` | trust_fleet_sanity_loop |
| `triage-retry-exhausted` | triage_retry_loop (config-backed but absent from `HYDRAFLOW_LABELS`) |
| `cost-budget` | cost_budget_watcher_loop |
| `cost-budget-exceeded`, `issue-cost-spike` | cost_budget_alerts |
| `arch-knowledge` | diagram_loop |
| `pricing-refresh` | pricing_refresh_loop |
| `sanity-loop-stalled`, `wiki-stale` | health_monitor_loop |
| `security` | security_patch_loop |
| `adr-draft` | adr_draft_opener |
| `hydraflow-ci-failure` | ci_monitor_loop |
| `hydraflow-branch-protection-drift` | branch_protection_auditor_loop |
| `hydraflow-gate-activation` | gate_activator_loop |
| `human-required`, `auto-agent-exhausted` | auto_agent_preflight_loop (`add_labels` path — same gh-fails-on-missing-label root cause) |

**Out of scope:** dynamic per-instance labels (`adapter-{adapter}`, `check-{check_id}`) — they can't be enumerated ahead of time.

## Mechanism

New `HYDRAFLOW_LITERAL_LABELS: tuple[tuple[str, str, str], ...]` of `(label_name, color_hex, description)` rows in `prep.py`. `ensure_labels` now iterates the config-backed rows **plus** these literal rows directly (no `getattr` — the names are already literal). Colors grouped by family: reddish = escalation/rc-red/revert, amber = `*-stuck`, purple = `*-drift`/`*-anomaly`, yellow = find-queue signals. The loops were **not** refactored to use config fields (too invasive); only the labels get created. Re-exported as `PRManager._HYDRAFLOW_LITERAL_LABELS` for symmetry with `_HYDRAFLOW_LABELS`.

## Operator action

Run `make ensure-labels` (→ `prep.ensure_labels`) to create these on each target repo.

## Tests

- Extended the exact created-label set assertion in `test_ensure_labels_exist_uses_config_label_names` (the full-Tests-job exact-set guard) to include the literal labels.
- Added `test_creates_ad_hoc_literal_labels` in `test_prep.py`.
- Updated all `len(HYDRAFLOW_LABELS)` count assertions across `test_prep.py`, `test_pr_manager_core.py`, `test_pr_manager_queries.py` to add the literal-label count.

## Verification

- `pytest tests/test_pr_manager_core.py tests/test_prep.py -q` → 251 passed
- `ruff check src/prep.py tests/...` → All checks passed
- `pyright src/prep.py` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)