### PR TITLE
fix(merge): auto-merge Auto-Agent PRs (agent/auto-agent-N) to end the contract-fix runaway

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-05T06:27:04.818531+00:00",
-  "commit_sha": "74932f6d4d213edef079e0db21132b4fd3280da9",
+  "regenerated_at": "2026-06-05T21:04:38.326404+00:00",
+  "commit_sha": "ec009139d24731311882a32fb3fba2ac48376542",
   "artifacts": {
     "loops.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "ports.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "labels.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "modules.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "events.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "adr_xref.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "mockworld.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "changelog.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "coverage_matrix.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "functional_areas.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "ubiquitous-language.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "74932f6d4d213edef079e0db21132b4fd3280da9"
+      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
-- `74932f6` — chore(arch): re-stamp generated artifacts for #9314 fix *(2026-06-05)*
-- `2b4b46c` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) *(2026-06-05)*
+- `ec00913` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) (#9316) (#9316) *(2026-06-05)*
 - `7316aba` — fix(wiki): repair malformed topic entries + guard against silent data loss (#9281) (#9281) *(2026-06-04)*
 - `e91dd05` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn (closes #9176) (#9256) (#9256) *(2026-06-04)*
 - `e451fa3` — fix(adr): update ADR-0009 citations to current symbols (closes #9173) (#9255) (#9255) *(2026-06-04)*
@@ -432,7 +431,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `7ade583` — Fixes #2267: Add ADR-0023 for multi-repo architecture wiring pattern (#2296) (#2296) *(2026-03-08)*
 - `4c09083` — Fixes #2264: [ADR] Draft decision from memory #2258: Implementation... (#2292) (#2292) *(2026-03-08)*
 - `c4b8ecd` — Fixes #2374: Add ADR-0023 for supersession regex verb form coverage (#2379) (#2379) *(2026-03-08)*
-- `7c6410a` — Fixes #2210: sync ADR index statuses (#2233) (#2233) *(2026-03-07)*
 
 
 <!-- arch:generated -->

--- a/src/dependabot_merge_loop.py
+++ b/src/dependabot_merge_loop.py
@@ -16,9 +16,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.dependabot_merge_loop")
 
+# Factory-owned branch prefix for Auto-Agent (preflight) PRs. These are opened
+# by the auto-agent subprocess under the ambient gh token (the owner account),
+# so they are NOT in ``settings.authors`` and the review→merge pipeline ignores
+# them (it keys on ``hydraflow-review`` + ``agent/issue-N``). Without this they
+# never land — they only get rebased by MergeStateWatcher — and pile up. The
+# prefix is exact and never used by a human or by the normal pipeline
+# (``agent/issue-N``), so matching on it is safe.
+_AUTO_AGENT_BRANCH_PREFIX = "agent/auto-agent-"
+
 
 class DependabotMergeLoop(BaseBackgroundLoop):
-    """Polls open PRs and auto-merges those authored by Dependabot and other configured bots."""
+    """Polls open PRs and auto-merges configured bot PRs + Auto-Agent PRs after CI passes."""
 
     def __init__(
         self,
@@ -54,7 +63,11 @@ class DependabotMergeLoop(BaseBackgroundLoop):
         bot_prs = [
             pr
             for pr in open_prs
-            if pr.author.lower() in bot_authors and pr.pr not in processed
+            if pr.pr not in processed
+            and (
+                pr.author.lower() in bot_authors
+                or pr.branch.startswith(_AUTO_AGENT_BRANCH_PREFIX)
+            )
         ]
 
         merged = 0

--- a/tests/sandbox_scenarios/scenarios/s09b_auto_agent_auto_merge.py
+++ b/tests/sandbox_scenarios/scenarios/s09b_auto_agent_auto_merge.py
@@ -1,0 +1,56 @@
+"""s09b — Auto-Agent PR (agent/auto-agent-N, owner-authored) + green CI → auto-merged.
+
+Auto-Agent preflight PRs ride the ``agent/auto-agent-<N>`` branch and are opened
+by the auto-agent subprocess under the ambient owner token — so they are NOT a
+configured bot author and the review->merge pipeline (keyed on hydraflow-review
++ agent/issue-N) never lands them. DependabotMergeLoop must merge them by branch
+prefix, otherwise they pile up green-but-unmerged.
+"""
+
+from __future__ import annotations
+
+from mockworld.seed import MockWorldSeed
+
+NAME = "s09b_auto_agent_auto_merge"
+DESCRIPTION = (
+    "Auto-Agent PR (agent/auto-agent-N, owner author) + green CI → "
+    "DependabotMergeLoop merges by branch prefix without human."
+)
+
+
+def seed() -> MockWorldSeed:
+    return MockWorldSeed(
+        prs=[
+            {
+                "number": 110,
+                "issue_number": 0,
+                "branch": "agent/auto-agent-9291",
+                "ci_status": "pass",
+                "merged": False,
+                # No workflow label, and the author is the owner token (NOT a
+                # configured bot) — this is exactly the PR shape that fell
+                # through every merge path before the branch-prefix fix.
+                "labels": [],
+                "author": "T-rav",
+            }
+        ],
+        # github_cache must run too: DependabotMergeLoop reads the label-agnostic
+        # all-open-PRs snapshot warmed by the github_cache loop.
+        loops_enabled=["dependabot_merge", "github_cache"],
+        cycles_to_run=3,
+    )
+
+
+async def assert_outcome(api, page) -> None:
+    # The merge is observable via the dependabot_merge worker-status event whose
+    # details carry the merged count (DependabotMergeLoop._do_work -> {"merged": N}).
+    await api.wait_until(
+        "/api/events",
+        lambda p: any(
+            e.get("type") == "background_worker_status"
+            and e.get("data", {}).get("worker") == "dependabot_merge"
+            and e.get("data", {}).get("details", {}).get("merged", 0) >= 1
+            for e in (p if isinstance(p, list) else [])
+        ),
+        timeout=120.0,
+    )

--- a/tests/scenarios/test_loops.py
+++ b/tests/scenarios/test_loops.py
@@ -324,3 +324,66 @@ class TestL8DependabotMergeSkipsOnFailure:
         assert stats["dependabot_merge"]["merged"] == 0
         # PR should NOT be merged
         assert world.github.pr(600).merged is False
+
+
+# ---------------------------------------------------------------------------
+# L7b: Dependabot Merge also lands Auto-Agent PRs (agent/auto-agent-N)
+# ---------------------------------------------------------------------------
+
+
+class TestL7bAutoAgentPrMerges:
+    """L7b: Auto-Agent preflight PRs ride agent/auto-agent-N and are authored by
+    the ambient owner token (not a bot author), so the review->merge pipeline
+    never lands them. DependabotMergeLoop merges them by branch prefix; normal
+    pipeline PRs (agent/issue-N) are left to the review loop."""
+
+    async def test_auto_agent_pr_merged_on_ci_pass(self, tmp_path):
+        world = MockWorld(tmp_path)
+
+        from mockworld.fakes.fake_github import FakePR
+        from models import PRListItem
+
+        agent_pr = PRListItem(
+            pr=700,
+            title="fix(contracts): expand GhCheckRun states",
+            author="T-rav",  # owner token — NOT a configured bot author
+            branch="agent/auto-agent-700",
+        )
+        world.github._prs[700] = FakePR(
+            number=700, issue_number=0, branch="agent/auto-agent-700"
+        )
+
+        await world.run_with_loops(["dependabot_merge"], cycles=1)
+        world._dependabot_cache.get_open_prs.return_value = [agent_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [agent_pr]
+
+        stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
+
+        assert stats["dependabot_merge"]["merged"] == 1
+        assert world.github.pr(700).merged is True
+
+    async def test_normal_pipeline_pr_not_merged(self, tmp_path):
+        """agent/issue-N PRs belong to the review->merge pipeline, not this loop."""
+        world = MockWorld(tmp_path)
+
+        from mockworld.fakes.fake_github import FakePR
+        from models import PRListItem
+
+        pipeline_pr = PRListItem(
+            pr=701,
+            title="feat: pipeline change",
+            author="T-rav",
+            branch="agent/issue-701",
+        )
+        world.github._prs[701] = FakePR(
+            number=701, issue_number=701, branch="agent/issue-701"
+        )
+
+        await world.run_with_loops(["dependabot_merge"], cycles=1)
+        world._dependabot_cache.get_open_prs.return_value = [pipeline_pr]
+        world._dependabot_cache.get_all_open_prs.return_value = [pipeline_pr]
+
+        stats = await world.run_with_loops(["dependabot_merge"], cycles=1)
+
+        assert stats["dependabot_merge"]["merged"] == 0
+        assert world.github.pr(701).merged is False

--- a/tests/test_dependabot_merge_loop.py
+++ b/tests/test_dependabot_merge_loop.py
@@ -18,13 +18,17 @@ from tests.helpers import make_bg_loop_deps
 
 
 def _make_pr(
-    pr: int, author: str = "dependabot[bot]", title: str = "Bump foo"
+    pr: int,
+    author: str = "dependabot[bot]",
+    title: str = "Bump foo",
+    branch: str = "",
 ) -> PRListItem:
     """Build a minimal PRListItem for testing."""
     return PRListItem(
         pr=pr,
         author=author,
         title=title,
+        branch=branch,
         url=f"https://github.com/o/r/pull/{pr}",
     )
 
@@ -306,3 +310,70 @@ class TestDependabotMergeLoopRun:
         await loop.run()
 
         loop._status_cb.assert_not_called()
+
+
+class TestDependabotMergeLoopAutoAgentBranch:
+    """Auto-Agent preflight PRs ride the factory-owned ``agent/auto-agent-N``
+    branch and are authored by the ambient owner token (not a bot author), so
+    the review->merge pipeline (keyed on hydraflow-review + agent/issue-N) never
+    lands them. The loop merges them by branch prefix so they don't pile up.
+    """
+
+    @pytest.mark.asyncio
+    async def test_merges_auto_agent_pr_despite_non_bot_author(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="agent/auto-agent-42")],
+            ci_result=(True, "All checks passed"),
+        )
+
+        result = await loop._do_work()
+
+        assert result["merged"] == 1
+        prs.merge_pr.assert_awaited_once_with(42, auto_rebase=True)
+        state.add_dependabot_merge_processed.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_does_not_merge_normal_pipeline_branch(self, tmp_path: Path) -> None:
+        """agent/issue-N PRs belong to the review->merge pipeline, not this loop."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="agent/issue-42")],
+        )
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_does_not_merge_arbitrary_owner_branch(self, tmp_path: Path) -> None:
+        """A hand-authored owner PR on an arbitrary branch must not auto-merge."""
+        loop, _, _, prs, _ = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="fix/manual-thing")],
+        )
+
+        result = await loop._do_work()
+
+        assert result == {"merged": 0, "skipped": 0, "failed": 0}
+        prs.wait_for_ci.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_auto_agent_pr_failing_ci_respects_failure_strategy(
+        self, tmp_path: Path
+    ) -> None:
+        loop, _, _, prs, state = _make_loop(
+            tmp_path,
+            open_prs=[_make_pr(42, author="T-rav", branch="agent/auto-agent-42")],
+            ci_result=(False, "2/5 checks failed: lint, test"),
+            failure_strategy="skip",
+        )
+
+        result = await loop._do_work()
+
+        assert result["skipped"] == 1
+        prs.merge_pr.assert_not_awaited()
+        state.add_dependabot_merge_processed.assert_not_called()


### PR DESCRIPTION
## Problem (root cause of the `fix(contracts)` PR runaway)

Auto-Agent preflight PRs ride branch **`agent/auto-agent-<N>`** (`auto_agent_preflight_loop.py:280`); the subprocess runs `gh pr create` under the **ambient owner token**, so they're authored by **`T-rav`** — not a configured bot. They have **no merge path**:
- the review→merge pipeline keys on `hydraflow-review` + `agent/issue-N` (`issue_fetcher.py`), and
- `DependabotMergeLoop` only merged PRs whose author is in `settings.authors` (`dependabot_merge_loop.py`).

So these PRs piled up **green-but-unmerged**; newer ones went **CONFLICTING** as they overlapped `contracts/shape_dispatchers.py` + `shapes.py` → an **unbounded runaway** (the contract drift never landed, so the auto-agent kept regenerating fixes). Observed live: 5–7 stuck `fix(contracts)` PRs accumulating over hours.

## Fix

Extend `DependabotMergeLoop`'s filter to also accept the factory-owned **`agent/auto-agent-`** branch prefix, regardless of author. Everything downstream already works (`wait_for_ci` → approve → `merge_pr(auto_rebase=True)`, squash + delete-branch), and `MergeStateWatcher` already rebases conflicting agent PRs source-agnostically. Lowest blast radius vs. provisioning a bot credential, adding the owner account to `settings.authors` (would auto-merge **all** human PRs), or routing through the LLM review pipeline.

## Tests (full pyramid)

- **Unit** (`tests/test_dependabot_merge_loop.py`): +4 — merges an `agent/auto-agent-N`/owner-authored PR; **negative guards** that `agent/issue-N` (normal pipeline) and arbitrary owner branches are **not** auto-merged; failing-CI respects `failure_strategy`.
- **MockWorld scenario** (`tests/scenarios/test_loops.py` L7b): positive merge + `agent/issue-N` negative.
- **Sandbox e2e** (`s09b_auto_agent_auto_merge.py`): companion to s09.

`make quality` + `make scenario-loops` green locally.

> Note: this fixes the *recurrence*. The 5 already-CONFLICTING contract PRs (#9295/#9300/#9319/#9324/#9326) have real content conflicts `gh pr update-branch` can't auto-resolve; they'll be superseded by fresh auto-agent PRs (which now auto-merge) or need manual resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)