### PR TITLE
feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T17:39:28.110182+00:00",
-  "commit_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15",
+  "regenerated_at": "2026-06-08T18:47:26.409809+00:00",
+  "commit_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb",
   "artifacts": {
     "loops.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "ports.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "labels.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "modules.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "events.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "adr_xref.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "mockworld.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "changelog.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "coverage_matrix.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "functional_areas.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "ubiquitous-language.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "4069df7cc37ce125101bf0527f6b50e5b245ac15"
+      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `d8df0e1` — feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a) (#9358) (#9358) *(2026-06-08)*
 - `4069df7` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) (#9355) (#9355) *(2026-06-08)*
 
 ## 2026-W23

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -33,7 +33,12 @@ from models import (
     OrchestratorStatusPayload,
 )
 from prompt_telemetry import PromptTelemetry
-from route_types import ControlStatusConfig, ControlStatusResponse, RepoSlugParam
+from route_types import (
+    REPO_ALL,
+    ControlStatusConfig,
+    ControlStatusResponse,
+    RepoSlugParam,
+)
 from update_check import load_cached_update_result
 
 if TYPE_CHECKING:
@@ -392,9 +397,15 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         "rc_cadence_hours",
     }
 
-    def _build_system_worker_inference_stats() -> dict[str, dict[str, int]]:
-        """Aggregate prompt-telemetry inference stats keyed by worker name."""
-        telemetry = PromptTelemetry(ctx.config)
+    def _build_system_worker_inference_stats(
+        cfg: HydraFlowConfig | None = None,
+    ) -> dict[str, dict[str, int]]:
+        """Aggregate prompt-telemetry inference stats keyed by worker name.
+
+        ``cfg`` defaults to the host config; pass the row's repo config so the
+        per-repo cost telemetry is read from that repo's store.
+        """
+        telemetry = PromptTelemetry(cfg or ctx.config)
         source_totals = telemetry.get_source_totals()
 
         worker_totals: dict[str, dict[str, int]] = {}
@@ -510,9 +521,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         return JSONResponse({"status": "stopping"})
 
     @router.post("/api/control/clear-credit-pause")
-    async def clear_credit_pause() -> JSONResponse:
-        """Clear an active credit pause, waking any sleeping loops."""
-        orch = ctx.get_orchestrator()
+    async def clear_credit_pause(repo: RepoSlugParam = None) -> JSONResponse:
+        """Clear an active credit pause, waking any sleeping loops.
+
+        Credit pause is per-orchestrator, so ``repo=__all__`` fans out and
+        clears every paused runtime; a single repo clears just that one.
+        """
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            cleared: list[str] = []
+            for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+                orch = _get_orch()
+                if orch and orch.credits_paused_until is not None:
+                    orch.clear_credit_pause()
+                    cleared.append(slug)
+            return JSONResponse({"status": "cleared", "repos": cleared})
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
         if not orch:
             return JSONResponse({"error": "no orchestrator"}, status_code=400)
         if orch.credits_paused_until is None:
@@ -520,37 +544,52 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         orch.clear_credit_pause()
         return JSONResponse({"status": "cleared"})
 
