### PR TITLE
feat: Work Stream epics + sessions aggregation (Phase 2b)

### DIFF
--- a/src/dashboard_routes/_epic_routes.py
+++ b/src/dashboard_routes/_epic_routes.py
@@ -6,30 +6,40 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse
 
 from dashboard_routes._routes import RouteContext
-from route_types import RepoSlugParam
+from route_types import REPO_ALL, RepoSlugParam
 
 
 def register(router: APIRouter, ctx: RouteContext) -> None:
     """Register epic-related routes on *router*."""
 
+    def _is_all(repo: str | None) -> bool:
+        return repo is not None and repo.strip().lower() == REPO_ALL
+
     @router.get("/api/epics")
     async def get_epics(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return all tracked epics with enriched sub-issue progress."""
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        orch = _get_orch()
-        if orch is None:
-            return JSONResponse([])
-        details = await orch.epic_manager.get_all_detail()
-        return JSONResponse([d.model_dump() for d in details])
+        """Return all tracked epics — unioned across repos for ``repo=__all__``
+        and tagged by repo slug (epic numbers collide across repos)."""
+        epics: list[dict[str, object]] = []
+        for _cfg, _state, _bus, get_orch, slug in ctx.resolve_runtimes(repo):
+            orch = get_orch()
+            if orch is None:
+                continue
+            for detail in await orch.epic_manager.get_all_detail():
+                epics.append({**detail.model_dump(), "repo": slug})
+        return JSONResponse(epics)
 
     @router.get("/api/epics/{epic_number}")
     async def get_epic_detail(
         epic_number: int,
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return full detail for a single epic including child issue info."""
+        """Return full detail for a single epic (requires a specific repo)."""
+        if _is_all(repo):
+            return JSONResponse(
+                {"error": "epic detail requires a specific repo"}, status_code=400
+            )
         _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
         orch = _get_orch()
         if orch is None:
@@ -49,6 +59,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         Returns a job_id. Completion is signalled via the EPIC_RELEASED WebSocket
         event — there is no REST polling endpoint for job status.
         """
+        if _is_all(repo):
+            return JSONResponse(
+                {"error": "epic release requires a specific repo"}, status_code=400
+            )
         _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
         orch = _get_orch()
         if orch is None:

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -494,11 +494,12 @@ class RouteContext:
         if slug is not None and self.registry is not None:
             matched = self.registry.get(slug)
             if matched is not None:
-                resolved_slug = matched.slug
+                # Tolerate minimal runtime doubles without a slug attr.
+                resolved_slug = getattr(matched, "slug", None) or slug
             else:
                 slug_lower = slug.lower()
                 for rt in self.registry.all:
-                    if rt.slug.lower() == slug_lower:
+                    if getattr(rt, "slug", "").lower() == slug_lower:
                         resolved_slug = rt.slug
                         break
         cfg, st, bus, get_orch = self.resolve_runtime(slug)
@@ -1991,11 +1992,17 @@ def create_router(
     async def get_sessions(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return session logs for the selected repo."""
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        sessions = _state.load_sessions()
+        """Return session logs — unioned across repos for ``repo=__all__``.
+
+        Each runtime's state is already repo-scoped, and ``SessionLog.repo``
+        + the ``{repo_slug}-{ts}`` session_id make entries self-identifying.
+        """
+        sessions = []
+        for _cfg, _state, _bus, _get_orch, _slug in _resolve_runtimes(repo):
+            sessions.extend(_state.load_sessions())
         repo_filter = (repo or "").strip()
-        if repo_filter and registry is None:
+        if repo_filter and repo_filter.lower() != REPO_ALL and registry is None:
+            # Legacy no-registry wiring: load_sessions returns ALL; filter by tag.
             normalized = repo_filter.lower()
             sessions = [
                 session
@@ -2009,19 +2016,22 @@ def create_router(
         session_id: str,
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Return a single session by ID with associated events."""
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        session = _state.get_session(session_id)
-        if session is None:
-            return JSONResponse({"error": "Session not found"}, status_code=404)
-        # Include events tagged with this session_id
-        all_events = _bus.get_history()
-        session_events = [
-            e.model_dump() for e in all_events if e.session_id == session_id
-        ]
-        data = session.model_dump()
-        data["events"] = session_events
-        return JSONResponse(data)
+        """Return a single session by ID with associated events.
+
+        Searches the resolved runtime(s) — for ``repo=__all__`` this finds the
+        owning repo across every line; for a specific repo it checks just that one.
+        """
+        for _cfg, _state, _bus, _get_orch, _slug in _resolve_runtimes(repo):
+            session = _state.get_session(session_id)
+            if session is None:
+                continue
+            session_events = [
+                e.model_dump() for e in _bus.get_history() if e.session_id == session_id
+            ]
+            data = session.model_dump()
+            data["events"] = session_events
+            return JSONResponse(data)
+        return JSONResponse({"error": "Session not found"}, status_code=404)
 
     @router.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket) -> None:

--- a/tests/test_dashboard_routes_epics_sessions_multirepo.py
+++ b/tests/test_dashboard_routes_epics_sessions_multirepo.py
@@ -1,0 +1,85 @@
+"""Epics + sessions endpoints aggregate across repos for repo=__all__."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from route_types import REPO_ALL
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+
+
+def _orch_with_epic(epic_number: int) -> MagicMock:
+    orch = MagicMock()
+    detail = MagicMock(model_dump=lambda en=epic_number: {"epic_number": en})
+    orch.epic_manager.get_all_detail = AsyncMock(return_value=[detail])
+    return orch
+
+
+def _state_with_session(slug: str) -> MagicMock:
+    st = MagicMock()
+    session = MagicMock(
+        repo=slug, model_dump=lambda s=slug: {"id": f"{s}-1", "repo": s}
+    )
+    st.load_sessions = MagicMock(return_value=[session])
+    return st
+
+
+@pytest.mark.asyncio
+async def test_epics_union_tagged_by_repo(config, event_bus, state, tmp_path):
+    # Same epic_number in both repos must NOT collide — keyed by (repo, number).
+    registry = make_registry(
+        {"slug": "owner-a", "orchestrator": _orch_with_epic(1)},
+        {"slug": "owner-b", "orchestrator": _orch_with_epic(1)},
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/epics")
+
+    resp = await endpoint(repo=REPO_ALL)
+    data = json.loads(resp.body)
+
+    assert {(e["epic_number"], e["repo"]) for e in data} == {
+        (1, "owner-a"),
+        (1, "owner-b"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_epic_detail_rejects_all(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    endpoint = find_endpoint(router, "/api/epics/{epic_number}")
+
+    resp = await endpoint(1, REPO_ALL)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_epic_release_rejects_all(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    endpoint = find_endpoint(router, "/api/epics/{epic_number}/release", "POST")
+
+    resp = await endpoint(1, REPO_ALL)
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_sessions_union_across_repos(config, event_bus, state, tmp_path):
+    registry = make_registry(
+        {"slug": "owner-a", "state": _state_with_session("owner-a")},
+        {"slug": "owner-b", "state": _state_with_session("owner-b")},
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/sessions")
+
+    resp = await endpoint(repo=REPO_ALL)
+    data = json.loads(resp.body)
+
+    assert {s["repo"] for s in data} == {"owner-a", "owner-b"}


### PR DESCRIPTION
Aggregates /api/epics (union tagged by repo; detail/release reject __all__) and /api/sessions (union; detail searches runtimes for the owner) across repos for repo=__all__. Builds on Phase 2a. Additive — frontend __all__ switch follows. pyright 0, ruff clean, new + existing epic/session tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)