### PR TITLE
fix(pr-manager): stop find_label_drift exceeding GitHub's GraphQL node limit

### DIFF
--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -1713,6 +1713,29 @@ class PRManager:
                 if pr_number is not None:
                     await self._remove_label("pr", pr_number, lbl)
 
+    async def _pr_commit_count(self, pr_number: int) -> int:
+        """Return the commit count for a single PR.
+
+        Fetched per-PR (not in the bulk ``pr list``) because requesting the
+        ``commits`` field for many PRs expands each commit's authors connection
+        and exceeds GitHub's GraphQL 500,000-node ceiling.
+        """
+        data = await self._gh_json_query(
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            self._repo,
+            "--json",
+            "commits",
+            dry_run_return={"commits": []},
+            error_log=f"find_label_drift: pr {pr_number} commits fetch failed",
+        )
+        if not isinstance(data, dict):
+            return 0
+        return len(data.get("commits") or [])
+
     async def find_label_drift(self) -> list[LabelDrift]:
         """Scan open PRs for cross-entity label drift vs their linked issues.
 
@@ -1733,7 +1756,7 @@ class PRManager:
             "--limit",
             "200",
             "--json",
-            "number,labels,body,commits",
+            "number,labels,body",
             dry_run_return=[],
             error_log="find_label_drift: pr list failed",
         )
@@ -1763,12 +1786,17 @@ class PRManager:
                 (lbl for lbl in pr_labels if lbl.startswith("hydraflow-")),
                 "",
             )
-            commits = len(pr.get("commits") or [])
             body = pr.get("body") or ""
             m = fixes_re.search(body)
             if not m:
                 continue
             issue_n = int(m.group(1))
+
+            # Commit count is fetched per-PR (only for Fixes-matched PRs, which
+            # already trigger an issue fetch below) — requesting `commits` in the
+            # bulk `pr list` expands each commit's authors connection and blows
+            # past GitHub's GraphQL 500k-node ceiling at --limit 200.
+            commits = await self._pr_commit_count(pr_n)
 
             issue_labels_raw = await self._gh_json_query(
                 "gh",

--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -716,7 +716,11 @@ _RETRYABLE_PATTERNS = (
 )
 # Rate-limit errors are handled by the global cooldown in run_subprocess(),
 # not by per-call retries which would just amplify the problem.
-_NON_RETRYABLE_PATTERNS = ("401", "403", "404")
+# "exceeds the maximum limit" is GitHub's GraphQL node-cost error — a
+# deterministic too-expensive-query failure that will never succeed on retry,
+# yet its message contains the substring "connection" (e.g. "authors
+# connection"), so without this guard _RETRYABLE_PATTERNS would retry it 3×.
+_NON_RETRYABLE_PATTERNS = ("401", "403", "404", "exceeds the maximum limit")
 
 
 def _is_retryable_error(stderr: str) -> bool:

--- a/tests/test_pr_manager_drift.py
+++ b/tests/test_pr_manager_drift.py
@@ -3,6 +3,11 @@
 See ADR-0056. Two drift kinds:
 - ``pr_ahead_of_issue``: issue at ready/plan, PR at review with commits
 - ``pr_at_pre_pr_stage``: PR labelled ready/plan but has commits
+
+The commit count is fetched per Fixes-matched PR via ``gh pr view --json
+commits`` (not the bulk ``pr list``, which would expand the authors connection
+and exceed GitHub's GraphQL node ceiling), so these tests script a
+``("pr", "view")`` response for matched PRs.
 """
 
 from __future__ import annotations
@@ -35,6 +40,10 @@ def _gh_responder(mapping: dict[tuple[str, ...], str]):
     return _side_effect
 
 
+def _commits_json(n: int) -> str:
+    return json.dumps({"commits": [{"oid": str(i)} for i in range(n)]})
+
+
 class TestFindLabelDrift:
     @pytest.mark.asyncio
     async def test_detects_issue_at_ready_pr_at_review(self, config, event_bus) -> None:
@@ -48,7 +57,6 @@ class TestFindLabelDrift:
                     "number": 100,
                     "labels": [{"name": "hydraflow-review"}],
                     "body": "## Summary\n\nFixes #42.\n",
-                    "commits": [{"oid": "a"}, {"oid": "b"}],
                 }
             ]
         )
@@ -60,6 +68,7 @@ class TestFindLabelDrift:
                 side_effect=_gh_responder(
                     {
                         ("pr", "list"): prs_json,
+                        ("pr", "view"): _commits_json(2),
                         ("issue", "view"): issue_json,
                     }
                 )
@@ -86,7 +95,6 @@ class TestFindLabelDrift:
                     "number": 200,
                     "labels": [{"name": "hydraflow-ready"}],
                     "body": "Fixes #99",
-                    "commits": [{"oid": "a"}, {"oid": "b"}, {"oid": "c"}],
                 }
             ]
         )