-    @router.get("/api/control/status")
-    async def get_control_status(
-        repo: RepoSlugParam = None,
-    ) -> JSONResponse:
-        """Return orchestrator run status, config summary, and version info."""
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        orch = _get_orch()
-        status = "idle"
-        current_session = None
-        latest_version = ""
-        update_available = False
-        if orch:
-            status = orch.run_status
-            current_session = orch.current_session_id
-        update_result = load_cached_update_result(current_version=get_app_version())
-        if update_result is not None:
-            latest_version = update_result.latest_version or ""
-            update_available = update_result.update_available
-        credits_until = (
-            orch.credits_paused_until.isoformat()
-            if orch and orch.credits_paused_until
-            else None
+    # Rollup precedence for the aggregate top-level status (highest → lowest).
+    _STATUS_PRECEDENCE = (
+        "credits_paused",
+        "auth_failed",
+        "running",
+        "stopping",
+        "done",
+        "idle",
+    )
+
+    def _control_status_config(
+        cfg: HydraFlowConfig, *, latest_version: str, update_available: bool
+    ) -> ControlStatusConfig:
+        return ControlStatusConfig(
+            app_version=get_app_version(),
+            latest_version=latest_version,
+            update_available=update_available,
+            repo=cfg.repo,
+            ready_label=cfg.ready_label,
+            find_label=cfg.find_label,
+            planner_label=cfg.planner_label,
+            review_label=cfg.review_label,
+            hitl_label=cfg.hitl_label,
+            hitl_active_label=cfg.hitl_active_label,
+            fixed_label=cfg.fixed_label,
+            max_triagers=cfg.max_triagers,
+            max_workers=cfg.max_workers,
+            max_planners=cfg.max_planners,
+            max_reviewers=cfg.max_reviewers,
+            max_hitl_workers=cfg.max_hitl_workers,
+            batch_size=cfg.batch_size,
+            model=cfg.model,
+            pr_unstick_batch_size=cfg.pr_unstick_batch_size,
+            workspace_base=str(cfg.workspace_base),
         )
+
+    def _runtime_status(orch: object | None) -> tuple[ControlStatus, str | None, bool]:
+        """Return (status, credits_paused_until_iso, mockworld_active) for one orch."""
+        status = getattr(orch, "run_status", "idle") if orch else "idle"
         try:
             control_status = ControlStatus(status)
         except ValueError:
             control_status = ControlStatus.IDLE
-        # Detect sandbox-mode by duck-typing the injected PRPort. Fake
-        # adapters carry ``_is_fake_adapter = True``; real ones do not.
-        # No conditional import / no isinstance check — the marker is the
-        # contract (ADR — sandbox tier scenario testing, Task 1.3).
+        credits = getattr(orch, "credits_paused_until", None) if orch else None
+        credits_until = credits.isoformat() if credits else None
+        # Sandbox-mode is duck-typed off the injected PRPort's _is_fake_adapter.
         mockworld_active = False
         if orch is not None:
             svc = getattr(orch, "_svc", None)
@@ -558,30 +597,79 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 mockworld_active = bool(
                     getattr(getattr(svc, "prs", None), "_is_fake_adapter", False)
                 )
+        return control_status, credits_until, mockworld_active
+
+    @router.get("/api/control/status")
+    async def get_control_status(
+        repo: RepoSlugParam = None,
+    ) -> JSONResponse:
+        """Return orchestrator run status, config summary, and version info.
+
+        For ``repo=__all__`` the top-level fields are a rollup and ``repos``
+        carries the per-repo breakdown; ``config`` is the default repo's.
+        """
+        update_result = load_cached_update_result(current_version=get_app_version())
+        latest_version = (
+            (update_result.latest_version or "") if update_result is not None else ""
+        )
+        update_available = (
+            update_result.update_available if update_result is not None else False
+        )
+
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            per_repo: list[dict[str, Any]] = []
+            statuses: list[str] = []
+            credits_candidates: list[str] = []
+            mockworld_any = False
+            for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+                cs, credits_until, mockworld = _runtime_status(_get_orch())
+                statuses.append(cs.value)
+                if credits_until:
+                    credits_candidates.append(credits_until)
+                mockworld_any = mockworld_any or mockworld
+                per_repo.append(
+                    {
+                        "slug": slug,
+                        "status": cs.value,
+                        "credits_paused_until": credits_until,
+                        "mockworld_active": mockworld,
+                        "config": _control_status_config(
+                            _cfg,
+                            latest_version=latest_version,
+                            update_available=update_available,
+                        ).model_dump(),
+                    }
+                )
+            rollup = next((s for s in _STATUS_PRECEDENCE if s in statuses), "idle")
+            d_cfg, _ds, _db, _dget = ctx.resolve_runtime(None)
+            response = ControlStatusResponse(
+                status=ControlStatus(rollup),
+                credits_paused_until=min(credits_candidates)
+                if credits_candidates
+                else None,
+                config=_control_status_config(
+                    d_cfg,
+                    latest_version=latest_version,
+                    update_available=update_available,
+                ),
+                mockworld_active=mockworld_any,
+                repos=per_repo,
+            )
+            data = response.model_dump()
+            data["current_session_id"] = None
+            return JSONResponse(data)
+
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
+        control_status, credits_until, mockworld_active = _runtime_status(orch)
+        current_session = orch.current_session_id if orch else None
         response = ControlStatusResponse(
             status=control_status,
             credits_paused_until=credits_until,
-            config=ControlStatusConfig(
-                app_version=get_app_version(),
+            config=_control_status_config(
+                _cfg,
                 latest_version=latest_version,
                 update_available=update_available,
-                repo=_cfg.repo,
-                ready_label=_cfg.ready_label,
-                find_label=_cfg.find_label,
-                planner_label=_cfg.planner_label,
-                review_label=_cfg.review_label,
-                hitl_label=_cfg.hitl_label,
-                hitl_active_label=_cfg.hitl_active_label,
-                fixed_label=_cfg.fixed_label,
-                max_triagers=_cfg.max_triagers,
-                max_workers=_cfg.max_workers,
-                max_planners=_cfg.max_planners,
-                max_reviewers=_cfg.max_reviewers,
-                max_hitl_workers=_cfg.max_hitl_workers,
-                batch_size=_cfg.batch_size,
-                model=_cfg.model,
-                pr_unstick_batch_size=_cfg.pr_unstick_batch_size,
-                workspace_base=str(_cfg.workspace_base),
             ),
             mockworld_active=mockworld_active,
         )
@@ -593,8 +681,29 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     async def credit_refresh(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Attempt to clear credit pause and resume processing."""
+        """Attempt to clear credit pause and resume processing.
+
+        ``probe_credit_availability`` is a single process-global check, so
+        ``repo=__all__`` probes once and resumes every paused runtime (parity
+        with ``clear-credit-pause``).
+        """
         from subprocess_util import probe_credit_availability
+
+        async def _refresh_all() -> JSONResponse:
+            paused = [
+                (slug, orch)
+                for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo)
+                if (orch := _get_orch()) and orch.credits_paused_until is not None
+            ]
+            if not paused:
+                return JSONResponse({"status": "not_paused"})
+            if not await probe_credit_availability():
+                return JSONResponse({"status": "still_exhausted"})
+            resumed = [slug for slug, orch in paused if orch.try_clear_credit_pause()]
+            return JSONResponse({"status": "resuming", "repos": resumed})
+
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return await _refresh_all()
 
         _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
         orch = _get_orch()
@@ -645,7 +754,20 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         body: dict[str, Any],
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Update runtime config fields. Pass ``persist: true`` to save to disk."""
+        """Update runtime config fields. Pass ``persist: true`` to save to disk.
+
+        Config writes target a single repo (or the default); ``repo=__all__``
+        is rejected, and ``gh_circuit_breaker_enabled`` is process-global so it
+        cannot be set per-repo.
+        """
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "message": "config writes require a specific repo, not __all__",
+                },
+                status_code=400,
+            )
         persist = body.pop("persist", False)
         _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
 
@@ -657,6 +779,16 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
             if not hasattr(_cfg, key):
                 continue
             updates[key] = value
+
+        if repo is not None and "gh_circuit_breaker_enabled" in updates:
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "message": "gh_circuit_breaker_enabled is process-global; "
+                    "it cannot be set per-repo",
+                },
+                status_code=400,
+            )
 
         if not updates:
             return JSONResponse({"status": "ok", "updated": {}})
