### PR TITLE
fix(live-corpus-replay): dedup escalation issue to prevent re-firing on every tick past threshold

### DIFF
--- a/src/live_corpus_replay_loop.py
+++ b/src/live_corpus_replay_loop.py
@@ -180,15 +180,27 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
 
             # If any signature reached the threshold, file an escalation
             # issue routed to the auto-agent preflight loop via the
-            # ``hitl-escalation`` label.
+            # ``hitl-escalation`` label.  Dedup-guarded so the escalation
+            # fires exactly once per drift run, not on every subsequent tick.
             if escalated_signatures:
-                escalated_issue = await self._file_escalation_issue(
-                    escalated_signatures
-                )
-        # Clean tick: clear all attempt counters so a future
-        # re-occurrence of the same drift starts fresh.
-        elif self._state is not None:
-            self._state.clear_live_corpus_drift_attempts()
+                esc_key = _escalation_dedup_key(escalated_signatures)
+                esc_seen = self._dedup.get()
+                if esc_key not in esc_seen:
+                    escalated_issue = await self._file_escalation_issue(
+                        escalated_signatures
+                    )
+                    if escalated_issue and escalated_issue != 0:
+                        esc_seen.add(esc_key)
+                        self._dedup.set_all(esc_seen)
+        # Clean tick: clear all attempt counters AND escalation dedup keys so
+        # a future re-occurrence of the same drift starts fresh.
+        else:
+            if self._state is not None:
+                self._state.clear_live_corpus_drift_attempts()
+            cur = self._dedup.get()
+            esc_keys = {k for k in cur if k.startswith("esc:")}
+            if esc_keys:
+                self._dedup.set_all(cur - esc_keys)
 
         return {
             "status": "ok",
@@ -311,3 +323,15 @@ def _fleet_dedup_key(drifted: list[tuple[Path, str]]) -> str:
     payload = {"signatures": sorted(sig for _path, sig in drifted)}
     blob = json.dumps(payload, sort_keys=True).encode("utf-8")
     return hashlib.sha256(blob).hexdigest()
+
+
+def _escalation_dedup_key(signatures: list[str]) -> str:
+    """Stable dedup key for an escalation issue.
+
+    Prefixed with ``"esc:"`` so it can be distinguished from drift dedup keys
+    in the shared DedupStore and removed on a clean tick (allowing a future
+    recurrence of the same drift to re-escalate).
+    """
+    payload = {"escalated": sorted(signatures)}
+    blob = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return "esc:" + hashlib.sha256(blob).hexdigest()

--- a/tests/test_live_corpus_replay_loop.py
+++ b/tests/test_live_corpus_replay_loop.py
@@ -360,3 +360,91 @@ async def test_clean_tick_clears_attempt_counters(tmp_path: Path) -> None:
 
     assert clean["drifted"] == 0
     assert state._attempts == {}, "clean tick must clear all counters"
+
+
+@pytest.mark.asyncio
+async def test_escalation_dedups_on_subsequent_ticks(tmp_path: Path) -> None:
+    """Escalation issue fires exactly once per drift run, not on every tick
+    after the threshold.
+
+    Regression for the missing escalation dedup: before the fix, every tick
+    past the threshold called _file_escalation_issue, filing a new hitl issue
+    each time.
+    """
+    pr = MagicMock()
+    # drift issue (tick 1), escalation issue (tick 3) — ticks 4+ must not
+    # file another escalation.
+    pr.create_issue = AsyncMock(side_effect=[4242, 5555])
+    loop, corpus, _pr, _state = _build_loop(
+        tmp_path, pr_manager=pr, max_drift_attempts=3
+    )
+    corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "99"],
+        stdout='{"state":"MERGED"}\n',
+        stderr="",
+        exit_code=0,
+    )
+
+    async def stale_fake(_sample):  # noqa: ANN001
+        return {"state": "OPEN"}
+
+    loop.register("github", "gh", stale_fake)
+
+    # Five ticks — threshold is 3, so ticks 3/4/5 all have the counter at ≥3.
+    for _ in range(5):
+        await loop._do_work()
+
+    # Only two create_issue calls total: the initial drift issue and one escalation.
+    assert pr.create_issue.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_clean_tick_resets_escalation_dedup(tmp_path: Path) -> None:
+    """After a clean tick the escalation dedup key is removed so a future
+    recurrence of the same drift can re-escalate."""
+    pr = MagicMock()
+    pr.create_issue = AsyncMock(side_effect=[4242, 5555, 6666, 7777])
+    loop, corpus, _pr, _state = _build_loop(
+        tmp_path, pr_manager=pr, max_drift_attempts=3
+    )
+    corpus.record(
+        adapter="github",
+        command="gh",
+        args=["pr", "view", "7"],
+        stdout='{"state":"MERGED"}\n',
+        stderr="",
+        exit_code=0,
+    )
+
+    async def stale_fake(_sample):  # noqa: ANN001
+        return {"state": "OPEN"}
+
+    async def fixed_fake(_sample):  # noqa: ANN001
+        return {"state": "MERGED"}
+
+    loop.register("github", "gh", stale_fake)
+    for _ in range(3):
+        await loop._do_work()
+    # Escalation dedup key is now stored.
+
+    # Clean tick — drift stops.
+    loop.register("github", "gh", fixed_fake)
+    await loop._do_work()
+
+    # Drift recurs — same signature, same escalation key, but dedup was cleared.
+    loop.register("github", "gh", stale_fake)
+    for _ in range(3):
+        await loop._do_work()
+
+    # The second drift run should have filed a second escalation.
+    escalation_calls = [
+        call
+        for call in pr.create_issue.await_args_list
+        if "hitl-escalation"
+        in (call.kwargs.get("labels") or (call.args[2] if len(call.args) > 2 else []))
+    ]
+    assert len(escalation_calls) == 2, (
+        "clean tick should clear escalation dedup so recurrence can re-escalate"
+    )


### PR DESCRIPTION
## Summary

- `_file_escalation_issue` had no dedup guard, so once a drift signature exceeded `live_corpus_max_drift_attempts`, it filed a new `hitl-escalation` issue on **every subsequent tick** — not just once per drift run
- Added the same `DedupStore` pattern used for the `hydraflow-find` drift issue, with `"esc:"`-prefixed keys so escalation dedup entries can be distinguished and cleaned independently
- On a clean tick, escalation dedup keys are removed (alongside the attempt counters), so a future recurrence of the same drift can re-escalate from scratch

## Context for #9301

The 10 stuck signatures in this escalation were **false-positives** from the `gh_shape_validator` incorrectly validating `--jq` outputs, stateless issue-list responses, and comments-only issue views. PRs #9298 and #9282 already fixed the root cause. The next clean tick of `LiveCorpusReplayLoop` will call `clear_live_corpus_drift_attempts()` and the counters will reset.

This PR fixes the adjacent bug found during investigation: without the escalation dedup, the loop was also filing a new `hitl-escalation` issue on every tick after threshold was hit, not just once.

## Test plan

- [ ] `test_escalation_dedups_on_subsequent_ticks` — 5 ticks past threshold produce exactly 2 `create_issue` calls (drift + one escalation), not 4
- [ ] `test_clean_tick_resets_escalation_dedup` — after a clean tick the escalation dedup key is cleared, so a recurrence fires a second escalation
- [ ] All 12 existing `test_live_corpus_replay_loop.py` tests still pass
- [ ] `make quality-lite` passes (lint + pyright + bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)