### PR TITLE
feat(ul): entry-evidence — 19 new entry links across 12 terms

### DIFF
--- a/docs/arch/generated/ubiquitous-language-context-map.md
+++ b/docs/arch/generated/ubiquitous-language-context-map.md
@@ -23,6 +23,7 @@ graph LR
     FakeCoverageAuditorLoop["FakeCoverageAuditorLoop<br/><i>loop</i>"]
     FlakeTrackerLoop["FlakeTrackerLoop<br/><i>loop</i>"]
     GitHubCacheLoop["GitHubCacheLoop<br/><i>loop</i>"]
+    GitHubCacheLoop["GitHubCacheLoop<br/><i>loop</i>"]
     LiveCorpusReplayLoop["LiveCorpusReplayLoop<br/><i>loop</i>"]
     MergeStateWatcherLoop["MergeStateWatcherLoop<br/><i>loop</i>"]
     PricingRefreshLoop["PricingRefreshLoop<br/><i>loop</i>"]
@@ -51,6 +52,14 @@ graph LR
     StateTracker["StateTracker<br/><i>service</i>"]
     WorkspacePort["WorkspacePort<br/><i>port</i>"]
   end
+  ADRReviewerLoop -->|depends_on| HydraFlowConfig
+  ADRReviewerLoop -->|depends_on| BaseBackgroundLoop
+  ADRReviewerLoop -->|implements| BaseBackgroundLoop
+  AdrTouchpointAuditorLoop -->|depends_on| BaseBackgroundLoop
+  AdrTouchpointAuditorLoop -->|depends_on| StateTracker
+  AdrTouchpointAuditorLoop -->|depends_on| HydraFlowConfig
+  AdrTouchpointAuditorLoop -->|implements| BaseBackgroundLoop
+  AgentPort -->|depends_on| Task
   AgentRunner -->|depends_on| PRPort
   AgentRunner -->|depends_on| WorkspacePort
   AgentRunner -->|depends_on| IssueStorePort
@@ -62,8 +71,107 @@ graph LR
   BaseBackgroundLoop -->|depends_on| HydraFlowConfig
   BotPRPort -->|depends_on| HydraFlowConfig
   BotPRPort -->|depends_on| BaseBackgroundLoop
+  CIMonitorLoop -->|depends_on| PRPort
+  CIMonitorLoop -->|depends_on| HydraFlowConfig
+  CIMonitorLoop -->|depends_on| BaseBackgroundLoop
+  CIMonitorLoop -->|implements| BaseBackgroundLoop
+  ContractRefreshLoop -->|depends_on| BaseBackgroundLoop
+  ContractRefreshLoop -->|depends_on| StateTracker
+  ContractRefreshLoop -->|depends_on| HydraFlowConfig
+  ContractRefreshLoop -->|implements| BaseBackgroundLoop
+  CorpusLearningLoop -->|depends_on| BaseBackgroundLoop
+  CorpusLearningLoop -->|depends_on| StateTracker
+  CorpusLearningLoop -->|depends_on| HydraFlowConfig
+  CorpusLearningLoop -->|implements| BaseBackgroundLoop
+  DependabotMergeLoop -->|depends_on| PRPort
+  DependabotMergeLoop -->|depends_on| HydraFlowConfig
+  DependabotMergeLoop -->|depends_on| BaseBackgroundLoop
+  DependabotMergeLoop -->|depends_on| StateTracker
+  DependabotMergeLoop -->|implements| BaseBackgroundLoop
+  DiagnosticLoop -->|depends_on| BaseBackgroundLoop
+  DiagnosticLoop -->|depends_on| StateTracker
+  DiagnosticLoop -->|depends_on| PRPort
+  DiagnosticLoop -->|depends_on| HydraFlowConfig
+  DiagnosticLoop -->|implements| BaseBackgroundLoop
+  DiagramLoop -->|depends_on| HydraFlowConfig
+  DiagramLoop -->|depends_on| BaseBackgroundLoop
+  DiagramLoop -->|implements| BaseBackgroundLoop
+  EdgeProposerLoop -->|depends_on| BaseBackgroundLoop
+  EdgeProposerLoop -->|depends_on| HydraFlowConfig
+  EdgeProposerLoop -->|depends_on| BotPRPort
+  EdgeProposerLoop -->|implements| BaseBackgroundLoop
+  EntryEvidenceLoop -->|depends_on| BaseBackgroundLoop
+  EntryEvidenceLoop -->|depends_on| RepoWikiStore
+  EntryEvidenceLoop -->|depends_on| HydraFlowConfig
+  EntryEvidenceLoop -->|depends_on| BotPRPort
+  EntryEvidenceLoop -->|implements| BaseBackgroundLoop
+  FakeCoverageAuditorLoop -->|depends_on| BaseBackgroundLoop
+  FakeCoverageAuditorLoop -->|depends_on| StateTracker
+  FakeCoverageAuditorLoop -->|depends_on| HydraFlowConfig
+  FakeCoverageAuditorLoop -->|implements| BaseBackgroundLoop
+  FlakeTrackerLoop -->|depends_on| BaseBackgroundLoop
+  FlakeTrackerLoop -->|depends_on| HydraFlowConfig
+  FlakeTrackerLoop -->|depends_on| StateTracker
+  FlakeTrackerLoop -->|implements| BaseBackgroundLoop
+  GitHubCacheLoop -->|depends_on| BaseBackgroundLoop
+  GitHubCacheLoop -->|depends_on| HydraFlowConfig
+  GitHubCacheLoop -->|implements| BaseBackgroundLoop
   IssueFetcherPort -->|depends_on| IssueStorePort
