### PR TITLE
feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T00:49:30.881730+00:00",
-  "commit_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e",
+  "regenerated_at": "2026-06-09T02:31:06.937013+00:00",
+  "commit_sha": "0be9dbc564f8dbca639911ed57298144c9c439da",
   "artifacts": {
     "loops.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "ports.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "labels.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "modules.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "events.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "adr_xref.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "mockworld.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "changelog.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "coverage_matrix.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "functional_areas.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "ubiquitous-language.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "6eb3eafd81b9110a31e67472f16b2f94d23da43e"
+      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `6eb3eaf` — feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3) *(2026-06-08)*
+- `0be9dbc` — feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3) (#9369) (#9369) *(2026-06-08)*
+- `98b2773` — feat(loops): RollupIssueManager + migrate StagingPromotionLoop to auto-close (#9359) (#9368) (#9368) *(2026-06-08)*
 - `ec58ffb` — feat(diagnostics): Factory Cost rollup endpoints aggregate across repos (Phase 3c-2) (#9367) (#9367) *(2026-06-08)*
 - `b5c9aa6` — feat(diagnostics): factory-metrics endpoints aggregate across repos (Phase 3c-1) (#9366) (#9366) *(2026-06-08)*
 - `b207b54` — feat(system): target the selected repo for bg-worker controls (Phase 3b-fe) (#9363) (#9363) *(2026-06-08)*

--- a/src/auto_agent_preflight_loop.py
+++ b/src/auto_agent_preflight_loop.py
@@ -166,7 +166,11 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
         )
         if denied is not None:
             await self._prs.add_labels(issue_number, ["human-required"])
-            self._audit_store.append(_skip_audit(issue_number, denied, "deny_list"))
+            self._audit_store.append(
+                _skip_audit(
+                    issue_number, denied, "deny_list", repo=self._config.repo_slug
+                )
+            )
             return {"status": "skipped_deny_list"}
 
         # Attempt-cap check.
@@ -233,6 +237,7 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
                 pr_url=result.pr_url,
                 diagnosis=result.diagnosis,
                 llm_summary=result.diagnosis[:500],
+                repo=self._config.repo_slug,
             )
         )
 
@@ -298,7 +303,7 @@ class AutoAgentPreflightLoop(BaseBackgroundLoop):
             return str(self._config.repo_root)
 
 
-def _skip_audit(issue: int, sub_label: str, reason: str):
+def _skip_audit(issue: int, sub_label: str, reason: str, repo: str = ""):
     from preflight.audit import PreflightAuditEntry
 
     return PreflightAuditEntry(
@@ -314,4 +319,5 @@ def _skip_audit(issue: int, sub_label: str, reason: str):
         pr_url=None,
         diagnosis=f"skipped: {reason}",
         llm_summary=f"skipped: {reason}",
+        repo=repo,
     )

--- a/src/dashboard_routes/_diagnostics_routes.py
+++ b/src/dashboard_routes/_diagnostics_routes.py
@@ -404,10 +404,22 @@ def build_diagnostics_router(
     # Repo-aware (Phase 3c-2): with ``ctx`` each endpoint builds per repo over
     # ``resolve_runtimes(repo)`` and folds the results (group-by-sum on the
     # phase/loop/model dimensions; per-issue rows carry a repo tag). ``ctx is
-    # None`` keeps the bare single-repo builder. NOTE: ``/auto-agent`` (Overview
-    # tab) is NOT yet repo-scoped — deferred to 3c-4 (its audit.jsonl store is
-    # at the shared data_root with no repo field, so it needs a data-layout
-    # migration, not just a read-side merge like factory-health got in 3c-3).
+    # None`` keeps the bare single-repo builder. ``/auto-agent`` (Phase 3c-4)
+    # reads ONE shared audit.jsonl and filters by each entry's ``repo`` stamp
+    # rather than unioning per-repo files.
+
+    def _audit_repos(repo: str | None) -> frozenset[str] | None:
+        """Acceptable ``entry.repo`` values for the requested scope (``None`` =
+        every repo). Legacy entries (``repo == ""``) were written by the single
+        pre-multi-repo host, so they fold into the host/default repo's scope.
+        """
+        if ctx is None:
+            return None
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return None
+        default = ctx.resolve_runtimes(None)[0][4]
+        slug = default if repo is None else ctx.resolve_runtimes(repo)[0][4]
+        return frozenset({slug, ""}) if slug == default else frozenset({slug})
 
     @router.get("/cost/rolling-24h")
     def cost_rolling_24h(repo: RepoSlugParam = None) -> dict[str, Any]:
@@ -506,14 +518,21 @@ def build_diagnostics_router(
         )
 
     @router.get("/auto-agent")
-    def auto_agent_stats() -> dict[str, Any]:
-        """Auto-agent dashboard payload (spec §6.2)."""
+    def auto_agent_stats(repo: RepoSlugParam = None) -> dict[str, Any]:
+        """Auto-agent dashboard payload (spec §6.2).
+
+        The preflight audit is ONE shared JSONL whose rows carry a ``repo``
+        stamp, so scoping filters by that stamp rather than unioning per-repo
+        files: ``repo=__all__`` keeps every row, a slug (or the default repo)
+        keeps its rows plus legacy unattributed rows for the host.
+        """
         from preflight.audit import PreflightAuditStore  # noqa: PLC0415
 
+        repos = _audit_repos(repo)
         audit = PreflightAuditStore(config.data_root)
-        today = audit.query_24h()
-        week = audit.query_7d()
-        top = audit.top_spend(n=5)
+        today = audit.query_24h(repos)
+        week = audit.query_7d(repos)
+        top = audit.top_spend(n=5, repos=repos)
         return {
             "today": _stats_payload(today),
             "last_7d": _stats_payload(week),

--- a/src/preflight/audit.py
+++ b/src/preflight/audit.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -24,6 +24,10 @@ class PreflightAuditEntry:
     pr_url: str | None
     diagnosis: str
     llm_summary: str
+    # Owning repo (dash slug), stamped by the preflight loop's config. Defaults
+    # to "" so rows written before multi-repo attribution stay readable; such
+    # legacy entries are attributed to the host/default repo on read.
+    repo: str = ""
 
 
 @dataclass(frozen=True)
@@ -52,6 +56,7 @@ class PreflightAuditStore:
     def _read_all(self) -> list[PreflightAuditEntry]:
         if not self._path.exists():
             return []
+        known = {f.name for f in fields(PreflightAuditEntry)}
         out: list[PreflightAuditEntry] = []
         with self._path.open("r", encoding="utf-8") as fh:
             for line in fh:
@@ -59,27 +64,40 @@ class PreflightAuditStore:
                 if not stripped:
                     continue
                 row = json.loads(stripped)
-                out.append(PreflightAuditEntry(**row))
+                # Tolerate forward-compat rows: drop keys this version doesn't
+                # know so a future writer field can't crash older readers.
+                # Missing keys still fall back to dataclass defaults (e.g. repo).
+                out.append(
+                    PreflightAuditEntry(**{k: v for k, v in row.items() if k in known})
+                )
         return out
 
-    def query_window(self, since: datetime) -> AuditWindowStats:
+    def query_window(
+        self, since: datetime, repos: frozenset[str] | None = None
+    ) -> AuditWindowStats:
         entries = [
             e
             for e in self._read_all()
-            if datetime.fromisoformat(e.ts.replace("Z", "+00:00")) >= since
+            if (repos is None or e.repo in repos)
+            and datetime.fromisoformat(e.ts.replace("Z", "+00:00")) >= since
         ]
         return _compute_window(entries)
 
-    def query_24h(self) -> AuditWindowStats:
-        return self.query_window(datetime.now(UTC) - timedelta(hours=24))
+    def query_24h(self, repos: frozenset[str] | None = None) -> AuditWindowStats:
+        return self.query_window(datetime.now(UTC) - timedelta(hours=24), repos)
 
-    def query_7d(self) -> AuditWindowStats:
-        return self.query_window(datetime.now(UTC) - timedelta(days=7))
+    def query_7d(self, repos: frozenset[str] | None = None) -> AuditWindowStats:
+        return self.query_window(datetime.now(UTC) - timedelta(days=7), repos)
 
     def top_spend(
-        self, n: int = 5, since: datetime | None = None
+        self,
+        n: int = 5,
+        since: datetime | None = None,
+        repos: frozenset[str] | None = None,
     ) -> list[PreflightAuditEntry]:
         entries = self._read_all()
+        if repos is not None:
+            entries = [e for e in entries if e.repo in repos]
         if since is not None:
             entries = [
                 e

--- a/src/ui/src/components/diagnostics/AutoAgentStats.jsx
+++ b/src/ui/src/components/diagnostics/AutoAgentStats.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 
 export function AutoAgentStats() {
+  const { fetchWithRepo, selectedRepoSlug } = useHydraFlow()
   const [data, setData] = useState(null)
   const [error, setError] = useState(null)
 
@@ -9,10 +11,13 @@ export function AutoAgentStats() {
     let cancelled = false
     const fetchStats = async () => {
       try {
-        const res = await fetch('/api/diagnostics/auto-agent')
+        const res = await fetchWithRepo('/api/diagnostics/auto-agent')
         if (!res.ok) throw new Error(`HTTP ${res.status}`)
         const json = await res.json()
-        if (!cancelled) setData(json)
+        if (!cancelled) {
+          setData(json)
+          setError(null)
+        }
       } catch (e) {
         if (!cancelled) setError(String(e))
       }
@@ -23,7 +28,7 @@ export function AutoAgentStats() {
       cancelled = true
       clearInterval(t)
     }
-  }, [])
+  }, [selectedRepoSlug, fetchWithRepo])
 
   if (error) {
     return (

--- a/src/ui/src/components/diagnostics/__tests__/AutoAgentStats.test.jsx
+++ b/src/ui/src/components/diagnostics/__tests__/AutoAgentStats.test.jsx
@@ -1,6 +1,25 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
+// `ctx.selectedRepoSlug` is mutable per-test. `fetchWithRepo` is a STABLE
+// hoisted reference (like the real useCallback-memoized fetcher) so the polling
+// effect that depends on it does not re-render-loop. It mirrors applyRepoParam
+// and delegates to the per-test `global.fetch` stub.
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
+
 const MOCK_DATA = {
   today: {
     spend_usd: 1.23,
@@ -38,6 +57,7 @@ global.fetch = vi.fn()
 
 beforeEach(() => {
   vi.clearAllMocks()
+  ctx.selectedRepoSlug = null
 })
 
 import { AutoAgentStats } from '../AutoAgentStats'
@@ -110,5 +130,19 @@ describe('AutoAgentStats', () => {
       expect(screen.getByTestId('auto-agent-stats')).toBeInTheDocument()
     })
     expect(screen.queryByTestId('auto-agent-top-spend')).not.toBeInTheDocument()
+  })
+
+  it('scopes the auto-agent fetch to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    global.fetch.mockResolvedValue({ ok: true, json: () => Promise.resolve(MOCK_DATA) })
+    render(<AutoAgentStats />)
+    // The repo slug must reach fetch — proving the data path
+    // component → fetchWithRepo → repo param → network.
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/diagnostics/auto-agent?repo=org-x',
+        undefined,
+      )
+    })
   })
 })

