### PR TITLE
fix(ul): route bot/caretaker PRs to config.base_branch() (root-cause UL→main runaway)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-06T02:58:52.449352+00:00",
-  "commit_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90",
+  "regenerated_at": "2026-06-06T03:58:56.138798+00:00",
+  "commit_sha": "cee79f96cce2850244f3de91372d2871d03272ad",
   "artifacts": {
     "loops.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "ports.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "labels.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "modules.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "events.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "adr_xref.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "mockworld.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "changelog.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "coverage_matrix.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "functional_areas.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "ubiquitous-language.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "42773dcb6a5fdf0963703f7f7bd770520226cf90"
+      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `15589dc` — fix(beads): create the bead task graph in the implement worktree (fix claim/close) (#9345) (#9345) *(2026-06-05)*
 - `f624cbd` — fix(beads): per-worktree embedded store + JSONL export (drop shared --server) (#9337) (#9337) *(2026-06-05)*
 - `9b97208` — fix(merge): auto-merge Auto-Agent PRs (agent/auto-agent-N) to end the contract-fix runaway (#9332) (#9332) *(2026-06-05)*
 - `ec00913` — fix(contracts): stop gh_shape_validator false-positives on projection-only pr/issue calls (closes #9314) (#9316) (#9316) *(2026-06-05)*

--- a/src/pricing_refresh_loop.py
+++ b/src/pricing_refresh_loop.py
@@ -214,7 +214,10 @@ class PricingRefreshLoop(BaseBackgroundLoop):
             files=files_to_commit,
             pr_title=pr_title,
             pr_body=pr_body,
-            base="main",
+            # Target the active integration branch (staging when ADR-0042 is
+            # enabled, else main); a hardcoded "main" is BLOCKED by branch
+            # protection and the PR piles up unmerged.
+            base=self._config.base_branch(),
             auto_merge=False,  # Always human-reviewed per spec §3.
             labels=["hydraflow-ready", "pricing-refresh"],
             raise_on_failure=False,

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1315,6 +1315,10 @@ def build_services(
     term_proposer_pr_port = OpenAutoPRBotPRPort(
         repo_root=config.repo_root,
         gh_token=credentials.gh_token,
+        # Route UL bot PRs to the active integration branch (staging when
+        # enabled, else main) per ADR-0042. Shared by all UL loops
+        # (term-proposer/-pruner, edge-proposer, entry-evidence).
+        base=config.base_branch(),
     )
     term_proposer_loop = TermProposerLoop(  # noqa: F841
         config=config,

--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -152,9 +152,16 @@ class OpenAutoPRBotPRPort:
     once the PR carries `hydraflow-ul-proposed`.
     """
 
-    def __init__(self, *, repo_root: Path, gh_token: str = "") -> None:
+    def __init__(
+        self, *, repo_root: Path, gh_token: str = "", base: str = "main"
+    ) -> None:
         self._repo_root = repo_root
         self._gh_token = gh_token
+        # Target branch for the bot PR. Callers pass ``config.base_branch()`` so
+        # UL PRs follow the two-tier branch model (ADR-0042): ``staging`` when
+        # staging is enabled, ``main`` otherwise. Defaults to ``main`` for the
+        # pre-staging single-tier case.
+        self._base = base
 
     async def open_bot_pr(
         self,
@@ -192,7 +199,7 @@ class OpenAutoPRBotPRPort:
             files=written_paths,
             pr_title=title,
             pr_body=body,
-            base="main",
+            base=self._base,
             auto_merge=False,
             gh_token=self._gh_token,
             raise_on_failure=False,

--- a/tests/test_pr_base_branch_convention.py
+++ b/tests/test_pr_base_branch_convention.py
@@ -1,0 +1,67 @@
+"""Convention guard: factory PR helpers must target the configured base branch.
+
+Root-cause guard for the UL→main PR runaway. Several loops (term-proposer/
+-pruner, edge-proposer, entry-evidence via OpenAutoPRBotPRPort, and
+pricing-refresh) opened PRs with a hardcoded ``base="main"`` instead of
+``config.base_branch()``. Under ADR-0042 (two-tier branch model) those PRs
+target ``main`` directly, get BLOCKED by branch protection (main only advances
+via ``rc/*`` promotion), and pile up unmerged.
+
+The fix is the established convention everywhere else: pass
+``self._config.base_branch()`` (``staging`` when staging is enabled, else
+``main``). This AST scan fails if any call to the ``auto_pr`` PR-opening
+helpers passes a *literal* ``base="main"`` — a runtime ``base_branch()`` call
+is fine, a string constant is the bug.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parent.parent / "src"
+
+# The auto_pr helpers that branch off / target ``origin/{base}``.
+_PR_HELPERS = {"open_automated_pr_async", "open_automated_pr"}
+
+
+def _called_name(func: ast.expr) -> str | None:
+    """Return the simple callee name for ``f(...)`` or ``mod.f(...)``."""
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _hardcoded_main_base_calls(tree: ast.Module) -> list[int]:
+    """Line numbers of PR-helper calls passing a literal ``base="main"``."""
+    violations: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if _called_name(node.func) not in _PR_HELPERS:
+            continue
+        for kw in node.keywords:
+            if kw.arg != "base":
+                continue
+            if isinstance(kw.value, ast.Constant) and kw.value.value == "main":
+                violations.append(node.lineno)
+    return violations
+
+
+def test_no_pr_helper_hardcodes_main_base() -> None:
+    offenders: dict[str, list[int]] = {}
+    for path in SRC_DIR.rglob("*.py"):
+        if "/ui/" in path.as_posix():
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        lines = _hardcoded_main_base_calls(tree)
+        if lines:
+            offenders[str(path.relative_to(SRC_DIR))] = lines
+
+    assert not offenders, (
+        "Factory PR helpers must target config.base_branch() (staging when "
+        'ADR-0042 is enabled), not a hardcoded base="main". Offending calls: '
+        f"{offenders}"
+    )

--- a/tests/test_pricing_refresh_base_branch.py
+++ b/tests/test_pricing_refresh_base_branch.py
@@ -1,0 +1,61 @@
+"""PricingRefreshLoop must target config.base_branch(), not a hardcoded main.
+
+Regression for the main-targeted-PR runaway (mirrors
+test_diagram_loop.test_regen_pr_uses_config_base_branch_staging). The pricing
+refresh PR previously hardcoded ``base="main"``; under ADR-0042 that PR is
+BLOCKED by branch protection and never merges.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from base_background_loop import LoopDeps
+from pricing_refresh_diff import PricingDiff
+from pricing_refresh_loop import PricingRefreshLoop
+
+
+@pytest.mark.asyncio
+async def test_refresh_pr_uses_config_base_branch_staging(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = MagicMock()
+    config.pricing_refresh_loop_enabled = True
+    config.base_branch.return_value = "staging"
+
+    deps = LoopDeps(
+        event_bus=MagicMock(),
+        stop_event=asyncio.Event(),
+        status_cb=MagicMock(),
+        enabled_cb=MagicMock(return_value=True),
+        sleep_fn=AsyncMock(),
+        interval_cb=MagicMock(return_value=86400),
+    )
+    loop = PricingRefreshLoop(config=config, pr_manager=MagicMock(), deps=deps)
+    loop._set_repo_root(tmp_path)
+
+    captured: dict = {}
+
+    import auto_pr as _auto_pr_mod
+
+    async def intercept(**kw):
+        captured["base"] = kw["base"]
+        from auto_pr import AutoPrResult
+
+        return AutoPrResult(
+            status="opened",
+            pr_url="https://github.com/T-rav/hydraflow/pull/1",
+            branch=kw["branch"],
+            error=None,
+        )
+
+    monkeypatch.setattr(_auto_pr_mod, "open_automated_pr_async", intercept)
+
+    diff = PricingDiff(updated={"claude-opus": {"input_cost_per_token": 1.0}})
+    await loop._open_or_update_refresh_pr(diff)
+
+    assert captured["base"] == "staging"

--- a/tests/test_term_proposer_runtime.py
+++ b/tests/test_term_proposer_runtime.py
@@ -119,9 +119,44 @@ class TestOpenAutoPRBotPRPort:
         assert captured["pr_title"] == "feat(ul): batch"
         assert captured["labels"] == ["hydraflow-ul-proposed"]
         assert captured["auto_merge"] is False  # DependabotMergeLoop handles merge
-        assert captured["base"] == "main"
+        assert captured["base"] == "main"  # default (single-tier / pre-staging)
         # 2 term files + the 2 regenerated ubiquitous-language views ride along.
         assert len(captured["files"]) == 4
+
+    @pytest.mark.asyncio
+    async def test_targets_configured_base_branch(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        # Regression (UL→main PR runaway): when staging is enabled the registry
+        # passes config.base_branch()=="staging"; the bot PR MUST target it, not
+        # a hardcoded "main". main-targeted PRs are BLOCKED by branch protection
+        # (main only advances via rc/* promotion) and pile up unmerged.
+        from auto_pr import AutoPrResult
+
+        captured: dict = {}
+
+        async def fake_open_automated_pr_async(**kwargs):
+            captured.update(kwargs)
+            return AutoPrResult(
+                status="opened",
+                pr_url="https://github.com/T-rav/hydraflow/pull/9001",
+                branch=kwargs["branch"],
+            )
+
+        monkeypatch.setattr(
+            "auto_pr.open_automated_pr_async", fake_open_automated_pr_async
+        )
+
+        port = OpenAutoPRBotPRPort(repo_root=tmp_path, gh_token="ghs_x", base="staging")
+        await port.open_bot_pr(
+            branch="ul-proposer/abc123",
+            title="feat(ul): batch",
+            body="body",
+            labels=["hydraflow-ul-proposed"],
+            files={"docs/wiki/terms/foo-loop.md": _term_file_str("FooLoop")},
+        )
+
+        assert captured["base"] == "staging"
 
     @pytest.mark.asyncio
     async def test_raises_on_open_failure(self, tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Root cause

The factory's UL loops (and pricing-refresh) opened PRs that targeted **`main`** instead of the active integration branch. Under ADR-0042's two-tier model, `main` only advances via `rc/*` promotion, so those PRs are **BLOCKED** by branch protection and pile up unmerged — the 8 stuck `ul-evidence/`, `ul-edges/`, `ul-proposer/` PRs all came from this.

Two PR-creation paths hardcoded `base="main"` instead of `config.base_branch()`:

| Path | Loops affected |
|------|----------------|
| `term_proposer_runtime.OpenAutoPRBotPRPort` | term-proposer, term-pruner, edge-proposer, entry-evidence (all share this port) |
| `pricing_refresh_loop` | pricing-refresh |

Every **other** PR-creating loop already did it right (`diagram`, `contract-refresh`, `repo-wiki`, `corpus-learning`, `adr-reviewer`, and the agent pipeline via `pr_manager.create_pr`). The one intentional `main` target — `pr_manager.create_promotion_pr` (RC→main) — is left as-is.

## Fix

- `OpenAutoPRBotPRPort.__init__` takes a `base` (defaults to `"main"` for the pre-staging single-tier case); `service_registry` constructs it with `base=config.base_branch()`. So when staging is enabled, **all four UL loops** target `staging`.
- `pricing_refresh_loop` → `base=config.base_branch()`.

## Guard against recurrence

- **`tests/test_pr_base_branch_convention.py`** — AST scan over `src/` that fails if any call to the `auto_pr` PR helpers passes a literal `base="main"`. This bug appeared in exactly this shape twice; the guard catches a third.
- **`tests/test_pricing_refresh_base_branch.py`** — pricing loop targets `staging` when `config.base_branch()=="staging"` (mirrors `test_diagram_loop`).
- `test_term_proposer_runtime` — added a `base="staging"` threading assertion.

The 8 existing main-targeted PRs will be **closed** once this lands (they were generated by the buggy code; new UL PRs will target staging correctly).

`make quality` (15711) + `make scenario` (184) + `make scenario-loops` (125) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)