### PR TITLE
fix(wiki): repair malformed topic entries + guard against silent data loss

### DIFF
--- a/docs/wiki/gotchas.md
+++ b/docs/wiki/gotchas.md
@@ -729,7 +729,7 @@ Example: Hook fails → fix code → try commit again, not `git commit --no-veri
 ```
 
 
-### Implement-phase: never publish work for `result.success is False`
+## Implement-phase: never publish work for `result.success is False`
 
 **Pattern:** A blocking post-implementation skill (`discover-completeness`,
 `scope-check`, `diff-sanity`) trips. The agent returns
@@ -751,6 +751,7 @@ also resets the worktree, discarding partial commits).
 ```json:entry
 {
   "id": "implement-phase-half-state-on-skill-failure",
+  "source_type": "manual",
   "topic": "implement_phase",
   "tags": ["state-machine", "ADR-0002", "skill-failure", "label-drift"],
   "rule": "Gate push_branch, _resolve_pr, and transition on (result.success or is_retry).",
@@ -765,7 +766,7 @@ also resets the worktree, discarding partial commits).
 }
 ```
 
-### swap_pipeline_labels: same label to both is wrong for ready/review boundary
+## swap_pipeline_labels: same label to both is wrong for ready/review boundary
 
 **Pattern:** `swap_pipeline_labels(issue_number, label, pr_number=pr)` applies
 the SAME label to issue and PR. For most transitions this is correct (e.g.
@@ -780,6 +781,7 @@ at ready waiting for impl, PR at review awaiting human), call
 ```json:entry
 {
   "id": "swap-pipeline-labels-ready-review-boundary",
+  "source_type": "manual",
   "topic": "label_state_machine",
   "tags": ["state-machine", "ADR-0002", "pr-unsticker", "label-drift"],
   "rule": "Across the ready/review boundary, swap issue and PR with separate calls.",

--- a/docs/wiki/testing.md
+++ b/docs/wiki/testing.md
@@ -19,7 +19,7 @@ regressions that call-count-only mocks hide.
 
 
 ```json:entry
