### PR TITLE
fix(scenario): don't hand the dashboard an empty repo registry (#9359)

### DIFF
--- a/tests/regressions/test_issue_9359_empty_registry_fallback.py
+++ b/tests/regressions/test_issue_9359_empty_registry_fallback.py
@@ -1,0 +1,54 @@
+"""Regression: MockWorld must not hand the dashboard an EMPTY repo registry.
+
+Issue #9359 — #9347 (multi-repo dashboard Phase 1) made MockWorld always pass
+its ``RepoRuntimeRegistry`` to the dashboard, even when no repo was registered.
+A non-None-but-empty registry flips the dashboard onto its multi-repo branches
+for single-repo browser scenarios: POST /api/control/start runs
+``registry.start_all()`` over zero runtimes (orchestrator stuck "idle") and
+resolve_runtime / is_repo_pipeline_active resolve an empty set (cards "0 merged",
+real-gh 401). The fix: pass the registry only once a repo is actually
+registered; otherwise fall back to the host/legacy path (pre-#9347 behaviour).
+
+This is a fast guard so the invariant is checked without the (slow, separate)
+browser-scenario gate that only runs at rc/* -> main promotion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.scenarios.fakes.mock_world import MockWorld
+
+
+@pytest.mark.asyncio
+async def test_dashboard_gets_no_registry_when_no_repos_registered(
+    tmp_path: Path,
+) -> None:
+    """With no add_repo, the dashboard must receive registry=None (host path)."""
+    world = MockWorld(tmp_path)
+    try:
+        await world.start_dashboard(with_orchestrator=False)
+        assert world._dashboard is not None
+        # The empty registry must NOT be handed to the dashboard — otherwise the
+        # registry-gated control/data routes resolve an empty set.
+        assert world._dashboard._registry is None
+    finally:
+        await world.stop_dashboard()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_gets_registry_once_a_repo_is_registered(
+    tmp_path: Path,
+) -> None:
+    """When a repo IS registered, the dashboard receives the live registry."""
+    world = MockWorld(tmp_path)
+    try:
+        world.add_repo("acme/widgets", str(tmp_path / "widgets"))
+        await world.start_dashboard(with_orchestrator=False)
+        assert world._dashboard is not None
+        assert world._dashboard._registry is world._registry
+        assert len(world._dashboard._registry) >= 1
+    finally:
+        await world.stop_dashboard()

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -779,7 +779,17 @@ class MockWorld:
             event_bus=bus,
             state=state,
             orchestrator=orchestrator,
-            registry=self._registry,
+            # #9347 began ALWAYS passing this registry to the dashboard, even
+            # empty. A non-None-but-empty registry flips the dashboard onto its
+            # multi-repo branches for single-repo browser scenarios: POST
+            # /api/control/start runs registry.start_all() over zero runtimes
+            # (orchestrator stuck "idle"), and resolve_runtime / is_pipeline_active
+            # resolve an empty set (cards "0 merged", flow-dots missing, routes
+            # fall back to real gh -> 401). Only hand the dashboard the registry
+            # once a repo is actually registered; otherwise use the host/legacy
+            # path (the pre-#9347 behaviour these scenarios were written against).
+            # See issue #9359.
+            registry=self._registry if len(self._registry) > 0 else None,
             default_repo_slug=config.repo.replace("/", "-") if config.repo else None,
         )
         await dashboard.start()


### PR DESCRIPTION
## Problem

The full `staging → main` promotion (#9356) failed Browser Scenarios with **12 failures** — the dashboard orchestrator wouldn't start (`orchestrator.running` stays `False`, status "idle"), pipeline cards never reached "merged", flow-dots were missing, and routes fell back to **real `gh` (HTTP 401)**.

Bisected to **#9347** (multi-repo dashboard Phase 1): `MockWorld.start_dashboard` began **always** passing its `RepoRuntimeRegistry` to the dashboard, even when empty. A non-None-but-empty registry flips the dashboard onto its multi-repo branches for single-repo scenarios:
- `POST /api/control/start` → `registry.start_all()` over **zero** runtimes (no-op) → orchestrator never starts;
- `resolve_runtime` / `is_repo_pipeline_active` → empty set → cards stuck, flow-dots gone, real-gh 401.

It slipped through because **Browser Scenarios only runs at `rc/* → main`** (skipped on PRs-to-staging), and the broken `StagingPromotionLoop` meant that gate hadn't run in ~4 days. (Filed that systemic gap in #9359; recommend running Browser Scenarios on PRs touching `dashboard_routes/`/`ui/`.)

## Fix

Production is correct — `server.py` always registers the host runtime, so its registry is never empty. Mirror that: **pass the registry to the dashboard only once a repo is actually registered**; otherwise use the host/legacy path (pre-#9347 behavior). One-line change in `tests/scenarios/fakes/mock_world.py`. **No production code touched.**

## Verification

- Full browser suite: **49 passed** (was 12 failing), 102s, no hang.
- Multi-repo tests unaffected (registry still passed when repos are added): 3 passed.
- `make quality`: **15813 passed**. `make scenario` + `make scenario-loops`: green.
- New fast regression test `tests/regressions/test_issue_9359_empty_registry_fallback.py` (2 passed) guards the invariant without the slow browser gate.

Closes #9359

🤖 Generated with [Claude Code](https://claude.com/claude-code)