### PR TITLE
feat: activate repo=__all__ aggregate view in the Work Stream UI (Phase 2c)

### DIFF
--- a/src/ui/src/components/RepoSelector.jsx
+++ b/src/ui/src/components/RepoSelector.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useHydraFlow } from '../context/HydraFlowContext'
-import { canonicalRepoSlug } from '../constants'
+import { canonicalRepoSlug, REPO_ALL } from '../constants'
 import { theme } from '../theme'
 
 function buildDisplayName(repo) {
@@ -76,11 +76,14 @@ export function RepoSelector({ onOpenRegister }) {
     return entries
   }, [supervisedRepos, runtimeMap, defaultRepoSlug])
 
+  // null (initial) and REPO_ALL (explicitly picked) both mean "All repos".
+  const isAllRepos = selectedRepoSlug == null || selectedRepoSlug === REPO_ALL
+
   const currentLabel = useMemo(() => {
-    if (!selectedRepoSlug) return 'All repos'
+    if (isAllRepos) return 'All repos'
     const match = repoOptions.find(opt => opt.filterSlug === selectedRepoSlug)
     return match?.label || 'All repos'
-  }, [repoOptions, selectedRepoSlug])
+  }, [repoOptions, selectedRepoSlug, isAllRepos])
 
   const handleSelect = (slug) => {
     selectRepo(slug)
@@ -106,10 +109,10 @@ export function RepoSelector({ onOpenRegister }) {
         <div style={styles.dropdown} role="listbox" data-testid="repo-selector-dropdown">
           <button
             type="button"
-            onClick={() => handleSelect(null)}
-            style={selectedRepoSlug == null ? optionActiveStyle : optionStyle}
+            onClick={() => handleSelect(REPO_ALL)}
+            style={isAllRepos ? optionActiveStyle : optionStyle}
             role="option"
-            aria-selected={selectedRepoSlug == null}
+            aria-selected={isAllRepos}
           >
             <span style={styles.optionLabel}>All repos</span>
             <span style={styles.optionStatus}>Aggregated</span>

--- a/src/ui/src/components/StreamCard.jsx
+++ b/src/ui/src/components/StreamCard.jsx
@@ -146,6 +146,20 @@ export function StreamCard({ issue, intent, defaultExpanded, onRequestChanges, t
             <span style={styles.issueNum}>#{issue.issueNumber}</span>
           )}
           <span style={styles.title}>{intent?.text || issue.title}</span>
+          {issue.repo && (
+            <span
+              style={{
+                ...badgeBase,
+                textTransform: 'none',
+                background: theme.surfaceInset,
+                color: theme.textMuted,
+              }}
+              data-testid={`repo-badge-${issue.issueNumber}`}
+              title={`repo: ${issue.repo}`}
+            >
+              {issue.repo}
+            </span>
+          )}
         </div>
         <div style={styles.headerRight}>
           {meta && (

--- a/src/ui/src/components/StreamView.jsx
+++ b/src/ui/src/components/StreamView.jsx
@@ -62,7 +62,7 @@ function PipelineFlow({ stageGroups }) {
               : dotStyles.base[group.stage.key]
             return (
               <span
-                key={issue.issueNumber}
+                key={`${issue.repo}#${issue.issueNumber}`}
                 style={dotStyle}
                 title={`#${issue.issueNumber}${isEpic ? ` (Epic #${issue.epicNumber})` : ''}`}
                 data-testid={`flow-dot-${issue.issueNumber}`}
@@ -197,7 +197,7 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
           <>
             {standalone.map(issue => (
               <StreamCard
-                key={issue.issueNumber}
+                key={`${issue.repo}#${issue.issueNumber}`}
                 issue={issue}
                 intent={intentMap.get(issue.issueNumber)}
                 defaultExpanded={issue.overallStatus === 'active'}
@@ -209,7 +209,7 @@ function StageSection({ stage, issues, workerCount, workerCap, queuedCount, inte
               <EpicContainer key={`epic-${epicNum}`} epicNumber={Number(epicNum)} issues={epicIssues}>
                 {epicIssues.map(issue => (
                   <StreamCard
-                    key={issue.issueNumber}
+                    key={`${issue.repo}#${issue.issueNumber}`}
                     issue={issue}
                     intent={intentMap.get(issue.issueNumber)}
                     defaultExpanded={issue.overallStatus === 'active'}
@@ -275,6 +275,7 @@ export function toStreamIssue(pipeIssue, stageKey, prs) {
     stages,
     epicNumber: pipeIssue.epic_number || 0,
     isEpicChild: pipeIssue.is_epic_child || false,
+    repo: pipeIssue.repo || '',
   }
 }
 

--- a/src/ui/src/components/__tests__/RepoSelector.test.jsx
+++ b/src/ui/src/components/__tests__/RepoSelector.test.jsx
@@ -89,7 +89,7 @@ describe('RepoSelector', () => {
     expect(screen.getByTestId('repo-selector-trigger')).toHaveTextContent('All repos')
   })
 
-  it('selects All repos by passing null slug', () => {
+  it('selects All repos by passing the __all__ aggregate slug', () => {
     const selectRepo = vi.fn()
     mockUseHydraFlow.mockReturnValue(makeContext({
       supervisedRepos: [{ slug: 'acme/app' }],
@@ -101,7 +101,19 @@ describe('RepoSelector', () => {
     // Click the "All repos" option
     const allReposOptions = screen.getAllByText('All repos')
     fireEvent.click(allReposOptions[allReposOptions.length - 1])
-    expect(selectRepo).toHaveBeenCalledWith(null)
+    expect(selectRepo).toHaveBeenCalledWith('__all__')
+  })
+
+  it('treats __all__ as All repos (label + highlight)', () => {
+    mockUseHydraFlow.mockReturnValue(makeContext({
+      supervisedRepos: [{ slug: 'acme/app' }],
+      selectedRepoSlug: '__all__',
+    }))
+    render(<RepoSelector />)
+    expect(screen.getByTestId('repo-selector-trigger')).toHaveTextContent('All repos')
+    fireEvent.click(screen.getByTestId('repo-selector-trigger'))
+    const allReposOption = screen.getAllByRole('option')[0]
+    expect(allReposOption).toHaveAttribute('aria-selected', 'true')
   })
 
   it('shows empty state when no repos are registered', () => {

--- a/src/ui/src/components/__tests__/StreamCard.test.jsx
+++ b/src/ui/src/components/__tests__/StreamCard.test.jsx
@@ -629,3 +629,15 @@ describe('StreamCard transcript rendering', () => {
     expect(screen.queryByText('View Transcript')).not.toBeInTheDocument()
   })
 })
+
+describe('StreamCard repo badge', () => {
+  it('renders the repo badge when issue.repo is set (aggregate view)', () => {
+    render(<StreamCard issue={makeIssue({ repo: 'owner-a' })} />)
+    expect(screen.getByTestId('repo-badge-42')).toHaveTextContent('owner-a')
+  })
+
+  it('hides the repo badge when issue.repo is empty (single-repo view)', () => {
+    render(<StreamCard issue={makeIssue({ repo: '' })} />)
+    expect(screen.queryByTestId('repo-badge-42')).toBeNull()
+  })
+})

--- a/src/ui/src/constants.js
+++ b/src/ui/src/constants.js
@@ -8,6 +8,11 @@ export function canonicalRepoSlug(value) {
   return String(value || '').trim().replace(/[\\/]+/g, '-')
 }
 
+// Reserved aggregate sentinel — selecting "All repos" sends repo=__all__ so the
+// backend unions every repo. Truthy + slash-free, so canonicalRepoSlug and the
+// context's normalizeRepoSlug pass it through unchanged (load-bearing).
+export const REPO_ALL = '__all__'
+
 /**
  * Statuses that indicate a worker is actively processing.
  * Used across dashboard components to filter/count active workers.

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useRef, useCallback, useReducer, useMemo } from 'react'
-import { MAX_EVENTS, SYSTEM_WORKER_INTERVALS, PIPELINE_POLL_SAFETY_NET_MS, WS_RECONNECT_BASE_MS, WS_RECONNECT_MAX_MS } from '../constants'
+import { MAX_EVENTS, SYSTEM_WORKER_INTERVALS, PIPELINE_POLL_SAFETY_NET_MS, WS_RECONNECT_BASE_MS, WS_RECONNECT_MAX_MS, REPO_ALL } from '../constants'
 import { deriveStageStatus } from '../hooks/useStageStatus'
 
 const emptyPipeline = {
@@ -82,18 +82,24 @@ function addEvent(state, action) {
   }
 }
 
+// Compound key so two repos' issue #5 don't collide when aggregating (repo=__all__).
+// Single-repo items carry their own repo slug, so the key is stable there too.
+function issueKey(item) {
+  return `${item?.repo ?? ''}#${item?.issue_number}`
+}
+
 function mergeStageIssues(existingIssues, incomingIssues) {
   // Server snapshot is authoritative: items absent from incoming are removed
   // (prevents ghost cards) and incoming fields (including status) override
   // local state for items still present.
-  const existingById = new Map(
+  const existingByKey = new Map(
     (existingIssues || [])
       .filter(item => item?.issue_number != null)
-      .map(item => [item.issue_number, item])
+      .map(item => [issueKey(item), item])
   )
   return (incomingIssues || []).map(item => {
     if (item?.issue_number == null) return item
-    const existing = existingById.get(item.issue_number)
+    const existing = existingByKey.get(issueKey(item))
     return existing ? { ...existing, ...item } : item
   })
 }
@@ -572,6 +578,13 @@ export function reducer(state, action) {
       // unwrapped. Normalize both to the bare stage map.
       const incoming = action.data?.stages ?? action.data ?? {}
       const allStages = ['triage', 'discover', 'shape', 'plan', 'implement', 'review', 'hitl', 'merged']
+      // REST aggregation tags each issue with its repo; a WS frame's issues are
+      // untagged but the event carries event.repo (threaded via onmessage) —
+      // stamp it so WS and REST frames key/merge consistently (no dup cards).
+      const frameRepo = action.repo
+      const tag = (issues) => (frameRepo
+        ? (issues || []).map(item => (item?.repo ? item : { ...item, repo: frameRepo }))
+        : (issues || []))
 
       const nextStages = Object.fromEntries(allStages.map((key) => {
         if (!Object.prototype.hasOwnProperty.call(incoming, key)) {
@@ -579,7 +592,7 @@ export function reducer(state, action) {
         }
         // Server snapshot is authoritative: reconcile stage membership so issues
         // absent from the snapshot are removed (eliminates ghost cards).
-        return [key, mergeStageIssues(state.pipelineIssues[key], incoming[key] || [])]
+        return [key, mergeStageIssues(state.pipelineIssues[key], tag(incoming[key] || []))]
       }))
 
       return {
@@ -1505,7 +1518,7 @@ export function HydraFlowProvider({ children }) {
     ws.onmessage = (e) => {
       try {
         const event = JSON.parse(e.data)
-        dispatch({ type: event.type, data: event.data, timestamp: event.timestamp, id: event.id })
+        dispatch({ type: event.type, data: event.data, timestamp: event.timestamp, id: event.id, repo: event.repo })
         if (event.timestamp && (!lastEventTsRef.current || event.timestamp > lastEventTsRef.current)) {
           lastEventTsRef.current = event.timestamp
         }
@@ -1623,7 +1636,9 @@ export function HydraFlowProvider({ children }) {
   )
 
   const repoFilteredSessions = useMemo(() => {
-    if (!state.selectedRepoSlug) return state.sessions
+    // null (initial) and __all__ (aggregate) both mean "no client-side filter" —
+    // the backend already unions sessions for __all__.
+    if (!state.selectedRepoSlug || state.selectedRepoSlug === REPO_ALL) return state.sessions
     return state.sessions.filter(s => {
       return normalizeRepoSlug(s.repo) === state.selectedRepoSlug
     })

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -91,6 +91,29 @@ describe('HydraFlowContext reducer', () => {
     expect(next.defaultRepoSlug).toBe('test-org-test-repo')
   })
 
+  it('SELECT_REPO accepts the __all__ aggregate slug', () => {
+    const next = reducer(initialState, { type: 'SELECT_REPO', data: { slug: '__all__' } })
+    expect(next.selectedRepoSlug).toBe('__all__')
+  })
+
+  it('PIPELINE_SNAPSHOT keeps cross-repo same-issue-number cards (compound key)', () => {
+    const next = reducer(initialState, {
+      type: 'PIPELINE_SNAPSHOT',
+      data: { plan: [{ issue_number: 5, repo: 'owner-a' }, { issue_number: 5, repo: 'owner-b' }] },
+    })
+    expect(next.pipelineIssues.plan).toHaveLength(2)
+    expect(next.pipelineIssues.plan.map(i => i.repo).sort()).toEqual(['owner-a', 'owner-b'])
+  })
+
+  it('PIPELINE_SNAPSHOT stamps WS-frame issues with the event repo', () => {
+    const next = reducer(initialState, {
+      type: 'PIPELINE_SNAPSHOT',
+      repo: 'owner-a',
+      data: { stages: { plan: [{ issue_number: 7 }] } },
+    })
+    expect(next.pipelineIssues.plan[0].repo).toBe('owner-a')
+  })
+
   it('GITHUB_METRICS action sets githubMetrics state', () => {
     const data = {
       open_by_label: { 'hydraflow-plan': 3, 'hydraflow-ready': 1 },


### PR DESCRIPTION
Flips the 'All repos' selector to send `repo=__all__`, lighting up the already-merged backend aggregation (pipeline/queue/stats/epics/sessions). Pipeline cards key by `(repo, issue_number)` (collision-safe) with per-repo badges; WS PIPELINE_SNAPSHOT frames are stamped with `event.repo` so WS-default and REST-aggregated frames merge, not duplicate. Non-aggregating endpoints treat `__all__` as default (graceful). Full vitest 1088 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)