### PR TITLE
fix(control): factory Stop halts every line; host repo uses full lifecycle

### DIFF
--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -472,11 +472,25 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     @router.post("/api/control/stop")
     async def stop_orchestrator() -> JSONResponse:
-        """Request a graceful stop of the running orchestrator."""
+        """Stop the entire factory — the host orchestrator and every line.
+
+        The factory-level Stop halts the host orchestrator *and* every
+        registered repo runtime (``registry.stop_all``), so no factory line
+        keeps running after a factory stop. Stopping a single line is handled
+        by ``POST /api/runtimes/{slug}/stop``.
+        """
         orch = ctx.get_orchestrator()
-        if not orch or not orch.running:
+        registry = ctx.registry
+        host_running = bool(orch and orch.running)
+        registry_running = bool(
+            registry is not None and any(rt.running for rt in registry.all)
+        )
+        if not host_running and not registry_running:
             return JSONResponse({"error": "not running"}, status_code=400)
-        await orch.request_stop()
+        if orch is not None and orch.running:
+            await orch.request_stop()
+        if registry is not None:
+            await registry.stop_all()
         return JSONResponse({"status": "stopping"})
 
     @router.post("/api/control/clear-credit-pause")

--- a/src/dashboard_routes/_state_routes.py
+++ b/src/dashboard_routes/_state_routes.py
@@ -157,15 +157,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         return JSONResponse(info.model_dump())
 
     @router.post("/api/runtimes/{slug}/start")
-    async def start_runtime(slug: str) -> JSONResponse:
+    async def start_runtime(slug: str) -> JSONResponse:  # noqa: PLR0911
         """Start a specific repo runtime."""
         if _is_default_repo(slug):
             orch = get_orchestrator()
-            if not orch or not orch.running:
-                return JSONResponse(
-                    {"error": "Orchestrator not running"}, status_code=400
-                )
+            if orch is None:
+                return JSONResponse({"error": "No orchestrator"}, status_code=400)
+            if orch.running:
+                return JSONResponse({"error": "Already running"}, status_code=409)
+            # Full restart. A prior Stop fully halts the host orchestrator
+            # (cancels every loop, including background workers), so the run
+            # task has exited — toggling pipeline_enabled alone would not
+            # revive the cancelled tasks. reset() clears mutable state per its
+            # contract; run() recreates all loops. Uniform with rt.start().
+            orch.reset()
             orch.pipeline_enabled = True
+            ctx.set_run_task(asyncio.create_task(orch.run()))
             return JSONResponse({"status": "started", "slug": slug})
 
         if registry is None:
@@ -187,7 +194,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             orch = get_orchestrator()
             if not orch or not orch.running:
                 return JSONResponse({"error": "Not running"}, status_code=400)
-            orch.pipeline_enabled = False
+            # Full stop: halt every loop (pipeline + background workers), not
+            # just pause the pipeline. Uniform with every other factory line,
+            # whose stop routes through rt.stop() -> orchestrator.stop().
+            await orch.request_stop()
             return JSONResponse({"status": "stopped", "slug": slug})
 
         if registry is None:

