### PR TITLE
feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T02:31:06.937013+00:00",
-  "commit_sha": "0be9dbc564f8dbca639911ed57298144c9c439da",
+  "regenerated_at": "2026-06-09T03:44:27.714130+00:00",
+  "commit_sha": "782dc5880b52220e53f2d1334b8a0885439b4945",
   "artifacts": {
     "loops.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "ports.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "labels.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "modules.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "events.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "adr_xref.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "mockworld.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "changelog.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "coverage_matrix.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "functional_areas.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "ubiquitous-language.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "0be9dbc564f8dbca639911ed57298144c9c439da"
+      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `91b6227` — feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4) (#9371) (#9371) *(2026-06-08)*
 - `0be9dbc` — feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3) (#9369) (#9369) *(2026-06-08)*
 - `98b2773` — feat(loops): RollupIssueManager + migrate StagingPromotionLoop to auto-close (#9359) (#9368) (#9368) *(2026-06-08)*
 - `ec58ffb` — feat(diagnostics): Factory Cost rollup endpoints aggregate across repos (Phase 3c-2) (#9367) (#9367) *(2026-06-08)*

--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -47,14 +47,17 @@ function formatResumeAt(isoString) {
   return d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })
 }
 
-function SystemAlertBanner({ alert, onDismiss, onRefreshCredit }) {
+function SystemAlertBanner({ alert, onDismiss, onRefreshCredit, onClearCredit }) {
   const [refreshState, setRefreshState] = useState('idle') // idle | checking | still_exhausted | error
+  const [clearState, setClearState] = useState('idle') // idle | clearing | error
   const timerRef = useRef(null)
+  const clearTimerRef = useRef(null)
   const isCreditAlert = alert?.message?.toLowerCase().includes('credit limit')
 
   useEffect(() => {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
     }
   }, [])
 
@@ -80,6 +83,20 @@ function SystemAlertBanner({ alert, onDismiss, onRefreshCredit }) {
     }
   }, [onRefreshCredit, refreshState])
 
