### PR TITLE
fix(contracts): stop gh_shape_validator false-positives on field-subset PR/issue calls (closes #9321)

### DIFF
--- a/src/contracts/shape_dispatchers.py
+++ b/src/contracts/shape_dispatchers.py
@@ -54,7 +54,14 @@ logger = logging.getLogger("hydraflow.contracts.shape_dispatchers")
 
 def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
     """``gh pr ...`` shape selection. Detect summary vs detail by which
-    detail-only fields are requested in ``--json FIELDS``."""
+    detail-only fields are requested in ``--json FIELDS``.
+
+    ``GhPRSummary`` requires ``state`` — only apply it when the call
+    explicitly requests that field.  PR calls that request fields outside
+    both shapes (e.g. ``--json commits``, ``--json reviews``,
+    ``--json title,body``) return ``None`` so the dispatcher skips them
+    rather than producing false-positive drift signals.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
@@ -67,23 +74,26 @@ def _pick_shape_for_pr(args: list[str]) -> type[BaseModel] | None:
     }
     if fields & detail_signals:
         return GhPRDetail
-    return GhPRSummary
+    if "state" in fields:
+        return GhPRSummary
+    return None
 
 
 def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
     """Issue shape selection based on which fields are requested.
 
-    ``GhIssueSummary`` requires ``state`` — only use it when the call
-    actually requests that field.  Narrow list calls (``number,title,...``
-    without ``state``) use ``GhIssueListItem`` instead.  Calls that
-    request fields outside both shapes (e.g. ``--json comments``) get
-    ``None`` so the dispatcher skips them rather than producing a
-    false-positive drift signal.
+    ``GhIssueSummary`` requires both ``state`` and ``number`` — only use
+    it when the call requests both fields.  Narrow list calls
+    (``number,title,...`` without ``state``) use ``GhIssueListItem``
+    instead.  Calls that request only ``state,stateReason`` (without
+    ``number``) or other fields outside both shapes return ``None`` so
+    the dispatcher skips them rather than producing false-positive drift
+    signals.
     """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
-    if "state" in fields:
+    if "state" in fields and "number" in fields:
         return GhIssueSummary
     if "number" in fields and "title" in fields:
         return GhIssueListItem
@@ -91,10 +101,20 @@ def _pick_shape_for_issue(args: list[str]) -> type[BaseModel] | None:
 
 
 def _pick_shape_for_issue_list(args: list[str]) -> type[BaseModel] | None:
+    """``gh issue list`` shape selection.
+
+    ``GhIssueListItem`` requires both ``number`` and ``title`` — only
+    apply it when the call requests both fields.  Calls requesting only
+    ``--json title`` (e.g. for dedup lookups) return ``None`` so the
+    dispatcher skips them rather than failing validation on the missing
+    ``number``.
+    """
     fields = _extract_json_fields(args)
     if fields is None:
         return None
-    return GhIssueListItem
+    if "number" in fields and "title" in fields:
+        return GhIssueListItem
+    return None
 
 
 def _pick_shape_for_checks(args: list[str]) -> type[BaseModel] | None:

--- a/tests/test_shape_dispatchers.py
+++ b/tests/test_shape_dispatchers.py
@@ -202,3 +202,102 @@ async def test_unknown_subcommand_skipped(tmp_path: Path) -> None:
         stdout='{"data": {}}\n',
     )
     assert await gh_shape_validator(sample) is None
