### PR TITLE
feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2)

### DIFF
--- a/docs/adr/0021-persistence-architecture-and-data-layout.md
+++ b/docs/adr/0021-persistence-architecture-and-data-layout.md
@@ -1,7 +1,7 @@
 # ADR-0021: Persistence Architecture and Data Layout
 
 **Status:** Accepted
-**Enforced by:** tests/test_state_persistence.py, tests/test_event_persistence.py
+**Enforced by:** tests/test_state_persistence.py, tests/test_event_persistence.py, tests/test_data_migration_d2.py
 **Date:** 2026-02-28
 
 ## Context
@@ -186,6 +186,63 @@ but the defaults ensure a single `data_root` change relocates everything.
   dual-path branches in seven consumers carried real maintenance cost for a
   feature that hadn't earned an ADR or a deployment.
 
+## Amendment (2026-06-08): repo-scope operational stores under the shared-data-root model (D2)
+
+**Context.** The original "Multi-repo isolation" guarantee above assumed the
+supervisor spawns *one process per repo, each with its own `HYDRAFLOW_HOME` →
+its own `data_root`* (ADR-0009). Under that model, stores resolved via
+`config.data_path(...)` (flat, under `data_root`) never collided — each repo had
+a private `data_root`. The multi-repo **dashboard** model (ADR-0007/0038) breaks
+that assumption: a single host process holds a `RepoRuntimeRegistry` of repo
+runtimes that **share one `data_root`** (the deployment sets `HYDRAFLOW_HOME`).
+Under a shared `data_root`, the flat per-repo operational stores collide across
+repos (e.g. issue #42's run artifacts from repo A overwrite repo B's).
+
+`state.json`, `events.jsonl`, and `sessions.jsonl` were already repo-scoped
+(`_resolve_repo_scoped_paths`). This amendment extends that scoping to the
+remaining per-repo *operational* stores.
+
+**Decision.** The following stores move from flat `data_path(...)` to
+repo-scoped `repo_data_root` (= `data_root/<repo_slug>`), via new
+`HydraFlowConfig` accessors (`repo_data_path()`, `repo_memory_dir`,
+`retrospectives_path`, `cost_inferences_path`, `pr_stats_path`; and
+`factory_metrics_path` is re-pointed):
+
+| Store | Old (flat) | New (repo-scoped) |
+|-------|-----------|-------------------|
+| Run artifacts | `data_root/runs/` | `repo_data_root/runs/` |
+| Cost inferences | `data_root/metrics/prompt/inferences.jsonl` | `repo_data_root/metrics/prompt/inferences.jsonl` |
+| PR telemetry aggregates | `data_root/metrics/prompt/pr_stats.json` | `repo_data_root/metrics/prompt/pr_stats.json` |
+| Factory metrics | `data_root/diagnostics/factory_metrics.jsonl` | `repo_data_root/diagnostics/factory_metrics.jsonl` |
+| Retrospective insights | `data_root/memory/{retrospectives.jsonl,filed_patterns.json,retrospective_queue.jsonl}` | `repo_data_root/memory/…` |
+| Harness insights | `data_root/memory/{harness_failures.jsonl,harness_suggestions.jsonl,harness_proposed.json}` | `repo_data_root/memory/…` |
+| Review insights | `data_root/memory/{reviews.jsonl,proposed_categories.json,proposal_metadata.json}` | `repo_data_root/memory/…` |
+
+This splits the `memory/` directory: per-repo **insight** files move to
+`repo_data_root/memory/` (via `config.repo_memory_dir`), while cross-repo
+**knowledge** files stay flat under `config.memory_dir` (`data_root/memory/`):
+`adr_decisions.jsonl`, `hitl_recommendations.jsonl`, `items.jsonl`,
+`verification_records.jsonl`.
+
+**One-time migration (host-only).** `data_migration.migrate_flat_operational_stores(config)`
+copies any existing flat store into the repo-scoped location, mirroring the
+copy-if-target-absent, `shutil.copy2`, log-on-`OSError` mechanism of
+`_resolve_repo_scoped_paths`. It is idempotent (skips when the scoped target
+exists) and runs **once at host startup** (`server._run`) with the *host* config,
+before any member runtime is built. Rationale: under a shared `data_root` the
+legacy flat data was written by the host process and is already comingled across
+repos, so it belongs to the default/host repo — "the default repo keeps its
+history". Member repos start clean and never claim the host's flat data. A no-op
+when `repo_data_root == data_root` (no slug to scope under).
+
+**Out of scope (deferred, same mechanism applies later).** These per-repo-ish
+stores remain flat for now and are candidates for a follow-up slice:
+`metrics/history_cache.json` (host-only — read/written only for the default repo,
+no cross-repo collision), `traces/`, `reflections/`, `outcomes.jsonl`,
+`item_scores.json`, health-monitor known-pattern / troubleshooting stores. The
+ADR-0010 migration of `log_dir`/`plans_dir` (whole-directory scoping) is likewise
+unchanged by this amendment.
+
 ## Related
 
 - Source memory: [#1624 — HydraFlow persistence architecture and data layout](https://github.com/T-rav/hydra/issues/1624)
@@ -193,6 +250,9 @@ but the defaults ensure a single `data_root` change relocates everything.
 - `src/state:StateTracker` — crash-recovery state persistence
 - `src/state/_session.py` — session history persistence (`sessions.jsonl`)
 - `src/config.py:_resolve_base_paths`, `src/config.py:_resolve_repo_and_identity`, `src/config.py:_resolve_repo_scoped_paths` — data root and path resolution
+- `src/data_migration.py:migrate_flat_operational_stores` — one-time host-only migration of flat per-repo stores to `repo_data_root` (Amendment D2)
+- `src/config.py:HydraFlowConfig.repo_data_path`, `repo_memory_dir`, `cost_inferences_path`, `retrospectives_path`, `factory_metrics_path` — repo-scoped store accessors (Amendment D2)
+- ADR-0007 (Dashboard API Multi-Repo Scoping), ADR-0038 (Multi-Repo Architecture Wiring Pattern) — the shared-`data_root` registry model that motivates Amendment D2
 - `src/config.py:load_config_file`, `src/config.py:save_config_file` — config snapshot persistence
 - `src/config.py:HydraFlowConfig.data_root` — data root configuration
 - `src/metrics_manager.py` — repo-slug namespaced metrics

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-06T03:58:56.138798+00:00",
-  "commit_sha": "cee79f96cce2850244f3de91372d2871d03272ad",
+  "regenerated_at": "2026-06-08T15:04:14.952010+00:00",
+  "commit_sha": "07d06054195e02c6308acaf94de236b6927cea7c",
   "artifacts": {
     "loops.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "ports.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "labels.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "modules.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "events.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "adr_xref.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "mockworld.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "changelog.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "coverage_matrix.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "functional_areas.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "ubiquitous-language.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "cee79f96cce2850244f3de91372d2871d03272ad"
+      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
     }
   }
 }

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T15:04:14.952010+00:00",
-  "commit_sha": "07d06054195e02c6308acaf94de236b6927cea7c",
+  "regenerated_at": "2026-06-08T15:48:03.831439+00:00",
+  "commit_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80",
   "artifacts": {
     "loops.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "ports.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "labels.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "modules.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "events.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "adr_xref.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "mockworld.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "changelog.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "coverage_matrix.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "functional_areas.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "ubiquitous-language.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "07d06054195e02c6308acaf94de236b6927cea7c"
+      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -28,7 +28,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0018 | `src.config`, `src.pr_manager`, `src.report_issue_loop`, `src.screenshot_scanner` |
 | ADR-0019 | `src.dashboard_routes`, `src.epic`, `src.issue_fetcher`, `src.post_merge_handler` |
 | ADR-0020 | — |
-| ADR-0021 | `src.config`, `src.file_util`, `src.metrics_manager`, `src.state._session` |
+| ADR-0021 | `src.config`, `src.data_migration`, `src.file_util`, `src.metrics_manager`, `src.state._session` |
 | ADR-0022 | `src.config`, `src.issue_store` |
 | ADR-0023 | — |
 | ADR-0024 | `src.agent`, `src.implement_phase`, `src.state` |
@@ -135,6 +135,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.dashboard_routes._cost_rollups` | ADR-0045 |
 | `src.dashboard_routes._diagnostics_routes` | ADR-0050 |
 | `src.dashboard_routes._routes` | ADR-0030 |
+| `src.data_migration` | ADR-0021 |
 | `src.discover_phase` | ADR-0031, ADR-0045 |
 | `src.discover_runner` | ADR-0031, ADR-0045, ADR-0063 |
 | `src.discovery_council` | ADR-0064 |

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -4,6 +4,10 @@
 
 Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdocs.yml`. Grouped by ISO week.
 
+## 2026-W24
+
+- `15e22ef` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) *(2026-06-08)*
+
 ## 2026-W23
 
 - `4187035` — fix(ul): route bot/caretaker PRs to config.base_branch(), not hardcoded main (#9346) (#9346) *(2026-06-05)*

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W23
 
+- `4187035` — fix(ul): route bot/caretaker PRs to config.base_branch(), not hardcoded main (#9346) (#9346) *(2026-06-05)*
 - `15589dc` — fix(beads): create the bead task graph in the implement worktree (fix claim/close) (#9345) (#9345) *(2026-06-05)*
 - `f624cbd` — fix(beads): per-worktree embedded store + JSONL export (drop shared --server) (#9337) (#9337) *(2026-06-05)*
 - `9b97208` — fix(merge): auto-merge Auto-Agent PRs (agent/auto-agent-N) to end the contract-fix runaway (#9332) (#9332) *(2026-06-05)*
@@ -419,21 +420,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `83cc8b3` — Fixes #2726: [ADR Follow-up] ADR-0012: Council requests changes (#2846) (#2846) *(2026-03-15)*
 - `8b7d06f` — Fixes #2720: Renumber ADR-0023 to ADR-0024 and update status to Accepted (#2816) (#2816) *(2026-03-15)*
 - `4eb1c9a` — Accept ADR-0010: worktree and path isolation (#2696) (#2696) *(2026-03-15)*
-- `a914647` — Fixes #2205: Remove CLI layer and consolidate into server API (#2457) (#2457) *(2026-03-09)*
-
-## 2026-W10
-
-- `29d8268` — Fixes #2382: Add ADR-0023 for duplicate class merge-artifact pattern (#2383) (#2383) *(2026-03-08)*
-- `cad34a6` — Fixes #2253: [ADR] Draft decision from memory #2251: ADR pre-review... (#2254) (#2254) *(2026-03-08)*
-- `4534df5` — Fixes #2373: Add ADR-0023 for dead class artifact detection in mock-based tests (#2378) (#2378) *(2026-03-08)*
-- `312fb6f` — Fixes #2356: Add ADR-0023 for toggle-state test consistency (#2369) (#2369) *(2026-03-08)*
-- `26ed00b` — Fixes #2355: ADR-0023 gate triage call on config toggle, not just HITL fallback (#2360) (#2360) *(2026-03-08)*
-- `1baa85a` — Fixes #2341: Add ADR-0023 for auto-triage toggle routing enforcement (#2344) (#2344) *(2026-03-08)*
-- `12d7c57` — Fixes #2306: Add ADR-0023 for stats counter placement in delegating helpers (#2324) (#2324) *(2026-03-08)*
-- `c22797d` — Fixes #2273: Add ADR-0023 for CLI argparse + config builder pattern (#2302) (#2302) *(2026-03-08)*
-- `7ade583` — Fixes #2267: Add ADR-0023 for multi-repo architecture wiring pattern (#2296) (#2296) *(2026-03-08)*
-- `4c09083` — Fixes #2264: [ADR] Draft decision from memory #2258: Implementation... (#2292) (#2292) *(2026-03-08)*
-- `c4b8ecd` — Fixes #2374: Add ADR-0023 for supersession regex verb form coverage (#2379) (#2379) *(2026-03-08)*
 
 
 <!-- arch:generated -->

--- a/scripts/audit_prompts.py
+++ b/scripts/audit_prompts.py
@@ -607,6 +607,10 @@ class _MinimalConfig:
         self.use_quality_gate_in_review = True
         self.max_ci_fix_attempts = 3
         self.repo = "owner/repo"
+        # Repo-scoped data dirs (ADR-0021 D2): mirror HydraFlowConfig so prompt
+        # builders that read repo_memory_dir resolve a real path here too.
+        self.repo_data_root = self.data_root / self.repo.replace("/", "-")
+        self.repo_memory_dir = self.repo_data_root / "memory"
         self.review_insight_window = 50
         self.review_pattern_threshold = 3
         # ADR reviewer fields

--- a/src/agent.py
+++ b/src/agent.py
@@ -153,7 +153,7 @@ Run through this checklist before your final commit:
             wiki_store=wiki_store,
             tribal_wiki_store=tribal_wiki_store,
         )
-        self._insights = ReviewInsightStore(config.memory_dir)
+        self._insights = ReviewInsightStore(config.repo_memory_dir)
         from context_cache import ContextSectionCache
 
         self._context_cache = ContextSectionCache(config)
@@ -399,7 +399,7 @@ Run through this checklist before your final commit:
         Returns an empty string if no data is available or on any error.
         """
         try:
-            reviews_path = self._config.memory_dir / "reviews.jsonl"
+            reviews_path = self._config.repo_memory_dir / "reviews.jsonl"
 
             def _load_feedback(_cfg: HydraFlowConfig) -> str:
                 recent = self._insights.load_recent(self._config.review_insight_window)
@@ -424,7 +424,7 @@ Run through this checklist before your final commit:
         Returns an empty list on any error.
         """
         try:
-            reviews_path = self._config.memory_dir / "reviews.jsonl"
+            reviews_path = self._config.repo_memory_dir / "reviews.jsonl"
 
             def _load_escalations(_cfg: HydraFlowConfig) -> str:
                 recent = self._insights.load_recent(self._config.review_insight_window)

--- a/src/config.py
+++ b/src/config.py
@@ -3030,12 +3030,26 @@ class HydraFlowConfig(BaseModel):
 
     @property
     def factory_metrics_path(self) -> Path:
-        """Path to the factory metrics JSONL store."""
-        return self.diagnostics_dir / "factory_metrics.jsonl"
+        """Path to the repo-scoped factory metrics JSONL store (ADR-0021 D2).
+
+        Served by ``/api/diagnostics/*``. Lives under
+        ``data_root/<repo_slug>/diagnostics`` so per-repo telemetry does not
+        collide under a shared ``data_root`` (e.g. ``HYDRAFLOW_HOME``).
+        """
+        return self.repo_data_root / "diagnostics" / "factory_metrics.jsonl"
 
     def data_path(self, *parts: str | os.PathLike[str]) -> Path:
         """Return an absolute path inside the HydraFlow data_root."""
         return self.data_root.joinpath(*parts)
+
+    def repo_data_path(self, *parts: str | os.PathLike[str]) -> Path:
+        """Return an absolute path inside the repo-scoped data dir.
+
+        Mirror of :meth:`data_path` but rooted at ``repo_data_root``
+        (``data_root/<repo_slug>``). Use for per-repo operational stores that
+        must not collide across repos sharing a ``data_root`` (ADR-0021 D2).
+        """
+        return self.repo_data_root.joinpath(*parts)
 
     def format_path_for_display(self, path: Path) -> str:
         """Return a human-friendly path relative to repo or data root when possible."""
@@ -3053,6 +3067,32 @@ class HydraFlowConfig(BaseModel):
     def repo_data_root(self) -> Path:
         """Return the repo-scoped data directory (``data_root / repo_slug``)."""
         return self.data_root / self.repo_slug
+
+    @property
+    def repo_memory_dir(self) -> Path:
+        """Repo-scoped memory dir for per-repo insight stores (ADR-0021 D2).
+
+        Holds the retrospective/harness/review insight files. Distinct from
+        :attr:`memory_dir` (flat ``data_root/memory``), which still hosts
+        cross-repo knowledge (e.g. ``adr_decisions.jsonl``,
+        ``hitl_recommendations.jsonl``).
+        """
+        return self.repo_data_root / "memory"
+
+    @property
+    def retrospectives_path(self) -> Path:
+        """Repo-scoped retrospective records store (``repo_memory_dir``)."""
+        return self.repo_memory_dir / "retrospectives.jsonl"
+
+    @property
+    def cost_inferences_path(self) -> Path:
+        """Repo-scoped LLM inference cost-telemetry store (ADR-0021 D2)."""
+        return self.repo_data_root / "metrics" / "prompt" / "inferences.jsonl"
+
+    @property
+    def pr_stats_path(self) -> Path:
+        """Repo-scoped per-PR telemetry aggregates (ADR-0021 D2)."""
+        return self.repo_data_root / "metrics" / "prompt" / "pr_stats.json"
 
     def base_branch(self) -> str:
         """Return the branch agent PRs should target.

--- a/src/dashboard_routes/_cost_rollups.py
+++ b/src/dashboard_routes/_cost_rollups.py
@@ -106,7 +106,7 @@ def iter_priced_inferences(
     * ``cost_usd``: ``float``; ``0.0`` when the pricing table has no entry.
     * ``phase``: canonical phase (via ``_phase_for_source``).
     """
-    path = config.data_path("metrics", "prompt", "inferences.jsonl")
+    path = config.cost_inferences_path
     if not path.is_file():
         return
     try:

--- a/src/dashboard_routes/_factory_health_routes.py
+++ b/src/dashboard_routes/_factory_health_routes.py
@@ -53,8 +53,8 @@ def build_factory_health_router(config: HydraFlowConfig) -> APIRouter:
 
     @router.get("/summary")
     def get_factory_health(repo: str = "") -> dict[str, Any]:
-        retro_path = config.data_path("memory", "retrospectives.jsonl")
-        telemetry_path = config.data_path("metrics", "prompt", "inferences.jsonl")
+        retro_path = config.retrospectives_path
+        telemetry_path = config.cost_inferences_path
         retro_entries = _load_jsonl(retro_path)
         telemetry_entries = _load_jsonl(telemetry_path)
         if repo:

--- a/src/dashboard_routes/_metrics_routes.py
+++ b/src/dashboard_routes/_metrics_routes.py
@@ -259,7 +259,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             generate_suggestions,
         )
 
-        memory_dir = ctx.config.data_path("memory")
+        memory_dir = ctx.config.repo_memory_dir
         store = HarnessInsightStore(memory_dir)
         records = store.load_recent(ctx.config.harness_insight_window)
         proposed = store.get_proposed_patterns()
@@ -289,7 +289,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         """Return raw failure records for historical analysis."""
         from harness_insights import HarnessInsightStore
 
-        memory_dir = ctx.config.data_path("memory")
+        memory_dir = ctx.config.repo_memory_dir
         store = HarnessInsightStore(memory_dir)
         records = store.load_recent(ctx.config.harness_insight_window)
         return JSONResponse([r.model_dump() for r in records])
@@ -299,7 +299,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         """Return aggregated review feedback patterns and category breakdown."""
         from review_insights import ReviewInsightStore, analyze_patterns
 
-        memory_dir = ctx.config.data_path("memory")
+        memory_dir = ctx.config.repo_memory_dir
         store = ReviewInsightStore(memory_dir)
         records = store.load_recent(ctx.config.review_insight_window)
         proposed = store.get_proposed_categories()
@@ -343,7 +343,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         """Return aggregated retrospective stats and recent entries."""
         from retrospective import RetrospectiveEntry
 
-        retro_path = ctx.config.data_path("memory", "retrospectives.jsonl")
+        retro_path = ctx.config.retrospectives_path
         entries: list[RetrospectiveEntry] = []
         if retro_path.exists():
             for line in retro_path.read_text().strip().splitlines():

--- a/src/data_migration.py
+++ b/src/data_migration.py
@@ -1,0 +1,110 @@
+"""One-time, idempotent migration of legacy flat per-repo stores (ADR-0021 D2).
+
+Historically several per-repo operational stores resolved via
+``config.data_path(...)`` — i.e. under the flat ``data_root``. That was safe
+under the original *process-per-repo* model (each process had its own
+``HYDRAFLOW_HOME`` → its own ``data_root``). Under the multi-repo dashboard
+model a single host process holds a registry of repo runtimes that share one
+``data_root``, so those flat stores collide across repos.
+
+This module relocates the affected stores into the repo-scoped layout
+(``data_root/<repo_slug>/...``), matching the migration mechanism already used
+for ``state.json``/``events.jsonl``/``sessions.jsonl`` in
+``config._resolve_repo_scoped_paths``.
+
+**Host-only.** Call once at host startup with the *host* config (see
+``server._run``). The legacy flat data was written by the host process before
+the scoped layout existed (and, under a shared ``data_root``, is already
+comingled across repos), so it belongs to the default/host repo — "the default
+repo keeps its history". Member repos start clean and never claim flat data.
+
+Idempotent: a store is migrated only when the scoped target is absent and the
+flat source exists; a copy failure is logged and skipped so startup never
+crashes on migration.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from config import HydraFlowConfig
+
+logger = logging.getLogger("hydraflow.data_migration")
+
+# Per-repo insight files under ``memory/`` that move to ``repo_memory_dir``.
+# NOTE: deliberately excludes cross-repo knowledge that stays flat
+# (``adr_decisions.jsonl``, ``hitl_recommendations.jsonl``, ``items.jsonl``,
+# ``verification_records.jsonl``) and out-of-scope per-repo stores deferred to a
+# follow-up (``outcomes.jsonl``, ``item_scores.json``, known-pattern /
+# troubleshooting files).
+_MEMORY_STORES: tuple[str, ...] = (
+    "retrospectives.jsonl",
+    "filed_patterns.json",
+    "retrospective_queue.jsonl",
+    "harness_failures.jsonl",
+    "harness_suggestions.jsonl",
+    "harness_proposed.json",
+    "reviews.jsonl",
+    "proposed_categories.json",
+    "proposal_metadata.json",
+)
+
+# Cost/telemetry files under ``metrics/prompt/`` that move to the scoped tree.
+_PROMPT_METRIC_STORES: tuple[str, ...] = (
+    "inferences.jsonl",
+    "pr_stats.json",
+)
+
+
+def _migrate_file(flat: Path, scoped: Path) -> None:
+    """Copy ``flat`` → ``scoped`` if the target is absent and the source exists."""
+    if flat == scoped or scoped.exists() or not flat.exists():
+        return
+    try:
+        scoped.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(flat, scoped)
+    except OSError as exc:
+        logger.warning("Failed to migrate %s → %s: %s", flat, scoped, exc)
+
+
+def _migrate_tree(flat: Path, scoped: Path) -> None:
+    """Copy directory tree ``flat`` → ``scoped`` if the target is absent."""
+    if flat == scoped or scoped.exists() or not flat.is_dir():
+        return
+    try:
+        shutil.copytree(flat, scoped)
+    except OSError as exc:
+        logger.warning("Failed to migrate tree %s → %s: %s", flat, scoped, exc)
+
+
+def migrate_flat_operational_stores(config: HydraFlowConfig) -> None:
+    """Relocate legacy flat per-repo stores into the repo-scoped layout.
+
+    Idempotent and host-only — see module docstring. A no-op when there is no
+    repo slug to scope under (``repo_data_root == data_root``).
+    """
+    data_root = config.data_root
+    scoped_root = config.repo_data_root
+    if scoped_root == data_root:
+        return
+
+    flat_memory = data_root / "memory"
+    for name in _MEMORY_STORES:
+        _migrate_file(flat_memory / name, config.repo_memory_dir / name)
+
+    flat_prompt = data_root / "metrics" / "prompt"
+    scoped_prompt = scoped_root / "metrics" / "prompt"
+    for name in _PROMPT_METRIC_STORES:
+        _migrate_file(flat_prompt / name, scoped_prompt / name)
+
+    _migrate_file(
+        data_root / "diagnostics" / "factory_metrics.jsonl",
+        config.factory_metrics_path,
+    )
+
+    _migrate_tree(data_root / "runs", scoped_root / "runs")

--- a/src/harness_insights.py
+++ b/src/harness_insights.py
@@ -455,7 +455,7 @@ async def auto_file_suggestions(
 
         import json as _json  # noqa: PLC0415
 
-        suggestions_path = config.data_path("memory", "harness_suggestions.jsonl")
+        suggestions_path = config.repo_memory_dir / "harness_suggestions.jsonl"
         suggestions_path.parent.mkdir(parents=True, exist_ok=True)
 
         for suggestion in suggestions:

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -374,7 +374,8 @@ class HealthMonitorLoop(BaseBackgroundLoop):
 
     @property
     def _failures_path(self) -> Path:
-        return self._config.memory_dir / "harness_failures.jsonl"
+        # Repo-scoped (ADR-0021 D2) — must match HarnessInsightStore's writer.
+        return self._config.repo_memory_dir / "harness_failures.jsonl"
 
     async def _do_work(self) -> dict[str, Any] | None:
         """Execute one health-monitor cycle."""
@@ -513,7 +514,7 @@ class HealthMonitorLoop(BaseBackgroundLoop):
                 auto_file_suggestions,
             )
 
-            store = HarnessInsightStore(self._config.memory_dir)
+            store = HarnessInsightStore(self._config.repo_memory_dir)
             await auto_file_suggestions(store, self._config)
         except ImportError:
             pass
@@ -523,8 +524,8 @@ class HealthMonitorLoop(BaseBackgroundLoop):
     async def _run_harness_suggestion_ingestion_cycle(self) -> None:
         """Read harness suggestions JSONL and file each as a memory item."""
         try:
-            suggestions_path = self._config.data_path(
-                "memory", "harness_suggestions.jsonl"
+            suggestions_path = (
+                self._config.repo_memory_dir / "harness_suggestions.jsonl"
             )
             if not suggestions_path.exists():
                 return
@@ -581,7 +582,7 @@ class HealthMonitorLoop(BaseBackgroundLoop):
                 verify_proposals,
             )
 
-            insight_store = ReviewInsightStore(self._config.memory_dir)
+            insight_store = ReviewInsightStore(self._config.repo_memory_dir)
             records = insight_store.load_recent(50)
             stale = verify_proposals(insight_store, records)
             for category in stale:

--- a/src/prompt_telemetry.py
+++ b/src/prompt_telemetry.py
@@ -50,9 +50,9 @@ class PromptTelemetry:
         pricing: ModelPricingTable | None = None,
     ) -> None:
         self._config = config
-        self._dir = config.data_path("metrics", "prompt")
-        self._inferences_file = self._dir / "inferences.jsonl"
-        self._pr_stats_file = self._dir / "pr_stats.json"
+        self._inferences_file = config.cost_inferences_path
+        self._pr_stats_file = config.pr_stats_path
+        self._dir = self._inferences_file.parent
         self._lock_file = self._dir / ".lock"
         self._pricing = pricing or load_pricing()
 

--- a/src/retrospective.py
+++ b/src/retrospective.py
@@ -61,10 +61,10 @@ class RetrospectiveCollector:
         self._prs = prs
         self._queue = queue
         self._obs: ObservabilityPort | None = observability
-        self._retro_path = config.data_path("memory", "retrospectives.jsonl")
+        self._retro_path = config.retrospectives_path
         self._filed = DedupStore(
             "filed_patterns",
-            config.data_path("memory", "filed_patterns.json"),
+            config.repo_memory_dir / "filed_patterns.json",
         )
 
     async def record(

--- a/src/run_recorder.py
+++ b/src/run_recorder.py
@@ -107,10 +107,10 @@ class RunContext:
 
 
 class RunRecorder:
-    """Records per-issue run artifacts under ``.hydraflow/runs/``."""
+    """Records per-issue run artifacts under ``.hydraflow/<repo_slug>/runs/``."""
 
     def __init__(self, config: HydraFlowConfig) -> None:
-        self._runs_dir = config.data_path("runs")
+        self._runs_dir = config.repo_data_path("runs")
 
     @property
     def runs_dir(self) -> Path:

--- a/src/server.py
+++ b/src/server.py
@@ -319,6 +319,14 @@ async def _run(config: HydraFlowConfig) -> None:
     # because these are heavyweight server-starting functions that bind ports
     # and block forever.  Extracting them as injectable dependencies would be
     # over-engineering for a two-branch dispatch function.
+    #
+    # One-time, host-only migration of legacy flat per-repo stores into the
+    # repo-scoped layout (ADR-0021 D2). Runs once with the host config before
+    # any runtime/member is built, so member repos never claim the host's
+    # legacy flat data. Idempotent — a no-op once migrated.
+    from data_migration import migrate_flat_operational_stores  # noqa: PLC0415
+
+    migrate_flat_operational_stores(config)
     if not await _run_preflight(config):
         return
     if config.dashboard_enabled:

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -537,7 +537,7 @@ def build_services(
 
     # Harness insight store (shared across phases)
     harness_insights = HarnessInsightStore(
-        config.data_path("memory"),
+        config.repo_memory_dir,
         sensor_enrichment_enabled=config.sensor_enrichment_enabled,
         observability=observability,
     )
@@ -821,7 +821,7 @@ def build_services(
         credentials=credentials,
     )
     retrospective_queue = RetrospectiveQueue(
-        config.data_path("memory", "retrospective_queue.jsonl"),
+        config.repo_memory_dir / "retrospective_queue.jsonl",
     )
     retrospective = RetrospectiveCollector(
         config,
@@ -858,7 +858,7 @@ def build_services(
     )
     # ReviewInsightStore shared between AgentRunner and ReviewPhase
     review_insights = ReviewInsightStore(
-        config.memory_dir,
+        config.repo_memory_dir,
         observability=observability,
     )
     # ``_insights`` is internal AgentRunner plumbing not part of any Port.

--- a/tests/regressions/test_lightweight_spawn_credit_telemetry.py
+++ b/tests/regressions/test_lightweight_spawn_credit_telemetry.py
@@ -166,7 +166,7 @@ class TestCostRollupCountsEstimatedSpend:
         from model_pricing import load_pricing
 
         config = ConfigFactory.create(repo_root=tmp_path / "repo")
-        path = config.data_path("metrics", "prompt", "inferences.jsonl")
+        path = config.cost_inferences_path
         path.parent.mkdir(parents=True, exist_ok=True)
         rows = [
             # char-estimated lightweight row: 0 actual tokens, stored estimate > 0

--- a/tests/scenarios/test_diagnostics_waterfall_scenario.py
+++ b/tests/scenarios/test_diagnostics_waterfall_scenario.py
@@ -26,6 +26,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from dashboard_routes._diagnostics_routes import build_diagnostics_router
+from tests.helpers import ConfigFactory
 
 pytestmark = pytest.mark.scenario_loops
 
@@ -64,10 +65,15 @@ class TestDiagnosticsWaterfallScenario:
         t1 = "2026-04-22T10:05:00+00:00"
         t2 = "2026-04-22T10:10:00+00:00"
 
+        (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+
         # Seed two inferences attributed to different runners (= different
-        # canonical phases via tracing_context.source_to_phase).
+        # canonical phases via tracing_context.source_to_phase). Inferences are
+        # repo-scoped (ADR-0021 D2) → seed under repo_data_root; traces stay
+        # flat under data_root.
         _write_inference(
-            tmp_path,
+            config.repo_data_root,
             timestamp=t0,
             source="triage",
             tool="claude",
@@ -81,7 +87,7 @@ class TestDiagnosticsWaterfallScenario:
             status="success",
         )
         _write_inference(
-            tmp_path,
+            config.repo_data_root,
             timestamp=t1,
             source="implementer",
             tool="claude",
@@ -97,7 +103,7 @@ class TestDiagnosticsWaterfallScenario:
         # Seed a subprocess trace (bash tool_call + one passed skill) so the
         # implement phase also surfaces "subprocess" and "skill" action kinds.
         _write_subprocess_trace(
-            tmp_path,
+            config.data_root,
             issue_n,
             "implement",
             1,
@@ -147,15 +153,6 @@ class TestDiagnosticsWaterfallScenario:
                 "turn_count": 0,
             },
         )
-
-        # Minimal HydraFlowConfig stand-in — the waterfall route only needs
-        # data_root (for traces) and data_path (used by _cost_rollups to
-        # resolve inferences.jsonl).
-        config = MagicMock()
-        config.data_root = tmp_path
-        config.data_path = tmp_path.joinpath
-        config.factory_metrics_path = tmp_path / "diagnostics" / "factory_metrics.jsonl"
-        config.repo = "o/r"
 
         # Bypass GitHub — the waterfall route calls fetch_issue_by_number
         # to hydrate issue_meta. We inject a fake fetcher that returns a

--- a/tests/scenarios/test_multi_repo_data_isolation.py
+++ b/tests/scenarios/test_multi_repo_data_isolation.py
@@ -1,0 +1,49 @@
+"""Scenario: two seeded repos get isolated per-repo operational stores (D2).
+
+ADR-0021 (amended) moves runs / insights / cost-telemetry / factory-metrics
+from the flat ``data_root`` into ``repo_data_root`` so they no longer collide
+when repos share a ``data_root``. This proves the repo-scoped accessors resolve
+to distinct paths per runtime and that writing one repo's store does not bleed
+into another's.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mockworld.seed import MockWorldSeed
+
+pytestmark = pytest.mark.scenario
+
+
+@pytest.mark.asyncio
+async def test_seeded_repos_have_isolated_operational_stores(
+    mock_world, tmp_path
+) -> None:
+    seed = MockWorldSeed(
+        repos=[
+            ("owner/alpha", str(tmp_path / "alpha")),
+            ("owner/beta", str(tmp_path / "beta")),
+        ],
+    )
+    mock_world.apply_seed(seed)
+
+    alpha = mock_world.registry.get("owner-alpha").config
+    beta = mock_world.registry.get("owner-beta").config
+
+    # Every in-scope D2 store resolves to a distinct path per repo.
+    for accessor in (
+        "repo_data_root",
+        "repo_memory_dir",
+        "retrospectives_path",
+        "cost_inferences_path",
+        "pr_stats_path",
+        "factory_metrics_path",
+    ):
+        assert getattr(alpha, accessor) != getattr(beta, accessor)
+    assert alpha.repo_data_path("runs") != beta.repo_data_path("runs")
+
+    # Writing alpha's retrospective store must not appear under beta's.
+    alpha.retrospectives_path.parent.mkdir(parents=True, exist_ok=True)
+    alpha.retrospectives_path.write_text('{"repo": "alpha"}\n')
+    assert not beta.retrospectives_path.exists()

--- a/tests/test_agent_execution.py
+++ b/tests/test_agent_execution.py
@@ -406,7 +406,7 @@ class TestBuildPrompt:
         """Prompt should include Common Review Feedback when review data exists."""
         from review_insights import ReviewInsightStore, ReviewRecord
 
-        store = ReviewInsightStore(config.repo_root / ".hydraflow" / "memory")
+        store = ReviewInsightStore(config.repo_memory_dir)
         for i in range(4):
             store.append_review(
                 ReviewRecord(
@@ -432,7 +432,7 @@ class TestBuildPrompt:
         """Prompt should include mandatory escalation block when patterns exceed threshold."""
         from review_insights import ReviewInsightStore, ReviewRecord
 
-        store = ReviewInsightStore(config.repo_root / ".hydraflow" / "memory")
+        store = ReviewInsightStore(config.repo_memory_dir)
         for i in range(3):
             store.append_review(
                 ReviewRecord(
@@ -457,7 +457,7 @@ class TestBuildPrompt:
     ) -> None:
         from review_insights import ReviewInsightStore, ReviewRecord
 
-        store = ReviewInsightStore(config.repo_root / ".hydraflow" / "memory")
+        store = ReviewInsightStore(config.repo_memory_dir)
         # Below default threshold of 3
         for i in range(2):
             store.append_review(

--- a/tests/test_cost_rollups_by_model.py
+++ b/tests/test_cost_rollups_by_model.py
@@ -5,26 +5,24 @@ from __future__ import annotations
 import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
+from config import HydraFlowConfig
 from dashboard_routes._cost_rollups import build_cost_by_model
+from tests.helpers import ConfigFactory
 
 
-def _write_inference(config, **fields) -> None:
-    d = config.data_root / "metrics" / "prompt"
-    d.mkdir(parents=True, exist_ok=True)
-    with (d / "inferences.jsonl").open("a", encoding="utf-8") as fh:
+def _write_inference(config: HydraFlowConfig, **fields) -> None:
+    config.cost_inferences_path.parent.mkdir(parents=True, exist_ok=True)
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(fields) + "\n")
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> MagicMock:
-    cfg = MagicMock()
-    cfg.data_root = tmp_path
-    cfg.data_path = tmp_path.joinpath
-    return cfg
+def config(tmp_path: Path) -> HydraFlowConfig:
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
 
 
 def test_build_cost_by_model_returns_one_row_per_model_sorted_descending(

--- a/tests/test_cost_rollups_helpers.py
+++ b/tests/test_cost_rollups_helpers.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from config import HydraFlowConfig
 from dashboard_routes._cost_rollups import (
     _parse_range,
     build_by_loop,
@@ -19,25 +20,25 @@ from dashboard_routes._cost_rollups import (
     iter_priced_inferences,
     iter_subprocess_traces,
 )
+from tests.helpers import ConfigFactory
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> MagicMock:
-    cfg = MagicMock()
-    cfg.data_root = tmp_path
-    cfg.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
-    cfg.repo = "o/r"
-    return cfg
+def config(tmp_path: Path) -> HydraFlowConfig:
+    # Real config (not a MagicMock) so cost_inferences_path / data_root carry
+    # the true repo-scoped layout instead of a slug-less approximation.
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
 
 
-def _write_inference(config: MagicMock, **fields) -> None:
-    d = config.data_root / "metrics" / "prompt"
+def _write_inference(config: HydraFlowConfig, **fields) -> None:
+    d = config.cost_inferences_path.parent
     d.mkdir(parents=True, exist_ok=True)
-    with (d / "inferences.jsonl").open("a", encoding="utf-8") as fh:
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(fields) + "\n")
 
 
-def _write_loop_trace(config: MagicMock, loop: str, **fields) -> None:
+def _write_loop_trace(config: HydraFlowConfig, loop: str, **fields) -> None:
     from trace_collector import _slug_for_loop  # noqa: PLC0415
 
     d = config.data_root / "traces" / "_loops" / _slug_for_loop(loop)
@@ -49,7 +50,7 @@ def _write_loop_trace(config: MagicMock, loop: str, **fields) -> None:
 
 
 def _write_subprocess(
-    config: MagicMock,
+    config: HydraFlowConfig,
     issue: int,
     phase: str,
     run_id: int,
@@ -540,9 +541,8 @@ def test_per_loop_cost_includes_model_breakdown_for_mixed_models(
     """build_per_loop_cost emits model_breakdown with one entry per model used."""
     from datetime import UTC, datetime, timedelta
 
-    config = MagicMock()
-    config.data_root = tmp_path
-    config.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
 
     now = datetime(2026, 4, 22, 12, tzinfo=UTC)
     started = now - timedelta(minutes=5)
@@ -598,9 +598,8 @@ def test_per_loop_cost_buckets_missing_model_under_unknown(
     """Records with empty/missing model bucket under 'unknown'."""
     from datetime import UTC, datetime, timedelta
 
-    config = MagicMock()
-    config.data_root = tmp_path
-    config.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
 
     now = datetime(2026, 4, 22, 12, tzinfo=UTC)
     started = now - timedelta(minutes=5)
@@ -629,9 +628,8 @@ def test_per_loop_cost_existing_fields_unchanged(tmp_path) -> None:
     """Regression: adding model_breakdown does not change existing field values."""
     from datetime import UTC, datetime, timedelta
 
-    config = MagicMock()
-    config.data_root = tmp_path
-    config.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    config = ConfigFactory.create(repo_root=tmp_path / "repo")
 
     now = datetime(2026, 4, 22, 12, tzinfo=UTC)
     started = now - timedelta(minutes=5)

--- a/tests/test_dashboard_routes_metrics.py
+++ b/tests/test_dashboard_routes_metrics.py
@@ -315,7 +315,7 @@ class TestReviewInsightsEndpoint:
 
         from review_insights import ReviewInsightStore, ReviewRecord
 
-        memory_dir = config.data_path("memory")
+        memory_dir = config.repo_memory_dir
         store = ReviewInsightStore(memory_dir)
         store.append_review(
             ReviewRecord(
@@ -385,7 +385,7 @@ class TestRetrospectivesEndpoint:
 
         from retrospective import RetrospectiveEntry
 
-        retro_path = config.data_path("memory", "retrospectives.jsonl")
+        retro_path = config.retrospectives_path
         retro_path.parent.mkdir(parents=True, exist_ok=True)
 
         entry = RetrospectiveEntry(
@@ -436,7 +436,7 @@ class TestRetrospectivesEdgeCases:
 
         from retrospective import RetrospectiveEntry
 
-        retro_path = config.data_path("memory", "retrospectives.jsonl")
+        retro_path = config.retrospectives_path
         retro_path.parent.mkdir(parents=True, exist_ok=True)
 
         valid = RetrospectiveEntry(

--- a/tests/test_data_migration_d2.py
+++ b/tests/test_data_migration_d2.py
@@ -1,0 +1,297 @@
+"""D2 data-layout migration — per-repo operational stores move to repo_data_root.
+
+Covers the new repo-scoped config accessors and the one-time idempotent
+migration that relocates legacy flat ``data_root/<store>`` content into the
+repo-scoped ``data_root/<repo_slug>/<store>`` layout. See ADR-0021 (amended).
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from config import HydraFlowConfig
+from data_migration import migrate_flat_operational_stores
+
+
+def _cfg(tmp_path: Path, repo: str = "acme/widgets") -> HydraFlowConfig:
+    return HydraFlowConfig(repo_root=tmp_path, repo=repo)
+
+
+class TestRepoScopedAccessors:
+    """New config accessors resolve in-scope stores under data_root/<repo_slug>."""
+
+    def test_repo_data_path_joins_under_repo_data_root(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.repo_data_path("runs") == cfg.repo_data_root / "runs"
+        assert cfg.repo_data_path("metrics", "prompt") == (
+            cfg.repo_data_root / "metrics" / "prompt"
+        )
+
+    def test_repo_memory_dir_is_scoped(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.repo_memory_dir == cfg.repo_data_root / "memory"
+        assert "acme-widgets" in str(cfg.repo_memory_dir)
+
+    def test_retrospectives_path_is_scoped(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.retrospectives_path == (
+            cfg.repo_data_root / "memory" / "retrospectives.jsonl"
+        )
+
+    def test_cost_inferences_path_is_scoped(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.cost_inferences_path == (
+            cfg.repo_data_root / "metrics" / "prompt" / "inferences.jsonl"
+        )
+
+    def test_pr_stats_path_is_scoped(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.pr_stats_path == (
+            cfg.repo_data_root / "metrics" / "prompt" / "pr_stats.json"
+        )
+
+    def test_factory_metrics_path_is_scoped(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        assert cfg.factory_metrics_path == (
+            cfg.repo_data_root / "diagnostics" / "factory_metrics.jsonl"
+        )
+        # No longer flat under data_root/diagnostics.
+        assert cfg.factory_metrics_path != cfg.data_root / "diagnostics" / (
+            "factory_metrics.jsonl"
+        )
+
+    def test_two_repos_get_separate_store_paths(self, tmp_path: Path) -> None:
+        cfg_a = _cfg(tmp_path, repo="org/alpha")
+        cfg_b = _cfg(tmp_path, repo="org/beta")
+        for accessor in (
+            "retrospectives_path",
+            "cost_inferences_path",
+            "factory_metrics_path",
+            "repo_memory_dir",
+        ):
+            assert getattr(cfg_a, accessor) != getattr(cfg_b, accessor)
+
+
+class TestFlatStoreMigration:
+    """Legacy flat stores are copied into the repo-scoped layout."""
+
+    def test_runs_tree_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_run = cfg.data_root / "runs" / "42" / "20260101-000000"
+        flat_run.mkdir(parents=True)
+        (flat_run / "manifest.json").write_text('{"issue": 42}')
+
+        migrate_flat_operational_stores(cfg)
+
+        scoped = (
+            cfg.repo_data_root / "runs" / "42" / "20260101-000000" / "manifest.json"
+        )
+        assert scoped.exists()
+        assert scoped.read_text() == '{"issue": 42}'
+
+    def test_cost_inferences_and_pr_stats_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_dir = cfg.data_root / "metrics" / "prompt"
+        flat_dir.mkdir(parents=True)
+        (flat_dir / "inferences.jsonl").write_text('{"cost_usd": 1.0}\n')
+        (flat_dir / "pr_stats.json").write_text('{"pr": 1}')
+
+        migrate_flat_operational_stores(cfg)
+
+        assert cfg.cost_inferences_path.read_text() == '{"cost_usd": 1.0}\n'
+        assert cfg.pr_stats_path.read_text() == '{"pr": 1}'
+
+    def test_factory_metrics_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat = cfg.data_root / "diagnostics" / "factory_metrics.jsonl"
+        flat.parent.mkdir(parents=True)
+        flat.write_text('{"event": "phase"}\n')
+
+        migrate_flat_operational_stores(cfg)
+
+        assert cfg.factory_metrics_path.read_text() == '{"event": "phase"}\n'
+
+    def test_retrospective_family_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_mem = cfg.data_root / "memory"
+        flat_mem.mkdir(parents=True)
+        (flat_mem / "retrospectives.jsonl").write_text('{"issue": 7}\n')
+        (flat_mem / "filed_patterns.json").write_text('["p1"]')
+        (flat_mem / "retrospective_queue.jsonl").write_text('{"kind": "verify"}\n')
+
+        migrate_flat_operational_stores(cfg)
+
+        scoped_mem = cfg.repo_memory_dir
+        assert (scoped_mem / "retrospectives.jsonl").read_text() == '{"issue": 7}\n'
+        assert (scoped_mem / "filed_patterns.json").read_text() == '["p1"]'
+        assert (scoped_mem / "retrospective_queue.jsonl").exists()
+
+    def test_harness_family_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_mem = cfg.data_root / "memory"
+        flat_mem.mkdir(parents=True)
+        (flat_mem / "harness_failures.jsonl").write_text('{"stage": "ci"}\n')
+        (flat_mem / "harness_suggestions.jsonl").write_text('{"hint": "x"}\n')
+        (flat_mem / "harness_proposed.json").write_text('["k1"]')
+
+        migrate_flat_operational_stores(cfg)
+
+        scoped_mem = cfg.repo_memory_dir
+        assert (
+            scoped_mem / "harness_failures.jsonl"
+        ).read_text() == '{"stage": "ci"}\n'
+        assert (scoped_mem / "harness_suggestions.jsonl").exists()
+        assert (scoped_mem / "harness_proposed.json").read_text() == '["k1"]'
+
+    def test_review_family_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_mem = cfg.data_root / "memory"
+        flat_mem.mkdir(parents=True)
+        (flat_mem / "reviews.jsonl").write_text('{"pr": 99}\n')
+        (flat_mem / "proposed_categories.json").write_text('["nit"]')
+        (flat_mem / "proposal_metadata.json").write_text('{"nit": {}}')
+
+        migrate_flat_operational_stores(cfg)
+
+        scoped_mem = cfg.repo_memory_dir
+        assert (scoped_mem / "reviews.jsonl").read_text() == '{"pr": 99}\n'
+        assert (scoped_mem / "proposed_categories.json").read_text() == '["nit"]'
+        assert (scoped_mem / "proposal_metadata.json").exists()
+
+    def test_host_shared_memory_files_not_migrated(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat_mem = cfg.data_root / "memory"
+        flat_mem.mkdir(parents=True)
+        # Out-of-scope host-shared stores must stay flat.
+        (flat_mem / "adr_decisions.jsonl").write_text('{"adr": 1}\n')
+        (flat_mem / "hitl_recommendations.jsonl").write_text('{"rec": 1}\n')
+        (flat_mem / "items.jsonl").write_text('{"item": 1}\n')
+        (flat_mem / "verification_records.jsonl").write_text('{"v": 1}\n')
+
+        migrate_flat_operational_stores(cfg)
+
+        scoped_mem = cfg.repo_memory_dir
+        for name in (
+            "adr_decisions.jsonl",
+            "hitl_recommendations.jsonl",
+            "items.jsonl",
+            "verification_records.jsonl",
+        ):
+            assert not (scoped_mem / name).exists()
+
+
+class TestMigrationIdempotency:
+    """Migration never overwrites already-scoped data and is safe to re-run."""
+
+    def test_does_not_overwrite_existing_scoped_file(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat = cfg.data_root / "diagnostics" / "factory_metrics.jsonl"
+        flat.parent.mkdir(parents=True)
+        flat.write_text('{"old": true}\n')
+        cfg.factory_metrics_path.parent.mkdir(parents=True)
+        cfg.factory_metrics_path.write_text('{"new": true}\n')
+
+        migrate_flat_operational_stores(cfg)
+
+        assert cfg.factory_metrics_path.read_text() == '{"new": true}\n'
+
+    def test_does_not_overwrite_existing_scoped_runs_tree(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        (cfg.data_root / "runs" / "1").mkdir(parents=True)
+        (cfg.data_root / "runs" / "1" / "old.txt").write_text("old")
+        scoped_runs = cfg.repo_data_root / "runs"
+        (scoped_runs / "2").mkdir(parents=True)
+        (scoped_runs / "2" / "new.txt").write_text("new")
+
+        migrate_flat_operational_stores(cfg)
+
+        # Existing scoped tree is left intact; flat tree is not merged in.
+        assert (scoped_runs / "2" / "new.txt").exists()
+        assert not (scoped_runs / "1" / "old.txt").exists()
+
+    def test_second_run_is_a_noop(self, tmp_path: Path) -> None:
+        cfg = _cfg(tmp_path)
+        flat = cfg.data_root / "memory" / "retrospectives.jsonl"
+        flat.parent.mkdir(parents=True)
+        flat.write_text('{"issue": 1}\n')
+
+        migrate_flat_operational_stores(cfg)
+        # Mutate the scoped copy; a second run must not re-copy over it.
+        cfg.retrospectives_path.write_text('{"issue": 2}\n')
+        migrate_flat_operational_stores(cfg)
+
+        assert cfg.retrospectives_path.read_text() == '{"issue": 2}\n'
+
+
+class TestMigrationResilience:
+    """A copy failure logs and continues — startup must never crash on migration."""
+
+    def test_copy_failure_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _cfg(tmp_path)
+        flat = cfg.data_root / "memory" / "retrospectives.jsonl"
+        flat.parent.mkdir(parents=True)
+        flat.write_text('{"issue": 1}\n')
+
+        def fail_copy(src: object, dst: object, **kw: object) -> None:
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(shutil, "copy2", fail_copy)
+
+        migrate_flat_operational_stores(cfg)  # must not raise
+        assert not cfg.retrospectives_path.exists()
+
+    def test_tree_copy_failure_does_not_raise(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _cfg(tmp_path)
+        flat_run = cfg.data_root / "runs" / "5"
+        flat_run.mkdir(parents=True)
+        (flat_run / "manifest.json").write_text("{}")
+
+        def fail_tree(src: object, dst: object, **kw: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(shutil, "copytree", fail_tree)
+
+        migrate_flat_operational_stores(cfg)  # must not raise
+        assert not (cfg.repo_data_root / "runs").exists()
+
+
+class TestMigrationScoping:
+    """Migration is a no-op when there is no repo slug to scope under."""
+
+    def test_noop_when_repo_data_root_equals_data_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cfg = _cfg(tmp_path)
+        # Force the degenerate case where scoping would copy onto itself.
+        monkeypatch.setattr(
+            type(cfg), "repo_data_root", property(lambda self: self.data_root)
+        )
+        flat = cfg.data_root / "memory" / "retrospectives.jsonl"
+        flat.parent.mkdir(parents=True)
+        flat.write_text("{}\n")
+
+        migrate_flat_operational_stores(cfg)  # must not raise or self-copy
+
+        assert flat.read_text() == "{}\n"
+
+    def test_two_repos_isolate_migrated_data(self, tmp_path: Path) -> None:
+        # Legacy flat data belongs to whichever config migrates it; each repo
+        # only ever migrates into its own slug.
+        flat_mem = tmp_path / ".hydraflow" / "memory"
+        flat_mem.mkdir(parents=True)
+        (flat_mem / "reviews.jsonl").write_text('{"pr": 1}\n')
+
+        cfg_a = _cfg(tmp_path, repo="org/alpha")
+        migrate_flat_operational_stores(cfg_a)
+
+        cfg_b = _cfg(tmp_path, repo="org/beta")
+        # Beta has its own (empty) scoped memory; alpha got the legacy data.
+        assert (cfg_a.repo_memory_dir / "reviews.jsonl").exists()
+        assert cfg_a.repo_memory_dir != cfg_b.repo_memory_dir

--- a/tests/test_diagnostics_cost_rollup_routes.py
+++ b/tests/test_diagnostics_cost_rollup_routes.py
@@ -11,17 +11,15 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from config import HydraFlowConfig
 from dashboard_routes._diagnostics_routes import build_diagnostics_router
+from tests.helpers import ConfigFactory
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> MagicMock:
-    cfg = MagicMock()
-    cfg.data_root = tmp_path
-    cfg.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
-    cfg.factory_metrics_path = tmp_path / "diagnostics" / "factory_metrics.jsonl"
-    cfg.repo = "o/r"
-    return cfg
+def config(tmp_path: Path) -> HydraFlowConfig:
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
 
 
 @pytest.fixture
@@ -31,10 +29,9 @@ def client(config) -> TestClient:
     return TestClient(app)
 
 
-def _write_inference(config, **fields) -> None:
-    d = config.data_root / "metrics" / "prompt"
-    d.mkdir(parents=True, exist_ok=True)
-    with (d / "inferences.jsonl").open("a", encoding="utf-8") as fh:
+def _write_inference(config: HydraFlowConfig, **fields) -> None:
+    config.cost_inferences_path.parent.mkdir(parents=True, exist_ok=True)
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(fields) + "\n")
 
 

--- a/tests/test_diagnostics_waterfall_route.py
+++ b/tests/test_diagnostics_waterfall_route.py
@@ -10,21 +10,19 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from config import HydraFlowConfig
 from dashboard_routes._diagnostics_routes import build_diagnostics_router
+from tests.helpers import ConfigFactory
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> MagicMock:
-    cfg = MagicMock()
-    cfg.data_root = tmp_path
-    cfg.data_path = tmp_path.joinpath
-    cfg.factory_metrics_path = tmp_path / "diagnostics" / "factory_metrics.jsonl"
-    cfg.repo = "o/r"
-    return cfg
+def config(tmp_path: Path) -> HydraFlowConfig:
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
 
 
 @pytest.fixture
-def client(config: MagicMock, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(config: HydraFlowConfig, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     fetcher = MagicMock()
     fetcher.fetch_issue_by_number = AsyncMock(
         return_value=MagicMock(
@@ -43,15 +41,19 @@ def client(config: MagicMock, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
-def _write_inference(config: MagicMock, **fields: object) -> None:
-    d = config.data_root / "metrics" / "prompt"
-    d.mkdir(parents=True, exist_ok=True)
-    with (d / "inferences.jsonl").open("a", encoding="utf-8") as fh:
+def _write_inference(config: HydraFlowConfig, **fields: object) -> None:
+    config.cost_inferences_path.parent.mkdir(parents=True, exist_ok=True)
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(fields) + "\n")
 
 
 def _write_trace(
-    config: MagicMock, issue: int, phase: str, run_id: int, idx: int, payload: dict
+    config: HydraFlowConfig,
+    issue: int,
+    phase: str,
+    run_id: int,
+    idx: int,
+    payload: dict,
 ) -> None:
     d = config.data_root / "traces" / str(issue) / phase / f"run-{run_id}"
     d.mkdir(parents=True, exist_ok=True)
@@ -59,7 +61,7 @@ def _write_trace(
 
 
 def test_waterfall_route_full_issue_returns_all_kinds(
-    client: TestClient, config: MagicMock
+    client: TestClient, config: HydraFlowConfig
 ) -> None:
     _write_inference(
         config,
@@ -153,7 +155,7 @@ def test_waterfall_route_full_issue_returns_all_kinds(
 
 
 def test_waterfall_route_partial_telemetry_returns_missing_phases(
-    client: TestClient, config: MagicMock
+    client: TestClient, config: HydraFlowConfig
 ) -> None:
     _write_inference(
         config,
@@ -179,7 +181,7 @@ def test_waterfall_route_partial_telemetry_returns_missing_phases(
 
 
 def test_waterfall_route_ghost_issue_still_returns_200(
-    config: MagicMock, monkeypatch: pytest.MonkeyPatch
+    config: HydraFlowConfig, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # Separate client with a fetcher that returns None (deleted/closed issue).
     fetcher = MagicMock()

--- a/tests/test_prompt_telemetry.py
+++ b/tests/test_prompt_telemetry.py
@@ -63,7 +63,7 @@ class TestPromptTelemetry:
             },
         )
 
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         assert inf_file.exists()
 
         rows = [ln for ln in inf_file.read_text().splitlines() if ln.strip()]
@@ -102,7 +102,7 @@ class TestPromptTelemetry:
             },
         )
 
-        pr_file = telemetry._config.data_path("metrics", "prompt", "pr_stats.json")
+        pr_file = telemetry._config.pr_stats_path
         assert pr_file.exists()
 
         rollup = json.loads(pr_file.read_text())
@@ -134,12 +134,12 @@ class TestPromptTelemetry:
             },
         )
 
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][0]
         )
 
-        pr_file = telemetry._config.data_path("metrics", "prompt", "pr_stats.json")
+        pr_file = telemetry._config.pr_stats_path
         rollup = json.loads(pr_file.read_text())
 
         lifetime = rollup["lifetime"]
@@ -166,14 +166,14 @@ class TestPromptTelemetry:
             stats={"input_tokens": 123, "output_tokens": 77, "total_tokens": 200},
         )
 
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["token_source"] == "actual"
         assert row["input_tokens"] == 123
         assert row["output_tokens"] == 77
         assert row["total_tokens"] == 200
 
-        pr_file = telemetry._config.data_path("metrics", "prompt", "pr_stats.json")
+        pr_file = telemetry._config.pr_stats_path
         rollup = json.loads(pr_file.read_text())
         pr = rollup["prs"]["202"]
         assert pr["total_tokens"] == 200
@@ -203,17 +203,13 @@ class TestPromptTelemetry:
             },
         )
 
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["usage_status"] == "unavailable"
         assert row["usage_available"] is False
         assert isinstance(row["raw_usage"], list)
 
-        rollup = json.loads(
-            telemetry._config.data_path(
-                "metrics", "prompt", "pr_stats.json"
-            ).read_text()
-        )
+        rollup = json.loads(telemetry._config.pr_stats_path.read_text())
         assert rollup["lifetime"]["usage_unavailable_calls"] == 1
 
     def test_get_session_and_lifetime_totals(self, telemetry):
@@ -296,7 +292,7 @@ class TestPromptTelemetry:
             stats={},
         )
 
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["status"] == "failed"
         assert row["token_source"] == "estimated"
@@ -324,12 +320,12 @@ class TestPromptTelemetry:
                 "section_chars": {"issue_body_before": 1000, "issue_body_after": 700},
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["pruned_chars_total"] == 123
         assert row["section_chars"]["issue_body_before"] == 1000
 
-        pr_file = telemetry._config.data_path("metrics", "prompt", "pr_stats.json")
+        pr_file = telemetry._config.pr_stats_path
         rollup = json.loads(pr_file.read_text())
         assert rollup["prs"]["500"]["pruned_chars_total"] == 123
 
@@ -352,7 +348,7 @@ class TestPromptTelemetry:
                 "context_chars_after": 1800,
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["pruned_chars_total"] == 500
 
@@ -408,7 +404,7 @@ class TestPromptTelemetry:
             success=True,
             stats={"input_tokens": 1000, "output_tokens": 500},
         )
-        inf_file = config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["estimated_cost_usd"] is not None
         assert row["estimated_cost_usd"] > 0
@@ -441,7 +437,7 @@ class TestPromptTelemetry:
             success=True,
             stats={},
         )
-        inf_file = config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = config.cost_inferences_path
         row = json.loads(inf_file.read_text().strip())
         assert row["estimated_cost_usd"] is None
 
@@ -478,7 +474,7 @@ class TestPromptTelemetry:
                 success=True,
                 stats={"input_tokens": 1000, "output_tokens": 200},
             )
-        pr_file = config.data_path("metrics", "prompt", "pr_stats.json")
+        pr_file = config.pr_stats_path
         rollup = json.loads(pr_file.read_text())
         pr_cost = rollup["prs"]["700"]["estimated_cost_usd"]
         single_cost = (15.0 * 1000 + 75.0 * 200) / 1_000_000
@@ -535,7 +531,7 @@ class TestZeroUsageSanityGuard:
                 "usage_status": "unavailable",
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
         )
@@ -564,7 +560,7 @@ class TestZeroUsageSanityGuard:
                 "usage_status": "available",
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
         )
@@ -592,7 +588,7 @@ class TestZeroUsageSanityGuard:
                 "usage_status": "unavailable",
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
         )
@@ -619,7 +615,7 @@ class TestZeroUsageSanityGuard:
                 "usage_status": "unavailable",
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
         )
@@ -651,7 +647,7 @@ class TestZeroUsageSanityGuard:
                 "usage_status": "available",
             },
         )
-        inf_file = telemetry._config.data_path("metrics", "prompt", "inferences.jsonl")
+        inf_file = telemetry._config.cost_inferences_path
         row = json.loads(
             [ln for ln in inf_file.read_text().splitlines() if ln.strip()][-1]
         )

--- a/tests/test_retrospective.py
+++ b/tests/test_retrospective.py
@@ -53,7 +53,7 @@ def _write_retro_entries(
     config: HydraFlowConfig, entries: list[RetrospectiveEntry]
 ) -> None:
     """Write retrospective entries to the JSONL file."""
-    retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+    retro_path = config.retrospectives_path
     retro_path.parent.mkdir(parents=True, exist_ok=True)
     with retro_path.open("w") as f:
         for entry in entries:
@@ -200,7 +200,7 @@ class TestJSONLStorage:
         )
         collector._append_entry(entry)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         assert retro_path.exists()
 
     def test_append_writes_valid_jsonl(self, config: HydraFlowConfig) -> None:
@@ -213,7 +213,7 @@ class TestJSONLStorage:
         )
         collector._append_entry(entry)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         lines = retro_path.read_text().strip().splitlines()
         assert len(lines) == 1
         data = json.loads(lines[0])
@@ -230,7 +230,7 @@ class TestJSONLStorage:
             )
             collector._append_entry(entry)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         lines = retro_path.read_text().strip().splitlines()
         assert len(lines) == 3
 
@@ -302,7 +302,7 @@ class TestRecord:
         )
         await collector.record(42, 101, review)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         assert retro_path.exists()
         lines = retro_path.read_text().strip().splitlines()
         assert len(lines) == 1
@@ -331,7 +331,7 @@ class TestRecord:
         review = ReviewResultFactory.create(merged=True)
         await collector.record(42, 101, review)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         lines = retro_path.read_text().strip().splitlines()
         data = json.loads(lines[0])
         assert data["planned_files"] == []
@@ -346,7 +346,7 @@ class TestRecord:
         review = ReviewResultFactory.create(merged=True)
         await collector.record(42, 101, review)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         lines = retro_path.read_text().strip().splitlines()
         data = json.loads(lines[0])
         assert data["actual_files"] == []
@@ -362,7 +362,7 @@ class TestRecord:
         review = ReviewResultFactory.create(merged=True)
         await collector.record(42, 101, review)
 
-        retro_path = config.repo_root / ".hydraflow" / "memory" / "retrospectives.jsonl"
+        retro_path = config.retrospectives_path
         lines = retro_path.read_text().strip().splitlines()
         data = json.loads(lines[0])
         assert data["quality_fix_rounds"] == 0
@@ -563,7 +563,7 @@ class TestPatternDetection:
         collector, mock_prs, _ = _make_collector(config)
 
         # Pre-populate filed patterns
-        filed_path = config.repo_root / ".hydraflow" / "memory" / "filed_patterns.json"
+        filed_path = config.repo_memory_dir / "filed_patterns.json"
         filed_path.parent.mkdir(parents=True, exist_ok=True)
         filed_path.write_text(json.dumps(["quality_fix"]))
 

--- a/tests/test_run_recorder.py
+++ b/tests/test_run_recorder.py
@@ -169,7 +169,7 @@ class TestRunRecorder:
         recorder = self._make_recorder(tmp_path)
 
         # Create two runs manually with known timestamps
-        runs_dir = tmp_path / "repo" / ".hydraflow" / "runs" / "42"
+        runs_dir = recorder.runs_dir / "42"
         for ts in ("20260101T100000Z", "20260101T200000Z"):
             run_dir = runs_dir / ts
             run_dir.mkdir(parents=True)
@@ -186,7 +186,7 @@ class TestRunRecorder:
     ) -> None:
         """A corrupt manifest is skipped; valid manifests still returned."""
         recorder = self._make_recorder(tmp_path)
-        runs_dir = tmp_path / "repo" / ".hydraflow" / "runs" / "42"
+        runs_dir = recorder.runs_dir / "42"
 
         # First run — corrupt manifest
         corrupt_dir = runs_dir / "20260101T100000Z"
@@ -209,7 +209,7 @@ class TestRunRecorder:
     def test_get_latest_returns_most_recent(self, tmp_path: Path) -> None:
         recorder = self._make_recorder(tmp_path)
 
-        runs_dir = tmp_path / "repo" / ".hydraflow" / "runs" / "42"
+        runs_dir = recorder.runs_dir / "42"
         for ts in ("20260101T100000Z", "20260101T200000Z"):
             run_dir = runs_dir / ts
             run_dir.mkdir(parents=True)
@@ -281,7 +281,7 @@ class TestRunRecorder:
 
     def test_skips_corrupt_manifest(self, tmp_path: Path) -> None:
         recorder = self._make_recorder(tmp_path)
-        runs_dir = tmp_path / "repo" / ".hydraflow" / "runs" / "42" / "20260101T000000Z"
+        runs_dir = recorder.runs_dir / "42" / "20260101T000000Z"
         runs_dir.mkdir(parents=True)
         (runs_dir / "manifest.json").write_text("not valid json {{{")
 
@@ -289,8 +289,10 @@ class TestRunRecorder:
         assert runs == []
 
     def test_runs_dir_property(self, tmp_path: Path) -> None:
-        recorder = self._make_recorder(tmp_path)
-        assert recorder.runs_dir == tmp_path / "repo" / ".hydraflow" / "runs"
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+        recorder = RunRecorder(config)
+        assert recorder.runs_dir == config.repo_data_path("runs")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -90,6 +90,22 @@ class TestRunDispatch:
             await _run(mock_config)
             mock_headless.assert_awaited_once_with(mock_config)
 
+    @pytest.mark.asyncio
+    async def test_run_migrates_flat_stores_with_host_config(self) -> None:
+        # The D2 flat-store migration must run once with the host config at
+        # startup; otherwise per-repo stores never relocate in prod (ADR-0021).
+        mock_config = MagicMock()
+        mock_config.dashboard_enabled = True
+
+        with (
+            patch("server._run_with_dashboard"),
+            patch("data_migration.migrate_flat_operational_stores") as mock_migrate,
+        ):
+            from server import _run
+
+            await _run(mock_config)
+            mock_migrate.assert_called_once_with(mock_config)
+
 
 class TestDetectSubmoduleParent:
     def test_returns_parent_when_git_is_file(self, tmp_path: Path) -> None:

--- a/tests/test_waterfall_builder.py
+++ b/tests/test_waterfall_builder.py
@@ -8,24 +8,28 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from config import HydraFlowConfig
 from dashboard_routes._waterfall_builder import (
     PHASE_ORDER,
     _phase_for_source,
     build_waterfall,
 )
+from tests.helpers import ConfigFactory
 
 
 @pytest.fixture
-def config(tmp_path: Path) -> MagicMock:
-    cfg = MagicMock()
-    cfg.data_root = tmp_path
-    cfg.data_path = lambda *parts: tmp_path.joinpath(*parts)  # noqa: PLW0108
-    cfg.repo = "o/r"
-    return cfg
+def config(tmp_path: Path) -> HydraFlowConfig:
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
 
 
 def _write_trace(
-    config: MagicMock, issue: int, phase: str, run_id: int, idx: int, payload: dict
+    config: HydraFlowConfig,
+    issue: int,
+    phase: str,
+    run_id: int,
+    idx: int,
+    payload: dict,
 ) -> None:
     run_dir = config.data_root / "traces" / str(issue) / phase / f"run-{run_id}"
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -34,15 +38,14 @@ def _write_trace(
     )
 
 
-def _write_inference(config: MagicMock, **fields) -> None:
-    inf_dir = config.data_root / "metrics" / "prompt"
-    inf_dir.mkdir(parents=True, exist_ok=True)
-    path = inf_dir / "inferences.jsonl"
+def _write_inference(config: HydraFlowConfig, **fields) -> None:
+    path = config.cost_inferences_path
+    path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(fields) + "\n")
 
 
-def _write_loop_trace(config: MagicMock, loop: str, **fields) -> None:
+def _write_loop_trace(config: HydraFlowConfig, loop: str, **fields) -> None:
     from trace_collector import _slug_for_loop  # noqa: PLC0415
 
     d = config.data_root / "traces" / "_loops" / _slug_for_loop(loop)


### PR DESCRIPTION
## Summary

Phase 2 **D2** of the multi-repo dashboard program: move per-repo **operational** stores from the flat `config.data_path(...)` (under `data_root`) to repo-scoped `config.repo_data_root` (`data_root/<repo_slug>`), so they no longer collide when repos share one `data_root`.

Under the original *process-per-repo* model (ADR-0009, separate `HYDRAFLOW_HOME` per repo) flat stores were collision-free. The multi-repo **dashboard** model (ADR-0007/0038) holds a `RepoRuntimeRegistry` in one host process that shares a single `data_root` (prod sets `HYDRAFLOW_HOME`) — so the flat stores collided across repos. `state.json`/`events.jsonl`/`sessions.jsonl` were already scoped; this extends scoping to the remaining operational stores.

## What moves (flat → `repo_data_root`)

| Store | New location |
|-------|-------------|
| Run artifacts | `repo_data_root/runs/` |
| Cost inferences + PR stats | `repo_data_root/metrics/prompt/{inferences.jsonl,pr_stats.json}` |
| Factory metrics | `repo_data_root/diagnostics/factory_metrics.jsonl` |
| Retrospective / harness / review insights | `repo_data_root/memory/…` (via `repo_memory_dir`) |

The `memory/` dir is split: per-repo **insight** files move; cross-repo **knowledge** (`adr_decisions`, `hitl_recommendations`, `items`, `verification_records`) deliberately stays flat under `memory_dir`. Deferred (documented in the ADR): `history_cache.json` (host-only), `traces/`, `reflections/`, health-monitor `outcomes`/`item_scores`/known-patterns/troubleshooting.

## How

- New `HydraFlowConfig` accessors: `repo_data_path()`, `repo_memory_dir`, `retrospectives_path`, `cost_inferences_path`, `pr_stats_path`; `factory_metrics_path` re-pointed. All ~20 reader/writer/construct sites switched (writers and every reader move together — no path drift).
- New `src/data_migration.py::migrate_flat_operational_stores(config)`: one-time, **idempotent**, **host-only** migration (mirrors `_resolve_repo_scoped_paths`' copy-if-absent / `copy2` / log-on-`OSError`). Wired into `server._run` with the host config *before* any member runtime — the legacy flat data is comingled and belongs to the default/host repo ("the default repo keeps its history"); members start clean. No-op when `repo_data_root == data_root`.
- **ADR-0021 amended** with rationale, the migrate/keep scope boundary, and deferred stores.

## Tests

- `tests/test_data_migration_d2.py` — accessors + per-store migration + idempotency (file & tree) + copy-failure resilience + no-slug no-op + two-repo isolation.
- `tests/test_server.py` — `_run` invokes the migration with the host config (wiring).
- `tests/scenarios/test_multi_repo_data_isolation.py` — two seeded repos resolve distinct store paths with no cross-repo bleed.
- Existing path-asserting tests updated to the scoped accessors (cost fixtures upgraded from MagicMock to real `ConfigFactory` configs).

## Verification

`make quality` (15802 passed) · `make scenario` / `make scenario-loops` · `make audit` · pinned ruff/pyright clean. Adversarial multi-agent review (drift / scope / migration-correctness / test-adequacy) converged: 1 confirmed finding (test fidelity), fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
