### PR TITLE
fix(contracts): skip gh_shape_validator on narrow --json queries missing required shape fields (closes #9303)

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -126,6 +126,19 @@ def _gh_subcommand(args: list[str]) -> str | None:
     return f"{args[0]}-{args[1]}"
 
 
+# Minimum fields a call must request before we'll validate against a shape.
+# Narrow queries (e.g. ``--json commits``, ``--json headRefOid``) omit
+# required fields, so validating against a shape that needs them produces
+# spurious drift signals.
+_SHAPE_REQUIRED_FIELDS: dict[str, frozenset[str]] = {
+    "GhPRSummary": frozenset({"number", "title", "state"}),
+    "GhPRDetail": frozenset({"number"}),
+    "GhIssueSummary": frozenset({"number", "state"}),
+    "GhIssueListItem": frozenset({"number", "title"}),
+    "GhCheckRun": frozenset({"name"}),
+}
+
+
 async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None:  # noqa: PLR0911
     """Dispatcher: validate ``sample.stdout`` against the matching shape.
 
@@ -135,7 +148,8 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
           this to file a single drift issue per signature.
         - ``None`` for samples this dispatcher has no opinion on
           (unknown subcommand, no ``--json`` flag, ``--jq`` transform
-          applied, empty stdout, etc.) — the loop treats those as
+          applied, empty stdout, requested fields don't cover the shape's
+          required fields, etc.) — the loop treats those as
           "skipped, no opinion".
     """
     if sample.adapter != "github" or sample.command != "gh":
@@ -160,6 +174,15 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
     elif subcommand == "pr-checks":
         shape_cls = _pick_shape_for_checks(sample.args)
     if shape_cls is None:
+        return None
+
+    # Only validate when the requested fields cover the shape's required
+    # fields.  Narrow queries (e.g. ``--json commits``, ``--json headRefOid``)
+    # don't request the required fields, so attempting to validate them
+    # produces false-positive drift for every valid call of that shape.
+    requested = _extract_json_fields(sample.args)
+    required = _SHAPE_REQUIRED_FIELDS.get(shape_cls.__name__, frozenset())
+    if requested is not None and not required.issubset(requested):
         return None
 
     try:

--- a/tests/regressions/regression_issue_9303.py
+++ b/tests/regressions/regression_issue_9303.py
@@ -1,0 +1,191 @@
+"""Regression tests for issue #9303.
+
+Bug: ``gh_shape_validator`` produced false-positive drift for narrow ``--json``
+field queries whose requested fields don't cover a shape's required fields.
+Seven drift signatures got stuck across 3+ loop ticks.
+
+The patterns that caused false positives:
+
+1. ``gh pr view N --json commits`` — no detail signal, routed to GhPRSummary
+   which requires number+title+state; ``{"commits":[]}`` satisfies none.
+
+2. ``gh pr view N --json reviews`` — no detail signal, same GhPRSummary path.
+
+3. ``gh pr view N --json headRefOid`` — IS a detail signal (GhPRDetail), but
+   GhPRDetail requires ``number``; ``{"headRefOid":"abc"}`` is missing it.
+
+4. ``gh pr view N --json title,body`` — no state or number → GhPRSummary fails.
+
+5. ``gh pr list --json number,labels,body`` — missing title+state.
+
+6. ``gh pr list --json number,mergedAt,title,files`` — missing state.
+
+7. ``gh issue list --json createdAt,closedAt`` — GhIssueListItem requires
+   number+title; date-only queries satisfy neither.
+
+Fix: ``gh_shape_validator`` now checks that the requested fields are a superset
+of the chosen shape's required fields before attempting validation.  Narrow
+queries return None (no opinion) rather than false-positive drift.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contracts.shadow import ShadowCorpus
+from contracts.shape_dispatchers import gh_shape_validator
+
+
+def _sample(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    stdout: str,
+    adapter: str = "github",
+    command: str = "gh",
+):
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter=adapter,
+        command=command,
+        args=args,
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    return corpus.load(path)
+
+
+@pytest.mark.asyncio
+async def test_pr_view_commits_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json commits`` omits required GhPRSummary fields.
+    Dispatcher must return None, not a false-positive drift signal."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "commits"],
+        stdout=json.dumps({"commits": [{"oid": "abc1234"}]}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_reviews_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json reviews`` has no detail signal and omits
+    required GhPRSummary fields — must be skipped, not false-positive."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "reviews"],
+        stdout=json.dumps(
+            {"reviews": [{"state": "APPROVED", "author": {"login": "dev"}}]}
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_head_ref_oid_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json headRefOid`` triggers GhPRDetail (detail signal)
+    but omits required ``number`` field — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "headRefOid"],
+        stdout=json.dumps({"headRefOid": "abc1234567890"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_title_body_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json title,body`` omits number and state.
+    GhPRSummary requires all three — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "title,body"],
+        stdout=json.dumps({"title": "Fix the thing", "body": "Details here"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_number_labels_body_skipped(tmp_path: Path) -> None:
+    """``gh pr list --json number,labels,body`` omits title and state.
+    GhPRSummary requires both — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,labels,body"],
+        stdout=json.dumps([{"number": 1, "labels": [], "body": "..."}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_without_state_skipped(tmp_path: Path) -> None:
+    """``gh pr list --json number,mergedAt,title,files`` omits state.
+    GhPRSummary requires state — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,mergedAt,title,files"],
+        stdout=json.dumps(
+            [
+                {
+                    "number": 5,
+                    "mergedAt": "2026-06-04T00:00:00Z",
+                    "title": "x",
+                    "files": [],
+                }
+            ]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_date_fields_only_skipped(tmp_path: Path) -> None:
+    """``gh issue list --json createdAt,closedAt`` omits number and title.
+    GhIssueListItem requires both — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "createdAt,closedAt"],
+        stdout=json.dumps(
+            [
+                {
+                    "createdAt": "2026-06-01T00:00:00Z",
+                    "closedAt": "2026-06-04T00:00:00Z",
+                }
+            ]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_with_required_fields_still_validates(tmp_path: Path) -> None:
+    """Full GhPRSummary fields → validation still runs and catches real drift."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,title,state"],
+        stdout=json.dumps([{"number": 1, "title": "x", "state": "UNKNOWN_STATE"}])
+        + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape_validation_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_without_name_skipped(tmp_path: Path) -> None:
+    """``gh pr checks --json conclusion`` omits name.
+    GhCheckRun requires name — must be skipped."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "42", "--json", "conclusion"],
+        stdout=json.dumps([{"conclusion": "SUCCESS"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None


### PR DESCRIPTION
## Summary

- `gh_shape_validator` was producing false-positive drift signals for `gh` calls whose `--json FIELDS` didn't include all required fields of the chosen shape
- Seven drift signatures accumulated for 3+ ticks and escalated to `hitl-escalation` as issue #9303
- Fix adds `_SHAPE_REQUIRED_FIELDS` check: if the requested fields don't cover the shape's required fields, the dispatcher returns `None` (no opinion) rather than a spurious validation failure

**Patterns fixed:**
| Call | Shape chosen | Problem |
|------|-------------|---------|
| `gh pr view N --json commits` | GhPRSummary | missing number+title+state |
| `gh pr view N --json reviews` | GhPRSummary | same |
| `gh pr view N --json headRefOid` | GhPRDetail | missing number |
| `gh pr view N --json title,body` | GhPRSummary | missing number+state |
| `gh pr list --json number,labels,body` | GhPRSummary | missing title+state |
| `gh pr list --json number,mergedAt,title,files` | GhPRSummary | missing state |
| `gh issue list --json createdAt,closedAt` | GhIssueListItem | missing number+title |
| `gh pr checks N --json conclusion` | GhCheckRun | missing name |

Validation still runs (and catches real drift) when the requested fields cover the shape's required fields.

## Test plan
- [x] `tests/regressions/regression_issue_9303.py` — 9 new regression tests, all passing
- [x] `tests/test_shape_dispatchers.py` — all existing tests pass
- [x] `make quality` — 15,675 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)