### PR TITLE
feat: Outcomes multi-repo aggregation + per-repo history scoping (Phase 2d)

### DIFF
--- a/src/dashboard_routes/_metrics_routes.py
+++ b/src/dashboard_routes/_metrics_routes.py
@@ -21,7 +21,7 @@ from models import (
     MetricsSnapshot,
 )
 from prompt_telemetry import PromptTelemetry
-from route_types import RepoSlugParam
+from route_types import REPO_ALL, RepoSlugParam
 
 if TYPE_CHECKING:
     from pr_manager import PRManager
@@ -95,10 +95,21 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         }
 
     @router.get("/api/issues/outcomes")
-    async def get_issue_outcomes() -> JSONResponse:
-        """Return all recorded issue outcomes."""
-        outcomes = ctx.state.get_all_outcomes()
-        return JSONResponse({k: v.model_dump() for k, v in outcomes.items()})
+    async def get_issue_outcomes(repo: RepoSlugParam = None) -> JSONResponse:
+        """Return all recorded issue outcomes (repo-scoped).
+
+        A specific repo (or the default) keeps the bare issue-number key for
+        backward compatibility. For ``repo=__all__`` outcomes are unioned across
+        repos and keyed ``{repo_slug}#{issue_number}`` (issue numbers collide
+        across repos); every entry is tagged with its ``repo`` slug regardless.
+        """
+        aggregate = repo is not None and repo.strip().lower() == REPO_ALL
+        result: dict[str, Any] = {}
+        for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+            for num, outcome in _state.get_all_outcomes().items():
+                key = f"{slug}#{num}" if aggregate else str(num)
+                result[key] = {**outcome.model_dump(), "repo": slug}
+        return JSONResponse(result)
 
     @router.get("/api/metrics")
     async def get_metrics(

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -797,9 +797,11 @@ def create_router(
             key=lambda lnk: lnk.target_id,
         )
 
-    def _new_issue_history_entry(issue_number: int) -> dict[str, Any]:
+    def _new_issue_history_entry(
+        issue_number: int, cfg: HydraFlowConfig
+    ) -> dict[str, Any]:
         """Create a blank history aggregation row for an issue."""
-        repo_slug = (config.repo or "").strip()
+        repo_slug = (cfg.repo or "").strip()
         if repo_slug.startswith("https://github.com/"):
             repo_slug = repo_slug[len("https://github.com/") :]
         elif repo_slug.startswith("http://github.com/"):
@@ -841,6 +843,7 @@ def create_router(
     def _build_issue_history_entry(
         row: dict[str, Any],
         outcome: IssueOutcome | None,
+        repo_slug: str = "",
     ) -> IssueHistoryEntry:
         """Build an ``IssueHistoryEntry`` from a raw aggregation row."""
         issue_number = int(row["issue_number"])
@@ -883,6 +886,7 @@ def create_router(
             first_seen=row.get("first_seen"),
             last_seen=row.get("last_seen"),
             outcome=outcome,
+            repo=repo_slug,
         )
 
     def _aggregate_telemetry_record(
@@ -935,6 +939,7 @@ def create_router(
         pr_to_issue: dict[int, int],
         since_dt: datetime | None,
         until_dt: datetime | None,
+        cfg: HydraFlowConfig,
     ) -> None:
         """Process event-bus events into *issue_rows* in place."""
         for event in events:
@@ -951,7 +956,7 @@ def create_router(
                 continue
 
             row = issue_rows.setdefault(
-                issue_number, _new_issue_history_entry(issue_number)
+                issue_number, _new_issue_history_entry(issue_number, cfg)
             )
             _touch_issue_timestamps(row, timestamp)
 
@@ -1029,6 +1034,8 @@ def create_router(
         issue_rows: dict[int, dict[str, Any]],
         requested_status: str,
         query_text: str,
+        state: StateTracker,
+        repo_slug: str = "",
     ) -> list[IssueHistoryEntry]:
         """Filter *issue_rows* and convert to ``IssueHistoryEntry`` objects."""
         items: list[IssueHistoryEntry] = []
@@ -1047,7 +1054,9 @@ def create_router(
                 continue
 
             items.append(
-                _build_issue_history_entry(row, state.get_outcome(issue_number))
+                _build_issue_history_entry(
+                    row, state.get_outcome(issue_number), repo_slug
+                )
             )
         return items
 
@@ -1057,12 +1066,26 @@ def create_router(
         requested_status: str,
         query_text: str,
         use_unfiltered: bool,
+        *,
+        cfg: HydraFlowConfig,
+        bus: EventBus,
+        state: StateTracker,
+        repo_slug: str,
+        use_cache: bool,
     ) -> list[IssueHistoryEntry]:
         """Enrich items via GitHub and backfill crate titles from milestones.
 
+        Runs against the runtime's own *cfg*/*state*/PR manager. The persistent
+        ``_history_cache`` (enriched-issue set + cached rows) is keyed to the
+        default runtime only, so it is read/written exclusively when *use_cache*
+        is True — per-repo / ``__all__`` requests track enrichment locally and
+        never mutate the default cache.
+
         Returns a (potentially rebuilt) items list.
         """
-        already_enriched: set[int] = _history_cache.get("enriched_issues", set())
+        already_enriched: set[int] = (
+            _history_cache.get("enriched_issues", set()) if use_cache else set()
+        )
         issue_lookup = {
             item.issue_number: issue_rows[item.issue_number] for item in items
         }
@@ -1078,15 +1101,18 @@ def create_router(
         ][:40]
         if enrich_candidates:
             await _enrich_issue_history_with_github(
-                {k: issue_lookup[k] for k in enrich_candidates}
+                {k: issue_lookup[k] for k in enrich_candidates}, cfg
             )
             already_enriched.update(enrich_candidates)
-            _history_cache["enriched_issues"] = already_enriched
-            if use_unfiltered and _history_cache["issue_rows"] is not None:
-                _history_cache["issue_rows"] = copy.deepcopy(issue_rows)
-                _save_history_cache()
+            if use_cache:
+                _history_cache["enriched_issues"] = already_enriched
+                if use_unfiltered and _history_cache["issue_rows"] is not None:
+                    _history_cache["issue_rows"] = copy.deepcopy(issue_rows)
+                    _save_history_cache()
             # Rebuild items from enriched rows.
-            items = _filter_rows_to_items(issue_rows, requested_status, query_text)
+            items = _filter_rows_to_items(
+                issue_rows, requested_status, query_text, state, repo_slug
+            )
 
         # Sort before crate-title backfill so milestone fetches are done
         # after ordering.  The caller applies the page limit after returning.
@@ -1105,7 +1131,8 @@ def create_router(
         if needs_title:
             try:
                 # ``list_milestones`` is concrete-only on PRManager.
-                milestones = await cast("PRManager", pr_manager).list_milestones(
+                manager = _pr_manager_for(cfg, bus)
+                milestones = await cast("PRManager", manager).list_milestones(
                     state="all"
                 )
                 title_map = {m.number: m.title for m in milestones}
@@ -1127,6 +1154,7 @@ def create_router(
                             backfilled = True
                 if (
                     backfilled
+                    and use_cache
                     and use_unfiltered
                     and _history_cache.get("issue_rows") is not None
                 ):
@@ -1175,13 +1203,15 @@ def create_router(
         return items
 
     async def _enrich_issue_history_with_github(
-        entries: dict[int, dict[str, Any]], limit: int = 150
+        entries: dict[int, dict[str, Any]],
+        cfg: HydraFlowConfig,
+        limit: int = 150,
     ) -> None:
         """Concurrently fetch GitHub metadata and apply it to history entries."""
         if not entries:
             return
 
-        fetcher = IssueFetcher(config, credentials=_creds)
+        fetcher = IssueFetcher(cfg, credentials=_creds)
         issue_numbers = sorted(entries.keys(), reverse=True)[:limit]
         sem = asyncio.Semaphore(6)
 
@@ -1759,25 +1789,28 @@ def create_router(
     except Exception:
         logger.warning("History cache warm-up failed", exc_info=True)
 
-    @router.get("/api/issues/history")
-    async def get_issue_history(
-        since: str | None = None,
-        until: str | None = None,
-        status: str | None = None,
-        query: str | None = None,
-        limit: int = 300,
-        repo: RepoSlugParam = None,
-    ) -> JSONResponse:
-        """Return issue lifecycle history with inference rollups (repo-scoped)."""
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
-        since_dt = _parse_iso_or_none(since)
-        until_dt = _parse_iso_or_none(until)
-        requested_status = (status or "").strip().lower()
-        query_text = (query or "").strip().lower()
-        clamped_limit = max(1, min(limit, 1000))
+    async def _collect_history_items(
+        cfg: HydraFlowConfig,
+        state: StateTracker,
+        bus: EventBus,
+        repo_slug: str,
+        *,
+        since_dt: datetime | None,
+        until_dt: datetime | None,
+        requested_status: str,
+        query_text: str,
+        use_cache: bool,
+    ) -> list[IssueHistoryEntry]:
+        """Build issue-history rows for ONE runtime, tagged with *repo_slug*.
 
-        telemetry = PromptTelemetry(_cfg)
-        all_events = _bus.get_history()
+        Reads the runtime's own telemetry/events/state. The persistent
+        ``_history_cache`` is keyed to the default runtime only, so it is
+        read/written exclusively when *use_cache* is True (``repo is None``);
+        per-repo and ``__all__`` requests build fresh so one repo's rollups
+        never bleed into another's view — or into the cached default.
+        """
+        telemetry = PromptTelemetry(cfg)
+        all_events = bus.get_history()
 
         # Check if we can reuse cached aggregation for the unfiltered case.
         use_unfiltered = since_dt is None and until_dt is None
@@ -1785,8 +1818,8 @@ def create_router(
         telem_mtime = telemetry.get_mtime()
         now = time.monotonic()
         cache_hit = (
-            use_unfiltered
-            and repo is None
+            use_cache
+            and use_unfiltered
             and _history_cache["issue_rows"] is not None
             and _history_cache["event_count"] == event_count
             and _history_cache["telemetry_mtime"] == telem_mtime
@@ -1824,7 +1857,7 @@ def create_router(
         elif use_issue_rollups:
             for issue_number, counters in telemetry.get_issue_totals().items():
                 row = issue_rows.setdefault(
-                    issue_number, _new_issue_history_entry(issue_number)
+                    issue_number, _new_issue_history_entry(issue_number, cfg)
                 )
                 for key in _INFERENCE_COUNTER_KEYS:
                     row["inference"][key] = _coerce_int(counters.get(key, 0))
@@ -1854,20 +1887,20 @@ def create_router(
                 if issue_number <= 0:
                     continue
                 row = issue_rows.setdefault(
-                    issue_number, _new_issue_history_entry(issue_number)
+                    issue_number, _new_issue_history_entry(issue_number, cfg)
                 )
                 _aggregate_telemetry_record(row, record, pr_to_issue, sum_counters=True)
 
         if not cache_hit:
             _process_events_into_rows(
-                all_events, issue_rows, pr_to_issue, since_dt, until_dt
+                all_events, issue_rows, pr_to_issue, since_dt, until_dt, cfg
             )
 
             # Store in cache if this was an unfiltered aggregation. Only the
             # default-repo view is cached: _history_cache is not repo-keyed, so
-            # a per-repo request must never read (see cache_hit above) or write
-            # it, or one repo's rollups would bleed into another's view.
-            if use_unfiltered and repo is None:
+            # a per-repo / __all__ request must never read (see cache_hit) or
+            # write it, or one repo's rollups would bleed into another's view.
+            if use_cache and use_unfiltered:
                 _history_cache["issue_rows"] = copy.deepcopy(issue_rows)
                 _history_cache["pr_to_issue"] = dict(pr_to_issue)
                 _history_cache["event_count"] = event_count
@@ -1875,11 +1908,76 @@ def create_router(
                 _history_cache_ts[0] = now
                 _save_history_cache()
 
-        items = _filter_rows_to_items(issue_rows, requested_status, query_text)
+        items = _filter_rows_to_items(
+            issue_rows, requested_status, query_text, state, repo_slug
+        )
 
         # Enrich via GitHub, backfill crate titles, sort.
         items = await _apply_enrichment_and_crate_titles(
-            items, issue_rows, requested_status, query_text, use_unfiltered
+            items,
+            issue_rows,
+            requested_status,
+            query_text,
+            use_unfiltered,
+            cfg=cfg,
+            bus=bus,
+            state=state,
+            repo_slug=repo_slug,
+            use_cache=use_cache,
+        )
+        return items
+
+    @router.get("/api/issues/history")
+    async def get_issue_history(
+        since: str | None = None,
+        until: str | None = None,
+        status: str | None = None,
+        query: str | None = None,
+        limit: int = 300,
+        repo: RepoSlugParam = None,
+    ) -> JSONResponse:
+        """Return issue lifecycle history with inference rollups (repo-scoped).
+
+        For ``repo=__all__`` the history is unioned across every runtime and
+        each row is tagged with its repo slug. Issue numbers collide across
+        repos, so rows are kept distinct per ``(repo, issue_number)`` (the
+        per-runtime lists are simply concatenated, never merged by number).
+        """
+        since_dt = _parse_iso_or_none(since)
+        until_dt = _parse_iso_or_none(until)
+        requested_status = (status or "").strip().lower()
+        query_text = (query or "").strip().lower()
+        clamped_limit = max(1, min(limit, 1000))
+
+        # The persistent history cache is keyed to the default runtime, so only
+        # a bare (repo is None) request may use it.
+        use_cache = repo is None
+
+        items: list[IssueHistoryEntry] = []
+        for _cfg, _state, _bus, _get_orch, slug in _resolve_runtimes(repo):
+            items.extend(
+                await _collect_history_items(
+                    _cfg,
+                    _state,
+                    _bus,
+                    slug,
+                    since_dt=since_dt,
+                    until_dt=until_dt,
+                    requested_status=requested_status,
+                    query_text=query_text,
+                    use_cache=use_cache,
+                )
+            )
+
+        # Order globally across runtimes (per-runtime lists were each sorted),
+        # then apply the page limit to the merged result.
+        items.sort(
+            key=lambda item: (
+                item.last_seen or "",
+                item.inference.get("total_tokens", 0),
+                item.issue_number,
+            ),
+            reverse=True,
         )
         items = items[:clamped_limit]
 

--- a/src/ui/src/components/IssueHistoryPanel.jsx
+++ b/src/ui/src/components/IssueHistoryPanel.jsx
@@ -203,7 +203,7 @@ function formatDuration(firstSeen, lastSeen) {
 const COLUMN_DEFS = [
   { key: 'number', label: '#', width: '52px', align: 'left', sortAccessor: item => item.issue_number },
   { key: 'title', label: 'Title', width: 'minmax(220px, 3fr)', align: 'left', sortAccessor: item => (item.title || '').toLowerCase() },
-  { key: 'repo', label: 'Repo', width: 'minmax(80px, 1fr)', align: 'left', sortAccessor: item => (extractRepoSlug(item.issue_url) || '').toLowerCase() },
+  { key: 'repo', label: 'Repo', width: 'minmax(80px, 1fr)', align: 'left', sortAccessor: item => (item.repo || extractRepoSlug(item.issue_url) || '').toLowerCase() },
   { key: 'stage', label: 'Stage', width: '84px', align: 'left', sortAccessor: item => item.status || 'unknown' },
   { key: 'outcome', label: 'Outcome', width: '100px', align: 'left', sortAccessor: item => item.outcome?.outcome || 'pending' },
   { key: 'prs', label: 'PRs', width: '40px', align: 'left', sortAccessor: item => item.prs?.length || 0 },
@@ -234,7 +234,7 @@ function sortItems(items, sortColumn, sortDirection) {
 }
 
 export function OutcomesPanel() {
-  const { issueHistory, selectedRepoSlug } = useHydraFlow()
+  const { issueHistory } = useHydraFlow()
   const [preset, setPreset] = useState('all')
   const [customStart, setCustomStart] = useState('')
   const [customEnd, setCustomEnd] = useState('')
@@ -314,16 +314,13 @@ export function OutcomesPanel() {
   )
 
   const filtered = useMemo(() => {
-    const slug = selectedRepoSlug
+    // Repo scoping is server-side: the backend returns only the selected
+    // repo's rows (or, for repo=__all__, the per-repo-tagged union), so there
+    // is no client-side repo filter here — that would blank the all-repos view.
     const q = search.trim().toLowerCase()
     const since = timeRange.since ? new Date(timeRange.since).getTime() : null
     const until = timeRange.until ? new Date(timeRange.until).getTime() : null
     return (payload.items || []).filter(item => {
-      if (slug) {
-        const sessions = Array.isArray(item.session_ids) ? item.session_ids : []
-        const matchesRepo = sessions.some((id) => typeof id === 'string' && id.startsWith(slug))
-        if (!matchesRepo) return false
-      }
       if (since || until) {
         const ts = item.last_seen ? new Date(item.last_seen).getTime() : 0
         if (since && ts < since) return false
@@ -338,7 +335,7 @@ export function OutcomesPanel() {
       if ((item.epic || '').toLowerCase().includes(q)) return true
       if ((item.crate_title || '').toLowerCase().includes(q)) return true
       if (item.crate_number != null && String(item.crate_number).includes(q)) return true
-      const repoSlug = extractRepoSlug(item.issue_url)
+      const repoSlug = item.repo || extractRepoSlug(item.issue_url)
       if (repoSlug && repoSlug.toLowerCase().includes(q)) return true
       if ((item.outcome?.reason || '').toLowerCase().includes(q)) return true
       return false
@@ -349,7 +346,6 @@ export function OutcomesPanel() {
     outcomeFilter,
     epicOnly,
     search,
-    selectedRepoSlug,
     timeRange.since,
     timeRange.until,
   ])
@@ -410,8 +406,8 @@ export function OutcomesPanel() {
 
   const visibleSavedTokens = estimateSavedTokens(visibleTotals.pruned_chars_total)
 
-  const toggleExpanded = (issueNumber) => {
-    setExpanded(prev => ({ ...prev, [issueNumber]: !prev[issueNumber] }))
+  const toggleExpanded = (rowKey) => {
+    setExpanded(prev => ({ ...prev, [rowKey]: !prev[rowKey] }))
   }
 
   const toggleGroupCollapse = (label) => {
@@ -457,10 +453,21 @@ export function OutcomesPanel() {
       )
     },
     repo: (item) => {
-      const repoSlug = extractRepoSlug(item.issue_url)
+      // Prefer the backend's canonical dash slug (owner-name); fall back to the
+      // owner/name parsed from the issue URL for rows without a repo tag.
+      // Render it verbatim (matching StreamCard / RepoSelector) \u2014 the dash slug
+      // can't be split into owner/name reliably, so don't fabricate a short name.
+      const repoSlug = item.repo || extractRepoSlug(item.issue_url)
+      if (!repoSlug) {
+        return <span style={styles.dimText}>{'\u2014'}</span>
+      }
       return (
-        <span style={styles.repoCell} title={repoSlug || ''}>
-          {repoSlug ? repoSlug.split('/')[1] || repoSlug : <span style={styles.dimText}>{'\u2014'}</span>}
+        <span
+          style={styles.repoBadge}
+          data-testid={`repo-badge-${item.issue_number}`}
+          title={`repo: ${repoSlug}`}
+        >
+          {repoSlug}
         </span>
       )
     },
@@ -501,13 +508,18 @@ export function OutcomesPanel() {
 
   function renderIssueRow(item) {
     const issueNum = item.issue_number
-    const isExpanded = !!expanded[issueNum]
+    // Issue numbers collide across repos in the all-repos view, so the React
+    // key and expand/collapse state are keyed by (repo, issue) — keying by the
+    // bare number would make two repos' same-numbered rows share a key and
+    // expand together.
+    const rowKey = `${item.repo || ''}#${issueNum}`
+    const isExpanded = !!expanded[rowKey]
     return (
-      <div key={issueNum} data-testid={`outcome-row-${issueNum}`} style={styles.rowWrap}>
+      <div key={rowKey} data-testid={`outcome-row-${issueNum}`} style={styles.rowWrap}>
         <div style={{ ...styles.row, gridTemplateColumns: gridColumns }}>
           <button
             type="button"
-            onClick={() => toggleExpanded(issueNum)}
+            onClick={() => toggleExpanded(rowKey)}
             style={styles.expandButton}
             aria-label={`Toggle issue ${issueNum}`}
           >
@@ -1065,13 +1077,20 @@ const styles = {
     textOverflow: 'ellipsis',
     maxWidth: 120,
   },
-  repoCell: {
+  repoBadge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '1px 6px',
+    borderRadius: 8,
+    fontSize: 9,
+    fontWeight: 600,
+    background: theme.surfaceInset,
     color: theme.textMuted,
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     minWidth: 0,
-    fontSize: 11,
+    maxWidth: '100%',
   },
   dimText: {
     color: theme.textMuted,

--- a/src/ui/src/components/__tests__/IssueHistoryPanel.test.jsx
+++ b/src/ui/src/components/__tests__/IssueHistoryPanel.test.jsx
@@ -91,11 +91,41 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
     expect(screen.getByText('No issues match this filter.')).toBeInTheDocument()
   })
 
-  it('filters rows by selected repo slug based on session ids', () => {
+  it('does not filter rows client-side by selected repo (backend scopes)', () => {
+    // The backend now returns only the selected repo's rows (or the per-repo
+    // tagged union for repo=__all__), so the panel must render every row it
+    // receives. The old session_ids client filter would have hidden rows here
+    // and blanked the all-repos view entirely.
     mockUseHydraFlow.mockReturnValue({ issueHistory: makePayload(), selectedRepoSlug: 'acme-app' })
     render(<OutcomesPanel />)
     expect(screen.getByText('Fix auth cache')).toBeInTheDocument()
-    expect(screen.queryByText('Merge docs')).toBeNull()
+    expect(screen.getByText('Merge docs')).toBeInTheDocument()
+  })
+
+  it('renders the repo badge from the backend repo field when present', () => {
+    const payload = makePayload()
+    payload.items[0].repo = 'owner-b'
+    mockUseHydraFlow.mockReturnValue({ issueHistory: payload, selectedRepoSlug: null })
+    render(<OutcomesPanel />)
+    expect(screen.getByTestId('repo-badge-10')).toHaveTextContent('owner-b')
+  })
+
+  it('expands same-numbered rows from different repos independently', () => {
+    const base = makePayload()
+    const payload = {
+      items: [
+        { ...base.items[0], issue_number: 42, repo: 'owner-a', title: 'Alpha 42' },
+        { ...base.items[1], issue_number: 42, repo: 'owner-b', title: 'Beta 42' },
+      ],
+      totals: { issues: 2 },
+    }
+    mockUseHydraFlow.mockReturnValue({ issueHistory: payload, selectedRepoSlug: null })
+    render(<OutcomesPanel />)
+    // Both repos' #42 render as distinct rows (compound React keys).
+    expect(screen.getAllByTestId('outcome-row-42')).toHaveLength(2)
+    // Expanding one must not expand the other (expand state keyed by repo+issue).
+    fireEvent.click(screen.getAllByLabelText('Toggle issue 42')[0])
+    expect(screen.getAllByText('Linked Issues')).toHaveLength(1)
   })
 
   it('expands an issue row to show rollup details with kind-aware linked issues', () => {
@@ -215,9 +245,10 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
   it('displays repo slug extracted from issue URL', async () => {
     render(<OutcomesPanel />)
     await waitFor(() => expect(screen.getByText('Fix auth cache')).toBeInTheDocument())
-    // Should extract and show repo name from GitHub URL
-    expect(screen.getByText('webapp')).toBeInTheDocument()
-    expect(screen.getByText('docs-site')).toBeInTheDocument()
+    // No backend repo field on these rows → falls back to the owner/name parsed
+    // from the GitHub URL, rendered verbatim (matching StreamCard's slug badge).
+    expect(screen.getByText('acme/webapp')).toBeInTheDocument()
+    expect(screen.getByText('acme/docs-site')).toBeInTheDocument()
   })
 
   it('displays outcome reason as subtitle under title', async () => {
@@ -320,8 +351,9 @@ describe('OutcomesPanel (merged History+Outcomes)', () => {
     })
     render(<OutcomesPanel />)
     await waitFor(() => expect(screen.getByText('Fix auth cache')).toBeInTheDocument())
-    // Should render without error — no repo slug shown
-    expect(screen.getByText('docs-site')).toBeInTheDocument()
+    // Should render without error — item 10 shows an em-dash (no url/repo),
+    // item 11 still shows its slug parsed from the URL.
+    expect(screen.getByText('acme/docs-site')).toBeInTheDocument()
   })
 
   describe('column sorting', () => {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1650,7 +1650,7 @@ export function HydraFlowProvider({ children }) {
     let cancelled = false
 
     const endpoints = [
-      { url: '/api/issues/history?limit=500', key: 'issueHistory' },
+      { url: '/api/issues/history?limit=500', key: 'issueHistory', repoScoped: true },
       { url: '/api/harness-insights', key: 'harnessInsights' },
       { url: '/api/review-insights', key: 'reviewInsights' },
       { url: '/api/retrospectives', key: 'retrospectives' },
@@ -1659,7 +1659,9 @@ export function HydraFlowProvider({ children }) {
 
     async function poll() {
       const results = await Promise.allSettled(
-        endpoints.map(({ url }) => fetch(url).then(r => r.ok ? r.json() : null))
+        endpoints.map(({ url, repoScoped }) =>
+          (repoScoped ? fetchWithRepo(url) : fetch(url)).then(r => r.ok ? r.json() : null)
+        )
       )
       if (cancelled) return
       const update = {}
@@ -1677,7 +1679,7 @@ export function HydraFlowProvider({ children }) {
     poll()
     const interval = setInterval(poll, 30_000)
     return () => { cancelled = true; clearInterval(interval) }
-  }, [state.connected])
+  }, [state.connected, fetchWithRepo])
 
   // Reflect WebSocket connection state as a DOM attribute so Playwright helpers
   // (wait_for_ws_ready) can detect readiness without polling JS state.

--- a/tests/scenarios/test_multi_repo_history_outcomes.py
+++ b/tests/scenarios/test_multi_repo_history_outcomes.py
@@ -1,0 +1,85 @@
+"""Scenario: /api/issues/history aggregates real per-repo outcomes for __all__.
+
+Unlike the duck-typed unit test, this drives the actual route through a
+MockWorld-seeded registry of real ``RepoRuntime`` objects (isolated config /
+state / event bus per repo), proving the closure-threading + (repo, issue)
+re-key hold end-to-end against colliding issue numbers across repos.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from events import EventType, HydraFlowEvent
+from mockworld.seed import MockWorldSeed
+from models import IssueOutcomeType
+from tests.helpers import find_endpoint, make_dashboard_router
+
+pytestmark = pytest.mark.scenario
+
+
+class _OfflineIssueFetcher:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def fetch_issue_by_number(self, issue_number: int) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_history_repo_all_aggregates_seeded_repo_outcomes(
+    mock_world, config, event_bus, state, tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setattr("dashboard_routes._routes.IssueFetcher", _OfflineIssueFetcher)
+    seed = MockWorldSeed(
+        repos=[
+            ("owner/alpha", str(tmp_path / "alpha")),
+            ("owner/beta", str(tmp_path / "beta")),
+        ],
+    )
+    mock_world.apply_seed(seed)
+
+    alpha = mock_world.registry.get("owner-alpha")
+    beta = mock_world.registry.get("owner-beta")
+    await alpha.event_bus.publish(
+        HydraFlowEvent(
+            type=EventType.ISSUE_CREATED,
+            data={"issue": 42, "title": "Alpha 42", "labels": ["epic:alpha"]},
+        )
+    )
+    alpha.state.record_outcome(
+        42, IssueOutcomeType.MERGED, reason="merged", pr_number=101, phase="review"
+    )
+    await beta.event_bus.publish(
+        HydraFlowEvent(
+            type=EventType.ISSUE_CREATED,
+            data={"issue": 42, "title": "Beta 42", "labels": ["epic:beta"]},
+        )
+    )
+    beta.state.record_outcome(
+        42, IssueOutcomeType.HITL_APPROVED, reason="approved", phase="hitl"
+    )
+
+    default_slug = config.repo.replace("/", "-")
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=mock_world.registry,
+        default_repo_slug=default_slug,
+    )
+    endpoint = find_endpoint(router, "/api/issues/history")
+
+    payload = json.loads((await endpoint(repo="__all__", limit=500)).body)
+    by_key = {(x["issue_number"], x["repo"]): x for x in payload["items"]}
+
+    assert (42, "owner-alpha") in by_key
+    assert (42, "owner-beta") in by_key
+    assert by_key[(42, "owner-alpha")]["outcome"]["outcome"] == "merged"
+    assert by_key[(42, "owner-beta")]["outcome"]["outcome"] == "hitl_approved"
+    assert "owner/alpha" in by_key[(42, "owner-alpha")]["issue_url"]
+    assert "owner/beta" in by_key[(42, "owner-beta")]["issue_url"]

--- a/tests/test_dashboard_routes_issue_history_multirepo.py
+++ b/tests/test_dashboard_routes_issue_history_multirepo.py
@@ -1,0 +1,296 @@
+"""Multi-repo aggregation + per-repo scoping for GET /api/issues/history (Phase 2d).
+
+Issue/PR numbers collide across repos, so the history endpoint must key rows by
+``(repo, issue_number)`` and read each repo's OWN outcome/url, never the default
+runtime's. These tests pin: ``repo=__all__`` unions colliding numbers without
+collapsing them, ``repo=<slug>`` scopes to one runtime's own data, and a
+per-repo request never reads or corrupts the default-repo history cache.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from events import EventBus, EventType, HydraFlowEvent
+from models import IssueOutcomeType
+from route_types import REPO_ALL
+from state import StateTracker
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+class _OfflineIssueFetcher:
+    """Stand-in for IssueFetcher that never touches the network."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def fetch_issue_by_number(self, issue_number: int) -> None:
+        return None
+
+
+class _RepoAwareFetcher:
+    """Fake IssueFetcher returning per-repo data so enrichment is observable."""
+
+    def __init__(self, cfg: Any, *args: Any, **kwargs: Any) -> None:
+        self._repo = cfg.repo
+
+    async def fetch_issue_by_number(self, issue_number: int) -> SimpleNamespace:
+        return SimpleNamespace(
+            title=f"{self._repo} #{issue_number} ENRICHED",
+            url=f"https://github.com/{self._repo}/issues/{issue_number}",
+            labels=[],
+            body="",
+            milestone_number=None,
+        )
+
+
+@pytest.fixture(autouse=True)
+def _offline_github(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep GitHub enrichment deterministic and offline for every test here."""
+    monkeypatch.setattr("dashboard_routes._routes.IssueFetcher", _OfflineIssueFetcher)
+
+
+async def _seed_runtime(
+    tmp_path: Path,
+    *,
+    slug: str,
+    repo: str,
+    issue: int,
+    outcome: IssueOutcomeType,
+    pr: int = 0,
+    enrichable: bool = False,
+) -> dict[str, Any]:
+    """Build a duck-typed runtime spec whose state holds *issue* with *outcome*.
+
+    The issue row is created from an ISSUE_CREATED event on the runtime's own
+    bus; ``enrichable=False`` seeds a title + epic so the row is NOT a GitHub
+    enrichment candidate (no network), while the issue_url is left to come from
+    the runtime's config so the closure-bug fix is observable.
+    """
+    cfg = ConfigFactory.create(repo=repo, repo_root=tmp_path / slug)
+    bus = EventBus()
+    st = StateTracker(tmp_path / f"{slug}-state.json")
+    data: dict[str, Any] = {"issue": issue}
+    if not enrichable:
+        data["title"] = f"{slug} issue {issue}"
+        data["labels"] = [f"epic:{slug}"]
+    await bus.publish(HydraFlowEvent(type=EventType.ISSUE_CREATED, data=data))
+    st.record_outcome(
+        issue,
+        outcome,
+        reason=f"{slug} resolution",
+        pr_number=pr or None,
+        phase="review",
+    )
+    return {"slug": slug, "config": cfg, "state": st, "event_bus": bus}
+
+
+@pytest.mark.asyncio
+async def test_history_repo_all_unions_colliding_issue_numbers(
+    config: Any, event_bus: Any, state: Any, tmp_path: Path
+) -> None:
+    """repo=__all__ keeps both repos' issue #42 with their distinct outcomes."""
+    spec_a = await _seed_runtime(
+        tmp_path,
+        slug="owner-a",
+        repo="owner/a",
+        issue=42,
+        outcome=IssueOutcomeType.MERGED,
+        pr=101,
+    )
+    spec_b = await _seed_runtime(
+        tmp_path,
+        slug="owner-b",
+        repo="owner/b",
+        issue=42,
+        outcome=IssueOutcomeType.HITL_APPROVED,
+        pr=202,
+    )
+    registry = make_registry(spec_a, spec_b)
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/issues/history")
+
+    payload = json.loads((await endpoint(repo=REPO_ALL, limit=500)).body)
+    by_key = {(x["issue_number"], x["repo"]): x for x in payload["items"]}
+
+    assert (42, "owner-a") in by_key
+    assert (42, "owner-b") in by_key
+    assert by_key[(42, "owner-a")]["outcome"]["outcome"] == "merged"
+    assert by_key[(42, "owner-b")]["outcome"]["outcome"] == "hitl_approved"
+
+
+@pytest.mark.asyncio
+async def test_history_singular_repo_returns_its_own_outcome_url_and_tag(
+    config: Any, event_bus: Any, state: Any, tmp_path: Path
+) -> None:
+    """repo=<slug> reads that runtime's outcome/url/tag, not the default's."""
+    spec_a = await _seed_runtime(
+        tmp_path,
+        slug="owner-a",
+        repo="owner/a",
+        issue=42,
+        outcome=IssueOutcomeType.MERGED,
+        pr=101,
+    )
+    spec_b = await _seed_runtime(
+        tmp_path,
+        slug="owner-b",
+        repo="owner/b",
+        issue=42,
+        outcome=IssueOutcomeType.HITL_APPROVED,
+        pr=202,
+    )
+    registry = make_registry(spec_a, spec_b)
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/issues/history")
+
+    payload = json.loads((await endpoint(repo="owner-b", limit=500)).body)
+    item = next(x for x in payload["items"] if x["issue_number"] == 42)
+
+    assert {x["repo"] for x in payload["items"]} == {"owner-b"}
+    assert item["repo"] == "owner-b"
+    assert item["outcome"] is not None
+    assert item["outcome"]["outcome"] == "hitl_approved"
+    assert "owner/b" in item["issue_url"]
+
+
+@pytest.mark.asyncio
+async def test_history_per_repo_request_does_not_corrupt_default_cache(
+    config: Any, event_bus: Any, state: Any, tmp_path: Path
+) -> None:
+    """A repo=<slug> request must not read or overwrite the default cache."""
+    await event_bus.publish(
+        HydraFlowEvent(
+            type=EventType.ISSUE_CREATED,
+            data={"issue": 7, "title": "Host seven", "labels": ["epic:host"]},
+        )
+    )
+    spec_b = await _seed_runtime(
+        tmp_path,
+        slug="owner-b",
+        repo="owner/b",
+        issue=42,
+        outcome=IssueOutcomeType.HITL_APPROVED,
+        pr=202,
+        enrichable=True,
+    )
+    registry = make_registry(spec_b)
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="host",
+    )
+    endpoint = find_endpoint(router, "/api/issues/history")
+
+    warm = json.loads((await endpoint(limit=100)).body)
+    assert {x["issue_number"] for x in warm["items"]} == {7}
+
+    await endpoint(repo="owner-b", limit=100)
+
+    after = json.loads((await endpoint(limit=100)).body)
+    assert {x["issue_number"] for x in after["items"]} == {7}
+
+
+@pytest.mark.asyncio
+async def test_outcomes_endpoint_scopes_and_tags_by_repo(
+    config: Any, event_bus: Any, state: Any, tmp_path: Path
+) -> None:
+    """/api/issues/outcomes scopes to one repo and unions __all__ with tags."""
+    spec_a = await _seed_runtime(
+        tmp_path,
+        slug="owner-a",
+        repo="owner/a",
+        issue=42,
+        outcome=IssueOutcomeType.MERGED,
+        pr=101,
+    )
+    spec_b = await _seed_runtime(
+        tmp_path,
+        slug="owner-b",
+        repo="owner/b",
+        issue=42,
+        outcome=IssueOutcomeType.HITL_APPROVED,
+        pr=202,
+    )
+    registry = make_registry(spec_a, spec_b)
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    endpoint = find_endpoint(router, "/api/issues/outcomes")
+
+    agg = json.loads((await endpoint(repo=REPO_ALL)).body)
+    assert agg["owner-a#42"]["outcome"] == "merged"
+    assert agg["owner-a#42"]["repo"] == "owner-a"
+    assert agg["owner-b#42"]["outcome"] == "hitl_approved"
+    assert agg["owner-b#42"]["repo"] == "owner-b"
+
+    scoped = json.loads((await endpoint(repo="owner-b")).body)
+    assert scoped["42"]["outcome"] == "hitl_approved"
+    assert scoped["42"]["repo"] == "owner-b"
+
+
+@pytest.mark.asyncio
+async def test_per_repo_request_enriches_despite_default_enriched_set(
+    config: Any,
+    event_bus: Any,
+    state: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repo=<slug> request enriches its own colliding issue number even after
+    the default cache already marked that number enriched (no cross-repo skip)."""
+    monkeypatch.setattr("dashboard_routes._routes.IssueFetcher", _RepoAwareFetcher)
+
+    # Host/default: issue #42 with no title/epic -> an enrichment candidate.
+    await event_bus.publish(
+        HydraFlowEvent(type=EventType.ISSUE_CREATED, data={"issue": 42})
+    )
+    # Second repo: also issue #42, also an enrichment candidate.
+    cfg_b = ConfigFactory.create(repo="owner/b", repo_root=tmp_path / "owner-b")
+    bus_b = EventBus()
+    state_b = StateTracker(tmp_path / "owner-b-state.json")
+    await bus_b.publish(
+        HydraFlowEvent(type=EventType.ISSUE_CREATED, data={"issue": 42})
+    )
+    registry = make_registry(
+        {"slug": "owner-b", "config": cfg_b, "state": state_b, "event_bus": bus_b}
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug=config.repo.replace("/", "-"),
+    )
+    endpoint = find_endpoint(router, "/api/issues/history")
+
+    # Warm the default cache: host #42 gets enriched, putting 42 in the default
+    # runtime's enriched_issues set (keyed by bare number).
+    warm = json.loads((await endpoint(limit=100)).body)
+    host_item = next(x for x in warm["items"] if x["issue_number"] == 42)
+    assert "ENRICHED" in host_item["title"]
+
+    # owner-b's #42 must still be enriched — the default cache's enriched set
+    # must not leak across repos and skip it.
+    b_payload = json.loads((await endpoint(repo="owner-b", limit=100)).body)
+    b_item = next(x for x in b_payload["items"] if x["issue_number"] == 42)
+    assert "owner/b" in b_item["title"]
+    assert "owner/b" in b_item["issue_url"]


### PR DESCRIPTION
## What & why

Phase 2d of the multi-repo dashboard program ([[project_multi_repo_scoping]]). The **Outcomes** tab is backed by `/api/issues/history`, the single most intricate endpoint in the feature. Its builder closures captured the **default** runtime's `config`/`state`/`pr_manager`, so:

- `?repo=B` returned **B's events but A's outcomes, `issue_url`, and GitHub enrichment** (the frontend Repo badge parsed the slug *from* `issue_url`, so the badge was wrong too).
- `?repo=__all__` returned **only the default repo** (it resolved through the singular `_resolve_runtime`).
- Any unfiltered `?repo=B` call **corrupted the default repo's persistent history cache** (and a default-cached enriched-issue number could **skip enrichment** for a *different* repo's same-numbered issue, since the cache is keyed by bare issue number).

## Backend (`_routes.py`)

- Thread per-runtime `cfg`/`state`/`repo_slug` through `_new_issue_history_entry`, `_process_events_into_rows`, `_filter_rows_to_items`, `_build_issue_history_entry`, `_apply_enrichment_and_crate_titles`, `_enrich_issue_history_with_github` via a new `_collect_history_items(cfg, state, bus, slug, …)` helper.
- `get_issue_history` now loops `_resolve_runtimes(repo)`: `repo=__all__` unions every runtime; rows are tagged with their repo slug and **kept distinct per `(repo, issue_number)`** (numbers collide across repos); global sort + page-limit applied to the merged list; totals summed.
- The persistent history cache (`issue_rows` + `enriched_issues`) is read/written **only when `repo is None`** (`use_cache`). Per-repo and `__all__` requests build fresh — fixing the default-cache corruption **and** the cross-repo enrichment-skip.

## `/api/issues/outcomes` (`_metrics_routes.py`)

Gained `repo` scoping; `__all__` unions with `{slug}#{num}` compound keys + a `repo` tag (bare-number key preserved for the single-repo/default case — backward-compatible). Zero-caller parity endpoint, kept consistent with the rest of the API.

## Frontend

- `issueHistory` poll now routes through `fetchWithRepo` (repo-scoped + refetches on repo switch); the other 4 centralized endpoints stay bare `fetch`.
- Repo column renders `item.repo` (the canonical dash slug, verbatim — matching StreamCard/RepoSelector), falling back to the URL-parsed slug.
- Removed the client-side `session_ids.startsWith(slug)` filter — it would have **blanked the all-repos view** and double-filtered single-repo.
- React keys + expand state keyed by `(repo, issue)` so colliding numbers don't share a key or expand together.

## Test plan (per the test pyramid)

- **Unit** (`tests/test_dashboard_routes_issue_history_multirepo.py`): `__all__` unions colliding `#42` with distinct outcomes; `?repo=B` returns B's own outcome/url/tag; per-repo request doesn't corrupt the default cache; per-repo request still enriches despite the default enriched-set (RED/GREEN mutation-verified against the guard); outcomes endpoint scoping + `__all__` compound keys.
- **MockWorld scenario** (`tests/scenarios/test_multi_repo_history_outcomes.py`): real `RepoRuntime`s, `?repo=__all__` aggregates two repos' `#42`.
- **Frontend** (`IssueHistoryPanel.test.jsx`): repo badge from backend field; same-numbered rows from different repos expand independently; verbatim slug display.
- ✅ `make quality` (15767 passed) · `make scenario` (187 passed) · vitest (1090 passed) · `vite build` · ruff clean · pyright 0 errors.

## Review

One Understand workflow + a 5-dimension adversarial review (→ per-finding verification) + a convergence pass (→ **CONVERGED, no material findings**). Confirmed findings fixed: badge now renders the slug verbatim (dropped dead `.split('/')` ); added the cross-repo enrichment-skip test. A `repo-badge` `data-testid` stays bare (intentionally consistent with the bare `outcome-row` testid + `getAllByTestId` collision pattern).

## Deferred

- Sandbox e2e for multi-repo — Phase 4 (needs sandbox registry + `api_client` POST wiring), consistent with 2a/2b/2c.
- A `HydraFlowContext` poll-rescope unit test — low/symmetric (no sibling endpoint has one; wiring reuses the verified `fetchWithRepo` helper).
- **D2 data migration** (flat `data_path()` stores → `repo_data_root`) remains its own isolated slice; until then per-repo runs/insights/metrics that live in flat stores aren't repo-split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)