### PR TITLE
feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T15:48:03.831439+00:00",
-  "commit_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80",
+  "regenerated_at": "2026-06-08T17:39:28.110182+00:00",
+  "commit_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15",
   "artifacts": {
     "loops.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "ports.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "labels.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "modules.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "events.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "adr_xref.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "mockworld.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "changelog.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "coverage_matrix.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "functional_areas.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "ubiquitous-language.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "75f5a6df014d8912c2518539713fd8d6a359ad80"
+      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `15e22ef` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) *(2026-06-08)*
+- `4069df7` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) (#9355) (#9355) *(2026-06-08)*
 
 ## 2026-W23
 

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -35,7 +35,7 @@ graph LR
     src_arch_generators -- "11" --> src_arch
     src_dashboard_routes -- "3" --> src_onboarding
     src_dashboard_routes -- "1" --> src_preflight
-    src_dashboard_routes -- "1" --> src_state
+    src_dashboard_routes -- "2" --> src_state
     src_mockworld_fakes -- "29" --> src_mockworld
     src_mockworld_fakes -- "1" --> src_telemetry
     src_preflight -- "1" --> src_runners

--- a/src/dashboard_routes/_hitl_routes.py
+++ b/src/dashboard_routes/_hitl_routes.py
@@ -19,10 +19,13 @@ from models import (
     IssueOutcomeType,
 )
 from ports import PRPort
-from route_types import RepoSlugParam
+from route_types import REPO_ALL, RepoSlugParam
 
 if TYPE_CHECKING:
+    from config import HydraFlowConfig
+    from events import EventBus
     from orchestrator import HydraFlowOrchestrator
+    from state import StateTracker
 
 logger = logging.getLogger("hydraflow.dashboard")
 
@@ -80,11 +83,12 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
     def _clear_hitl_state(
         orch: HydraFlowOrchestrator | None,
         issue_number: int,
+        state: StateTracker,
     ) -> None:
-        """Clear all HITL tracking state for an issue."""
+        """Clear all HITL tracking state for an issue (on the row's state)."""
         if orch:
             orch.skip_hitl_issue(issue_number)
-        ctx.state.clear_hitl_state(issue_number)
+        state.clear_hitl_state(issue_number)
 
     async def _resolve_hitl_item(
         issue_number: int,
@@ -95,10 +99,17 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         comment_body: str,
         outcome_type: IssueOutcomeType,
         reason: str,
+        state: StateTracker,
+        bus: EventBus,
+        pr_manager: PRPort,
     ) -> JSONResponse:
-        """Clear HITL state, record outcome, post comment, and publish event."""
-        _clear_hitl_state(orch, issue_number)
-        ctx.state.record_outcome(
+        """Clear HITL state, record outcome, post comment, and publish event.
+
+        Operates on the *row's* repo objects (state/bus/pr_manager) so a
+        mutation never touches the default repo's persistence.
+        """
+        _clear_hitl_state(orch, issue_number, state)
+        state.record_outcome(
             issue_number,
             outcome_type,
             reason=reason,
@@ -106,7 +117,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         )
 
         try:
-            await ctx.pr_manager.post_comment(
+            await pr_manager.post_comment(
                 issue_number,
                 f"**{comment_heading}** — {comment_body}\n\n---\n*HydraFlow Dashboard*",
             )
@@ -118,7 +129,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 exc_info=True,
             )
 
-        await ctx.event_bus.publish(
+        await bus.publish(
             HydraFlowEvent(
                 type=EventType.HITL_UPDATE,
                 data=HITLUpdatePayload(
@@ -131,73 +142,101 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         )
         return JSONResponse({"status": "ok"})
 
+    def _enrich_hitl_data(
+        data: dict[str, Any],
+        issue_num: int,
+        *,
+        cfg: HydraFlowConfig,
+        state: StateTracker,
+    ) -> None:
+        """Enrich one item's dict from the row's repo state/config in place.
+
+        Reads cause/summary/visual evidence from the **row's** state (not the
+        host's) and schedules summary warming with the row's state/config/
+        issue-fetcher — fixing the latent bug where issue #N of a non-default
+        repo was enriched (and warmed) against the default repo.
+        """
+        cause = state.get_hitl_cause(issue_num)
+        origin = state.get_hitl_origin(issue_num)
+        if not cause and origin:
+            if origin in cfg.review_label:
+                cause = "Review escalation"
+            elif origin in cfg.find_label:
+                cause = "Triage escalation"
+            else:
+                cause = "Escalation (reason not recorded)"
+        if cause:
+            data["cause"] = cause
+        if cause and (
+            "epic detected" in cause.lower() or "bug report detected" in cause.lower()
+        ):
+            data["issueTypeReview"] = True
+        cached_summary = state.get_hitl_summary(issue_num)
+        data["llmSummary"] = cached_summary or ""
+        data["llmSummaryUpdatedAt"] = state.get_hitl_summary_updated_at(issue_num)
+        visual_ev = state.get_hitl_visual_evidence(issue_num)
+        if visual_ev:
+            data["visualEvidence"] = visual_ev.model_dump()
+        if (
+            not cached_summary
+            and cfg.transcript_summarization_enabled
+            and not cfg.dry_run
+            and bool(ctx.credentials.gh_token)
+            and ctx.hitl_summary_retry_due(issue_num, state=state)
+        ):
+            fetcher = ctx.issue_fetcher_for(cfg)
+            warm_task = asyncio.create_task(
+                ctx.warm_hitl_summary(
+                    issue_num,
+                    cause=cause or "",
+                    origin=origin,
+                    state=state,
+                    config=cfg,
+                    issue_fetcher=fetcher,
+                )
+            )
+            _pending_warm_tasks.add(warm_task)
+            warm_task.add_done_callback(_pending_warm_tasks.discard)
+            warm_task.add_done_callback(_log_warm_failure)
+
     @router.get("/api/hitl")
     async def get_hitl(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Fetch issues/PRs labeled for human-in-the-loop (stuck on CI)."""
-        if not ctx.is_repo_pipeline_active(repo):
-            return JSONResponse([])
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        orch = _get_orch()
-        # Use cached data when available
-        if orch and isinstance(getattr(orch, "github_cache", None), GitHubDataCache):
-            items = orch.github_cache.get_hitl_items()
-        else:
-            hitl_labels = list(
-                dict.fromkeys([*_cfg.hitl_label, *_cfg.hitl_active_label])
-            )
-            manager = ctx.pr_manager_for(_cfg, _bus)
-            items = await manager.list_hitl_items(hitl_labels)
-        enriched = []
-        for item in items:
-            data = (
-                dict(item) if isinstance(item, dict) else item.model_dump(by_alias=True)
-            )
-            issue_num: int = int(
-                data.get("issue", 0) if isinstance(item, dict) else item.issue
-            )
-            if orch:
-                data["status"] = orch.get_hitl_status(issue_num)
-            cause = _state.get_hitl_cause(issue_num)
-            origin = _state.get_hitl_origin(issue_num)
-            if not cause and origin:
-                if origin in _cfg.review_label:
-                    cause = "Review escalation"
-                elif origin in _cfg.find_label:
-                    cause = "Triage escalation"
-                else:
-                    cause = "Escalation (reason not recorded)"
-            if cause:
-                data["cause"] = cause
-            # Flag items held for issue type review
-            if cause and (
-                "epic detected" in cause.lower()
-                or "bug report detected" in cause.lower()
+        """Fetch issues/PRs labeled for human-in-the-loop, unioned across repos.
+
+        For ``repo=__all__`` every registered repo contributes its HITL items
+        tagged with its slug — **including stopped repos** (stuck issues matter
+        regardless of pipeline state), so there is no top-level active-gate;
+        each item is enriched against its own repo's state/config.
+        """
+        enriched: list[dict[str, Any]] = []
+        for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+            orch = _get_orch()
+            if orch and isinstance(
+                getattr(orch, "github_cache", None), GitHubDataCache
             ):
-                data["issueTypeReview"] = True
-            cached_summary = ctx.state.get_hitl_summary(issue_num)
-            data["llmSummary"] = cached_summary or ""
-            data["llmSummaryUpdatedAt"] = ctx.state.get_hitl_summary_updated_at(
-                issue_num
-            )
-            visual_ev = ctx.state.get_hitl_visual_evidence(issue_num)
-            if visual_ev:
-                data["visualEvidence"] = visual_ev.model_dump()
-            if (
-                not cached_summary
-                and ctx.config.transcript_summarization_enabled
-                and not ctx.config.dry_run
-                and bool(ctx.credentials.gh_token)
-                and ctx.hitl_summary_retry_due(issue_num)
-            ):
-                warm_task = asyncio.create_task(
-                    ctx.warm_hitl_summary(issue_num, cause=cause or "", origin=origin)
+                items = orch.github_cache.get_hitl_items()
+            else:
+                hitl_labels = list(
+                    dict.fromkeys([*_cfg.hitl_label, *_cfg.hitl_active_label])
                 )
-                _pending_warm_tasks.add(warm_task)
-                warm_task.add_done_callback(_pending_warm_tasks.discard)
-                warm_task.add_done_callback(_log_warm_failure)
-            enriched.append(data)
+                manager = ctx.pr_manager_for(_cfg, _bus)
+                items = await manager.list_hitl_items(hitl_labels)
+            for item in items:
+                data = (
+                    dict(item)
+                    if isinstance(item, dict)
+                    else item.model_dump(by_alias=True)
+                )
+                issue_num: int = int(
+                    data.get("issue", 0) if isinstance(item, dict) else item.issue
+                )
+                if orch:
+                    data["status"] = orch.get_hitl_status(issue_num)
+                _enrich_hitl_data(data, issue_num, cfg=_cfg, state=_state)
+                data["repo"] = slug
+                enriched.append(data)
 
         return JSONResponse(enriched)
 
@@ -209,42 +248,68 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
 
         Cap-hit escalation surface from :class:`SandboxFailureFixerLoop`
         (after 3 failed auto-fix attempts the loop swaps
-        ``sandbox-fail-auto-fix`` for ``sandbox-hitl``). Separate from
-        ``/api/hitl`` so PR-shaped payloads don't contaminate the
-        issue-shaped contract there — the dashboard merges client-side.
+        ``sandbox-fail-auto-fix`` for ``sandbox-hitl``). Unioned across repos
+        for ``repo=__all__`` (each PR tagged with its repo slug). Separate from
+        ``/api/hitl`` so PR-shaped payloads don't contaminate the issue-shaped
+        contract there — the dashboard merges client-side.
         """
-        if not ctx.is_repo_pipeline_active(repo):
-            return JSONResponse({"items": []})
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        manager = ctx.pr_manager_for(_cfg, _bus)
-        payload = await sandbox_hitl_handler(prs=manager)
-        return JSONResponse(payload)
+        merged: list[dict[str, Any]] = []
+        for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+            manager = ctx.pr_manager_for(_cfg, _bus)
+            payload = await sandbox_hitl_handler(prs=manager)
+            for pr in payload["items"]:
+                pr["repo"] = slug
+                merged.append(pr)
+        return JSONResponse({"items": merged})
+
+    def _reject_repo_all(repo: str | None) -> JSONResponse | None:
+        """Return a 400 when a row-scoped mutation is called with repo=__all__."""
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return JSONResponse(
+                {"status": "error", "detail": "this action requires a specific repo"},
+                status_code=400,
+            )
+        return None
 
     @router.get("/api/hitl/{issue_number}/summary")
-    async def get_hitl_summary(issue_number: int) -> JSONResponse:
-        """Return cached HITL summary, generating one if missing."""
-        cached = ctx.state.get_hitl_summary(issue_number)
+    async def get_hitl_summary(
+        issue_number: int, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Return cached HITL summary, generating one if missing (row's repo).
+
+        A single issue's summary is repo-scoped, so ``repo=__all__`` is
+        rejected — there is no aggregate summary for one issue number.
+        """
+        if (rejected := _reject_repo_all(repo)) is not None:
+            return rejected
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        cached = _state.get_hitl_summary(issue_number)
         if cached:
             return JSONResponse(
                 {
                     "issue": issue_number,
                     "summary": cached,
-                    "updated_at": ctx.state.get_hitl_summary_updated_at(issue_number),
+                    "updated_at": _state.get_hitl_summary_updated_at(issue_number),
                     "cached": True,
                 }
             )
 
-        cause = ctx.state.get_hitl_cause(issue_number) or ""
-        origin = ctx.state.get_hitl_origin(issue_number)
+        cause = _state.get_hitl_cause(issue_number) or ""
+        origin = _state.get_hitl_origin(issue_number)
         summary = await ctx.compute_hitl_summary(
-            issue_number, cause=cause, origin=origin
+            issue_number,
+            cause=cause,
+            origin=origin,
+            state=_state,
+            config=_cfg,
+            issue_fetcher=ctx.issue_fetcher_for(_cfg),
         )
         if summary:
             return JSONResponse(
                 {
                     "issue": issue_number,
                     "summary": summary,
-                    "updated_at": ctx.state.get_hitl_summary_updated_at(issue_number),
+                    "updated_at": _state.get_hitl_summary_updated_at(issue_number),
                     "cached": False,
                 }
             )
@@ -258,9 +323,14 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         )
 
     @router.post("/api/hitl/{issue_number}/correct")
-    async def hitl_correct(issue_number: int, body: dict[str, Any]) -> JSONResponse:
-        """Submit a correction for a HITL issue to guide retry."""
-        orch = ctx.get_orchestrator()
+    async def hitl_correct(
+        issue_number: int, body: dict[str, Any], repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Submit a correction for a HITL issue to guide retry (row's repo)."""
+        if (rejected := _reject_repo_all(repo)) is not None:
+            return rejected
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
         correction = body.get("correction") or ""
@@ -272,11 +342,11 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         orch.submit_hitl_correction(issue_number, correction)
 
         # Swap labels for immediate dashboard feedback
-        await ctx.pr_manager.swap_pipeline_labels(
-            issue_number, ctx.config.hitl_active_label[0]
+        await ctx.pr_manager_for(_cfg, _bus).swap_pipeline_labels(
+            issue_number, _cfg.hitl_active_label[0]
         )
 
-        await ctx.event_bus.publish(
+        await _bus.publish(
             HydraFlowEvent(
                 type=EventType.HITL_UPDATE,
                 data=HITLUpdatePayload(
@@ -289,16 +359,19 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return JSONResponse({"status": "ok"})
 
     @router.post("/api/hitl/{issue_number}/skip")
-    async def hitl_skip(issue_number: int, body: HITLSkipRequest) -> JSONResponse:
-        """Remove a HITL issue from the queue without action (reason required)."""
-        orch = ctx.get_orchestrator()
+    async def hitl_skip(
+        issue_number: int, body: HITLSkipRequest, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Remove a HITL issue from the queue without action (row's repo)."""
+        if (rejected := _reject_repo_all(repo)) is not None:
+            return rejected
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
 
-        # Read origin before clearing state
-        ctx.state.get_hitl_origin(issue_number)
-
-        await ctx.pr_manager.close_issue(issue_number)
+        pr_manager = ctx.pr_manager_for(_cfg, _bus)
+        await pr_manager.close_issue(issue_number)
 
         return await _resolve_hitl_item(
             issue_number,
@@ -308,15 +381,24 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             comment_body=f"Operator skipped this issue.\n\n**Reason:** {body.reason}",
             outcome_type=IssueOutcomeType.HITL_SKIPPED,
             reason=body.reason,
+            state=_state,
+            bus=_bus,
+            pr_manager=pr_manager,
         )
 
     @router.post("/api/hitl/{issue_number}/close")
-    async def hitl_close(issue_number: int, body: HITLCloseRequest) -> JSONResponse:
-        """Close a HITL issue on GitHub (reason required)."""
-        orch = ctx.get_orchestrator()
+    async def hitl_close(
+        issue_number: int, body: HITLCloseRequest, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Close a HITL issue on GitHub (row's repo)."""
+        if (rejected := _reject_repo_all(repo)) is not None:
+            return rejected
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
-        await ctx.pr_manager.close_issue(issue_number)
+        pr_manager = ctx.pr_manager_for(_cfg, _bus)
+        await pr_manager.close_issue(issue_number)
 
         return await _resolve_hitl_item(
             issue_number,
@@ -326,22 +408,31 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             comment_body=f"Operator closed this issue.\n\n**Reason:** {body.reason}",
             outcome_type=IssueOutcomeType.HITL_CLOSED,
             reason=body.reason,
+            state=_state,
+            bus=_bus,
+            pr_manager=pr_manager,
         )
 
     @router.post("/api/hitl/{issue_number}/approve-process")
-    async def hitl_approve_process(issue_number: int) -> JSONResponse:
-        """Approve a HITL item held for issue type review.
+    async def hitl_approve_process(
+        issue_number: int, repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Approve a HITL item held for issue type review (row's repo).
 
         All issue types (bugs, epics, etc.) route to triage first.
         """
-        orch = ctx.get_orchestrator()
+        if (rejected := _reject_repo_all(repo)) is not None:
+            return rejected
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
         if not orch:
             return JSONResponse({"status": "no orchestrator"}, status_code=400)
 
-        target_label = ctx.config.find_label[0]
+        target_label = _cfg.find_label[0]
         target_stage = "triage"
 
-        await ctx.pr_manager.swap_pipeline_labels(issue_number, target_label)
+        pr_manager = ctx.pr_manager_for(_cfg, _bus)
+        await pr_manager.swap_pipeline_labels(issue_number, target_label)
 
         return await _resolve_hitl_item(
             issue_number,
@@ -354,6 +445,9 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             ),
             outcome_type=IssueOutcomeType.HITL_APPROVED,
             reason=f"Operator approved issue type for processing ({target_stage})",
+            state=_state,
+            bus=_bus,
+            pr_manager=pr_manager,
         )
 
     @router.get("/api/human-input")

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -345,7 +345,9 @@ class RouteContext:
     # Derived state — initialised in __post_init__
     issue_fetcher: IssueFetcher = field(init=False)
     hitl_summarizer: TranscriptSummarizer = field(init=False)
-    hitl_summary_inflight: set[int] = field(init=False)
+    # Keys are bare ``int`` issue numbers on the host path and
+    # ``(repo_slug, issue)`` tuples on repo-scoped paths (see warm_hitl_summary).
+    hitl_summary_inflight: set[object] = field(init=False)
     hitl_summary_slots: asyncio.Semaphore = field(init=False)
 
     def __post_init__(self) -> None:
@@ -535,6 +537,16 @@ class RouteContext:
             return self.pr_manager
         return PRManager(cfg, bus)
 
+    def issue_fetcher_for(self, cfg: HydraFlowConfig) -> IssueFetcher:
+        """Return the shared IssueFetcher for the host config; else a repo-scoped one.
+
+        Mirrors :meth:`pr_manager_for` so a non-default repo fetches its own
+        issues while the host path keeps using the (mockable) shared fetcher.
+        """
+        if cfg is self.config:
+            return self.issue_fetcher
+        return IssueFetcher(cfg, credentials=self.credentials)
+
     def list_repo_records(self) -> list[RepoRecord]:
         """Return repo records from the callback or store, with error fallback."""
         if self.list_repos_cb is not None:
@@ -567,9 +579,16 @@ class RouteContext:
             return self.allowed_repo_roots_fn()
         return _allowed_repo_roots()
 
-    def hitl_summary_retry_due(self, issue_number: int) -> bool:
-        """Return True if enough time has passed to retry a failed HITL summary."""
-        failed_at, _ = self.state.get_hitl_summary_failure(issue_number)
+    def hitl_summary_retry_due(
+        self, issue_number: int, *, state: StateTracker | None = None
+    ) -> bool:
+        """Return True if enough time has passed to retry a failed HITL summary.
+
+        ``state`` defaults to the host state; pass the row's repo state so the
+        cooldown is read from the repo that owns the issue (ADR-0007 multi-repo).
+        """
+        st = state or self.state
+        failed_at, _ = st.get_hitl_summary_failure(issue_number)
         failed_dt = _parse_iso_or_none(failed_at)
         if failed_dt is None:
             return True
@@ -577,50 +596,88 @@ class RouteContext:
         return age >= self.hitl_summary_cooldown_seconds
 
     async def compute_hitl_summary(
-        self, issue_number: int, *, cause: str, origin: str | None
+        self,
+        issue_number: int,
+        *,
+        cause: str,
+        origin: str | None,
+        state: StateTracker | None = None,
+        config: HydraFlowConfig | None = None,
+        issue_fetcher: IssueFetcher | None = None,
     ) -> str | None:
-        """Fetch issue, generate and normalise a HITL summary, then persist to state."""
+        """Fetch issue, generate and normalise a HITL summary, then persist to state.
+
+        The ``state``/``config``/``issue_fetcher`` overrides default to the host
+        runtime; callers serving a non-default repo MUST pass that repo's objects
+        so the issue is fetched from the right GitHub repo and the summary is
+        persisted to the right state — otherwise issue #N of repo B would be
+        fetched from repo A and stored under A.
+        """
+        st = state or self.state
+        cfg = config or self.config
+        fetcher = issue_fetcher or self.issue_fetcher
         if (
-            not self.config.transcript_summarization_enabled
-            or self.config.dry_run
+            not cfg.transcript_summarization_enabled
+            or cfg.dry_run
             or not self.credentials.gh_token
         ):
             return None
-        issue = await self.issue_fetcher.fetch_issue_by_number(issue_number)
+        issue = await fetcher.fetch_issue_by_number(issue_number)
         if issue is None:
-            self.state.set_hitl_summary_failure(issue_number, "Issue fetch failed")
+            st.set_hitl_summary_failure(issue_number, "Issue fetch failed")
             return None
         context = _build_hitl_context(issue, cause=cause, origin=origin)
         generated = await self.hitl_summarizer.summarize_hitl_context(context)
         if not generated:
-            self.state.set_hitl_summary_failure(
-                issue_number, "Summary model returned empty"
-            )
+            st.set_hitl_summary_failure(issue_number, "Summary model returned empty")
             return None
         summary = _normalise_summary_lines(generated)
         if not summary:
-            self.state.set_hitl_summary_failure(
+            st.set_hitl_summary_failure(
                 issue_number, "Summary normalization produced empty output"
             )
             return None
-        self.state.set_hitl_summary(issue_number, summary)
-        self.state.clear_hitl_summary_failure(issue_number)
+        st.set_hitl_summary(issue_number, summary)
+        st.clear_hitl_summary_failure(issue_number)
         return summary
 
     async def warm_hitl_summary(
-        self, issue_number: int, *, cause: str, origin: str | None
+        self,
+        issue_number: int,
+        *,
+        cause: str,
+        origin: str | None,
+        state: StateTracker | None = None,
+        config: HydraFlowConfig | None = None,
+        issue_fetcher: IssueFetcher | None = None,
     ) -> None:
-        """Schedule background HITL summary generation, guarded by inflight tracking."""
-        if issue_number in self.hitl_summary_inflight:
+        """Schedule background HITL summary generation, guarded by inflight tracking.
+
+        Pass the row's repo ``state``/``config``/``issue_fetcher`` for non-default
+        repos (see :meth:`compute_hitl_summary`).
+        """
+        # Key the in-flight guard by (repo_slug, issue) when a repo config is
+        # given, so warming repo A's issue #42 does not transiently suppress
+        # repo B's issue #42 (same number, different repo). The host path keeps
+        # the bare-int key for back-compat.
+        inflight_key: object = (
+            (config.repo_slug, issue_number) if config is not None else issue_number
+        )
+        if inflight_key in self.hitl_summary_inflight:
             return
-        self.hitl_summary_inflight.add(issue_number)
+        self.hitl_summary_inflight.add(inflight_key)
         try:
             async with self.hitl_summary_slots:
                 await self.compute_hitl_summary(
-                    issue_number, cause=cause, origin=origin
+                    issue_number,
+                    cause=cause,
+                    origin=origin,
+                    state=state,
+                    config=config,
+                    issue_fetcher=issue_fetcher,
                 )
         except Exception as exc:
-            self.state.set_hitl_summary_failure(
+            (state or self.state).set_hitl_summary_failure(
                 issue_number,
                 f"{type(exc).__name__}: {exc}",
             )
@@ -629,7 +686,7 @@ class RouteContext:
                 issue_number,
             )
         finally:
-            self.hitl_summary_inflight.discard(issue_number)
+            self.hitl_summary_inflight.discard(inflight_key)
 
 
 def _build_hitl_context(issue: GitHubIssue, *, cause: str, origin: str | None) -> str:

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -2984,6 +2984,7 @@ class PRManager:
             pr=pr_number,
             pr_url=pr_url,
             branch=branch,
+            repo=self._config.repo_slug,
         )
 
     @staticmethod

--- a/src/ui/src/components/HITLTable.jsx
+++ b/src/ui/src/components/HITLTable.jsx
@@ -3,13 +3,24 @@ import { theme } from '../theme'
 import { PIPELINE_STAGES } from '../constants'
 import { useHITLCorrection } from '../hooks/useHITLCorrection'
 
+// Composite row identity — colliding issue numbers across repos must not share
+// per-row state (corrections/summaries/expand) in aggregate mode. Falls back to
+// the bare issue number when no repo is present (single-repo payloads).
+const rowKey = (item) =>
+  item.repo ? `${item.repo}#${item.issue}` : String(item.issue)
+
 export function HITLTable({ items, onRefresh }) {
+  // Only one row is expanded at a time (expandedIssue is a single composite
+  // key, not a set). Per-row data-testids stay keyed by the bare issue number,
+  // so in aggregate mode colliding issue numbers share a testid — selecting the
+  // detail/action testids is unambiguous precisely because at most one of them
+  // is expanded (and thus rendered) at once.
   const [expandedIssue, setExpandedIssue] = useState(null)
   const [summaryExpandedIssue, setSummaryExpandedIssue] = useState(null)
   const [summaries, setSummaries] = useState(() =>
     Object.fromEntries(
       (items || []).map(item => [
-        item.issue,
+        rowKey(item),
         {
           text: item.llmSummary || '',
           updatedAt: item.llmSummaryUpdatedAt || null,
@@ -52,15 +63,16 @@ export function HITLTable({ items, onRefresh }) {
     setSummaries(prev => {
       const next = { ...prev }
       for (const item of items || []) {
+        const key = rowKey(item)
         if (item.llmSummary) {
-          next[item.issue] = {
+          next[key] = {
             text: item.llmSummary,
             updatedAt: item.llmSummaryUpdatedAt || null,
             loading: false,
             error: '',
           }
-        } else if (!next[item.issue]) {
-          next[item.issue] = {
+        } else if (!next[key]) {
+          next[key] = {
             text: '',
             updatedAt: null,
             loading: false,
@@ -72,30 +84,34 @@ export function HITLTable({ items, onRefresh }) {
     })
   }, [items])
 
-  const visibleItems = items.filter(item => !closedIssues.has(item.issue))
+  const visibleItems = items.filter(item => !closedIssues.has(rowKey(item)))
 
-  const toggleExpand = (issueNum) => {
-    setExpandedIssue(prev => prev === issueNum ? null : issueNum)
+  const toggleExpand = (key) => {
+    setExpandedIssue(prev => prev === key ? null : key)
   }
 
-  const toggleSummaryExpand = (issueNum) => {
-    setSummaryExpandedIssue(prev => prev === issueNum ? null : issueNum)
+  const toggleSummaryExpand = (key) => {
+    setSummaryExpandedIssue(prev => prev === key ? null : key)
   }
 
-  const ensureSummary = async (issueNum) => {
-    const existing = summaries[issueNum]
+  const ensureSummary = async (item) => {
+    const key = rowKey(item)
+    const existing = summaries[key]
     if (existing?.text || existing?.loading) return
     setSummaries(prev => ({
       ...prev,
-      [issueNum]: { ...(prev[issueNum] || {}), loading: true, error: '' },
+      [key]: { ...(prev[key] || {}), loading: true, error: '' },
     }))
     try {
-      const resp = await fetch(`/api/hitl/${issueNum}/summary`)
+      const url = item.repo
+        ? `/api/hitl/${item.issue}/summary?repo=${encodeURIComponent(item.repo)}`
+        : `/api/hitl/${item.issue}/summary`
+      const resp = await fetch(url)
       if (!resp.ok) throw new Error(`status ${resp.status}`)
       const payload = await resp.json()
       setSummaries(prev => ({
         ...prev,
-        [issueNum]: {
+        [key]: {
           text: payload.summary || '',
           updatedAt: payload.updated_at || null,
           loading: false,
@@ -105,8 +121,8 @@ export function HITLTable({ items, onRefresh }) {
     } catch {
       setSummaries(prev => ({
         ...prev,
-        [issueNum]: {
-          ...(prev[issueNum] || {}),
+        [key]: {
+          ...(prev[key] || {}),
           loading: false,
           error: 'Could not generate context summary yet.',
         },
@@ -114,71 +130,75 @@ export function HITLTable({ items, onRefresh }) {
     }
   }
 
-  const toggleExpandAndLoadSummary = (issueNum) => {
-    toggleExpand(issueNum)
+  const toggleExpandAndLoadSummary = (item) => {
+    toggleExpand(rowKey(item))
     setSummaryExpandedIssue(null)
-    void ensureSummary(issueNum)
+    void ensureSummary(item)
   }
 
-  const handleCorrectionChange = (issueNum, value) => {
-    setCorrections(prev => ({ ...prev, [issueNum]: value }))
+  const handleCorrectionChange = (key, value) => {
+    setCorrections(prev => ({ ...prev, [key]: value }))
   }
 
-  const handleRetry = async (issueNum) => {
-    const text = (corrections[issueNum] || '').trim()
+  const handleRetry = async (item) => {
+    const key = rowKey(item)
+    const text = (corrections[key] || '').trim()
     if (!text) return
-    setActionLoading({ issue: issueNum, action: 'retry' })
-    await submitCorrection(issueNum, text)
-    setCorrections(prev => ({ ...prev, [issueNum]: '' }))
+    setActionLoading({ key, action: 'retry' })
+    await submitCorrection(item.issue, text, item.repo)
+    setCorrections(prev => ({ ...prev, [key]: '' }))
     setActionLoading(null)
     onRefresh()
   }
 
-  const handleSkip = async (issueNum) => {
-    setActionLoading({ issue: issueNum, action: 'skip' })
-    setActionError(prev => ({ ...prev, [issueNum]: null }))
-    const reason = corrections[issueNum] || ''
-    const ok = await skipIssue(issueNum, reason)
+  const handleSkip = async (item) => {
+    const key = rowKey(item)
+    setActionLoading({ key, action: 'skip' })
+    setActionError(prev => ({ ...prev, [key]: null }))
+    const reason = corrections[key] || ''
+    const ok = await skipIssue(item.issue, reason, item.repo)
     if (!ok) {
-      setActionError(prev => ({ ...prev, [issueNum]: 'Skip failed. Try again.' }))
+      setActionError(prev => ({ ...prev, [key]: 'Skip failed. Try again.' }))
     }
     setActionLoading(null)
     if (ok) setExpandedIssue(null)
     onRefresh()
   }
 
-  const handleClose = async (issueNum) => {
-    setActionLoading({ issue: issueNum, action: 'close' })
-    setActionError(prev => ({ ...prev, [issueNum]: null }))
-    const reason = corrections[issueNum] || ''
-    const ok = await closeIssue(issueNum, reason)
+  const handleClose = async (item) => {
+    const key = rowKey(item)
+    setActionLoading({ key, action: 'close' })
+    setActionError(prev => ({ ...prev, [key]: null }))
+    const reason = corrections[key] || ''
+    const ok = await closeIssue(item.issue, reason, item.repo)
     if (ok) {
       setClosedIssues(prev => {
         const next = new Set(prev)
-        next.add(issueNum)
+        next.add(key)
         return next
       })
       setExpandedIssue(null)
     } else {
-      setActionError(prev => ({ ...prev, [issueNum]: 'Close failed. Try again.' }))
+      setActionError(prev => ({ ...prev, [key]: 'Close failed. Try again.' }))
     }
     setActionLoading(null)
     onRefresh()
   }
 
-  const handleApproveProcess = async (issueNum) => {
-    setActionLoading({ issue: issueNum, action: 'approve-process' })
-    await approveProcess(issueNum)
+  const handleApproveProcess = async (item) => {
+    const key = rowKey(item)
+    setActionLoading({ key, action: 'approve-process' })
+    await approveProcess(item.issue, item.repo)
     setActionLoading(null)
     setExpandedIssue(null)
     onRefresh()
   }
 
-  const isActionLoading = (issueNum, action) =>
-    actionLoading && actionLoading.issue === issueNum && actionLoading.action === action
+  const isActionLoading = (key, action) =>
+    actionLoading && actionLoading.key === key && actionLoading.action === action
 
-  const isAnyActionLoading = (issueNum) =>
-    actionLoading && actionLoading.issue === issueNum
+  const isAnyActionLoading = (key) =>
+    actionLoading && actionLoading.key === key
 
   return (
     <div style={styles.container}>
@@ -219,16 +239,22 @@ export function HITLTable({ items, onRefresh }) {
         </thead>
         <tbody>
           {visibleItems.map((item) => {
-            const isExpanded = expandedIssue === item.issue
+            const key = rowKey(item)
+            const isExpanded = expandedIssue === key
             const status = item.status || 'pending'
             return (
-              <React.Fragment key={item.issue}>
+              <React.Fragment key={key}>
                 <tr
-                  onClick={() => toggleExpandAndLoadSummary(item.issue)}
+                  onClick={() => toggleExpandAndLoadSummary(item)}
                   style={isExpanded ? styles.rowActive : styles.row}
                   data-testid={`hitl-row-${item.issue}`}
                 >
                   <td style={styles.td}>
+                    {item.repo && (
+                      <span style={styles.repoBadge} data-testid={`hitl-repo-${item.issue}`}>
+                        {item.repo}
+                      </span>
+                    )}
                     <a href={item.issueUrl || item.prUrl || '#'} target="_blank" rel="noreferrer" style={styles.link}
                        onClick={e => e.stopPropagation()}>
                       {item.type === 'pr' ? `PR #${item.pr || item.number}` : `#${item.issue}`}
@@ -269,24 +295,24 @@ export function HITLTable({ items, onRefresh }) {
                             <span style={styles.summaryTitle}>LLM Context Summary</span>
                             <button
                               style={styles.summaryToggle}
-                              onClick={e => { e.stopPropagation(); toggleSummaryExpand(item.issue) }}
-                              disabled={!summaries[item.issue]?.text}
+                              onClick={e => { e.stopPropagation(); toggleSummaryExpand(key) }}
+                              disabled={!summaries[key]?.text}
                               data-testid={`hitl-summary-toggle-${item.issue}`}
                             >
-                              {summaryExpandedIssue === item.issue ? 'Show less' : 'Show more'}
+                              {summaryExpandedIssue === key ? 'Show less' : 'Show more'}
                             </button>
                           </div>
                           <div
                             style={
-                              summaryExpandedIssue === item.issue
+                              summaryExpandedIssue === key
                                 ? styles.summaryExpanded
                                 : styles.summaryCollapsed
                             }
                             data-testid={`hitl-summary-${item.issue}`}
                           >
-                            {summaries[item.issue]?.loading
+                            {summaries[key]?.loading
                               ? 'Generating summary...'
-                              : summaries[item.issue]?.text || summaries[item.issue]?.error || 'Summary pending. Refresh in a few seconds.'}
+                              : summaries[key]?.text || summaries[key]?.error || 'Summary pending. Refresh in a few seconds.'}
                           </div>
                         </div>
                         {item.visualEvidence && item.visualEvidence.items && item.visualEvidence.items.length > 0 && (
@@ -339,49 +365,49 @@ export function HITLTable({ items, onRefresh }) {
                         <textarea
                           style={styles.textarea}
                           placeholder="Provide correction guidance..."
-                          value={corrections[item.issue] || ''}
-                          onChange={e => handleCorrectionChange(item.issue, e.target.value)}
+                          value={corrections[key] || ''}
+                          onChange={e => handleCorrectionChange(key, e.target.value)}
                           onClick={e => e.stopPropagation()}
                           data-testid={`hitl-textarea-${item.issue}`}
                         />
                         <div style={styles.actions}>
                           <button
                             style={styles.retryBtn}
-                            disabled={!(corrections[item.issue] || '').trim() || isAnyActionLoading(item.issue)}
-                            onClick={e => { e.stopPropagation(); handleRetry(item.issue) }}
+                            disabled={!(corrections[key] || '').trim() || isAnyActionLoading(key)}
+                            onClick={e => { e.stopPropagation(); handleRetry(item) }}
                             data-testid={`hitl-retry-${item.issue}`}
                           >
-                            {isActionLoading(item.issue, 'retry') ? 'Processing...' : 'Retry with guidance'}
+                            {isActionLoading(key, 'retry') ? 'Processing...' : 'Retry with guidance'}
                           </button>
                           <button
                             style={styles.skipBtn}
-                            disabled={isAnyActionLoading(item.issue)}
-                            onClick={e => { e.stopPropagation(); handleSkip(item.issue) }}
+                            disabled={isAnyActionLoading(key)}
+                            onClick={e => { e.stopPropagation(); handleSkip(item) }}
                             data-testid={`hitl-skip-${item.issue}`}
                           >
-                            {isActionLoading(item.issue, 'skip') ? 'Skipping...' : 'Skip'}
+                            {isActionLoading(key, 'skip') ? 'Skipping...' : 'Skip'}
                           </button>
                           <button
                             style={styles.closeBtn}
-                            disabled={isAnyActionLoading(item.issue)}
-                            onClick={e => { e.stopPropagation(); handleClose(item.issue) }}
+                            disabled={isAnyActionLoading(key)}
+                            onClick={e => { e.stopPropagation(); handleClose(item) }}
                             data-testid={`hitl-close-${item.issue}`}
                           >
-                            {isActionLoading(item.issue, 'close') ? 'Closing...' : 'Close issue'}
+                            {isActionLoading(key, 'close') ? 'Closing...' : 'Close issue'}
                           </button>
                           {item.issueTypeReview && (
                             <button
                               style={styles.approveProcessBtn}
-                              disabled={isAnyActionLoading(item.issue)}
-                              onClick={e => { e.stopPropagation(); handleApproveProcess(item.issue) }}
+                              disabled={isAnyActionLoading(key)}
+                              onClick={e => { e.stopPropagation(); handleApproveProcess(item) }}
                               data-testid={`hitl-approve-process-${item.issue}`}
                             >
-                              {isActionLoading(item.issue, 'approve-process') ? 'Approving...' : 'Approve'}
+                              {isActionLoading(key, 'approve-process') ? 'Approving...' : 'Approve'}
                             </button>
                           )}
                         </div>
-                        {actionError[item.issue] && (
-                          <div style={styles.actionError}>{actionError[item.issue]}</div>
+                        {actionError[key] && (
+                          <div style={styles.actionError}>{actionError[key]}</div>
                         )}
                       </div>
                     </td>
@@ -513,6 +539,11 @@ const styles = {
   row: { cursor: 'pointer' },
   rowActive: { cursor: 'pointer', background: theme.surfaceInset },
   link: { color: theme.accent, textDecoration: 'none' },
+  repoBadge: {
+    display: 'inline-block', marginRight: 6, fontSize: 9, padding: '1px 6px',
+    borderRadius: 8, background: theme.surfaceInset, color: theme.textMuted,
+    verticalAlign: 'middle',
+  },
   causeText: { fontSize: 11, color: theme.orange, fontWeight: 500 },
   causePlaceholder: { color: theme.textMuted, fontStyle: 'italic' },
   detailCell: { padding: 0, borderBottom: `1px solid ${theme.border}` },

--- a/src/ui/src/components/__tests__/HITLTable.test.jsx
+++ b/src/ui/src/components/__tests__/HITLTable.test.jsx
@@ -496,3 +496,85 @@ describe('HITLTable component', () => {
     expect(runLink.getAttribute('href')).toBe('https://ci.example.com/run/123')
   })
 })
+
+describe('HITLTable multi-repo (aggregate mode)', () => {
+  const collidingItems = [
+    { issue: 42, title: 'A bug', repo: 'org-a', branch: 'a/42', status: 'pending' },
+    { issue: 42, title: 'B bug', repo: 'org-b', branch: 'b/42', status: 'pending' },
+  ]
+
+  it('renders a per-repo badge for each row', () => {
+    render(<HITLTable items={collidingItems} onRefresh={() => {}} />)
+    expect(screen.getByText('org-a')).toBeInTheDocument()
+    expect(screen.getByText('org-b')).toBeInTheDocument()
+  })
+
+  it('keeps per-row correction state isolated for colliding issue numbers', () => {
+    render(<HITLTable items={collidingItems} onRefresh={() => {}} />)
+    const rows = screen.getAllByTestId('hitl-row-42')
+
+    // Expand org-a's #42 and type a correction.
+    fireEvent.click(rows[0])
+    fireEvent.change(screen.getByTestId('hitl-textarea-42'), {
+      target: { value: 'guidance for A' },
+    })
+
+    // Expanding org-b's #42 (single-expand) shows an EMPTY textarea — not A's.
+    fireEvent.click(rows[1])
+    expect(screen.getByTestId('hitl-textarea-42').value).toBe('')
+
+    // Re-expanding org-a's #42 still shows A's correction (composite keying).
+    fireEvent.click(screen.getAllByTestId('hitl-row-42')[0])
+    expect(screen.getByTestId('hitl-textarea-42').value).toBe('guidance for A')
+  })
+
+  it('targets the row’s own repo when closing a colliding issue', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock
+    render(<HITLTable items={collidingItems} onRefresh={() => {}} />)
+
+    // Expand org-b's #42 and close it.
+    fireEvent.click(screen.getAllByTestId('hitl-row-42')[1])
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('hitl-close-42'))
+    })
+
+    const closeCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/close'))
+    expect(closeCall[0]).toBe('/api/hitl/42/close?repo=org-b')
+  })
+
+  it('fetches the summary with the row’s repo for a colliding issue', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ summary: 'B summary', updated_at: null }),
+    })
+    global.fetch = fetchMock
+    render(<HITLTable items={collidingItems} onRefresh={() => {}} />)
+
+    // Expanding org-b's #42 triggers a repo-scoped summary fetch.
+    await act(async () => {
+      fireEvent.click(screen.getAllByTestId('hitl-row-42')[1])
+    })
+
+    const summaryCall = fetchMock.mock.calls.find(c => String(c[0]).includes('/summary'))
+    expect(summaryCall[0]).toBe('/api/hitl/42/summary?repo=org-b')
+  })
+
+  it('closing a colliding issue removes only that repo’s row', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    global.fetch = fetchMock
+    render(<HITLTable items={collidingItems} onRefresh={() => {}} />)
+    expect(screen.getAllByTestId('hitl-row-42')).toHaveLength(2)
+
+    fireEvent.click(screen.getAllByTestId('hitl-row-42')[1])
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('hitl-close-42'))
+    })
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('hitl-row-42')).toHaveLength(1)
+    })
+    expect(screen.getByText('org-a')).toBeInTheDocument()
+    expect(screen.queryByText('org-b')).not.toBeInTheDocument()
+  })
+})

--- a/src/ui/src/hooks/__tests__/useHITLCorrection.test.js
+++ b/src/ui/src/hooks/__tests__/useHITLCorrection.test.js
@@ -149,4 +149,33 @@ describe('useHITLCorrection', () => {
     expect(result.current.closeIssue).toBe(firstRender.closeIssue)
     expect(result.current.approveProcess).toBe(firstRender.approveProcess)
   })
+
+  it('appends ?repo= to every mutation when a repo slug is given', async () => {
+    const { result } = renderHook(() => useHITLCorrection())
+
+    await act(async () => {
+      await result.current.submitCorrection(42, 'fix', 'org-b')
+      await result.current.skipIssue(42, 'reason', 'org-b')
+      await result.current.closeIssue(42, 'reason', 'org-b')
+      await result.current.approveProcess(42, 'org-b')
+    })
+
+    const urls = fetchMock.mock.calls.map(call => call[0])
+    expect(urls).toEqual([
+      '/api/hitl/42/correct?repo=org-b',
+      '/api/hitl/42/skip?repo=org-b',
+      '/api/hitl/42/close?repo=org-b',
+      '/api/hitl/42/approve-process?repo=org-b',
+    ])
+  })
+
+  it('omits the repo query param when no repo is given (single-repo)', async () => {
+    const { result } = renderHook(() => useHITLCorrection())
+
+    await act(async () => {
+      await result.current.submitCorrection(42, 'fix')
+    })
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/hitl/42/correct')
+  })
 })

--- a/src/ui/src/hooks/useHITLCorrection.js
+++ b/src/ui/src/hooks/useHITLCorrection.js
@@ -1,8 +1,13 @@
 import { useCallback } from 'react'
 
+// Append the row's repo slug so a mutation in aggregate ("All repos") mode
+// targets the issue's own repo, not the default one (ADR-0007 multi-repo).
+const withRepo = (path, repo) =>
+  repo ? `${path}?repo=${encodeURIComponent(repo)}` : path
+
 export function useHITLCorrection() {
-  const submitCorrection = useCallback(async (issueNumber, correction) => {
-    const resp = await fetch(`/api/hitl/${issueNumber}/correct`, {
+  const submitCorrection = useCallback(async (issueNumber, correction, repo) => {
+    const resp = await fetch(withRepo(`/api/hitl/${issueNumber}/correct`, repo), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ correction }),
@@ -10,8 +15,8 @@ export function useHITLCorrection() {
     return resp.ok
   }, [])
 
-  const skipIssue = useCallback(async (issueNumber, reason) => {
-    const resp = await fetch(`/api/hitl/${issueNumber}/skip`, {
+  const skipIssue = useCallback(async (issueNumber, reason, repo) => {
+    const resp = await fetch(withRepo(`/api/hitl/${issueNumber}/skip`, repo), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ reason: reason || 'Skipped by operator' }),
@@ -19,8 +24,8 @@ export function useHITLCorrection() {
     return resp.ok
   }, [])
 
-  const closeIssue = useCallback(async (issueNumber, reason) => {
-    const resp = await fetch(`/api/hitl/${issueNumber}/close`, {
+  const closeIssue = useCallback(async (issueNumber, reason, repo) => {
+    const resp = await fetch(withRepo(`/api/hitl/${issueNumber}/close`, repo), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ reason: reason || 'Closed by operator' }),
@@ -28,10 +33,13 @@ export function useHITLCorrection() {
     return resp.ok
   }, [])
 
-  const approveProcess = useCallback(async (issueNumber) => {
-    const resp = await fetch(`/api/hitl/${issueNumber}/approve-process`, {
-      method: 'POST',
-    })
+  const approveProcess = useCallback(async (issueNumber, repo) => {
+    const resp = await fetch(
+      withRepo(`/api/hitl/${issueNumber}/approve-process`, repo),
+      {
+        method: 'POST',
+      },
+    )
     return resp.ok
   }, [])
 

--- a/tests/test_dashboard_routes_hitl_multirepo.py
+++ b/tests/test_dashboard_routes_hitl_multirepo.py
@@ -1,0 +1,226 @@
+"""HITL endpoints aggregate across repos and mutations target the row's repo.
+
+Phase 3a of the multi-repo dashboard program: ``/api/hitl`` unions items across
+repos for ``repo=__all__`` (tagging each with its repo slug and **including
+stopped repos**), ``repo=<slug>`` scopes to one repo, and the mutations
+(correct/skip/close/approve-process) resolve and act on the row's own
+state/pr_manager/event_bus.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from config import HydraFlowConfig
+from models import HITLItem
+from route_types import REPO_ALL
+from tests.conftest import make_state
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+def _repo_cfg(tmp_path, name: str) -> HydraFlowConfig:
+    (tmp_path / name).mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / name, repo=f"org/{name}")
+
+
+def _patched_pr_managers(items_by_slug: dict[str, list[HITLItem]]):
+    """Patch PRManager so each repo-scoped pr_manager_for returns a mock.
+
+    pr_manager_for(cfg, bus) constructs PRManager(cfg, bus) for non-default
+    configs; intercept it and hand back a per-repo AsyncMock keyed by slug.
+    """
+    managers: dict[str, AsyncMock] = {}
+
+    def _factory(cfg, bus):
+        slug = cfg.repo_slug
+        mgr = managers.get(slug)
+        if mgr is None:
+            mgr = AsyncMock()
+            mgr.list_hitl_items = AsyncMock(return_value=items_by_slug.get(slug, []))
+            mgr.close_issue = AsyncMock()
+            mgr.post_comment = AsyncMock()
+            mgr.swap_pipeline_labels = AsyncMock()
+            managers[slug] = mgr
+        return mgr
+
+    return patch("dashboard_routes._routes.PRManager", _factory), managers
+
+
+@pytest.mark.asyncio
+async def test_hitl_unions_and_tags_by_repo_including_stopped(
+    config, event_bus, state, tmp_path
+):
+    cfg_a, cfg_b = _repo_cfg(tmp_path, "a"), _repo_cfg(tmp_path, "b")
+    state_a, state_b = make_state(tmp_path / "sa"), make_state(tmp_path / "sb")
+    state_a.set_hitl_cause(42, "CI failed in A")
+    state_b.set_hitl_cause(42, "CI failed in B")
+
+    orch_a = MagicMock(running=True)
+    orch_a.get_hitl_status.return_value = "pending"
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": cfg_a,
+            "state": state_a,
+            "event_bus": event_bus,
+            "orchestrator": orch_a,
+            "running": True,
+        },
+        # org-b is STOPPED (no orchestrator, running=False) — must still appear.
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": state_b,
+            "event_bus": event_bus,
+            "orchestrator": None,
+            "running": False,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    get_hitl = find_endpoint(router, "/api/hitl")
+
+    items_by_slug = {
+        "org-a": [HITLItem(issue=42, title="A bug", pr=101)],
+        "org-b": [HITLItem(issue=42, title="B bug", pr=202)],
+    }
+    pman, _ = _patched_pr_managers(items_by_slug)
+    with pman:
+        resp = await get_hitl(repo=REPO_ALL)
+    rows = json.loads(resp.body)
+
+    # Both repos present (incl. STOPPED org-b), each tagged with its slug.
+    assert {r["repo"] for r in rows} == {"org-a", "org-b"}
+    # Colliding issue #42 from two repos → two distinct rows, each enriched
+    # from its OWN repo's state (the latent-bug fix).
+    by_repo = {r["repo"]: r for r in rows}
+    assert by_repo["org-a"]["cause"] == "CI failed in A"
+    assert by_repo["org-b"]["cause"] == "CI failed in B"
+
+
+@pytest.mark.asyncio
+async def test_hitl_scopes_to_one_repo(config, event_bus, state, tmp_path):
+    cfg_a, cfg_b = _repo_cfg(tmp_path, "a"), _repo_cfg(tmp_path, "b")
+    state_a, state_b = make_state(tmp_path / "sa"), make_state(tmp_path / "sb")
+    state_a.set_hitl_cause(1, "A")
+    state_b.set_hitl_cause(2, "B")
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": cfg_a,
+            "state": state_a,
+            "event_bus": event_bus,
+            "orchestrator": None,
+            "running": True,
+        },
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": state_b,
+            "event_bus": event_bus,
+            "orchestrator": None,
+            "running": True,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    get_hitl = find_endpoint(router, "/api/hitl")
+
+    pman, _ = _patched_pr_managers(
+        {
+            "org-a": [HITLItem(issue=1, title="A", pr=1)],
+            "org-b": [HITLItem(issue=2, title="B", pr=2)],
+        }
+    )
+    with pman:
+        resp = await get_hitl(repo="org-b")
+    rows = json.loads(resp.body)
+    assert {r["repo"] for r in rows} == {"org-b"}
+    assert {r["issue"] for r in rows} == {2}
+
+
+@pytest.mark.asyncio
+async def test_hitl_default_repo_unchanged_without_registry(
+    config, event_bus, state, tmp_path
+):
+    router, pr_mgr = make_dashboard_router(config, event_bus, state, tmp_path)
+    state.set_hitl_cause(7, "default cause")
+    pr_mgr.list_hitl_items = AsyncMock(return_value=[HITLItem(issue=7, title="x")])
+    get_hitl = find_endpoint(router, "/api/hitl")
+
+    resp = await get_hitl()
+    rows = json.loads(resp.body)
+    assert len(rows) == 1
+    assert rows[0]["cause"] == "default cause"
+
+
+@pytest.mark.asyncio
+async def test_hitl_close_targets_row_repo(config, event_bus, state, tmp_path):
+    cfg_a, cfg_b = _repo_cfg(tmp_path, "a"), _repo_cfg(tmp_path, "b")
+    state_a, state_b = make_state(tmp_path / "sa"), make_state(tmp_path / "sb")
+    orch_b = MagicMock(running=True)
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": cfg_a,
+            "state": state_a,
+            "event_bus": event_bus,
+            "orchestrator": MagicMock(running=True),
+            "running": True,
+        },
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": state_b,
+            "event_bus": event_bus,
+            "orchestrator": orch_b,
+            "running": True,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry
+    )
+    hitl_close = find_endpoint(router, "/api/hitl/{issue_number}/close", "POST")
+
+    pman, managers = _patched_pr_managers({})
+    from models import HITLCloseRequest
+
+    with pman:
+        resp = await hitl_close(42, HITLCloseRequest(reason="done"), repo="org-b")
+    assert json.loads(resp.body)["status"] == "ok"
+
+    # B's pr_manager closed the issue; A's was never constructed/touched.
+    assert "org-b" in managers
+    managers["org-b"].close_issue.assert_awaited_once_with(42)
+    assert "org-a" not in managers
+    # B's orchestrator cleared HITL state; A's did not.
+    orch_b.skip_hitl_issue.assert_called_once_with(42)
+
+
+@pytest.mark.asyncio
+async def test_hitl_mutation_rejects_all_repos(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    hitl_close = find_endpoint(router, "/api/hitl/{issue_number}/close", "POST")
+    from models import HITLCloseRequest
+
+    resp = await hitl_close(42, HITLCloseRequest(reason="x"), repo=REPO_ALL)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_hitl_summary_rejects_all_repos(config, event_bus, state, tmp_path):
+    # A single issue's summary is repo-scoped — repo=__all__ has no meaning.
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    summary = find_endpoint(router, "/api/hitl/{issue_number}/summary")
+    resp = await summary(42, repo=REPO_ALL)
+    assert resp.status_code == 400

--- a/tests/test_dashboard_routes_state.py
+++ b/tests/test_dashboard_routes_state.py
@@ -1411,6 +1411,20 @@ class TestRepoScopedEndpoints:
                 self.origin_calls.append(issue)
                 return config.review_label[0]
 
+            # get_hitl now reads the summary surface from the row's runtime
+            # state too (not the host ctx.state) — the fake must provide it.
+            def get_hitl_summary(self, issue: int) -> str:
+                return ""
+
+            def get_hitl_summary_updated_at(self, issue: int) -> str | None:
+                return None
+
+            def get_hitl_visual_evidence(self, issue: int) -> object | None:
+                return None
+
+            def get_hitl_summary_failure(self, issue: int) -> tuple[str | None, str]:
+                return (None, "")
+
         runtime = SimpleNamespace(
             config=config.model_copy(),
             event_bus=MagicMock(),

--- a/tests/test_route_context.py
+++ b/tests/test_route_context.py
@@ -753,3 +753,42 @@ class TestCreateRouterUsesRouteContext:
     def test_route_context_is_importable(self) -> None:
         """RouteContext can be imported from dashboard_routes."""
         assert RouteContext is not None
+
+
+@pytest.mark.asyncio
+async def test_warm_hitl_summary_inflight_keyed_per_repo(
+    config, event_bus, state, tmp_path, monkeypatch
+) -> None:
+    """Same issue number in two repos must both warm — not collide on the int key."""
+    import asyncio  # noqa: PLC0415
+
+    ctx = _make_ctx(config, event_bus, state, tmp_path)
+    release = asyncio.Event()
+    seen: list[str] = []
+
+    async def _fake_compute(
+        issue_number, *, cause, origin, state=None, config=None, issue_fetcher=None
+    ):
+        seen.append(config.repo_slug if config is not None else "host")
+        await release.wait()
+
+    monkeypatch.setattr(ctx, "compute_hitl_summary", _fake_compute)
+    cfg_a = config.model_copy(update={"repo": "org/a"})
+    cfg_b = config.model_copy(update={"repo": "org/b"})
+
+    t1 = asyncio.create_task(
+        ctx.warm_hitl_summary(42, cause="", origin=None, config=cfg_a)
+    )
+    t2 = asyncio.create_task(
+        ctx.warm_hitl_summary(42, cause="", origin=None, config=cfg_b)
+    )
+    for _ in range(100):
+        if len(seen) == 2:
+            break
+        await asyncio.sleep(0)
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    # Both repos' #42 reached compute — neither was suppressed by a shared
+    # int inflight key.
+    assert sorted(seen) == ["org-a", "org-b"]


### PR DESCRIPTION
## Summary

**Phase 3a** of the multi-repo dashboard program: make the **HITL** vertical a true aggregate-vs-scoped surface (spec §4.3). Builds on Phases 1–2 + D2.

## Backend (`_hitl_routes.py`, `RouteContext`)

- **Read aggregation** — `/api/hitl` and `/api/sandbox-hitl` loop `resolve_runtimes(repo)`, tag each item with its repo slug, and **include stopped repos** (stuck issues matter regardless of pipeline state — the top-level `is_repo_pipeline_active` gate is gone). Colliding issue numbers across repos stay distinct (`data["repo"]=slug`, never merged by number).
- **Latent-bug fix** — the per-item enrichment (cause / cached summary / visual evidence / summary *warming*) now reads the **row's** `_state`/`_cfg`, not the host `ctx.state`/`ctx.config`. Previously issue #N of a non-default repo was enriched against the default repo, and warming fetched #N from the *wrong* repo's GitHub and wrote the summary to the wrong state. The summary methods (`compute_hitl_summary`/`warm_hitl_summary`/`hitl_summary_retry_due`) are parameterized with per-repo `(state, config, issue_fetcher)` (back-compat: default to `self.*`); a new `issue_fetcher_for(cfg)` mirrors `pr_manager_for`. The in-flight guard is keyed by `(repo_slug, issue)` so repo A's #42 no longer suppresses repo B's #42.
- **Mutations target the row's repo** — `correct`/`skip`/`close`/`approve-process` + `get_hitl_summary` take `repo`, reject `repo=__all__` with 400, resolve via `resolve_runtime(repo)`, and act on that runtime's orchestrator/state/event-bus/pr-manager. Shared closures `_clear_hitl_state`/`_resolve_hitl_item` now take the row's `state`/`bus`/`pr_manager`.
- `HITLItem.repo` stamped at construction in `pr_manager._build_hitl_item`.

## Frontend (`HITLTable.jsx`, `useHITLCorrection.js`)

- `useHITLCorrection` appends `?repo=` to every mutation; `HITLTable` uses composite `${repo}#${issue}` row identity for all per-row state (corrections / summaries / actionLoading / closedIssues / expand), threads `item.repo` to every mutation + the summary fetch, and renders a per-repo badge.

## Tests

- `tests/test_dashboard_routes_hitl_multirepo.py` — union+tag incl. a stopped repo, per-repo scope, default-no-registry unchanged, `close` targets the row's repo, `close`/`summary` reject `__all__`.
- `tests/test_route_context.py` — inflight key is per-repo (two repos' #42 both warm concurrently).
- vitest — composite row-state isolation, per-repo badge, row-repo mutation/summary targeting, colliding-issue close removes only that repo's row.

## Verification

`make quality` (full `pytest tests/` — also satisfies the spec's orchestrator-fake DoD), `make scenario` / `make scenario-loops`, vitest (UI), UI build, ruff/pyright clean. Adversarial multi-agent review (drift / aggregation / warming / frontend) converged; the two confirmed real issues (`get_hitl_summary` __all__ guard, inflight cross-repo collision) are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
