### PR TITLE
feat(diagnostics): Factory Cost rollup endpoints aggregate across repos (Phase 3c-2)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T22:21:34.726246+00:00",
-  "commit_sha": "b207b54d38828b47bbec1cda4922772147fe9527",
+  "regenerated_at": "2026-06-08T23:29:22.745274+00:00",
+  "commit_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "ports.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "labels.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "modules.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "events.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "adr_xref.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "mockworld.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "changelog.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "coverage_matrix.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "functional_areas.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `b5c9aa6` — feat(diagnostics): factory-metrics endpoints aggregate across repos (Phase 3c-1) (#9366) (#9366) *(2026-06-08)*
 - `b207b54` — feat(system): target the selected repo for bg-worker controls (Phase 3b-fe) (#9363) (#9363) *(2026-06-08)*
 - `5d58cdb` — feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend) (#9360) (#9360) *(2026-06-08)*
 - `d8df0e1` — feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a) (#9358) (#9358) *(2026-06-08)*

--- a/src/dashboard_routes/_cost_merge.py
+++ b/src/dashboard_routes/_cost_merge.py
@@ -1,0 +1,263 @@
+"""Cross-repo merges for the Factory Cost rollup endpoints (Phase 3c-2).
+
+The per-repo builders in :mod:`dashboard_routes._cost_rollups` each read one
+repo's cost stores. Under ``repo=__all__`` the diagnostics router calls a
+builder once per registered repo and folds the results here. The cost
+dimensions (phase / loop / model) are *not* repo-specific, so the aggregate is
+a straight group-by-sum; only per-issue rows carry a ``repo`` tag, since issue
+numbers collide across repos and must stay distinct.
+
+Merging a single-element list is identity-equivalent to the bare builder output
+(modulo the additive ``repo`` tag on top-issue rows), so the router can route
+both the single-repo and aggregate paths through these functions.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+# Numeric precision used by the builders for USD amounts.
+_USD_PLACES = 6
+
+
+def merge_rolling_24h(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Fold several :func:`build_rolling_24h` payloads into one.
+
+    Totals and the phase/loop breakdowns sum across repos; ``window_hours`` is
+    constant (24) and ``generated_at`` takes the latest stamp.
+    """
+    total_cost = 0.0
+    total_in = 0
+    total_out = 0
+    phase: dict[str, dict[str, float | int]] = defaultdict(
+        lambda: {"cost_usd": 0.0, "tokens_in": 0, "tokens_out": 0}
+    )
+    loop: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"ticks": 0, "wall_clock_seconds": 0}
+    )
+    generated_at = ""
+
+    for res in results:
+        tot = res.get("total") or {}
+        total_cost += float(tot.get("cost_usd", 0.0) or 0.0)
+        total_in += int(tot.get("tokens_in", 0) or 0)
+        total_out += int(tot.get("tokens_out", 0) or 0)
+        for row in res.get("by_phase") or []:
+            bucket = phase[str(row.get("phase"))]
+            bucket["cost_usd"] = float(bucket["cost_usd"]) + float(
+                row.get("cost_usd", 0.0) or 0.0
+            )
+            bucket["tokens_in"] = int(bucket["tokens_in"]) + int(
+                row.get("tokens_in", 0) or 0
+            )
+            bucket["tokens_out"] = int(bucket["tokens_out"]) + int(
+                row.get("tokens_out", 0) or 0
+            )
+        for row in res.get("by_loop") or []:
+            lbucket = loop[str(row.get("loop"))]
+            lbucket["ticks"] += int(row.get("ticks", 0) or 0)
+            lbucket["wall_clock_seconds"] += int(row.get("wall_clock_seconds", 0) or 0)
+        generated_at = max(generated_at, str(res.get("generated_at", "") or ""))
+
+    by_phase = [
+        {
+            "phase": name,
+            "cost_usd": round(float(b["cost_usd"]), _USD_PLACES),
+            "tokens_in": int(b["tokens_in"]),
+            "tokens_out": int(b["tokens_out"]),
+        }
+        for name, b in sorted(phase.items())
+    ]
+    by_loop = [
+        {
+            "loop": name,
+            "ticks": int(b["ticks"]),
+            "wall_clock_seconds": int(b["wall_clock_seconds"]),
+        }
+        for name, b in sorted(loop.items())
+    ]
+    return {
+        "generated_at": generated_at,
+        "window_hours": 24,
+        "total": {
+            "cost_usd": round(total_cost, _USD_PLACES),
+            "tokens_in": total_in,
+            "tokens_out": total_out,
+        },
+        "by_phase": by_phase,
+        "by_loop": by_loop,
+    }
+
+
+def merge_top_issues(
+    per_repo: list[tuple[str, list[dict[str, Any]]]],
+    *,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    """Fold per-repo :func:`build_top_issues` lists into a global top-N.
+
+    Each input is ``(repo_slug, rows)``; rows are tagged with their repo (issue
+    numbers collide across repos and must stay distinct), concatenated, sorted
+    descending by cost, and truncated. A globally top-N issue is necessarily
+    top-N within its own repo, so merging already-truncated lists is safe.
+    """
+    tagged: list[dict[str, Any]] = []
+    for slug, rows in per_repo:
+        for row in rows:
+            tagged.append({**row, "repo": slug})
+    tagged.sort(
+        key=lambda r: (
+            -float(r.get("cost_usd", 0.0) or 0.0),
+            str(r.get("repo", "")),
+            int(r.get("issue", 0) or 0),
+        )
+    )
+    return tagged[: max(1, int(limit))]
+
+
+def merge_by_loop(results: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Fold several :func:`build_by_loop` lists into one, recomputing shares."""
+    loop: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"ticks": 0, "wall_clock_seconds": 0}
+    )
+    for rows in results:
+        for row in rows:
+            bucket = loop[str(row.get("loop"))]
+            bucket["ticks"] += int(row.get("ticks", 0) or 0)
+            bucket["wall_clock_seconds"] += int(row.get("wall_clock_seconds", 0) or 0)
+
+    total_ticks = sum(b["ticks"] for b in loop.values()) or 1
+    return [
+        {
+            "loop": name,
+            "ticks": int(b["ticks"]),
+            "wall_clock_seconds": int(b["wall_clock_seconds"]),
+            "share_of_ticks": round(b["ticks"] / total_ticks, 4),
+        }
+        for name, b in sorted(loop.items())
+    ]
+
+
+def _empty_model() -> dict[str, float | int]:
+    return {
+        "cost_usd": 0.0,
+        "calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+
+
+def _add_model_bucket(dst: dict[str, float | int], src: dict[str, Any]) -> None:
+    dst["cost_usd"] = float(dst["cost_usd"]) + float(src.get("cost_usd", 0.0) or 0.0)
+    dst["calls"] = int(dst["calls"]) + int(src.get("calls", 0) or 0)
+    dst["input_tokens"] = int(dst["input_tokens"]) + int(
+        src.get("input_tokens", 0) or 0
+    )
+    dst["output_tokens"] = int(dst["output_tokens"]) + int(
+        src.get("output_tokens", 0) or 0
+    )
+    dst["cache_read_tokens"] = int(dst["cache_read_tokens"]) + int(
+        src.get("cache_read_tokens", 0) or 0
+    )
+    dst["cache_write_tokens"] = int(dst["cache_write_tokens"]) + int(
+        src.get("cache_write_tokens", 0) or 0
+    )
+
+
+def _finalize_model_bucket(b: dict[str, float | int]) -> dict[str, float | int]:
+    return {
+        "cost_usd": round(float(b["cost_usd"]), _USD_PLACES),
+        "calls": int(b["calls"]),
+        "input_tokens": int(b["input_tokens"]),
+        "output_tokens": int(b["output_tokens"]),
+        "cache_read_tokens": int(b["cache_read_tokens"]),
+        "cache_write_tokens": int(b["cache_write_tokens"]),
+    }
+
+
+def merge_cost_by_model(results: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Fold several :func:`build_cost_by_model` lists, grouping by model."""
+    by_model: dict[str, dict[str, float | int]] = defaultdict(_empty_model)
+    for rows in results:
+        for row in rows:
+            _add_model_bucket(by_model[str(row.get("model"))], row)
+
+    merged = [
+        {"model": name, **_finalize_model_bucket(b)} for name, b in by_model.items()
+    ]
+    merged.sort(key=lambda r: (-float(r["cost_usd"]), str(r["model"])))
+    return merged
+
+
+def merge_per_loop_cost(results: list[list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Fold several :func:`build_per_loop_cost` lists, grouping by loop.
+
+    Additive counters sum; ``tick_cost_avg_usd`` is recomputed from the merged
+    cost/ticks; ``last_tick_at`` takes the latest stamp; ``model_breakdown`` is
+    merged per model. (``tick_cost_avg_usd_prev_period`` is currently a 0.0
+    stub upstream, so its sum stays 0.0.)
+    """
+    _ADDITIVE = (
+        "cost_usd",
+        "tokens_in",
+        "tokens_out",
+        "llm_calls",
+        "issues_filed",
+        "issues_closed",
+        "escalations",
+        "ticks",
+        "ticks_errored",
+        "wall_clock_seconds",
+        "tick_cost_avg_usd_prev_period",
+    )
+    acc: dict[str, dict[str, Any]] = {}
+    models: dict[str, dict[str, dict[str, float | int]]] = defaultdict(
+        lambda: defaultdict(_empty_model)
+    )
+    last_tick: dict[str, str] = defaultdict(str)
+
+    for rows in results:
+        for row in rows:
+            name = str(row.get("loop"))
+            bucket = acc.setdefault(name, dict.fromkeys(_ADDITIVE, 0))
+            for key in _ADDITIVE:
+                bucket[key] = bucket[key] + (row.get(key, 0) or 0)
+            for model, mb in (row.get("model_breakdown") or {}).items():
+                _add_model_bucket(models[name][str(model)], mb)
+            last_tick[name] = max(
+                last_tick[name], str(row.get("last_tick_at", "") or "")
+            )
+
+    merged: list[dict[str, Any]] = []
+    for name in sorted(acc):
+        b = acc[name]
+        ticks = int(b["ticks"])
+        cost = float(b["cost_usd"])
+        merged.append(
+            {
+                "loop": name,
+                "cost_usd": round(cost, _USD_PLACES),
+                "tokens_in": int(b["tokens_in"]),
+                "tokens_out": int(b["tokens_out"]),
+                "llm_calls": int(b["llm_calls"]),
+                "issues_filed": int(b["issues_filed"]),
+                "issues_closed": int(b["issues_closed"]),
+                "escalations": int(b["escalations"]),
+                "ticks": ticks,
+                "ticks_errored": int(b["ticks_errored"]),
+                "tick_cost_avg_usd": round(cost / ticks, _USD_PLACES) if ticks else 0.0,
+                "wall_clock_seconds": int(b["wall_clock_seconds"]),
+                "last_tick_at": last_tick[name] or None,
+                "tick_cost_avg_usd_prev_period": round(
+                    float(b["tick_cost_avg_usd_prev_period"]), _USD_PLACES
+                ),
+                "model_breakdown": {
+                    model: _finalize_model_bucket(mb)
+                    for model, mb in sorted(models[name].items())
+                },
+            }
+        )
+    return merged

--- a/src/dashboard_routes/_diagnostics_routes.py
+++ b/src/dashboard_routes/_diagnostics_routes.py
@@ -22,6 +22,13 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter, HTTPException, Query
 
 import dashboard_routes._cost_rollups as _cost_rollups_mod
+from dashboard_routes._cost_merge import (
+    merge_by_loop,
+    merge_cost_by_model,
+    merge_per_loop_cost,
+    merge_rolling_24h,
+    merge_top_issues,
+)
 from dashboard_routes._cost_rollups import (
     _parse_range,
     build_by_loop,
@@ -252,6 +259,17 @@ def build_diagnostics_router(
                 events.append(event)
         return events
 
+    def _runtimes(repo: str | None) -> list[tuple[HydraFlowConfig, str]]:
+        """``(config, slug)`` pairs for cost rollups to aggregate over.
+
+        One element for a concrete slug or ``None`` (the default repo), every
+        registered repo for ``__all__``. Callers guard ``ctx is None`` first and
+        read the bare config, so this is only reached in the multi-repo path.
+        """
+        if ctx is None:
+            return [(config, "")]
+        return [(cfg, slug) for cfg, _s, _b, _g, slug in ctx.resolve_runtimes(repo)]
+
     @router.get("/overview")
     def overview(
         range: str = Query("7d"), repo: RepoSlugParam = None
@@ -383,19 +401,26 @@ def build_diagnostics_router(
         return _cache_hit_rate_buckets(events)
 
     # --- Cost-rollup endpoints (§4.11 points 4–5) ---------------------------
-    # NOTE: these still read the bare ``config`` (host/default repo) and are not
-    # yet repo-scoped — multi-repo cost aggregation is deferred to Phase 3c-2
-    # (along with the Factory Cost sub-tab). Do not assume ``repo`` here yet.
+    # Repo-aware (Phase 3c-2): with ``ctx`` each endpoint builds per repo over
+    # ``resolve_runtimes(repo)`` and folds the results (group-by-sum on the
+    # phase/loop/model dimensions; per-issue rows carry a repo tag). ``ctx is
+    # None`` keeps the bare single-repo builder. NOTE: ``/auto-agent`` (Overview
+    # tab) is NOT yet repo-scoped — its percentile merge is deferred to 3c-3.
 
     @router.get("/cost/rolling-24h")
-    def cost_rolling_24h() -> dict[str, Any]:
+    def cost_rolling_24h(repo: RepoSlugParam = None) -> dict[str, Any]:
         """Total cost burned in the last 24h, grouped by phase and loop (§4.11 point 4)."""
-        return build_rolling_24h(config)
+        if ctx is None:
+            return build_rolling_24h(config)
+        return merge_rolling_24h(
+            [build_rolling_24h(cfg) for cfg, _slug in _runtimes(repo)]
+        )
 
     @router.get("/cost/top-issues")
     def cost_top_issues(
         range: str = Query("7d"),
         limit: int = Query(10, ge=1, le=100),
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
         """Most expensive issues in the window (§4.11 point 4)."""
         try:
@@ -403,42 +428,79 @@ def build_diagnostics_router(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         now = datetime.now(UTC)
-        return build_top_issues(config, since=now - window, until=now, limit=limit)
+        if ctx is None:
+            return build_top_issues(config, since=now - window, until=now, limit=limit)
+        per_repo = [
+            (slug, build_top_issues(cfg, since=now - window, until=now, limit=limit))
+            for cfg, slug in _runtimes(repo)
+        ]
+        return merge_top_issues(per_repo, limit=limit)
 
     @router.get("/cost/by-loop")
-    def cost_by_loop_route(range: str = Query("7d")) -> list[dict[str, Any]]:
+    def cost_by_loop_route(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> list[dict[str, Any]]:
         """Per-loop tick and wall-clock share over the range (§4.11 point 4)."""
         try:
             window = _parse_range(range)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         now = datetime.now(UTC)
-        return build_by_loop(config, since=now - window, until=now)
+        if ctx is None:
+            return build_by_loop(config, since=now - window, until=now)
+        return merge_by_loop(
+            [
+                build_by_loop(cfg, since=now - window, until=now)
+                for cfg, _slug in _runtimes(repo)
+            ]
+        )
 
     @router.get("/cost/by-model")
-    def cost_by_model_route(range: str = Query("7d")) -> list[dict[str, Any]]:
+    def cost_by_model_route(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> list[dict[str, Any]]:
         """Cross-loop spend broken out by model over the range."""
         try:
             window = _parse_range(range)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         now = _cost_rollups_mod._utcnow()
-        return build_cost_by_model(config, since=now - window, until=now)
+        if ctx is None:
+            return build_cost_by_model(config, since=now - window, until=now)
+        return merge_cost_by_model(
+            [
+                build_cost_by_model(cfg, since=now - window, until=now)
+                for cfg, _slug in _runtimes(repo)
+            ]
+        )
 
     @router.get("/loops/cost")
-    def loops_cost(range: str = Query("7d")) -> list[dict[str, Any]]:
+    def loops_cost(
+        range: str = Query("7d"), repo: RepoSlugParam = None
+    ) -> list[dict[str, Any]]:
         """Per-loop machinery-level cost dashboard (§4.11 point 5)."""
         try:
             window = _parse_range(range)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         now = datetime.now(UTC)
-        event_bus = _event_bus_for_rollup(config)
-        return build_per_loop_cost(
-            config,
-            since=now - window,
-            until=now,
-            event_bus=event_bus,
+        if ctx is None:
+            return build_per_loop_cost(
+                config,
+                since=now - window,
+                until=now,
+                event_bus=_event_bus_for_rollup(config),
+            )
+        return merge_per_loop_cost(
+            [
+                build_per_loop_cost(
+                    cfg,
+                    since=now - window,
+                    until=now,
+                    event_bus=_event_bus_for_rollup(cfg),
+                )
+                for cfg, _slug in _runtimes(repo)
+            ]
         )
 
     @router.get("/auto-agent")

--- a/src/ui/src/components/diagnostics/FactoryCostTab.jsx
+++ b/src/ui/src/components/diagnostics/FactoryCostTab.jsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { theme } from '../../theme'
+import { REPO_ALL } from '../../constants'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 import { CostByModelChart } from './CostByModelChart'
 import { FactoryCostSummary } from './FactoryCostSummary'
 import { PerLoopCostTable } from './PerLoopCostTable'
@@ -19,6 +21,7 @@ import { WaterfallView } from './WaterfallView'
  */
 
 export function FactoryCostTab({ range = '7d' }) {
+  const { fetchWithRepo, selectedRepoSlug } = useHydraFlow()
   const [rolling24h, setRolling24h] = useState(null)
   const [rollingError, setRollingError] = useState(null)
   const [topIssues, setTopIssues] = useState([])
@@ -33,10 +36,10 @@ export function FactoryCostTab({ range = '7d' }) {
     let cancelled = false
     const q = `?range=${encodeURIComponent(range)}`
     Promise.allSettled([
-      fetch('/api/diagnostics/cost/rolling-24h').then((r) => r.json()),
-      fetch(`/api/diagnostics/cost/top-issues${q}&limit=10`).then((r) => r.json()),
-      fetch(`/api/diagnostics/loops/cost${q}`).then((r) => r.json()),
-      fetch(`/api/diagnostics/cost/by-model${q}`).then((r) => r.json()),
+      fetchWithRepo('/api/diagnostics/cost/rolling-24h').then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/cost/top-issues${q}&limit=10`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/loops/cost${q}`).then((r) => r.json()),
+      fetchWithRepo(`/api/diagnostics/cost/by-model${q}`).then((r) => r.json()),
     ]).then((results) => {
       if (cancelled) return
       const [rolling, top, loops, byModel] = results
@@ -60,33 +63,48 @@ export function FactoryCostTab({ range = '7d' }) {
     return () => {
       cancelled = true
     }
-  }, [range])
+  }, [range, selectedRepoSlug, fetchWithRepo])
 
-  const loadWaterfall = useCallback(async (issueNumber) => {
-    const n = Number(issueNumber)
-    if (!n || !Number.isFinite(n) || n <= 0) {
-      setWaterfallError(new Error('Enter a positive issue number'))
-      setWaterfallPayload(null)
-      return
-    }
-    setSelectedIssue(n)
-    setWaterfallError(null)
-    try {
-      const r = await fetch(`/api/diagnostics/issue/${n}/waterfall`)
-      if (!r.ok) {
-        throw new Error(`waterfall ${r.status}`)
+  const loadWaterfall = useCallback(
+    async (issueNumber, repo) => {
+      const n = Number(issueNumber)
+      if (!n || !Number.isFinite(n) || n <= 0) {
+        setWaterfallError(new Error('Enter a positive issue number'))
+        setWaterfallPayload(null)
+        return
       }
-      setWaterfallPayload(await r.json())
-    } catch (err) {
-      setWaterfallError(err)
-      setWaterfallPayload(null)
-    }
-  }, [])
+      // A waterfall resolves a single repo's traces. Top-issue rows carry their
+      // own repo (under "All repos" the list unions several); manual input uses
+      // the selected repo. The aggregate sentinel has no single home, so ask
+      // the operator to pick one rather than silently hitting the default repo.
+      const scope = repo || selectedRepoSlug
+      if (scope === REPO_ALL) {
+        setWaterfallError(new Error('Select a specific repo to load a waterfall'))
+        setWaterfallPayload(null)
+        return
+      }
+      setSelectedIssue(n)
+      setWaterfallError(null)
+      const base = `/api/diagnostics/issue/${n}/waterfall`
+      const url = scope ? `${base}?repo=${encodeURIComponent(scope)}` : base
+      try {
+        const r = await fetch(url)
+        if (!r.ok) {
+          throw new Error(`waterfall ${r.status}`)
+        }
+        setWaterfallPayload(await r.json())
+      } catch (err) {
+        setWaterfallError(err)
+        setWaterfallPayload(null)
+      }
+    },
+    [selectedRepoSlug],
+  )
 
   const handleTopIssueClick = useCallback(
     (row) => {
       setWaterfallInput(String(row.issue))
-      loadWaterfall(row.issue)
+      loadWaterfall(row.issue, row.repo)
     },
     [loadWaterfall],
   )
@@ -118,7 +136,7 @@ export function FactoryCostTab({ range = '7d' }) {
           ) : (
             <ul style={styles.ul}>
               {topIssues.map((row) => (
-                <li key={row.issue} style={styles.li}>
+                <li key={`${row.repo || ''}#${row.issue}`} style={styles.li}>
                   <button
                     type="button"
                     style={styles.link}
@@ -126,6 +144,7 @@ export function FactoryCostTab({ range = '7d' }) {
                   >
                     #{row.issue}
                   </button>
+                  {row.repo ? <span style={styles.repoBadge}>{row.repo}</span> : null}
                   <span style={styles.liMeta}>
                     ${Number(row.cost_usd || 0).toFixed(4)} ·{' '}
                     {Number(row.wall_clock_seconds || 0)}s
@@ -208,6 +227,15 @@ const styles = {
   },
   liMeta: {
     color: theme.textMuted,
+    fontFamily: 'monospace',
+  },
+  repoBadge: {
+    fontSize: 10,
+    color: theme.textMuted,
+    background: theme.surface,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 4,
+    padding: '1px 5px',
     fontFamily: 'monospace',
   },
   link: {

--- a/src/ui/src/components/diagnostics/__tests__/FactoryCostTab.test.jsx
+++ b/src/ui/src/components/diagnostics/__tests__/FactoryCostTab.test.jsx
@@ -1,5 +1,27 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// `ctx.selectedRepoSlug` is mutable per-test. `fetchWithRepo` is a STABLE
+// reference (defined once) — like the real useCallback-memoized fetcher — so
+// the component's effect, which depends on it, does not re-run every render.
+// It mirrors applyRepoParam (appends the selected slug) and delegates to the
+// per-test `global.fetch` stub so URL assertions see the real request.
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    // Mirror the real applyRepoParam exactly, incl. encodeURIComponent.
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
+
 import { FactoryCostTab } from '../FactoryCostTab'
 
 // Sanity-check render tests for the §4.11p2 Task 14 composition tab.
@@ -46,6 +68,7 @@ describe('FactoryCostTab', () => {
   let originalFetch
   beforeEach(() => {
     originalFetch = global.fetch
+    ctx.selectedRepoSlug = null
   })
   afterEach(() => {
     global.fetch = originalFetch
@@ -124,6 +147,44 @@ describe('FactoryCostTab', () => {
     await waitFor(() => {
       expect(screen.getByTestId('seg-claude-opus-4-7')).toBeInTheDocument()
       expect(screen.getByTestId('seg-claude-sonnet-4-6')).toBeInTheDocument()
+    })
+  })
+
+  it('scopes cost requests to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    global.fetch = buildFetchStub()
+    render(<FactoryCostTab range="7d" />)
+    // The repo slug must reach fetch on EVERY cost endpoint, proving the data
+    // path component → fetchWithRepo → repo param → network.
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map(([u]) => u)
+      for (const path of ['/cost/rolling-24h', '/cost/top-issues', '/loops/cost', '/cost/by-model']) {
+        expect(urls.some((u) => u.includes(path) && u.includes('repo=org-x'))).toBe(true)
+      }
+    })
+  })
+
+  it('scopes the top-issue waterfall to the row owning repo', async () => {
+    global.fetch = vi.fn((url) => {
+      if (url.includes('/cost/top-issues')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ issue: 42, repo: 'org-b', cost_usd: 1, wall_clock_seconds: 1 }]),
+        })
+      }
+      if (url.includes('/waterfall')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ phases: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+    ctx.selectedRepoSlug = '__all__'
+    render(<FactoryCostTab range="7d" />)
+    const link = await screen.findByText('#42')
+    fireEvent.click(link)
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/diagnostics/issue/42/waterfall?repo=org-b',
+      )
     })
   })
 })

--- a/tests/test_cost_merge.py
+++ b/tests/test_cost_merge.py
@@ -1,0 +1,211 @@
+"""Unit tests for the cross-repo cost-rollup merges (Phase 3c-2).
+
+Each merge folds several per-repo builder payloads into the aggregate the
+``repo=__all__`` Factory Cost endpoints return: group-by-sum on the phase /
+loop / model dimensions, with per-issue rows kept distinct by repo.
+"""
+
+from __future__ import annotations
+
+from dashboard_routes._cost_merge import (
+    merge_by_loop,
+    merge_cost_by_model,
+    merge_per_loop_cost,
+    merge_rolling_24h,
+    merge_top_issues,
+)
+
+
+def test_merge_rolling_24h_sums_totals_and_breakdowns():
+    a = {
+        "generated_at": "2026-06-08T10:00:00+00:00",
+        "window_hours": 24,
+        "total": {"cost_usd": 1.5, "tokens_in": 100, "tokens_out": 50},
+        "by_phase": [
+            {"phase": "implement", "cost_usd": 1.5, "tokens_in": 100, "tokens_out": 50}
+        ],
+        "by_loop": [{"loop": "rc_budget", "ticks": 2, "wall_clock_seconds": 4}],
+    }
+    b = {
+        "generated_at": "2026-06-08T11:00:00+00:00",
+        "window_hours": 24,
+        "total": {"cost_usd": 2.5, "tokens_in": 200, "tokens_out": 75},
+        "by_phase": [
+            {"phase": "implement", "cost_usd": 2.0, "tokens_in": 150, "tokens_out": 50},
+            {"phase": "review", "cost_usd": 0.5, "tokens_in": 50, "tokens_out": 25},
+        ],
+        "by_loop": [{"loop": "rc_budget", "ticks": 3, "wall_clock_seconds": 6}],
+    }
+    merged = merge_rolling_24h([a, b])
+    assert merged["total"] == {"cost_usd": 4.0, "tokens_in": 300, "tokens_out": 125}
+    # Latest stamp wins; window is constant.
+    assert merged["generated_at"] == "2026-06-08T11:00:00+00:00"
+    assert merged["window_hours"] == 24
+    by_phase = {r["phase"]: r for r in merged["by_phase"]}
+    assert by_phase["implement"]["cost_usd"] == 3.5
+    assert by_phase["implement"]["tokens_in"] == 250
+    assert by_phase["review"]["cost_usd"] == 0.5
+    assert merged["by_loop"] == [
+        {"loop": "rc_budget", "ticks": 5, "wall_clock_seconds": 10}
+    ]
+
+
+def test_merge_rolling_24h_single_element_is_identity():
+    one = {
+        "generated_at": "2026-06-08T10:00:00+00:00",
+        "window_hours": 24,
+        "total": {"cost_usd": 1.5, "tokens_in": 100, "tokens_out": 50},
+        "by_phase": [
+            {"phase": "implement", "cost_usd": 1.5, "tokens_in": 100, "tokens_out": 50}
+        ],
+        "by_loop": [{"loop": "rc_budget", "ticks": 2, "wall_clock_seconds": 4}],
+    }
+    assert merge_rolling_24h([one]) == one
+
+
+def test_merge_top_issues_tags_repo_and_keeps_collisions_distinct():
+    a = [{"issue": 1, "cost_usd": 5.0, "wall_clock_seconds": 10}]
+    b = [{"issue": 1, "cost_usd": 3.0, "wall_clock_seconds": 8}]
+    merged = merge_top_issues([("org-a", a), ("org-b", b)], limit=10)
+    # Same issue number in two repos → two distinct rows, each repo-tagged.
+    assert len(merged) == 2
+    assert {(r["issue"], r["repo"]) for r in merged} == {(1, "org-a"), (1, "org-b")}
+    # Sorted descending by cost.
+    assert merged[0]["repo"] == "org-a"
+
+
+def test_merge_top_issues_global_limit_after_union():
+    a = [{"issue": 1, "cost_usd": 9.0, "wall_clock_seconds": 1}]
+    b = [
+        {"issue": 2, "cost_usd": 8.0, "wall_clock_seconds": 1},
+        {"issue": 3, "cost_usd": 1.0, "wall_clock_seconds": 1},
+    ]
+    merged = merge_top_issues([("org-a", a), ("org-b", b)], limit=2)
+    assert [r["issue"] for r in merged] == [1, 2]
+
+
+def test_merge_by_loop_sums_and_recomputes_share():
+    a = [{"loop": "triage", "ticks": 1, "wall_clock_seconds": 2, "share_of_ticks": 1.0}]
+    b = [{"loop": "triage", "ticks": 3, "wall_clock_seconds": 6, "share_of_ticks": 1.0}]
+    merged = merge_by_loop([a, b])
+    assert merged == [
+        {"loop": "triage", "ticks": 4, "wall_clock_seconds": 8, "share_of_ticks": 1.0}
+    ]
+
+
+def test_merge_by_loop_share_across_two_loops():
+    a = [{"loop": "triage", "ticks": 1, "wall_clock_seconds": 1, "share_of_ticks": 1.0}]
+    b = [{"loop": "plan", "ticks": 3, "wall_clock_seconds": 1, "share_of_ticks": 1.0}]
+    merged = {r["loop"]: r["share_of_ticks"] for r in merge_by_loop([a, b])}
+    assert merged == {"triage": 0.25, "plan": 0.75}
+
+
+def test_merge_cost_by_model_groups_and_sorts():
+    a = [
+        {
+            "model": "sonnet",
+            "cost_usd": 1.0,
+            "calls": 1,
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+    ]
+    b = [
+        {
+            "model": "sonnet",
+            "cost_usd": 2.0,
+            "calls": 2,
+            "input_tokens": 20,
+            "output_tokens": 10,
+            "cache_read_tokens": 1,
+            "cache_write_tokens": 2,
+        },
+        {
+            "model": "haiku",
+            "cost_usd": 5.0,
+            "calls": 1,
+            "input_tokens": 4,
+            "output_tokens": 2,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        },
+    ]
+    merged = merge_cost_by_model([a, b])
+    # Descending by cost → haiku (5.0) then sonnet (3.0).
+    assert [r["model"] for r in merged] == ["haiku", "sonnet"]
+    sonnet = next(r for r in merged if r["model"] == "sonnet")
+    assert sonnet["cost_usd"] == 3.0
+    assert sonnet["calls"] == 3
+    assert sonnet["input_tokens"] == 30
+    assert sonnet["cache_write_tokens"] == 2
+
+
+def test_merge_per_loop_cost_sums_and_merges_model_breakdown():
+    def _row(cost, ticks, model_cost):
+        return {
+            "loop": "implement",
+            "cost_usd": cost,
+            "tokens_in": 10,
+            "tokens_out": 5,
+            "llm_calls": 1,
+            "issues_filed": 1,
+            "issues_closed": 0,
+            "escalations": 0,
+            "ticks": ticks,
+            "ticks_errored": 0,
+            "tick_cost_avg_usd": round(cost / ticks, 6) if ticks else 0.0,
+            "wall_clock_seconds": 3,
+            "last_tick_at": "2026-06-08T10:00:00+00:00",
+            "tick_cost_avg_usd_prev_period": 0.0,
+            "model_breakdown": {
+                "sonnet": {
+                    "cost_usd": model_cost,
+                    "calls": 1,
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                }
+            },
+        }
+
+    a = [_row(2.0, 2, 2.0)]
+    b = [{**_row(4.0, 2, 4.0), "last_tick_at": "2026-06-08T12:00:00+00:00"}]
+    merged = merge_per_loop_cost([a, b])
+    assert len(merged) == 1
+    row = merged[0]
+    assert row["loop"] == "implement"
+    assert row["cost_usd"] == 6.0
+    assert row["ticks"] == 4
+    # avg recomputed from merged cost/ticks, not averaged.
+    assert row["tick_cost_avg_usd"] == 1.5
+    # latest tick stamp wins.
+    assert row["last_tick_at"] == "2026-06-08T12:00:00+00:00"
+    # model_breakdown folded.
+    assert row["model_breakdown"]["sonnet"]["cost_usd"] == 6.0
+    assert row["model_breakdown"]["sonnet"]["calls"] == 2
+
+
+def test_merge_per_loop_cost_zero_ticks_avg_is_zero():
+    row = {
+        "loop": "idle",
+        "cost_usd": 0.0,
+        "tokens_in": 0,
+        "tokens_out": 0,
+        "llm_calls": 0,
+        "issues_filed": 0,
+        "issues_closed": 0,
+        "escalations": 0,
+        "ticks": 0,
+        "ticks_errored": 0,
+        "tick_cost_avg_usd": 0.0,
+        "wall_clock_seconds": 0,
+        "last_tick_at": None,
+        "tick_cost_avg_usd_prev_period": 0.0,
+        "model_breakdown": {},
+    }
+    merged = merge_per_loop_cost([[row]])
+    assert merged[0]["tick_cost_avg_usd"] == 0.0
+    assert merged[0]["last_tick_at"] is None

--- a/tests/test_diagnostics_cost_multirepo.py
+++ b/tests/test_diagnostics_cost_multirepo.py
@@ -1,0 +1,218 @@
+"""Factory Cost rollup endpoints aggregate across repos (Phase 3c-2).
+
+The ``/api/diagnostics/cost/*`` and ``/loops/cost`` endpoints read each repo's
+(D2-scoped) cost stores. ``repo=__all__`` unions every repo before aggregating;
+a specific slug scopes to that repo. The router is wired with ``ctx`` via
+``make_dashboard_router(registry=...)``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from config import HydraFlowConfig
+from route_types import REPO_ALL
+from tests.conftest import make_state
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+def _recent() -> str:
+    return (datetime.now(UTC) - timedelta(hours=1)).isoformat()
+
+
+def _write_inference(config: HydraFlowConfig, **fields) -> None:
+    config.cost_inferences_path.parent.mkdir(parents=True, exist_ok=True)
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(fields) + "\n")
+
+
+def _write_loop_trace(config: HydraFlowConfig, loop: str, **fields) -> None:
+    from trace_collector import _slug_for_loop  # noqa: PLC0415
+
+    d = config.data_root / "traces" / "_loops" / _slug_for_loop(loop)
+    d.mkdir(parents=True, exist_ok=True)
+    payload = {"kind": "loop", "loop": loop, **fields}
+    (d / f"run-{fields['started_at'].replace(':', '')}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def _seed_inference(
+    config: HydraFlowConfig, *, issue: int, model: str, tokens_in: int
+) -> None:
+    _write_inference(
+        config,
+        timestamp=_recent(),
+        source="implementer",
+        tool="claude",
+        model=model,
+        issue_number=issue,
+        input_tokens=tokens_in,
+        output_tokens=tokens_in // 2,
+        cache_creation_input_tokens=0,
+        cache_read_input_tokens=0,
+        duration_seconds=float(issue),
+        status="success",
+    )
+
+
+def _repo_config(tmp_path: Path, name: str) -> HydraFlowConfig:
+    repo_root = tmp_path / name / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=repo_root, repo=f"org/{name}")
+
+
+def _two_repo_router(tmp_path, event_bus, state, config, *, seed_a, seed_b):
+    cfg_a = _repo_config(tmp_path, "a")
+    cfg_b = _repo_config(tmp_path, "b")
+    seed_a(cfg_a)
+    seed_b(cfg_b)
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": cfg_a,
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry, default_repo_slug="org-a"
+    )
+    return router, cfg_a, cfg_b
+
+
+def test_cost_by_model_unions_across_repos(config, event_bus, state, tmp_path):
+    router, _a, _b = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _seed_inference(
+            c, issue=1, model="claude-sonnet-4-6", tokens_in=100
+        ),
+        seed_b=lambda c: (
+            _seed_inference(c, issue=2, model="claude-sonnet-4-6", tokens_in=200),
+            _seed_inference(c, issue=3, model="claude-haiku-4-5", tokens_in=40),
+        ),
+    )
+    by_model = find_endpoint(router, "/api/diagnostics/cost/by-model")
+    rows = by_model(range="7d", repo=REPO_ALL)
+    by_name = {r["model"]: r for r in rows}
+    # Sonnet appears in both repos → calls summed; haiku only in org-b.
+    assert by_name["claude-sonnet-4-6"]["calls"] == 2
+    assert by_name["claude-sonnet-4-6"]["input_tokens"] == 300
+    assert "claude-haiku-4-5" in by_name
+
+
+def test_cost_by_model_scopes_to_one_repo(config, event_bus, state, tmp_path):
+    router, _a, _b = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _seed_inference(
+            c, issue=1, model="claude-sonnet-4-6", tokens_in=100
+        ),
+        seed_b=lambda c: _seed_inference(
+            c, issue=2, model="claude-haiku-4-5", tokens_in=40
+        ),
+    )
+    by_model = find_endpoint(router, "/api/diagnostics/cost/by-model")
+    rows = by_model(range="7d", repo="org-b")
+    assert {r["model"] for r in rows} == {"claude-haiku-4-5"}
+
+
+def test_top_issues_unions_and_tags_repo(config, event_bus, state, tmp_path):
+    # Both repos own an issue #1 — distinct issues, must stay two repo-tagged rows.
+    router, _a, _b = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _seed_inference(
+            c, issue=1, model="claude-sonnet-4-6", tokens_in=500
+        ),
+        seed_b=lambda c: _seed_inference(
+            c, issue=1, model="claude-sonnet-4-6", tokens_in=300
+        ),
+    )
+    top = find_endpoint(router, "/api/diagnostics/cost/top-issues")
+    rows = top(range="7d", limit=10, repo=REPO_ALL)
+    assert {(r["issue"], r["repo"]) for r in rows} == {(1, "org-a"), (1, "org-b")}
+
+
+def test_rolling_24h_unions_totals(config, event_bus, state, tmp_path):
+    router, _a, _b = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _seed_inference(
+            c, issue=1, model="claude-sonnet-4-6", tokens_in=100
+        ),
+        seed_b=lambda c: _seed_inference(
+            c, issue=2, model="claude-sonnet-4-6", tokens_in=200
+        ),
+    )
+    rolling = find_endpoint(router, "/api/diagnostics/cost/rolling-24h")
+    body = rolling(repo=REPO_ALL)
+    assert body["window_hours"] == 24
+    assert body["total"]["tokens_in"] == 300
+
+
+def test_cost_by_loop_unions_across_repos(config, event_bus, state, tmp_path):
+    def seed(c):
+        _write_loop_trace(
+            c,
+            "rc_budget",
+            command=["gh"],
+            exit_code=0,
+            duration_ms=1000,
+            started_at=_recent(),
+        )
+
+    router, _a, _b = _two_repo_router(
+        tmp_path, event_bus, state, config, seed_a=seed, seed_b=seed
+    )
+    by_loop = find_endpoint(router, "/api/diagnostics/cost/by-loop")
+    rows = by_loop(range="7d", repo=REPO_ALL)
+    rc = next(r for r in rows if r["loop"] == "rc_budget")
+    # One tick per repo → two ticks unioned; sole loop owns the full share.
+    assert rc["ticks"] == 2
+    assert rc["share_of_ticks"] == 1.0
+
+
+def test_loops_cost_unions_across_repos(config, event_bus, state, tmp_path):
+    def seed(c):
+        _write_loop_trace(
+            c,
+            "rc_budget",
+            command=["gh"],
+            exit_code=0,
+            duration_ms=2000,
+            started_at=_recent(),
+        )
+
+    router, _a, _b = _two_repo_router(
+        tmp_path, event_bus, state, config, seed_a=seed, seed_b=seed
+    )
+    loops_cost = find_endpoint(router, "/api/diagnostics/loops/cost")
+    rows = loops_cost(range="7d", repo=REPO_ALL)
+    rc = next(r for r in rows if r["loop"] == "rc_budget")
+    assert rc["ticks"] == 2
+    assert rc["wall_clock_seconds"] == 4


### PR DESCRIPTION
## What

Phase **3c-2** of the multi-repo dashboard scoping program: the Diagnostics **Factory Cost** sub-tab now aggregates across repos.

The cost-rollup endpoints — `/cost/rolling-24h`, `/cost/top-issues`, `/cost/by-loop`, `/cost/by-model`, `/loops/cost` — gain a `repo` query param. With `ctx` they build per repo over `resolve_runtimes(repo)` and fold the results:

- **`repo=__all__`** → union every registered repo
- **concrete slug** → scope to that repo
- **`ctx is None`** → bare single-repo builder, unchanged (the 25 legacy cost-rollup tests call `build_diagnostics_router(config)` directly and are untouched)

## Folding — new `dashboard_routes/_cost_merge.py`

Mirrors Phase 2a's `_stats_merge.py`: group-by-sum on the **phase / loop / model** dimensions (not repo-specific). Per-issue **top-cost rows** are the exception — issue numbers collide across repos, so `merge_top_issues` tags each row with its repo and keeps collisions distinct. Merging already-truncated per-repo top-N lists into a global top-N is sound (a global top-N issue is necessarily top-N within its own repo). `merge_per_loop_cost` folds the nested `model_breakdown` per model and recomputes `tick_cost_avg_usd` from the merged cost/ticks.

## Frontend

`FactoryCostTab` routes its four cost fetches through the repo-aware `fetchWithRepo`, re-fetches on repo change, renders a repo badge on top-issue rows, and scopes the per-issue **waterfall** drill-down to the **row's own repo** (the aggregate sentinel has no single home, so manual-input under "All repos" asks the operator to pick a repo rather than silently hitting the default).

## Deferred to Phase 3c-3 (noted in-code)

`/auto-agent` + the **Overview-tab** `AutoAgentStats`/`FactoryHealthSection` (percentile/health merges + `/api/factory-health/*`) — a separate concern from the Cost tab.

## Tests

- `tests/test_cost_merge.py` — merge math, same-issue collisions, single-element identity, model-breakdown fold, zero-tick avg.
- `tests/test_diagnostics_cost_multirepo.py` — **real** `ConfigFactory` configs seeded with cost data, asserting cross-repo union + single-repo scoping per endpoint.
- `FactoryCostTab` frontend — repo param reaches `fetch` on **all four** endpoints; row-scoped waterfall.

> Note: the test's `fetchWithRepo` mock is a **stable hoisted reference** mirroring the real `useCallback`-memoized fetcher. An earlier unstable mock made the effect (which depends on it) re-render-loop to a worker OOM — production is unaffected because the real fetcher is memoized.

## Verification

- `make quality` ✅ 15854 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- UI `vitest` ✅ 1105 passed · `npm run build` ✅
- Two adversarial fresh-eyes reviews (backend + frontend) — **no production bugs**; the two flagged test-fidelity nits (encodeURIComponent parity, assert all 4 endpoints) are applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)