+  const handleClear = useCallback(async () => {
+    if (!onClearCredit || clearState === 'clearing') return
+    setClearState('clearing')
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+    const result = await onClearCredit()
+    if (result.ok) {
+      // Cleared — banner will be removed by the status event.
+      setClearState('idle')
+    } else {
+      setClearState('error')
+      clearTimerRef.current = setTimeout(() => setClearState('idle'), 5000)
+    }
+  }, [onClearCredit, clearState])
+
   if (!alert) return null
   const resumeTime = formatResumeAt(alert.resume_at)
   return (
@@ -93,6 +110,9 @@ function SystemAlertBanner({ alert, onDismiss, onRefreshCredit }) {
       {refreshState === 'error' && (
         <span style={styles.alertStillExhausted}>Refresh failed</span>
       )}
+      {clearState === 'error' && (
+        <span style={styles.alertStillExhausted}>Clear failed</span>
+      )}
       {isCreditAlert && onRefreshCredit && (
         <button
           onClick={handleRefresh}
@@ -100,6 +120,17 @@ function SystemAlertBanner({ alert, onDismiss, onRefreshCredit }) {
           style={refreshState === 'checking' ? styles.alertRefreshDisabled : styles.alertRefresh}
         >
           {refreshState === 'checking' ? 'Checking...' : 'Refresh'}
+        </button>
+      )}
+      {isCreditAlert && onClearCredit && (
+        <button
+          onClick={handleClear}
+          disabled={clearState === 'clearing'}
+          title="Force-clear the credit pause without probing (manual override)"
+          style={clearState === 'clearing' ? styles.alertRefreshDisabled : styles.alertRefresh}
+          data-testid="credit-force-clear"
+        >
+          {clearState === 'clearing' ? 'Clearing...' : 'Force clear'}
         </button>
       )}
       {onDismiss && (
@@ -157,7 +188,7 @@ function AppContent() {
   const {
     connected, orchestratorStatus, workers, prs,
     hitlItems, humanInputRequests, submitHumanInput, refreshHitl,
-    backgroundWorkers, systemAlert, dismissSystemAlert, refreshCreditStatus, intents, toggleBgWorker, triggerBgWorker, updateBgWorkerInterval,
+    backgroundWorkers, systemAlert, dismissSystemAlert, refreshCreditStatus, clearCreditPause, intents, toggleBgWorker, triggerBgWorker, updateBgWorkerInterval,
     requestChanges,
     config,
     reporterId,
@@ -198,7 +229,7 @@ function AppContent() {
       <SessionSidebar />
 
       <div style={styles.main}>
-        <SystemAlertBanner alert={systemAlert} onDismiss={dismissSystemAlert} onRefreshCredit={refreshCreditStatus} />
+        <SystemAlertBanner alert={systemAlert} onDismiss={dismissSystemAlert} onRefreshCredit={refreshCreditStatus} onClearCredit={clearCreditPause} />
         <ConfigWarningBanner warning={configWarning} />
         <HumanInputBanner requests={humanInputRequests} onSubmit={submitHumanInput} />
         <ProjectView project={selectedProject} />

--- a/src/ui/src/components/PipelineControlPanel.jsx
+++ b/src/ui/src/components/PipelineControlPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react'
 import { theme } from '../theme'
-import { PIPELINE_LOOPS, PIPELINE_STAGES, ACTIVE_STATUSES, WORKER_COUNT_MIN, WORKER_COUNT_MAX } from '../constants'
+import { PIPELINE_LOOPS, PIPELINE_STAGES, ACTIVE_STATUSES, WORKER_COUNT_MIN, WORKER_COUNT_MAX, REPO_ALL } from '../constants'
 import { useHydraFlow } from '../context/HydraFlowContext'
 
 function formatDuration(startTime) {
@@ -95,8 +95,13 @@ function PipelineWorkerCard({ workerKey, worker }) {
   )
 }
 
+// Worker mutations target one orchestrator, so under "All repos" the backend
+// rejects config writes — disable the per-repo controls and tell the operator.
+const AGGREGATE_EDIT_TIP = 'Select a specific repo to edit worker settings'
+
 export function PipelineControlPanel({ onToggleBgWorker }) {
   const { workers, stageStatus, hitlItems, refreshControlStatus, selectedRepoSlug } = useHydraFlow()
+  const isAggregate = selectedRepoSlug === REPO_ALL
   const workerCaps = stageStatus?.workerCaps || {}
 
   const [localCaps, setLocalCaps] = useState({})
@@ -117,6 +122,8 @@ export function PipelineControlPanel({ onToggleBgWorker }) {
   }, [workerCapsKey])
 
   const updateWorkerCount = useCallback(async (loopKey, configKey, newValue) => {
+    // Config writes target a single repo; the backend 400s repo=__all__.
+    if (selectedRepoSlug === REPO_ALL) return
     setLocalCaps(caps => ({ ...caps, [loopKey]: newValue }))
     try {
       const url = selectedRepoSlug
@@ -168,8 +175,9 @@ export function PipelineControlPanel({ onToggleBgWorker }) {
               {loop.configKey && effectiveMax != null ? (
                 <>
                   <button
-                    style={effectiveMax <= WORKER_COUNT_MIN ? capBtnDisabled : capBtn}
-                    disabled={effectiveMax <= WORKER_COUNT_MIN}
+                    style={(isAggregate || effectiveMax <= WORKER_COUNT_MIN) ? capBtnDisabled : capBtn}
+                    disabled={isAggregate || effectiveMax <= WORKER_COUNT_MIN}
+                    title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
                     onClick={() => updateWorkerCount(loop.key, loop.configKey, effectiveMax - 1)}
                     data-testid={`dec-${loop.key}`}
                     aria-label={`Decrease ${loop.label} workers`}
@@ -183,8 +191,9 @@ export function PipelineControlPanel({ onToggleBgWorker }) {
                     {effectiveMax}
                   </span>
                   <button
-                    style={effectiveMax >= WORKER_COUNT_MAX ? capBtnDisabled : capBtn}
-                    disabled={effectiveMax >= WORKER_COUNT_MAX}
+                    style={(isAggregate || effectiveMax >= WORKER_COUNT_MAX) ? capBtnDisabled : capBtn}
+                    disabled={isAggregate || effectiveMax >= WORKER_COUNT_MAX}
+                    title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
                     onClick={() => updateWorkerCount(loop.key, loop.configKey, effectiveMax + 1)}
                     data-testid={`inc-${loop.key}`}
                     aria-label={`Increase ${loop.label} workers`}
@@ -203,7 +212,12 @@ export function PipelineControlPanel({ onToggleBgWorker }) {
               <span style={styles.loopCountLabel}>workers</span>
               {onToggleBgWorker && (
                 <button
-                  style={enabled ? styles.toggleOn : styles.toggleOff}
+                  style={{
+                    ...(enabled ? styles.toggleOn : styles.toggleOff),
+                    ...(isAggregate ? { opacity: 0.45, cursor: 'not-allowed' } : {}),
+                  }}
+                  disabled={isAggregate}
+                  title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
                   onClick={() => onToggleBgWorker(loop.key, !enabled)}
                 >
                   {enabled ? 'On' : 'Off'}

--- a/src/ui/src/components/SystemPanel.jsx
+++ b/src/ui/src/components/SystemPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo, lazy, Suspense } from 'react'
 import { theme } from '../theme'
-import { BACKGROUND_WORKERS, WORKER_GROUPS, INTERVAL_PRESETS, WORKER_PRESETS, EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS, UNSTICK_BATCH_OPTIONS } from '../constants'
+import { BACKGROUND_WORKERS, WORKER_GROUPS, INTERVAL_PRESETS, WORKER_PRESETS, EDITABLE_INTERVAL_WORKERS, SYSTEM_WORKER_INTERVALS, UNSTICK_BATCH_OPTIONS, REPO_ALL } from '../constants'
 import { useHydraFlow } from '../context/HydraFlowContext'
 import { Livestream } from './Livestream'
 import { PipelineControlPanel } from './PipelineControlPanel'
@@ -70,7 +70,13 @@ function formatTimestamp(ts) {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 
-function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssues, orchestratorStatus, onToggleBgWorker, onTriggerBgWorker, onUpdateInterval, events, extraContent }) {
+// Worker mutations target a single orchestrator, so under "All repos" the
+// backend rejects them and the context handlers are no-ops. Disable the
+// controls visibly (rather than letting clicks silently do nothing) and tell
+// the operator how to act.
+const AGGREGATE_EDIT_TIP = 'Select a specific repo to edit worker settings'
+
+function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssues, orchestratorStatus, onToggleBgWorker, onTriggerBgWorker, onUpdateInterval, events, extraContent, isAggregate }) {
   const [showIntervalEditor, setShowIntervalEditor] = useState(false)
   const [triggerLoading, setTriggerLoading] = useState(false)
   const isPipelinePoller = def.key === 'pipeline_poller'
@@ -177,7 +183,12 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
         )}
         {showToggle && (
           <button
-            style={enabled ? styles.toggleOn : styles.toggleOff}
+            style={{
+              ...(enabled ? styles.toggleOn : styles.toggleOff),
+              ...(isAggregate ? styles.controlDisabled : {}),
+            }}
+            disabled={isAggregate}
+            title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
             onClick={() => onToggleBgWorker(def.key, !enabled)}
           >
             {enabled ? 'On' : 'Off'}
@@ -185,8 +196,12 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
         )}
         {onTriggerBgWorker && orchRunning && !isPipelinePoller && (
           <button
-            style={triggerLoading ? styles.runNowLoading : styles.runNow}
-            disabled={triggerLoading}
+            style={{
+              ...(triggerLoading ? styles.runNowLoading : styles.runNow),
+              ...(isAggregate ? styles.controlDisabled : {}),
+            }}
+            disabled={triggerLoading || isAggregate}
+            title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
             data-testid={`run-now-${def.key}`}
             onClick={async () => {
               setTriggerLoading(true)
@@ -219,7 +234,7 @@ function BackgroundWorkerCard({ def, state, pipelinePollerLastRun, pipelineIssue
               {' \u00b7 Next '}{formatNextRun(lastRun, effectiveInterval)}
             </span>
           )}
-          {isEditable && onUpdateInterval && (
+          {isEditable && onUpdateInterval && !isAggregate && (
             <span
               style={styles.editIntervalLink}
               onClick={() => setShowIntervalEditor(!showIntervalEditor)}
@@ -273,11 +288,14 @@ const WORKERS_BY_GROUP = WORKER_GROUPS.map(group => ({
 
 function UnstickWorkersDropdown() {
   const { config, selectedRepoSlug } = useHydraFlow()
+  const isAggregate = selectedRepoSlug === REPO_ALL
   const [localValue, setLocalValue] = useState(null)
 
   const currentValue = localValue !== null ? localValue : (config?.pr_unstick_batch_size ?? 3)
 
   const handleChange = useCallback(async (e) => {
+    // Config writes target a single repo; the backend 400s repo=__all__.
+    if (selectedRepoSlug === REPO_ALL) return
     const newValue = parseInt(e.target.value, 10)
     setLocalValue(newValue)
     try {
@@ -308,7 +326,9 @@ function UnstickWorkersDropdown() {
       <select
         value={currentValue}
         onChange={handleChange}
-        style={styles.workersSelect}
+        disabled={isAggregate}
+        title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
+        style={{ ...styles.workersSelect, ...(isAggregate ? styles.controlDisabled : {}) }}
         data-testid="unstick-workers-dropdown"
       >
         {UNSTICK_BATCH_OPTIONS.map(n => (
@@ -525,6 +545,7 @@ function StagingPromotionStatusRow() {
 
 function StagingPromotionSettingsPanel() {
   const { config, selectedRepoSlug } = useHydraFlow()
+  const isAggregate = selectedRepoSlug === REPO_ALL
   const [local, setLocal] = useState(null)
   const [savingField, setSavingField] = useState(null)
   const [error, setError] = useState(null)
@@ -537,6 +558,8 @@ function StagingPromotionSettingsPanel() {
   }
 
   const patchField = useCallback(async (field, value) => {
+    // Config writes target a single repo; the backend 400s repo=__all__.
+    if (selectedRepoSlug === REPO_ALL) return
     const prev = current[field]
     setLocal({ ...current, [field]: value })
     setSavingField(field)
@@ -571,7 +594,8 @@ function StagingPromotionSettingsPanel() {
           <input
             type="checkbox"
             checked={!!current.staging_enabled}
-            disabled={savingField === 'staging_enabled'}
+            disabled={isAggregate || savingField === 'staging_enabled'}
+            title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
             onChange={e => patchField('staging_enabled', e.target.checked)}
             data-testid="staging-enabled-toggle"
           />
@@ -585,7 +609,8 @@ function StagingPromotionSettingsPanel() {
         <input
           type="text"
           value={current.main_branch}
-          disabled={savingField === 'main_branch'}
+          disabled={isAggregate || savingField === 'main_branch'}
+          title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
           onChange={e => setLocal({ ...current, main_branch: e.target.value })}
           onBlur={e => {
             const val = e.target.value.trim()
@@ -600,7 +625,8 @@ function StagingPromotionSettingsPanel() {
         <input
           type="text"
           value={current.staging_branch}
-          disabled={savingField === 'staging_branch'}
+          disabled={isAggregate || savingField === 'staging_branch'}
+          title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
           onChange={e => setLocal({ ...current, staging_branch: e.target.value })}
           onBlur={e => {
             const val = e.target.value.trim()
@@ -617,7 +643,8 @@ function StagingPromotionSettingsPanel() {
           min="1"
           max="168"
           value={current.rc_cadence_hours}
-          disabled={savingField === 'rc_cadence_hours'}
+          disabled={isAggregate || savingField === 'rc_cadence_hours'}
+          title={isAggregate ? AGGREGATE_EDIT_TIP : undefined}
           onChange={e => setLocal({ ...current, rc_cadence_hours: Number(e.target.value) })}
           onBlur={e => {
             const val = Number(e.target.value)
@@ -692,7 +719,7 @@ function StagingBranchSetupButton() {
 }
 
 
-function WorkerGroupSection({ group, backgroundWorkers, pipelinePollerLastRun, pipelineIssues, orchestratorStatus, onToggleBgWorker, onTriggerBgWorker, onUpdateInterval, events }) {
+function WorkerGroupSection({ group, backgroundWorkers, pipelinePollerLastRun, pipelineIssues, orchestratorStatus, onToggleBgWorker, onTriggerBgWorker, onUpdateInterval, events, isAggregate }) {
   const [collapsed, setCollapsed] = useState(false)
   const workerCount = group.workers.length
   const activeCount = group.workers.filter(w => {
@@ -730,6 +757,7 @@ function WorkerGroupSection({ group, backgroundWorkers, pipelinePollerLastRun, p
                 onTriggerBgWorker={onTriggerBgWorker}
                 onUpdateInterval={onUpdateInterval}
                 events={events}
+                isAggregate={isAggregate}
                 extraContent={
                   def.key === 'dependabot_merge' ? <DependabotMergeSettingsPanel /> :
                   def.key === 'pr_unsticker' ? <UnstickWorkersDropdown /> :
@@ -746,8 +774,9 @@ function WorkerGroupSection({ group, backgroundWorkers, pipelinePollerLastRun, p
 }
 
 export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWorker, onUpdateInterval }) {
-  const { pipelinePollerLastRun, orchestratorStatus, events, pipelineIssues } = useHydraFlow()
+  const { pipelinePollerLastRun, orchestratorStatus, events, pipelineIssues, selectedRepoSlug } = useHydraFlow()
   const [activeSubTab, setActiveSubTab] = useState('workers')
+  const isAggregate = selectedRepoSlug === REPO_ALL
 
   return (
     <div style={styles.container}>
@@ -768,6 +797,13 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
       <div style={styles.subTabContent} data-testid="system-subtab-content">
         {activeSubTab === 'workers' && (
           <div style={styles.workersContent}>
+            {isAggregate && (
+              <div style={styles.aggregateNotice} data-testid="workers-aggregate-notice">
+                Showing worker status across all repos. Worker controls are
+                per-repo — select a specific repo to toggle, trigger, or
+                reschedule a worker.
+              </div>
+            )}
             {WORKERS_BY_GROUP.map((group) => (
               <WorkerGroupSection
                 key={group.key}
@@ -780,6 +816,7 @@ export function SystemPanel({ backgroundWorkers, onToggleBgWorker, onTriggerBgWo
                 onTriggerBgWorker={onTriggerBgWorker}
                 onUpdateInterval={onUpdateInterval}
                 events={events}
+                isAggregate={isAggregate}
               />
             ))}
           </div>
@@ -840,6 +877,20 @@ const styles = {
     flex: 1,
     overflowY: 'auto',
     padding: 20,
+  },
+  aggregateNotice: {
+    background: theme.surfaceInset,
+    border: `1px solid ${theme.border}`,
+    borderRadius: 6,
+    padding: '8px 12px',
+    marginBottom: 16,
+    color: theme.textMuted,
+    fontSize: 12,
+    lineHeight: 1.5,
+  },
+  controlDisabled: {
+    opacity: 0.45,
+    cursor: 'not-allowed',
   },
   diagnosticsLoading: {
     padding: 32,

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -34,6 +34,7 @@ const { mockState } = vi.hoisted(() => {
       systemAlert: null,
       dismissSystemAlert: vi.fn(),
       refreshCreditStatus: vi.fn().mockResolvedValue({ ok: true, status: 'resuming' }),
+      clearCreditPause: vi.fn().mockResolvedValue({ ok: true, status: 'cleared' }),
       sessions: [],
       issueHistory: null,
       harnessInsights: null,
@@ -79,6 +80,7 @@ beforeEach(() => {
   mockState.orchestratorStatus = 'running'
   mockState.systemAlert = null
   mockState.refreshCreditStatus = vi.fn().mockResolvedValue({ ok: true, status: 'resuming' })
+  mockState.clearCreditPause = vi.fn().mockResolvedValue({ ok: true, status: 'cleared' })
   mockState.dismissSystemAlert = vi.fn()
   cleanup()
 })
@@ -392,6 +394,30 @@ describe('SystemAlertBanner refresh button', () => {
     const { default: App } = await import('../../App')
     render(<App />)
     expect(screen.queryByText('Refresh')).toBeNull()
+    mockState.systemAlert = null
+  })
+
+  it('shows a Force clear button on credit alerts that calls clearCreditPause', async () => {
+    mockState.systemAlert = {
+      message: 'Credit limit reached. Pausing all loops.',
+      source: 'implement',
+    }
+    const { default: App } = await import('../../App')
+    render(<App />)
+    const forceClear = screen.getByTestId('credit-force-clear')
+    expect(forceClear).toHaveTextContent('Force clear')
+    await act(async () => {
+      fireEvent.click(forceClear)
+    })
+    expect(mockState.clearCreditPause).toHaveBeenCalled()
+    mockState.systemAlert = null
+  })
+
+  it('does not show Force clear for non-credit alerts', async () => {
+    mockState.systemAlert = { message: 'Auth failed. Check your API key.', source: 'plan' }
+    const { default: App } = await import('../../App')
+    render(<App />)
+    expect(screen.queryByTestId('credit-force-clear')).toBeNull()
     mockState.systemAlert = null
   })
 

--- a/src/ui/src/components/__tests__/PipelineControlPanel.test.jsx
+++ b/src/ui/src/components/__tests__/PipelineControlPanel.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
-import { PIPELINE_LOOPS } from '../../constants'
+import { PIPELINE_LOOPS, REPO_ALL } from '../../constants'
 import { deriveStageStatus } from '../../hooks/useStageStatus'
 
 const mockUseHydraFlow = vi.fn()
@@ -255,6 +255,23 @@ describe('PipelineControlPanel', () => {
         expect(screen.getByTestId(`dec-${loop.key}`)).not.toBeDisabled()
         expect(screen.getByTestId(`inc-${loop.key}`)).not.toBeDisabled()
       }
+    })
+
+    it('disables count controls and fires no write under "All repos" (__all__)', () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+      vi.stubGlobal('fetch', fetchMock)
+      mockUseHydraFlow.mockReturnValue(defaultMockContext({
+        selectedRepoSlug: REPO_ALL,
+        pipelineStats: buildPipelineStats({ triage: 5, discover: 5, shape: 5, plan: 5, implement: 5, review: 5 }),
+      }))
+      render(<PipelineControlPanel onToggleBgWorker={vi.fn()} />)
+      for (const loop of PIPELINE_LOOPS) {
+        expect(screen.getByTestId(`dec-${loop.key}`)).toBeDisabled()
+        expect(screen.getByTestId(`inc-${loop.key}`)).toBeDisabled()
+      }
+      // A config write must not fire against repo=__all__ (the backend 400s it).
+      fireEvent.click(screen.getByTestId('inc-implement'))
+      expect(fetchMock).not.toHaveBeenCalled()
     })
 
     it('calls PATCH /api/control/config with persist:true on increment', async () => {

--- a/src/ui/src/components/__tests__/SystemPanel.test.jsx
+++ b/src/ui/src/components/__tests__/SystemPanel.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, within, waitFor } from '@testing-library/react'
-import { BACKGROUND_WORKERS } from '../../constants'
+import { BACKGROUND_WORKERS, REPO_ALL } from '../../constants'
 import { deriveStageStatus } from '../../hooks/useStageStatus'
 
 const mockUseHydraFlow = vi.fn()
@@ -295,6 +295,59 @@ describe('SystemPanel', () => {
       const dependabotCard = screen.getByTestId('worker-card-dependabot_merge')
       fireEvent.click(within(dependabotCard).getByText('Off'))
       expect(onToggle).toHaveBeenCalledWith('dependabot_merge', true)
+    })
+
+    describe('aggregate mode (All repos)', () => {
+      it('shows the aggregate notice and disables worker controls under __all__', () => {
+        const onToggle = vi.fn()
+        mockUseHydraFlow.mockReturnValue(defaultMockContext({
+          orchestratorStatus: 'running',
+          backgroundWorkers: mockBgWorkers,
+          selectedRepoSlug: REPO_ALL,
+        }))
+        render(
+          <SystemPanel
+            backgroundWorkers={mockBgWorkers}
+            onToggleBgWorker={onToggle}
+            onTriggerBgWorker={vi.fn()}
+          />,
+        )
+        expect(screen.getByTestId('workers-aggregate-notice')).toBeInTheDocument()
+        // Worker mutations target one orchestrator, so the toggle is disabled and
+        // a click is inert (the backend would reject it under __all__).
+        const card = screen.getByTestId('worker-card-dependabot_merge')
+        const toggle = within(card).getByText('Off')
+        expect(toggle).toBeDisabled()
+        fireEvent.click(toggle)
+        expect(onToggle).not.toHaveBeenCalled()
+        // Run Now is disabled too.
+        screen.getAllByTestId(/^run-now-/).forEach((btn) => expect(btn).toBeDisabled())
+      })
+
+      it('omits the notice and keeps controls enabled for a specific repo', () => {
+        mockUseHydraFlow.mockReturnValue(defaultMockContext({
+          orchestratorStatus: 'running',
+          backgroundWorkers: mockBgWorkers,
+          selectedRepoSlug: 'org-a',
+        }))
+        render(<SystemPanel backgroundWorkers={mockBgWorkers} onToggleBgWorker={vi.fn()} />)
+        expect(screen.queryByTestId('workers-aggregate-notice')).not.toBeInTheDocument()
+        const card = screen.getByTestId('worker-card-dependabot_merge')
+        expect(within(card).getByText('Off')).not.toBeDisabled()
+      })
+
+      it('disables embedded per-repo config controls (unstick, staging) under __all__', () => {
+        mockUseHydraFlow.mockReturnValue(defaultMockContext({
+          orchestratorStatus: 'running',
+          backgroundWorkers: mockBgWorkers,
+          selectedRepoSlug: REPO_ALL,
+          config: { pr_unstick_batch_size: 3, staging_enabled: false, main_branch: 'main', staging_branch: 'staging', rc_cadence_hours: 4 },
+        }))
+        render(<SystemPanel backgroundWorkers={mockBgWorkers} onToggleBgWorker={vi.fn()} />)
+        expect(screen.getByTestId('unstick-workers-dropdown')).toBeDisabled()
+        expect(screen.getByTestId('staging-enabled-toggle')).toBeDisabled()
+        expect(screen.getByTestId('main-branch-input')).toBeDisabled()
+      })
     })
 
     it('non-system workers show On when orchestrator running and no state reported', () => {

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -1410,6 +1410,21 @@ export function HydraFlowProvider({ children }) {
     }
   }, [fetchWithRepo])
 
+  // Force-clear a credit pause (manual override; credit-refresh only resumes
+  // when probing finds credits restored). Scoped to the selected repo via
+  // fetchWithRepo; under "All repos" the backend fans out to every paused repo.
+  const clearCreditPause = useCallback(async () => {
+    try {
+      const res = await fetchWithRepo('/api/control/clear-credit-pause', { method: 'POST' })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) return { ok: false, status: data.error || 'error' }
+      await refreshControlStatus()
+      return { ok: true, status: data.status || 'cleared' }
+    } catch {
+      return { ok: false, status: 'error' }
+    }
+  }, [fetchWithRepo, refreshControlStatus])
+
   const startOrchestrator = useCallback(async () => {
     if (state.selectedRepoSlug) {
       const result = await startRuntime(state.selectedRepoSlug)
@@ -1723,6 +1738,7 @@ export function HydraFlowProvider({ children }) {
     updateBgWorkerInterval,
     dismissSystemAlert: useCallback(() => dispatch({ type: 'CLEAR_SYSTEM_ALERT' }), [dispatch]),
     refreshCreditStatus,
+    clearCreditPause,
     refreshHitl: fetchHitlItems,
     selectRepo,
     addRepoBySlug,


### PR DESCRIPTION
## What

Phase **3b-fe polish** — make the System tab coherent under "All repos" and add a manual credit-pause override. Frontend-only (the backend endpoints already exist from 3b-backend #9360).

## Aggregate-mode worker affordances

Worker controls are per-orchestrator — the backend rejects them under `repo=__all__` and the context handlers are already silent no-ops there. This PR makes that **visible** instead of leaving clickable-but-inert controls:

- Worker **toggle / Run Now / interval-edit** disabled with a `Select a specific repo to edit worker settings` tooltip (`isAggregate` threaded SystemPanel → WorkerGroupSection → BackgroundWorkerCard)
- An **aggregate-mode notice** atop the Workers sub-tab
- **Review-flagged consistency gaps closed**: the embedded per-repo config writes — `UnstickWorkersDropdown`, `StagingPromotionSettingsPanel`, and `PipelineControlPanel`'s worker-count ±buttons + loop toggle — now guard against `repo=__all__` and disable their controls. Previously they fired `PATCH /api/control/config?repo=__all__`, which the backend **400s** (so they'd fail + leave an optimistic-update mismatch).

## Force clear-credit-pause

New `clearCreditPause` context handler (`POST /api/control/clear-credit-pause` via `fetchWithRepo`, then `refreshControlStatus`) + a **"Force clear"** button in the credit-limit banner. Unlike `credit-refresh` (which only resumes when probing finds credits restored), this is a manual override; it stays **enabled under `__all__`** because the backend fans the clear out to every paused repo. Also split the banner's shared timer ref so a concurrent refresh+clear can't clobber each other's timeout.

## Deferred

The full per-repo worker **grid** under `__all__` (today the union shows one arbitrary repo's status per worker name) needs a reducer rework to key worker state by `(repo, name)` and preserve the repo tag through WS tick events — a larger change than this affordance polish.

## Tests

- **SystemPanel**: aggregate notice + disabled toggle/Run-Now + inert click + enabled-for-a-specific-repo + disabled embedded config controls (unstick/staging/main-branch)
- **PipelineControlPanel**: ±buttons disabled + no config write fires under `__all__`
- **App**: force-clear button calls `clearCreditPause`, hidden for non-credit alerts

## Verification

- `make quality` ✅ 15890 passed (frontend-only; confirms no Python impact)
- UI `vitest` ✅ 1113 passed · `npm run build` ✅
- Adversarial fresh-eyes review — caught the live-config-mutation consistency gaps (now fixed + tested) and a minor shared-timer issue (fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)