### PR TITLE
feat(system): target the selected repo for bg-worker controls (Phase 3b-fe)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T18:47:26.409809+00:00",
-  "commit_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb",
+  "regenerated_at": "2026-06-08T20:53:56.839257+00:00",
+  "commit_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe",
   "artifacts": {
     "loops.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "ports.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "labels.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "modules.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "events.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "adr_xref.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "mockworld.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "changelog.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "coverage_matrix.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "functional_areas.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "ubiquitous-language.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "d8df0e13ce5e2ef2103af981104bdec3f9251edb"
+      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `5d58cdb` — feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend) (#9360) (#9360) *(2026-06-08)*
 - `d8df0e1` — feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a) (#9358) (#9358) *(2026-06-08)*
 - `4069df7` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) (#9355) (#9355) *(2026-06-08)*
 

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -941,38 +941,56 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
         workers = _workers_for_runtime(_cfg, _state, _get_orch(), repo or "")
         return JSONResponse(BackgroundWorkersResponse(workers=workers).model_dump())
 
+    def _resolve_orch_for(repo: str | None) -> tuple[Any, JSONResponse | None]:
+        """Resolve the row's orchestrator, or a 400 response (incl. __all__)."""
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return None, JSONResponse(
+                {"error": "this action requires a specific repo"}, status_code=400
+            )
+        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
+        orch = _get_orch()
+        if not orch:
+            return None, JSONResponse({"error": "no orchestrator"}, status_code=400)
+        return orch, None
+
     @router.post("/api/control/bg-worker")
-    async def toggle_bg_worker(body: dict[str, Any]) -> JSONResponse:
-        """Enable or disable a background worker."""
+    async def toggle_bg_worker(
+        body: dict[str, Any], repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Enable or disable a background worker (on the row's repo)."""
         name = body.get("name")
         enabled = body.get("enabled")
         if not name or enabled is None:
             return JSONResponse(
                 {"error": "name and enabled are required"}, status_code=400
             )
-        orch = ctx.get_orchestrator()
-        if not orch:
-            return JSONResponse({"error": "no orchestrator"}, status_code=400)
+        orch, rejected = _resolve_orch_for(repo)
+        if rejected is not None:
+            return rejected
         orch.set_bg_worker_enabled(name, bool(enabled))
         return JSONResponse({"status": "ok", "name": name, "enabled": bool(enabled)})
 
     @router.post("/api/control/bg-worker/trigger")
-    async def trigger_bg_worker(body: dict[str, Any]) -> JSONResponse:
-        """Trigger an immediate execution of a background worker."""
+    async def trigger_bg_worker(
+        body: dict[str, Any], repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Trigger an immediate execution of a background worker (row's repo)."""
         name = body.get("name")
         if not name:
             return JSONResponse({"error": "name is required"}, status_code=400)
-        orch = ctx.get_orchestrator()
-        if not orch:
-            return JSONResponse({"error": "no orchestrator"}, status_code=400)
+        orch, rejected = _resolve_orch_for(repo)
+        if rejected is not None:
+            return rejected
         triggered = orch.trigger_bg_worker(name)
         if not triggered:
             return JSONResponse({"error": f"unknown worker '{name}'"}, status_code=404)
         return JSONResponse({"status": "ok", "name": name})
 
     @router.post("/api/control/bg-worker/interval")
-    async def set_bg_worker_interval(body: dict[str, Any]) -> JSONResponse:
-        """Update the polling interval for a background worker."""
+    async def set_bg_worker_interval(
+        body: dict[str, Any], repo: RepoSlugParam = None
+    ) -> JSONResponse:
+        """Update the polling interval for a background worker (row's repo)."""
         name = body.get("name")
         interval = body.get("interval_seconds")
         if not name or interval is None:
@@ -995,9 +1013,9 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
                 {"error": f"interval_seconds must be between {lo} and {hi}"},
                 status_code=422,
             )
-        orch = ctx.get_orchestrator()
-        if not orch:
-            return JSONResponse({"error": "no orchestrator"}, status_code=400)
+        orch, rejected = _resolve_orch_for(repo)
+        if rejected is not None:
+            return rejected
         orch.set_bg_worker_interval(name, interval)
         return JSONResponse(
             {"status": "ok", "name": name, "interval_seconds": interval}

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1307,21 +1307,25 @@ export function HydraFlowProvider({ children }) {
     dispatch({ type: 'SESSION_RESET' })
   }, [])
 
+  // Worker controls act on ONE repo (the selected one), so they are no-ops in
+  // aggregate mode — the backend rejects repo=__all__ for these mutations.
   const toggleBgWorker = useCallback(async (name, enabled) => {
+    if (state.selectedRepoSlug === REPO_ALL) return
     // Optimistic local update — works even when backend is down
     dispatch({ type: 'TOGGLE_BG_WORKER', data: { name, enabled } })
     try {
-      await fetch('/api/control/bg-worker', {
+      await fetch(applyRepoParam('/api/control/bg-worker'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, enabled }),
       })
     } catch { /* ignore — local state already updated */ }
-  }, [])
+  }, [applyRepoParam, state.selectedRepoSlug])
 
   const triggerBgWorker = useCallback(async (name) => {
+    if (state.selectedRepoSlug === REPO_ALL) return false
     try {
-      const resp = await fetch('/api/control/bg-worker/trigger', {
+      const resp = await fetch(applyRepoParam('/api/control/bg-worker/trigger'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name }),
@@ -1330,19 +1334,20 @@ export function HydraFlowProvider({ children }) {
     } catch {
       return false
     }
-  }, [])
+  }, [applyRepoParam, state.selectedRepoSlug])
 
   const updateBgWorkerInterval = useCallback(async (name, intervalSeconds) => {
+    if (state.selectedRepoSlug === REPO_ALL) return
     // Optimistic local update
     dispatch({ type: 'UPDATE_BG_WORKER_INTERVAL', data: { name, interval_seconds: intervalSeconds } })
     try {
-      await fetch('/api/control/bg-worker/interval', {
+      await fetch(applyRepoParam('/api/control/bg-worker/interval'), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name, interval_seconds: intervalSeconds }),
       })
     } catch { /* ignore — local state already updated */ }
-  }, [])
+  }, [applyRepoParam, state.selectedRepoSlug])
 
   const requestChanges = useCallback(async (issueNumber, feedback, stage) => {
     try {
@@ -1473,13 +1478,15 @@ export function HydraFlowProvider({ children }) {
       fetchWithRepo('/api/system/workers')
         .then(r => r.json())
         .then(data => {
-          // Sync local toggle overrides to backend
+          // Sync local toggle overrides to the backend — but only when a
+          // single repo is selected; worker mutations are per-repo and the
+          // backend rejects repo=__all__, so skip the push in aggregate mode.
           const localWorkers = bgWorkersRef.current
-          if (localWorkers.length > 0 && data.workers) {
+          if (state.selectedRepoSlug !== REPO_ALL && localWorkers.length > 0 && data.workers) {
             const backendMap = Object.fromEntries(data.workers.map(w => [w.name, w.enabled]))
             for (const lw of localWorkers) {
               if (lw.enabled !== undefined && backendMap[lw.name] !== undefined && lw.enabled !== backendMap[lw.name]) {
-                fetch('/api/control/bg-worker', {
+                fetch(applyRepoParam('/api/control/bg-worker'), {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/json' },
                   body: JSON.stringify({ name: lw.name, enabled: lw.enabled }),
@@ -1574,7 +1581,7 @@ export function HydraFlowProvider({ children }) {
       console.warn('[HydraFlow] WebSocket error; awaiting close for reconnect', err)
     }
     wsRef.current = ws
-  }, [state.selectedRepoSlug, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
+  }, [state.selectedRepoSlug, applyRepoParam, fetchLifetimeStats, fetchHitlItems, fetchGithubMetrics, fetchMetricsHistory, fetchPipeline, fetchPipelineStats, fetchEpics, fetchSessions, fetchRepos, fetchRuntimes, fetchWithRepo])
 
   useEffect(() => {
     const poll = () => {

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -708,6 +708,46 @@ describe('startRuntime compatibility flow', () => {
       body: JSON.stringify({ slug: 'demo' }),
     })
   })
+
+  it('threads the selected repo to bg-worker mutations and no-ops in all-mode', async () => {
+    vi.resetModules()
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    })
+
+    const { HydraFlowProvider, useHydraFlow } = await import('../HydraFlowContext')
+    let cap = null
+    function Cap() {
+      cap = useHydraFlow()
+      return <div>ready</div>
+    }
+    await act(async () => {
+      render(
+        <HydraFlowProvider>
+          <Cap />
+        </HydraFlowProvider>
+      )
+    })
+
+    // A specific repo selected → the bg-worker POST carries ?repo=.
+    await act(async () => { cap.selectRepo('org-b') })
+    await act(async () => { await cap.toggleBgWorker('pr_unsticker', false) })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      '/api/control/bg-worker?repo=org-b',
+      expect.objectContaining({ method: 'POST' })
+    )
+
+    // Aggregate mode → worker mutations are no-ops (backend rejects __all__).
+    fetchSpy.mockClear()
+    await act(async () => { cap.selectRepo('__all__') })
+    await act(async () => { await cap.toggleBgWorker('pr_unsticker', true) })
+    const bgCalls = fetchSpy.mock.calls.filter(c =>
+      String(c[0]).includes('/api/control/bg-worker')
+    )
+    expect(bgCalls).toHaveLength(0)
+  })
   it('falls back to /api/repos/add by path when POST /api/repos is not supported', async () => {
     vi.resetModules()
 

--- a/tests/test_dashboard_routes_control_multirepo.py
+++ b/tests/test_dashboard_routes_control_multirepo.py
@@ -341,3 +341,34 @@ async def test_credit_refresh_fans_out(config, event_bus, state, tmp_path):
         data = json.loads((await endpoint(repo=REPO_ALL)).body)
     assert data["status"] == "resuming"
     assert set(data["repos"]) == {"org-a", "org-b"}
+
+
+@pytest.mark.asyncio
+async def test_bg_worker_toggle_targets_row_repo(config, event_bus, state, tmp_path):
+    orch_b = MagicMock()
+    registry = _two_repo_registry(event_bus, tmp_path, MagicMock(), orch_b)
+    router = _router(config, event_bus, state, tmp_path, registry)
+    toggle = find_endpoint(router, "/api/control/bg-worker", "POST")
+    resp = await toggle({"name": "pr_unsticker", "enabled": False}, repo="org-b")
+    assert json.loads(resp.body)["status"] == "ok"
+    orch_b.set_bg_worker_enabled.assert_called_once_with("pr_unsticker", False)
+
+
+@pytest.mark.asyncio
+async def test_bg_worker_toggle_rejects_all_repos(config, event_bus, state, tmp_path):
+    router, _ = make_dashboard_router(config, event_bus, state, tmp_path)
+    toggle = find_endpoint(router, "/api/control/bg-worker", "POST")
+    resp = await toggle({"name": "pr_unsticker", "enabled": True}, repo=REPO_ALL)
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_bg_worker_trigger_targets_row_repo(config, event_bus, state, tmp_path):
+    orch_b = MagicMock()
+    orch_b.trigger_bg_worker.return_value = True
+    registry = _two_repo_registry(event_bus, tmp_path, MagicMock(), orch_b)
+    router = _router(config, event_bus, state, tmp_path, registry)
+    trigger = find_endpoint(router, "/api/control/bg-worker/trigger", "POST")
+    resp = await trigger({"name": "pr_unsticker"}, repo="org-b")
+    assert json.loads(resp.body)["status"] == "ok"
+    orch_b.trigger_bg_worker.assert_called_once_with("pr_unsticker")


### PR DESCRIPTION
## Summary

**Phase 3b-fe** of the multi-repo dashboard program: make the System tab's **background-worker controls target the selected repo** (they hit the host orchestrator before, regardless of which repo was selected). Completes the functional multi-repo correctness of the System vertical built in #9360.

## Changes

**Backend (`_control_routes.py`)** — `/api/control/bg-worker`, `/bg-worker/trigger`, `/bg-worker/interval` gain an optional `repo` and resolve the **row's** orchestrator via `resolve_runtime(repo)` (shared `_resolve_orch_for` helper); `repo=__all__` is rejected with 400 (single-worker mutations are per-repo).

**Frontend (`HydraFlowContext.jsx`)** — `toggleBgWorker` / `triggerBgWorker` / `updateBgWorkerInterval` thread the selected repo via `applyRepoParam` (so managing a specific repo's workers works), and are safe no-ops in aggregate (`__all__`) mode since the backend rejects per-repo-less worker mutations. The reconnect worker-override sync is likewise skipped in aggregate mode and carries the repo otherwise.

## Tests

- `test_dashboard_routes_control_multirepo.py` — bg-worker toggle/trigger target the row's repo; toggle rejects `__all__`.
- `HydraFlowContext.test.jsx` — toggle threads `?repo=` for a selected repo and no-ops in `__all__` mode.

## Verification

`make quality` (full `pytest`), `make scenario`/`scenario-loops`, `make audit`, full vitest (1098) + UI build, ruff/pyright clean.

## Deferred (System frontend polish, follow-up)

The control-status **rollup** is already consumed (top-level status). Still open: a per-repo worker **display** in aggregate mode (SystemPanel renders a static worker-group list matched by name — a real UI redesign), disabling the worker/config controls in all-mode with a "select a repo to edit" affordance, and the clear-credit-pause force-clear button (credit-refresh is already wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
