### PR TITLE
feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-08T23:29:22.745274+00:00",
-  "commit_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df",
+  "regenerated_at": "2026-06-09T00:23:04.336383+00:00",
+  "commit_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0",
   "artifacts": {
     "loops.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "ports.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "labels.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "modules.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "events.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "adr_xref.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "mockworld.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "changelog.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "coverage_matrix.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "functional_areas.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "ubiquitous-language.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "b5c9aa6f481274ef26d151bb6aa5a3abb3d7b6df"
+      "source_sha": "ec58ffb0b8e8457bcc98f1ba01677ca5ddad89e0"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `ec58ffb` — feat(diagnostics): Factory Cost rollup endpoints aggregate across repos (Phase 3c-2) (#9367) (#9367) *(2026-06-08)*
 - `b5c9aa6` — feat(diagnostics): factory-metrics endpoints aggregate across repos (Phase 3c-1) (#9366) (#9366) *(2026-06-08)*
 - `b207b54` — feat(system): target the selected repo for bg-worker controls (Phase 3b-fe) (#9363) (#9363) *(2026-06-08)*
 - `5d58cdb` — feat(system): aggregate control status/workers + fan-out credit + config guards (Phase 3b backend) (#9360) (#9360) *(2026-06-08)*

--- a/src/dashboard_routes/_diagnostics_routes.py
+++ b/src/dashboard_routes/_diagnostics_routes.py
@@ -405,7 +405,9 @@ def build_diagnostics_router(
     # ``resolve_runtimes(repo)`` and folds the results (group-by-sum on the
     # phase/loop/model dimensions; per-issue rows carry a repo tag). ``ctx is
     # None`` keeps the bare single-repo builder. NOTE: ``/auto-agent`` (Overview
-    # tab) is NOT yet repo-scoped — its percentile merge is deferred to 3c-3.
+    # tab) is NOT yet repo-scoped — deferred to 3c-4 (its audit.jsonl store is
+    # at the shared data_root with no repo field, so it needs a data-layout
+    # migration, not just a read-side merge like factory-health got in 3c-3).
 
     @router.get("/cost/rolling-24h")
     def cost_rolling_24h(repo: RepoSlugParam = None) -> dict[str, Any]:

--- a/src/dashboard_routes/_factory_health_routes.py
+++ b/src/dashboard_routes/_factory_health_routes.py
@@ -14,9 +14,11 @@ from typing import TYPE_CHECKING, Any
 from fastapi import APIRouter
 
 from factory_health import compute_summary
+from route_types import RepoSlugParam
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
+    from dashboard_routes._routes import RouteContext
 
 logger = logging.getLogger("hydraflow.dashboard.factory_health")
 
@@ -46,20 +48,48 @@ def _load_jsonl(path: Any) -> list[dict[str, Any]]:
     return entries
 
 
-def build_factory_health_router(config: HydraFlowConfig) -> APIRouter:
-    """Build the ``/api/factory-health`` router."""
+def build_factory_health_router(
+    config: HydraFlowConfig, ctx: RouteContext | None = None
+) -> APIRouter:
+    """Build the ``/api/factory-health`` router.
+
+    With *ctx* the summary honors a ``repo`` query param: ``repo=__all__``
+    unions every repo's (D2-scoped) retrospective + telemetry stores, a specific
+    slug scopes to that repo, and ``None`` resolves the default. Without *ctx*
+    (legacy single-repo callers) it reads the bare *config* stores unchanged.
+    """
 
     router = APIRouter(prefix="/api/factory-health", tags=["factory-health"])
 
+    def _tagged(path: Any, slug: str) -> list[dict[str, Any]]:
+        """Load entries from *path*, tagging each with its owning repo slug.
+
+        The slug keeps the cohort join (telemetry → retro, by issue) correct
+        when the union spans repos whose issue numbers collide.
+        """
+        rows = _load_jsonl(path)
+        for row in rows:
+            row["repo"] = slug
+        return rows
+
     @router.get("/summary")
-    def get_factory_health(repo: str = "") -> dict[str, Any]:
-        retro_path = config.retrospectives_path
-        telemetry_path = config.cost_inferences_path
-        retro_entries = _load_jsonl(retro_path)
-        telemetry_entries = _load_jsonl(telemetry_path)
-        if repo:
-            retro_entries = [e for e in retro_entries if e.get("repo") == repo]
-            telemetry_entries = [e for e in telemetry_entries if e.get("repo") == repo]
+    def get_factory_health(repo: RepoSlugParam = None) -> dict[str, Any]:
+        if ctx is None:
+            return compute_summary(
+                _load_jsonl(config.retrospectives_path),
+                _load_jsonl(config.cost_inferences_path),
+            )
+        retro_entries: list[dict[str, Any]] = []
+        telemetry_entries: list[dict[str, Any]] = []
+        for cfg, _s, _b, _g, slug in ctx.resolve_runtimes(repo):
+            retro_entries.extend(_tagged(cfg.retrospectives_path, slug))
+            telemetry_entries.extend(_tagged(cfg.cost_inferences_path, slug))
+        # The union spans per-repo append-only files; the health windows are
+        # positional (no timestamp sort downstream), so order by each entry's
+        # timestamp to restore a chronological view — "recent N" then means
+        # recent across all repos, not just the last file read.
+        retro_entries.sort(key=lambda e: str(e.get("timestamp", "")))
+        telemetry_entries.sort(key=lambda e: str(e.get("timestamp", "")))
         return compute_summary(retro_entries, telemetry_entries)
 
     return router

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -1757,7 +1757,7 @@ def create_router(
     # --- Factory health routes (longitudinal retrospective analysis) ---
     from dashboard_routes._factory_health_routes import build_factory_health_router
 
-    router.include_router(build_factory_health_router(config))
+    router.include_router(build_factory_health_router(config, ctx))
 
     # --- Issue history cache ---
     # Cache the aggregated issue_rows + pr_to_issue for the unfiltered case.

--- a/src/factory_health.py
+++ b/src/factory_health.py
@@ -101,23 +101,30 @@ def compute_cohorts(
 ) -> dict[str, dict[str, Any]]:
     """Split retrospective entries into memory-available and memory-unavailable cohorts.
 
-    Joins on ``issue_number``. An issue is "memory available" if any
-    matching telemetry record has ``context_chars_before > 0``.
+    Joins on ``(repo, issue_number)``. An issue is "memory available" if any
+    matching telemetry record has ``context_chars_before > 0``. The ``repo`` key
+    keeps the join correct when entries are unioned across repos (issue numbers
+    collide — every repo numbers from 1); single-repo entries carry no ``repo``
+    tag (``None``), so they key uniformly and behave exactly as before.
     """
-    # Build lookup: issue_number → max context_chars_before
-    context_by_issue: dict[int, int] = {}
+    # Build lookup: (repo, issue_number) → max context_chars_before
+    context_by_issue: dict[tuple[Any, int], int] = {}
     for t in telemetry_entries:
         issue = t.get("issue_number")
         chars = t.get("context_chars_before", 0)
         if isinstance(issue, int) and isinstance(chars, int | float):
-            context_by_issue[issue] = max(context_by_issue.get(issue, 0), int(chars))
+            key = (t.get("repo"), issue)
+            context_by_issue[key] = max(context_by_issue.get(key, 0), int(chars))
 
     available: list[dict[str, Any]] = []
     unavailable: list[dict[str, Any]] = []
 
     for entry in retro_entries:
         issue = entry.get("issue_number")
-        if isinstance(issue, int) and context_by_issue.get(issue, 0) > 0:
+        if (
+            isinstance(issue, int)
+            and context_by_issue.get((entry.get("repo"), issue), 0) > 0
+        ):
             available.append(entry)
         else:
             unavailable.append(entry)

--- a/src/ui/src/components/diagnostics/FactoryHealthSection.jsx
+++ b/src/ui/src/components/diagnostics/FactoryHealthSection.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 
 /**
  * Inline SVG sparkline — renders a polyline from an array of numeric values.
@@ -133,13 +134,14 @@ function RegressionAlerts({ regressions }) {
 }
 
 export function FactoryHealthSection() {
+  const { fetchWithRepo, selectedRepoSlug } = useHydraFlow()
   const [data, setData] = useState(null)
   const [loading, setLoading] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    fetch('/api/factory-health/summary')
+    fetchWithRepo('/api/factory-health/summary')
       .then((r) => r.json())
       .then((d) => {
         if (!cancelled) setData(d)
@@ -151,7 +153,7 @@ export function FactoryHealthSection() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [selectedRepoSlug, fetchWithRepo])
 
   if (loading && !data) {
     return <div style={styles.loading}>Loading factory health…</div>

--- a/src/ui/src/components/diagnostics/__tests__/FactoryHealthSection.test.jsx
+++ b/src/ui/src/components/diagnostics/__tests__/FactoryHealthSection.test.jsx
@@ -1,11 +1,32 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// `ctx.selectedRepoSlug` is mutable per-test. `fetchWithRepo` is a STABLE
+// hoisted reference (like the real useCallback-memoized fetcher) so the effect
+// that depends on it does not re-render-loop. It mirrors applyRepoParam and
+// delegates to the per-test `global.fetch` stub.
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
+
 import { FactoryHealthSection } from '../FactoryHealthSection'
 
 describe('FactoryHealthSection', () => {
   let originalFetch
   beforeEach(() => {
     originalFetch = global.fetch
+    ctx.selectedRepoSlug = null
   })
   afterEach(() => {
     global.fetch = originalFetch
@@ -18,9 +39,23 @@ describe('FactoryHealthSection', () => {
     })
     const { container } = render(<FactoryHealthSection />)
     // Wait one microtask for the fetch promise + setData re-render to settle.
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
     // Component must not throw. It should render nothing (loading disappears, no data shape → null).
     // A narrow behavioural assertion: no "Factory Health Trends" heading, no crash.
     expect(container.textContent).not.toMatch(/Factory Health Trends/)
+  })
+
+  it('fetches health scoped to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    render(<FactoryHealthSection />)
+    // The repo slug must reach fetch — proving the data path
+    // component → fetchWithRepo → repo param → network.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/factory-health/summary?repo=org-x',
+        undefined,
+      )
+    })
   })
 })

--- a/tests/test_factory_health_multirepo.py
+++ b/tests/test_factory_health_multirepo.py
@@ -1,0 +1,185 @@
+"""Factory-health summary aggregates across repos (Phase 3c-3).
+
+``/api/factory-health/summary`` reads each repo's (D2-scoped) retrospective +
+telemetry stores. ``repo=__all__`` unions every repo (sorting the merged
+entries by timestamp so the positional health windows stay chronological); a
+specific slug scopes to that repo. The router is wired with ``ctx`` via
+``make_dashboard_router(registry=...)``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from config import HydraFlowConfig
+from route_types import REPO_ALL
+from tests.conftest import make_state
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+def _retro(issue: int, ts: str) -> dict:
+    return {
+        "issue_number": issue,
+        "pr_number": issue,
+        "timestamp": ts,
+        "plan_accuracy_pct": 90.0,
+        "planned_files": [],
+        "actual_files": [],
+        "unplanned_files": [],
+        "missed_files": [],
+        "quality_fix_rounds": 1,
+        "review_verdict": "approve",
+        "reviewer_fixes_made": 0,
+        "ci_fix_rounds": 0,
+        "duration_seconds": 100.0,
+    }
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _repo_config(tmp_path: Path, name: str) -> HydraFlowConfig:
+    repo_root = tmp_path / name / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=repo_root, repo=f"org/{name}")
+
+
+def _two_repo_router(tmp_path, event_bus, state, config, *, seed_a, seed_b):
+    cfg_a = _repo_config(tmp_path, "a")
+    cfg_b = _repo_config(tmp_path, "b")
+    seed_a(cfg_a)
+    seed_b(cfg_b)
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": cfg_a,
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+        {
+            "slug": "org-b",
+            "config": cfg_b,
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "orchestrator": None,
+        },
+    )
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry, default_repo_slug="org-a"
+    )
+    return router
+
+
+def _cohort_total(summary: dict) -> int:
+    cohorts = summary["cohorts"]
+    return cohorts["memory_available"]["count"] + cohorts["memory_unavailable"]["count"]
+
+
+def test_factory_health_unions_retros_across_repos(config, event_bus, state, tmp_path):
+    router = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _write_jsonl(
+            c.retrospectives_path, [_retro(1, "2026-06-08T01:00:00Z")]
+        ),
+        seed_b=lambda c: _write_jsonl(
+            c.retrospectives_path, [_retro(2, "2026-06-08T02:00:00Z")]
+        ),
+    )
+    summary = find_endpoint(router, "/api/factory-health/summary")
+    body = summary(repo=REPO_ALL)
+    # Both repos' retrospectives are folded into the aggregate cohorts.
+    assert _cohort_total(body) == 2
+
+
+def test_factory_health_scopes_to_one_repo(config, event_bus, state, tmp_path):
+    router = _two_repo_router(
+        tmp_path,
+        event_bus,
+        state,
+        config,
+        seed_a=lambda c: _write_jsonl(
+            c.retrospectives_path, [_retro(1, "2026-06-08T01:00:00Z")]
+        ),
+        seed_b=lambda c: _write_jsonl(
+            c.retrospectives_path,
+            [_retro(2, "2026-06-08T02:00:00Z"), _retro(3, "2026-06-08T03:00:00Z")],
+        ),
+    )
+    summary = find_endpoint(router, "/api/factory-health/summary")
+    assert _cohort_total(summary(repo="org-a")) == 1
+    assert _cohort_total(summary(repo="org-b")) == 2
+
+
+def test_factory_health_memory_cohort_uses_each_repos_telemetry(
+    config, event_bus, state, tmp_path
+):
+    # org-a's issue has telemetry with context → memory_available; org-b's has
+    # none → memory_unavailable. The union must read EACH repo's telemetry.
+    def seed_a(c):
+        _write_jsonl(c.retrospectives_path, [_retro(1, "2026-06-08T01:00:00Z")])
+        _write_jsonl(
+            c.cost_inferences_path,
+            [
+                {
+                    "issue_number": 1,
+                    "context_chars_before": 500,
+                    "timestamp": "2026-06-08T00:59:00Z",
+                }
+            ],
+        )
+
+    def seed_b(c):
+        _write_jsonl(c.retrospectives_path, [_retro(2, "2026-06-08T02:00:00Z")])
+
+    router = _two_repo_router(
+        tmp_path, event_bus, state, config, seed_a=seed_a, seed_b=seed_b
+    )
+    summary = find_endpoint(router, "/api/factory-health/summary")
+    body = summary(repo=REPO_ALL)
+    assert body["cohorts"]["memory_available"]["count"] == 1
+    assert body["cohorts"]["memory_unavailable"]["count"] == 1
+
+
+def test_factory_health_cohort_join_does_not_cross_repos(
+    config, event_bus, state, tmp_path
+):
+    # Both repos own issue #1 (every repo numbers from 1). org-a has memory
+    # telemetry for #1; org-b does not. org-b's #1 must NOT be marked
+    # memory-available by org-a's telemetry — the join is keyed on (repo, issue).
+    def seed_a(c):
+        _write_jsonl(c.retrospectives_path, [_retro(1, "2026-06-08T01:00:00Z")])
+        _write_jsonl(
+            c.cost_inferences_path,
+            [
+                {
+                    "issue_number": 1,
+                    "context_chars_before": 500,
+                    "timestamp": "2026-06-08T00:59:00Z",
+                }
+            ],
+        )
+
+    def seed_b(c):
+        _write_jsonl(c.retrospectives_path, [_retro(1, "2026-06-08T02:00:00Z")])
+
+    router = _two_repo_router(
+        tmp_path, event_bus, state, config, seed_a=seed_a, seed_b=seed_b
+    )
+    summary = find_endpoint(router, "/api/factory-health/summary")
+    body = summary(repo=REPO_ALL)
+    assert body["cohorts"]["memory_available"]["count"] == 1
+    assert body["cohorts"]["memory_unavailable"]["count"] == 1


### PR DESCRIPTION
## What

Phase **3c-3** of the multi-repo dashboard scoping program: the Diagnostics **Factory Health** panel (Overview tab) now aggregates across repos.

`build_factory_health_router(config, ctx=None)` gains an optional `RouteContext`. `/api/factory-health/summary` honors a `repo` param: with `ctx`, **`repo=__all__`** unions every repo's D2-scoped retrospective + telemetry stores, a concrete slug scopes to that repo, and `None` resolves the default. **`ctx is None`** keeps the bare single-repo path (existing route tests call `build_factory_health_router(config)` directly — untouched).

## Chronological union

The merged entries are **sorted by `timestamp`** before `compute_summary` — the rolling-average and regression windows are *positional* (no downstream sort), so chronological ordering keeps "recent N" meaning recent **across all repos**, not just the last file read.

## Cross-repo correctness fix (found in review)

`compute_cohorts`' telemetry→retrospective memory-cohort join now keys on **`(repo, issue_number)`**, not bare `issue_number`. Every repo numbers issues from 1, so under `__all__` a naive join would let org-a's issue #5 telemetry mark **org-b's** issue #5 as memory-available. Entries are tagged with their owning repo slug at union time; single-repo entries carry no tag (`None`) and key uniformly, so the single-repo path is unchanged. A regression test (`test_factory_health_cohort_join_does_not_cross_repos`) covers the same-issue-number-across-repos case.

## Frontend

`FactoryHealthSection` reads through the repo-aware `fetchWithRepo` and re-fetches on repo change (deps `[selectedRepoSlug, fetchWithRepo]`).

## Deferred to Phase 3c-4 (noted in-code)

`/auto-agent` + `AutoAgentStats` — its `audit.jsonl` store sits at the **shared** `data_root` with **no `repo` field**, so making it repo-aware needs a writer + data-layout migration (D2-style), not a read-side merge. That's a distinct, meatier slice.

## Tests

- `tests/test_factory_health_multirepo.py` — **real** `ConfigFactory` configs seeded with retro+telemetry: cross-repo union, single-repo scoping, per-repo telemetry attribution, and the **cohort-collision guard**.
- `FactoryHealthSection` frontend — repo param reaches `fetch`. The `fetchWithRepo` mock is a stable hoisted ref mirroring the real memoized fetcher (avoids the re-render-loop OOM seen in a prior slice).

## Verification

- `make quality` ✅ 15870 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- UI `vitest` ✅ 1106 passed · `npm run build` ✅
- Adversarial fresh-eyes review — caught the cross-repo cohort-collision bug (now fixed + regression-tested) and a test sentinel-fidelity nit (`"approved"`→`"approve"`, applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)