### PR TITLE
fix(pr-manager): list_issue_comments returns comments again (unpack + gh shape)

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -87,6 +87,22 @@ def load_pricing(*args: Any, **kwargs: Any) -> Any:
 __all__ = ["CommentFormatter", "SelfReviewError", "PRManager"]
 
 
+def _normalise_issue_comment(comment: dict[str, Any]) -> dict[str, Any]:
+    """Map a ``gh issue view --json comments`` object to the stable port shape.
+
+    gh emits GraphQL-shaped ``author.login`` / ``createdAt``; the port contract
+    (and the fake) expose REST-shaped ``user.login`` / ``created_at``. Accept
+    either input so the contract holds across gh versions.
+    """
+    author = comment.get("author") or comment.get("user") or {}
+    login = author.get("login", "") if isinstance(author, dict) else ""
+    return {
+        "user": {"login": login},
+        "body": comment.get("body", ""),
+        "created_at": comment.get("createdAt") or comment.get("created_at") or "",
+    }
+
+
 class PRManager:
     """Pushes branches, creates PRs, merges, and manages labels."""
 
@@ -1196,12 +1212,13 @@ class PRManager:
     async def list_issue_comments(self, issue_number: int) -> list[dict[str, Any]]:
         """List comments on a GitHub issue (oldest first; max 100).
 
-        Returns dicts with `user.login`, `body`, `created_at` keys
-        (matches `gh issue view --json comments` shape).
+        Normalises ``gh issue view --json comments`` (which yields GraphQL-shaped
+        ``author.login`` / ``createdAt``) into the stable port contract: dicts
+        with ``user.login``, ``body`` and ``created_at`` keys.
         """
         self._assert_repo()
         try:
-            output, _ = await self._run_gh(
+            output = await self._run_gh(
                 "gh",
                 "issue",
                 "view",
@@ -1220,7 +1237,7 @@ class PRManager:
             logger.warning("Bad comments JSON for issue #%d: %s", issue_number, exc)
             return []
         comments = payload.get("comments") or []
-        return list(comments)
+        return [_normalise_issue_comment(c) for c in comments if isinstance(c, dict)]
 
     async def submit_review(
         self, pr_number: int, verdict: ReviewVerdict, body: str

--- a/tests/test_pr_manager_list_issue_comments.py
+++ b/tests/test_pr_manager_list_issue_comments.py
@@ -1,0 +1,75 @@
+"""Regression: PRManager.list_issue_comments unpack + gh shape normalisation.
+
+``_run_gh`` returns a single ``str``, but ``list_issue_comments`` unpacked it
+as ``output, _ = await self._run_gh(...)`` — Python iterated the JSON string
+and raised ``ValueError: too many values to unpack (expected 2)``, which the
+broad ``except`` swallowed, so the method returned ``[]`` for every issue on
+every call. Separately, ``gh issue view --json comments`` emits GraphQL-shaped
+``author.login`` / ``createdAt`` (verified against issue #9275), not the
+documented ``user.login`` / ``created_at`` — so even after the unpack fix the
+preflight consumer would render ``?`` authors and empty timestamps.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from pr_manager import _normalise_issue_comment
+from tests.helpers import make_pr_manager
+
+
+@pytest.mark.asyncio
+async def test_list_issue_comments_returns_normalised_comments(
+    config, event_bus
+) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    gh_payload = json.dumps(
+        {
+            "comments": [
+                {
+                    "author": {"login": "alice"},
+                    "body": "first",
+                    "createdAt": "2026-06-05T01:00:00Z",
+                },
+                {
+                    "author": {"login": "bob"},
+                    "body": "second",
+                    "createdAt": "2026-06-05T02:00:00Z",
+                },
+            ]
+        }
+    )
+    mgr._run_gh = AsyncMock(return_value=gh_payload)
+
+    comments = await mgr.list_issue_comments(42)
+
+    assert [c["user"]["login"] for c in comments] == ["alice", "bob"]
+    assert [c["body"] for c in comments] == ["first", "second"]
+    assert comments[0]["created_at"] == "2026-06-05T01:00:00Z"
+
+
+@pytest.mark.asyncio
+async def test_list_issue_comments_empty_when_none(config, event_bus) -> None:
+    mgr = make_pr_manager(config, event_bus)
+    mgr._run_gh = AsyncMock(return_value=json.dumps({"comments": []}))
+
+    assert await mgr.list_issue_comments(42) == []
+
+
+def test_normalise_issue_comment_accepts_graphql_and_rest_shapes() -> None:
+    graphql = _normalise_issue_comment(
+        {"author": {"login": "gh"}, "body": "b", "createdAt": "T1"}
+    )
+    rest = _normalise_issue_comment(
+        {"user": {"login": "rest"}, "body": "b", "created_at": "T2"}
+    )
+
+    assert graphql == {"user": {"login": "gh"}, "body": "b", "created_at": "T1"}
+    assert rest == {"user": {"login": "rest"}, "body": "b", "created_at": "T2"}


### PR DESCRIPTION
## Problem

`PRManager.list_issue_comments` unpacked `_run_gh` (which returns a single `str`) as `output, _ = await self._run_gh(...)`. Python iterated the JSON string and raised `ValueError: too many values to unpack (expected 2)`, swallowed by the broad `except` — so the method returned `[]` for **every issue on every call** since PR #8431 (the `Failed to list comments for issue #9275` warning in the logs). The sole consumer (Auto-Agent pre-flight context) therefore built context with **zero** issue comments, silently degrading triage.

Separately, `gh issue view --json comments` emits GraphQL-shaped `author.login` / `createdAt` — **verified against issue #9275** (`user`/`created_at` come back `null`) — not the documented `user.login` / `created_at`. So once the unpack was fixed the consumer would still render `?` authors and blank timestamps.

## Fix

- Drop the spurious tuple-unpack (the only such `_run_gh` unpack in the file).
- Add `_normalise_issue_comment` to map gh's `author.login`/`createdAt` to the documented stable `user.login`/`created_at` shape (accepts either input, so it's robust across gh versions). This keeps the fake faithful and the consumer correct.

## Test

Unit tests drive the **real** `PRManager.list_issue_comments` (closing the mock-only fidelity gap that hid this since #8431) plus shape-normalisation cases. `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)