### PR TITLE
fix(loops): auto-close PricingRefresh issues on recovery (#9359)

### DIFF
--- a/src/pricing_refresh_loop.py
+++ b/src/pricing_refresh_loop.py
@@ -102,6 +102,9 @@ class PricingRefreshLoop(BaseBackgroundLoop):
             await self._open_parse_issue(str(exc))
             return {"drift": False, "error": "parse"}
 
+        # Upstream parsed cleanly — close any open parse-error issue (#9359).
+        await self._close_issue_if_open(f"{_ISSUE_TITLE_PREFIX} upstream parse error")
+
         upstream = filter_anthropic_entries(upstream_raw)
         local = self._read_local_models()
 
@@ -114,6 +117,9 @@ class PricingRefreshLoop(BaseBackgroundLoop):
                 "error": "bounds",
                 "violations": len(diff.bounds_violations),
             }
+
+        # No bounds violations — close any open bounds-violation issue (#9359).
+        await self._close_issue_if_open(f"{_ISSUE_TITLE_PREFIX} bounds violation")
 
         if not diff.updated and not diff.added:
             return {"drift": False}
@@ -288,6 +294,15 @@ class PricingRefreshLoop(BaseBackgroundLoop):
             body="\n".join(body_lines),
             labels=["hydraflow-find", "pricing-refresh"],
         )
+
+    async def _close_issue_if_open(self, title: str) -> None:
+        """Close a `[pricing-refresh]` issue once its condition clears (#9359)."""
+        existing = await self._pr_manager.find_existing_issue(title)
+        if existing:
+            await self._pr_manager.post_comment(
+                existing, "Pricing-refresh condition resolved — auto-closing."
+            )
+            await self._pr_manager.close_issue(existing)
 
     async def _open_parse_issue(self, detail: str) -> None:
         title = f"{_ISSUE_TITLE_PREFIX} upstream parse error"

--- a/tests/test_pricing_refresh_loop_scenario.py
+++ b/tests/test_pricing_refresh_loop_scenario.py
@@ -433,3 +433,34 @@ async def test_pr_helper_exception_reverts_pricing_file(repo_root: Path) -> None
         await loop._do_work()
 
     assert pricing_path.read_text() == before
+
+
+async def test_clean_tick_closes_open_pricing_issues(repo_root: Path) -> None:
+    """#9359: a clean parse + no bounds violations auto-closes any open
+    `[pricing-refresh]` parse-error / bounds-violation issues."""
+    upstream_payload = {
+        "claude-haiku-4-5-20251001": {
+            "litellm_provider": "anthropic",
+            "input_cost_per_token": 1e-6,
+            "output_cost_per_token": 5e-6,
+            "cache_creation_input_token_cost": 1.25e-6,
+            "cache_read_input_token_cost": 1e-7,
+        },
+    }
+    loop, pr_manager = _build_loop(repo_root)
+    pr_manager.find_existing_issue = AsyncMock(return_value=88)  # both "open"
+
+    pr_helper = AsyncMock()
+    with (
+        patch(
+            "pricing_refresh_loop.PricingRefreshLoop._fetch_upstream",
+            return_value=upstream_payload,
+        ),
+        patch("auto_pr.open_automated_pr_async", pr_helper),
+    ):
+        result = await loop._do_work()
+
+    assert result == {"drift": False}
+    # Parse-error AND bounds-violation issues both auto-close on a clean tick.
+    assert pr_manager.close_issue.await_count == 2
+    assert {c.args[0] for c in pr_manager.close_issue.await_args_list} == {88}


### PR DESCRIPTION
Batch 4 of the issue-filing-loop audit. PricingRefreshLoop filed `[pricing-refresh]` parse-error / bounds-violation issues (stable titles, `find_existing`-gated) but never closed them on recovery.

- On a **clean upstream parse**, close any open `[pricing-refresh] upstream parse error` issue.
- When there are **no bounds violations**, close any open `[pricing-refresh] bounds violation` issue.

Minimal `find_existing_issue` + `close_issue` (no DedupStore). 1 new test asserts a clean tick closes both.

**Verification:** `make quality` **15893 passed**; `make scenario` + `make scenario-loops` green.

**Progress: 7 loops migrated** (StagingPromotion, CostBudget, Diagram, GateActivator, BranchProtection, Pricing + the `RollupIssueManager`). Remaining are bespoke (no longer mechanical): SecurityPatch (constructor `state` + `resolve_all_except`), HealthMonitor (variable titles), PrinciplesAudit/SkillPromptEval (per-check FAIL→PASS), ContractRefresh (variable title), FlakeTracker (dedup/escalation entanglement). StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)