+
+
+# --- Regression tests for false-positive drift signatures (issue #9321) ---
+# These calls produce output whose fields don't match GhPRSummary/GhIssueSummary
+# required fields — the dispatcher must return None (no opinion) rather than
+# applying the wrong shape and generating spurious drift.
+
+
+@pytest.mark.asyncio
+async def test_pr_view_commits_only_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json commits: no state/detail signals → no opinion."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "commits"],
+        stdout=json.dumps({"commits": [{"oid": "abc123", "messageHeadline": "fix: x"}]})
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_reviews_only_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json reviews: no state/detail signals → no opinion."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "reviews"],
+        stdout=json.dumps(
+            {"reviews": [{"state": "APPROVED", "author": {"login": "alice"}}]}
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_view_title_body_skipped(tmp_path: Path) -> None:
+    """gh pr view N --json title,body: missing state → no opinion (GhPRSummary requires state)."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "view", "42", "--json", "title,body"],
+        stdout=json.dumps({"title": "fix: bug", "body": "closes #41"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_pr_list_number_labels_body_skipped(tmp_path: Path) -> None:
+    """gh pr list --json number,labels,body: missing state → no opinion."""
+    sample = _sample(
+        tmp_path,
+        args=["pr", "list", "--json", "number,labels,body"],
+        stdout=json.dumps(
+            [{"number": 1, "labels": [{"name": "bug"}], "body": "fixes #1"}]
+        )
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_state_reason_only_skipped(tmp_path: Path) -> None:
+    """gh issue view N --json state,stateReason: missing number → no opinion.
+
+    GhIssueSummary requires number; calls omitting it must be skipped to
+    avoid false-positive drift (stuck signature in issue #9321).
+    """
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "7", "--json", "state,stateReason"],
+        stdout=json.dumps({"state": "CLOSED", "stateReason": "completed"}) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_list_title_only_skipped(tmp_path: Path) -> None:
+    """gh issue list --json title: missing number → no opinion.
+
+    GhIssueListItem requires number; calls omitting it must be skipped to
+    avoid false-positive drift (pattern from rc_budget_loop dedup checks).
+    """
+    sample = _sample(
+        tmp_path,
+        args=["issue", "list", "--json", "title"],
+        stdout=json.dumps([{"title": "fix: stuck drift"}]) + "\n",
+    )
+    assert await gh_shape_validator(sample) is None
+
+
+@pytest.mark.asyncio
+async def test_issue_view_with_number_and_state_validates(tmp_path: Path) -> None:
+    """gh issue view N --json number,state,stateReason: both required fields → GhIssueSummary used."""
+    sample = _sample(
+        tmp_path,
+        args=["issue", "view", "7", "--json", "number,state,stateReason"],
+        stdout=json.dumps({"number": 7, "state": "CLOSED", "stateReason": "completed"})
+        + "\n",
+    )
+    assert await gh_shape_validator(sample) is None


### PR DESCRIPTION
## Summary

- `_pick_shape_for_pr`: now returns `None` (no opinion) for calls requesting `commits`, `reviews`, `title,body`, or other field sets that lack `state` — the required discriminator for `GhPRSummary`. Previously applied `GhPRSummary` to all non-detail-signal calls, generating spurious drift signatures for any `gh pr view` call whose output didn't include `number`/`title`/`state`.
- `_pick_shape_for_issue`: now requires both `state` AND `number` before routing to `GhIssueSummary`. Previously, `gh issue view N --json state,stateReason` (missing `number`) triggered false-positive validation failures.
- `_pick_shape_for_issue_list`: now requires both `number` AND `title`. Previously, `gh issue list --json title` (missing `number`) produced spurious failures.

This fixes the 10 stuck drift signatures from escalation issue #9321.

## Root cause

`GhPRSummary` requires `number`, `title`, and `state`, but `_pick_shape_for_pr` applied it to any `gh pr` call without detail-signal fields — including calls like `gh pr view N --json commits` or `gh pr view N --json reviews` whose outputs only contain `commits`/`reviews`. Each distinct sample in the shadow corpus produced its own unique drift signature (hash includes `args` and actual output), so multiple PRs × multiple call patterns accumulated to the 10 stuck signatures.

## Test plan

- [x] 7 new regression tests in `tests/test_shape_dispatchers.py` covering each false-positive call pattern
- [x] Existing 12 tests in the file remain passing
- [x] `tests/test_live_corpus_replay_loop.py` (12 tests) — no regressions
- [x] `tests/test_contracts_shapes.py` (16 tests) — no regressions
- [x] `make quality-lite` — lint, typecheck, security all pass
- [x] Pre-commit hooks (lint, arch-check) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)