### PR TITLE
feat(loops): RollupIssueManager + migrate StagingPromotionLoop to auto-close (#9359)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T22:21:34.726246+00:00",
-  "commit_sha": "b207b54d38828b47bbec1cda4922772147fe9527",
+  "regenerated_at": "2026-06-09T00:09:32.113557+00:00",
+  "commit_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "ports.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "labels.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "modules.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "events.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "adr_xref.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "mockworld.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "changelog.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "coverage_matrix.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "functional_areas.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b207b54d38828b47bbec1cda4922772147fe9527"
+      "source_sha": "5792a0798f61c1d3fd933d7974500d99fb6c9177"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `b5c9aa6` — feat(diagnostics): factory-metrics endpoints aggregate across repos (Phase 3c-1) (#9366) (#9366) *(2026-06-08)*
 - `b207b54` — feat(system): target the selected repo for bg-worker controls (Phase 3b-fe) (#9363) (#9363) *(2026-06-08)*
 - `5d58cdb` — feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend) (#9360) (#9360) *(2026-06-08)*
 - `d8df0e1` — feat(hitl): aggregate HITL across repos + row-scoped mutations (Phase 3a) (#9358) (#9358) *(2026-06-08)*

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -29,7 +29,7 @@ graph LR
     src -- "1" --> src_observability
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
-    src -- "48" --> src_state
+    src -- "49" --> src_state
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch

--- a/src/models.py
+++ b/src/models.py
@@ -1889,6 +1889,12 @@ class StateData(BaseModel):
     # rollup issue number + the set of PR numbers currently listed in the body.
     # Used so subsequent ticks update the body in-place rather than re-filing.
     adr_rollup_issues: dict[str, dict] = Field(default_factory=dict)
+    # Generic rollup tracking for RollupIssueManager (#9359 hygiene). Keyed by
+    # "{namespace}:{subject}" (e.g. "staging_promotion:rc_ci"); value is
+    # {"issue_number": int, "content_hash": str}. Lets any loop keep ONE open
+    # issue per subject (create-once, update_issue_body on change) and close it
+    # on resolve — so resolved conditions stop accumulating stale find-issues.
+    rollup_issues: dict[str, dict] = Field(default_factory=dict)
     memory_backlog_attempts: dict[str, int] = Field(default_factory=dict)
     # TriageRetryLoop (ADR-0063 W2) — per-issue retry counters and the
     # ISO-8601 timestamp of the last retry attempt, used to honour the

--- a/src/rollup_issue_manager.py
+++ b/src/rollup_issue_manager.py
@@ -1,0 +1,137 @@
+"""RollupIssueManager — one open issue per subject, auto-closed on resolve.
+
+#9359 issue-hygiene. Most caretaker loops file a GitHub find-issue when a
+condition goes bad but never close it when the condition recovers, so resolved
+conditions accumulate as stale open issues (the bulk of the backlog this
+session pruned). This centralizes the proven rollup pattern from
+``AdrTouchpointAuditorLoop`` / ``FakeCoverageAuditorLoop`` /
+``LiveCorpusReplayLoop``:
+
+- :meth:`ensure` — create ONE issue per subject, or update its body in place
+  when the variable content changes (no-op when unchanged).
+- :meth:`resolve` — close the issue when the condition clears (idempotent).
+- :meth:`resolve_all_except` — for set-based reconcilers, close every tracked
+  subject that is no longer active.
+
+Titles MUST be stable (no counts / SHAs / PR numbers) — variable content goes in
+the BODY, which :meth:`ensure` diffs via a content hash so redundant
+``update_issue_body`` calls are skipped. State lives under
+``state.rollup_issues`` keyed ``"{namespace}:{subject}"``; if that state is lost
+but the issue still exists, ``PRManager.create_issue`` returns the existing
+number (exact-title dedup), so :meth:`ensure` re-adopts it rather than filing a
+duplicate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ports import PRPort
+    from state import StateTracker
+
+logger = logging.getLogger("hydraflow.rollup_issue_manager")
+
+
+def _content_hash(title: str, body: str) -> str:
+    return hashlib.sha256(f"{title}\n{body}".encode()).hexdigest()
+
+
+class RollupIssueManager:
+    """Keep one open GitHub issue per subject under a namespace."""
+
+    def __init__(
+        self,
+        *,
+        pr: PRPort,
+        state: StateTracker,
+        namespace: str,
+        labels: list[str],
+    ) -> None:
+        self._pr = pr
+        self._state = state
+        self._namespace = namespace
+        self._labels = list(labels)
+
+    def _key(self, subject: str) -> str:
+        return f"{self._namespace}:{subject}"
+
+    async def ensure(
+        self,
+        subject: str,
+        *,
+        title: str,
+        body: str,
+        extra_labels: list[str] | None = None,
+    ) -> int:
+        """Keep ONE open issue for *subject*.
+
+        Creates it on first use, updates the body in place when *body* changes,
+        and no-ops when unchanged. Returns the issue number (``0`` on a create
+        failure — caller should retry next tick).
+        """
+        key = self._key(subject)
+        content_hash = _content_hash(title, body)
+        tracked = self._state.get_rollup_issue(key)
+        if tracked and tracked["issue_number"]:
+            number = tracked["issue_number"]
+            if tracked["content_hash"] != content_hash:
+                await self._pr.update_issue_body(number, body)
+                self._state.set_rollup_issue(
+                    key, issue_number=number, content_hash=content_hash
+                )
+            return number
+
+        labels = self._labels + list(extra_labels or [])
+        number = await self._pr.create_issue(title, body, labels)
+        if number and number != 0:
+            self._state.set_rollup_issue(
+                key, issue_number=number, content_hash=content_hash
+            )
+        else:
+            # create_issue's documented 0-sentinel: don't persist — retry next
+            # tick rather than latch a phantom issue #0.
+            logger.warning(
+                "rollup ensure: create_issue returned 0 for %r; will retry", key
+            )
+        return number
+
+    async def resolve(self, subject: str, *, comment: str | None = None) -> bool:
+        """Close the tracked issue for *subject* and clear its state.
+
+        Idempotent — a no-op (returns ``False``) when nothing is tracked, so it
+        is safe to call on every clean tick. Returns ``True`` if it closed an
+        issue.
+        """
+        key = self._key(subject)
+        tracked = self._state.get_rollup_issue(key)
+        if not (tracked and tracked["issue_number"]):
+            return False
+        number = tracked["issue_number"]
+        if comment:
+            await self._pr.post_comment(number, comment)
+        await self._pr.close_issue(number)
+        self._state.clear_rollup_issue(key)
+        return True
+
+    async def resolve_all_except(
+        self, active_subjects: Iterable[str], *, comment: str | None = None
+    ) -> int:
+        """Close every tracked subject in this namespace NOT in *active_subjects*.
+
+        For set-based reconcilers (e.g. open security alerts, currently-flaky
+        tests): pass the still-active subjects; everything else self-closes.
+        Returns the number of issues closed.
+        """
+        active_keys = {self._key(s) for s in active_subjects}
+        closed = 0
+        for key in self._state.get_rollup_issue_keys(self._namespace):
+            if key in active_keys:
+                continue
+            subject = key[len(self._namespace) + 1 :]
+            if await self.resolve(subject, comment=comment):
+                closed += 1
+        return closed

--- a/src/staging_promotion_loop.py
+++ b/src/staging_promotion_loop.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 import ci_sentinels
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
+from rollup_issue_manager import RollupIssueManager
 
 if TYPE_CHECKING:
     from ports import PRPort
@@ -44,6 +45,20 @@ class StagingPromotionLoop(BaseBackgroundLoop):
 
     def _get_default_interval(self) -> int:
         return self._config.staging_promotion_interval
+
+    def _rollups(self) -> RollupIssueManager | None:
+        """One rolling "promotion CI is failing" issue, auto-closed on a green
+        promotion — replaces the per-PR ``RC promotion #N failed CI`` pile-up
+        (#9219..#9342). ``None`` when state is absent (unit tests fall back to
+        create_issue's stable-title dedup)."""
+        if self._state is None:
+            return None
+        return RollupIssueManager(
+            pr=self._prs,
+            state=self._state,
+            namespace="staging_promotion",
+            labels=list(self._config.find_label or ["hydraflow-find"]),
+        )
 
     async def _do_work(self) -> dict[str, Any] | None:
         if not self._enabled_cb(self._worker_name):
@@ -93,6 +108,17 @@ class StagingPromotionLoop(BaseBackgroundLoop):
                     # A green promotion clears the consecutive-failure streak so
                     # a future stall re-escalates from scratch (#9359 hardening).
                     self._state.reset_consecutive_rc_failures()
+                    # CI is green again — close the single rolling "promotion CI
+                    # failing" issue if one is open (#9359 issue-hygiene).
+                    rollups = self._rollups()
+                    if rollups is not None:
+                        await rollups.resolve(
+                            "rc_ci",
+                            comment=(
+                                f"RC promotion to {self._config.main_branch} "
+                                "succeeded — auto-closing."
+                            ),
+                        )
                 return {"status": "promoted", "pr": pr_number}
             logger.warning("Promotion merge failed for PR #%d", pr_number)
             return {"status": "merge_failed", "pr": pr_number}
@@ -147,17 +173,28 @@ class StagingPromotionLoop(BaseBackgroundLoop):
         }
 
     async def _file_failure_issue(self, pr_number: int, summary: str) -> int:
-        labels = self._config.find_label or ["hydraflow-find"]
-        title = f"RC promotion #{pr_number} failed CI"
+        # STABLE title (no PR number) so a single rolling issue tracks "promotion
+        # CI is currently failing", updated in place each cadence tick and closed
+        # automatically on the next green promotion. The old per-PR title filed a
+        # brand-new issue every tick (#9219..#9342). #9359 issue-hygiene.
+        labels = list(self._config.find_label or ["hydraflow-find"])
+        title = f"RC promotion to {self._config.main_branch} failing CI"
         body = (
             f"Automated promotion PR #{pr_number} failed CI and was closed.\n\n"
-            f"The StagingPromotionLoop will retry on the next cadence tick.\n\n"
+            f"The StagingPromotionLoop retries on each cadence tick; this issue "
+            f"updates in place while staging→{self._config.main_branch} CI stays "
+            f"red, and auto-closes on the next green promotion.\n\n"
             "Investigate whether the failure is:\n"
             "- a real regression → fix before the next cadence\n"
             "- a flake → re-open the PR or wait for the next cycle\n"
             "- an environmental issue → fix CI config\n\n"
             f"```\n{summary}\n```"
         )
+        rollups = self._rollups()
+        if rollups is not None:
+            return await rollups.ensure("rc_ci", title=title, body=body)
+        # State-less fallback (unit tests): create_issue's exact-title dedup on
+        # the now-stable title still prevents per-tick pile-up.
         try:
             return await self._prs.create_issue(title, body, labels)
         except Exception:  # noqa: BLE001
@@ -185,8 +222,8 @@ class StagingPromotionLoop(BaseBackgroundLoop):
             f"The StagingPromotionLoop has failed to promote `staging` → "
             f"`{self._config.main_branch}` **{failures} times in a row** "
             f"(latest: RC PR #{pr_number}). `main` is not advancing.\n\n"
-            "Per-failure `RC promotion #N failed CI` issues track each red PR, "
-            "but this escalation means the pipeline itself needs a human:\n"
+            "A single rolling `RC promotion to main failing CI` issue tracks the "
+            "red state, but this escalation means the pipeline needs a human:\n"
             "- a real regression on `staging` blocking every RC (run the failing "
             "gate locally to bisect), or\n"
             "- a systemic CI/promotion-loop defect (e.g. the #9351 timeout "

--- a/src/state/__init__.py
+++ b/src/state/__init__.py
@@ -44,6 +44,7 @@ from ._principles_audit import PrinciplesAuditStateMixin
 from ._rc_budget import RCBudgetStateMixin
 from ._report import ReportStateMixin
 from ._review import ReviewStateMixin
+from ._rollup_issues import RollupIssueStateMixin
 from ._route_back import RouteBackStateMixin
 from ._sandbox_failure_fixer import SandboxFailureFixerStateMixin
 from ._security_patch import SecurityPatchStateMixin
@@ -80,6 +81,7 @@ class StateTracker(
     PrinciplesAuditStateMixin,
     CorpusLearningStateMixin,
     ReportStateMixin,
+    RollupIssueStateMixin,
     ShapeStateMixin,
     DependabotMergeStateMixin,
     StaleIssueStateMixin,

--- a/src/state/_rollup_issues.py
+++ b/src/state/_rollup_issues.py
@@ -1,0 +1,60 @@
+"""State accessors for RollupIssueManager (#9359 issue-hygiene).
+
+Generic per-subject rollup-issue tracking so any caretaker loop can keep ONE
+open GitHub issue per subject (create-once, update body on change) and close it
+when the condition resolves — instead of leaving resolved-condition find-issues
+to accumulate. Keyed by ``"{namespace}:{subject}"``; value is
+``{"issue_number": int, "content_hash": str}``.
+
+This is intentionally a NEW, generic field separate from the loop-specific
+``adr_rollup_issues`` / ``fake_coverage_rollup_issues`` (those already work and
+have their own schemas — re-plumbing them is out of scope).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from models import StateData
+
+
+class RollupIssueStateMixin:
+    """Generic ``{namespace}:{subject}`` -> rollup-issue tracking."""
+
+    _data: StateData
+
+    def save(self) -> None: ...  # provided by CoreMixin
+
+    def get_rollup_issue(self, key: str) -> dict | None:
+        """Return ``{"issue_number": int, "content_hash": str}`` or ``None``."""
+        entry = self._data.rollup_issues.get(key)
+        if not entry:
+            return None
+        return {
+            "issue_number": int(entry.get("issue_number", 0)),
+            "content_hash": str(entry.get("content_hash", "")),
+        }
+
+    def set_rollup_issue(
+        self, key: str, *, issue_number: int, content_hash: str
+    ) -> None:
+        rollups = dict(self._data.rollup_issues)
+        rollups[key] = {
+            "issue_number": int(issue_number),
+            "content_hash": content_hash,
+        }
+        self._data.rollup_issues = rollups
+        self.save()
+
+    def clear_rollup_issue(self, key: str) -> None:
+        if key in self._data.rollup_issues:
+            rollups = dict(self._data.rollup_issues)
+            rollups.pop(key, None)
+            self._data.rollup_issues = rollups
+            self.save()
+
+    def get_rollup_issue_keys(self, namespace: str) -> list[str]:
+        """All tracked keys under ``namespace`` (i.e. ``"{namespace}:..."``)."""
+        prefix = f"{namespace}:"
+        return [k for k in self._data.rollup_issues if k.startswith(prefix)]

--- a/tests/test_rollup_issue_manager.py
+++ b/tests/test_rollup_issue_manager.py
@@ -1,0 +1,105 @@
+"""Unit tests for RollupIssueManager (#9359 issue-hygiene)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rollup_issue_manager import RollupIssueManager
+from state import StateTracker
+
+
+def _make(tmp_path: Path, *, create_return: int = 100):
+    pr = MagicMock()
+    pr.create_issue = AsyncMock(return_value=create_return)
+    pr.update_issue_body = AsyncMock()
+    pr.close_issue = AsyncMock()
+    pr.post_comment = AsyncMock()
+    state = StateTracker(state_file=tmp_path / "s.json")
+    mgr = RollupIssueManager(
+        pr=pr, state=state, namespace="ns", labels=["hydraflow-find"]
+    )
+    return mgr, pr, state
+
+
+@pytest.mark.asyncio
+async def test_ensure_creates_once_and_tracks(tmp_path: Path) -> None:
+    mgr, pr, state = _make(tmp_path)
+    n = await mgr.ensure("subj", title="T", body="B")
+    assert n == 100
+    pr.create_issue.assert_awaited_once_with("T", "B", ["hydraflow-find"])
+    assert state.get_rollup_issue("ns:subj")["issue_number"] == 100
+
+
+@pytest.mark.asyncio
+async def test_ensure_unchanged_body_is_noop(tmp_path: Path) -> None:
+    mgr, pr, _state = _make(tmp_path)
+    await mgr.ensure("subj", title="T", body="B")
+    n = await mgr.ensure("subj", title="T", body="B")
+    assert n == 100
+    pr.create_issue.assert_awaited_once()  # not re-created
+    pr.update_issue_body.assert_not_awaited()  # body unchanged
+
+
+@pytest.mark.asyncio
+async def test_ensure_changed_body_updates_in_place(tmp_path: Path) -> None:
+    mgr, pr, _state = _make(tmp_path)
+    await mgr.ensure("subj", title="T", body="B1")
+    n = await mgr.ensure("subj", title="T", body="B2")
+    assert n == 100
+    pr.create_issue.assert_awaited_once()  # still only one create
+    pr.update_issue_body.assert_awaited_once_with(100, "B2")
+
+
+@pytest.mark.asyncio
+async def test_ensure_zero_sentinel_not_tracked(tmp_path: Path) -> None:
+    mgr, pr, state = _make(tmp_path, create_return=0)
+    n = await mgr.ensure("subj", title="T", body="B")
+    assert n == 0
+    assert state.get_rollup_issue("ns:subj") is None  # not latched
+    # next tick retries the create
+    await mgr.ensure("subj", title="T", body="B")
+    assert pr.create_issue.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_closes_and_clears(tmp_path: Path) -> None:
+    mgr, pr, state = _make(tmp_path)
+    await mgr.ensure("subj", title="T", body="B")
+    closed = await mgr.resolve("subj", comment="done")
+    assert closed is True
+    pr.post_comment.assert_awaited_once_with(100, "done")
+    pr.close_issue.assert_awaited_once_with(100)
+    assert state.get_rollup_issue("ns:subj") is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_untracked_is_idempotent_noop(tmp_path: Path) -> None:
+    mgr, pr, _state = _make(tmp_path)
+    closed = await mgr.resolve("never-filed")
+    assert closed is False
+    pr.close_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_resolve_all_except_closes_only_inactive(tmp_path: Path) -> None:
+    pr = MagicMock()
+    pr.update_issue_body = AsyncMock()
+    pr.close_issue = AsyncMock()
+    pr.post_comment = AsyncMock()
+    # distinct issue numbers per subject
+    pr.create_issue = AsyncMock(side_effect=[201, 202, 203])
+    state = StateTracker(state_file=tmp_path / "s.json")
+    mgr = RollupIssueManager(pr=pr, state=state, namespace="alerts", labels=["x"])
+
+    for s in ("a", "b", "c"):
+        await mgr.ensure(s, title=f"alert {s}", body="b")
+
+    closed = await mgr.resolve_all_except({"b"}, comment="resolved")
+    assert closed == 2
+    assert {c.args[0] for c in pr.close_issue.await_args_list} == {201, 203}
+    assert state.get_rollup_issue("alerts:b")["issue_number"] == 202
+    assert state.get_rollup_issue("alerts:a") is None
+    assert state.get_rollup_issue("alerts:c") is None

--- a/tests/test_staging_promotion_loop.py
+++ b/tests/test_staging_promotion_loop.py
@@ -292,7 +292,10 @@ class TestOpenPromotionFailing:
         prs.create_issue.assert_called_once()
         args, _kwargs = prs.create_issue.call_args
         title, body, labels = args
-        assert "RC promotion #99 failed CI" in title
+        # Stable title (no PR number) so one rolling issue dedups across ticks;
+        # the PR number + failure summary live in the body (#9359).
+        assert title == "RC promotion to main failing CI"
+        assert "#99" in body
         assert "scenario suite failed" in body
         assert labels == ["hydraflow-find"]
 
@@ -578,3 +581,43 @@ class TestSentinelFidelity:
         prs.close_issue.assert_not_called()
         assert state.get_consecutive_rc_failures() == 0
         assert _escalation_calls(prs) == []
+
+
+class TestRollingFailureIssue:
+    """#9359 issue-hygiene: one rolling 'promotion CI failing' issue, auto-closed
+    on the next green promotion (replaces the per-PR pile-up #9219..#9342)."""
+
+    @pytest.mark.asyncio
+    async def test_red_then_green_files_one_issue_and_auto_closes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop, prs = _make_loop(
+            tmp_path,
+            monkeypatch,
+            open_promotion=_make_pr(number=99),
+            ci_result=(False, "boom"),
+        )
+        prs.create_issue = AsyncMock(return_value=7001)
+        prs.update_issue_body = AsyncMock()
+        state = StateTracker(state_file=tmp_path / "s.json")
+        loop._state = state  # type: ignore[attr-defined]
+
+        # Red tick: files exactly ONE rolling issue, tracked in state.
+        r1 = await loop._do_work()
+        assert r1["status"] == "ci_failed"
+        prs.create_issue.assert_awaited_once()
+        assert state.get_rollup_issue("staging_promotion:rc_ci")["issue_number"] == 7001
+
+        # Second red tick (same body) must NOT file a new issue.
+        await loop._do_work()
+        prs.create_issue.assert_awaited_once()
+
+        # Green tick: promotion succeeds → the rolling issue auto-closes.
+        prs.wait_for_ci.return_value = (True, "ok")
+        prs.merge_promotion_pr = AsyncMock(return_value=True)
+        prs.get_pr_head_sha = AsyncMock(return_value="greensha")
+        r2 = await loop._do_work()
+
+        assert r2["status"] == "promoted"
+        prs.close_issue.assert_any_await(7001)
+        assert state.get_rollup_issue("staging_promotion:rc_ci") is None

--- a/tests/test_state_tracking.py
+++ b/tests/test_state_tracking.py
@@ -148,6 +148,7 @@ class TestInitialization:
             "adr_audit_attempts",
             # Per-ADR rollup tracking (#8987) — see ADR-0056 amendment.
             "adr_rollup_issues",
+            "rollup_issues",
             # MemoryBacklogLoop (ADR-0057)
             "memory_backlog_attempts",
             # TriageRetryLoop (ADR-0063 W2)


### PR DESCRIPTION
## Why

An audit of all 27 issue-filing caretaker loops (workflow-driven) found **16 of 30 file-points are GAPs** — and the dominant pattern is **"never auto-closes on recovery"**: a loop files a find-issue when a condition goes bad but only clears internal state when it recovers, never closing the GitHub issue. Resolved conditions then accumulate as stale open issues — the bulk of the 132-issue backlog this session pruned (not, as first assumed, per-tick duplication; `create_issue` already dedups on exact title).

This PR adds the **reusable mechanism** and migrates the **worst piler**. The other 15 GAP loops then become a mechanical follow-up (stabilize title → `ensure()` → `resolve()` in the recovery branch).

## What

**`RollupIssueManager`** (`src/rollup_issue_manager.py`) — extracts the proven pattern from `AdrTouchpointAuditorLoop` / `FakeCoverageAuditorLoop` / `LiveCorpusReplayLoop`:
- `ensure(subject, title, body)` — one open issue per subject: create once, `update_issue_body` on body change (content-hash diff), no-op otherwise. Stable titles required; if state is lost, `create_issue`'s exact-title dedup re-adopts the existing issue.
- `resolve(subject)` — close + clear on recovery (idempotent → safe every clean tick).
- `resolve_all_except(active)` — set-based reconciler (alerts, flaky test-ids).
- Backed by `StateData.rollup_issues` (`"{namespace}:{subject}" → {issue_number, content_hash}`) via `RollupIssueStateMixin`.

**StagingPromotionLoop migration** — the per-PR `RC promotion #N failed CI` title filed a *new* issue every cadence tick (#9219..#9342). Now **one rolling `RC promotion to {main} failing CI` issue**, updated in place while CI is red and **auto-closed on the next green promotion**.

## Verification
- 7 `RollupIssueManager` unit tests (create-once / hash-skip / update / 0-sentinel / resolve / idempotent / resolve_all_except); a loop red→green rolling-issue test proving exactly one issue is filed and then closed.
- `make quality` **15856 passed** (the lone failure was stale arch artifacts from the new module — regenerated here); `make scenario` + `make scenario-loops` green.

## Follow-ups (audit-specced, not in this PR)
Tier-1 pilers: FlakeTracker, ReportIssueLoop, StagingBisect (needs human sign-off — HITL escalations), RCBudget. Tier-2 auto-close gaps: PrinciplesAudit, SecurityPatch, HealthMonitor, SkillPromptEval, ContractRefresh, FakeCoverage-retirement. Tier-3 mechanical batch: GateActivator, BranchProtection, CostBudget, Pricing, Diagram. Plus an **observability-only `FactoryIssueJanitor`** (closing mode needs an ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)