### PR TITLE
fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-05T06:24:31.629860+00:00",
-  "commit_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5",
+  "regenerated_at": "2026-06-05T06:27:04.818531+00:00",
+  "commit_sha": "74932f6d4d213edef079e0db21132b4fd3280da9",
   "artifacts": {
     "loops.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "ports.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "labels.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "modules.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "events.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "adr_xref.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "mockworld.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "changelog.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "coverage_matrix.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "functional_areas.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "ubiquitous-language.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
+      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-05T06:23:52.786660+00:00",
-  "commit_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0",
+  "regenerated_at": "2026-06-05T06:24:31.629860+00:00",
+  "commit_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "ports.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "labels.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "modules.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "events.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "adr_xref.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "mockworld.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "changelog.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "coverage_matrix.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "functional_areas.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
+      "source_sha": "2b4b46c9c99babbd427afa177a48ea944aa2faa5"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-05T00:28:56.593298+00:00",
-  "commit_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3",
+  "regenerated_at": "2026-06-05T06:23:52.786660+00:00",
+  "commit_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0",
   "artifacts": {
     "loops.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "ports.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "labels.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "modules.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "events.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "adr_xref.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "mockworld.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "changelog.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "coverage_matrix.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "functional_areas.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "ubiquitous-language.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "6ccf1f57474f8a03c2389f54167ef9505c0dbcc3"
+      "source_sha": "b27eb8b3612ef84f0191619bfa045c01f20727c0"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,10 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
-- `6ccf1f5` — chore(arch): re-stamp generated artifacts after staging merge *(2026-06-04)*
-- `96a2fdc` — Merge remote-tracking branch 'origin/staging' into HEAD *(2026-06-04)*
+- `7316aba` — fix(wiki): repair malformed topic entries + guard against silent data loss (#9281) (#9281) *(2026-06-04)*
+- `e91dd05` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn (closes #9176) (#9256) (#9256) *(2026-06-04)*
 - `e451fa3` — fix(adr): update ADR-0009 citations to current symbols (closes #9173) (#9255) (#9255) *(2026-06-04)*
-- `d500472` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn *(2026-06-04)*
 - `455bf0e` — chore(gates): target main ruleset by explicit refs/heads/main, not ~DEFAULT_BRANCH (#9252) (#9252) *(2026-06-04)*
 - `eff5ffc` — Merge pull request #9250 from T-rav/rc/2026-06-04-1254 *(2026-06-04)*
 - `90878f5` — fix(adr): use bare paths in ADR-0069/0072 Enforced-by lines (#9247) (#9247) *(2026-06-04)*
@@ -432,7 +431,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `4c09083` — Fixes #2264: [ADR] Draft decision from memory #2258: Implementation... (#2292) (#2292) *(2026-03-08)*
 - `c4b8ecd` — Fixes #2374: Add ADR-0023 for supersession regex verb form coverage (#2379) (#2379) *(2026-03-08)*
 - `7c6410a` — Fixes #2210: sync ADR index statuses (#2233) (#2233) *(2026-03-07)*
-- `b1df31d` — Fixes #1977: Document cross-phase integration harness (#2146) (#2146) *(2026-03-06)*
 
 
 <!-- arch:generated -->

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `2b4b46c` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) *(2026-06-05)*
 - `7316aba` — fix(wiki): repair malformed topic entries + guard against silent data loss (#9281) (#9281) *(2026-06-04)*
 - `e91dd05` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn (closes #9176) (#9256) (#9256) *(2026-06-04)*
 - `e451fa3` — fix(adr): update ADR-0009 citations to current symbols (closes #9173) (#9255) (#9255) *(2026-06-04)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `74932f6` — chore(arch): re-stamp generated artifacts for #9314 fix *(2026-06-05)*
 - `2b4b46c` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) *(2026-06-05)*
 - `7316aba` — fix(wiki): repair malformed topic entries + guard against silent data loss (#9281) (#9281) *(2026-06-04)*
 - `e91dd05` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn (closes #9176) (#9256) (#9256) *(2026-06-04)*

--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -54,7 +54,14 @@ logger = logging.getLogger("hydraflow.contracts.shape_dispatchers")
 
 def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
     """``gh pr ...`` shape selection. Detect summary vs detail by which
-    detail-only fields are requested in ``--json FIELDS``."""
+    detail-only fields are requested in ``--json FIELDS``.
+
+    Only select a shape when ALL of its required fields are present in the
+    requested field set.  Narrow projection calls (e.g. ``--json commits``,
+    ``--json reviews``, ``--json headRefOid``) don't include all required
+    fields, so the dispatcher returns ``None`` to avoid false-positive drift
+    signals for those projection-only shadow-corpus samples.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
@@ -66,24 +73,33 @@ def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
         "isDraft",
     }
     if fields & detail_signals:
+        # GhPRDetail requires number — skip projection-only calls like --json headRefOid
+        if "number" not in fields:
+            return None
         return GhPRDetail
+    # GhPRSummary requires number, title, state
+    if not {"number", "title", "state"} <= fields:
+        return None
     return GhPRSummary
 
 
 def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
     """Issue shape selection based on which fields are requested.
 
-    ``GhIssueSummary`` requires ``state`` — only use it when the call
-    actually requests that field.  Narrow list calls (``number,title,...``
-    without ``state``) use ``GhIssueListItem`` instead.  Calls that
+    ``GhIssueSummary`` requires ``number`` and ``state`` — only use it when
+    the call requests both.  Narrow calls like ``--json state,stateReason``
+    (which omit ``number``) would otherwise fail validation on the required
+    ``number`` field, producing a false-positive drift signal.  Calls that
     request fields outside both shapes (e.g. ``--json comments``) get
-    ``None`` so the dispatcher skips them rather than producing a
-    false-positive drift signal.
+    ``None`` so the dispatcher skips them.
     """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
     if "state" in fields:
+        # GhIssueSummary requires both number and state
+        if "number" not in fields:
+            return None
         return GhIssueSummary
     if "number" in fields and "title" in fields:
         return GhIssueListItem

--- a/tests/regressions/regression_issue_9314.py
+++ b/tests/regressions/regression_issue_9314.py
@@ -1,0 +1,204 @@
+"""Regression tests for issue #9314.
+
+Five shadow-corpus call patterns produced false-positive drift signals because
+``gh_shape_validator`` attempted shape validation even when the requested
+``--json`` fields didn't include all required fields for the chosen model:
+
+1. ``gh pr view N --json commits`` — ``GhPRSummary`` requires ``number``,
+   ``title``, ``state``; the response only has ``commits``.
+
+2. ``gh pr view N --json reviews`` — same required fields missing.
+
+3. ``gh pr view N --json headRefOid`` — ``headRefOid`` is a detail-signal so
+   ``GhPRDetail`` is selected, but ``GhPRDetail`` requires ``number`` which
+   isn't in the requested field set.
+
+4. ``gh issue view N --json state,stateReason`` — ``GhIssueSummary`` requires
+   ``number`` and ``state``; the call omits ``number``.
+
+5. ``gh pr list --json number,labels,body,commits`` — ``GhPRSummary`` requires
+   ``title`` and ``state``; both are absent from the field set.
+
+The fix: ``_pick_shape_for_pr`` and ``_pick_shape_for_issue`` now guard on the
+required fields of the target shape before returning it.  When required fields
+are absent from the requested set, the dispatcher returns ``None`` (no opinion)
+instead of attempting validation that is guaranteed to fail.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contracts.shadow import ShadowCorpus
+from contracts.shape_dispatchers import gh_shape_validator
+
+
+def _sample(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    stdout: str,
+    adapter: str = "github",
+    command: str = "gh",
+):
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter=adapter,
+        command=command,
+        args=args,
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    return corpus.load(path)
+
+
+@pytest.mark.asyncio
+async def test_pr_view_commits_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json commits`` returns a ``commits`` array; the
+    response omits ``number``, ``title``, ``state`` that ``GhPRSummary``
+    requires.  The dispatcher must return None rather than a false drift."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--repo", "org/repo", "--json", "commits"],
+        stdout=json.dumps(
+            {"commits": [{"oid": "abc1234", "messageHeadline": "fix: something"}]}
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_reviews_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json reviews`` returns a ``reviews`` array; the
+    response omits the required fields for any PR shape."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--repo", "org/repo", "--json", "reviews"],
+        stdout=json.dumps(
+            {"reviews": [{"state": "APPROVED", "author": {"login": "alice"}}]}
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_head_ref_oid_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json headRefOid`` — ``headRefOid`` triggers the detail
+    signal so ``GhPRDetail`` would be selected, but ``GhPRDetail`` requires
+    ``number`` which is absent.  Must return None."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--repo", "org/repo", "--json", "headRefOid"],
+        stdout=json.dumps({"headRefOid": "def5678abcdef" * 3}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_state_statereason_only_skipped(tmp_path: Path) -> None:
+    """``gh issue view N --json state,stateReason`` omits ``number`` which
+    ``GhIssueSummary`` requires.  Dispatcher must return None."""
+    sample = _sample(
+        tmp_path,
+        args=[
+            "issue",
+            "view",
+            "9314",
+            "--repo",
+            "org/repo",
+            "--json",
+            "state,stateReason",
+        ],
+        stdout=json.dumps({"state": "CLOSED", "stateReason": "COMPLETED"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_narrow_fields_skipped(tmp_path: Path) -> None:
+    """``gh pr list --json number,labels,body,commits`` omits ``title`` and
+    ``state`` that ``GhPRSummary`` requires.  Dispatcher must return None."""
+    sample = _sample(
+        tmp_path,
+        args=[
+            "pr",
+            "list",
+            "--repo",
+            "org/repo",
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,labels,body,commits",
+        ],
+        stdout=json.dumps(
+            [
+                {
+                    "number": 100,
+                    "labels": [{"name": "hydraflow-review"}],
+                    "body": "Fixes #99",
+                    "commits": [{"oid": "abc1234"}],
+                }
+            ]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# Confirm that well-formed calls still validate — the fix must not suppress
+# genuine drift signals.
+
+
+@pytest.mark.asyncio
+async def test_pr_view_full_summary_fields_still_validates(tmp_path: Path) -> None:
+    """A PR view with number,title,state present still routes to GhPRSummary
+    and catches a real drift (bad state value)."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "number,title,state"],
+        stdout=json.dumps({"number": 42, "title": "Fix it", "state": "QUEUED"}) + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape"] == "GhPRSummary"
+
+
+@pytest.mark.asyncio
+async def test_pr_view_detail_with_number_still_validates(tmp_path: Path) -> None:
+    """A PR detail view with number present still routes to GhPRDetail
+    and catches a real drift (bad mergeable value)."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "number,headRefName,mergeable"],
+        stdout=json.dumps(
+            {"number": 42, "headRefName": "feat/x", "mergeable": "PROBABLY"}
+        )
+        + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape"] == "GhPRDetail"
+
+
+@pytest.mark.asyncio
+async def test_issue_view_with_number_and_state_still_validates(tmp_path: Path) -> None:
+    """An issue view with number,state present still routes to GhIssueSummary
+    and catches a real drift (bad state value)."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "9314", "--json", "number,state,stateReason"],
+        stdout=json.dumps({"number": 9314, "state": "ARCHIVED", "stateReason": None})
+        + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape"] == "GhIssueSummary"


### PR DESCRIPTION
## Summary

Five `gh` call patterns in the shadow corpus were producing false-positive drift signatures that exhausted the `LiveCorpusReplayLoop`'s 3-tick retry budget and escalated to HITL (issue #9314). All five come from projection-only `--json` field sets that don't include all the required fields for the chosen Pydantic shape:

- `gh pr view N --json commits` → `GhPRSummary` requires `number/title/state`, only `commits` present
- `gh pr view N --json reviews` → same required fields absent  
- `gh pr view N --json headRefOid` → `GhPRDetail` requires `number`, only `headRefOid` present (a detail-signal)
- `gh issue view N --json state,stateReason` → `GhIssueSummary` requires `number+state`, `number` absent
- `gh pr list --json number,labels,body,commits` → `GhPRSummary` requires `title+state`, both absent

**Fix:** `_pick_shape_for_pr` now guards on `number` for `GhPRDetail` and `{number, title, state}` for `GhPRSummary`. `_pick_shape_for_issue` now guards on `number` before selecting `GhIssueSummary`. Projection-only calls return `None` (no opinion) — the loop treats them as skipped samples, not drift.

## Test plan

- [ ] `tests/regressions/regression_issue_9314.py` — 8 tests: 5 regression tests (one per stuck pattern, all must return `None`) + 3 positive tests confirming genuine drift is still detected after the fix
- [ ] All pre-existing shape dispatcher tests pass (`tests/test_shape_dispatchers.py`)
- [ ] Full regression suite passes (418 tests total)
- [ ] Lint, pyright, bandit all pass (pre-push hook confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)