--- a/src/ui/src/components/SessionSidebar.jsx
+++ b/src/ui/src/components/SessionSidebar.jsx
@@ -60,7 +60,7 @@ export function SessionSidebar() {
     sessions,
     selectedRepoSlug,
     stageStatus,
-    orchestratorStatus,
+    connected,
     selectRepo,
     supervisedRepos = [],
     runtimes = [],
@@ -159,8 +159,11 @@ export function SessionSidebar() {
           const rt = entry.runtime
           const isRunning = rt?.running ?? entry.info?.running ?? false
           const lastError = rt?.last_error || null
-          const orchRunning = orchestratorStatus === 'running'
-          const disabled = !orchRunning && !isRunning
+          // Each factory line is an independent runtime: its Start/Stop is
+          // gated only on server connectivity, not on the host orchestrator
+          // running. The host repo is just another line — stopping it must
+          // not disable the control needed to start it again.
+          const disabled = !connected
           const slug = entry.repoSlug || entry.displayName
 
           return (
@@ -188,7 +191,7 @@ export function SessionSidebar() {
                       disabled={disabled}
                       style={isRunning ? styles.runtimeStopBtn : disabled ? styles.runtimeDisabledBtn : styles.runtimeStartBtn}
                       aria-label={isRunning ? 'Stop repo' : 'Start repo'}
-                      title={disabled ? 'Start the orchestrator first' : isRunning ? 'Stop processing' : 'Start processing'}
+                      title={disabled ? 'Disconnected from server' : isRunning ? 'Stop processing' : 'Start processing'}
                     >
                       {isRunning ? '■' : '▶'}
                     </button>

--- a/src/ui/src/components/__tests__/SessionSidebar.test.jsx
+++ b/src/ui/src/components/__tests__/SessionSidebar.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 
 const mockContext = {
   sessions: [],
@@ -7,6 +7,7 @@ const mockContext = {
   selectedRepoSlug: null,
   stageStatus: null,
   orchestratorStatus: 'stopped',
+  connected: true,
   selectRepo: vi.fn(),
   supervisedRepos: [],
   runtimes: [],
@@ -29,10 +30,35 @@ describe('SessionSidebar last-run summary', () => {
     mockContext.supervisedRepos = []
     mockContext.runtimes = []
     mockContext.orchestratorStatus = 'stopped'
+    mockContext.connected = true
     mockContext.stageStatus = null
     mockContext.currentSessionId = null
+    mockContext.startRuntime = vi.fn()
+    mockContext.stopRuntime = vi.fn()
   })
   afterEach(() => { vi.useRealTimers() })
+
+  it('starts a stopped factory line even when the host orchestrator is down', () => {
+    mockContext.orchestratorStatus = 'idle'
+    mockContext.supervisedRepos = [{ slug: 'owner/host', path: '/p/host', running: false }]
+    mockContext.runtimes = [{ slug: 'owner/host', running: false }]
+    render(<SessionSidebar />)
+    const startBtn = screen.getByLabelText('Start repo')
+    expect(startBtn).not.toBeDisabled()
+    fireEvent.click(startBtn)
+    expect(mockContext.startRuntime).toHaveBeenCalledWith('owner/host')
+  })
+
+  it('disables a line\'s control when disconnected from the server', () => {
+    mockContext.connected = false
+    mockContext.supervisedRepos = [{ slug: 'owner/host', path: '/p/host', running: false }]
+    mockContext.runtimes = [{ slug: 'owner/host', running: false }]
+    render(<SessionSidebar />)
+    const startBtn = screen.getByLabelText('Start repo')
+    expect(startBtn).toBeDisabled()
+    fireEvent.click(startBtn)
+    expect(mockContext.startRuntime).not.toHaveBeenCalled()
+  })
 
   it('shows "never run" for a repo with no sessions', () => {
     mockContext.supervisedRepos = [{ slug: 'owner/alpha', path: '/p/alpha', running: false }]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1483,6 +1483,8 @@ def make_dashboard_router(
     default_repo_slug=None,
     allowed_repo_roots_fn=None,
     credentials=None,
+    set_orchestrator=None,
+    set_run_task=None,
 ):
     """Create a dashboard router with test-friendly defaults.
 
@@ -1508,6 +1510,10 @@ def make_dashboard_router(
         Optional callable returning allowed filesystem roots.
     credentials:
         Optional ``Credentials`` instance for route context.
+    set_orchestrator / set_run_task:
+        Optional callbacks wired into the route context so tests can spy on
+        orchestrator replacement and run-task scheduling (e.g. verifying the
+        host repo's Start restarts the orchestrator).
     """
     from dashboard_routes import create_router
     from pr_manager import PRManager
@@ -1519,8 +1525,8 @@ def make_dashboard_router(
         state=state,
         pr_manager=pr_mgr,
         get_orchestrator=get_orch or (lambda: None),
-        set_orchestrator=lambda o: None,
-        set_run_task=lambda t: None,
+        set_orchestrator=set_orchestrator or (lambda o: None),
+        set_run_task=set_run_task or (lambda t: None),
         ui_dist_dir=ui_dist_dir or (tmp_path / "no-dist"),
         template_dir=template_dir or (tmp_path / "no-templates"),
         credentials=credentials,

--- a/tests/test_dashboard_routes_core.py
+++ b/tests/test_dashboard_routes_core.py
@@ -567,6 +567,55 @@ class TestStopOrchestratorEndpoint:
         assert data["status"] == "stopping"
         mock_orch.request_stop.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_factory_stop_halts_host_and_all_registered_lines(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        import json
+
+        mock_orch = MagicMock()
+        mock_orch.running = True
+        mock_orch.request_stop = AsyncMock()
+        mock_registry = MagicMock()
+        mock_registry.all = []
+        mock_registry.stop_all = AsyncMock()
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            get_orch=lambda: mock_orch,
+            registry=mock_registry,
+        )
+        endpoint = find_endpoint(router, "/api/control/stop")
+        response = await endpoint()
+        data = json.loads(response.body)
+        assert data["status"] == "stopping"
+        mock_orch.request_stop.assert_awaited_once()
+        mock_registry.stop_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_factory_stop_halts_registered_lines_when_host_idle(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        running_line = MagicMock()
+        running_line.running = True
+        mock_registry = MagicMock()
+        mock_registry.all = [running_line]
+        mock_registry.stop_all = AsyncMock()
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            get_orch=lambda: None,
+            registry=mock_registry,
+        )
+        endpoint = find_endpoint(router, "/api/control/stop")
+        response = await endpoint()
+        assert response.status_code == 200
+        mock_registry.stop_all.assert_awaited_once()
+
 
 # ---------------------------------------------------------------------------
 # SPA endpoints: / and /{path:path}

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -1864,3 +1864,78 @@ class TestRuntimeEndpointsWithRegistry:
 # ---------------------------------------------------------------------------
 # GET /api/retrospectives — edge cases
 # ---------------------------------------------------------------------------
+
+
+class TestDefaultRepoRuntimeFullLifecycle:
+    """Host (default) repo factory line uses the full orchestrator lifecycle.
+
+    The legacy pipeline-toggle behavior is gone: the host line's Stop fully
+    halts the orchestrator (every loop, including background workers) and its
+    Start restarts it — identical to every other factory line.
+    """
+
+    @pytest.mark.asyncio
+    async def test_stop_host_repo_fully_halts_orchestrator(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        mock_orch = MagicMock()
+        mock_orch.running = True
+        mock_orch.request_stop = AsyncMock()
+
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+        endpoint = find_endpoint(router, "/api/runtimes/{slug}/stop")
+
+        resp = await endpoint(config.repo)
+
+        data = json.loads(resp.body)
+        assert resp.status_code == 200
+        assert data["status"] == "stopped"
+        mock_orch.request_stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_start_host_repo_restarts_stopped_orchestrator(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        mock_orch = MagicMock()
+        mock_orch.running = False
+        mock_orch.reset = MagicMock()
+        mock_orch.run = AsyncMock()
+        captured: dict[str, object] = {}
+
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            get_orch=lambda: mock_orch,
+            set_run_task=lambda task: captured.__setitem__("task", task),
+        )
+        endpoint = find_endpoint(router, "/api/runtimes/{slug}/start")
+
+        resp = await endpoint(config.repo)
+
+        data = json.loads(resp.body)
+        assert resp.status_code == 200
+        assert data["status"] == "started"
+        mock_orch.reset.assert_called_once()
+        assert mock_orch.pipeline_enabled is True
+        assert "task" in captured
+        await captured["task"]  # drain the scheduled restart task
+
+    @pytest.mark.asyncio
+    async def test_start_host_repo_conflicts_when_already_running(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        mock_orch = MagicMock()
+        mock_orch.running = True
+
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+        )
+        endpoint = find_endpoint(router, "/api/runtimes/{slug}/start")
+
+        resp = await endpoint(config.repo)
+
+        assert resp.status_code == 409


### PR DESCRIPTION
## Problem

The Stop button did not halt background workers. In multi-repo mode (the default here), the UI never hits a "stop everything" path:

- **Per-line Stop on the host/"default" repo** only set `orch.pipeline_enabled = False`. That pauses the pipeline phase loops (which gate on `pipeline_enabled`) but leaves the ~45 background/caretaker loops running — they gate on `_stop_event`, which this path never sets.
- **Factory-level `/api/control/stop`** only stopped the host orchestrator and never called `registry.stop_all()`, so other registered lines kept running too.

Registered (non-default) lines were already correct: their Stop routes through `rt.stop()` → `orchestrator.stop()` (full halt). The host line was the odd one out — that asymmetry *was* "the default repo behavior."

## Fix

Remove the default-repo special-casing so every factory line behaves uniformly (full stop = kill every loop, incl. background workers; full restart on Start).

- **`_state_routes.py`** — host repo per-line **Stop** → `orch.request_stop()` (sets `_stop_event` + cancels all 53 loop tasks). Per-line **Start** → `orch.reset()` + a fresh `run()` task (a full stop exits the run task, so toggling the flag alone would not revive cancelled loops). Now returns `409` when already running, like every other line.
- **`_control_routes.py`** — factory-level `/api/control/stop` halts the host **and** `registry.stop_all()` (every line). Returns `400` only when nothing is running anywhere.
- **`SessionSidebar.jsx`** — a factory line's Start/Stop is gated on `connected`, not the host orchestrator's status. Without this, fully stopping the host would set `orchestratorStatus !== 'running'` and **disable the very button needed to restart it** (the old host-as-master assumption).

## Scope

Confirmed with the requester: **both** per-line full-lifecycle *and* factory-level stop-all. Not in scope: registering the host repo into the `RepoRuntimeRegistry` to delete the `_is_default_repo` branch entirely (larger refactor of `server.py` startup), and making factory **Start** start every line (Stop was the ask).

## Testing

TDD red→green throughout.

- **Backend unit** (`tests/test_dashboard_routes_state.py`): host-repo Stop calls `request_stop`; host-repo Start restarts a stopped orchestrator (`reset` + new run task, `pipeline_enabled=True`); host-repo Start conflicts (409) when running.
- **Backend unit** (`tests/test_dashboard_routes_core.py`): factory Stop halts host + `registry.stop_all()`; factory Stop still stops registered lines when the host is idle.
- **UI component** (`SessionSidebar.test.jsx`): a stopped line's Start is enabled even when the host orchestrator is down; line control is disabled when disconnected.
- Full `pytest tests/`: **15,692 passed** (the lone red was an env artifact — `mkdocs` not on `PATH` in my ad-hoc runner; passes with the venv bin on PATH). Whole-repo `ruff`, `pyright`, `bandit`, UL-lint, and the `make quality` UI subset (App + socket + SessionSidebar = 90) all green.

Test-pyramid note: the new behavior is route-wiring + UI gating, covered by unit + component tests; the underlying `orchestrator.stop()` halting all loops is pre-existing tested behavior. A Tier-C Playwright e2e (click host-line Stop → assert workers halt; factory Stop → assert all lines stop) is a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)