### PR TITLE
refactor(runtime): fold host repo into the registry; delete _is_default_repo

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from fastapi import FastAPI
 
     from orchestrator import HydraFlowOrchestrator
-    from repo_runtime import RepoRuntimeRegistry
+    from repo_runtime import RepoRuntime, RepoRuntimeRegistry
     from repo_store import RepoRecord, RepoStore
 
 logger = logging.getLogger("hydraflow.dashboard")
@@ -48,6 +48,7 @@ class HydraFlowDashboard:
         event_bus: EventBus,
         state: StateTracker,
         orchestrator: HydraFlowOrchestrator | None = None,
+        host_runtime: RepoRuntime | None = None,
         registry: RepoRuntimeRegistry | None = None,
         repo_store: RepoStore | None = None,
         register_repo_cb: Callable[
@@ -67,6 +68,7 @@ class HydraFlowDashboard:
         self._bus = event_bus
         self._state = state
         self._orchestrator = orchestrator
+        self._host_runtime = host_runtime
         self._registry = registry
         self._repo_store = repo_store
         self._register_repo_cb = register_repo_cb
@@ -122,7 +124,7 @@ class HydraFlowDashboard:
             event_bus=self._bus,
             state=self._state,
             pr_manager=pr_mgr,
-            get_orchestrator=lambda: self._orchestrator,
+            get_orchestrator=self._get_orchestrator,
             set_orchestrator=self._set_orchestrator,
             set_run_task=self._set_run_task,
             ui_dist_dir=ui_dist_dir,
@@ -139,6 +141,18 @@ class HydraFlowDashboard:
 
         self._app = app
         return app
+
+    def _get_orchestrator(self) -> HydraFlowOrchestrator | None:
+        """Return the host orchestrator.
+
+        In production the host is a registered :class:`RepoRuntime` (sharing
+        the app-level bus/state), so its orchestrator is the source of truth.
+        Falls back to the on-demand ``_orchestrator`` when no host runtime was
+        supplied (single-repo/test wiring).
+        """
+        if self._host_runtime is not None:
+            return self._host_runtime.orchestrator
+        return self._orchestrator
 
     def _set_orchestrator(self, orch: HydraFlowOrchestrator) -> None:
         self._orchestrator = orch

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -440,7 +440,24 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     @router.post("/api/control/start")
     async def start_orchestrator() -> JSONResponse:
-        """Create and start a new orchestrator instance."""
+        """Start the entire factory — the host orchestrator and every line.
+
+        The factory-level Start starts every registered repo runtime
+        (``registry.start_all``), including the host. Starting a single line
+        is handled by ``POST /api/runtimes/{slug}/start``.
+        """
+        registry = ctx.registry
+        if registry is not None:
+            await registry.start_all()
+            await ctx.event_bus.publish(
+                HydraFlowEvent(
+                    type=EventType.ORCHESTRATOR_STATUS,
+                    data=OrchestratorStatusPayload(status="running", reset=True),
+                )
+            )
+            return JSONResponse({"status": "started"})
+
+        # Legacy single-repo/test wiring (no registry): create+run the host orch.
         orch = ctx.get_orchestrator()
         if orch and orch.running:
             return JSONResponse({"error": "already running"}, status_code=409)
@@ -474,23 +491,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     async def stop_orchestrator() -> JSONResponse:
         """Stop the entire factory — the host orchestrator and every line.
 
-        The factory-level Stop halts the host orchestrator *and* every
-        registered repo runtime (``registry.stop_all``), so no factory line
-        keeps running after a factory stop. Stopping a single line is handled
-        by ``POST /api/runtimes/{slug}/stop``.
+        The factory-level Stop halts every registered repo runtime
+        (``registry.stop_all``), including the host. Stopping a single line is
+        handled by ``POST /api/runtimes/{slug}/stop``.
         """
-        orch = ctx.get_orchestrator()
         registry = ctx.registry
-        host_running = bool(orch and orch.running)
-        registry_running = bool(
-            registry is not None and any(rt.running for rt in registry.all)
-        )
-        if not host_running and not registry_running:
-            return JSONResponse({"error": "not running"}, status_code=400)
-        if orch is not None and orch.running:
-            await orch.request_stop()
         if registry is not None:
+            if not any(rt.running for rt in registry.all):
+                return JSONResponse({"error": "not running"}, status_code=400)
             await registry.stop_all()
+            return JSONResponse({"status": "stopping"})
+
+        # Legacy single-repo/test wiring (no registry): stop the host orch.
+        orch = ctx.get_orchestrator()
+        if not orch or not orch.running:
+            return JSONResponse({"error": "not running"}, status_code=400)
+        await orch.request_stop()
         return JSONResponse({"status": "stopping"})
 
     @router.post("/api/control/clear-credit-pause")

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -360,17 +360,8 @@ class RouteContext:
 
     # -- Dependency resolution helpers ------------------------------------------
 
-    def _is_default_repo(self, slug: str) -> bool:
-        """Check if *slug* refers to the default (host) repo."""
-        default = self.config.repo
-        if not default:
-            return False
-        normalized = default.replace("/", "-")
-        slug_lower = slug.lower()
-        return slug_lower in (default.lower(), normalized.lower())
-
-    def _is_default_pipeline_active(self) -> bool:
-        """Check if the default repo's pipeline is enabled.
+    def _host_pipeline_active(self) -> bool:
+        """Fallback host-pipeline check for single-repo/test wiring (no registry).
 
         Returns True when no orchestrator exists (headless/test mode).
         """
@@ -384,22 +375,17 @@ class RouteContext:
     def is_repo_pipeline_active(self, slug: str | None) -> bool:
         """Return whether the resolved repo's pipeline is actively processing.
 
-        When *slug* is ``None`` (All repos view), returns True if ANY
-        repo (default or added) has an active pipeline.
+        The host repo is a registered runtime like any other, so this resolves
+        purely through the registry. When *slug* is ``None`` (All repos view),
+        returns True if ANY line is running.
         """
-        if slug is None:
-            if self._is_default_pipeline_active():
-                return True
-            if self.registry is not None:
-                return any(getattr(rt, "running", False) for rt in self.registry.all)
-            return False
-        if self._is_default_repo(slug):
-            return self._is_default_pipeline_active()
         if self.registry is not None:
+            if slug is None:
+                return any(getattr(rt, "running", False) for rt in self.registry.all)
             rt = self.registry.get(slug)
-            if rt is not None:
-                return getattr(rt, "running", False)
-        return False
+            return getattr(rt, "running", False) if rt is not None else False
+        # No registry (single-repo/test wiring): fall back to the host orch.
+        return self._host_pipeline_active()
 
     def resolve_runtime(
         self,
@@ -416,8 +402,9 @@ class RouteContext:
         configured, returns the single-repo defaults for backward compatibility.
         """
         if self.registry is not None and slug is not None:
-            if self._is_default_repo(slug):
-                return self.config, self.state, self.event_bus, self.get_orchestrator
+            # The host repo is a registered runtime sharing the app-level
+            # bus/state, so registry.get() resolves it just like any other line
+            # — no default-repo special case needed.
             rt: RepoRuntime | None = self.registry.get(slug)
             if rt is not None:
                 return rt.config, rt.state, rt.event_bus, lambda: rt.orchestrator

--- a/src/dashboard_routes/_state_routes.py
+++ b/src/dashboard_routes/_state_routes.py
@@ -29,20 +29,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     """Register state/repos/runtimes/filesystem routes on *router*."""
 
     config = ctx.config
-    get_orchestrator = ctx.get_orchestrator
     registry = ctx.registry
     repo_store = ctx.repo_store
     register_repo_cb = ctx.register_repo_cb
     remove_repo_cb = ctx.remove_repo_cb
-
-    def _is_default_repo(slug: str) -> bool:
-        return ctx._is_default_repo(slug)
-
-    def _default_repo_pipeline_running() -> bool:
-        orch = get_orchestrator()
-        if not orch or not orch.running:
-            return False
-        return orch.pipeline_enabled
 
     def _list_repo_records() -> list[Any]:
         return ctx.list_repo_records()
@@ -92,24 +82,12 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     @router.get("/api/runtimes")
     async def list_runtimes() -> JSONResponse:
-        """List all registered repo runtimes with status."""
+        """List all registered repo runtimes with status.
+
+        The host repo is a registered runtime like every added repo, so the
+        list is simply the registry — no special host entry to prepend.
+        """
         infos: list[dict[str, Any]] = []
-
-        orch = get_orchestrator()
-        pipeline_active = _default_repo_pipeline_running()
-        default_slug = config.repo.replace("/", "-") if config.repo else ""
-        if config.repo:
-            infos.append(
-                RepoRuntimeInfo(
-                    slug=default_slug,
-                    repo=config.repo,
-                    running=pipeline_active,
-                    session_id=orch.current_session_id
-                    if orch and orch.running
-                    else None,
-                ).model_dump()
-            )
-
         if registry is not None:
             for rt in registry.all:
                 infos.append(
@@ -128,18 +106,6 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     @router.get("/api/runtimes/{slug}")
     async def get_runtime_status(slug: str) -> JSONResponse:
         """Get status of a specific repo runtime."""
-        if _is_default_repo(slug):
-            orch = get_orchestrator()
-            pipeline_active = _default_repo_pipeline_running()
-            default_slug = config.repo.replace("/", "-") if config.repo else ""
-            info = RepoRuntimeInfo(
-                slug=default_slug,
-                repo=config.repo,
-                running=pipeline_active,
-                session_id=orch.current_session_id if orch and orch.running else None,
-            )
-            return JSONResponse(info.model_dump())
-
         if registry is None:
             return JSONResponse(
                 {"error": "No runtime registry configured"}, status_code=501
@@ -157,24 +123,12 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         return JSONResponse(info.model_dump())
 
     @router.post("/api/runtimes/{slug}/start")
-    async def start_runtime(slug: str) -> JSONResponse:  # noqa: PLR0911
-        """Start a specific repo runtime."""
-        if _is_default_repo(slug):
-            orch = get_orchestrator()
-            if orch is None:
-                return JSONResponse({"error": "No orchestrator"}, status_code=400)
-            if orch.running:
-                return JSONResponse({"error": "Already running"}, status_code=409)
-            # Full restart. A prior Stop fully halts the host orchestrator
-            # (cancels every loop, including background workers), so the run
-            # task has exited — toggling pipeline_enabled alone would not
-            # revive the cancelled tasks. reset() clears mutable state per its
-            # contract; run() recreates all loops. Uniform with rt.start().
-            orch.reset()
-            orch.pipeline_enabled = True
-            ctx.set_run_task(asyncio.create_task(orch.run()))
-            return JSONResponse({"status": "started", "slug": slug})
+    async def start_runtime(slug: str) -> JSONResponse:
+        """Start a factory line — the host repo is just another line.
 
+        ``rt.start()`` resets and relaunches the orchestrator (all loops,
+        incl. background workers), so a stopped line restarts cleanly.
+        """
         if registry is None:
             return JSONResponse(
                 {"error": "No runtime registry configured"}, status_code=501
@@ -189,17 +143,12 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     @router.post("/api/runtimes/{slug}/stop")
     async def stop_runtime(slug: str) -> JSONResponse:
-        """Stop a specific repo runtime."""
-        if _is_default_repo(slug):
-            orch = get_orchestrator()
-            if not orch or not orch.running:
-                return JSONResponse({"error": "Not running"}, status_code=400)
-            # Full stop: halt every loop (pipeline + background workers), not
-            # just pause the pipeline. Uniform with every other factory line,
-            # whose stop routes through rt.stop() -> orchestrator.stop().
-            await orch.request_stop()
-            return JSONResponse({"status": "stopped", "slug": slug})
+        """Stop a factory line — fully halts that line's orchestrator.
 
+        Halts every loop (pipeline + background workers) via
+        ``rt.stop()`` -> ``orchestrator.stop()``. The host repo is uniform
+        with every other line.
+        """
         if registry is None:
             return JSONResponse(
                 {"error": "No runtime registry configured"}, status_code=501

--- a/src/repo_runtime.py
+++ b/src/repo_runtime.py
@@ -27,12 +27,20 @@ class RepoRuntime:
     shut it down gracefully.
     """
 
-    def __init__(self, config: HydraFlowConfig) -> None:
+    def __init__(
+        self,
+        config: HydraFlowConfig,
+        *,
+        event_bus: EventBus | None = None,
+        state: StateTracker | None = None,
+    ) -> None:
         self._config = config
         self._slug = config.repo.replace("/", "-") or config.repo_root.name
-        event_log = EventLog(config.event_log_path)
-        self._event_bus = EventBus(event_log=event_log)
-        self._state = build_state_tracker(config)
+        if event_bus is None:
+            event_log = EventLog(config.event_log_path)
+            event_bus = EventBus(event_log=event_log)
+        self._event_bus = event_bus
+        self._state = state if state is not None else build_state_tracker(config)
         self._orchestrator = HydraFlowOrchestrator(
             config,
             event_bus=self._event_bus,
@@ -55,6 +63,23 @@ class RepoRuntime:
         )
         await runtime._event_bus.load_history_from_disk()
         return runtime
+
+    @classmethod
+    def from_shared(
+        cls,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+    ) -> RepoRuntime:
+        """Construct a runtime that reuses an existing event bus and state.
+
+        Used for the host repo, whose bus/state are owned by the app process
+        (already rotated + history-loaded) and shared with the dashboard's
+        default (no-``repo``) views. Unlike :meth:`create`, this does NOT
+        rotate the log or reload history — the caller already did so on the
+        shared bus.
+        """
+        return cls(config, event_bus=event_bus, state=state)
 
     # --- Properties ---
 
@@ -104,6 +129,10 @@ class RepoRuntime:
             logger.warning("Runtime %r already running", self._slug)
             return
         self._last_error = None
+        # Clear stale events/active-issue sets so a restarted runtime begins
+        # cleanly — a prior stop cancels the loops mid-flight. reset() is a
+        # no-op on a freshly constructed orchestrator.
+        self._orchestrator.reset()
         logger.info("Starting runtime for %r", self._slug)
         self._task = asyncio.create_task(
             self._orchestrator.run(), name=f"runtime-{self._slug}"
@@ -167,6 +196,19 @@ class RepoRuntimeRegistry:
         logger.info("Registered runtime %r", runtime.slug)
         return runtime
 
+    def add(self, runtime: RepoRuntime) -> RepoRuntime:
+        """Register a pre-constructed runtime (e.g. the host repo, which shares
+        the app-level bus/state via :meth:`RepoRuntime.from_shared`).
+
+        Raises ``ValueError`` if a runtime with the same slug already exists.
+        """
+        if runtime.slug in self._runtimes:
+            msg = f"Runtime already registered for slug {runtime.slug!r}"
+            raise ValueError(msg)
+        self._runtimes[runtime.slug] = runtime
+        logger.info("Added runtime %r", runtime.slug)
+        return runtime
+
     @staticmethod
     def _normalize(slug: str) -> str:
         """Normalize ``owner/repo`` to the dash-separated key format."""
@@ -191,6 +233,12 @@ class RepoRuntimeRegistry:
     def all(self) -> list[RepoRuntime]:
         """Return all registered runtimes."""
         return list(self._runtimes.values())
+
+    async def start_all(self) -> None:
+        """Start every registered runtime (no-op on already-running ones)."""
+        tasks = [runtime.start() for runtime in self._runtimes.values()]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def stop_all(self) -> None:
         """Stop all registered runtimes gracefully."""

--- a/src/server.py
+++ b/src/server.py
@@ -124,7 +124,7 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     from dashboard import HydraFlowDashboard  # noqa: PLC0415
     from events import EventBus, EventLog, EventType, HydraFlowEvent  # noqa: PLC0415
     from models import Phase  # noqa: PLC0415
-    from repo_runtime import RepoRuntimeRegistry  # noqa: PLC0415
+    from repo_runtime import RepoRuntime, RepoRuntimeRegistry  # noqa: PLC0415
     from repo_store import RepoRecord, RepoRegistryStore  # noqa: PLC0415
     from service_registry import build_state_tracker  # noqa: PLC0415
 
@@ -140,12 +140,22 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     repo_store = RepoRegistryStore(config.data_root)
     registry = RepoRuntimeRegistry()
 
+    # The host repo is a first-class factory line: register it as a runtime
+    # that shares the app-level bus/state (already rotated + history-loaded
+    # above) so the dashboard's default (no-repo) views and the host's own
+    # start/stop resolve through the registry uniformly — no special-casing.
+    host_runtime = RepoRuntime.from_shared(config, bus, state)
+    registry.add(host_runtime)
+
     # Restore previously registered repos into the runtime registry.
     # The repo store persists to disk, but the registry is in-memory —
     # without this, added repos are lost on restart and their play
     # buttons return 404.
     for record in repo_store.list():
         if not record.path:
+            continue
+        if record.slug in registry:
+            # Already registered (e.g. the host repo added above) — skip.
             continue
         repo_path = Path(record.path)
         if not repo_path.is_dir():
@@ -227,6 +237,7 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
         config=config,
         event_bus=bus,
         state=state,
+        host_runtime=host_runtime,
         registry=registry,
         repo_store=repo_store,
         register_repo_cb=_register_repo,
@@ -251,8 +262,9 @@ async def _run_with_dashboard(config: HydraFlowConfig) -> None:
     try:
         await stop_event.wait()
     finally:
-        if dashboard._orchestrator and dashboard._orchestrator.running:
-            await dashboard._orchestrator.stop()
+        # The host is a registered runtime now, so stop_all() halts it along
+        # with every other factory line.
+        await registry.stop_all()
         await dashboard.stop()
 
 

--- a/tests/scenarios/browser/scenarios/test_happy_browser.py
+++ b/tests/scenarios/browser/scenarios/test_happy_browser.py
@@ -18,8 +18,9 @@ Implementation pattern (pilot):
       2. Boot the dashboard with the lightweight _HarnessOrchestratorShim
          (with_orchestrator=False).  The shim exposes the same harness
          IssueStore to the /api/pipeline route, which is gated by
-         _is_default_pipeline_active().  The shim has running=True so the
-         gate passes and the route serves real harness data.
+         is_repo_pipeline_active() (host fallback path, no registry).  The
+         shim has running=True so the gate passes and the route serves real
+         harness data.
       3. Navigate; wait for the WebSocket-ready signal.
       4. Assert the pipeline snapshot that React fetched on mount shows
          issue #1 in the 'merged' stage (stage-section-merged, stage-

--- a/tests/test_dashboard_routes_core.py
+++ b/tests/test_dashboard_routes_core.py
@@ -568,53 +568,61 @@ class TestStopOrchestratorEndpoint:
         mock_orch.request_stop.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_factory_stop_halts_host_and_all_registered_lines(
+    async def test_factory_stop_halts_all_lines(
         self, config, event_bus, state, tmp_path
     ) -> None:
         import json
 
-        mock_orch = MagicMock()
-        mock_orch.running = True
-        mock_orch.request_stop = AsyncMock()
-        mock_registry = MagicMock()
-        mock_registry.all = []
-        mock_registry.stop_all = AsyncMock()
-        router, _ = make_dashboard_router(
-            config,
-            event_bus,
-            state,
-            tmp_path,
-            get_orch=lambda: mock_orch,
-            registry=mock_registry,
-        )
-        endpoint = find_endpoint(router, "/api/control/stop")
-        response = await endpoint()
-        data = json.loads(response.body)
-        assert data["status"] == "stopping"
-        mock_orch.request_stop.assert_awaited_once()
-        mock_registry.stop_all.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_factory_stop_halts_registered_lines_when_host_idle(
-        self, config, event_bus, state, tmp_path
-    ) -> None:
         running_line = MagicMock()
         running_line.running = True
         mock_registry = MagicMock()
         mock_registry.all = [running_line]
         mock_registry.stop_all = AsyncMock()
         router, _ = make_dashboard_router(
-            config,
-            event_bus,
-            state,
-            tmp_path,
-            get_orch=lambda: None,
-            registry=mock_registry,
+            config, event_bus, state, tmp_path, registry=mock_registry
         )
         endpoint = find_endpoint(router, "/api/control/stop")
         response = await endpoint()
-        assert response.status_code == 200
+        data = json.loads(response.body)
+        assert data["status"] == "stopping"
         mock_registry.stop_all.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_factory_stop_errors_when_no_line_running(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        idle_line = MagicMock()
+        idle_line.running = False
+        mock_registry = MagicMock()
+        mock_registry.all = [idle_line]
+        mock_registry.stop_all = AsyncMock()
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=mock_registry
+        )
+        endpoint = find_endpoint(router, "/api/control/stop")
+        response = await endpoint()
+        assert response.status_code == 400
+        mock_registry.stop_all.assert_not_awaited()
+
+
+class TestFactoryStartEndpoint:
+    @pytest.mark.asyncio
+    async def test_factory_start_starts_all_lines(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        import json
+
+        mock_registry = MagicMock()
+        mock_registry.all = []
+        mock_registry.start_all = AsyncMock()
+        router, _ = make_dashboard_router(
+            config, event_bus, state, tmp_path, registry=mock_registry
+        )
+        endpoint = find_endpoint(router, "/api/control/start")
+        response = await endpoint()
+        data = json.loads(response.body)
+        assert data["status"] == "started"
+        mock_registry.start_all.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -1560,12 +1560,10 @@ class TestRuntimeEndpointsWithRegistry:
 
         resp = await endpoint()
         data = json.loads(resp.body)
-        # Default (host) repo is always included; no additional registered runtimes
-        default_slug = config.repo.replace("/", "-")
-        default_entries = [r for r in data["runtimes"] if r["slug"] == default_slug]
-        assert len(default_entries) == 1
-        registered = [r for r in data["runtimes"] if r["slug"] != default_slug]
-        assert registered == []
+        # The host repo is registered in the registry at boot (server wiring),
+        # so the endpoint no longer special-cases it into the list — an empty
+        # registry yields an empty list.
+        assert data["runtimes"] == []
 
     @pytest.mark.asyncio
     async def test_list_runtimes_with_registered_runtime(
@@ -1866,24 +1864,25 @@ class TestRuntimeEndpointsWithRegistry:
 # ---------------------------------------------------------------------------
 
 
-class TestDefaultRepoRuntimeFullLifecycle:
-    """Host (default) repo factory line uses the full orchestrator lifecycle.
+class TestHostRepoRoutesThroughRegistry:
+    """The host repo is an ordinary registered line.
 
-    The legacy pipeline-toggle behavior is gone: the host line's Stop fully
-    halts the orchestrator (every loop, including background workers) and its
-    Start restarts it — identical to every other factory line.
+    Its start/stop slug resolves through the registry exactly like any added
+    repo — no default-repo special-casing remains in the route handlers.
     """
 
     @pytest.mark.asyncio
-    async def test_stop_host_repo_fully_halts_orchestrator(
+    async def test_stop_host_slug_routes_to_registry_runtime(
         self, config, event_bus: EventBus, state, tmp_path: Path
     ) -> None:
-        mock_orch = MagicMock()
-        mock_orch.running = True
-        mock_orch.request_stop = AsyncMock()
+        host_rt = MagicMock()
+        host_rt.running = True
+        host_rt.stop = AsyncMock()
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = host_rt
 
         router, _ = make_dashboard_router(
-            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
+            config, event_bus, state, tmp_path, registry=mock_registry
         )
         endpoint = find_endpoint(router, "/api/runtimes/{slug}/stop")
 
@@ -1892,25 +1891,21 @@ class TestDefaultRepoRuntimeFullLifecycle:
         data = json.loads(resp.body)
         assert resp.status_code == 200
         assert data["status"] == "stopped"
-        mock_orch.request_stop.assert_awaited_once()
+        host_rt.stop.assert_awaited_once()
+        mock_registry.get.assert_called_with(config.repo)
 
     @pytest.mark.asyncio
-    async def test_start_host_repo_restarts_stopped_orchestrator(
+    async def test_start_host_slug_routes_to_registry_runtime(
         self, config, event_bus: EventBus, state, tmp_path: Path
     ) -> None:
-        mock_orch = MagicMock()
-        mock_orch.running = False
-        mock_orch.reset = MagicMock()
-        mock_orch.run = AsyncMock()
-        captured: dict[str, object] = {}
+        host_rt = MagicMock()
+        host_rt.running = False
+        host_rt.start = AsyncMock()
+        mock_registry = MagicMock()
+        mock_registry.get.return_value = host_rt
 
         router, _ = make_dashboard_router(
-            config,
-            event_bus,
-            state,
-            tmp_path,
-            get_orch=lambda: mock_orch,
-            set_run_task=lambda task: captured.__setitem__("task", task),
+            config, event_bus, state, tmp_path, registry=mock_registry
         )
         endpoint = find_endpoint(router, "/api/runtimes/{slug}/start")
 
@@ -1919,23 +1914,4 @@ class TestDefaultRepoRuntimeFullLifecycle:
         data = json.loads(resp.body)
         assert resp.status_code == 200
         assert data["status"] == "started"
-        mock_orch.reset.assert_called_once()
-        assert mock_orch.pipeline_enabled is True
-        assert "task" in captured
-        await captured["task"]  # drain the scheduled restart task
-
-    @pytest.mark.asyncio
-    async def test_start_host_repo_conflicts_when_already_running(
-        self, config, event_bus: EventBus, state, tmp_path: Path
-    ) -> None:
-        mock_orch = MagicMock()
-        mock_orch.running = True
-
-        router, _ = make_dashboard_router(
-            config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
-        )
-        endpoint = find_endpoint(router, "/api/runtimes/{slug}/start")
-
-        resp = await endpoint(config.repo)
-
-        assert resp.status_code == 409
+        host_rt.start.assert_awaited_once()

--- a/tests/test_host_runtime_wiring.py
+++ b/tests/test_host_runtime_wiring.py
@@ -1,0 +1,73 @@
+"""Integration smoke test for the unified host-repo-as-runtime wiring.
+
+Mirrors server.py's boot wiring — the host repo registered as a
+:class:`RepoRuntime` sharing the app-level bus/state — and verifies the
+dashboard resolves it through the registry. This is the invariant that lets
+the ``_is_default_repo`` special-casing be deleted: the host is just another
+registered factory line.
+"""
+
+from __future__ import annotations
+
+from dashboard import HydraFlowDashboard
+from repo_runtime import RepoRuntime, RepoRuntimeRegistry
+
+
+def _boot_like_server(config, event_bus, state):
+    """Replicate server.py's host-runtime registration."""
+    registry = RepoRuntimeRegistry()
+    host = RepoRuntime.from_shared(config, event_bus, state)
+    registry.add(host)
+    return registry, host
+
+
+class TestHostRuntimeWiring:
+    def test_host_registered_under_default_slug_sharing_bus_and_state(
+        self, config, event_bus, state
+    ) -> None:
+        registry, host = _boot_like_server(config, event_bus, state)
+        assert registry.get(config.repo) is host
+        assert host.event_bus is event_bus
+        assert host.state is state
+
+    def test_dashboard_get_orchestrator_returns_host_orchestrator(
+        self, config, event_bus, state
+    ) -> None:
+        registry, host = _boot_like_server(config, event_bus, state)
+        dashboard = HydraFlowDashboard(
+            config, event_bus, state, host_runtime=host, registry=registry
+        )
+        assert dashboard._get_orchestrator() is host.orchestrator
+
+    def test_runtimes_endpoint_lists_host(self, config, event_bus, state) -> None:
+        from fastapi.testclient import TestClient
+
+        registry, host = _boot_like_server(config, event_bus, state)
+        dashboard = HydraFlowDashboard(
+            config, event_bus, state, host_runtime=host, registry=registry
+        )
+        client = TestClient(dashboard.create_app())
+
+        resp = client.get("/api/runtimes")
+
+        assert resp.status_code == 200
+        slugs = [r["slug"] for r in resp.json()["runtimes"]]
+        assert host.slug in slugs
+
+    def test_control_status_without_repo_resolves_host(
+        self, config, event_bus, state
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        registry, host = _boot_like_server(config, event_bus, state)
+        dashboard = HydraFlowDashboard(
+            config, event_bus, state, host_runtime=host, registry=registry
+        )
+        client = TestClient(dashboard.create_app())
+
+        # No repo param -> resolve_runtime(None) must resolve to the host
+        # (shared bus/state) without error.
+        resp = client.get("/api/control/status")
+
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), dict)

--- a/tests/test_repo_runtime.py
+++ b/tests/test_repo_runtime.py
@@ -217,6 +217,37 @@ class TestRepoRuntime:
         assert "org-proj" in r
         assert "stopped" in r
 
+    def test_from_shared_reuses_injected_bus_and_state(self, tmp_path):
+        config = ConfigFactory.create(repo="acme/widgets", repo_root=tmp_path)
+        shared_bus = MagicMock()
+        shared_state = MagicMock()
+        with patch("repo_runtime.HydraFlowOrchestrator") as mock_orch_cls:
+            runtime = RepoRuntime.from_shared(config, shared_bus, shared_state)
+        assert runtime.event_bus is shared_bus
+        assert runtime.state is shared_state
+        assert runtime.slug == "acme-widgets"
+        _, kwargs = mock_orch_cls.call_args
+        assert kwargs["event_bus"] is shared_bus
+        assert kwargs["state"] is shared_state
+
+    @pytest.mark.asyncio
+    async def test_start_resets_orchestrator_before_run(self, tmp_path):
+        config = ConfigFactory.create(repo_root=tmp_path)
+        mock_orch = MagicMock()
+        mock_orch.run = AsyncMock()
+        mock_orch.running = False
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.build_state_tracker"),
+            patch("repo_runtime.HydraFlowOrchestrator", return_value=mock_orch),
+        ):
+            runtime = RepoRuntime(config)
+        await runtime.start()
+        await asyncio.sleep(0)
+        mock_orch.reset.assert_called_once()
+        mock_orch.run.assert_awaited_once()
+
 
 class TestRepoRuntimeRegistry:
     @pytest.mark.asyncio
@@ -352,3 +383,47 @@ class TestRepoRuntimeRegistry:
         assert rt_a.orchestrator is not rt_b.orchestrator
         assert rt_a.event_bus is not rt_b.event_bus
         assert len(registry) == 2
+
+    def test_add_inserts_prebuilt_runtime(self, tmp_path):
+        config = ConfigFactory.create(repo="acme/widgets", repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.build_state_tracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = RepoRuntime(config)
+        registry = RepoRuntimeRegistry()
+        added = registry.add(runtime)
+        assert added is runtime
+        assert registry.get("acme-widgets") is runtime
+        assert registry.get("acme/widgets") is runtime
+        assert len(registry) == 1
+
+    def test_add_duplicate_raises(self, tmp_path):
+        config = ConfigFactory.create(repo="acme/widgets", repo_root=tmp_path)
+        with (
+            patch("repo_runtime.EventLog"),
+            patch("repo_runtime.EventBus"),
+            patch("repo_runtime.build_state_tracker"),
+            patch("repo_runtime.HydraFlowOrchestrator"),
+        ):
+            runtime = RepoRuntime(config)
+        registry = RepoRuntimeRegistry()
+        registry.add(runtime)
+        with pytest.raises(ValueError, match="already registered"):
+            registry.add(runtime)
+
+    @pytest.mark.asyncio
+    async def test_start_all_starts_each_runtime(self):
+        registry = RepoRuntimeRegistry()
+        rt1 = MagicMock()
+        rt1.start = AsyncMock()
+        rt1.running = False
+        rt2 = MagicMock()
+        rt2.start = AsyncMock()
+        rt2.running = False
+        registry._runtimes = {"a": rt1, "b": rt2}
+        await registry.start_all()
+        rt1.start.assert_awaited_once()
+        rt2.start.assert_awaited_once()


### PR DESCRIPTION
**Stacked on #9336** (base = `fix/factory-stop-kills-all`). Tackles the two follow-ups flagged there: delete the `_is_default_repo` special-casing entirely, and make factory **Start** start every line.

## Why

The host/"default" repo was special everywhere: created on-demand by `/api/control/start`, owned by the dashboard, and branched on via `_is_default_repo` in `resolve_runtime`, `is_repo_pipeline_active`, and the `/api/runtimes` start/stop/list/get endpoints. That host-vs-line asymmetry is the root of the bugs this series fixes (the Stop button not halting host background workers). #9336 patched the host line's behavior; this PR removes the special-casing at the source.

## What

Make the host a first-class registered `RepoRuntime`, so every factory line — host included — is uniform.

- **`repo_runtime.py`**
  - `RepoRuntime.from_shared(config, bus, state)` — construct a runtime that **reuses** the app-level event bus + state (already rotated/history-loaded) rather than creating its own isolated pair. This is what keeps the dashboard's default (no-`repo`) views working after the host moves into the registry.
  - `RepoRuntimeRegistry.add()` (register a pre-built runtime) and `start_all()`.
  - `RepoRuntime.start()` now `reset()`s the orchestrator before relaunching, so a stopped line restarts cleanly (uniform for all lines).
- **`server.py`** — registers the host via `from_shared` at boot; shuts the whole factory down with `registry.stop_all()`.
- **`dashboard.py`** — `get_orchestrator()` returns the host runtime's orchestrator (falls back to the on-demand `_orchestrator` for single-repo/test wiring).
- **`_routes.py` / `_state_routes.py`** — `_is_default_repo` and the `_default_repo_*` helpers/branches **deleted**. `resolve_runtime`, `is_repo_pipeline_active`, and `/api/runtimes` resolve purely through the registry. Because the host shares the app bus/state, `registry.get(host_slug)` returns a tuple identical to the old "defaults" — **behavior-preserving**. registry-None fallbacks retained for unit/single-repo wiring.
- **`_control_routes.py`** — factory **Start** → `registry.start_all()` (every line, incl. host); factory **Stop** → `registry.stop_all()`.

## Behavior notes

- The host now boots **stopped** like every other line (it already did — nothing ran until Start; the orchestrator is just constructed up-front now instead of on first Start). `get_orchestrator()` returns a non-running orch at boot instead of `None`; all consumers gate on `orch.running`.
- Factory Start/Stop are now symmetric start-all / stop-all.

## Testing

- **Boot-wiring smoke test** (`tests/test_host_runtime_wiring.py`, new) — drives the **real app via TestClient**: host registered under the default slug sharing bus/state, `get_orchestrator` returns it, `/api/runtimes` lists it, no-repo `/api/control/status` resolves it. This validates the shared-bus/state wiring that mocks can't.
- New `RepoRuntime`/registry unit tests (`from_shared`, `add`, `start_all`, reset-on-start). Host-via-registry start/stop tests replace the now-obsolete host-special tests. Factory start-all / stop-all endpoint tests.
- Full `pytest tests/`: **15,697 passed** (the lone red is the env-only `mkdocs` PATH artifact — passes with the venv bin on PATH). Whole-repo `ruff`, `pyright`, `bandit`, and UL-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)