-{"id":"01JRC_MOCKWORLD_FAKE_PORT_ASSERTIONS","title":"Assert MockWorld side effects through fake adapters","topic":"mockworld","source_type":"manual","source_issue":"hydraflow-wgac","source_repo":"T-rav/hydraflow","created_at":"2026-05-30T21:15:00+00:00","updated_at":"2026-05-30T21:15:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
+{"id":"01JRC_MOCKWORLD_FAKE_PORT_ASSERTIONS","title":"Assert MockWorld side effects through fake adapters","topic":"mockworld","source_type":"manual","source_issue":null,"source_repo":"T-rav/hydraflow","created_at":"2026-05-30T21:15:00+00:00","updated_at":"2026-05-30T21:15:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
 ```
 
 
@@ -66,7 +66,7 @@ that decide the outcome being asserted.
 
 
 ```json:entry
-{"id":"01JRC_TEST_VALUE_REVIEW_GATE","title":"Enforce test-value standards during review","topic":"testing","source_type":"manual","source_issue":"hydraflow-1x87","source_repo":"T-rav/hydraflow","created_at":"2026-05-31T23:45:00+00:00","updated_at":"2026-05-31T23:45:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
+{"id":"01JRC_TEST_VALUE_REVIEW_GATE","title":"Enforce test-value standards during review","topic":"testing","source_type":"manual","source_issue":null,"source_repo":"T-rav/hydraflow","created_at":"2026-05-31T23:45:00+00:00","updated_at":"2026-05-31T23:45:00+00:00","valid_to":null,"superseded_by":null,"superseded_reason":null,"confidence":"high","stale":false,"corroborations":1}
 ```
 
 

--- a/src/repo_wiki.py
+++ b/src/repo_wiki.py
@@ -1470,8 +1470,19 @@ class RepoWikiStore:
                 if not metadata.get("title"):
                     metadata["title"] = title
                 entries.append(WikiEntry.model_validate(metadata))
-            except Exception:  # noqa: BLE001
-                logger.warning("Skipping malformed entry in %s", topic_path)
+            except Exception as exc:  # noqa: BLE001
+                # Surface the offending entry id and the validation reason so
+                # drift is diagnosable from the log alone (the bare path is not).
+                try:
+                    entry_id = str(json.loads(meta_match.group(1)).get("id", ""))
+                except Exception:  # noqa: BLE001
+                    entry_id = "<invalid-json>"
+                logger.warning(
+                    "Skipping malformed entry %s in %s: %s",
+                    entry_id or "<no-id>",
+                    topic_path,
+                    exc,
+                )
 
         return entries
 

--- a/tests/test_wiki_topic_pages_parse.py
+++ b/tests/test_wiki_topic_pages_parse.py
@@ -1,0 +1,66 @@
+"""Guard: every committed ``docs/wiki/*.md`` topic page parses with zero skips.
+
+The ``RepoWikiLoop`` re-reads these pages on every tick and, during ingest,
+does a read-modify-write of each topic file. An entry that fails
+``WikiEntry`` validation is dropped with a ``Skipping malformed entry``
+warning — and because the dropped entry is absent from the rewrite, the next
+ingest write can *permanently delete* it from disk. So a malformed committed
+entry is not merely log noise; it is a latent data-loss bug.
+
+This regression locks the fix for the gotchas.md (h3-section folding +
+missing ``source_type``) and testing.md (string ``source_issue``) defects by
+asserting the live topic pages all round-trip through ``_load_topic_entries``
+without a single skip.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from repo_wiki import RepoWikiStore
+
+WIKI_DIR = Path(__file__).resolve().parents[1] / "docs" / "wiki"
+_SKIP_MARKER = "Skipping malformed entry"
+
+
+def _skip_warnings(records: list[logging.LogRecord]) -> list[str]:
+    return [r.getMessage() for r in records if _SKIP_MARKER in r.getMessage()]
+
+
+def test_all_wiki_topic_pages_parse_without_skips(tmp_path, caplog) -> None:
+    store = RepoWikiStore(tmp_path)
+    pages = sorted(WIKI_DIR.glob("*.md"))
+    assert pages, f"no wiki topic pages found under {WIKI_DIR}"
+
+    offenders: dict[str, list[str]] = {}
+    for page in pages:
+        with caplog.at_level(logging.WARNING, logger="hydraflow.repo_wiki"):
+            caplog.clear()
+            store._load_topic_entries(page)
+            skips = _skip_warnings(caplog.records)
+        if skips:
+            offenders[page.name] = skips
+
+    assert not offenders, f"malformed wiki entries skipped during parse: {offenders}"
+
+
+def test_malformed_entry_warning_names_entry_id_and_reason(tmp_path, caplog) -> None:
+    page = tmp_path / "broken.md"
+    page.write_text(
+        "# Broken\n\n"
+        "## A rule with an incomplete entry\n\n"
+        "Some prose.\n\n"
+        '```json:entry\n{"id": "broken-entry-xyz", "topic": "testing"}\n```\n'
+    )
+    store = RepoWikiStore(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="hydraflow.repo_wiki"):
+        entries = store._load_topic_entries(page)
+
+    assert entries == []
+    skips = _skip_warnings(caplog.records)
+    assert len(skips) == 1
+    message = skips[0]
+    assert "broken-entry-xyz" in message
+    assert "source_type" in message


### PR DESCRIPTION
## Problem

`RepoWikiLoop` logged `Skipping malformed entry` for `docs/wiki/gotchas.md` (×1) and `docs/wiki/testing.md` (×2). Root causes:

- **gotchas.md** used h3 (`###`) subsections for two entries. `_load_topic_entries` splits topic pages on `## ` only, so those folded into the preceding `## Never use git commit…` section; `meta_matches[-1]` then validated a block missing the required `source_type` → ValidationError → the whole section's entries dropped.
- **testing.md** had two entries with a string `source_issue` (`hydraflow-wgac` / `hydraflow-1x87`) in an `int | None` field.

This is **not just log noise**: `ingest` does a read-modify-write of each topic page, so a dropped entry is absent from the rewrite — the next `RepoWikiLoop` tick could **permanently delete** 3 knowledge entries from disk.

## Fix

- `gotchas.md`: promote the two `###` entries to `##` (recovers two currently-shadowed entries, incl. `implement-phase-half-state-on-skill-failure`) and add `source_type` to both slim blocks.
- `testing.md`: set the non-numeric `source_issue` values to `null`.
- `repo_wiki.py`: name the offending entry id + validation reason in the warning (the bare path was undiagnosable).
- **Guard test**: assert every `docs/wiki/*.md` round-trips through `_load_topic_entries` with zero skips, so this can't recur silently.

## Test

`make quality` green (lint, types, security, full pytest). New `tests/test_wiki_topic_pages_parse.py` is RED on the pre-fix tree, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)