+  IssueFetcherPort -->|depends_on| Task
   IssueStorePort -->|depends_on| Task
+  LiveCorpusReplayLoop -->|depends_on| HydraFlowConfig
+  LiveCorpusReplayLoop -->|depends_on| BaseBackgroundLoop
+  LiveCorpusReplayLoop -->|depends_on| StateTracker
+  LiveCorpusReplayLoop -->|implements| BaseBackgroundLoop
+  MergeStateWatcherLoop -->|depends_on| PRPort
+  MergeStateWatcherLoop -->|depends_on| HydraFlowConfig
+  MergeStateWatcherLoop -->|depends_on| BaseBackgroundLoop
+  MergeStateWatcherLoop -->|implements| BaseBackgroundLoop
+  ObservabilityPort -->|depends_on| Task
+  PricingRefreshLoop -->|depends_on| BaseBackgroundLoop
+  PricingRefreshLoop -->|depends_on| HydraFlowConfig
+  PricingRefreshLoop -->|implements| BaseBackgroundLoop
   PRPort -->|depends_on| Task
+  PRUnstickerLoop -->|depends_on| PRPort
+  PRUnstickerLoop -->|depends_on| HydraFlowConfig
+  PRUnstickerLoop -->|depends_on| BaseBackgroundLoop
+  PRUnstickerLoop -->|implements| BaseBackgroundLoop
+  RCBudgetLoop -->|depends_on| BaseBackgroundLoop
+  RCBudgetLoop -->|depends_on| StateTracker
+  RCBudgetLoop -->|depends_on| HydraFlowConfig
+  RCBudgetLoop -->|implements| BaseBackgroundLoop
+  ReportIssueLoop -->|depends_on| BaseBackgroundLoop
+  ReportIssueLoop -->|depends_on| StateTracker
+  ReportIssueLoop -->|depends_on| HydraFlowConfig
+  ReportIssueLoop -->|implements| BaseBackgroundLoop
+  ReviewInsightStorePort -->|depends_on| Task
+  RouteBackCounterPort -->|depends_on| PRPort
+  SentryLoop -->|depends_on| BaseBackgroundLoop
+  SentryLoop -->|depends_on| StateTracker
+  SentryLoop -->|depends_on| HydraFlowConfig
+  SentryLoop -->|implements| BaseBackgroundLoop
+  SkillPromptEvalLoop -->|depends_on| BaseBackgroundLoop
+  SkillPromptEvalLoop -->|depends_on| StateTracker
+  SkillPromptEvalLoop -->|depends_on| HydraFlowConfig
+  SkillPromptEvalLoop -->|implements| BaseBackgroundLoop
+  StaleIssueGCLoop -->|depends_on| PRPort
+  StaleIssueGCLoop -->|depends_on| HydraFlowConfig
+  StaleIssueGCLoop -->|depends_on| BaseBackgroundLoop
+  StaleIssueGCLoop -->|implements| BaseBackgroundLoop
+  TermPrunerLoop -->|depends_on| BotPRPort
+  TermPrunerLoop -->|depends_on| HydraFlowConfig
+  TermPrunerLoop -->|depends_on| BaseBackgroundLoop
+  TermPrunerLoop -->|implements| BaseBackgroundLoop
+  WikiRotDetectorLoop -->|depends_on| BaseBackgroundLoop
+  WikiRotDetectorLoop -->|depends_on| StateTracker
+  WikiRotDetectorLoop -->|depends_on| RepoWikiStore
+  WikiRotDetectorLoop -->|depends_on| HydraFlowConfig
+  WikiRotDetectorLoop -->|implements| BaseBackgroundLoop
+  WorkspaceGCLoop -->|depends_on| PRPort
+  WorkspaceGCLoop -->|depends_on| WorkspacePort
+  WorkspaceGCLoop -->|depends_on| HydraFlowConfig
+  WorkspaceGCLoop -->|depends_on| BaseBackgroundLoop
+  WorkspaceGCLoop -->|depends_on| StateTracker
+  WorkspaceGCLoop -->|implements| BaseBackgroundLoop
   WorkspacePort -->|depends_on| Task
 ```

--- a/docs/arch/generated/ubiquitous-language.md
+++ b/docs/arch/generated/ubiquitous-language.md
@@ -2,7 +2,7 @@
 
 # Ubiquitous Language
 
-_41 terms across 3 bounded contexts._
+_42 terms across 3 bounded contexts._
 
 See [ADR-0053](../../adr/0053-ubiquitous-language-as-living-artifact.md) for the governing pattern.
 
@@ -213,6 +213,18 @@ Trust-fleet loop that detects persistently flaky tests by parsing JUnit XML from
 - Flake detection requires at least one pass AND one fail within the window — pure-fail tests are not flakes.
 - Maximum 3 repair attempts per test before HITL escalation; the dedup key for the `hydraflow-find` issue does not reset until the escalation is resolved.
 - Kill-switch is via `enabled_cb("flake_tracker")` (ADR-0049).
+
+## GitHubCacheLoop
+
+**Kind:** `loop` · **Context:** `caretaker` · **Anchor:** `src/github_cache_loop.py:GitHubCacheLoop` · **Confidence:** `accepted`
+**Aliases:** `github cache loop`, `github data cache loop`, `github poller`
+
+Centralized GitHub data poller that replaces the pattern where every dashboard endpoint and background worker makes its own `gh api` calls (ADR-0041). A single `GitHubCacheLoop` polls GitHub on a fixed interval and stores results in `GitHubDataCache` — in memory and on disk. Dashboard endpoints and background workers read from the cache instantly rather than hitting the API. Write operations (create PR, merge, comment, label swap) still call `gh` directly because they need immediate confirmation.
+
+**Invariants:**
+- Only one instance per repo runtime; all read consumers share the same cache snapshot.
+- Write operations bypass the cache and call `gh` directly.
+- Cache staleness is observable: each `CacheSnapshot` carries a `fetched_at` timestamp; `age_seconds` is infinite until the first poll completes.
 
 ## GitHubCacheLoop
 

--- a/docs/wiki/terms/agent-port.md
+++ b/docs/wiki/terms/agent-port.md
@@ -5,13 +5,13 @@ kind: "port"
 bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:AgentPort"
 aliases: ["agent port", "agent runner port"]
-related: []
-evidence: []
+related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ26X"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-updated_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/agent-runner.md
+++ b/docs/wiki/terms/agent-runner.md
@@ -6,12 +6,12 @@ bounded_context: "builder"
 code_anchor: "src/agent.py:AgentRunner"
 aliases: ["agent runner", "implement runner", "claude agent runner"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K7"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K8"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K6"}, {"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}]
-evidence: []
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ26R", "01KQP0XFBGMB32VFGNPV8GZ26X"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668798+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/base-background-loop.md
+++ b/docs/wiki/terms/base-background-loop.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/base_background_loop.py:BaseBackgroundLoop"
 aliases: ["base background loop", "loop base class"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}]
-evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P"]
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P", "01KRBX2N4QP7VW8FGH3J5YD0M3", "01KRBX2N4QP7VW8FGH3J5YD0M5"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668776+00:00"
-updated_at: "2026-06-04T05:06:42.396716+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/event-bus.md
+++ b/docs/wiki/terms/event-bus.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/events.py:EventBus"
 aliases: ["pub/sub bus", "hydraflow event bus"]
 related: []
-evidence: ["01KQP0XFBGMB32VFGNPV8GZ268"]
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KRADV2026B0PHASE0003", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668765+00:00"
-updated_at: "2026-06-04T05:06:42.396716+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/issue-fetcher-port.md
+++ b/docs/wiki/terms/issue-fetcher-port.md
@@ -5,13 +5,13 @@ kind: "port"
 bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:IssueFetcherPort"
 aliases: ["issue fetcher port", "github issue fetching port"]
-related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}]
-evidence: []
+related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}, {"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M2", "01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-updated_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/issue-store-port.md
+++ b/docs/wiki/terms/issue-store-port.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:IssueStorePort"
 aliases: ["issue store port", "issue queue port", "work queue port"]
 related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-evidence: []
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668794+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/pr-port.md
+++ b/docs/wiki/terms/pr-port.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:PRPort"
 aliases: ["pr port", "pull request port", "github pr port"]
 related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-evidence: []
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M2", "01KRBX2N4QP7VW8FGH3J5YD0M3", "01KRBX2N4QP7VW8FGH3J5YD0M5"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668784+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/repo-wiki-store.md
+++ b/docs/wiki/terms/repo-wiki-store.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/repo_wiki.py:RepoWikiStore"
 aliases: ["repo wiki store", "wiki store", "per-repo wiki"]
 related: []
-evidence: []
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M2"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668780+00:00"
-updated_at: "2026-05-05T03:35:36.668781+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/review-insight-store-port.md
+++ b/docs/wiki/terms/review-insight-store-port.md
@@ -5,13 +5,13 @@ kind: "port"
 bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:ReviewInsightStorePort"
 aliases: ["review insight store port", "review insight port"]
-related: []
-evidence: []
+related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ26W", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-updated_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/route-back-counter-port.md
+++ b/docs/wiki/terms/route-back-counter-port.md
@@ -5,13 +5,13 @@ kind: "port"
 bounded_context: "shared-kernel"
 code_anchor: "src/route_back.py:RouteBackCounterPort"
 aliases: ["route-back counter port", "route back counter", "precondition retry counter port"]
-related: []
-evidence: []
+related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K7"}]
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-updated_at: "2026-05-19T00:00:00.000000+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/state-tracker.md
+++ b/docs/wiki/terms/state-tracker.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/state/__init__.py:StateTracker"
 aliases: ["state tracker", "state facade", "state mixin facade"]
 related: []
-evidence: []
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668771+00:00"
-updated_at: "2026-05-05T03:35:36.668772+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/task.md
+++ b/docs/wiki/terms/task.md
@@ -6,12 +6,12 @@ bounded_context: "builder"
 code_anchor: "src/models.py:Task"
 aliases: ["work item", "ticket"]
 related: []
-evidence: []
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ26W"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-07T15:20:32.920858+00:00"
-updated_at: "2026-05-07T15:20:32.920863+00:00"
+updated_at: "2026-06-05T01:05:34.672901+00:00"
 proposed_by: "TermProposerLoop"
 proposed_at: "2026-05-07T15:20:32.920451+00:00"
 proposal_signals: ["S2"]


### PR DESCRIPTION
Auto-generated batch from `EntryEvidenceLoop` (ADR-0062).

Entry → term backlinks added:
- `AgentPort` ← entry `01KQP0XFBGMB32VFGNPV8GZ26X`
- `AgentRunner` ← entry `01KQP0XFBGMB32VFGNPV8GZ26R`
- `AgentRunner` ← entry `01KQP0XFBGMB32VFGNPV8GZ26X`
- `BaseBackgroundLoop` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M3`
- `BaseBackgroundLoop` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M5`
- `EventBus` ← entry `01KRADV2026B0PHASE0003`
- `EventBus` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M3`
- `IssueFetcherPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M2`
- `IssueFetcherPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `IssueStorePort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `PRPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M2`
- `PRPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M3`
- `PRPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M5`
- `RepoWikiStore` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M2`
- `ReviewInsightStorePort` ← entry `01KQP0XFBGMB32VFGNPV8GZ26W`
- `ReviewInsightStorePort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M3`
- `RouteBackCounterPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `StateTracker` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `Task` ← entry `01KQP0XFBGMB32VFGNPV8GZ26W`

Matches are LLM-validated (one call per uncached entry) against the
live `TermStore`. Idempotent: re-runs skip entries already linked.

Auto-merge on CI green via `DependabotMergeLoop`.

Generated by `EntryEvidenceLoop`