@@ -701,13 +833,13 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
         return JSONResponse({"status": "ok", "updated": applied})
 
-    @router.get("/api/system/workers")
-    async def get_system_workers(
-        repo: RepoSlugParam = None,
-    ) -> JSONResponse:
-        """Return last known status of each background worker."""
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        orch = _get_orch()
+    def _workers_for_runtime(
+        _cfg: HydraFlowConfig,
+        _state: Any,
+        orch: Any,
+        slug: str,
+    ) -> list[BackgroundWorkerStatus]:
+        """Build the worker-status list for one runtime, tagged with its slug."""
         bg_states = orch.get_bg_worker_states() if orch else {}
         persisted_states: dict[str, BackgroundWorkerState] = {}
         if not orch:
@@ -715,14 +847,14 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 persisted_states = _state.get_bg_worker_states()
             except Exception:  # pragma: no cover - defensive guard
                 logger.exception("Failed to load persisted bg worker states")
-        inference_by_worker = _build_system_worker_inference_stats()
+        inference_by_worker = _build_system_worker_inference_stats(_cfg)
         disabled_workers: set[str] = set()
         if not orch:
             try:
                 disabled_workers = _state.get_disabled_workers()
             except Exception:  # pragma: no cover - defensive guard
                 logger.exception("Failed to load persisted disabled workers")
