### PR TITLE
fix(beads): make BeadsManager.init idempotent (stop plan-pool worker crashes)

### DIFF
--- a/src/beads_manager.py
+++ b/src/beads_manager.py
@@ -101,11 +101,27 @@ class BeadsManager:
         Uses ``--server`` to avoid the embedded Dolt CGO requirement.
         Server mode uses a Dolt SQL server backend which works in all
         environments including Docker containers built without CGO.
+
+        Idempotent: ``bd init`` aborts with rc=1 ("This workspace is already
+        initialized." / "Found existing Dolt database") when a database already
+        exists for *cwd*. That is benign — the planner calls ``init`` once per
+        planned issue against the shared repo root, so the second issue onward
+        would otherwise raise ``RuntimeError`` and silently drop the whole plan
+        pool worker mid-decomposition. Treat the already-initialized signal as
+        success; re-raise every other failure.
         """
         try:
             await run_subprocess("bd", "init", "--server", cwd=cwd, timeout=30.0)
         except FileNotFoundError as exc:
             raise BeadsNotInstalledError() from exc
+        except RuntimeError as exc:
+            msg = str(exc).lower()
+            if "already initialized" in msg or "found existing dolt database" in msg:
+                logger.debug(
+                    "beads already initialized in %s — treating as success", cwd
+                )
+                return
+            raise
 
     async def create_task(self, title: str, priority: str, cwd: Path) -> str:
         """Create a bead task, returning the bead ID.

--- a/tests/test_beads_manager.py
+++ b/tests/test_beads_manager.py
@@ -119,6 +119,22 @@ async def test_init_runtime_error(manager):
             await manager.init(Path("/repo"))
 
 
+@pytest.mark.asyncio()
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "Command ('bd', 'init', '--server') failed (rc=1): Error:\n"
+        "⚠ This workspace is already initialized.\nAborting.",
+        "Command failed (rc=1): Found existing Dolt database: dolt server at "
+        "127.0.0.1:55405",
+    ],
+)
+async def test_init_already_initialized_is_noop(manager, stderr):
+    with patch("beads_manager.run_subprocess", new_callable=AsyncMock) as mock_run:
+        mock_run.side_effect = RuntimeError(stderr)
+        await manager.init(Path("/repo"))  # must not raise
+
+
 # ---------------------------------------------------------------------------
 # create_task — `bd create "title" -p <priority> --silent`
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`bd init --server` aborts with rc=1 ("This workspace is already initialized." / "Found existing Dolt database") when a database already exists for the cwd. `init()` only caught `FileNotFoundError`, so the rc=1 `RuntimeError` propagated. The planner calls `init(repo_root)` **once per planned issue** against the shared repo root, so from the second issue onward `init` raised and the plan pool worker was silently dropped mid-`_create_beads_from_plan` (non-fatal at `phase_utils.py:101`) — no bead graph, no mapping, no comment for that issue, plus the recurring `Pool worker failed` warnings (observed in the `amplifier` managed repo).

## Fix

Treat the benign already-initialized signal as success; re-raise everything else. The same `BeadsManager.init` backs the implementer's per-worktree init, so this hardens both paths.

## Test

`test_init_already_initialized_is_noop` (both stderr variants) + existing `test_init_runtime_error` still re-raises unrelated errors. `make quality` green.

## Follow-up (not in this PR)

The broader **per-worktree JSONL source of truth** redesign you requested — unique `--database` + `--from-jsonl` seeding + `bd export`, and moving bead creation into the worktree so planner+implementer+agent share one store — changes the plan→implement pipeline contract and needs **sandbox e2e against a live Dolt server** to validate bd's `--from-jsonl`/init/export interaction. This PR is the certain, isolated crash-fix; the redesign is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)