### PR TITLE
ci(browser): run a Browser Scenarios fast subset on dashboard PRs (#9359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       dockerfiles: ${{ steps.filter.outputs.dockerfiles }}
       compose: ${{ steps.filter.outputs.compose }}
       sandbox_scenarios: ${{ steps.filter.outputs.sandbox_scenarios }}
+      dashboard: ${{ steps.filter.outputs.dashboard }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -78,6 +79,19 @@ jobs:
               - 'docker-compose*.yml'
             sandbox_scenarios:
               - 'tests/sandbox_scenarios/**'
+            dashboard:
+              # The dashboard FRONT-end and the BACK-end the browser scenarios
+              # boot (the real dashboard server + repo-runtime registry). #9347
+              # broke orchestrator-start via these backend files; the `ui`
+              # signal alone would not have tripped. See issue #9359.
+              - 'src/ui/**'
+              - 'src/dashboard.py'
+              - 'src/dashboard_routes/**'
+              - 'src/server.py'
+              - 'src/repo_runtime.py'
+              - 'src/route_types.py'
+              - 'tests/scenarios/browser/**'
+              - 'tests/scenarios/fakes/mock_world.py'
 
   lint:
     name: Lint & Format
@@ -343,6 +357,57 @@ jobs:
           path: /tmp/sandbox-results/
           retention-days: 7
 
+  # PR-time early warning for dashboard regressions. The full Browser Scenarios
+  # suite only runs at rc/*->main promotion (rc-promotion-scenario.yml), which
+  # meant the #9347 dashboard regression rode into staging unvalidated for ~4
+  # days while the (separately-broken) promotion loop wasn't cutting RCs. This
+  # runs a fast smoke+happy+controls subset on PR->staging whenever dashboard
+  # front- or back-end code changes — catching orchestrator-start / pipeline
+  # regressions at PR time. The full suite stays the final gate at promotion.
+  # See issue #9359.
+  scenario-browser-fast:
+    name: Browser Scenarios (PR→staging fast subset)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: github.base_ref == 'staging' && needs.changes.outputs.dashboard == 'true'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: src/ui/package-lock.json
+      - name: Install Python deps
+        run: uv sync --all-extras
+      - name: Build UI
+        working-directory: src/ui
+        run: |
+          npm ci
+          npm run build
+      - name: Install Chromium
+        run: uv run python -m playwright install --with-deps chromium
+      - name: Browser smoke + happy + orchestrator-controls subset
+        run: |
+          PYTHONPATH=src uv run pytest \
+            tests/scenarios/browser/test_smoke.py \
+            tests/scenarios/browser/scenarios/test_happy_browser.py \
+            tests/scenarios/browser/workflows/test_orchestrator_controls.py \
+            -m scenario_browser --reruns=1 -v
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scenario-browser-fast-trace
+          path: tests/scenarios/browser/_artifacts/
+          retention-days: 7
+
   sandbox-full:
     name: Sandbox (rc/* promotion PR full suite)
     runs-on: ubuntu-latest
@@ -413,7 +478,7 @@ jobs:
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
-    needs: [changes, lint, typecheck, security, arch, test, smoke, scenario, regression, audit, ui-build]
+    needs: [changes, lint, typecheck, security, arch, test, smoke, scenario, regression, audit, ui-build, scenario-browser-fast]
     if: always()
     steps:
       - name: Require all CI jobs to have passed or been skipped

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -788,7 +788,9 @@ class MockWorld:
             # fall back to real gh -> 401). Only hand the dashboard the registry
             # once a repo is actually registered; otherwise use the host/legacy
             # path (the pre-#9347 behaviour these scenarios were written against).
-            # See issue #9359.
+            # See issue #9359. This invariant is now also guarded at PR time by
+            # the `scenario-browser-fast` CI job (ci.yml), so dashboard
+            # regressions no longer wait for the rc/*->main promotion gate.
             registry=self._registry if len(self._registry) > 0 else None,
             default_repo_slug=config.repo.replace("/", "-") if config.repo else None,
         )


### PR DESCRIPTION
## The process gap this fixes

Post-mortem of this session's cascade found the **compounding link**: the only CI gate that boots the real dashboard — **Browser Scenarios** — runs *exclusively* at `rc/* → main` promotion (`rc-promotion-scenario.yml`), never on PRs-to-staging. So when the `StagingPromotionLoop` went silently dead (#9351), an entire validation class died with it, and the #9347 dashboard regression rode into staging unvalidated for ~4 days while ~100 commits accumulated.

The existing `ui` paths-filter wouldn't have helped either — #9347 broke the dashboard **backend** (`dashboard_routes/`, `server.py`, `repo_runtime.py`), not just `src/ui/`.

## Fix

Decouple browser validation from promotion-loop health. Add a `scenario-browser-fast` job that runs a **smoke + happy + orchestrator-controls subset** (~6–8 min) on `PR → staging` whenever dashboard **front- or back-end** code changes:

- New `dashboard` paths-filter: `src/ui/**`, `src/dashboard.py`, `src/dashboard_routes/**`, `src/server.py`, `src/repo_runtime.py`, `src/route_types.py`, `tests/scenarios/browser/**`, `tests/scenarios/fakes/mock_world.py`.
- Mirrors the proven `sandbox-fast` precedent (`base_ref == staging` + path-gated) and the working full Browser Scenarios env setup.
- Wired into the **`ci-gate` umbrella** (`if: always()`, skip-as-pass) — non-dashboard PRs are unaffected and **no branch-protection change** is needed. Required-when-it-runs.
- The full 45-min suite + Trust + Sandbox-full stay the final gate at promotion.

**#9347 broke `test_orchestrator_controls` (orchestrator-start), which the subset covers** — so that exact regression would have failed at PR time instead of 4 days later.

## Verification

- `ci.yml` YAML valid; `scenario-browser-fast` in `ci-gate` needs; `make gen-gates-check` in sync; `make audit` 90 PASS / 0 FAIL.
- Subset (smoke + happy + orchestrator-controls) passes locally on staging HEAD.
- **This PR touches `mock_world.py` (a dashboard path), so the new job runs on itself** — live validation that it executes and passes.

Part of the factory-process hardening from issue #9359. Follow-ups (separate PRs): consecutive-RC-failure HITL escalation; CI sentinel single-source (`ci_timeout()`/`CI_STOPPED`) to kill the fake-fidelity string class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)