### PR TITLE
fix(adr): update ADR-0009 citations to current symbols (closes #9173)

### DIFF
--- a/docs/adr/0009-multi-repo-process-per-repo-model.md
+++ b/docs/adr/0009-multi-repo-process-per-repo-model.md
@@ -7,23 +7,24 @@
 ## Context
 
 HydraFlow needs to manage multiple GitHub repositories simultaneously while
-keeping each repo's pipeline state, worktrees, and agent processes fully
+keeping each repo's pipeline state, workspaces, and agent processes fully
 isolated. A single-process multi-repo model would require threading repo
 identity through every component (`StateTracker`, `EventBus`, `IssueStore`,
-`WorktreeManager`, worker pools) and risk shared-state bugs between repos.
+`WorkspaceManager`, worker pools) and risk shared-state bugs between repos.
 
-The supervisor (`hf_cli/supervisor_service.py`) already manages repo lifecycle
-via a module-global `RUNNERS` dict of `RepoProcess` structs. Each
-`RepoProcess` holds a `subprocess.Popen` handle, a dynamically allocated TCP
-port, and the repo's filesystem path. The orchestrator (`orchestrator.py`)
-creates a full `HydraFlowOrchestrator` per process with its own `StateTracker`,
-`EventBus`, `IssueStore`, and service registry built by `build_services()`.
+The `RepoRuntimeRegistry` (`repo_runtime.py`) manages repo lifecycle via a
+per-slug registry of `RepoRuntime` instances. Each `RepoRuntime` owns its own
+`asyncio` task, `EventBus`, `StateTracker`, and orchestrator, registered via
+`RepoRuntimeRegistry.register()` and started via `RepoRuntime.start()`. The
+orchestrator (`orchestrator.py`) creates a full `HydraFlowOrchestrator` per
+runtime with its own `StateTracker`, `EventBus`, `IssueStore`, and service
+registry built by `build_services()`.
 
 Runtime state for each managed repo lives under `.hydraflow/` in the repo
