### PR TITLE
fix(loops): auto-close HealthMonitor dead-man-switch issues on recovery (#9359)

### DIFF
--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -1053,9 +1053,16 @@ class HealthMonitorLoop(BaseBackgroundLoop):
             if self._sanity_noop_streak >= _SANITY_NOOP_STREAK_THRESHOLD:
                 noop_tripped = True
             else:
-                # Recovery — sanity loop ticking with real work. Clear
-                # dedup so a future stall files a fresh issue.
+                # Recovery — sanity loop ticking with real work. Close any open
+                # stall issue and clear dedup so a future stall files fresh
+                # (#9359 issue-hygiene).
                 if dedup_key in filed_keys:
+                    await self._close_issues_by_label(
+                        prs,
+                        "sanity-loop-stalled",
+                        "trust_fleet_sanity is ticking with real work again — "
+                        "auto-closing.",
+                    )
                     self._sanity_stall_dedup.set_all(filed_keys - {dedup_key})
                 return
         else:
@@ -1151,8 +1158,14 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         filed_keys = self._wiki_stall_dedup.get()
 
         if elapsed_s < threshold_s:
-            # Recovered — clear dedup so a future stall files a fresh issue.
+            # Recovered — close the open wiki-stale issue and clear dedup so a
+            # future stall files a fresh issue (#9359 issue-hygiene).
             if dedup_key in filed_keys:
+                await self._close_issues_by_label(
+                    prs,
+                    "wiki-stale",
+                    "docs/wiki/log.jsonl is moving again — auto-closing.",
+                )
                 self._wiki_stall_dedup.set_all(filed_keys - {dedup_key})
             return
 
@@ -1192,3 +1205,25 @@ class HealthMonitorLoop(BaseBackgroundLoop):
         )
         filed_keys = self._wiki_stall_dedup.get()
         self._wiki_stall_dedup.set_all(filed_keys | {dedup_key})
+
+    async def _close_issues_by_label(
+        self, prs: PRPort, label: str, comment: str
+    ) -> None:
+        """Close every open issue carrying *label* when a dead-man-switch
+        recovers (#9359). Titles embed elapsed-time so they can't be found by
+        title; the label is the stable handle."""
+        try:
+            issues = await prs.list_issues_by_label(label)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "health_monitor: could not list %s issues to close",
+                label,
+                exc_info=True,
+            )
+            return
+        for issue in issues:
+            number = issue.get("number")
+            if not number:
+                continue
+            await prs.post_comment(number, comment)
+            await prs.close_issue(number)

--- a/tests/test_health_monitor_sanity_stall.py
+++ b/tests/test_health_monitor_sanity_stall.py
@@ -29,6 +29,7 @@ def hm_env(tmp_path: Path):
     bg_workers.worker_enabled = {"trust_fleet_sanity": True}
     prs = AsyncMock()
     prs.create_issue = AsyncMock(return_value=17)
+    prs.list_issues_by_label = AsyncMock(return_value=[])
     # ``__new__`` bypasses the ctor; inject the attrs the dead-man-switch
     # uses directly. The real ctor sets all of these — see HealthMonitorLoop.
     hm = HealthMonitorLoop.__new__(HealthMonitorLoop)
@@ -194,3 +195,31 @@ async def test_noop_streak_resets_on_real_work(hm_env) -> None:
     await hm._check_sanity_loop_staleness()
     assert hm._sanity_noop_streak == 0
     prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_closes_open_stall_issue(hm_env) -> None:
+    """#9359: on recovery (real work again), the open sanity-loop-stalled issue
+    is auto-closed via its label."""
+    hm, state, _bg_workers, prs = hm_env
+    stale = (datetime.now(UTC) - timedelta(seconds=2400)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {"status": "ok", "last_run": stale, "details": {}},
+    }
+    await hm._check_sanity_loop_staleness()
+    assert prs.create_issue.await_count == 1
+
+    # Recovery — heartbeat fresh AND real work (workers_scanned > 0).
+    recent = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+    state.get_worker_heartbeats.return_value = {
+        "trust_fleet_sanity": {
+            "status": "ok",
+            "last_run": recent,
+            "details": {"workers_scanned": 5},
+        },
+    }
+    prs.list_issues_by_label = AsyncMock(
+        return_value=[{"number": 91, "title": "x", "body": "", "updated_at": ""}]
+    )
+    await hm._check_sanity_loop_staleness()
+    prs.close_issue.assert_awaited_once_with(91)

--- a/tests/test_health_monitor_wiki_stall.py
+++ b/tests/test_health_monitor_wiki_stall.py
@@ -27,6 +27,7 @@ def hm_env(tmp_path: Path):
     )
     prs = AsyncMock()
     prs.create_issue = AsyncMock(return_value=42)
+    prs.list_issues_by_label = AsyncMock(return_value=[])
     hm = HealthMonitorLoop.__new__(HealthMonitorLoop)
     hm._config = cfg
     hm._prs = prs
@@ -120,3 +121,21 @@ async def test_no_prs_dependency_is_silent_noop(hm_env) -> None:
     log_path.write_text("{}\n")
     _set_mtime(log_path, age_days=10)
     await hm._check_wiki_freshness()
+
+
+async def test_recovery_closes_open_wiki_stale_issue(hm_env) -> None:
+    """#9359: when the wiki log moves again, the open wiki-stale issue closes."""
+    hm, prs, repo_root = hm_env
+    log_path = repo_root / "docs" / "wiki" / "log.jsonl"
+    log_path.write_text("{}\n")
+    _set_mtime(log_path, age_days=10)
+    await hm._check_wiki_freshness()
+    assert prs.create_issue.await_count == 1
+
+    # Recovery — log is fresh again AND an issue is open.
+    _set_mtime(log_path, age_days=0)
+    prs.list_issues_by_label = AsyncMock(
+        return_value=[{"number": 73, "title": "x", "body": "", "updated_at": ""}]
+    )
+    await hm._check_wiki_freshness()
+    prs.close_issue.assert_awaited_once_with(73)


### PR DESCRIPTION
Batch 5 of the issue-filing-loop audit. HealthMonitorLoop's **two dead-man-switches** (trust_fleet_sanity stall, wiki-freshness stall) filed `sanity-loop-stalled` / `wiki-stale` issues but only cleared their **local dedup** on recovery — the GitHub issues stayed open forever.

Their titles embed elapsed-time (`...silent for {N}s` / `...not moved in {N}d`), so they can't be found by title — closed by **label** via `list_issues_by_label` at the existing recovery/dedup-clear branches. Gated on the dedup key being present, so **no API call on healthy ticks**.

- New shared `_close_issues_by_label(prs, label, comment)` helper.
- 2 new tests (sanity + wiki recovery each closes the open issue).

**Verification:** `make quality` **15895 passed**; `make scenario` + `make scenario-loops` green.

**Progress: 8 loops migrated** (StagingPromotion, CostBudget, Diagram, GateActivator, BranchProtection, Pricing, HealthMonitor×2-switches + the `RollupIssueManager`). Remaining: SecurityPatch (constructor `state`), PrinciplesAudit/SkillPromptEval (per-check FAIL→PASS), ContractRefresh, FlakeTracker. StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)