-        workers = []
+        workers: list[BackgroundWorkerStatus] = []
         for name, label, description in _bg_worker_defs:
             enabled = (
                 orch.is_bg_worker_enabled(name)
@@ -774,6 +906,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                         interval_seconds=interval,
                         next_run=_compute_next_run(last_run, interval),
                         details=details,
+                        repo=slug,
                     )
                 )
             else:
@@ -785,8 +918,27 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                         enabled=enabled,
                         interval_seconds=interval,
                         details=inference_by_worker.get(name, {}),
+                        repo=slug,
                     )
                 )
+        return workers
+
+    @router.get("/api/system/workers")
+    async def get_system_workers(
+        repo: RepoSlugParam = None,
+    ) -> JSONResponse:
+        """Return last known status of each background worker.
+
+        For ``repo=__all__`` every repo's workers are unioned (not merged) and
+        each row is tagged with its repo slug.
+        """
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            workers: list[BackgroundWorkerStatus] = []
+            for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+                workers.extend(_workers_for_runtime(_cfg, _state, _get_orch(), slug))
+            return JSONResponse(BackgroundWorkersResponse(workers=workers).model_dump())
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        workers = _workers_for_runtime(_cfg, _state, _get_orch(), repo or "")
         return JSONResponse(BackgroundWorkersResponse(workers=workers).model_dump())
 
     @router.post("/api/control/bg-worker")

--- a/src/models.py
+++ b/src/models.py
@@ -2349,6 +2349,11 @@ class ControlStatusResponse(BaseModel):
     # The React UI renders MockWorldBanner when this is True so operators
     # can never confuse a sandbox tab with a production tab.
     mockworld_active: bool = False
+    # Per-repo breakdown for ``repo=__all__`` aggregate mode (empty for a single
+    # repo). Each entry: ``{slug, status, credits_paused_until, mockworld_active,
+    # config}``. The top-level fields above are a rollup; ``config`` is the
+    # default repo's (back-compat).
+    repos: list[dict[str, Any]] = Field(default_factory=list)
 
 
 # --- TypedDicts for replacing Any annotations ---