-directory (or under `$HYDRAFLOW_HOME/<repo_slug>/` when the supervisor sets
-`HYDRAFLOW_HOME`). Worktree paths are scoped via
-`config.worktree_path_for_issue()` which resolves to
-`<worktree_base>/<repo_slug>/issue-<num>`. The `_resolve_repo_scoped_paths()`
+directory (or under `$HYDRAFLOW_HOME/<repo_slug>/` when the runtime sets
+`HYDRAFLOW_HOME`). Workspace paths are scoped via
+`config.workspace_path_for_issue()` which resolves to
+`<workspace_base>/<repo_slug>/issue-<num>`. The `_resolve_repo_scoped_paths()`
 helper in `config.py` ensures state files (`state.json`, `events.jsonl`,
 `sessions.jsonl`) are placed under the repo slug subdirectory,
 with automatic migration of legacy flat files. (`config.json` is not
@@ -47,8 +48,8 @@ Adopt the **process-per-repo** model as the canonical multi-repo architecture:
    `_resolve_base_paths()` reads this environment variable to set `data_root`,
    ensuring all state files, event logs, and session logs are isolated per repo.
 
-3. **Repo-scoped worktrees.** `WorktreeManager` resolves worktree paths under
-   `<worktree_base>/<repo_slug>/issue-<num>`, eliminating collision risk for
+3. **Repo-scoped workspaces.** `WorkspaceManager` resolves workspace paths under
+   `<workspace_base>/<repo_slug>/issue-<num>`, eliminating collision risk for
    same-numbered issues across repos. Per-repo `asyncio.Lock` instances
    (`_WORKTREE_LOCKS` keyed by `wt:<repo_slug>`) prevent concurrent
    create/destroy races within a single process.
@@ -116,8 +117,8 @@ Adopt the **process-per-repo** model as the canonical multi-repo architecture:
 - ADR-0001 (Five Concurrent Async Loops)
 - ADR-0006 (RepoRuntime Isolation Architecture) — superseded by this ADR
 - ADR-0008 (Multi-Repo Dashboard Architecture)
-- `src/hf_cli/supervisor_service.py:_start_repo`, `src/hf_cli/supervisor_service.py:RUNNERS` — TCP protocol
-- `src/config.py:_resolve_base_paths`, `src/config.py:_resolve_repo_scoped_paths`, `src/config.py:HydraFlowConfig.worktree_path_for_issue`
+- `src/repo_runtime.py:RepoRuntimeRegistry.register`, `src/repo_runtime.py:RepoRuntime.start` — per-repo runtime lifecycle (replaced the former `supervisor_service` `_start_repo`/`RUNNERS` subprocess+TCP registry)
+- `src/config.py:_resolve_base_paths`, `src/config.py:_resolve_repo_scoped_paths`, `src/config.py:HydraFlowConfig.workspace_path_for_issue`
 - `src/orchestrator.py:HydraFlowOrchestrator.__init__`
-- `src/worktree.py:WorktreeManager`
+- `src/workspace.py:WorkspaceManager`
 - `src/state:StateTracker`

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-04T15:55:20.752653+00:00",
-  "commit_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a",
+  "regenerated_at": "2026-06-04T23:59:14.256184+00:00",
+  "commit_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3",
   "artifacts": {
     "loops.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "ports.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "labels.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "modules.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "events.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "adr_xref.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "mockworld.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "changelog.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "coverage_matrix.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "functional_areas.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "ubiquitous-language.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "718f42bc8e242a7b3e23439743da7beab5ea2b1a"
+      "source_sha": "455bf0e90f798e6d24f8aa633754ede18d16cdf3"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -16,7 +16,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0006 | `src.events`, `src.hf_cli.supervisor_service`, `src.issue_store`, `src.orchestrator`, `src.state` |
 | ADR-0007 | `src.dashboard`, `src.dashboard_routes`, `src.hf_cli.supervisor_client`, `src.hf_cli.supervisor_service` |
 | ADR-0008 | `src.dashboard`, `src.dashboard_routes`, `src.hf_cli.supervisor_service` |
-| ADR-0009 | `src.config`, `src.hf_cli.supervisor_service`, `src.orchestrator`, `src.worktree` |
+| ADR-0009 | `src.config`, `src.orchestrator`, `src.repo_runtime`, `src.workspace` |
 | ADR-0010 | `src.config`, `src.docker_runner`, `src.metrics_manager`, `src.worktree` |
 | ADR-0011 | `src.epic`, `src.models`, `src.pr_manager` |
 | ADR-0012 | `src.epic`, `src.epic_monitor_loop`, `src.models`, `src.post_merge_handler`, `src.review_phase` |
@@ -157,7 +157,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.health_monitor_loop` | ADR-0045, ADR-0046 |
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
-| `src.hf_cli.supervisor_service` | ADR-0006, ADR-0007, ADR-0008, ADR-0009 |
+| `src.hf_cli.supervisor_service` | ADR-0006, ADR-0007, ADR-0008 |
 | `src.hindsight` | ADR-0032 |
 | `src.implement_phase` | ADR-0005, ADR-0014, ADR-0024, ADR-0063 |
 | `src.issue_cache` | ADR-0041 |
@@ -199,7 +199,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.prompt_builder` | ADR-0043 |
 | `src.prompt_template` | ADR-0043 |
 | `src.rc_budget_loop` | ADR-0045 |
-| `src.repo_runtime` | ADR-0038 |
+| `src.repo_runtime` | ADR-0009, ADR-0038 |
 | `src.repo_wiki` | ADR-0032, ADR-0053, ADR-0061 |
 | `src.repo_wiki_loop` | ADR-0032, ADR-0053 |
 | `src.report_issue_loop` | ADR-0013, ADR-0018, ADR-0045 |
@@ -251,8 +251,8 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.wiki_carryover` | ADR-0064 |
 | `src.wiki_compiler` | ADR-0032 |
 | `src.wiki_rot_detector_loop` | ADR-0045 |
-| `src.workspace` | ADR-0055 |
+| `src.workspace` | ADR-0009, ADR-0055 |
 | `src.workspace_gc_loop` | ADR-0069 |
-| `src.worktree` | ADR-0003, ADR-0009, ADR-0010 |
+| `src.worktree` | ADR-0003, ADR-0010 |
 
 <!-- arch:generated -->

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,14 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `455bf0e` — chore(gates): target main ruleset by explicit refs/heads/main, not ~DEFAULT_BRANCH (#9252) (#9252) *(2026-06-04)*
+- `eff5ffc` — Merge pull request #9250 from T-rav/rc/2026-06-04-1254 *(2026-06-04)*
+- `90878f5` — fix(adr): use bare paths in ADR-0069/0072 Enforced-by lines (#9247) (#9247) *(2026-06-04)*
+- `adae9a8` — Accept ADR-0071: route back counter port (#9218) (#9218) *(2026-06-04)*
+- `b7119da` — feat(log-ingest): 4h loop that clusters/dedups log errors+warnings into fix-issues (#9245) (#9245) *(2026-06-04)*
 - `07b8937` — Revert "feat(honeycomb): low-noise SLO/burn-alert issue-ingestion loop (default-disabled) (#9237)" (#9244) (#9244) *(2026-06-04)*
 - `b3d0896` — feat(honeycomb): low-noise SLO/burn-alert issue-ingestion loop (default-disabled) (#9237) (#9237) *(2026-06-04)*
+- `05ea34a` — feat(ul): entry-evidence — 4 new entry links across 2 terms *(2026-06-03)*
 - `7bbc795` — test(sandbox): e2e backfill batch 1 — workspace_gc, runs_gc, health_monitor, merge_state_watcher (#9159) (#9159) *(2026-06-02)*
 - `1209d49` — fix(sandbox): skip ContractRefreshLoop external recorders in the air-gapped sandbox (s30) (#9152) (#9152) *(2026-06-02)*
 - `abb52ba` — fix(dependabot): cache all open PRs so DependabotMergeLoop can see bot PRs (s09) (#9151) (#9151) *(2026-06-02)*
@@ -423,7 +429,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `c4b8ecd` — Fixes #2374: Add ADR-0023 for supersession regex verb form coverage (#2379) (#2379) *(2026-03-08)*
 - `7c6410a` — Fixes #2210: sync ADR index statuses (#2233) (#2233) *(2026-03-07)*
 - `b1df31d` — Fixes #1977: Document cross-phase integration harness (#2146) (#2146) *(2026-03-06)*
-- `548bf0b` — Fixes #2031: normalize superseded ADR statuses (#2158) (#2158) *(2026-03-06)*
 
 
 <!-- arch:generated -->

--- a/tests/regressions/test_issue_9173.py
+++ b/tests/regressions/test_issue_9173.py
@@ -1,0 +1,112 @@
+"""Regression reproduction for issue #9173 — ADR-0009 cited-module drift.
+
+Issue #9173 is an `adr_touchpoint_auditor` rollup: modules cited by
+**ADR-0009 (Multi-Repo Process-Per-Repo Model, status: Accepted)** drifted
+across 10 merged PRs without the ADR being updated. The auditor fires on a
+file-level signal (cited `src/` file touched, ADR file absent from the diff),
+so it cannot tell whether the ADR's *content* is still accurate.
+
+This test reproduces the underlying drift concretely: it parses ADR-0009 with
+the project's own citation parser (``adr_index.parse_adr_file`` — the same
+regex/index the auditor and the P2 CI gate use) and asserts every
+``src/<file>.py:<Symbol>`` anchor still resolves to live code via AST.
+
+It is RED today because ADR-0009 cites code that has since been renamed or
+deleted:
+
+  * ``src/config.py:HydraFlowConfig.worktree_path_for_issue`` — the method was
+    renamed to ``workspace_path_for_issue`` (worktree→workspace refactor).
+  * ``src/worktree.py:WorktreeManager`` — ``src/worktree.py`` no longer exists;
+    the type is now ``WorkspaceManager`` in ``src/workspace.py``.
+  * ``src/hf_cli/supervisor_service.py:_start_repo`` / ``:RUNNERS`` — that
+    supervisor module file no longer exists under that path.
+
+The test goes GREEN once ADR-0009 is updated to cite the current symbols
+(repair option 1 in the issue) — i.e. it tracks resolution of the actual
+drift, not the auditor's coarse touch signal.
+
+NOTE: this is a *reproduction*, not a fix. Do not edit ``src/`` to make it
+pass — the ADR markdown is what is stale.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from adr_index import parse_adr_file
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADR_GLOB = "0009-*.md"
+
+
+def _find_adr_0009() -> Path:
+    matches = sorted((_REPO_ROOT / "docs" / "adr").glob(_ADR_GLOB))
+    assert matches, "ADR-0009 markdown file not found under docs/adr/"
+    return matches[0]
+
+
+def _module_defines(tree: ast.Module, dotted: str) -> bool:
+    """True iff *dotted* (e.g. ``Class.method`` or ``func`` or ``NAME``) is
+    defined at the corresponding nesting level in *tree*."""
+    parts = dotted.split(".")
+
+    def names_in(body: list[ast.stmt]) -> set[str]:
+        found: set[str] = set()
+        for node in body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                found.add(node.name)
+            elif isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        found.add(tgt.id)
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                found.add(node.target.id)
+        return found
+
+    body: list[ast.stmt] = list(tree.body)
+    for i, part in enumerate(parts):
+        if part not in names_in(body):
+            return False
+        if i == len(parts) - 1:
+            return True
+        # Descend into the named class to resolve the next path component.
+        nxt = next(
+            (n for n in body if isinstance(n, ast.ClassDef) and n.name == part),
+            None,
+        )
+        if nxt is None:
+            return False
+        body = list(nxt.body)
+    return True
+
+
+def test_issue_9173_adr_0009_citations_resolve_to_live_code() -> None:
+    """Every ``src/...py:Symbol`` anchor in ADR-0009 must resolve in live code.
+
+    RED for issue #9173: ADR-0009 cites renamed/deleted symbols and files.
+    """
+    adr = parse_adr_file(_find_adr_0009())
+
+    missing_files: list[str] = []
+    missing_symbols: list[str] = []
+
+    for cited_file, symbols in sorted(adr.source_symbols.items()):
+        abs_path = _REPO_ROOT / cited_file
+        if not abs_path.is_file():
+            missing_files.append(cited_file)
+            continue
+        if not symbols:
+            continue  # bare file citation, nothing to resolve at symbol level
+        tree = ast.parse(abs_path.read_text())
+        for symbol in sorted(symbols):
+            if not _module_defines(tree, symbol):
+                missing_symbols.append(f"{cited_file}:{symbol}")
+
+    violations = [f"missing file: {f}" for f in missing_files] + [
+        f"missing symbol: {s}" for s in missing_symbols
+    ]
+    assert not violations, (
+        "ADR-0009 cites code that no longer exists (drift, issue #9173):\n  "
+        + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## What

ADR-0009 (Multi-Repo Process-Per-Repo Model, status: Accepted) cited code symbols that were renamed or moved across the `worktree`→`workspace` and `supervisor_service`→`repo_runtime` refactors. The `adr_touchpoint_auditor` flagged the resulting drift across 10 merged PRs (#9123, #9127, #9130, #9138, #9146, #9148, #9152, #9153, #9156, #9161). This is repair option 1 from #9173 — update the ADR to cite the current symbols.

## Stale anchors → live symbols

| Stale citation | Live symbol (verified via AST) |
|---|---|
| `src/config.py:HydraFlowConfig.worktree_path_for_issue` | `src/config.py:HydraFlowConfig.workspace_path_for_issue` |
| `src/worktree.py:WorktreeManager` (file deleted) | `src/workspace.py:WorkspaceManager` |
| `src/hf_cli/supervisor_service.py:_start_repo` / `:RUNNERS` (path deleted) | `src/repo_runtime.py:RepoRuntimeRegistry.register` / `RepoRuntime.start` |

The subprocess + TCP supervisor registry (`_start_repo`/`RUNNERS`) was replaced by the in-process `RepoRuntimeRegistry` (`src/repo_runtime.py`). Context/Decision prose updated to match the live symbols. No DECISION change — this is drift-repair of stale code citations, not an architectural reversal (`Skip-ADR:` noted in the commit).

## Test

Adds `tests/regressions/test_issue_9173.py` (the saved reproduction): parses ADR-0009 with the project's own `adr_index.parse_adr_file` and asserts every `src/<file>.py:<Symbol>` anchor resolves to live code via AST. RED before this change, GREEN after. The test is not weakened.

## Verification

- `pytest tests/regressions/test_issue_9173.py -q` → green
- `make arch-regen-stage` → regenerated `docs/arch/generated/adr_xref.md` (+ `changelog.md`, `.meta.json`); `make arch-check` → exit 0
- `ruff check` on changed files → all checks passed

Closes #9173

🤖 Generated with [Claude Code](https://claude.com/claude-code)