--- a/tests/test_diagnostics_auto_agent_multirepo.py
+++ b/tests/test_diagnostics_auto_agent_multirepo.py
@@ -1,0 +1,124 @@
+"""Auto-agent stats scope by repo (Phase 3c-4).
+
+Unlike the cost/health endpoints, the preflight audit is ONE shared
+``auto_agent/audit.jsonl`` whose rows carry a ``repo`` stamp. So
+``/api/diagnostics/auto-agent`` filters by that stamp rather than unioning
+per-repo files: ``repo=__all__`` keeps every row, a slug (or the default repo)
+keeps its rows plus legacy unattributed (``repo == ""``) rows for the host.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from config import HydraFlowConfig
+from preflight.audit import PreflightAuditStore
+from route_types import REPO_ALL
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+
+
+def _recent() -> str:
+    return (datetime.now(UTC) - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+
+
+def _entry(issue: int, repo: str, cost: float) -> dict:
+    return {
+        "ts": _recent(),
+        "issue": issue,
+        "sub_label": "hydraflow-ready",
+        "attempt_n": 1,
+        "prompt_hash": "",
+        "cost_usd": cost,
+        "wall_clock_s": 1.0,
+        "tokens": 10,
+        "status": "resolved",
+        "pr_url": None,
+        "diagnosis": "",
+        "llm_summary": "",
+        "repo": repo,
+    }
+
+
+def _seed_audit(config: HydraFlowConfig, entries: list[dict]) -> None:
+    path = config.data_root / "auto_agent" / "audit.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+def _router(config, event_bus, state, tmp_path):
+    registry = make_registry({"slug": "org-a"}, {"slug": "org-b"})
+    router, _ = make_dashboard_router(
+        config, event_bus, state, tmp_path, registry=registry, default_repo_slug="org-a"
+    )
+    return find_endpoint(router, "/api/diagnostics/auto-agent")
+
+
+# 2 org-a rows, 1 org-b row, 1 legacy (pre-multi-repo, unattributed).
+_ENTRIES = [
+    _entry(1, "org-a", 1.0),
+    _entry(2, "org-a", 2.0),
+    _entry(3, "org-b", 3.0),
+    _entry(4, "", 4.0),
+]
+
+
+def test_auto_agent_all_repos_counts_every_row(config, event_bus, state, tmp_path):
+    _seed_audit(config, _ENTRIES)
+    auto_agent = _router(config, event_bus, state, tmp_path)
+    body = auto_agent(repo=REPO_ALL)
+    assert body["today"]["attempts"] == 4
+
+
+def test_auto_agent_default_repo_includes_legacy_host_rows(
+    config, event_bus, state, tmp_path
+):
+    _seed_audit(config, _ENTRIES)
+    auto_agent = _router(config, event_bus, state, tmp_path)
+    # Default (org-a) → its 2 rows + the legacy unattributed row (host).
+    assert auto_agent(repo=None)["today"]["attempts"] == 3
+    assert auto_agent(repo="org-a")["today"]["attempts"] == 3
+
+
+def test_auto_agent_non_default_repo_excludes_legacy(
+    config, event_bus, state, tmp_path
+):
+    _seed_audit(config, _ENTRIES)
+    auto_agent = _router(config, event_bus, state, tmp_path)
+    # org-b is not the host → only its own row, no legacy.
+    body = auto_agent(repo="org-b")
+    assert body["today"]["attempts"] == 1
+    assert body["top_spend"][0]["issue"] == 3
+
+
+def test_auto_agent_legacy_only_single_repo(config, event_bus, state, tmp_path):
+    # A pre-3c-4 store (all rows unattributed) still shows under the host/default.
+    _seed_audit(config, [_entry(1, "", 1.0), _entry(2, "", 2.0)])
+    auto_agent = _router(config, event_bus, state, tmp_path)
+    assert auto_agent(repo=None)["today"]["attempts"] == 2
+    assert auto_agent(repo=REPO_ALL)["today"]["attempts"] == 2
+
+
+def test_store_repos_filter(tmp_path):
+    # Store-level: repos=None keeps all; a frozenset keeps only those repos.
+    cfg_root = tmp_path / "data"
+    store = PreflightAuditStore(cfg_root)
+    (cfg_root / "auto_agent").mkdir(parents=True, exist_ok=True)
+    (cfg_root / "auto_agent" / "audit.jsonl").write_text(
+        "\n".join(json.dumps(e) for e in _ENTRIES) + "\n"
+    )
+    assert store.query_24h().attempts == 4
+    assert store.query_24h(frozenset({"org-a", ""})).attempts == 3
+    assert store.query_24h(frozenset({"org-b"})).attempts == 1
+
+
+def test_store_tolerates_forward_compat_extra_keys(tmp_path):
+    # A row written by a future version with an unknown field must not crash the
+    # reader — unknown keys are dropped, missing keys fall back to defaults.
+    cfg_root = tmp_path / "data"
+    (cfg_root / "auto_agent").mkdir(parents=True, exist_ok=True)
+    row = _entry(1, "org-a", 1.0)
+    row["future_field"] = "ignored"
+    (cfg_root / "auto_agent" / "audit.jsonl").write_text(json.dumps(row) + "\n")
+    store = PreflightAuditStore(cfg_root)
+    assert store.query_24h().attempts == 1


### PR DESCRIPTION
## What

Phase **3c-4** — the final Diagnostics panel goes repo-aware: **auto-agent stats** (`/api/diagnostics/auto-agent`). This completes the Diagnostics tab's multi-repo scoping.

Unlike cost/health (per-repo D2 files), the preflight audit is **one shared** `<data_root>/auto_agent/audit.jsonl`. Per your chosen approach, rather than a data-layout migration, each row now carries a **`repo` stamp** and the read side filters by it.

## Writer

`PreflightAuditEntry` gains a `repo: str = ""` field; `AutoAgentPreflightLoop` stamps `repo=self._config.repo_slug` on both the main append and the deny-list skip entry.

## Read

`PreflightAuditStore.query_window/query_24h/query_7d/top_spend` gain an optional `repos: frozenset[str] | None` filter (None = all). `auto_agent_stats(repo)` resolves that set:
- **`__all__`** → all rows
- **concrete slug / default repo** → that slug's rows
- **legacy rows** (`repo == ""`, written before this change by the single pre-multi-repo host) → folded into the **host/default** repo's scope and into `__all__`; a **non-default** repo excludes them
- **`ctx is None`** (single-repo installs) → unfiltered

## Hardening (from review)

`_read_all` now drops unknown keys before constructing the frozen dataclass, so a **future writer field can't crash older readers** (missing keys still fall back to defaults).

## Frontend

`AutoAgentStats` reads through `fetchWithRepo` and re-fetches on repo change (deps `[selectedRepoSlug, fetchWithRepo]`), keeping its 30s poll.

## Scope notes (from review)

- The preflight **runner's** `gather_context`/`run_preflight` still pass `repo_slug=""` — that's the *agent execution context* (wiki lookups), separate from these stats, and a **pre-existing** gap left for a follow-up.
- An **unregistered** slug degrades to the default repo, **consistent** with the other repo-scoped endpoints' `resolve_runtimes` fallback (the frontend only ever sends a valid slug or `__all__`).

## Tests

`tests/test_diagnostics_auto_agent_multirepo.py` — shared-file repo-stamp filtering: `__all__`, default-includes-legacy-host, non-default-excludes-legacy, legacy-only single repo, store-level filter, and the forward-compat extra-key row. `AutoAgentStats` frontend repo-param test (stable hoisted mock).

## Verification

- `make quality` ✅ 15886 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- UI `vitest` ✅ 1107 passed · `npm run build` ✅
- Adversarial fresh-eyes review — core confirmed correct; one hardening (unknown-key tolerance) applied, two findings documented as pre-existing/out-of-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)