### PR TITLE
harden(promotion): single-source CI sentinels + escalate repeated RC failures (#9359)

### DIFF
--- a/src/ci_sentinels.py
+++ b/src/ci_sentinels.py
@@ -1,0 +1,43 @@
+"""Shared CI wait-result sentinels (single source of truth).
+
+``PRManager.wait_for_ci`` returns a free-form ``(passed, summary)`` tuple.
+Callers (notably :class:`StagingPromotionLoop`) branch on ``summary`` to tell a
+real CI *failure* apart from an *incomplete* wait — the poll window elapsed
+while CI was still running, or the kill-switch fired. Those non-failure cases
+must be retried, not treated as a failure (closing a still-green PR).
+
+Historically the producer (``pr_manager``) and the consumer (the loop)
+hard-coded these strings independently and they DRIFTED: the producer emitted
+``"Timeout after 60s"`` while the loop guarded on the literal ``"timed out"`` —
+which that string does not contain — so every slow-CI tick force-closed a GREEN
+rc PR and the staging→main pipeline silently stalled for ~3 days (issues
+#9219..#9342, fixed in #9351). This module makes the sentinels AND the
+"incomplete → retry" classification one shared symbol so producer and consumer
+can never drift again. A contract test pins it.
+"""
+
+from __future__ import annotations
+
+# wait_for_ci returns this when the kill-switch fires mid-poll — not a failure.
+CI_STOPPED = "Stopped"
+
+_CI_TIMEOUT_PREFIX = "Timeout after "
+
+
+def ci_timeout(timeout: int) -> str:
+    """Summary ``wait_for_ci`` returns when the poll window elapses with CI
+    still pending (not a failure — retry on the next tick)."""
+    return f"{_CI_TIMEOUT_PREFIX}{timeout}s"
+
+
+def is_ci_incomplete(summary: str) -> bool:
+    """``True`` when ``wait_for_ci`` returned WITHOUT a CI verdict — it timed out
+    while CI was still running, or was stopped by the kill-switch. Such a PR must
+    be left open and retried, NOT treated as a CI failure. ``False`` for a real
+    failure summary (e.g. ``"ci failed: scenario tests"``)."""
+    return (
+        summary == CI_STOPPED
+        or summary.startswith(_CI_TIMEOUT_PREFIX)
+        # Defensive: tolerate any legacy/alternate "timed out" phrasing too.
+        or "timed out" in summary.lower()
+    )

--- a/src/config.py
+++ b/src/config.py
@@ -154,6 +154,11 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ),
     ("gate_activator_interval", "HYDRAFLOW_GATE_ACTIVATOR_INTERVAL", 604800),
     ("rc_cadence_hours", "HYDRAFLOW_RC_CADENCE_HOURS", 4),
+    (
+        "rc_consecutive_failure_escalation_threshold",
+        "HYDRAFLOW_RC_CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD",
+        3,
+    ),
     ("staging_promotion_interval", "HYDRAFLOW_STAGING_PROMOTION_INTERVAL", 300),
     ("staging_rc_retention_days", "HYDRAFLOW_STAGING_RC_RETENTION_DAYS", 7),
     ("staging_bisect_interval", "HYDRAFLOW_STAGING_BISECT_INTERVAL", 600),
