### PR TITLE
fix(contracts): route issue-list to GhIssueListItem dispatcher (closes #9278)

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ValidationError
 
 from contracts.shapes import (
     GhCheckRun,
+    GhIssueListItem,
     GhIssueSummary,
     GhPRDetail,
     GhPRSummary,
@@ -74,6 +75,13 @@ def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
     if fields is None:
         return None
     return GhIssueSummary
+
+
+def _pick_shape_for_issue_list(args: list[str]) -> type[BaseModel] | None:
+    fields = _extract_json_fields(args)
+    if fields is None:
+        return None
+    return GhIssueListItem
 
 
 def _pick_shape_for_checks(args: list[str]) -> type[BaseModel] | None:
@@ -127,8 +135,10 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
     shape_cls: type[BaseModel] | None = None
     if subcommand in ("pr-view", "pr-list"):
         shape_cls = _pick_shape_for_pr(sample.args)
-    elif subcommand in ("issue-view", "issue-list"):
+    elif subcommand == "issue-view":
         shape_cls = _pick_shape_for_issue(sample.args)
+    elif subcommand == "issue-list":
+        shape_cls = _pick_shape_for_issue_list(sample.args)
     elif subcommand == "pr-checks":
         shape_cls = _pick_shape_for_checks(sample.args)
     if shape_cls is None:

--- a/tests/test_shape_dispatchers.py
+++ b/tests/test_shape_dispatchers.py
@@ -159,6 +159,42 @@ async def test_non_json_stdout_skipped(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_issue_list_without_state_validates_cleanly(tmp_path: Path) -> None:
+    """gh issue list --json number,title omits 'state' (filtered server-side).
+
+    Previously routed to GhIssueSummary which requires state, producing
+    spurious drift for every issue-list shadow sample (signature 5653c1c6d466).
+    Now routed to GhIssueListItem which only requires number and title.
+    """
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,title"],
+        stdout=json.dumps(
+            [
+                {"number": 9278, "title": "Drift survived LiveCorpusReplayLoop"},
+                {"number": 9100, "title": "Another open issue"},
+            ]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_drifted_number_type_returns_diff(tmp_path: Path) -> None:
+    """issue-list with a wrong-typed number field trips GhIssueListItem validation."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,title"],
+        stdout=json.dumps([{"number": "not-an-int", "title": "x"}]) + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape_validation_failed"] is True
+    assert result["shape"] == "GhIssueListItem"
+
+
+@pytest.mark.asyncio
 async def test_unknown_subcommand_skipped(tmp_path: Path) -> None:
     sample = _sample(
         tmp_path,


### PR DESCRIPTION
## Summary

- `gh issue list --json ...` omits `state` (server-side filtered), so validating against `GhIssueSummary` (which requires `state`) always failed, producing a persistent drift signature (`5653c1c6d466`) on every shadow-corpus tick
- `GhIssueListItem` was already the intended shape for list calls (its docstring says so) but was never wired into `gh_shape_validator`
- Split `issue-view` / `issue-list` routing in `gh_shape_validator` and add `_pick_shape_for_issue_list` → `GhIssueListItem`

## Test plan

- [x] `test_issue_list_without_state_validates_cleanly` — the stuck drift case: `["number", "title"]` payload validates cleanly against `GhIssueListItem`
- [x] `test_issue_list_drifted_number_type_returns_diff` — type drift on `number` still surfaces through the new shape
- [x] All existing `test_shape_dispatchers.py` tests pass (10 → 12 tests)
- [x] `tests/scenarios/test_v2_drift_chain_mockworld.py` passes
- [x] `tests/regressions/test_pr_8939_live_corpus_replay_wiring.py` passes
- [x] `make quality-lite` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)