### PR TITLE
fix(contracts): stop 13 false-positive drift signatures in gh_shape_validator (closes #9320)

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -35,6 +35,7 @@ from pydantic import BaseModel, ValidationError
 
 from contracts.shapes import (
     GhCheckRun,
+    GhIssueListItem,
     GhIssueSummary,
     GhPRDetail,
     GhPRSummary,
@@ -53,7 +54,14 @@ logger = logging.getLogger("hydraflow.contracts.shape_dispatchers")
 
 def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
     """``gh pr ...`` shape selection. Detect summary vs detail by which
-    detail-only fields are requested in ``--json FIELDS``."""
+    detail-only fields are requested in ``--json FIELDS``.
+
+    Only select a shape when ALL of its required fields are present in the
+    requested field set.  Narrow projection calls (e.g. ``--json commits``,
+    ``--json reviews``, ``--json headRefOid``) don't include all required
+    fields, so the dispatcher returns ``None`` to avoid false-positive drift
+    signals for those projection-only shadow-corpus samples.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
@@ -65,20 +73,56 @@ def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
         "isDraft",
     }
     if fields & detail_signals:
+        # GhPRDetail requires number — skip projection-only calls like --json headRefOid
+        if "number" not in fields:
+            return None
         return GhPRDetail
+    # GhPRSummary requires number, title, state
+    if not {"number", "title", "state"} <= fields:
+        return None
     return GhPRSummary
 
 
 def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
+    """Issue shape selection for ``issue-view`` calls.
+
+    ``GhIssueSummary`` requires ``number`` and ``state`` — only use it when
+    the call requests both.  Narrow calls like ``--json state,stateReason``
+    (which omit ``number``) would otherwise fail validation on the required
+    ``number`` field, producing a false-positive drift signal.  Calls that
+    request fields outside both shapes (e.g. ``--json comments``) get
+    ``None`` so the dispatcher skips them.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
-    return GhIssueSummary
+    if "state" in fields:
+        # GhIssueSummary requires both number and state
+        if "number" not in fields:
+            return None
+        return GhIssueSummary
+    if "number" in fields and "title" in fields:
+        return GhIssueListItem
+    return None
+
+
+def _pick_shape_for_issue_list(args: list[str]) -> type[BaseModel] | None:
+    fields = _extract_json_fields(args)
+    if fields is None:
+        return None
+    # GhIssueListItem requires number and title; skip date-only or other
+    # narrow queries that omit them (e.g. --json createdAt,closedAt).
+    if not {"number", "title"} <= fields:
+        return None
+    return GhIssueListItem
 
 
 def _pick_shape_for_checks(args: list[str]) -> type[BaseModel] | None:
     fields = _extract_json_fields(args)
     if fields is None:
+        return None
+    # GhCheckRun requires name; skip projection-only calls like --json conclusion.
+    if "name" not in fields:
         return None
     return GhCheckRun
 
@@ -120,6 +164,10 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
         return None
     if not sample.stdout.strip():
         return None
+    # --jq transforms output to an arbitrary shape (scalar, array, etc.);
+    # shape validation against a fixed Pydantic model is meaningless.
+    if "--jq" in sample.args:
+        return None
     subcommand = _gh_subcommand(sample.args)
     if subcommand is None:
         return None
@@ -127,8 +175,10 @@ async def gh_shape_validator(sample: ShadowSample) -> dict[str, object] | None: 
     shape_cls: type[BaseModel] | None = None
     if subcommand in ("pr-view", "pr-list"):
         shape_cls = _pick_shape_for_pr(sample.args)
-    elif subcommand in ("issue-view", "issue-list"):
+    elif subcommand == "issue-view":
         shape_cls = _pick_shape_for_issue(sample.args)
+    elif subcommand == "issue-list":
+        shape_cls = _pick_shape_for_issue_list(sample.args)
     elif subcommand == "pr-checks":
         shape_cls = _pick_shape_for_checks(sample.args)
     if shape_cls is None:

--- a/src/contracts/shapes.py
+++ b/src/contracts/shapes.py
@@ -41,7 +41,25 @@ from pydantic import BaseModel, ConfigDict, Field
 _GhIssueState = Literal["OPEN", "CLOSED"]
 _GhPRState = Literal["OPEN", "CLOSED", "MERGED"]
 _GhMergeable = Literal["MERGEABLE", "CONFLICTING", "UNKNOWN"]
-_GhCheckState = Literal["QUEUED", "IN_PROGRESS", "COMPLETED", "PENDING", "WAITING"]
+_GhCheckState = Literal[
+    # In-progress statuses
+    "QUEUED",
+    "IN_PROGRESS",
+    "COMPLETED",
+    "PENDING",
+    "WAITING",
+    # Terminal conclusion values that gh collapses into the state field
+    # for finished check runs (gh pr checks --json state returns these)
+    "SUCCESS",
+    "FAILURE",
+    "NEUTRAL",
+    "CANCELLED",
+    "TIMED_OUT",
+    "ACTION_REQUIRED",
+    "STALE",
+    "SKIPPED",
+    "STARTUP_FAILURE",
+]
 _GhCheckConclusion = Literal[
     "SUCCESS",
     "FAILURE",

--- a/src/live_corpus_replay_loop.py
+++ b/src/live_corpus_replay_loop.py
@@ -180,15 +180,27 @@ class LiveCorpusReplayLoop(BaseBackgroundLoop):
 
             # If any signature reached the threshold, file an escalation
             # issue routed to the auto-agent preflight loop via the
-            # ``hitl-escalation`` label.
+            # ``hitl-escalation`` label.  Dedup-guarded so the escalation
+            # fires exactly once per drift run, not on every subsequent tick.
             if escalated_signatures:
-                escalated_issue = await self._file_escalation_issue(
-                    escalated_signatures
-                )
-        # Clean tick: clear all attempt counters so a future
-        # re-occurrence of the same drift starts fresh.
-        elif self._state is not None:
-            self._state.clear_live_corpus_drift_attempts()
+                esc_key = _escalation_dedup_key(escalated_signatures)
+                esc_seen = self._dedup.get()
+                if esc_key not in esc_seen:
+                    escalated_issue = await self._file_escalation_issue(
+                        escalated_signatures
+                    )
+                    if escalated_issue and escalated_issue != 0:
+                        esc_seen.add(esc_key)
+                        self._dedup.set_all(esc_seen)
+        # Clean tick: clear all attempt counters AND escalation dedup keys so
+        # a future re-occurrence of the same drift starts fresh.
+        else:
+            if self._state is not None:
+                self._state.clear_live_corpus_drift_attempts()
+            cur = self._dedup.get()
+            esc_keys = {k for k in cur if k.startswith("esc:")}
+            if esc_keys:
+                self._dedup.set_all(cur - esc_keys)
 
         return {
             "status": "ok",
@@ -311,3 +323,15 @@ def _fleet_dedup_key(drifted: list[tuple[Path, str]]) -> str:
     payload = {"signatures": sorted(sig for _path, sig in drifted)}
     blob = json.dumps(payload, sort_keys=True).encode("utf-8")
     return hashlib.sha256(blob).hexdigest()
+
+
+def _escalation_dedup_key(signatures: list[str]) -> str:
+    """Stable dedup key for an escalation issue.
+
+    Prefixed with ``"esc:"`` so it can be distinguished from drift dedup keys
+    in the shared DedupStore and removed on a clean tick (allowing a future
+    recurrence of the same drift to re-escalate).
+    """
+    payload = {"escalated": sorted(signatures)}
+    blob = json.dumps(payload, sort_keys=True).encode("utf-8")
+    return "esc:" + hashlib.sha256(blob).hexdigest()

--- a/tests/regressions/regression_issue_9320.py
+++ b/tests/regressions/regression_issue_9320.py
@@ -1,0 +1,354 @@
+"""Regression tests for issue #9320.
+
+13 drift signatures survived LiveCorpusReplayLoop's 3-tick retry budget because
+``gh_shape_validator`` generated false-positive validation errors for several
+classes of shadow-corpus call patterns that all existed in main before this fix:
+
+1. **Issue-list vs issue-view routing** — ``gh issue list`` was validated against
+   ``GhIssueSummary`` which requires ``state``, but list calls omit it.
+   Fix: route issue-list to ``_pick_shape_for_issue_list`` using ``GhIssueListItem``.
+
+2. **--jq transforms** — ``gh pr list --json number --jq length`` produces scalar
+   stdout; shape validation is meaningless.
+   Fix: skip validation when ``--jq`` is present in args.
+
+3. **Comments-only and narrow issue views** — ``gh issue view N --json comments``
+   has no fields matching either issue shape.
+   Fix: ``_pick_shape_for_issue`` returns ``None`` when neither ``state`` nor
+   both ``number+title`` are present.
+
+4. **Projection-only PR calls** — calls like ``gh pr view N --json commits``,
+   ``--json reviews``, or ``--json headRefOid`` omit required fields.
+   Fix: ``_pick_shape_for_pr`` guards on required fields before selecting a shape.
+
+5. **Projection-only issue calls** — ``gh issue view N --json state,stateReason``
+   omits ``number`` which ``GhIssueSummary`` requires.
+   Fix: ``_pick_shape_for_issue`` guards on both ``number+state``.
+
+6. **Narrow pr-checks and issue-list calls** — ``gh pr checks --json conclusion``
+   omits ``name`` required by ``GhCheckRun``; ``gh issue list --json createdAt``
+   omits ``number+title`` required by ``GhIssueListItem``.
+   Fix: required-field guards in ``_pick_shape_for_checks`` and
+   ``_pick_shape_for_issue_list``.
+
+7. **Terminal check-run states** — ``gh pr checks --json state`` returns terminal
+   conclusion values (``SUCCESS``, ``FAILURE``, ``SKIPPED``, etc.) for finished
+   check runs; ``_GhCheckState`` only listed in-progress statuses.
+   Fix: expand ``_GhCheckState`` to include all terminal values.
+
+8. **Escalation re-fire** — ``LiveCorpusReplayLoop._file_escalation_issue`` had no
+   dedup guard so it filed a new ``hitl-escalation`` issue on every tick past the
+   threshold.
+   Fix: ``_escalation_dedup_key`` + DedupStore guard in ``_do_work``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from contracts.shadow import ShadowCorpus
+from contracts.shape_dispatchers import gh_shape_validator
+from live_corpus_replay_loop import _escalation_dedup_key, _fleet_dedup_key
+
+
+def _sample(
+    tmp_path: Path,
+    *,
+    args: list[str],
+    stdout: str,
+    adapter: str = "github",
+    command: str = "gh",
+):
+    corpus = ShadowCorpus(tmp_path)
+    path = corpus.record(
+        adapter=adapter,
+        command=command,
+        args=args,
+        stdout=stdout,
+        stderr="",
+        exit_code=0,
+    )
+    assert path is not None
+    return corpus.load(path)
+
+
+# ── Pattern 1: issue-list vs issue-view routing ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_issue_list_without_state_uses_list_item_shape(tmp_path: Path) -> None:
+    """``gh issue list --json number,title`` must not fail on missing ``state``."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,title"],
+        stdout=json.dumps([{"number": 1, "title": "fix: something"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_with_state_uses_summary_shape(tmp_path: Path) -> None:
+    """``gh issue view N --json number,state`` validates against GhIssueSummary."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "1", "--json", "number,state"],
+        stdout=json.dumps({"number": 1, "state": "OPEN"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_ignores_extra_fields(tmp_path: Path) -> None:
+    """GhIssueListItem uses extra='ignore' so unexpected extra fields don't drift."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number,title,state"],
+        stdout=json.dumps([{"number": 1, "title": "t", "state": "OPEN"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 2: --jq transforms ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_jq_transform_skipped(tmp_path: Path) -> None:
+    """``gh pr list --json number --jq length`` produces non-JSON; skip."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number", "--jq", "length"],
+        stdout="5\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_jq_transform_on_issue_list_skipped(tmp_path: Path) -> None:
+    """``gh issue list --json number --jq '.[].number'`` produces scalar output."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "number", "--jq", ".[].number"],
+        stdout="1\n2\n3\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 3: comments-only and narrow views ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_issue_view_comments_only_skipped(tmp_path: Path) -> None:
+    """``gh issue view N --json comments`` has no fields matching any shape."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "1", "--json", "comments"],
+        stdout=json.dumps({"comments": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 4: projection-only PR calls ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pr_view_commits_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json commits`` omits all required summary/detail fields."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "1", "--json", "commits"],
+        stdout=json.dumps({"commits": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_reviews_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json reviews`` omits all required fields."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "1", "--json", "reviews"],
+        stdout=json.dumps({"reviews": []}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_head_ref_oid_only_skipped(tmp_path: Path) -> None:
+    """``gh pr view N --json headRefOid`` is a detail signal but omits ``number``."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "1", "--json", "headRefOid"],
+        stdout=json.dumps({"headRefOid": "abc123"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_partial_fields_skipped(tmp_path: Path) -> None:
+    """``gh pr list --json number,labels,body,commits`` omits title and state."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,labels,body,commits"],
+        stdout=json.dumps([{"number": 1, "labels": [], "body": "", "commits": []}])
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 5: projection-only issue calls ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_issue_view_state_reason_only_skipped(tmp_path: Path) -> None:
+    """``gh issue view N --json state,stateReason`` omits ``number``."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "1", "--json", "state,stateReason"],
+        stdout=json.dumps({"state": "CLOSED", "stateReason": "completed"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 6: narrow pr-checks and issue-list ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_conclusion_only_skipped(tmp_path: Path) -> None:
+    """``gh pr checks --json conclusion`` omits ``name`` required by GhCheckRun."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "conclusion"],
+        stdout=json.dumps([{"conclusion": "SUCCESS"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_state_only_skipped(tmp_path: Path) -> None:
+    """``gh pr checks --json state`` omits ``name``."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "state"],
+        stdout=json.dumps([{"state": "COMPLETED"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_date_only_skipped(tmp_path: Path) -> None:
+    """``gh issue list --json createdAt,closedAt`` omits number+title."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "createdAt,closedAt"],
+        stdout=json.dumps([{"createdAt": "2026-06-01T00:00:00Z", "closedAt": None}])
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+# ── Pattern 7: terminal check-run states ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_success_state_validates(tmp_path: Path) -> None:
+    """``gh pr checks --json name,state`` returning ``state=SUCCESS`` must pass."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "name,state"],
+        stdout=json.dumps([{"name": "ci/test", "state": "SUCCESS"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_failure_state_validates(tmp_path: Path) -> None:
+    """``state=FAILURE`` is a terminal value that must be accepted."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "name,state"],
+        stdout=json.dumps([{"name": "ci/lint", "state": "FAILURE"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_skipped_state_validates(tmp_path: Path) -> None:
+    """``state=SKIPPED`` is a terminal value that must be accepted."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "name,state"],
+        stdout=json.dumps([{"name": "ci/deploy", "state": "SKIPPED"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_cancelled_state_validates(tmp_path: Path) -> None:
+    """``state=CANCELLED`` is a terminal value that must be accepted."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "name,state"],
+        stdout=json.dumps([{"name": "ci/build", "state": "CANCELLED"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_checks_unknown_state_fails(tmp_path: Path) -> None:
+    """An unrecognised check state still triggers drift detection."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "checks", "1", "--json", "name,state"],
+        stdout=json.dumps([{"name": "ci/test", "state": "BRAND_NEW_STATE"}]) + "\n",
+    )
+    result = await gh_shape_validator(sample)
+    assert result is not None
+    assert result["shape_validation_failed"] is True
+
+
+# ── Pattern 8: escalation dedup ──────────────────────────────────────────────
+
+
+def test_escalation_dedup_key_stable() -> None:
+    """Same signature list always produces same escalation key."""
+    sigs = ["abc123", "def456"]
+    assert _escalation_dedup_key(sigs) == _escalation_dedup_key(sigs)
+
+
+def test_escalation_dedup_key_order_independent() -> None:
+    """Key is independent of signature list order."""
+    assert _escalation_dedup_key(["a", "b"]) == _escalation_dedup_key(["b", "a"])
+
+
+def test_escalation_dedup_key_prefixed() -> None:
+    """Escalation key starts with 'esc:' to distinguish from drift keys."""
+    key = _escalation_dedup_key(["sig1"])
+    assert key.startswith("esc:")
+
+
+def test_escalation_dedup_key_differs_from_fleet_key() -> None:
+    """Escalation key must differ from fleet drift dedup key for same sigs."""
+    from pathlib import Path as P
+
+    sigs = ["abc123fullhex"]
+    esc_key = _escalation_dedup_key(sigs)
+    fleet_key = _fleet_dedup_key([(P("x.yaml"), s) for s in sigs])
+    assert esc_key != fleet_key
+
+
+def test_escalation_dedup_key_persists_in_store(tmp_path: Path) -> None:
+    """Escalation dedup key written to DedupStore survives a get() round-trip."""
+    from dedup_store import DedupStore
+
+    dedup = DedupStore("live_corpus_replay", tmp_path / "dedup.json")
+    sigs = ["deadbeef" * 8]
+    esc_key = _escalation_dedup_key(sigs)
+
+    seen = dedup.get()
+    seen.add(esc_key)
+    dedup.set_all(seen)
+
+    assert esc_key in dedup.get()


### PR DESCRIPTION
## Summary

- **Root cause**: Seven false-positive patterns in `gh_shape_validator` caused 13 drift signatures to survive `LiveCorpusReplayLoop`'s 3-tick retry budget and escalate to #9320
- **Fix**: Adds required-field guards, `--jq` skip, split `issue-view`/`issue-list` routing, expanded `_GhCheckState` with terminal values, and escalation dedup guard in the loop
- **Tests**: 24 regression tests in `tests/regressions/regression_issue_9320.py` covering all 8 fix patterns; 60 total tests pass including all prior related tests

## Changes

**`src/contracts/shapes.py`**: Expand `_GhCheckState` to include terminal conclusion values (`SUCCESS`, `FAILURE`, `NEUTRAL`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, `STALE`, `SKIPPED`, `STARTUP_FAILURE`) that `gh pr checks --json state` returns for finished check runs.

**`src/contracts/shape_dispatchers.py`**:
- Skip validation when `--jq` is in args (produces scalar/non-JSON output)
- Split `issue-view` → `_pick_shape_for_issue` and `issue-list` → `_pick_shape_for_issue_list` (list calls omit `state`)
- Guard `_pick_shape_for_pr` on required fields (`number` for detail, `number+title+state` for summary)
- Guard `_pick_shape_for_issue` on `number+state` before selecting `GhIssueSummary`
- Guard `_pick_shape_for_issue_list` on `number+title` before selecting `GhIssueListItem`
- Guard `_pick_shape_for_checks` on `name` before selecting `GhCheckRun`

**`src/live_corpus_replay_loop.py`**: Add `_escalation_dedup_key` + DedupStore guard so the escalation issue fires once per drift run (not every tick), with `esc:`-prefixed keys cleared on clean ticks for re-escalation.

## Test plan

- [x] 24 regression tests in `tests/regressions/regression_issue_9320.py` — one per false-positive pattern + dedup key properties
- [x] 10 existing `tests/test_live_corpus_replay_loop.py` tests pass
- [x] 10 existing `tests/test_shape_dispatchers.py` tests pass
- [x] 16 existing `tests/test_contracts_shapes.py` tests pass
- [x] Lint, typecheck, security: all clean
- [x] Pre-push `make quality-lite` passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)