### PR TITLE
feat(diagnostics): factory-metrics endpoints aggregate across repos (Phase 3c-1)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T20:53:56.839257+00:00",
-  "commit_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe",
+  "regenerated_at": "2026-06-08T22:21:34.726246+00:00",
+  "commit_sha": "b207b54d38828b47bbec1cda4922772147fe9527",
   "artifacts": {
     "loops.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "ports.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "labels.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "modules.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "events.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "adr_xref.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "mockworld.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "changelog.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "coverage_matrix.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "functional_areas.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "ubiquitous-language.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "bac443c2d7b5d0c3a63ae3350cea4bf7247b57fe"
+      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `b207b54` — feat(system): target the selected repo for bg-worker controls (Phase 3b-fe) (#9363) (#9363) *(2026-06-08)*
 - `5d58cdb` — feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend) (#9360) (#9360) *(2026-06-08)*
 - `d8df0e1` — feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a) (#9358) (#9358) *(2026-06-08)*
 - `4069df7` — feat(persistence): repo-scope per-repo operational stores under shared data_root (ADR-0021 D2) (#9355) (#9355) *(2026-06-08)*

--- a/src/dashboard_routes/_diagnostics_routes.py
+++ b/src/dashboard_routes/_diagnostics_routes.py
@@ -40,9 +40,11 @@ from factory_metrics import (
     issues_table,
     load_metrics,
 )
+from route_types import REPO_ALL, RepoSlugParam
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
+    from dashboard_routes._routes import RouteContext
     from events import EventBus
     from issue_fetcher import IssueFetcher
 
@@ -197,30 +199,73 @@ def _issue_meta_from_github_issue(issue_number: int, gh_issue: Any) -> dict[str,
     }
 
 
-def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
+def build_diagnostics_router(
+    config: HydraFlowConfig, ctx: RouteContext | None = None
+) -> APIRouter:
     """Build the ``/api/diagnostics`` router.
 
     The returned router exposes GET endpoints that read from the factory
     metrics JSONL store, the per-run trace artifact directory, and the
     shared cost-rollup aggregator.
+
+    When *ctx* is provided the factory-metrics endpoints honor a ``repo``
+    query param: ``repo=__all__`` unions every repo's factory-metrics events
+    before aggregating, and a specific slug scopes to that repo; per-issue
+    endpoints resolve that single repo's config. Without *ctx* (legacy
+    single-repo callers) every endpoint reads the bare *config*.
     """
 
     router = APIRouter(prefix="/api/diagnostics", tags=["diagnostics"])
 
-    def _load(time_range: str) -> list[dict[str, Any]]:
-        return load_metrics(config.factory_metrics_path, time_range=time_range)
+    def _config_for(repo: str | None) -> HydraFlowConfig:
+        """The single resolved config for per-issue trace endpoints.
+
+        Per-issue traces live under exactly one repo's ``data_root``, so a
+        concrete slug is required. ``__all__`` has no single home and is
+        rejected — the UI scopes each drill-down to the row's owning repo
+        (carried on the issues-table row), never the aggregate sentinel.
+        """
+        if ctx is None:
+            return config
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            raise HTTPException(
+                status_code=400,
+                detail="repo=__all__ is not valid for per-issue endpoints; pass a repo slug",
+            )
+        cfg, _s, _b, _g = ctx.resolve_runtime(repo)
+        return cfg
+
+    def _load(time_range: str, repo: str | None = None) -> list[dict[str, Any]]:
+        """Load factory-metrics events, unioned across the resolved repos.
+
+        Each event is tagged with its owning repo slug so downstream rows (the
+        per-issue table in particular) stay attributable when ``__all__`` unions
+        repos whose issue numbers collide. Legacy single-repo callers (``ctx is
+        None``) read the bare config and leave events untagged.
+        """
+        if ctx is None:
+            return load_metrics(config.factory_metrics_path, time_range=time_range)
+        events: list[dict[str, Any]] = []
+        for cfg, _s, _b, _g, slug in ctx.resolve_runtimes(repo):
+            for event in load_metrics(cfg.factory_metrics_path, time_range=time_range):
+                event["repo"] = slug
+                events.append(event)
+        return events
 
     @router.get("/overview")
-    def overview(range: str = Query("7d")) -> dict[str, Any]:
-        events = _load(range)
+    def overview(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> dict[str, Any]:
+        events = _load(range, repo)
         return headline_metrics(events)
 
     @router.get("/tools")
     def tools(
         range: str = Query("7d"),
         top_n: int = Query(10, ge=1, le=100),
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        events = _load(range)
+        events = _load(range, repo)
         return [
             {"name": name, "count": count}
             for name, count in aggregate_top_tools(events, top_n=top_n)
@@ -230,16 +275,18 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
     def skills(
         range: str = Query("7d"),
         top_n: int = Query(10, ge=1, le=100),
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        events = _load(range)
+        events = _load(range, repo)
         return aggregate_top_skills(events, top_n=top_n)
 
     @router.get("/subagents")
     def subagents(
         range: str = Query("7d"),
         top_n: int = Query(10, ge=1, le=100),
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        events = _load(range)
+        events = _load(range, repo)
         # aggregate_top_subagents returns list[tuple[str, int]] — currently
         # always [] until per-subagent name attribution lands in the
         # collector. The wrapping below assumes the tuple shape and will
@@ -250,23 +297,27 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
         ]
 
     @router.get("/cost-by-phase")
-    def cost_by_phase_route(range: str = Query("7d")) -> dict[str, int]:
-        events = _load(range)
+    def cost_by_phase_route(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> dict[str, int]:
+        events = _load(range, repo)
         return cost_by_phase(events)
 
     @router.get("/issues")
     def issues(
         range: str = Query("7d"),
         sort: str = Query("tokens"),
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        events = _load(range)
+        events = _load(range, repo)
         rows = issues_table(events)
         return _sort_issues(rows, sort)
 
     @router.get("/issue/{issue}/waterfall")
-    def issue_waterfall(issue: int) -> dict[str, Any]:
+    def issue_waterfall(issue: int, repo: RepoSlugParam = None) -> dict[str, Any]:
         """Return the per-issue cost/phase waterfall (spec §4.11 point 1)."""
-        fetcher = _build_issue_fetcher(config)
+        cfg = _config_for(repo)
+        fetcher = _build_issue_fetcher(cfg)
         try:
             gh_issue = asyncio.run(fetcher.fetch_issue_by_number(issue))
         except Exception:
@@ -277,13 +328,15 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
             )
             gh_issue = None
         issue_meta = _issue_meta_from_github_issue(issue, gh_issue)
-        return build_waterfall(config, issue=issue, issue_meta=issue_meta)
+        return build_waterfall(cfg, issue=issue, issue_meta=issue_meta)
 
     @router.get("/issue/{issue}/{phase}")
-    def issue_phase(issue: int, phase: str) -> list[dict[str, Any]]:
+    def issue_phase(
+        issue: int, phase: str, repo: RepoSlugParam = None
+    ) -> list[dict[str, Any]]:
         if not _PHASE_PATTERN.fullmatch(phase):
             raise HTTPException(status_code=404, detail="not found")
-        phase_dir = _safe_traces_subdir(config.data_root, issue, phase)
+        phase_dir = _safe_traces_subdir(_config_for(repo).data_root, issue, phase)
         if phase_dir is None or not phase_dir.is_dir():
             raise HTTPException(status_code=404, detail="not found")
         summaries: list[dict[str, Any]] = []
@@ -299,10 +352,14 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
         return summaries
 
     @router.get("/issue/{issue}/{phase}/{run_id}")
-    def issue_phase_run(issue: int, phase: str, run_id: int) -> dict[str, Any]:
+    def issue_phase_run(
+        issue: int, phase: str, run_id: int, repo: RepoSlugParam = None
+    ) -> dict[str, Any]:
         if not _PHASE_PATTERN.fullmatch(phase):
             raise HTTPException(status_code=404, detail="not found")
-        run_dir = _safe_traces_subdir(config.data_root, issue, phase, f"run-{run_id}")
+        run_dir = _safe_traces_subdir(
+            _config_for(repo).data_root, issue, phase, f"run-{run_id}"
+        )
         if run_dir is None or not run_dir.is_dir():
             raise HTTPException(status_code=404, detail="not found")
         summary_path = run_dir / "summary.json"
@@ -319,11 +376,16 @@ def build_diagnostics_router(config: HydraFlowConfig) -> APIRouter:
         return {"summary": summary, "subprocesses": subprocesses}
 
     @router.get("/cache")
-    def cache(range: str = Query("7d")) -> list[dict[str, Any]]:
-        events = _load(range)
+    def cache(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> list[dict[str, Any]]:
+        events = _load(range, repo)
         return _cache_hit_rate_buckets(events)
 
     # --- Cost-rollup endpoints (§4.11 points 4–5) ---------------------------
+    # NOTE: these still read the bare ``config`` (host/default repo) and are not
+    # yet repo-scoped — multi-repo cost aggregation is deferred to Phase 3c-2
+    # (along with the Factory Cost sub-tab). Do not assume ``repo`` here yet.
 
     @router.get("/cost/rolling-24h")
     def cost_rolling_24h() -> dict[str, Any]:

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1729,7 +1729,7 @@ def create_router(
     # --- Diagnostics routes (factory metrics + trace artifacts) ---
     from dashboard_routes._diagnostics_routes import build_diagnostics_router
 
-    router.include_router(build_diagnostics_router(config))
+    router.include_router(build_diagnostics_router(config, ctx))
 
     # --- Trust-fleet routes (§12.1; Plan 5b-3 schema) -----------------------
     from types import SimpleNamespace  # noqa: PLC0415

--- a/src/factory_metrics.py
+++ b/src/factory_metrics.py
@@ -284,6 +284,9 @@ def issues_table(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
         rows.append(
             {
                 "issue": event.get("issue"),
+                # Owning repo slug (set by the diagnostics loader when unioning
+                # ``__all__``); ``None`` for legacy single-repo events.
+                "repo": event.get("repo"),
                 "phase": event.get("phase"),
                 "run_id": event.get("run_id"),
                 "tokens": _event_tokens_total(event),

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -24,6 +24,8 @@ function defaultMockContext(overrides = {}) {
     metrics: null,
     metricsHistory: null,
     githubMetrics: null,
+    selectedRepoSlug: null,
+    fetchWithRepo: (url, opts) => fetch(url, opts),
     ...overrides,
   }
 }

--- a/src/ui/src/components/diagnostics/DiagnosticsTab.jsx
+++ b/src/ui/src/components/diagnostics/DiagnosticsTab.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 import { HeadlineCards } from './HeadlineCards'
 import { TopBarChart } from './TopBarChart'
 import { CostByPhaseChart } from './CostByPhaseChart'
@@ -11,6 +12,7 @@ import { FactoryCostTab } from './FactoryCostTab'
 import { AutoAgentStats } from './AutoAgentStats'
 
 export function DiagnosticsTab() {
+  const { fetchWithRepo, selectedRepoSlug } = useHydraFlow()
   const [range, setRange] = useState('7d')
   const [subTab, setSubTab] = useState('overview')
   const [overview, setOverview] = useState(null)
@@ -29,13 +31,13 @@ export function DiagnosticsTab() {
     const params = `?range=${encodeURIComponent(range)}`
     setLoading(true)
     Promise.all([
-      fetch(`/api/diagnostics/overview${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/tools${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/skills${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/subagents${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/cost-by-phase${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/cache${params}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/issues${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/overview${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/tools${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/skills${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/subagents${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/cost-by-phase${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/cache${params}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/issues${params}`).then((r) => r.json()),
     ])
       .then(([ov, tl, sk, sa, cbp, ch, is]) => {
         if (cancelled) return
@@ -58,12 +60,18 @@ export function DiagnosticsTab() {
     return () => {
       cancelled = true
     }
-  }, [range, subTab])
+  }, [range, subTab, selectedRepoSlug, fetchWithRepo])
 
   const handleRowClick = useCallback(async (row) => {
-    const url = `/api/diagnostics/issue/${row.issue}/${row.phase}/${row.run_id}`
+    const base = `/api/diagnostics/issue/${row.issue}/${row.phase}/${row.run_id}`
+    // Each row carries its owning repo (under "All repos" the table unions
+    // several repos whose issue numbers may collide), so scope the drill-down
+    // to that row's repo explicitly rather than the globally-selected slug —
+    // letting fetchWithRepo append __all__ here would resolve the wrong traces.
     try {
-      const r = await fetch(url)
+      const r = row.repo
+        ? await fetch(`${base}?repo=${encodeURIComponent(row.repo)}`)
+        : await fetchWithRepo(base)
       if (!r.ok) {
         setSelectedRun({
           summary: null,
@@ -76,7 +84,7 @@ export function DiagnosticsTab() {
     } catch (err) {
       setSelectedRun({ summary: null, subprocesses: [], error: String(err) })
     }
-  }, [])
+  }, [fetchWithRepo])
 
   return (
     <div style={styles.tab}>

--- a/src/ui/src/components/diagnostics/IssueTable.jsx
+++ b/src/ui/src/components/diagnostics/IssueTable.jsx
@@ -19,6 +19,11 @@ export function IssueTable({ rows, onRowClick }) {
     return <div style={styles.empty}>No data</div>
   }
 
+  // Only surface the repo column when rows are repo-attributed (an "All repos"
+  // union, where the same issue number can appear under different repos).
+  // Single-repo views leave it off and render exactly as before.
+  const showRepo = rows.some((row) => row.repo)
+
   return (
     <div style={styles.container}>
       <div style={styles.title}>Per-Issue</div>
@@ -26,6 +31,7 @@ export function IssueTable({ rows, onRowClick }) {
         <thead>
           <tr>
             <th style={styles.th}>#</th>
+            {showRepo && <th style={styles.th}>Repo</th>}
             <th style={styles.th}>Phase</th>
             <th style={styles.th}>Run</th>
             <th style={styles.thRight}>Tokens</th>
@@ -37,7 +43,7 @@ export function IssueTable({ rows, onRowClick }) {
         <tbody>
           {rows.map((row, i) => (
             <tr
-              key={`${row.issue}-${row.phase}-${row.run_id}-${i}`}
+              key={`${row.repo || ''}-${row.issue}-${row.phase}-${row.run_id}-${i}`}
               style={{
                 ...styles.tr,
                 ...(row.crashed ? styles.trCrashed : {}),
@@ -45,6 +51,7 @@ export function IssueTable({ rows, onRowClick }) {
               onClick={() => onRowClick(row)}
             >
               <td style={styles.td}>{row.issue}</td>
+              {showRepo && <td style={styles.td}>{row.repo}</td>}
               <td style={styles.td}>{row.phase}</td>
               <td style={styles.td}>{row.run_id}</td>
               <td style={styles.tdRight}>{formatTokens(row.tokens)}</td>

--- a/src/ui/src/components/diagnostics/__tests__/DiagnosticsTab.test.jsx
+++ b/src/ui/src/components/diagnostics/__tests__/DiagnosticsTab.test.jsx
@@ -1,8 +1,21 @@
-import { render, screen, waitFor } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('echarts-for-react', () => ({
   default: () => <div data-testid="echarts" />,
+}))
+
+// `ctx.selectedRepoSlug` is mutable per-test so we can exercise both the
+// single-repo (null) and a concrete-repo selection.
+const { mockFetchWithRepo, ctx } = vi.hoisted(() => ({
+  mockFetchWithRepo: vi.fn(),
+  ctx: { selectedRepoSlug: null },
+}))
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({
+    fetchWithRepo: mockFetchWithRepo,
+    selectedRepoSlug: ctx.selectedRepoSlug,
+  }),
 }))
 
 const MOCK_AUTO_AGENT = {
@@ -23,12 +36,39 @@ global.fetch = vi.fn((url) => {
   if (url.includes('/auto-agent')) {
     return Promise.resolve({ ok: true, json: () => Promise.resolve(MOCK_AUTO_AGENT) })
   }
+  if (url.includes('/issues')) {
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([
+        { issue: 7, repo: 'org-b', phase: 'implement', run_id: 1, tokens: 100, duration_seconds: 10, tool_count: 1, skill_pass_count: 0, skill_total: 0, crashed: false },
+      ]),
+    })
+  }
+  if (url.includes('/issue/')) {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ summary: {}, subprocesses: [] }) })
+  }
   return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+})
+
+// The repo-aware fetcher mirrors the real applyRepoParam: it appends the
+// selected repo slug to the URL before hitting the network. Modeling it here
+// lets the tests assert the repo param actually reaches fetch (not just that
+// the component called *some* fetcher).
+mockFetchWithRepo.mockImplementation((url, opts) => {
+  const sep = url.includes('?') ? '&' : '?'
+  const scoped = ctx.selectedRepoSlug ? `${url}${sep}repo=${ctx.selectedRepoSlug}` : url
+  return global.fetch(scoped, opts)
 })
 
 import { DiagnosticsTab } from '../DiagnosticsTab'
 
 describe('DiagnosticsTab', () => {
+  beforeEach(() => {
+    ctx.selectedRepoSlug = null
+    global.fetch.mockClear()
+    mockFetchWithRepo.mockClear()
+  })
+
   it('fetches and renders overview', async () => {
     render(<DiagnosticsTab />)
     await waitFor(() => {
@@ -39,5 +79,49 @@ describe('DiagnosticsTab', () => {
   it('renders range filter dropdown', async () => {
     render(<DiagnosticsTab />)
     expect(await screen.findByLabelText(/Range/i)).toBeInTheDocument()
+  })
+
+  it('routes diagnostics through the repo-aware fetcher', async () => {
+    render(<DiagnosticsTab />)
+    await waitFor(() => {
+      expect(mockFetchWithRepo).toHaveBeenCalledWith(
+        expect.stringContaining('/api/diagnostics/overview')
+      )
+    })
+    expect(mockFetchWithRepo).toHaveBeenCalledWith(
+      expect.stringContaining('/api/diagnostics/issues')
+    )
+  })
+
+  it('scopes diagnostics requests to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    render(<DiagnosticsTab />)
+    // The repo slug must actually reach fetch — proves the data path
+    // component → fetchWithRepo → repo param → network, not merely that a
+    // fetcher was called.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('repo=org-x'),
+        undefined,
+      )
+    })
+  })
+
+  it('scopes the per-issue drill-down to the row owning repo', async () => {
+    // Under "All repos" each row carries its own repo; the drill-down must use
+    // that repo, never the aggregate sentinel.
+    ctx.selectedRepoSlug = '__all__'
+    render(<DiagnosticsTab />)
+    const cell = await screen.findByText('7')
+    fireEvent.click(cell.closest('tr'))
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/diagnostics/issue/7/implement/1?repo=org-b'
+      )
+    })
+    // It must NOT fall back to the __all__ sentinel for the drill-down.
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('/issue/7/implement/1?repo=__all__')
+    )
   })
 })

--- a/src/ui/src/components/diagnostics/__tests__/IssueTable.test.jsx
+++ b/src/ui/src/components/diagnostics/__tests__/IssueTable.test.jsx
@@ -25,4 +25,20 @@ describe('IssueTable', () => {
     render(<IssueTable rows={[]} onRowClick={() => {}} />)
     expect(screen.getByText(/No data/i)).toBeInTheDocument()
   })
+
+  it('omits the repo column for single-repo rows', () => {
+    render(<IssueTable rows={sample} onRowClick={() => {}} />)
+    expect(screen.queryByText('Repo')).not.toBeInTheDocument()
+  })
+
+  it('shows a repo column when rows are repo-attributed', () => {
+    const repoRows = [
+      { ...sample[0], repo: 'org-a' },
+      { ...sample[1], repo: 'org-b' },
+    ]
+    render(<IssueTable rows={repoRows} onRowClick={() => {}} />)
+    expect(screen.getByText('Repo')).toBeInTheDocument()
+    expect(screen.getByText('org-a')).toBeInTheDocument()
+    expect(screen.getByText('org-b')).toBeInTheDocument()
+  })
 })

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1735,6 +1735,7 @@ export function HydraFlowProvider({ children }) {
     stopOrchestrator,
     releaseEpic,
     refreshControlStatus,
+    fetchWithRepo,
   }
 
   return (

--- a/tests/test_diagnostics_multirepo.py
+++ b/tests/test_diagnostics_multirepo.py
@@ -1,0 +1,231 @@
+"""Diagnostics factory-metrics endpoints aggregate across repos (Phase 3c).
+
+``/api/diagnostics/*`` reads each repo's (D2-scoped) ``factory_metrics.jsonl``;
+``repo=__all__`` unions every repo's events before aggregating, a specific slug
+scopes to that repo, and the per-issue trace endpoints resolve a single repo.
+The router is wired with ``ctx`` through ``create_router`` (see _routes.py).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from route_types import REPO_ALL
+from tests.conftest import make_state
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+
+
+def _recent_ts() -> str:
+    return (datetime.now(UTC) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+
+def _event(issue: int) -> dict:
+    return {
+        "timestamp": _recent_ts(),
+        "issue": issue,
+        "phase": "implement",
+        "run_id": 1,
+        "tokens": {
+            "input": 1000,
+            "output": 500,
+            "cache_read": 200,
+            "cache_creation": 0,
+        },
+        "tools": {"Read": 5, "Bash": 2},
+        "skills": [{"name": "diff-sanity", "passed": True, "attempts": 1}],
+        "subagents": 1,
+        "duration_seconds": 12.0,
+        "crashed": False,
+    }
+
+
+def _repo_metrics_config(tmp_path: Path, name: str, issue: int) -> MagicMock:
+    cfg = MagicMock()
+    repo_root = tmp_path / name
+    # Mirror the D2 layout: per-repo operational stores live under the repo's
+    # data_root; factory metrics under data_root/diagnostics. data_root is set
+    # explicitly so per-issue trace endpoints (which read cfg.data_root) resolve
+    # a real directory rather than a truthy MagicMock that hides path bugs.
+    cfg.data_root = repo_root
+    cfg.factory_metrics_path = repo_root / "diagnostics" / "factory_metrics.jsonl"
+    cfg.factory_metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg.factory_metrics_path.write_text(json.dumps(_event(issue)) + "\n")
+    return cfg
+
+
+def _seed_trace(cfg: MagicMock, issue: int, phase: str, run_id: int) -> None:
+    """Write a minimal per-run trace summary under the repo's data_root."""
+    run_dir = cfg.data_root / "traces" / str(issue) / phase / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "summary.json").write_text(
+        json.dumps({"run_id": run_id, "tokens": 1700}), encoding="utf-8"
+    )
+
+
+def _registry(event_bus, tmp_path):
+    return make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_metrics_config(tmp_path, "a", 1),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_metrics_config(tmp_path, "b", 2),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_overview_unions_across_repos(
+    config, event_bus, state, tmp_path
+):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=_registry(event_bus, tmp_path),
+        default_repo_slug="org-a",
+    )
+    overview = find_endpoint(router, "/api/diagnostics/overview")
+    body = overview(range="7d", repo=REPO_ALL)
+    # Two repos, one run each → unioned headline.
+    assert body["total_runs"] == 2
+    assert body["total_tokens"] == 3400
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_overview_scopes_to_one_repo(
+    config, event_bus, state, tmp_path
+):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=_registry(event_bus, tmp_path),
+        default_repo_slug="org-a",
+    )
+    overview = find_endpoint(router, "/api/diagnostics/overview")
+    body = overview(range="7d", repo="org-b")
+    assert body["total_runs"] == 1
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_issues_union_keeps_both_repos(
+    config, event_bus, state, tmp_path
+):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=_registry(event_bus, tmp_path),
+        default_repo_slug="org-a",
+    )
+    issues = find_endpoint(router, "/api/diagnostics/issues")
+    rows = issues(range="7d", sort="tokens", repo=REPO_ALL)
+    assert {r["issue"] for r in rows} == {1, 2}
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_issues_rows_carry_repo_attribution(
+    config, event_bus, state, tmp_path
+):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=_registry(event_bus, tmp_path),
+        default_repo_slug="org-a",
+    )
+    issues = find_endpoint(router, "/api/diagnostics/issues")
+    rows = issues(range="7d", sort="tokens", repo=REPO_ALL)
+    # Each unioned row knows its owning repo so the UI can disambiguate and the
+    # drill-down can scope to the right repo's traces.
+    assert {r["repo"] for r in rows} == {"org-a", "org-b"}
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_issues_same_number_across_repos_stays_distinct(
+    config, event_bus, state, tmp_path
+):
+    # Both repos own an issue #1 — they are different issues and must remain two
+    # rows, distinguished by repo, not collapsed into one.
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_metrics_config(tmp_path, "a", 1),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_metrics_config(tmp_path, "b", 1),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry, default_repo_slug="org-a"
+    )
+    issues = find_endpoint(router, "/api/diagnostics/issues")
+    rows = issues(range="7d", sort="tokens", repo=REPO_ALL)
+    assert len(rows) == 2
+    assert {(r["issue"], r["repo"]) for r in rows} == {(1, "org-a"), (1, "org-b")}
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_issue_phase_scopes_traces_to_one_repo(
+    config, event_bus, state, tmp_path
+):
+    registry = _registry(event_bus, tmp_path)
+    # Seed a run trace only under org-b's data_root for issue 2.
+    org_b_cfg = registry.get("org-b").config
+    _seed_trace(org_b_cfg, issue=2, phase="implement", run_id=1)
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry, default_repo_slug="org-a"
+    )
+    issue_phase = find_endpoint(router, "/api/diagnostics/issue/{issue}/{phase}")
+    # Scoped to org-b → the seeded trace is found.
+    summaries = issue_phase(issue=2, phase="implement", repo="org-b")
+    assert [s["run_id"] for s in summaries] == [1]
+    # Scoped to org-a → org-a has no such trace → 404 (proves per-repo scoping).
+    with pytest.raises(HTTPException) as excinfo:
+        issue_phase(issue=2, phase="implement", repo="org-a")
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_issue_phase_rejects_repo_all(
+    config, event_bus, state, tmp_path
+):
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=_registry(event_bus, tmp_path),
+        default_repo_slug="org-a",
+    )
+    # Per-issue traces have no single home under __all__; the endpoint must
+    # reject the aggregate sentinel rather than silently serving the host repo.
+    issue_phase = find_endpoint(router, "/api/diagnostics/issue/{issue}/{phase}")
+    with pytest.raises(HTTPException) as excinfo:
+        issue_phase(issue=2, phase="implement", repo=REPO_ALL)
+    assert excinfo.value.status_code == 400


### PR DESCRIPTION
## What

Phase **3c-1** of the multi-repo dashboard scoping program: make the Diagnostics **overview** repo-aware in the post-#9338 registry model.

`build_diagnostics_router(config, ctx=None)` gains an optional `RouteContext`. The factory-metrics endpoints now honor a `repo` query param:

- **`repo=__all__`** → union every registered repo's D2-scoped `factory_metrics.jsonl`, then aggregate
- **concrete slug** → scope to that repo
- **`None`** → resolve the default repo (unchanged single-repo behavior)

The signature is **backward-compatible**: `ctx=None` reads the bare `config` exactly as before, so the 25 existing diagnostics tests are untouched.

## Per-issue drill-down correctness

Per-issue trace endpoints (`issue/{n}/waterfall`, `issue/{n}/{phase}`, `issue/{n}/{phase}/{run_id}`) resolve **exactly one** repo via `_config_for`, which **rejects `__all__` with a 400** — a per-run trace has no single home under the aggregate. To route the drill-down correctly when `__all__` unions repos whose issue numbers collide:

- `_load` tags each unioned event with its owning **repo slug**
- `issues_table` rows now carry `repo`
- `IssueTable` surfaces a **conditional Repo column** (disambiguates same-issue-number rows across repos)
- the frontend drill-down scopes to **the row's own repo**, not the selected `__all__` slug (avoids serving the wrong repo's traces)

## Frontend

- `DiagnosticsTab` routes its reads through the repo-aware `fetchWithRepo` (now exposed on the context `value`)
- `SystemPanel` test mock context gains `fetchWithRepo`/`selectedRepoSlug` so the lazily-mounted tab renders

## Deferred to Phase 3c-2 (noted in-code)

The cost-rollup endpoints (`/cost/*`, `/loops/cost`, `/auto-agent`) and the **Factory Cost** sub-tab remain host-scoped — multi-repo cost aggregation + that sub-tab's frontend is the next slice.

## Tests

- **Backend** (`tests/test_diagnostics_multirepo.py`): cross-repo union, single-repo scoping, row repo-attribution, same-issue-number-across-repos stays distinct, per-issue scopes to one repo's traces, per-issue rejects `__all__`. Test config fixtures use the real D2 layout (`data_root` set) so per-issue path resolution is exercised, not mock-shimmed.
- **Frontend**: repo param actually reaches `fetch` (full data path, not just "a fetcher was called"), row-scoped drill-down uses `row.repo`, IssueTable repo column shows/hides correctly.

## Verification

- `make quality` ✅ 15837 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125
- `make audit` ✅ PASS 90 / FAIL 0
- UI `vitest` ✅ 1103 passed · `npm run build` ✅
- Two adversarial fresh-eyes review passes; second pass reached convergence (no material findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)