--- a/tests/test_dashboard_routes_control_multirepo.py
+++ b/tests/test_dashboard_routes_control_multirepo.py
@@ -1,0 +1,343 @@
+"""System control endpoints aggregate across repos (Phase 3b).
+
+``/api/control/status`` rolls up per-repo runtime status (with a ``repos`` list),
+``/api/system/workers`` unions workers tagged by repo, ``clear-credit-pause``
+fans out, and config writes are guarded (``repo=__all__`` and the process-global
+``gh_circuit_breaker_enabled`` are rejected).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from config import HydraFlowConfig
+from route_types import REPO_ALL
+from tests.conftest import make_state
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+def _repo_cfg(tmp_path, name: str) -> HydraFlowConfig:
+    (tmp_path / name).mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / name, repo=f"org/{name}")
+
+
+def _orch(run_status: str, *, paused: datetime | None = None) -> MagicMock:
+    orch = MagicMock()
+    orch.run_status = run_status
+    orch.credits_paused_until = paused
+    orch.current_session_id = None
+    orch._svc = None
+    return orch
+
+
+@pytest.mark.asyncio
+async def test_control_status_rolls_up_across_repos(config, event_bus, state, tmp_path):
+    paused_at = datetime(2026, 1, 2, tzinfo=UTC)
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": _orch("running"),
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_cfg(tmp_path, "b"),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": _orch("credits_paused", paused=paused_at),
+        },
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    endpoint = find_endpoint(router, "/api/control/status")
+
+    data = json.loads((await endpoint(repo=REPO_ALL)).body)
+
+    # Per-repo breakdown present and tagged.
+    assert {r["slug"] for r in data["repos"]} == {"org-a", "org-b"}
+    # Rollup precedence: credits_paused > running.
+    assert data["status"] == "credits_paused"
+    assert data["credits_paused_until"] == paused_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_control_status_scopes_to_one_repo(config, event_bus, state, tmp_path):
+    cfg_b = _repo_cfg(tmp_path, "b")
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": _orch("idle"),
+        },
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": _orch("running"),
+        },
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    endpoint = find_endpoint(router, "/api/control/status")
+
+    data = json.loads((await endpoint(repo="org-b")).body)
+    assert data["status"] == "running"
+    assert data["config"]["repo"] == "org/b"
+    assert data.get("repos", []) == []
+
+
+@pytest.mark.asyncio
+async def test_system_workers_union_tags_repo(config, event_bus, state, tmp_path):
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_cfg(tmp_path, "b"),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    endpoint = find_endpoint(router, "/api/system/workers")
+
+    data = json.loads((await endpoint(repo=REPO_ALL)).body)
+    repos_seen = {w["repo"] for w in data["workers"]}
+    assert repos_seen == {"org-a", "org-b"}
+    # Same worker name appears once per repo (union, not merged).
+    names_a = [w["name"] for w in data["workers"] if w["repo"] == "org-a"]
+    names_b = [w["name"] for w in data["workers"] if w["repo"] == "org-b"]
+    assert names_a == names_b
+    assert len(names_a) > 0
+
+
+@pytest.mark.asyncio
+async def test_clear_credit_pause_fans_out(config, event_bus, state, tmp_path):
+    paused = datetime(2026, 1, 2, tzinfo=UTC)
+    orch_a = _orch("credits_paused", paused=paused)
+    orch_b = _orch("credits_paused", paused=paused)
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": orch_a,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_cfg(tmp_path, "b"),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": orch_b,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    endpoint = find_endpoint(router, "/api/control/clear-credit-pause", "POST")
+
+    resp = await endpoint(repo=REPO_ALL)
+    assert resp.status_code == 200
+    orch_a.clear_credit_pause.assert_called_once()
+    orch_b.clear_credit_pause.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_patch_config_rejects_all_repos(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    patch_config = find_endpoint(router, "/api/control/config", "PATCH")
+    resp = await patch_config({"max_workers": 4}, repo=REPO_ALL)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_config_rejects_gh_circuit_breaker_per_repo(
+    config, event_bus, state, tmp_path
+):
+    cfg_b = _repo_cfg(tmp_path, "b")
+    registry = make_registry(
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    patch_config = find_endpoint(router, "/api/control/config", "PATCH")
+    resp = await patch_config({"gh_circuit_breaker_enabled": False}, repo="org-b")
+    assert resp.status_code == 400
+
+
+def _two_repo_registry(event_bus, tmp_path, orch_a, orch_b):
+    return make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": orch_a,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_cfg(tmp_path, "b"),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": orch_b,
+        },
+    )
+
+
+def _router(config, event_bus, state, tmp_path, registry):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    return router
+
+
+@pytest.mark.asyncio
+async def test_control_status_all_idle_rolls_up_idle(
+    config, event_bus, state, tmp_path
+):
+    registry = _two_repo_registry(event_bus, tmp_path, _orch("idle"), _orch("idle"))
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/control/status")
+    data = json.loads((await endpoint(repo=REPO_ALL)).body)
+    assert data["status"] == "idle"
+    assert data["credits_paused_until"] is None
+
+
+@pytest.mark.asyncio
+async def test_control_status_selects_earliest_credits_paused_until(
+    config, event_bus, state, tmp_path
+):
+    later = datetime(2026, 1, 5, tzinfo=UTC)
+    earlier = datetime(2026, 1, 2, tzinfo=UTC)
+    registry = _two_repo_registry(
+        event_bus,
+        tmp_path,
+        _orch("credits_paused", paused=later),
+        _orch("credits_paused", paused=earlier),
+    )
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/control/status")
+    data = json.loads((await endpoint(repo=REPO_ALL)).body)
+    assert data["credits_paused_until"] == earlier.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_system_workers_single_repo_tags_with_slug(
+    config, event_bus, state, tmp_path
+):
+    registry = _two_repo_registry(event_bus, tmp_path, None, None)
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/system/workers")
+    data = json.loads((await endpoint(repo="org-a")).body)
+    assert {w["repo"] for w in data["workers"]} == {"org-a"}
+
+
+@pytest.mark.asyncio
+async def test_clear_credit_pause_single_not_paused_returns_400(
+    config, event_bus, state, tmp_path
+):
+    registry = _two_repo_registry(
+        event_bus, tmp_path, _orch("idle"), _orch("idle", paused=None)
+    )
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/control/clear-credit-pause", "POST")
+    resp = await endpoint(repo="org-b")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_clear_credit_pause_all_only_clears_paused(
+    config, event_bus, state, tmp_path
+):
+    orch_a = _orch("credits_paused", paused=datetime(2026, 1, 2, tzinfo=UTC))
+    orch_b = _orch("idle", paused=None)
+    registry = _two_repo_registry(event_bus, tmp_path, orch_a, orch_b)
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/control/clear-credit-pause", "POST")
+    resp = await endpoint(repo=REPO_ALL)
+    assert json.loads(resp.body)["repos"] == ["org-a"]
+    orch_a.clear_credit_pause.assert_called_once()
+    orch_b.clear_credit_pause.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_credit_refresh_fans_out(config, event_bus, state, tmp_path):
+    from unittest.mock import AsyncMock, patch
+
+    orch_a = _orch("credits_paused", paused=datetime(2026, 1, 2, tzinfo=UTC))
+    orch_b = _orch("credits_paused", paused=datetime(2026, 1, 2, tzinfo=UTC))
+    orch_a.try_clear_credit_pause.return_value = True
+    orch_b.try_clear_credit_pause.return_value = True
+    registry = _two_repo_registry(event_bus, tmp_path, orch_a, orch_b)
+    router = _router(config, event_bus, state, tmp_path, registry)
+    endpoint = find_endpoint(router, "/api/control/credit-refresh", "POST")
+
+    with patch(
+        "subprocess_util.probe_credit_availability",
+        AsyncMock(return_value=True),
+    ):
+        data = json.loads((await endpoint(repo=REPO_ALL)).body)
+    assert data["status"] == "resuming"
+    assert set(data["repos"]) == {"org-a", "org-b"}


### PR DESCRIPTION
## Summary

**Phase 3b (System — backend)** of the multi-repo dashboard program: make the System control API aggregate-vs-scoped (spec §4.4 + §5). Backend only; the frontend wiring (rollup display, bg-worker repo threading, clear-credit UI) follows as a tight 3b-fe slice. Backward-compatible — the existing single-repo dashboard keeps working.

Note: start/stop are already process-global (`registry.start_all()`/`stop_all()` since #9338), so the spec's fan-out concern is already handled — no change there.

## Changes (`_control_routes.py`, `models.py`)

- **`/api/control/status`** — for `repo=__all__`, loops `resolve_runtimes`, builds a `repos[]` per-repo breakdown (`{slug, status, credits_paused_until, mockworld_active, config}`) plus a **rollup**: top-level `status` by precedence (`credits_paused > auth_failed > running > stopping > done > idle`), `credits_paused_until` = earliest non-null, `mockworld_active` = `any()`, top-level `config` = the default repo's (back-compat). Single-repo path unchanged (refactored through shared `_runtime_status`/`_control_status_config` helpers). `ControlStatusResponse` gains `repos: list[dict]`.
- **`/api/control/clear-credit-pause`** — gains `repo`; `repo=__all__` fans out over `resolve_runtimes`, clearing each *paused* orchestrator; the single-repo path keeps its "not paused"/"no orchestrator" 400s.
- **`PATCH /api/control/config`** — `repo=__all__` → 400 (config writes target a specific repo); `gh_circuit_breaker_enabled` with a specific repo → 400 (it's process-global). The host/default path still toggles the breaker.
- **`/api/system/workers`** — extracted `_workers_for_runtime(cfg, state, orch, slug)` tagging `BackgroundWorkerStatus.repo`; `repo=__all__` unions across runtimes (not merged). `_build_system_worker_inference_stats(cfg)` parameterized so per-repo cost telemetry reads that repo's (D2-migrated) store.

## Tests

`tests/test_dashboard_routes_control_multirepo.py` — status rollup precedence + `repos[]`, single-repo scope, workers union + repo tags, clear-credit fan-out, config `__all__` → 400, `gh_circuit_breaker` per-repo → 400.

## Verification

`make quality` (full `pytest tests/` — the orchestrator-fake DoD), `make scenario`/`scenario-loops`, `make audit`, ruff/pyright clean. Adversarial multi-agent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
