### PR TITLE
feat: Work Stream pipeline aggregation across repos (Phase 2a)

### DIFF
--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -64,7 +64,7 @@ from models import (
     IssueOutcomeType,
     PipelineIssue,
     PipelineSnapshot,
-    PipelineSnapshotEntry,
+    PipelineStats,
     QueueStats,
     parse_task_links,
 )
@@ -78,6 +78,11 @@ from transcript_summarizer import TranscriptSummarizer
 
 if TYPE_CHECKING:
     from orchestrator import HydraFlowOrchestrator
+from dashboard_routes._stats_merge import (
+    merge_lifetime_stats,
+    merge_pipeline_stats,
+    merge_queue_stats,
+)
 from repo_runtime import RepoRuntime, RepoRuntimeRegistry
 from repo_store import RepoRecord, RepoStore
 
@@ -376,11 +381,11 @@ class RouteContext:
         """Return whether the resolved repo's pipeline is actively processing.
 
         The host repo is a registered runtime like any other, so this resolves
-        purely through the registry. When *slug* is ``None`` (All repos view),
-        returns True if ANY line is running.
+        purely through the registry. When *slug* is ``None`` or the ``REPO_ALL``
+        sentinel (All repos view), returns True if ANY line is running.
         """
         if self.registry is not None:
-            if slug is None:
+            if slug is None or slug.strip().lower() == REPO_ALL:
                 return any(getattr(rt, "running", False) for rt in self.registry.all)
             rt = self.registry.get(slug)
             return getattr(rt, "running", False) if rt is not None else False
