### PR TITLE
fix(config): coerce repo-overlay values to their declared field types

### DIFF
--- a/src/runtime_config.py
+++ b/src/runtime_config.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from config import HydraFlowConfig, load_config_file
+
+logger = logging.getLogger("hydraflow.runtime_config")
 
 
 def _default_data_root_path() -> Path:
@@ -19,6 +24,25 @@ def _default_data_root_path() -> Path:
 
 DEFAULT_CONFIG_PATH = _default_data_root_path() / "config.json"
 DEFAULT_LOG_FILE = _default_data_root_path() / "logs" / "hydraflow.log"
+
+
+def _coerce_overlay_value(field_name: str, value: Any) -> Any:
+    """Coerce a raw overlay value to its config field's declared type.
+
+    The overlay assigns via ``object.__setattr__``, which bypasses Pydantic
+    validation/coercion — so nested-model fields (notably
+    ``managed_repos: list[ManagedRepo]``) would be left as raw dicts, breaking
+    attribute access (``mr.enabled``) and emitting serializer warnings on
+    ``model_dump()``. Validate through the field's annotation so the value
+    matches the constructor path. Fall back to the raw value for any annotation
+    that cannot be adapted (arbitrary types) so behavior never regresses.
+    """
+    annotation = HydraFlowConfig.model_fields[field_name].annotation
+    try:
+        return TypeAdapter(annotation).validate_python(value)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("overlay: leaving %s un-coerced (%s)", field_name, exc)
+        return value
 
 
 def apply_repo_config_overlay(
@@ -34,7 +58,7 @@ def apply_repo_config_overlay(
     known_fields = set(HydraFlowConfig.model_fields.keys())
     for key, val in repo_cfg.items():
         if key in known_fields and key not in explicit:
-            object.__setattr__(config, key, val)
+            object.__setattr__(config, key, _coerce_overlay_value(key, val))
 
 
 def load_runtime_config(

--- a/tests/test_runtime_config_overlay_coercion.py
+++ b/tests/test_runtime_config_overlay_coercion.py
@@ -1,0 +1,55 @@
+"""Regression: apply_repo_config_overlay coerces nested-model fields.
+
+The overlay assigned config-file values via ``object.__setattr__``, bypassing
+Pydantic coercion — so ``managed_repos`` (``list[ManagedRepo]``) stayed a list
+of raw dicts. That broke attribute access (``mr.enabled`` in
+``PrinciplesAuditLoop`` -> ``AttributeError``) and emitted
+``PydanticSerializationUnexpectedValue`` warnings on ``config.model_dump()``.
+Reproduces against the production-shaped 'T-rav/poop-scoop' managed slug.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+
+from config import HydraFlowConfig, ManagedRepo
+from runtime_config import apply_repo_config_overlay, load_runtime_config
+
+
+def test_overlay_coerces_managed_repos_dicts_to_models(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps({"managed_repos": [{"slug": "T-rav/poop-scoop", "enabled": True}]})
+    )
+    config = HydraFlowConfig(config_file=cfg_path)
+
+    apply_repo_config_overlay(config)
+
+    assert config.managed_repos
+    assert all(isinstance(mr, ManagedRepo) for mr in config.managed_repos)
+    assert config.managed_repos[0].slug == "T-rav/poop-scoop"
+    # Attribute access that raised AttributeError on raw dicts in audit loops.
+    assert config.managed_repos[0].enabled is True
+
+
+def test_overlay_managed_repos_serialize_without_warning(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "config.json"
+    cfg_path.write_text(
+        json.dumps({"managed_repos": [{"slug": "acme/widget", "enabled": False}]})
+    )
+    config = load_runtime_config(config_file=cfg_path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        dumped = config.model_dump(mode="json")
+
+    offenders = [
+        str(w.message)
+        for w in caught
+        if "ManagedRepo" in str(w.message) or "managed_repos" in str(w.message)
+    ]
+    assert not offenders, offenders
+    assert dumped["managed_repos"][0]["slug"] == "acme/widget"
+    assert config.managed_repos[0].enabled is False


### PR DESCRIPTION
## Problem

`apply_repo_config_overlay` applied config-file values via `object.__setattr__`, **bypassing Pydantic validation/coercion**. So `managed_repos` (typed `list[ManagedRepo]`) was left as a list of raw dicts loaded from JSON:

- `config.model_dump()` emitted `PydanticSerializationUnexpectedValue(Expected ManagedRepo …)` warnings (RunRecorder, dashboard `patch_config`) — seen in prod with the `T-rav/poop-scoop` managed slug.
- **Latent functional bug**: `PrinciplesAuditLoop` iterates `for mr in managed_repos: if not mr.enabled` → `AttributeError: 'dict' object has no attribute 'enabled'` (verified by execution).

## Fix

Coerce each overlay value through its field's `TypeAdapter` so nested-model (and `Path`) fields match the constructor path. Falls back to the raw value for any annotation that can't be adapted (arbitrary types), so behavior never regresses.

## Test

Unit tests: overlay yields real `ManagedRepo` instances; `model_dump()` emits no serializer warning; `.enabled` access works. `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)