@@ -941,6 +946,10 @@ class HydraFlowConfig(BaseModel):
     fake_coverage_stuck_label: list[str] = Field(
         default=["hydraflow-fake-coverage-stuck"],
         description="Labels for stuck fake-coverage gaps (paired with hitl_escalation_label)",
+    )
+    rc_promotion_stuck_label: list[str] = Field(
+        default=["rc-promotion-stuck"],
+        description="Label for repeated staging→main promotion failures (paired with hitl_escalation_label)",
     )
     max_diagnosticians: int = Field(
         default=1,
@@ -1905,6 +1914,15 @@ class HydraFlowConfig(BaseModel):
         ge=1,
         le=168,
         description="Hours between release-candidate cuts",
+    )
+    rc_consecutive_failure_escalation_threshold: int = Field(
+        default=3,
+        ge=1,
+        le=50,
+        description=(
+            "Consecutive RC-promotion CI failures before StagingPromotionLoop "
+            "files one hitl-escalation issue (so a multi-day stall is noticed)"
+        ),
     )
     rc_branch_prefix: str = Field(
         default="rc/",

--- a/src/models.py
+++ b/src/models.py
@@ -1929,6 +1929,11 @@ class StateData(BaseModel):
     last_green_rc_sha: str = ""
     last_rc_red_sha: str = ""
     rc_cycle_id: int = 0
+    # StagingPromotionLoop consecutive-failure streak. Incremented on each RC
+    # promotion CI failure, reset to 0 on a green promotion. Crossing
+    # ``rc_consecutive_failure_escalation_threshold`` files one HITL escalation
+    # so a multi-day pipeline stall can't pass unnoticed (#9359 hardening).
+    consecutive_rc_failures: int = 0
     auto_reverts_in_cycle: int = 0
     auto_reverts_successful: int = 0
     flake_reruns_total: int = 0

--- a/src/pr_manager.py
+++ b/src/pr_manager.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Literal, TypeVar
 from urllib.parse import quote
 
+import ci_sentinels
 from comment_formatter import CommentFormatter, SelfReviewError
 from config import Credentials, HydraFlowConfig
 from events import EventBus, EventType, HydraFlowEvent
@@ -2490,7 +2491,7 @@ class PRManager:
         elapsed = 0
         while elapsed < timeout:
             if stop_event.is_set():
-                return False, "Stopped"
+                return False, ci_sentinels.CI_STOPPED
 
             checks = await self.get_pr_checks(pr_number)
 
@@ -2508,7 +2509,7 @@ class PRManager:
                 # retries on the next loop tick.
                 try:
                     await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
-                    return False, "Stopped"
+                    return False, ci_sentinels.CI_STOPPED
                 except TimeoutError:
                     elapsed += poll_interval
                     continue
@@ -2534,7 +2535,7 @@ class PRManager:
                 )
                 try:
                     await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
-                    return False, "Stopped"
+                    return False, ci_sentinels.CI_STOPPED
                 except TimeoutError:
                     elapsed += poll_interval
                     continue
@@ -2556,7 +2557,7 @@ class PRManager:
             await self._bus.publish(HydraFlowEvent(type=EventType.CI_CHECK, data=data))
             return passed, msg
 
-        return False, f"Timeout after {timeout}s"
+        return False, ci_sentinels.ci_timeout(timeout)
 
     # --- PR activity query helpers ---
 

