### PR TITLE
fix(adversarial): tolerate fenced/prose agent JSON across the pipeline

### DIFF
--- a/src/adversarial_agents.py
+++ b/src/adversarial_agents.py
@@ -12,7 +12,9 @@ behavior change — just a shared Protocol so call sites can type against
 
 from __future__ import annotations
 
-from typing import Protocol
+import json
+import re
+from typing import Any, Protocol
 
 
 class AgentLike(Protocol):
@@ -25,3 +27,67 @@ class AgentLike(Protocol):
     """
 
     async def run(self, system_prompt: str, user_message: str) -> str: ...
+
+
+_FENCE_RE = re.compile(r"^\s*```(?:json)?\s*\n(.*?)\n```\s*$", re.DOTALL)
+
+
+def _first_json_object(text: str) -> str | None:
+    """Return the first balanced top-level ``{...}`` object substring, or None."""
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    return None
+
+
+def extract_json(raw: str) -> Any:
+    """Parse JSON from an adversarial agent's reply, tolerating fences/prose.
+
+    The lightweight agent path returns the model's free-form stdout, which
+    commonly wraps the JSON in a ```` ```json ```` fence or prepends prose. This
+    tries a direct parse, then strips a surrounding markdown fence, then falls
+    back to the first balanced ``{...}`` object.
+
+    Raises ``json.JSONDecodeError`` when no JSON can be recovered (including
+    empty/whitespace-only input) so callers' existing fail-closed
+    ``except json.JSONDecodeError`` paths still fire.
+    """
+    text = (raw or "").strip()
+    if not text:
+        raise json.JSONDecodeError("empty agent output", raw or "", 0)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    fence = _FENCE_RE.match(text)
+    if fence:
+        inner = fence.group(1).strip()
+        try:
+            return json.loads(inner)
+        except json.JSONDecodeError:
+            text = inner
+    obj = _first_json_object(text)
+    if obj is not None:
+        return json.loads(obj)
+    raise json.JSONDecodeError("no JSON object found in agent output", text, 0)

--- a/src/assumption_surfacer.py
+++ b/src/assumption_surfacer.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import cast
 
 from exception_classify import reraise_on_credit_or_bug
-from src.adversarial_agents import AgentLike
+from src.adversarial_agents import AgentLike, extract_json
 from src.pending_concerns import Concern, Phase
 
 logger = logging.getLogger(__name__)
@@ -87,7 +87,7 @@ class AssumptionSurfacer:
 
         try:
             raw = await self.agent.run(_SYSTEM_PROMPT, user_msg)
-            data = json.loads(raw)
+            data = extract_json(raw)
         except json.JSONDecodeError as exc:
             logger.warning("AssumptionSurfacer JSON parse failure: %s", exc)
             return SurfacerOutput()

--- a/src/plan_council.py
+++ b/src/plan_council.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
 
-from src.adversarial_agents import AgentLike
+from src.adversarial_agents import AgentLike, extract_json
 from src.pending_concerns import Concern
 from src.plan_council_prompts import (
     BUILDER_PROMPT,
@@ -99,7 +99,7 @@ class PlanCouncil:
     async def _run_voter(self, role: str, user_msg: str) -> list[Concern]:
         raw = await self.agents[role].run(_PROMPTS[role], user_msg)
         try:
-            data = json.loads(raw)
+            data = extract_json(raw)
         except json.JSONDecodeError:
             logger.warning("PlanCouncil voter %s returned non-JSON", role)
             return []

--- a/src/spec_ac_generator.py
+++ b/src/spec_ac_generator.py
@@ -14,7 +14,7 @@ import logging
 from dataclasses import dataclass
 
 from exception_classify import reraise_on_credit_or_bug
-from src.adversarial_agents import AgentLike
+from src.adversarial_agents import AgentLike, extract_json
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class SpecACGenerator:
         user_msg = f"## Plan\n{plan_text}\n"
         try:
             raw = await self.agent.run(_SYSTEM_PROMPT, user_msg)
-            data = json.loads(raw)
+            data = extract_json(raw)
         except json.JSONDecodeError as exc:
             logger.warning("SpecACGenerator JSON parse failure: %s", exc)
             return []

--- a/src/spec_judge.py
+++ b/src/spec_judge.py
@@ -21,7 +21,7 @@ from datetime import UTC, datetime
 from typing import Literal
 
 from exception_classify import reraise_on_credit_or_bug
-from src.adversarial_agents import AgentLike
+from src.adversarial_agents import AgentLike, extract_json
 from src.pending_concerns import Concern
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ class SpecJudge:
 
         try:
             raw = await self.agent.run(_SYSTEM_PROMPT, user_msg)
-            data = json.loads(raw)
+            data = extract_json(raw)
         except json.JSONDecodeError as exc:
             logger.warning("SpecJudge JSON parse failure: %s", exc)
             return _parse_failure_result(

--- a/tests/test_adversarial_json_extract.py
+++ b/tests/test_adversarial_json_extract.py
@@ -1,0 +1,97 @@
+"""extract_json + SpecJudge tolerance for fenced/prose/empty agent output.
+
+The lightweight adversarial agent path returns the model's free-form stdout,
+which commonly wraps JSON in a ```json fence or prepends prose, and returns ""
+on soft-fail. A bare ``json.loads`` on that raises
+``Expecting value: line 1 column 1 (char 0)``, which SpecJudge mistook for an
+unparseable spec and converted into a false SPEC-JUDGE-001/HIGH carryover.
+``extract_json`` recovers the JSON from fenced/prose replies while still
+raising ``json.JSONDecodeError`` on genuinely-empty/no-JSON input so the
+fail-closed path still fires.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from src.adversarial_agents import extract_json
+from src.spec_judge import JudgeResult, SpecJudge
+
+
+class _StubAgent:
+    def __init__(self, payload: str) -> None:
+        self.payload = payload
+
+    async def run(self, system_prompt: str, user_message: str) -> str:
+        return self.payload
+
+
+def test_extract_json_parses_bare_object() -> None:
+    assert extract_json('{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_strips_json_fence() -> None:
+    assert extract_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_extract_json_strips_bare_fence() -> None:
+    assert extract_json('```\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_extract_json_tolerates_leading_prose() -> None:
+    assert extract_json('Here is the result:\n{"a": 1}') == {"a": 1}
+
+
+def test_extract_json_tolerates_trailing_prose() -> None:
+    assert extract_json('{"a": 1}\nHope that helps!') == {"a": 1}
+
+
+def test_extract_json_handles_nested_braces_and_string_braces() -> None:
+    raw = '{"a": "x}y", "b": {"c": 2}}'
+    assert extract_json(raw) == {"a": "x}y", "b": {"c": 2}}
+
+
+@pytest.mark.parametrize("raw", ["", "   \n  ", "just prose, no json"])
+def test_extract_json_raises_on_no_recoverable_json(raw: str) -> None:
+    with pytest.raises(json.JSONDecodeError):
+        extract_json(raw)
+
+
+@pytest.mark.asyncio
+async def test_spec_judge_parses_fenced_output() -> None:
+    payload = '```json\n{"verdict": "PASS", "findings": []}\n```'
+    judge = SpecJudge(agent=_StubAgent(payload))
+
+    result = await judge.evaluate(plan_text="a plan", acceptance_criteria=["AC1"])
+
+    assert isinstance(result, JudgeResult)
+    assert result.verdict == "PASS"
+    assert result.findings == []
+
+
+@pytest.mark.asyncio
+async def test_spec_judge_parses_prose_wrapped_findings() -> None:
+    payload = (
+        "Sure, here is my judgement:\n"
+        '{"verdict": "FAIL", "findings": '
+        '[{"severity": "HIGH", "concern": "AC1 is not observable"}]}'
+    )
+    judge = SpecJudge(agent=_StubAgent(payload))
+
+    result = await judge.evaluate(plan_text="a plan", acceptance_criteria=["AC1"])
+
+    assert result.verdict == "FAIL"
+    assert [f.concern for f in result.findings] == ["AC1 is not observable"]
+
+
+@pytest.mark.asyncio
+async def test_spec_judge_fails_closed_on_empty_output() -> None:
+    judge = SpecJudge(agent=_StubAgent(""))
+
+    result = await judge.evaluate(plan_text="a plan", acceptance_criteria=["AC1"])
+
+    assert result.verdict == "FAIL"
+    assert len(result.findings) == 1
+    assert result.findings[0].id == "SPEC-JUDGE-001"
+    assert result.findings[0].severity == "HIGH"


### PR DESCRIPTION
## Problem

SpecJudge / SpecACGenerator / AssumptionSurfacer / PlanCouncil parsed agent output with a bare `json.loads`. The production lightweight agent path returns the model's **free-form stdout** (no `--output-format json`), so Haiku commonly wraps JSON in a ```` ```json ```` fence or prepends prose, and the subprocess runner returns `""` on soft-fail. Either shape raises `Expecting value: line 1 column 1 (char 0)`.

- For **SpecJudge** that became a false `SPEC-JUDGE-001|HIGH` concern forwarded into implementation (the `Adversarial carryover for issue #5 / #13` log lines).
- For the siblings it silently dropped real findings / acceptance criteria.

## Fix

Shared `extract_json()` (direct parse → strip markdown fence → first balanced `{...}` object), routed into all four stages. It still **raises `json.JSONDecodeError` on empty/no-JSON input**, so every stage's existing fail-closed `except` path is preserved (SpecJudge still emits SPEC-JUDGE-001 on *truly* empty output — just not on valid fenced output).

## Test

`tests/test_adversarial_json_extract.py`: fenced/prose/trailing-prose/nested-brace/empty/no-json cases + SpecJudge fenced→PASS, prose→parsed, empty→fail-closed. The stub-only suites never exercised the real plain-text adapter contract. `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)