### PR TITLE
feat(atlas): /api/atlas/* endpoints scope by repo (Phase 5a)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T03:44:27.714130+00:00",
-  "commit_sha": "782dc5880b52220e53f2d1334b8a0885439b4945",
+  "regenerated_at": "2026-06-09T05:08:33.667500+00:00",
+  "commit_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13",
   "artifacts": {
     "loops.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "ports.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "labels.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "modules.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "events.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "adr_xref.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "mockworld.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "changelog.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "coverage_matrix.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "functional_areas.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "ubiquitous-language.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "782dc5880b52220e53f2d1334b8a0885439b4945"
+      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `1f68711` — feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish) (#9374) (#9374) *(2026-06-08)*
 - `91b6227` — feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4) (#9371) (#9371) *(2026-06-08)*
 - `0be9dbc` — feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3) (#9369) (#9369) *(2026-06-08)*
 - `98b2773` — feat(loops): RollupIssueManager + migrate StagingPromotionLoop to auto-close (#9359) (#9368) (#9368) *(2026-06-08)*

--- a/src/dashboard_routes/_atlas_routes.py
+++ b/src/dashboard_routes/_atlas_routes.py
@@ -14,11 +14,13 @@ from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 
+from route_types import REPO_ALL, RepoSlugParam
 from ubiquitous_language import TermStore
 
 if TYPE_CHECKING:
     from fastapi import APIRouter
 
+    from config import HydraFlowConfig
     from dashboard_routes._routes import RouteContext
 
 logger = logging.getLogger("hydraflow.dashboard.atlas")
@@ -37,26 +39,26 @@ _WIKI_TOPICS: tuple[str, ...] = (
 )
 
 
-def _terms_root(ctx: RouteContext) -> Path:
-    return (ctx.config.repo_root / "docs" / "wiki" / "terms").resolve()
+def _terms_root(cfg: HydraFlowConfig) -> Path:
+    return (cfg.repo_root / "docs" / "wiki" / "terms").resolve()
 
 
-def _adr_root(ctx: RouteContext) -> Path:
-    return (ctx.config.repo_root / "docs" / "adr").resolve()
+def _adr_root(cfg: HydraFlowConfig) -> Path:
+    return (cfg.repo_root / "docs" / "adr").resolve()
 
 
-def _wiki_root(ctx: RouteContext) -> Path:
-    return (ctx.config.repo_root / ctx.config.repo_wiki_path).resolve()
+def _wiki_root(cfg: HydraFlowConfig) -> Path:
+    return (cfg.repo_root / cfg.repo_wiki_path).resolve()
 
 
-def _iter_wiki_entries(ctx: RouteContext):
+def _iter_wiki_entries(cfg: HydraFlowConfig):
     """Yield {id, owner, repo, topic, filename, status} for every wiki entry.
 
     Walks the tracked ``repo_wiki/`` layout. Used by the entry-graph and
     discovered-bucket endpoints. Yields no results when the directory is
     absent or empty.
     """
-    root = _wiki_root(ctx)
+    root = _wiki_root(cfg)
     if not root.is_dir():
         return
     for owner_dir in sorted(root.iterdir()):
@@ -186,17 +188,169 @@ def _adr_summary_from_path(path: Path) -> dict[str, Any] | None:
     }
 
 
+def _build_graph(
+    cfg: HydraFlowConfig,
+    *,
+    include_adrs: bool,
+    include_entries: bool,
+    id_prefix: str = "",
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, dict[str, str]]]:
+    """Assemble one repo's term/ADR/entry graph.
+
+    ``id_prefix`` namespaces every node id, parent ref, and edge endpoint so
+    several repos can be unioned (``repo=__all__``) without id collisions; it is
+    ``""`` for a single-repo graph (preserving the legacy un-prefixed ids).
+    Edges stay within the repo because targets are prefixed identically.
+    """
+
+    def _nid(raw: str) -> str:
+        return f"{id_prefix}{raw}"
+
+    store = TermStore(_terms_root(cfg))
+    terms = store.list()
+    contexts_seen: dict[str, dict[str, str]] = {}
+    nodes: list[dict[str, Any]] = []
+    edges: list[dict[str, Any]] = []
+
+    for term in terms:
+        ctx_id = _nid(term.bounded_context.value)
+        contexts_seen.setdefault(
+            ctx_id, {"id": ctx_id, "label": term.bounded_context.value}
+        )
+        nodes.append(
+            {
+                "id": _nid(term.id),
+                "type": "term",
+                "name": term.name,
+                "kind": term.kind.value,
+                "confidence": term.confidence,
+                "parent": ctx_id,
+                "code_anchor": term.code_anchor,
+            }
+        )
+        for rel in term.related:
+            edges.append(
+                {
+                    "source": _nid(term.id),
+                    "target": _nid(rel.target),
+                    "kind": rel.kind.value,
+                }
+            )
+
+    if include_adrs:
+        adr_root = _adr_root(cfg)
+        if adr_root.is_dir():
+            term_lookup: dict[str, str] = {}
+            for term in terms:
+                term_lookup[term.name.lower()] = term.id
+                for alias in term.aliases:
+                    term_lookup.setdefault(alias.lower(), term.id)
+
+            adr_context_added = False
+            for path in sorted(adr_root.glob("*.md")):
+                summary = _adr_summary_from_path(path)
+                if summary is None:
+                    continue
+                if not adr_context_added:
+                    adr_ctx = _nid("adrs")
+                    contexts_seen.setdefault(adr_ctx, {"id": adr_ctx, "label": "adrs"})
+                    adr_context_added = True
+                adr_id = _nid(f"adr-{summary['number']}")
+                nodes.append(
+                    {
+                        "id": adr_id,
+                        "type": "adr",
+                        "name": f"ADR-{summary['number']:04d}",
+                        "title": summary["title"],
+                        "status": summary["status"],
+                        "parent": _nid("adrs"),
+                    }
+                )
+                try:
+                    text = path.read_text(encoding="utf-8")
+                except OSError:
+                    continue
+                related_lines = _adr_related_terms(text)
+                seen_targets: set[str] = set()
+                for line in related_lines:
+                    line_lower = line.lower()
+                    for needle, term_id in term_lookup.items():
+                        if term_id in seen_targets:
+                            continue
+                        pattern = rf"\b{re.escape(needle)}\b"
+                        if re.search(pattern, line_lower):
+                            edges.append(
+                                {
+                                    "source": adr_id,
+                                    "target": _nid(term_id),
+                                    "kind": "relates_to",
+                                }
+                            )
+                            seen_targets.add(term_id)
+
+    if include_entries:
+        entry_to_term: dict[str, str] = {}
+        term_by_id = {t.id: t for t in terms}
+        for term in terms:
+            for entry_id in term.evidence:
+                entry_to_term.setdefault(entry_id, term.id)
+
+        for entry in _iter_wiki_entries(cfg):
+            eid = entry["id"]
+            term_id = entry_to_term.get(eid)
+            if term_id is None:
+                continue
+            anchor = term_by_id.get(term_id)
+            parent = _nid(anchor.bounded_context.value) if anchor is not None else None
+            node_id = _nid(f"entry-{entry['owner']}-{entry['repo']}-{eid}")
+            nodes.append(
+                {
+                    "id": node_id,
+                    "type": "entry",
+                    "name": entry["filename"],
+                    "topic": entry["topic"],
+                    "parent": parent,
+                    "owner": entry["owner"],
+                    "repo": entry["repo"],
+                    "entry_id": eid,
+                }
+            )
+            edges.append(
+                {
+                    "source": node_id,
+                    "target": _nid(term_id),
+                    "kind": "evidence_for",
+                }
+            )
+
+    return nodes, edges, contexts_seen
+
+
 def register(router: APIRouter, ctx: RouteContext) -> None:
     """Attach /api/atlas/* handlers to ``router``."""
 
+    def _is_all(repo: str | None) -> bool:
+        return repo is not None and repo.strip().lower() == REPO_ALL
+
+    def _cfg_for(repo: str | None) -> HydraFlowConfig:
+        """Single config for a host-only-parameterized read.
+
+        Atlas terms/ADRs are host-only compiled knowledge (D4): ``__all__`` and
+        ``None`` both resolve the default/host repo's roots. A specific slug
+        reads that repo's roots so a supervised repo that *does* ship
+        ``docs/wiki/terms``/``docs/adr`` renders when selected.
+        """
+        cfg, _s, _b, _g = ctx.resolve_runtime(None if _is_all(repo) else repo)
+        return cfg
+
     @router.get("/api/atlas/terms")
-    def list_atlas_terms() -> list[dict[str, Any]]:
-        store = TermStore(_terms_root(ctx))
+    def list_atlas_terms(repo: RepoSlugParam = None) -> list[dict[str, Any]]:
+        store = TermStore(_terms_root(_cfg_for(repo)))
         return [_term_summary(t) for t in store.list()]
 
     @router.get("/api/atlas/terms/{term_id}")
-    def get_atlas_term(term_id: str) -> dict[str, Any]:
-        store = TermStore(_terms_root(ctx))
+    def get_atlas_term(term_id: str, repo: RepoSlugParam = None) -> dict[str, Any]:
+        store = TermStore(_terms_root(_cfg_for(repo)))
         terms = store.list()
         by_id = {t.id: t for t in terms}
         if term_id not in by_id:
@@ -205,165 +359,73 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
 
     @router.get("/api/atlas/graph")
     def get_atlas_graph(
-        include_adrs: bool = True, include_entries: bool = False
+        include_adrs: bool = True,
+        include_entries: bool = False,
+        repo: RepoSlugParam = None,
     ) -> dict[str, Any]:
-        store = TermStore(_terms_root(ctx))
-        terms = store.list()
-        contexts_seen: dict[str, dict[str, str]] = {}
-        nodes: list[dict[str, Any]] = []
-        edges: list[dict[str, Any]] = []
-
-        for term in terms:
-            ctx_id = term.bounded_context.value
-            contexts_seen.setdefault(ctx_id, {"id": ctx_id, "label": ctx_id})
-            nodes.append(
-                {
-                    "id": term.id,
-                    "type": "term",
-                    "name": term.name,
-                    "kind": term.kind.value,
-                    "confidence": term.confidence,
-                    "parent": ctx_id,
-                    "code_anchor": term.code_anchor,
-                }
-            )
-            for rel in term.related:
-                edges.append(
-                    {
-                        "source": term.id,
-                        "target": rel.target,
-                        "kind": rel.kind.value,
-                    }
+        if _is_all(repo):
+            # Union every repo's graph; namespace node ids by slug so terms
+            # sharing an id across repos don't collide. Edges stay within a
+            # repo because targets carry the same prefix.
+            nodes: list[dict[str, Any]] = []
+            edges: list[dict[str, Any]] = []
+            contexts: dict[str, dict[str, str]] = {}
+            for cfg, _s, _b, _g, slug in ctx.resolve_runtimes(repo):
+                n, e, c = _build_graph(
+                    cfg,
+                    include_adrs=include_adrs,
+                    include_entries=include_entries,
+                    id_prefix=f"{slug}/",
                 )
-
-        if include_adrs:
-            adr_root = _adr_root(ctx)
-            if adr_root.is_dir():
-                # Pre-build a lookup of {lowercased name|alias: term.id}.
-                term_lookup: dict[str, str] = {}
-                for term in terms:
-                    term_lookup[term.name.lower()] = term.id
-                    for alias in term.aliases:
-                        term_lookup.setdefault(alias.lower(), term.id)
-
-                adr_context_added = False
-                for path in sorted(adr_root.glob("*.md")):
-                    summary = _adr_summary_from_path(path)
-                    if summary is None:
-                        continue
-                    if not adr_context_added:
-                        contexts_seen.setdefault(
-                            "adrs", {"id": "adrs", "label": "adrs"}
-                        )
-                        adr_context_added = True
-                    adr_id = f"adr-{summary['number']}"
-                    nodes.append(
-                        {
-                            "id": adr_id,
-                            "type": "adr",
-                            "name": f"ADR-{summary['number']:04d}",
-                            "title": summary["title"],
-                            "status": summary["status"],
-                            "parent": "adrs",
-                        }
-                    )
-                    try:
-                        text = path.read_text(encoding="utf-8")
-                    except OSError:
-                        continue
-                    related_lines = _adr_related_terms(text)
-                    seen_targets: set[str] = set()
-                    for line in related_lines:
-                        line_lower = line.lower()
-                        for needle, term_id in term_lookup.items():
-                            # Word-boundary match — substring matching gave
-                            # spurious edges (e.g., the term "Task" matched
-                            # incidental prose like "this ADR task").
-                            if term_id in seen_targets:
-                                continue
-                            pattern = rf"\b{re.escape(needle)}\b"
-                            if re.search(pattern, line_lower):
-                                edges.append(
-                                    {
-                                        "source": adr_id,
-                                        "target": term_id,
-                                        "kind": "relates_to",
-                                    }
-                                )
-                                seen_targets.add(term_id)
-
-        if include_entries:
-            # Build a {entry_id: term_id} reverse index from the evidence
-            # lists. Entries that don't appear get routed to the Discovered
-            # bucket; entries with multiple terms attach to the first one
-            # we see (collisions are rare and a single attachment is enough
-            # for graph navigation).
-            entry_to_term: dict[str, str] = {}
-            term_by_id = {t.id: t for t in terms}
-            for term in terms:
-                for entry_id in term.evidence:
-                    entry_to_term.setdefault(entry_id, term.id)
-
-            for entry in _iter_wiki_entries(ctx):
-                eid = entry["id"]
-                term_id = entry_to_term.get(eid)
-                if term_id is None:
-                    # Orphan entries surface via /api/atlas/discovered, not
-                    # the main graph payload — keeps the canvas focused on
-                    # the term-anchored network.
-                    continue
-                anchor = term_by_id.get(term_id)
-                parent = anchor.bounded_context.value if anchor is not None else None
-                node_id = f"entry-{entry['owner']}-{entry['repo']}-{eid}"
-                nodes.append(
-                    {
-                        "id": node_id,
-                        "type": "entry",
-                        "name": entry["filename"],
-                        "topic": entry["topic"],
-                        "parent": parent,
-                        "owner": entry["owner"],
-                        "repo": entry["repo"],
-                        "entry_id": eid,
-                    }
-                )
-                edges.append(
-                    {
-                        "source": node_id,
-                        "target": term_id,
-                        "kind": "evidence_for",
-                    }
-                )
-
-        return {
-            "nodes": nodes,
-            "edges": edges,
-            "contexts": list(contexts_seen.values()),
-        }
+                nodes.extend(n)
+                edges.extend(e)
+                contexts.update(c)
+            return {"nodes": nodes, "edges": edges, "contexts": list(contexts.values())}
+        n, e, c = _build_graph(
+            _cfg_for(repo),
+            include_adrs=include_adrs,
+            include_entries=include_entries,
+        )
+        return {"nodes": n, "edges": e, "contexts": list(c.values())}
 
     @router.get("/api/atlas/discovered")
-    def list_atlas_discovered() -> list[dict[str, Any]]:
+    def list_atlas_discovered(repo: RepoSlugParam = None) -> list[dict[str, Any]]:
         """Wiki entries with no term-evidence backlink (the Discovered bucket).
 
         The frontend renders these inside a virtual 'discovered' subgraph
         with dashed-grey styling so operators can see what knowledge the
-        term proposer hasn't classified yet (ADR-0061).
+        term proposer hasn't classified yet (ADR-0061). ``repo=__all__`` unions
+        every repo's orphans, tagging each with the runtime ``scope_repo`` and
+        deduping by the wiki-layout ``(owner, repo, id)``.
         """
-        store = TermStore(_terms_root(ctx))
-        linked: set[str] = set()
-        for term in store.list():
-            for entry_id in term.evidence:
-                linked.add(entry_id)
-        out: list[dict[str, Any]] = []
-        for entry in _iter_wiki_entries(ctx):
-            if entry["id"] in linked:
-                continue
-            out.append(entry)
-        return out
+
+        def _orphans(cfg: HydraFlowConfig, slug: str | None = None):
+            store = TermStore(_terms_root(cfg))
+            linked: set[str] = set()
+            for term in store.list():
+                for entry_id in term.evidence:
+                    linked.add(entry_id)
+            for entry in _iter_wiki_entries(cfg):
+                if entry["id"] in linked:
+                    continue
+                yield {**entry, "scope_repo": slug} if slug is not None else entry
+
+        if _is_all(repo):
+            seen: set[tuple[str, str, str]] = set()
+            out: list[dict[str, Any]] = []
+            for cfg, _s, _b, _g, slug in ctx.resolve_runtimes(repo):
+                for entry in _orphans(cfg, slug):
+                    key = (entry["owner"], entry["repo"], entry["id"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    out.append(entry)
+            return out
+        return list(_orphans(_cfg_for(repo)))
 
     @router.get("/api/atlas/adrs")
-    def list_atlas_adrs() -> list[dict[str, Any]]:
-        root = _adr_root(ctx)
+    def list_atlas_adrs(repo: RepoSlugParam = None) -> list[dict[str, Any]]:
+        root = _adr_root(_cfg_for(repo))
         if not root.is_dir():
             return []
         out: list[dict[str, Any]] = []
@@ -374,8 +436,8 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return out
 
     @router.get("/api/atlas/adrs/{number}")
-    def get_atlas_adr(number: int) -> dict[str, Any]:
-        root = _adr_root(ctx)
+    def get_atlas_adr(number: int, repo: RepoSlugParam = None) -> dict[str, Any]:
+        root = _adr_root(_cfg_for(repo))
         if not root.is_dir():
             raise HTTPException(status_code=404, detail="adr dir not found")
         prefix = f"{number:04d}-"
@@ -398,19 +460,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             }
         raise HTTPException(status_code=404, detail="adr not found")
 
-    @router.get("/api/atlas/term-loops/status")
-    def get_term_loops_status() -> dict[str, Any]:
-        """Last-tick snapshot for the term-graph maintenance loops (P2-T6).
-
-        Reads from StateTracker.get_worker_heartbeats() — same source the
-        SystemPanel background-worker tiles consume. Returns one entry per
-        relevant loop. When the orchestrator has never run, every entry is
-        present with last_run=None so the UI can render "never run" without
-        special-casing absence.
-        """
+    def _loops_snapshot(state: Any) -> dict[str, Any]:
         loops = ("term_proposer", "term_pruner", "edge_proposer")
         try:
-            heartbeats = ctx.state.get_worker_heartbeats()
+            heartbeats = state.get_worker_heartbeats()
         except Exception:  # noqa: BLE001 — diagnostics endpoint, never fail
             heartbeats = {}
         out: dict[str, Any] = {}
@@ -424,3 +477,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 "last_action_count": details.get("count"),
             }
         return out
+
+    @router.get("/api/atlas/term-loops/status")
+    def get_term_loops_status(repo: RepoSlugParam = None) -> dict[str, Any]:
+        """Last-tick snapshot for the term-graph maintenance loops (P2-T6).
+
+        Reads from StateTracker.get_worker_heartbeats() — same source the
+        SystemPanel background-worker tiles consume. ``repo=__all__`` nests one
+        snapshot per repo under ``repos[]``; a specific slug (or ``None``)
+        returns that repo's flat loop map.
+        """
+        if _is_all(repo):
+            return {
+                "repos": [
+                    {"repo": slug, "loops": _loops_snapshot(state)}
+                    for _cfg, state, _b, _g, slug in ctx.resolve_runtimes(repo)
+                ]
+            }
+        _cfg, state, _b, _g = ctx.resolve_runtime(repo)
+        return _loops_snapshot(state)

--- a/tests/test_atlas_routes_multirepo.py
+++ b/tests/test_atlas_routes_multirepo.py
@@ -1,0 +1,145 @@
+"""Atlas routes scope by repo (Phase 5a).
+
+Terms/ADRs/graph are host-only compiled knowledge (D4): ``repo=__all__`` and
+``None`` read the default/host repo's roots, a specific slug reads that repo's
+roots (so a supervised repo that ships docs renders when selected). The wiki
+``discovered`` bucket and the ``graph`` genuinely aggregate across repos under
+``__all__`` (namespaced node ids; ``scope_repo``-tagged + deduped orphans).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from config import HydraFlowConfig
+from state import StateTracker
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+from ubiquitous_language import BoundedContext, Term, TermKind, TermStore
+
+
+def _config_with_term(root: Path, term_name: str, term_id: str) -> HydraFlowConfig:
+    repo_root = root
+    repo_root.mkdir(parents=True, exist_ok=True)
+    store = TermStore(repo_root / "docs" / "wiki" / "terms")
+    store.write(
+        Term(
+            id=term_id,
+            name=term_name,
+            kind=TermKind.SERVICE,
+            bounded_context=BoundedContext.SHARED_KERNEL,
+            definition=f"{term_name} definition.",
+            invariants=[],
+            code_anchor=f"src/{term_name.lower()}.py",
+            confidence="accepted",
+        )
+    )
+    return HydraFlowConfig(repo_root=repo_root)
+
+
+def _seed_orphan_wiki(cfg: HydraFlowConfig, entry_id: str, issue: str) -> None:
+    d = cfg.repo_root / cfg.repo_wiki_path / "acme" / "widgets" / "architecture"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{entry_id}-issue-{issue}-note.md").write_text("# note\n", encoding="utf-8")
+
+
+def _two_repo_router(tmp_path: Path):
+    # App/host config == org-a; registry holds org-a (default) + org-b.
+    cfg_a = _config_with_term(tmp_path / "a", "EventBus", "01A0000000000000000000")
+    cfg_b = _config_with_term(tmp_path / "b", "WidgetFactory", "01B0000000000000000000")
+    state_a = StateTracker(tmp_path / "state_a.json")
+    state_b = StateTracker(tmp_path / "state_b.json")
+    registry = make_registry(
+        {"slug": "org-a", "config": cfg_a, "state": state_a, "orchestrator": None},
+        {"slug": "org-b", "config": cfg_b, "state": state_b, "orchestrator": None},
+    )
+    router, _ = make_dashboard_router(
+        cfg_a,
+        None,
+        state_a,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    return router, cfg_a, cfg_b
+
+
+def test_terms_scope_to_selected_repo(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    terms = find_endpoint(router, "/api/atlas/terms", method="GET")
+    assert {t["name"] for t in terms(repo="org-a")} == {"EventBus"}
+    assert {t["name"] for t in terms(repo="org-b")} == {"WidgetFactory"}
+
+
+def test_terms_all_and_none_are_host_only(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    terms = find_endpoint(router, "/api/atlas/terms", method="GET")
+    # D4: terms are host-only compiled knowledge — __all__ and None both read
+    # the host/default (org-a) roots, NOT a union.
+    assert {t["name"] for t in terms(repo="__all__")} == {"EventBus"}
+    assert {t["name"] for t in terms(repo=None)} == {"EventBus"}
+
+
+def test_graph_all_namespaces_node_ids_per_repo(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    graph = find_endpoint(router, "/api/atlas/graph", method="GET")
+    body = graph(include_adrs=False, include_entries=False, repo="__all__")
+    ids = {n["id"] for n in body["nodes"]}
+    # Every node is namespaced by its owning repo slug so ids can't collide.
+    assert any(i.startswith("org-a/") for i in ids)
+    assert any(i.startswith("org-b/") for i in ids)
+    assert all(i.startswith(("org-a/", "org-b/")) for i in ids)
+    # Contexts namespaced too (so the term's parent ref resolves within-repo).
+    ctx_ids = {c["id"] for c in body["contexts"]}
+    assert all(c.startswith(("org-a/", "org-b/")) for c in ctx_ids)
+
+
+def test_graph_single_repo_keeps_unprefixed_ids(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    graph = find_endpoint(router, "/api/atlas/graph", method="GET")
+    body = graph(include_adrs=False, include_entries=False, repo="org-b")
+    ids = {n["id"] for n in body["nodes"]}
+    # A single repo keeps the legacy un-prefixed term ids.
+    assert "01B0000000000000000000" in ids
+
+
+def test_discovered_all_unions_and_tags_scope_repo(tmp_path: Path):
+    router, cfg_a, cfg_b = _two_repo_router(tmp_path)
+    # Seed an orphan wiki entry (no term evidence) in each repo, distinct ids.
+    _seed_orphan_wiki(cfg_a, "1", "11")
+    _seed_orphan_wiki(cfg_b, "2", "22")
+    discovered = find_endpoint(router, "/api/atlas/discovered", method="GET")
+    rows = discovered(repo="__all__")
+    by_id = {r["id"]: r for r in rows}
+    assert {"1", "2"} <= set(by_id)
+    assert by_id["1"]["scope_repo"] == "org-a"
+    assert by_id["2"]["scope_repo"] == "org-b"
+
+
+def test_discovered_all_dedupes_same_entry_across_repos(tmp_path: Path):
+    router, cfg_a, cfg_b = _two_repo_router(tmp_path)
+    # The SAME wiki-layout key (owner=acme, repo=widgets, id=1) in both repos.
+    _seed_orphan_wiki(cfg_a, "1", "42")
+    _seed_orphan_wiki(cfg_b, "1", "42")
+    discovered = find_endpoint(router, "/api/atlas/discovered", method="GET")
+    rows = discovered(repo="__all__")
+    # Dedup by (owner, repo, id): exactly one survives, the first repo wins.
+    assert [r["id"] for r in rows].count("1") == 1
+    assert next(r for r in rows if r["id"] == "1")["scope_repo"] == "org-a"
+
+
+def test_term_loops_all_nests_per_repo(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    status = find_endpoint(router, "/api/atlas/term-loops/status", method="GET")
+    body = status(repo="__all__")
+    assert {r["repo"] for r in body["repos"]} == {"org-a", "org-b"}
+    # Each repo entry carries the loop snapshot.
+    assert "term_proposer" in body["repos"][0]["loops"]
+
+
+def test_term_loops_single_repo_is_flat(tmp_path: Path):
+    router, _a, _b = _two_repo_router(tmp_path)
+    status = find_endpoint(router, "/api/atlas/term-loops/status", method="GET")
+    body = status(repo="org-a")
+    # Specific slug → flat loop map (backward-compatible shape).
+    assert "term_proposer" in body
+    assert "repos" not in body


### PR DESCRIPTION
## What

Phase **5a** of the multi-repo program: make the `/api/atlas/*` knowledge-graph endpoints repo-aware. Backend-only; the frontend (AtlasExplorer threading) is 5c.

The root helpers (`_terms_root`/`_adr_root`/`_wiki_root`/`_iter_wiki_entries`) now take a **`cfg`** instead of `ctx`, and every handler gains `repo: RepoSlugParam = None`.

## D4 — host-only terms/ADRs/graph, parameterized

Terms/ADRs/graph are host-only compiled knowledge: **`__all__` and `None` resolve the default/host repo's roots**, while a **specific slug** reads that repo's roots (so a supervised repo that ships `docs/wiki/terms`/`docs/adr` renders when selected). `/terms`, `/terms/{id}`, `/adrs`, `/adrs/{n}` use this single-config `_cfg_for` pattern.

## Genuinely-aggregating endpoints under `__all__`

- **`/graph`**: unions every repo via `resolve_runtimes`, **namespacing** node ids / parent refs / context ids / edge endpoints with `f"{slug}/"` so ids can't collide and edges stay within-repo. Extracted to a reusable `_build_graph(cfg, *, id_prefix="")`; a single repo keeps the **legacy un-prefixed ids** (byte-for-byte backward-compatible).
- **`/discovered`**: unions orphan wiki entries, tagging each with **`scope_repo`** (the runtime slug, distinct from the wiki-layout owner/repo) and deduping by `(owner, repo, id)`.
- **`/term-loops/status`**: nests one snapshot per repo under `repos[]`; a specific slug (or `None`) keeps the flat loop map.

## Backward compatibility

`register(router, ctx)` is unchanged in signature; the frontend doesn't pass `repo` yet, so **`repo=None` reproduces the prior host-only behavior exactly** — the 46 existing atlas tests are untouched. 5b (`/api/wiki/*` + MaintenanceView) and 5c (AtlasExplorer frontend) follow.

## Tests

`tests/test_atlas_routes_multirepo.py` — terms scope-to-slug + host-only `__all__`/None; graph `__all__` namespacing + single-repo un-prefixed; discovered union + `scope_repo` + **same-key dedup**; term-loops per-repo nesting + flat single.

## Verification

- `make quality` ✅ 15901 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- Adversarial review — **no production bugs** (backward-compat verified field-by-field across the graph refactor); two test-quality improvements applied (dedup-collision test, `cfg.repo_wiki_path`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)