### PR TITLE
fix(trust): carve out FakeDocker fault helpers as test-helpers (closes #9177)

### DIFF
--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -65,6 +65,11 @@ _HELPER_NAMES = frozenset(
 _FAKE_HELPER_OVERRIDES: dict[tuple[str, str], str] = {
     ("FakeGitHub", "clear_rate_limit"): "test-helper",
     ("FakeGitHub", "set_rate_limit_mode"): "test-helper",
+    # FakeDocker's single-shot fault-injection helpers have no real-adapter
+    # counterpart (the real container runner has no fail_next/clear_fault), so
+    # no cassette can record them — mirror the FakeGitHub carve-out (#9177).
+    ("FakeDocker", "clear_fault"): "test-helper",
+    ("FakeDocker", "fail_next"): "test-helper",
 }
 
 

--- a/tests/regressions/test_issue_9177.py
+++ b/tests/regressions/test_issue_9177.py
@@ -1,0 +1,80 @@
+"""Regression reproduction for issue #9177 — FakeDocker adapter-surface gap.
+
+Issue #9177 is a `fake_coverage_auditor` rollup (#8986): the auditor reports
+that ``FakeDocker`` exposes public methods classified as **adapter-surface**
+with no matching cassette under ``tests/trust/contracts/cassettes/docker/``:
+
+  * ``clear_fault``
+  * ``fail_next``
+
+These are single-shot fault-injection helpers — they have no real-adapter
+counterpart (the real container runner has no ``fail_next``/``clear_fault``
+method), which is exactly why no cassette can record them. ``FakeGitHub``'s
+analogous fault helpers (``clear_rate_limit`` / ``set_rate_limit_mode``) are
+already carved out as ``test-helper`` via ``_FAKE_HELPER_OVERRIDES`` in
+``fake_coverage_auditor_loop`` — the FakeDocker pair is not, so the auditor
+mis-files them as an un-cassetted adapter surface.
+
+This test reproduces the auditor's finding using the auditor's *own* logic:
+it catalogs ``FakeDocker``'s adapter-surface methods and the recorded docker
+cassettes, then asserts every adapter-surface method has cassette coverage.
+
+It is RED today because ``clear_fault`` and ``fail_next`` are flagged as
+adapter-surface yet have no cassette. The test goes GREEN once the gap is
+closed by *either* supported repair:
+
+  1. Recording a cassette for each method (the issue's literal repair), OR
+  2. Reclassifying them as ``test-helper`` via ``_FAKE_HELPER_OVERRIDES``
+     (the FakeGitHub-style carve-out).
+
+Both repairs empty the uncovered set, so this assertion tracks the real gap
+rather than one particular fix.
+
+NOTE: this is a *reproduction*, not a fix. Do not edit ``src/`` to make it
+pass — the fix belongs to whoever resolves #9177.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fake_coverage_auditor_loop import (
+    _FAKE_TO_CASSETTE_DIR,
+    catalog_cassette_methods,
+    catalog_fake_methods,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FAKE = "FakeDocker"
+
+
+def test_issue_9177_fake_docker_adapter_surface_is_cassetted() -> None:
+    """Every ``FakeDocker`` adapter-surface method must have a docker cassette.
+
+    RED for issue #9177: ``clear_fault`` and ``fail_next`` are classified as
+    adapter-surface but no cassette under
+    ``tests/trust/contracts/cassettes/docker/`` records them.
+    """
+    fake_dir = _REPO_ROOT / "src" / "mockworld" / "fakes"
+    catalog = catalog_fake_methods(fake_dir)
+    assert _FAKE in catalog, f"{_FAKE} not found by catalog_fake_methods"
+
+    surface = catalog[_FAKE]["adapter-surface"]
+
+    cassette_dir = (
+        _REPO_ROOT
+        / "tests"
+        / "trust"
+        / "contracts"
+        / "cassettes"
+        / _FAKE_TO_CASSETTE_DIR[_FAKE]
+    )
+    cassetted = catalog_cassette_methods(cassette_dir)
+
+    uncovered = sorted(method for method in surface if method not in cassetted)
+
+    assert not uncovered, (
+        f"{_FAKE} adapter-surface methods with no matching cassette "
+        f"(issue #9177): {uncovered}. Repair by recording a cassette for each, "
+        f"or reclassify them as test-helpers via _FAKE_HELPER_OVERRIDES."
+    )


### PR DESCRIPTION
## Bug

Issue #9177 (a `fake_coverage_auditor` rollup, #8986) reports `FakeDocker` exposes two public methods classified as **adapter-surface** with no matching cassette under `tests/trust/contracts/cassettes/docker/`:

- `clear_fault`
- `fail_next`

These are single-shot fault-injection helpers. The real container runner exposes no `fail_next`/`clear_fault`, so **no cassette can ever record them** — the literal "record a cassette" repair is impossible. The auditor mis-filed them as un-cassetted adapter surface.

## Repair

`FakeGitHub`'s analogous fault helpers (`clear_rate_limit` / `set_rate_limit_mode`) are already carved out as `test-helper` via `_FAKE_HELPER_OVERRIDES` in `src/fake_coverage_auditor_loop.py`. This PR mirrors that carve-out for the FakeDocker pair, removing them from the adapter surface so the auditor stops flagging a gap with no valid cassette-based fix.

## Test

Adds `tests/regressions/test_issue_9177.py`, which catalogs `FakeDocker`'s adapter-surface methods using the auditor's *own* logic (`catalog_fake_methods` / `catalog_cassette_methods`) and asserts every adapter-surface method has cassette coverage. RED before the carve-out (both methods flagged uncovered), GREEN after.

Verified: regression + scenario + `fake_coverage_auditor` unit tests pass; ruff + pyright clean on changed files.

Closes #9177

🤖 Generated with [Claude Code](https://claude.com/claude-code)