@@ -1391,26 +1396,37 @@ def create_router(
     async def get_stats(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return lifetime stats and optional queue depths."""
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        data: dict[str, Any] = _state.get_lifetime_stats().model_dump()
-        orch = _get_orch()
-        if orch:
-            data["queue"] = orch.issue_store.get_queue_stats().model_dump()
+        """Return lifetime stats and optional queue depths.
+
+        For ``repo=__all__`` the lifetime stats are summed across every repo and
+        the queue depths are merged across the active lines.
+        """
+        runtimes = _resolve_runtimes(repo)
+        data: dict[str, Any] = merge_lifetime_stats(
+            [st.get_lifetime_stats() for _cfg, st, _bus, _go, _slug in runtimes]
+        ).model_dump()
+        queues: list[QueueStats] = []
+        for _cfg, _st, _bus, get_orch, _slug in runtimes:
+            orch = get_orch()
+            if orch:
+                queues.append(orch.issue_store.get_queue_stats())
+        if queues:
+            data["queue"] = merge_queue_stats(queues).model_dump()
         return JSONResponse(data)
 
     @router.get("/api/queue")
     async def get_queue(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return current queue depths, active counts, and throughput."""
-        if not _is_pipeline_active(repo):
-            return JSONResponse(QueueStats().model_dump())
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        orch = _get_orch()
-        if orch:
-            return JSONResponse(orch.issue_store.get_queue_stats().model_dump())
-        return JSONResponse(QueueStats().model_dump())
+        """Return current queue depths, merged across active lines for __all__."""
+        queues: list[QueueStats] = []
+        for _cfg, _st, _bus, get_orch, slug in _resolve_runtimes(repo):
+            if not _is_pipeline_active(slug):
+                continue
+            orch = get_orch()
+            if orch:
+                queues.append(orch.issue_store.get_queue_stats())
+        return JSONResponse(merge_queue_stats(queues).model_dump())
 
     @router.post("/api/request-changes")
     async def request_changes(
@@ -1422,6 +1438,14 @@ def create_router(
         escalation event all land on the SELECTED repo — not the default one —
         in a multi-repo deployment.
         """
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "detail": "request-changes requires a specific repo",
+                },
+                status_code=400,
+            )
         _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
         issue_number: int | None = body.get("issue_number")
         feedback = (body.get("feedback") or "").strip()
@@ -1469,39 +1493,41 @@ def create_router(
     async def get_pipeline(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return current pipeline snapshot with issues per stage."""
-        if not _is_pipeline_active(repo):
-            return JSONResponse(PipelineSnapshot().model_dump())
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        orch = _get_orch()
-        if orch:
+        """Return the pipeline snapshot — issues per stage, unioned across repos
+        for ``repo=__all__`` with each issue tagged by its repo slug."""
+        merged_stages: dict[str, list[PipelineIssue]] = {}
+        for _cfg, _st, _bus, get_orch, slug in _resolve_runtimes(repo):
+            if not _is_pipeline_active(slug):
+                continue
+            orch = get_orch()
+            if orch is None:
+                continue
             raw = orch.issue_store.get_pipeline_snapshot()
-            mapped: dict[str, list[PipelineSnapshotEntry]] = {}
             for backend_stage, issues in raw.items():
                 frontend_stage = _STAGE_NAME_MAP.get(backend_stage, backend_stage)
-                mapped[frontend_stage] = issues
-            snapshot = PipelineSnapshot(
-                stages={
-                    k: [PipelineIssue.model_validate(i) for i in v]
-                    for k, v in mapped.items()
-                }
-            )
-            return JSONResponse(snapshot.model_dump())
-        return JSONResponse(PipelineSnapshot().model_dump())
+                bucket = merged_stages.setdefault(frontend_stage, [])
+                for entry in issues:
+                    bucket.append(
+                        PipelineIssue.model_validate(entry).model_copy(
+                            update={"repo": slug}
+                        )
+                    )
+        return JSONResponse(PipelineSnapshot(stages=merged_stages).model_dump())
 
     @router.get("/api/pipeline/stats")
     async def get_pipeline_stats(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return lightweight pipeline stats (counts only, no issue details)."""
-        if not _is_pipeline_active(repo):
-            return JSONResponse({})
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        orch = _get_orch()
-        if orch:
-            stats = orch.build_pipeline_stats()
-            return JSONResponse(stats.model_dump())
-        return JSONResponse({})
+        """Return lightweight pipeline stats — merged across active lines for __all__."""
+        stats_list: list[PipelineStats] = []
+        for _cfg, _st, _bus, get_orch, slug in _resolve_runtimes(repo):
+            if not _is_pipeline_active(slug):
+                continue
+            orch = get_orch()
+            if orch:
+                stats_list.append(orch.build_pipeline_stats())
+        merged = merge_pipeline_stats(stats_list)
+        return JSONResponse(merged.model_dump() if merged is not None else {})
 
     @router.get("/api/events")
     async def get_events(

--- a/src/dashboard_routes/_stats_merge.py
+++ b/src/dashboard_routes/_stats_merge.py
@@ -1,0 +1,149 @@
+"""Pure helpers that merge per-repo stats into a cross-repo aggregate.
+
+Used by the Work Stream read endpoints when ``repo=__all__``: each per-runtime
+stats object is summed/concatenated/maxed field-by-field. Kept pure and
+side-effect-free so the merge rules are independently testable.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from typing import Any
+
+from models import (
+    LifetimeStats,
+    PipelineStats,
+    QueueStats,
+    StageStats,
+    ThroughputStats,
+)
+
+
+def _sum_int_maps(maps: Iterable[dict[str, int]]) -> dict[str, int]:
+    """Key-wise sum of ``dict[str, int]`` maps."""
+    out: dict[str, int] = defaultdict(int)
+    for m in maps:
+        for key, value in m.items():
+            out[key] += value
+    return dict(out)
+
+
+def merge_queue_stats(items: list[QueueStats]) -> QueueStats:
+    """Sum queue depths/counts; max the last-poll timestamp."""
+    if not items:
+        return QueueStats()
+    timestamps = [q.last_poll_timestamp for q in items if q.last_poll_timestamp]
+    return QueueStats(
+        queue_depth=_sum_int_maps(q.queue_depth for q in items),
+        active_count=_sum_int_maps(q.active_count for q in items),
+        total_processed=_sum_int_maps(q.total_processed for q in items),
+        dedup_stats=_sum_int_maps(q.dedup_stats for q in items),
+        last_poll_timestamp=max(timestamps) if timestamps else None,
+        in_flight_count=sum(q.in_flight_count for q in items),
+    )
+
+
+def _merge_stage_stats(items: list[StageStats]) -> StageStats:
+    caps = [s.worker_cap for s in items if s.worker_cap is not None]
+    return StageStats(
+        queued=sum(s.queued for s in items),
+        active=sum(s.active for s in items),
+        completed_session=sum(s.completed_session for s in items),
+        completed_lifetime=sum(s.completed_lifetime for s in items),
+        worker_count=sum(s.worker_count for s in items),
+        worker_cap=sum(caps) if caps else None,
+    )
+
+
+def merge_pipeline_stats(items: list[PipelineStats]) -> PipelineStats | None:
+    """Merge per-stage StageStats, sum throughput, max uptime/timestamp."""
+    if not items:
+        return None
+    stage_keys = {k for p in items for k in p.stages}
+    merged_stages = {
+        key: _merge_stage_stats([p.stages[key] for p in items if key in p.stages])
+        for key in stage_keys
+    }
+    throughput = ThroughputStats(
+        triage=sum(p.throughput.triage for p in items),
+        plan=sum(p.throughput.plan for p in items),
+        implement=sum(p.throughput.implement for p in items),
+        review=sum(p.throughput.review for p in items),
+        hitl=sum(p.throughput.hitl for p in items),
+    )
+    return PipelineStats(
+        timestamp=max(p.timestamp for p in items),
+        stages=merged_stages,
+        queue=merge_queue_stats([p.queue for p in items]),
+        throughput=throughput,
+        uptime_seconds=max(p.uptime_seconds for p in items),
+    )
+
+
+_LIFETIME_INT_FIELDS = (
+    "issues_completed",
+    "prs_merged",
+    "issues_created",
+    "total_quality_fix_rounds",
+    "total_ci_fix_rounds",
+    "total_hitl_escalations",
+    "total_review_request_changes",
+    "total_review_approvals",
+    "total_reviewer_fixes",
+    "total_outcomes_merged",
+    "total_outcomes_already_satisfied",
+    "total_outcomes_hitl_closed",
+    "total_outcomes_hitl_skipped",
+    "total_outcomes_failed",
+    "total_outcomes_manual_close",
+    "total_outcomes_hitl_approved",
+    "total_outcomes_verify_pending",
+    "total_outcomes_verify_resolved",
+)
+_LIFETIME_FLOAT_FIELDS = (
+    "total_implementation_seconds",
+    "total_review_seconds",
+    "total_plan_seconds",
+    "total_triage_seconds",
+)
+# Concatenated (NOT summed) so downstream percentile math stays correct.
+_LIFETIME_LIST_FIELDS = (
+    "plan_durations",
+    "implement_durations",
+    "review_durations",
+    "merge_durations",
+)
+
+
+def merge_lifetime_stats(items: list[LifetimeStats]) -> LifetimeStats:
+    """Sum scalar counters, CONCAT duration lists (percentile correctness),
+    union ``fired_thresholds``, and merge ``retries_per_stage`` by issue→stage."""
+    if not items:
+        return LifetimeStats()
+    merged: dict[str, Any] = {
+        field: sum(getattr(x, field) for x in items) for field in _LIFETIME_INT_FIELDS
+    }
+    for field in _LIFETIME_FLOAT_FIELDS:
+        merged[field] = sum(getattr(x, field) for x in items)
+    for field in _LIFETIME_LIST_FIELDS:
+        merged[field] = [d for x in items for d in getattr(x, field)]
+
+    seen: set[str] = set()
+    fired: list[str] = []
+    for x in items:
+        for threshold in x.fired_thresholds:
+            if threshold not in seen:
+                seen.add(threshold)
+                fired.append(threshold)
+    merged["fired_thresholds"] = fired
+
+    retries: dict[str, dict[str, int]] = {}
+    for x in items:
+        for issue, stages in x.retries_per_stage.items():
+            dest = retries.setdefault(issue, {})
+            for stage, count in stages.items():
+                dest[stage] = dest.get(stage, 0) + count
+    merged["retries_per_stage"] = retries
+
+    return LifetimeStats(**merged)

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -648,10 +648,12 @@ class TestGetStatsEndpoint:
     async def test_includes_queue_when_orchestrator_present(
         self, config, event_bus, state, tmp_path
     ) -> None:
+        from models import QueueStats
+
         mock_orch = MagicMock()
         mock_orch.issue_store = MagicMock()
         mock_orch.issue_store.get_queue_stats = MagicMock(
-            return_value=MagicMock(model_dump=lambda: {"triage": 0, "plan": 0})
+            return_value=QueueStats(in_flight_count=2)
         )
         router, _ = make_dashboard_router(
             config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
@@ -692,10 +694,12 @@ class TestGetQueueEndpoint:
     async def test_returns_queue_from_orchestrator(
         self, config, event_bus, state, tmp_path
     ) -> None:
+        from models import QueueStats
+
         mock_orch = MagicMock()
         mock_orch.issue_store = MagicMock()
         mock_orch.issue_store.get_queue_stats = MagicMock(
-            return_value=MagicMock(model_dump=lambda: {"triage": 3, "plan": 1})
+            return_value=QueueStats(queue_depth={"plan": 3})
         )
         router, _ = make_dashboard_router(
             config, event_bus, state, tmp_path, get_orch=lambda: mock_orch
@@ -703,7 +707,7 @@ class TestGetQueueEndpoint:
         endpoint = find_endpoint(router, "/api/queue")
         response = await endpoint()
         data = json.loads(response.body)
-        assert data["triage"] == 3
+        assert data["queue_depth"]["plan"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dashboard_routes_workstream_multirepo.py
+++ b/tests/test_dashboard_routes_workstream_multirepo.py
@@ -1,0 +1,87 @@
+"""Work Stream REST endpoints aggregate across repos for repo=__all__."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from models import QueueStats
+from route_types import REPO_ALL
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+
+
+def _runtime_spec(slug, *, snapshot=None, queue=None):
+    orch = MagicMock()
+    orch.running = True
+    orch.issue_store.get_pipeline_snapshot = MagicMock(return_value=snapshot or {})
+    orch.issue_store.get_queue_stats = MagicMock(return_value=queue or QueueStats())
+    return {"slug": slug, "running": True, "orchestrator": orch}
+
+
+@pytest.mark.asyncio
+async def test_pipeline_unions_and_tags_by_repo(config, event_bus, state, tmp_path):
+    registry = make_registry(
+        _runtime_spec("owner-a", snapshot={"ready": [{"issue_number": 1}]}),
+        _runtime_spec("owner-b", snapshot={"ready": [{"issue_number": 2}]}),
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/pipeline")
+
+    resp = await endpoint(repo=REPO_ALL)
+    data = json.loads(resp.body)
+
+    # "ready" backend stage maps to frontend "implement"
+    implement = data["stages"]["implement"]
+    assert {i["issue_number"] for i in implement} == {1, 2}
+    assert {i["repo"] for i in implement} == {"owner-a", "owner-b"}
+
+
+@pytest.mark.asyncio
+async def test_queue_sums_across_repos(config, event_bus, state, tmp_path):
+    registry = make_registry(
+        _runtime_spec("owner-a", queue=QueueStats(in_flight_count=2)),
+        _runtime_spec("owner-b", queue=QueueStats(in_flight_count=3)),
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/queue")
+
+    resp = await endpoint(repo=REPO_ALL)
+    data = json.loads(resp.body)
+
+    assert data["in_flight_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_pipeline_scopes_to_one_repo(config, event_bus, state, tmp_path):
+    registry = make_registry(
+        _runtime_spec("owner-a", snapshot={"ready": [{"issue_number": 1}]}),
+        _runtime_spec("owner-b", snapshot={"ready": [{"issue_number": 2}]}),
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/pipeline")
+
+    resp = await endpoint(repo="owner-a")
+    data = json.loads(resp.body)
+
+    implement = data["stages"]["implement"]
+    assert {i["issue_number"] for i in implement} == {1}
+
+
+@pytest.mark.asyncio
+async def test_request_changes_rejects_all(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    endpoint = find_endpoint(router, "/api/request-changes", "POST")
+
+    resp = await endpoint(
+        {"issue_number": 1, "feedback": "x", "stage": "review"}, REPO_ALL
+    )
+
+    assert resp.status_code == 400

--- a/tests/test_stats_merge.py
+++ b/tests/test_stats_merge.py
@@ -1,0 +1,94 @@
+"""Cross-repo stats merge helpers."""
+
+from __future__ import annotations
+
+from dashboard_routes._stats_merge import (
+    merge_lifetime_stats,
+    merge_pipeline_stats,
+    merge_queue_stats,
+)
+from models import LifetimeStats, PipelineStats, QueueStats, StageStats
+
+
+def test_merge_queue_stats_sums_maps_and_maxes_timestamp() -> None:
+    a = QueueStats(
+        queue_depth={"plan": 2, "review": 1},
+        in_flight_count=3,
+        last_poll_timestamp="2026-06-06T10:00:00",
+        dedup_stats={"hits": 5},
+    )
+    b = QueueStats(
+        queue_depth={"plan": 4, "implement": 1},
+        in_flight_count=2,
+        last_poll_timestamp="2026-06-06T12:00:00",
+        dedup_stats={"hits": 1},
+    )
+
+    merged = merge_queue_stats([a, b])
+
+    assert merged.queue_depth == {"plan": 6, "review": 1, "implement": 1}
+    assert merged.in_flight_count == 5
+    assert merged.last_poll_timestamp == "2026-06-06T12:00:00"
+    assert merged.dedup_stats == {"hits": 6}
+
+
+def test_merge_queue_stats_empty() -> None:
+    assert merge_queue_stats([]) == QueueStats()
+
+
+def test_merge_pipeline_stats_merges_stages_and_sums_throughput() -> None:
+    a = PipelineStats(
+        timestamp="2026-06-06T10:00:00",
+        stages={"plan": StageStats(queued=2, active=1, worker_cap=3)},
+        uptime_seconds=100.0,
+    )
+    a.throughput.plan = 4.0
+    b = PipelineStats(
+        timestamp="2026-06-06T11:00:00",
+        stages={"plan": StageStats(queued=1, active=2, worker_cap=2)},
+        uptime_seconds=250.0,
+    )
+    b.throughput.plan = 1.5
+
+    merged = merge_pipeline_stats([a, b])
+
+    assert merged is not None
+    assert merged.stages["plan"].queued == 3
+    assert merged.stages["plan"].active == 3
+    assert merged.stages["plan"].worker_cap == 5
+    assert merged.throughput.plan == 5.5
+    assert merged.uptime_seconds == 250.0
+    assert merged.timestamp == "2026-06-06T11:00:00"
+
+
+def test_merge_pipeline_stats_empty_is_none() -> None:
+    assert merge_pipeline_stats([]) is None
+
+
+def test_merge_lifetime_concats_durations_and_sums_counters() -> None:
+    a = LifetimeStats(
+        issues_completed=3,
+        plan_durations=[1.0, 2.0],
+        fired_thresholds=["t1"],
+        retries_per_stage={"42": {"plan": 1}},
+    )
+    b = LifetimeStats(
+        issues_completed=2,
+        plan_durations=[3.0],
+        fired_thresholds=["t1", "t2"],
+        retries_per_stage={"42": {"plan": 2}, "7": {"review": 1}},
+    )
+
+    merged = merge_lifetime_stats([a, b])
+
+    assert merged.issues_completed == 5
+    # CONCAT (not sum) so percentile math stays correct
+    assert merged.plan_durations == [1.0, 2.0, 3.0]
+    # union, order-preserving, deduped
+    assert merged.fired_thresholds == ["t1", "t2"]
+    # merged by issue -> stage
+    assert merged.retries_per_stage == {"42": {"plan": 3}, "7": {"review": 1}}
+
+
+def test_merge_lifetime_empty() -> None:
+    assert merge_lifetime_stats([]) == LifetimeStats()


### PR DESCRIPTION
First slice of Phase 2 (Work Stream + Outcomes). Backend REST aggregation for the
Work Stream **pipeline/queue/stats** endpoints when `repo=__all__`.

## What's here
- **`_stats_merge.py`** — pure, tested merge helpers: key-wise sum of int maps,
  CONCAT duration lists (percentile correctness), union `fired_thresholds`,
  merge `retries_per_stage` by issue→stage, max timestamps/uptime.
- **4 read endpoints** (`/api/pipeline`, `/api/queue`, `/api/stats`,
  `/api/pipeline/stats`) loop `resolve_runtimes` and merge: pipeline unions
  issues per stage **tagged by repo slug** (`model_copy`); stats summed.
- **`is_repo_pipeline_active` learns `REPO_ALL`** — without this the whole
  pipeline/queue view zeroes out in all-mode.
- **`/api/request-changes` rejects `__all__`** (mutations need a specific repo).

## Scope / sequencing
Backend-only and **additive** — the frontend doesn't send `repo=__all__` yet, so
existing single-repo behaviour is unchanged. First of several Phase-2 slices;
epics/sessions, Outcomes (+ D2 `repo_data_root` migration), and the frontend
follow as separate PRs.

## Verification
pyright 0 errors, ruff clean, new merge-helper + aggregation tests, all 395
endpoint-touching tests green (updated 2 pre-existing queue tests that used
fabricated dicts to real `QueueStats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)