### PR TITLE
fix(contracts): stop partial-field gh calls generating false drift signatures (#9299)

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ValidationError
 
 from contracts.shapes import (
     GhCheckRun,
+    GhIssueListItem,
     GhIssueSummary,
     GhPRDetail,
     GhPRSummary,
@@ -65,7 +66,15 @@ def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
         "isDraft",
     }
     if fields & detail_signals:
+        # GhPRDetail requires 'number'; partial fetches like --json commits
+        # or --json headRefOid omit it — return None rather than false-drift.
+        if "number" not in fields:
+            return None
         return GhPRDetail
+    # GhPRSummary requires 'number', 'title', 'state'; partial fetches like
+    # --json number,labels,body or --json commits skip validation.
+    if not {"number", "title", "state"} <= fields:
+        return None
     return GhPRSummary
 
 
@@ -73,7 +82,21 @@ def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
     fields = _extract_json_fields(args)
     if fields is None:
         return None
+    # GhIssueSummary requires 'number' and 'state'; partial fetches like
+    # --json state,stateReason or --json comments skip validation.
+    if not {"number", "state"} <= fields:
+        return None
     return GhIssueSummary
+
+
+def _pick_shape_for_issue_list(args: list[str]) -> type[BaseModel] | None:
+    fields = _extract_json_fields(args)
+    if fields is None:
+        return None
+    # GhIssueListItem requires 'number' and 'title'; skip partial fetches.
+    if not {"number", "title"} <= fields:
+        return None
+    return GhIssueListItem
 
 
 def _pick_shape_for_checks(args: list[str]) -> type[BaseModel] | None:
@@ -127,8 +150,10 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
     shape_cls: type[BaseModel] | None = None
     if subcommand in ("pr-view", "pr-list"):
         shape_cls = _pick_shape_for_pr(sample.args)
-    elif subcommand in ("issue-view", "issue-list"):
+    elif subcommand == "issue-view":
         shape_cls = _pick_shape_for_issue(sample.args)
+    elif subcommand == "issue-list":
+        shape_cls = _pick_shape_for_issue_list(sample.args)
     elif subcommand == "pr-checks":
         shape_cls = _pick_shape_for_checks(sample.args)
     if shape_cls is None:

--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -41,7 +41,27 @@ from pydantic import BaseModel, ConfigDict, Field
 _GhIssueState = Literal["OPEN", "CLOSED"]
 _GhPRState = Literal["OPEN", "CLOSED", "MERGED"]
 _GhMergeable = Literal["MERGEABLE", "CONFLICTING", "UNKNOWN"]
-_GhCheckState = Literal["QUEUED", "IN_PROGRESS", "COMPLETED", "PENDING", "WAITING"]
+_GhCheckState = Literal[
+    # raw check run status (in-progress phases)
+    "QUEUED",
+    "IN_PROGRESS",
+    "COMPLETED",
+    "PENDING",
+    "WAITING",
+    "REQUESTED",
+    # conclusion-based terminal states — gh pr checks --json collapses
+    # status+conclusion into a single "effective state" field, so these
+    # appear in ``state`` rather than a separate ``conclusion`` field.
+    "SUCCESS",
+    "FAILURE",
+    "NEUTRAL",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STALE",
+    "SKIPPED",
+    "STARTUP_FAILURE",
+]
 _GhCheckConclusion = Literal[
     "SUCCESS",
     "FAILURE",

--- a/tests/regressions/test_issue_9299.py
+++ b/tests/regressions/test_issue_9299.py
@@ -1,0 +1,125 @@
+"""Regression: partial-field gh calls must not generate false drift signatures.
+
+Issue #9299 — LiveCorpusReplayLoop accumulated 11 stuck drift signatures
+because ``gh_shape_validator`` validated partial-field gh responses against
+shapes that require fields not present in the response:
+
+  * ``gh pr view N --json commits``       → only "commits", but GhPRSummary
+    requires "number", "title", "state"
+  * ``gh issue view N --json state,stateReason`` → missing "number" required
+    by GhIssueSummary
+  * ``gh pr list --json number,labels,body`` → missing "title","state" for
+    GhPRSummary
+
+The fix adds required-field coverage guards to every _pick_shape_for_* helper
+so that partial fetches return None (no opinion) instead of forcing the sample
+through an incompatible shape.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contracts.shadow import ShadowCorpus
+from contracts.shape_dispatchers import gh_shape_validator
+
+
+def _sample(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    stdout: str,
+    adapter: str = "github",
+    command: str = "gh",
+):
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter=adapter,
+        command=command,
+        args=args,
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    return corpus.load(path)
+
+
+@pytest.mark.asyncio
+async def test_partial_pr_view_commits_returns_none(tmp_path: Path) -> None:
+    """gh pr view N --json commits omits number/title/state → no false drift."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "commits"],
+        stdout=json.dumps({"commits": [{"oid": "abc123"}]}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_partial_issue_view_state_reason_returns_none(tmp_path: Path) -> None:
+    """gh issue view N --json state,stateReason omits number → no false drift."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "9299", "--json", "state,stateReason"],
+        stdout=json.dumps({"state": "OPEN", "stateReason": None}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_partial_pr_list_no_title_returns_none(tmp_path: Path) -> None:
+    """gh pr list --json number,labels,body omits title/state → no false drift."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,labels,body"],
+        stdout=json.dumps([{"number": 1, "labels": [], "body": "desc"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_partial_pr_view_reviews_returns_none(tmp_path: Path) -> None:
+    """gh pr view N --json reviews omits required fields → no false drift."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "reviews"],
+        stdout=json.dumps({"reviews": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_full_pr_summary_still_validates(tmp_path: Path) -> None:
+    """A full gh pr list payload with all required fields still validates cleanly."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,title,state"],
+        stdout=json.dumps([{"number": 1, "title": "fix", "state": "OPEN"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_full_issue_summary_still_detects_drift(tmp_path: Path) -> None:
+    """A full gh issue view payload with an invalid state value still drifts."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "9299", "--json", "number,title,state,labels,body"],
+        stdout=json.dumps(
+            {
+                "number": 9299,
+                "title": "Test",
+                "state": "INVALID_STATE",
+                "labels": [],
+                "body": "",
+            }
+        )
+        + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape_validation_failed"] is True

--- a/tests/test_shape_dispatchers.py
+++ b/tests/test_shape_dispatchers.py
@@ -166,3 +166,97 @@ async def test_unknown_subcommand_skipped(tmp_path: Path) -> None:
         stdout='{"data": {}}\n',
     )
     assert await gh_shape_validator(sample) is None
+
+
+# --- Regression: partial-field fetches must not produce false drift (#9299) ---
+
+
+@pytest.mark.asyncio
+async def test_issue_view_partial_state_only_skipped(tmp_path: Path) -> None:
+    """gh issue view N --json state,stateReason omits 'number' — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "123", "--json", "state,stateReason"],
+        stdout=json.dumps({"state": "CLOSED", "stateReason": "completed"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_comments_only_skipped(tmp_path: Path) -> None:
+    """gh issue view N --json comments omits required fields — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "123", "--json", "comments"],
+        stdout=json.dumps({"comments": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_commits_only_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json commits omits required fields — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "commits"],
+        stdout=json.dumps({"commits": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_reviews_only_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json reviews omits required fields — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "reviews"],
+        stdout=json.dumps({"reviews": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_partial_fields_skipped(tmp_path: Path) -> None:
+    """gh pr list --json number,labels,body omits 'title','state' — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,labels,body"],
+        stdout=json.dumps([{"number": 1, "labels": [], "body": "x"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_full_fields_validates(tmp_path: Path) -> None:
+    """gh issue list --json number,title,body validates against GhIssueListItem."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,title,body,updatedAt"],
+        stdout=json.dumps(
+            [{"number": 1, "title": "bug x", "body": "desc", "updatedAt": "2026-01-01"}]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_partial_fields_skipped(tmp_path: Path) -> None:
+    """gh issue list --json number,body omits 'title' — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,body"],
+        stdout=json.dumps([{"number": 1, "body": "x"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_detail_partial_no_number_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json headRefOid (detail signal, no 'number') — must skip."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "headRefOid"],
+        stdout=json.dumps({"headRefOid": "abc123"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None


### PR DESCRIPTION
## Summary

- `gh_shape_validator` was routing partial-field gh calls (e.g. `--json commits`, `--json state,stateReason`, `--json number,labels,body`) to Pydantic shapes that require fields absent from those responses — every unique call site created a new stuck drift signature in `LiveCorpusReplayLoop`.
- Added required-field coverage guards to `_pick_shape_for_pr` and `_pick_shape_for_issue`: if the requested field set doesn't cover the shape's required fields, return `None` (no opinion) instead of false-failing validation.
- Added `_pick_shape_for_issue_list` (routes `issue-list` to `GhIssueListItem` which only requires `number` + `title`), separated from `issue-view` routing.
- Expanded `_GhCheckState` in `shapes.py` to include terminal conclusion values (`SUCCESS`, `FAILURE`, `NEUTRAL`, etc.) that `gh pr checks --json` collapses into the `state` field.

## Test plan

- [x] 8 new regression tests in `test_shape_dispatchers.py` covering all false-drift patterns from the 11 stuck signatures
- [x] All 34 tests in `test_shape_dispatchers.py` + `test_contracts_shapes.py` pass
- [x] `make quality-lite` passes (lint, typecheck, security)
- [x] Pre-push hook passes

Closes #9299

🤖 Generated with [Claude Code](https://claude.com/claude-code)