### PR TITLE
fix(contracts): stop gh_shape_validator false-positives on --jq, stateless issue lists, and comments-only views

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ValidationError
 
 from contracts.shapes import (
     GhCheckRun,
+    GhIssueListItem,
     GhIssueSummary,
     GhPRDetail,
     GhPRSummary,
@@ -70,10 +71,23 @@ def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
 
 
 def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
+    """Issue shape selection based on which fields are requested.
+
+    ``GhIssueSummary`` requires ``state`` — only use it when the call
+    actually requests that field.  Narrow list calls (``number,title,...``
+    without ``state``) use ``GhIssueListItem`` instead.  Calls that
+    request fields outside both shapes (e.g. ``--json comments``) get
+    ``None`` so the dispatcher skips them rather than producing a
+    false-positive drift signal.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
-    return GhIssueSummary
+    if "state" in fields:
+        return GhIssueSummary
+    if "number" in fields and "title" in fields:
+        return GhIssueListItem
+    return None
 
 
 def _pick_shape_for_checks(args: list[str]) -> type[BaseModel] | None:
@@ -113,12 +127,17 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
         - A diff-payload dict if validation fails — the loop fingerprints
           this to file a single drift issue per signature.
         - ``None`` for samples this dispatcher has no opinion on
-          (unknown subcommand, no ``--json`` flag, empty stdout, etc.) —
-          the loop treats those as "skipped, no opinion".
+          (unknown subcommand, no ``--json`` flag, ``--jq`` transform
+          applied, empty stdout, etc.) — the loop treats those as
+          "skipped, no opinion".
     """
     if sample.adapter != "github" or sample.command != "gh":
         return None
     if not sample.stdout.strip():
+        return None
+    # --jq transforms output to an arbitrary shape (scalar, array, etc.);
+    # shape validation against a fixed Pydantic model is meaningless.
+    if "--jq" in sample.args:
         return None
     subcommand = _gh_subcommand(sample.args)
     if subcommand is None:

--- a/tests/regressions/regression_issue_9297.py
+++ b/tests/regressions/regression_issue_9297.py
@@ -1,0 +1,120 @@
+"""Regression tests for issue #9297.
+
+Bug: ``gh_shape_validator`` produced false-positive drift for three common call
+patterns, causing 10 drift signatures to get stuck across 3+ loop ticks:
+
+1. ``gh pr list --json number --jq length`` — the ``--jq`` flag transforms the
+   output to a scalar (``'0'``), not a gh JSON shape.  The dispatcher was
+   returning ``GhPRSummary`` and failing to validate the scalar.
+
+2. ``gh issue list --json number,title,body,updatedAt`` — ``GhIssueSummary``
+   requires ``state`` (not in the requested field set), so every well-formed
+   result tripped a ``ValidationError``.
+
+3. ``gh issue view N --json comments`` — ``{"comments":[]}`` has no ``number``
+   or ``state``, again tripping ``GhIssueSummary`` validation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contracts.shadow import ShadowCorpus
+from contracts.shape_dispatchers import gh_shape_validator
+
+
+def _sample(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    stdout: str,
+    adapter: str = "github",
+    command: str = "gh",
+):
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter=adapter,
+        command=command,
+        args=args,
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    return corpus.load(path)
+
+
+@pytest.mark.asyncio
+async def test_jq_flag_skips_validation(tmp_path: Path) -> None:
+    """``--jq`` transforms output to an arbitrary scalar — dispatcher should
+    return None (no opinion) rather than attempting shape validation."""
+    sample = _sample(
+        tmp_path,
+        args=[
+            "pr",
+            "list",
+            "--head",
+            "agent/issue-9278",
+            "--state",
+            "open",
+            "--json",
+            "number",
+            "--jq",
+            "length",
+        ],
+        stdout="0",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_without_state_validates_as_list_item(tmp_path: Path) -> None:
+    """``gh issue list --json number,title,body,updatedAt`` omits ``state``.
+    The dispatcher must not apply ``GhIssueSummary`` (which requires ``state``);
+    it should use ``GhIssueListItem`` instead and pass cleanly."""
+    sample = _sample(
+        tmp_path,
+        args=[
+            "issue",
+            "list",
+            "--repo",
+            "org/repo",
+            "--label",
+            "hitl-escalation",
+            "--state",
+            "closed",
+            "--json",
+            "number,title,body,updatedAt",
+            "--limit",
+            "200",
+        ],
+        stdout=json.dumps(
+            [
+                {
+                    "number": 1,
+                    "title": "HITL: trust-loop anomaly",
+                    "body": "details",
+                    "updatedAt": "2026-06-04T00:00:00Z",
+                },
+            ]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_comments_only_skipped(tmp_path: Path) -> None:
+    """``gh issue view N --json comments`` returns ``{"comments":[]}``.
+    No shape covers a payload with only ``comments``; dispatcher should return
+    None (no opinion) rather than forcing ``GhIssueSummary`` and failing on
+    missing ``number``/``state``."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "9291", "--json", "comments"],
+        stdout=json.dumps({"comments": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None


### PR DESCRIPTION
## Summary

Fixes #9297 — 10 drift signatures stuck for 3+ ticks due to false-positive validation failures in `gh_shape_validator`.

Three root causes:

- **`--jq` transforms**: `gh pr list --json number --jq length` produces scalar stdout (`'0'`), not a JSON shape. The dispatcher was attempting `GhPRSummary` validation and failing. Fix: skip when `--jq` is in args.
- **Stateless issue lists**: `gh issue list --json number,title,body,updatedAt` omits `state` (the `--state` flag already filters). `GhIssueSummary` requires `state`, so every well-formed response tripped a `ValidationError`. Fix: use `GhIssueListItem` when `state` is absent; fall back to `None` (no opinion) when neither issue shape fits.
- **Comments-only views**: `gh issue view N --json comments` returns `{"comments":[]}` which has no fields matching `GhIssueSummary`. Fix: same field-aware dispatch — return `None` for payloads with only `comments`.

## Test plan

- [x] `tests/regressions/regression_issue_9297.py` — 3 new regression tests, one per pattern (all were red before this fix, all green after)
- [x] `tests/test_shape_dispatchers.py` — 10 existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)