### PR TITLE
fix(loops): auto-close CostBudget + Diagram issues on recovery (#9359)

### DIFF
--- a/src/cost_budget_watcher_loop.py
+++ b/src/cost_budget_watcher_loop.py
@@ -145,6 +145,10 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
                 "killed_count": len(killed),
             }
 
+        # Under cap — close the open cap-exceeded issue (fulfilling the promise
+        # in its body) so a recovered budget doesn't leave a stale issue (#9359).
+        await self._close_issue_if_open(cap=cap, total=total)
+
         if previously_killed:
             await self._reenable_caretakers(previously_killed)
             return {
@@ -218,3 +222,15 @@ class CostBudgetWatcherLoop(BaseBackgroundLoop):
             body=body,
             labels=["hydraflow-find", "cost-budget"],
         )
+
+    async def _close_issue_if_open(self, *, cap: float, total: float) -> None:
+        """Close the open cap-exceeded issue when spend recovers under cap."""
+        existing = await self._pr_manager.find_existing_issue(_ISSUE_TITLE)
+        if not existing:
+            return
+        await self._pr_manager.post_comment(
+            existing,
+            f"Rolling-24h spend (${total:.2f}) is back under the cap "
+            f"(${cap:.2f}) — caretakers re-enabled, auto-closing.",
+        )
+        await self._pr_manager.close_issue(existing)

--- a/src/diagram_loop.py
+++ b/src/diagram_loop.py
@@ -217,6 +217,19 @@ class DiagramLoop(BaseBackgroundLoop):
     async def _ensure_coverage_issue(self) -> None:
         items = await self._unassigned_items()
         if not items["loops"] and not items["ports"]:
+            # Resolved — every loop/port is now assigned to a functional area.
+            # Close the open coverage issue if one exists (#9359 issue-hygiene)
+            # rather than leaving it stale forever.
+            open_number = await self._pr_manager.find_existing_issue(
+                _COVERAGE_ISSUE_TITLE
+            )
+            if open_number:
+                await self._pr_manager.post_comment(
+                    open_number,
+                    "All loops/ports are now assigned to a functional area — "
+                    "auto-closing.",
+                )
+                await self._pr_manager.close_issue(open_number)
             return
         existing_number = await self._pr_manager.find_existing_issue(
             _COVERAGE_ISSUE_TITLE

--- a/tests/test_cost_budget_watcher_scenario.py
+++ b/tests/test_cost_budget_watcher_scenario.py
@@ -164,3 +164,25 @@ async def test_kill_switch_short_circuits(monkeypatch: pytest.MonkeyPatch) -> No
     assert result == {"skipped": "kill_switch"}
     mock_rolling.assert_not_called()
     bg.set_enabled.assert_not_called()
+
+
+async def test_recovery_closes_open_cost_issue() -> None:
+    """#9359: spend back under cap → the open cap-exceeded issue auto-closes."""
+    loop, bg, pr, state = _build_loop(cap=10.0)
+    pr.find_existing_issue = AsyncMock(return_value=77)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_rolling:
+        mock_rolling.return_value = {"total": {"cost_usd": 3.0}}
+        result = await loop._do_work()
+    assert result["action"] == "ok"
+    pr.close_issue.assert_awaited_once_with(77)
+    pr.post_comment.assert_awaited_once()
+
+
+async def test_under_cap_no_close_when_no_open_issue() -> None:
+    """Under cap with no open issue → no close attempt."""
+    loop, bg, pr, state = _build_loop(cap=10.0)
+    pr.find_existing_issue = AsyncMock(return_value=0)
+    with patch("cost_budget_watcher_loop.build_rolling_24h") as mock_rolling:
+        mock_rolling.return_value = {"total": {"cost_usd": 3.0}}
+        await loop._do_work()
+    pr.close_issue.assert_not_awaited()

--- a/tests/test_diagram_loop.py
+++ b/tests/test_diagram_loop.py
@@ -112,3 +112,40 @@ async def test_regen_pr_uses_config_base_branch_staging(
     monkeypatch.setattr(_auto_pr_mod, "open_automated_pr_async", intercept)
     await loop._open_or_update_regen_pr(["M docs/arch/generated/loops.md"])
     assert captured["base"] == "staging"
+
+
+@pytest.mark.asyncio
+async def test_coverage_issue_auto_closes_when_all_assigned(loop_deps, monkeypatch):
+    """#9359: when no loops/ports are unassigned, the open coverage issue closes."""
+    pr_manager = MagicMock()
+    pr_manager.find_existing_issue = AsyncMock(return_value=55)
+    pr_manager.post_comment = AsyncMock()
+    pr_manager.close_issue = AsyncMock()
+    pr_manager.create_issue = AsyncMock(return_value=0)
+    loop = DiagramLoop(config=MagicMock(), pr_manager=pr_manager, deps=loop_deps)
+
+    monkeypatch.setattr(
+        loop, "_unassigned_items", AsyncMock(return_value={"loops": [], "ports": []})
+    )
+    await loop._ensure_coverage_issue()
+
+    pr_manager.close_issue.assert_awaited_once_with(55)
+    pr_manager.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_coverage_issue_noop_when_resolved_and_none_open(loop_deps, monkeypatch):
+    """All assigned AND no open issue → nothing closed, nothing filed."""
+    pr_manager = MagicMock()
+    pr_manager.find_existing_issue = AsyncMock(return_value=0)
+    pr_manager.close_issue = AsyncMock()
+    pr_manager.create_issue = AsyncMock(return_value=0)
+    loop = DiagramLoop(config=MagicMock(), pr_manager=pr_manager, deps=loop_deps)
+
+    monkeypatch.setattr(
+        loop, "_unassigned_items", AsyncMock(return_value={"loops": [], "ports": []})
+    )
+    await loop._ensure_coverage_issue()
+
+    pr_manager.close_issue.assert_not_awaited()
+    pr_manager.create_issue.assert_not_awaited()


### PR DESCRIPTION
Tier-3 of the issue-filing-loop audit (PR #9368 established the pattern). Both loops file a single stable-title find-issue when a condition is bad but **never closed it on recovery** — the dominant backlog driver.

- **CostBudgetWatcherLoop** — when rolling-24h spend drops back under the cap, close the open `[cost-budget] daily cap exceeded` issue with a recovery comment (the issue body *already promised* this auto-close).
- **DiagramLoop** — when every loop/port is assigned to a functional area, close the open `unassigned functional area` coverage issue.

Both use the minimal `find_existing_issue` + `close_issue` (single stable-title issue, **no DedupStore to reconcile** → zero risk of suppressing future issues).

**Verification:** 4 new tests (recovery-closes + no-op-when-none-open); `make quality` **15883 passed**; `make scenario` + `make scenario-loops` green.

Next batches: GateActivator/BranchProtection (variable title / DedupStore-clear-on-resolve) → per-subject loops (FlakeTracker `resolve_all_except`, SecurityPatch, PrinciplesAudit). StagingBisect needs human sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)