--- a/src/prep.py
+++ b/src/prep.py
@@ -47,6 +47,11 @@ HYDRAFLOW_LABELS: tuple[tuple[str, str, str], ...] = (
         "Fake coverage gap unresolved after retries",
     ),
     (
+        "rc_promotion_stuck_label",
+        "b60205",
+        "staging→main promotion stuck (repeated RC failures)",
+    ),
+    (
         "adr_drift_label",
         "5319e7",
         "ADR drift — cited modules changed without ADR update",

--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import ci_sentinels
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
 
@@ -89,23 +90,21 @@ class StagingPromotionLoop(BaseBackgroundLoop):
                     if head_sha:
                         self._state.set_last_green_rc_sha(head_sha)
                         self._state.reset_auto_reverts_in_cycle()
+                    # A green promotion clears the consecutive-failure streak so
+                    # a future stall re-escalates from scratch (#9359 hardening).
+                    self._state.reset_consecutive_rc_failures()
                 return {"status": "promoted", "pr": pr_number}
             logger.warning("Promotion merge failed for PR #%d", pr_number)
             return {"status": "merge_failed", "pr": pr_number}
 
-        # wait_for_ci returns "Timeout after {N}s" when CI is still running past
-        # the poll window, and "Stopped" when the kill-switch fires mid-poll.
-        # Neither is a real CI failure — leave the PR open for the next cadence
-        # tick rather than force-closing a still-green RC PR. The old guard only
-        # matched the literal substring "timed out", which "Timeout after 60s"
-        # does NOT contain, so every slow-CI tick closed a passing PR and filed a
-        # noise issue — issues #9219..#9342, ~3 days of stalled main promotion.
-        summary_lower = summary.lower()
-        if (
-            summary_lower.startswith("timeout")
-            or "timed out" in summary_lower
-            or summary == "Stopped"
-        ):
+        # wait_for_ci can return WITHOUT a CI verdict: a timeout (the poll window
+        # elapsed while CI was still running) or "Stopped" (kill-switch fired
+        # mid-poll). Neither is a CI failure — leave the PR open for the next
+        # cadence tick rather than force-closing a still-green RC PR. The
+        # sentinel + "incomplete" classification are single-sourced in
+        # ci_sentinels so the producer (pr_manager) and this consumer can't drift
+        # again — that drift stalled main promotion ~3 days (#9219..#9342, #9351).
+        if ci_sentinels.is_ci_incomplete(summary):
             return {"status": "ci_pending", "pr": pr_number}
 
         issue_number = await self._file_failure_issue(pr_number, summary)
@@ -132,6 +131,15 @@ class StagingPromotionLoop(BaseBackgroundLoop):
                 red_sha = ""
             if red_sha:
                 self._state.set_last_rc_red_sha_and_bump_cycle(red_sha)
+            # Repeated-failure escalation: one per-PR find-issue per failure
+            # gives no signal that the WHOLE pipeline is stuck. After N
+            # consecutive failures escalate ONCE to a human, so a multi-day stall
+            # (like #9219..#9342, where main silently didn't advance for ~3 days)
+            # can't pass unnoticed. Fires exactly once per streak (== threshold);
+            # the next green promotion resets the counter. #9359 hardening.
+            failures = self._state.increment_consecutive_rc_failures()
+            if failures == self._config.rc_consecutive_failure_escalation_threshold:
+                await self._file_repeated_failure_escalation(pr_number, failures)
         return {
             "status": "ci_failed",
             "pr": pr_number,
@@ -154,6 +162,44 @@ class StagingPromotionLoop(BaseBackgroundLoop):
             return await self._prs.create_issue(title, body, labels)
         except Exception:  # noqa: BLE001
             logger.exception("Failed to file hydraflow-find issue for PR %d", pr_number)
+            return 0
+
+    async def _file_repeated_failure_escalation(
+        self, pr_number: int, failures: int
+    ) -> int:
+        """Escalate to a human when promotions fail repeatedly.
+
+        Per-PR ``RC promotion #N failed CI`` find-issues give no signal that the
+        WHOLE staging→main pipeline is stuck — exactly how the #9351 timeout bug
+        stalled ``main`` for ~3 days unnoticed. After
+        ``rc_consecutive_failure_escalation_threshold`` consecutive failures we
+        file ONE ``hitl-escalation`` issue so a human looks at the pipeline, not
+        just the latest red PR.
+        """
+        labels = list(self._config.hitl_escalation_label or ["hitl-escalation"])
+        for lbl in self._config.rc_promotion_stuck_label:
+            if lbl not in labels:
+                labels.append(lbl)
+        title = f"staging→main promotion stuck: {failures} consecutive RC failures"
+        body = (
+            f"The StagingPromotionLoop has failed to promote `staging` → "
+            f"`{self._config.main_branch}` **{failures} times in a row** "
+            f"(latest: RC PR #{pr_number}). `main` is not advancing.\n\n"
+            "Per-failure `RC promotion #N failed CI` issues track each red PR, "
+            "but this escalation means the pipeline itself needs a human:\n"
+            "- a real regression on `staging` blocking every RC (run the failing "
+            "gate locally to bisect), or\n"
+            "- a systemic CI/promotion-loop defect (e.g. the #9351 timeout "
+            "misclassification that silently force-closed green PRs).\n\n"
+            "This fires once per failure streak; the next successful promotion "
+            "clears the counter."
+        )
+        try:
+            return await self._prs.create_issue(title, body, labels)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to file repeated-failure escalation (failures=%d)", failures
+            )
             return 0
 
     async def _cut_new_rc(self) -> dict[str, Any]:

--- a/src/state/_staging_bisect.py
+++ b/src/state/_staging_bisect.py
@@ -43,6 +43,23 @@ class StagingBisectStateMixin:
         self._data.last_green_rc_sha = sha
         self.save()
 
+    # --- consecutive_rc_failures (repeated-failure escalation, #9359) ---
+
+    def get_consecutive_rc_failures(self) -> int:
+        return int(self._data.consecutive_rc_failures)
+
+    def increment_consecutive_rc_failures(self) -> int:
+        """Bump the streak and return the new count."""
+        self._data.consecutive_rc_failures = int(self._data.consecutive_rc_failures) + 1
+        self.save()
+        return self._data.consecutive_rc_failures
+
+    def reset_consecutive_rc_failures(self) -> None:
+        """Clear the streak — called on a green promotion."""
+        if self._data.consecutive_rc_failures != 0:
+            self._data.consecutive_rc_failures = 0
+            self.save()
+
     # --- last_rc_red_sha + rc_cycle_id ---
 
     def get_last_rc_red_sha(self) -> str:

--- a/tests/regressions/test_issue_9351_ci_sentinel_contract.py
+++ b/tests/regressions/test_issue_9351_ci_sentinel_contract.py
@@ -1,0 +1,41 @@
+"""Contract: the CI wait sentinels are single-sourced so producer and consumer
+can never drift again.
+
+Issue #9351 — ``PRManager.wait_for_ci`` emitted ``"Timeout after 60s"`` while
+``StagingPromotionLoop`` guarded on the literal ``"timed out"`` (which that
+string does not contain), so every slow-CI tick force-closed a GREEN rc PR and
+``main`` silently stopped advancing for ~3 days. The producer string and the
+consumer's "is this incomplete, retry?" classification are now one shared symbol
+(``src/ci_sentinels.py``). This pins that contract: the exact string the
+producer emits MUST be classified as incomplete by the consumer's predicate.
+"""
+
+from __future__ import annotations
+
+from ci_sentinels import CI_STOPPED, ci_timeout, is_ci_incomplete
+
+
+def test_producer_timeout_string_is_classified_incomplete() -> None:
+    """The EXACT summary wait_for_ci returns on timeout -> incomplete (retry)."""
+    # ci_timeout() is what pr_manager.wait_for_ci returns; is_ci_incomplete() is
+    # what StagingPromotionLoop guards on. They must agree by construction.
+    assert ci_timeout(60) == "Timeout after 60s"
+    assert is_ci_incomplete(ci_timeout(60)) is True
+    assert is_ci_incomplete(ci_timeout(1800)) is True
+
+
+def test_stopped_sentinel_is_classified_incomplete() -> None:
+    """Kill-switch 'Stopped' is not a CI failure — leave the PR open."""
+    assert CI_STOPPED == "Stopped"
+    assert is_ci_incomplete(CI_STOPPED) is True
+
+
+def test_real_failure_summary_is_not_incomplete() -> None:
+    """A genuine CI failure must NOT be misclassified as incomplete."""
+    assert is_ci_incomplete("ci failed: scenario tests") is False
+    assert is_ci_incomplete("Sandbox (rc/* promotion PR full suite) failed") is False
+
+
+def test_legacy_timed_out_phrasing_still_tolerated() -> None:
+    """Defensive: any alternate 'timed out' phrasing is also treated as pending."""
+    assert is_ci_incomplete("timed out waiting for checks") is True

--- a/tests/test_pr_manager_core.py
+++ b/tests/test_pr_manager_core.py
@@ -1732,6 +1732,7 @@ async def test_ensure_labels_exist_uses_config_label_names(config, event_bus, tm
         "hydraflow-adapter-surface",
         "hydraflow-test-helper",
         "hydraflow-fake-coverage-stuck",
+        "rc-promotion-stuck",
         "hydraflow-adr-drift",
         "hydraflow-adr-drift-stuck",
         "hydraflow-log-ingest",

--- a/tests/test_staging_promotion_loop.py
+++ b/tests/test_staging_promotion_loop.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from base_background_loop import LoopDeps
+from ci_sentinels import ci_timeout
 from config import HydraFlowConfig
 from events import EventBus
 from models import PRInfo
@@ -478,3 +479,102 @@ class TestStateWritesOnCIFailed:
         assert result["status"] == "ci_pending"
         assert state.get_last_rc_red_sha() == ""
         assert state.get_rc_cycle_id() == 0
+
+
+def _escalation_calls(prs: MagicMock) -> list:
+    """create_issue calls whose labels include the rc-promotion-stuck escalation."""
+    out = []
+    for call in prs.create_issue.await_args_list:
+        labels = call.kwargs.get("labels") or (
+            call.args[2] if len(call.args) > 2 else []
+        )
+        if "rc-promotion-stuck" in labels:
+            out.append(call)
+    return out
+
+
+class TestRepeatedFailureEscalation:
+    """#9359 hardening: repeated RC-promotion failures escalate ONCE to a human
+    so a multi-day pipeline stall (like #9219..#9342) can't pass unnoticed."""
+
+    @pytest.mark.asyncio
+    async def test_escalates_once_when_streak_hits_threshold(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDRAFLOW_RC_CONSECUTIVE_FAILURE_ESCALATION_THRESHOLD", "2")
+        loop, prs = _make_loop(
+            tmp_path,
+            monkeypatch,
+            open_promotion=_make_pr(number=70),
+            ci_result=(False, "ci failed: scenario tests"),
+        )
+        state = StateTracker(state_file=tmp_path / "s.json")
+        loop._state = state  # type: ignore[attr-defined]
+
+        # Two consecutive failing promotions reach the threshold.
+        await loop._do_work()
+        assert state.get_consecutive_rc_failures() == 1
+        assert _escalation_calls(prs) == []  # not yet
+
+        await loop._do_work()
+        assert state.get_consecutive_rc_failures() == 2
+        escalations = _escalation_calls(prs)
+        assert len(escalations) == 1
+        assert "hydraflow-hitl-escalation" in (
+            escalations[0].kwargs.get("labels") or escalations[0].args[2]
+        )
+
+        # A third failure must NOT re-escalate (fires once per streak).
+        await loop._do_work()
+        assert state.get_consecutive_rc_failures() == 3
+        assert len(_escalation_calls(prs)) == 1
+
+    @pytest.mark.asyncio
+    async def test_green_promotion_resets_the_streak(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs = _make_loop(
+            tmp_path,
+            monkeypatch,
+            open_promotion=_make_pr(number=71),
+            ci_result=(False, "boom"),
+        )
+        state = StateTracker(state_file=tmp_path / "s.json")
+        loop._state = state  # type: ignore[attr-defined]
+
+        await loop._do_work()
+        assert state.get_consecutive_rc_failures() == 1
+
+        # Next tick: CI is green and the promotion merges -> streak resets.
+        prs.wait_for_ci.return_value = (True, "ok")
+        prs.merge_promotion_pr = AsyncMock(return_value=True)
+        prs.get_pr_head_sha = AsyncMock(return_value="greensha")
+        result = await loop._do_work()
+
+        assert result["status"] == "promoted"
+        assert state.get_consecutive_rc_failures() == 0
+
+
+class TestSentinelFidelity:
+    @pytest.mark.asyncio
+    async def test_producer_timeout_sentinel_is_pending_not_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Feed the loop the EXACT symbol pr_manager.wait_for_ci emits on timeout
+        (ci_timeout) — it must classify as pending, never a failure. Couples the
+        consumer to the real producer string, not a hand-written literal."""
+        loop, prs = _make_loop(
+            tmp_path,
+            monkeypatch,
+            open_promotion=_make_pr(number=72),
+            ci_result=(False, ci_timeout(60)),
+        )
+        state = StateTracker(state_file=tmp_path / "s.json")
+        loop._state = state  # type: ignore[attr-defined]
+
+        result = await loop._do_work()
+
+        assert result == {"status": "ci_pending", "pr": 72}
+        prs.close_issue.assert_not_called()
+        assert state.get_consecutive_rc_failures() == 0
+        assert _escalation_calls(prs) == []

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -114,6 +114,7 @@ class TestInitialization:
             "last_green_audit",
             "last_green_rc_sha",
             "last_rc_red_sha",
+            "consecutive_rc_failures",
             "managed_repos_onboarding_status",
             "onboarding_drafts",
             "principles_drift_attempts",


### PR DESCRIPTION
Factory-process hardening from this session's post-mortem (issue #9359). Two fixes, each closing a failure **class** rather than the instances already patched.

## FIX A — CI sentinel single source
Both #9351 and #9359 were **fake-fidelity gaps**: a test/caller branched on a string the producer never actually emits. #9351's was the worst — the loop matched the literal `"timed out"` while `wait_for_ci` returned `"Timeout after 60s"`, so every slow-CI tick force-closed a **green** RC PR and `main` silently stalled for ~3 days.

New `src/ci_sentinels.py` owns the sentinels and the classification in one place:
- `ci_timeout(t)` / `CI_STOPPED` — the producer strings.
- `is_ci_incomplete(summary)` — the "timed-out-or-stopped → retry, don't fail" predicate.

`PRManager.wait_for_ci` (producer) now returns `ci_timeout()`/`CI_STOPPED`; `StagingPromotionLoop` (consumer) guards on `is_ci_incomplete()`. They **cannot drift again**. A contract test pins that the exact producer string is classified incomplete.

## FIX B — repeated-failure escalation (the "why nobody noticed for 4 days" fix)
The loop filed one per-PR `RC promotion #N failed CI` find-issue per failure but gave **no signal that the whole pipeline was stuck**. Now:
- `StateData.consecutive_rc_failures` — incremented per CI failure, reset to 0 on a green promotion.
- After `rc_consecutive_failure_escalation_threshold` (default 3) consecutive failures, file **one** `hitl-escalation` + `rc-promotion-stuck` issue → a human looks at the *pipeline*, not just the latest red PR. Fires once per streak.
- New `rc-promotion-stuck` label registered in `prep.HYDRAFLOW_LABELS` so `ensure-labels` provisions it (else `create_issue` silently returns 0).

## Verification
- `make quality` **15840 passed**; `make scenario` + `make scenario-loops` green.
- New tests: ci-sentinel contract; escalates-once-at-threshold; green-promotion-resets-streak; producer-timeout-sentinel-is-pending (couples the loop to the real producer symbol, not a literal). State key-set test updated.

Completes the post-mortem "implement now" set (FIX 1 = #9364, the dashboard PR gate, already merged). Remaining items (rollup-mixin refactor, issue-janitor, `create_issue` dedup-key API) are proposed and await sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)