@@ -98,6 +106,7 @@ class TestFindLabelDrift:
                 side_effect=_gh_responder(
                     {
                         ("pr", "list"): prs_json,
+                        ("pr", "view"): _commits_json(3),
                         ("issue", "view"): issue_json,
                     }
                 )
@@ -121,7 +130,6 @@ class TestFindLabelDrift:
                     "number": 300,
                     "labels": [{"name": "hydraflow-review"}],
                     "body": "Fixes #7",
-                    "commits": [{"oid": "x"}],
                 }
             ]
         )
@@ -133,6 +141,7 @@ class TestFindLabelDrift:
                 side_effect=_gh_responder(
                     {
                         ("pr", "list"): prs_json,
+                        ("pr", "view"): _commits_json(1),
                         ("issue", "view"): issue_json,
                     }
                 )
@@ -153,7 +162,6 @@ class TestFindLabelDrift:
                     "number": 400,
                     "labels": [{"name": "hydraflow-review"}],
                     "body": "no fixes link here",
-                    "commits": [{"oid": "x"}],
                 }
             ]
         )
@@ -165,6 +173,33 @@ class TestFindLabelDrift:
             drift = await mgr.find_label_drift()
 
         assert drift == []
+
+    @pytest.mark.asyncio
+    async def test_bulk_pr_list_does_not_request_commits(
+        self, config, event_bus
+    ) -> None:
+        """The bulk ``pr list`` must not request ``commits`` — that field
+        expands each commit's authors connection and exceeds GitHub's GraphQL
+        500k-node ceiling at --limit 200 (the original failure)."""
+        mgr = make_pr_manager(config, event_bus)
+        calls: list[tuple[str, ...]] = []
+
+        async def _record(*args, **kwargs):
+            calls.append(args)
+            if "list" in args:
+                return json.dumps([])
+            return json.dumps({"labels": []})
+
+        with patch(
+            "pr_manager.run_subprocess_with_retry",
+            new=AsyncMock(side_effect=_record),
+        ):
+            await mgr.find_label_drift()
+
+        pr_list_calls = [a for a in calls if "list" in a]
+        assert pr_list_calls
+        for call_args in pr_list_calls:
+            assert "commits" not in ",".join(call_args)
 
 
 class TestFindLabelDriftAutoCloseKeywords:
@@ -190,7 +225,6 @@ class TestFindLabelDriftAutoCloseKeywords:
                     "number": 500,
                     "labels": [{"name": "hydraflow-review"}],
                     "body": f"## Summary\n\n{keyword} #42.\n",
-                    "commits": [{"oid": "a"}],
                 }
             ]
         )
@@ -202,6 +236,7 @@ class TestFindLabelDriftAutoCloseKeywords:
                 side_effect=_gh_responder(
                     {
                         ("pr", "list"): prs_json,
+                        ("pr", "view"): _commits_json(1),
                         ("issue", "view"): issue_json,
                     }
                 )

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -274,6 +274,20 @@ class TestIsRetryableError:
     def test_not_retryable_on_generic_error(self) -> None:
         assert _is_retryable_error("something else went wrong") is False
 
+    def test_not_retryable_on_graphql_node_limit(self) -> None:
+        """GraphQL node-cost errors are deterministic — never succeed on retry.
+
+        Their message contains the substring 'connection' ('authors
+        connection'), which would otherwise match _RETRYABLE_PATTERNS and burn
+        3 retries on a guaranteed failure.
+        """
+        msg = (
+            "GraphQL: By the time this query traverses to the authors "
+            "connection, it is requesting up to 1,000,000 possible nodes which "
+            "exceeds the maximum limit of 500,000."
+        )
+        assert _is_retryable_error(msg) is False
+
 
 # --- run_subprocess_with_retry ---
 


### PR DESCRIPTION
## Problem

`find_label_drift` fetched `gh pr list --json number,labels,body,commits --limit 200`. The `commits` field expands each commit's **authors** connection, so GitHub estimated >500,000 nodes and failed the query **deterministically** (the `find_label_drift: pr list failed … exceeds the maximum limit of 500,000` log line). Worse, the message contains "authors connection", so `_is_retryable_error` matched the bare `connection` pattern and **retried it 3×** before degrading. Net effect: ADR-0056 label-drift reconciliation was 100% disabled on repos crossing the ceiling (this repo today).

## Fix

- Bulk `pr list` now requests only `number,labels,body`.
- Commit count is fetched **per Fixes-matched PR** via `gh pr view --json commits` — a small subset that already triggers a per-PR issue fetch; single-PR queries never hit the node ceiling — preserving accurate `pr_commits`.
- Mark GraphQL node-cost errors (`exceeds the maximum limit`) non-retryable so they fail fast instead of burning 3 retries.

The `FakeGitHub` mirror reads `pr.commits` in-memory (no bulk query), so its accurate-count behavior is unchanged.

## Test

Per-PR commits responder in drift tests; guard that the bulk list omits `commits`; retry-classification test for the node-limit message. `make quality` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)