### PR TITLE
fix(beads): per-worktree embedded store + JSONL export (drop shared --server)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-05T21:04:38.326404+00:00",
-  "commit_sha": "ec009139d24731311882a32fb3fba2ac48376542",
+  "regenerated_at": "2026-06-05T23:02:37.354555+00:00",
+  "commit_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681",
   "artifacts": {
     "loops.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "ports.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "labels.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "modules.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "events.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "adr_xref.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "mockworld.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "changelog.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "coverage_matrix.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "functional_areas.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "ubiquitous-language.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "ec009139d24731311882a32fb3fba2ac48376542"
+      "source_sha": "334dac46ed2888be66b2b42c8db665b1d1d0e681"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `9b97208` — fix(merge): auto-merge Auto-Agent PRs (agent/auto-agent-N) to end the contract-fix runaway (#9332) (#9332) *(2026-06-05)*
 - `ec00913` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) (#9316) (#9316) *(2026-06-05)*
 - `7316aba` — fix(wiki): repair malformed topic entries + guard against silent data loss (#9281) (#9281) *(2026-06-04)*
 - `e91dd05` — fix(adr): stop ADR-0011 false-positive drift on unrelated core-module churn (closes #9176) (#9256) (#9256) *(2026-06-04)*

--- a/src/beads_manager.py
+++ b/src/beads_manager.py
@@ -96,22 +96,35 @@ class BeadsManager:
             raise BeadsNotInstalledError() from exc
 
     async def init(self, cwd: Path) -> None:
-        """Initialize a beads project in *cwd* (idempotent).
+        """Initialize a per-worktree beads project in *cwd* (idempotent).
 
-        Uses ``--server`` to avoid the embedded Dolt CGO requirement.
-        Server mode uses a Dolt SQL server backend which works in all
-        environments including Docker containers built without CGO.
+        Uses bd's default **embedded** Dolt store (bd >= 1.0): an in-process
+        engine with no separate ``dolt sql-server`` — so each worktree gets its
+        own isolated ``.beads/embeddeddolt`` (no shared server, no cross-worktree
+        "already initialized" collisions). ``--skip-agents``/``--skip-hooks``
+        stop bd from rewriting the worktree's CLAUDE.md or installing git hooks.
 
-        Idempotent: ``bd init`` aborts with rc=1 ("This workspace is already
-        initialized." / "Found existing Dolt database") when a database already
-        exists for *cwd*. That is benign — the planner calls ``init`` once per
-        planned issue against the shared repo root, so the second issue onward
-        would otherwise raise ``RuntimeError`` and silently drop the whole plan
-        pool worker mid-decomposition. Treat the already-initialized signal as
-        success; re-raise every other failure.
+        Idempotent: if ``.beads/metadata.json`` already exists the workspace is
+        initialized — skip (bd re-init aborts on existing data). The broad
+        already-initialized signals are also swallowed defensively.
+
+        Container fallback: if embedded Dolt is unavailable (no CGO, e.g. a
+        slim container image), fall back to external ``--server`` mode, which
+        works without CGO. JSONL export (:meth:`export`) works in either mode.
         """
+        if (cwd / ".beads" / "metadata.json").exists():
+            logger.debug("beads already initialized in %s — skipping init", cwd)
+            return
         try:
-            await run_subprocess("bd", "init", "--server", cwd=cwd, timeout=30.0)
+            await run_subprocess(
+                "bd",
+                "init",
+                "--skip-agents",
+                "--skip-hooks",
+                "-q",
+                cwd=cwd,
+                timeout=60.0,
+            )
         except FileNotFoundError as exc:
             raise BeadsNotInstalledError() from exc
         except RuntimeError as exc:
@@ -121,7 +134,52 @@ class BeadsManager:
                     "beads already initialized in %s — treating as success", cwd
                 )
                 return
+            if "cgo" in msg or "embedded dolt" in msg:
+                logger.info(
+                    "embedded beads unavailable in %s (%s) — falling back to --server",
+                    cwd,
+                    exc,
+                )
+                await self._init_server(cwd)
+                return
             raise
+
+    async def _init_server(self, cwd: Path) -> None:
+        """Fallback init using an external Dolt sql-server (no CGO required)."""
+        try:
+            await run_subprocess(
+                "bd",
+                "init",
+                "--server",
+                "--skip-agents",
+                "--skip-hooks",
+                "-q",
+                cwd=cwd,
+                timeout=60.0,
+            )
+        except RuntimeError as exc:
+            msg = str(exc).lower()
+            if "already initialized" in msg or "found existing dolt database" in msg:
+                return
+            raise
+
+    async def export(self, cwd: Path) -> None:
+        """Write the per-worktree JSONL artifact ``.beads/issues.jsonl``.
+
+        bd's store is the embedded Dolt engine; this exports it to newline-
+        delimited JSON so each worktree carries a plain-text ``issues.jsonl``.
+        Best-effort: an export failure must never fail the pipeline.
+        """
+        try:
+            output = await run_subprocess("bd", "export", cwd=cwd, timeout=30.0)
+        except (FileNotFoundError, OSError, RuntimeError) as exc:
+            logger.warning("bd export failed in %s: %s", cwd, exc)
+            return
+        target = cwd / ".beads" / "issues.jsonl"
+        try:
+            target.write_text(output)
+        except OSError as exc:
+            logger.warning("failed writing %s: %s", target, exc)
 
     async def create_task(self, title: str, priority: str, cwd: Path) -> str:
         """Create a bead task, returning the bead ID.
@@ -207,6 +265,10 @@ class BeadsManager:
             for dep_id in phase.depends_on:
                 parent_bead = mapping[dep_id]
                 await self.add_dependency(child_bead, parent_bead, cwd)
+
+        # Refresh the per-worktree JSONL artifact so the created beads land in
+        # .beads/issues.jsonl (best-effort; never fails the pipeline).
+        await self.export(cwd)
 
         return mapping
 

--- a/src/mockworld/fakes/fake_beads.py
+++ b/src/mockworld/fakes/fake_beads.py
@@ -10,6 +10,7 @@ accept a BeadsManager can accept FakeBeads without modification.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -63,6 +64,24 @@ class FakeBeads:
         """Mark the fake as initialised (idempotent)."""
         _ = cwd
         self._initialized = True
+
+    async def export(self, cwd: Path) -> None:
+        """Write in-memory tasks to ``.beads/issues.jsonl`` (mirrors BeadsManager)."""
+        target = cwd / ".beads" / "issues.jsonl"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        lines = [
+            json.dumps(
+                {
+                    "_type": "issue",
+                    "id": t.task_id,
+                    "title": t.title,
+                    "status": t.status,
+                    "priority": t.priority,
+                }
+            )
+            for t in self._tasks.values()
+        ]
+        target.write_text("\n".join(lines) + ("\n" if lines else ""))
 
     async def create_task(self, title: str, priority: str, cwd: Path) -> str:
         """Create an in-memory bead task and return its generated ID."""
@@ -153,6 +172,8 @@ class FakeBeads:
             for dep_id in phase.depends_on:
                 parent_bead = mapping[dep_id]
                 await self.add_dependency(child_bead, parent_bead, cwd)
+
+        await self.export(cwd)
 
         return mapping
 

--- a/tests/scenarios/fakes/test_fake_beads.py
+++ b/tests/scenarios/fakes/test_fake_beads.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -184,3 +185,23 @@ async def test_show_returns_bead_task_shape() -> None:
     assert task.priority == 0
     assert task.status == "open"
     assert task.depends_on == []
+
+
+# ---------------------------------------------------------------------------
+# export — writes the per-worktree .beads/issues.jsonl artifact
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio()
+async def test_export_writes_issues_jsonl(tmp_path: Path) -> None:
+    beads = FakeBeads()
+    await beads.init(cwd=tmp_path)
+    await beads.create_task(title="alpha", priority="0", cwd=tmp_path)
+    await beads.create_task(title="beta", priority="1", cwd=tmp_path)
+
+    await beads.export(cwd=tmp_path)
+
+    jsonl = tmp_path / ".beads" / "issues.jsonl"
+    assert jsonl.exists()
+    lines = [ln for ln in jsonl.read_text().splitlines() if ln.strip()]
+    assert {json.loads(ln)["title"] for ln in lines} == {"alpha", "beta"}

--- a/tests/test_beads_manager.py
+++ b/tests/test_beads_manager.py
@@ -94,13 +94,74 @@ async def test_ensure_installed_npm_fails_to_install(manager):
 
 
 @pytest.mark.asyncio()
-async def test_init_success(manager):
+async def test_init_success_uses_embedded(manager, tmp_path):
+    """Default init uses bd's embedded store (no --server), skipping agent/hook
+    setup so it never rewrites the worktree's CLAUDE.md."""
     with patch("beads_manager.run_subprocess", new_callable=AsyncMock) as mock_run:
         mock_run.return_value = "Initialized"
-        await manager.init(Path("/repo"))
+        await manager.init(tmp_path)
         mock_run.assert_called_once_with(
-            "bd", "init", "--server", cwd=Path("/repo"), timeout=30.0
+            "bd",
+            "init",
+            "--skip-agents",
+            "--skip-hooks",
+            "-q",
+            cwd=tmp_path,
+            timeout=60.0,
         )
+
+
+@pytest.mark.asyncio()
+async def test_init_skips_when_metadata_exists(manager, tmp_path):
+    """Idempotent: an existing .beads/metadata.json means already-initialized —
+    no bd subprocess is spawned (bd re-init aborts)."""
+    (tmp_path / ".beads").mkdir()
+    (tmp_path / ".beads" / "metadata.json").write_text("{}")
+    with patch("beads_manager.run_subprocess", new_callable=AsyncMock) as mock_run:
+        await manager.init(tmp_path)
+        mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio()
+async def test_init_falls_back_to_server_on_cgo(manager, tmp_path):
+    """Where embedded Dolt is unavailable (no CGO), init retries with --server."""
+    calls: list[tuple] = []
+
+    async def _side_effect(*args, **kwargs):
+        calls.append(args)
+        if "--server" not in args:
+            raise RuntimeError("embedded Dolt requires CGO; use server mode")
+        return "Initialized"
+
+    with patch("beads_manager.run_subprocess", new=AsyncMock(side_effect=_side_effect)):
+        await manager.init(tmp_path)
+
+    assert any("--server" not in c for c in calls), "should try embedded first"
+    assert any("--server" in c for c in calls), "should fall back to --server"
+
+
+@pytest.mark.asyncio()
+async def test_export_writes_issues_jsonl(manager, tmp_path):
+    (tmp_path / ".beads").mkdir()
+    payload = '{"_type":"issue","id":"x","title":"t","status":"open"}\n'
+    with patch(
+        "beads_manager.run_subprocess", new=AsyncMock(return_value=payload)
+    ) as mock_run:
+        await manager.export(tmp_path)
+        mock_run.assert_called_once_with("bd", "export", cwd=tmp_path, timeout=30.0)
+    assert (tmp_path / ".beads" / "issues.jsonl").read_text() == payload
+
+
+@pytest.mark.asyncio()
+async def test_export_best_effort_on_failure(manager, tmp_path):
+    """An export failure must not raise (never fail the pipeline)."""
+    (tmp_path / ".beads").mkdir()
+    with patch(
+        "beads_manager.run_subprocess",
+        new=AsyncMock(side_effect=RuntimeError("bd export boom")),
+    ):
+        await manager.export(tmp_path)  # must not raise
+    assert not (tmp_path / ".beads" / "issues.jsonl").exists()
 
 
 @pytest.mark.asyncio()
@@ -389,7 +450,8 @@ async def test_create_from_phases(manager):
     ]
 
     with patch("beads_manager.run_subprocess", new_callable=AsyncMock) as mock_run_fn:
-        mock_run_fn.side_effect = ["repo-id1", "repo-id2", "ok"]
+        # create P1, create P2, dep add, then the trailing `bd export`.
+        mock_run_fn.side_effect = ["repo-id1", "repo-id2", "ok", ""]
         mapping = await manager.create_from_phases(phases, 42, Path("/repo"))
 
     assert mapping == {"P1": "repo-id1", "P2": "repo-id2"}


### PR DESCRIPTION
## What

Switches beads from a shared external Dolt **`--server`** to bd's **embedded** in-process store, **per worktree**, with a plain-text **`.beads/issues.jsonl`** artifact. This is the #4 beads redesign ("jsonl per worktree, no shared db-server").

## Why

bd 0.63.x forced `--server` because embedded Dolt needed CGO (unavailable in the agent image). **bd 1.0.x makes embedded the default and the CGO blocker is gone** (verified on host: `bd init` with no `--server` → in-process `.beads/embeddeddolt`, no server process). Server mode was the root of the original `bd init` crash (shared server "already initialized") and the auto-agent-PR churn.

## Change

- **`init()`**: embedded (no `--server`) + `--skip-agents --skip-hooks` (critical — otherwise `bd init` **rewrites the worktree's CLAUDE.md** and installs git hooks); idempotency guard on `.beads/metadata.json` (bd re-init aborts on existing data); **auto-fallback to `--server` on a CGO error** so it still works in any container.
- **`export()`**: writes `.beads/issues.jsonl` (called from `create_from_phases`) — each worktree carries the JSONL artifact.
- **`FakeBeads`** mirrors `export()`.
- Tests: embedded-init shape, metadata-skip idempotency, CGO→server fallback, export (success + best-effort failure), fake export.

## Notes / scope

- **bd version**: embedded needs bd ≥ 1.0; older bd auto-falls-back to `--server`. JSONL export works in both modes. (The Dockerfiles install `@beads/bd` latest, so rebuilt agent images get 1.x; no Dockerfile change needed thanks to the fallback.)
- **True no-db** (zero Dolt) isn't available in bd 1.0.5 — `no-db: true` is a vestigial config comment (verified: `bd create` → "no beads database found" without a store). Embedded is the closest no-shared-server model while keeping bd.
- The pre-existing planner(host)/implementer(clone) bead **disconnect** (agent `claim`/`close` hit an empty clone store) is unchanged here — separate follow-up.

`make quality` + `make scenario` + `make scenario-loops` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)