### PR TITLE
fix(loops): auto-close SkillPromptEval drift issues on FAIL→PASS (#9359)

### DIFF
--- a/src/skill_prompt_eval_loop.py
+++ b/src/skill_prompt_eval_loop.py
@@ -111,11 +111,26 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
             logger.warning("trust-adversarial non-JSON response")
             return []
 
-    async def _file_drift_issue(self, case: dict[str, Any], last_status: str) -> int:
-        title = (
+    @staticmethod
+    def _drift_title(case: dict[str, Any]) -> str:
+        # Single source so the file path and the close-on-recovery path can never
+        # drift apart (#9359 / fake-fidelity lesson).
+        return (
             f"Skill prompt drift: {case.get('skill', '?')} "
             f"missed {case.get('case_id', '?')}"
         )
+
+    async def _resolve_drift_issue(self, case: dict[str, Any]) -> None:
+        """Close the open drift issue when a case is passing again (#9359)."""
+        existing = await self._pr.find_existing_issue(self._drift_title(case))
+        if existing:
+            await self._pr.post_comment(
+                existing, "Skill-prompt case is passing again — auto-closing."
+            )
+            await self._pr.close_issue(existing)
+
+    async def _file_drift_issue(self, case: dict[str, Any], last_status: str) -> int:
+        title = self._drift_title(case)
         body = (
             f"## Regression\n\n"
             f"Case `{case.get('case_id')}` regressed "
@@ -253,6 +268,7 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
         }
         filed = 0
         escalated = 0
+        resolved = 0
         dedup = self._dedup.get()
         # Per-tick seed: stable within one invocation, diverse across ticks
         # (matches plan decision #5 — seed-stable per workflow run).
@@ -263,8 +279,8 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                 continue
             was = last_green.get(case_id, "PASS")
             now = case.get("status")
+            key = f"skill_prompt_eval:{case_id}"
             if was == "PASS" and now == "FAIL":
-                key = f"skill_prompt_eval:{case_id}"
                 if key in dedup:
                     continue
                 attempts = self._state.inc_skill_prompt_attempts(case_id)
@@ -276,6 +292,15 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
                     filed += 1
                 dedup.add(key)
                 self._dedup.set_all(dedup)
+            elif now == "PASS" and key in dedup:
+                # Recovery — the case passes again. Close the open drift issue
+                # and clear its dedup/attempts so a future regression re-files
+                # (#9359 issue-hygiene).
+                await self._resolve_drift_issue(case)
+                dedup.discard(key)
+                self._dedup.set_all(dedup)
+                self._state.clear_skill_prompt_attempts(case_id)
+                resolved += 1
 
         # Save the new snapshot — tests that currently PASS become the
         # new last-green. Tests that remain FAIL stay in the dedup set.
@@ -305,6 +330,7 @@ class SkillPromptEvalLoop(BaseBackgroundLoop):
             "status": "ok",
             "filed": filed,
             "escalated": escalated,
+            "resolved": resolved,
             "weak_cases_flagged": weak_flagged,
             "cases_seen": len(cases),
         }

--- a/tests/test_skill_prompt_eval_loop.py
+++ b/tests/test_skill_prompt_eval_loop.py
@@ -254,3 +254,38 @@ async def test_do_work_caps_corpus_cases(loop_env) -> None:
     # available, or count attempts. Simpler: assert state inc was
     # called <= cap times.
     assert state.inc_skill_prompt_attempts.call_count <= 50
+
+
+async def test_recovery_closes_drift_issue_and_clears(loop_env, monkeypatch) -> None:
+    """#9359: a case that passes again (its dedup key set) closes the open drift
+    issue, clears the dedup key + attempts."""
+    cfg, state, pr, dedup = loop_env
+    dedup.get.return_value = {"skill_prompt_eval:case_shrink_001"}
+    pr.find_existing_issue = AsyncMock(return_value=88)
+    stop = asyncio.Event()
+    loop = SkillPromptEvalLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_run_corpus() -> list[dict]:
+        return [
+            {
+                "case_id": "case_shrink_001",
+                "skill": "diff_sanity",
+                "status": "PASS",
+                "provenance": "hand-crafted",
+                "expected_catcher": "diff_sanity",
+            },
+        ]
+
+    async def fake_reconcile():
+        return None
+
+    monkeypatch.setattr(loop, "_run_corpus", fake_run_corpus)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+
+    stats = await loop._do_work()
+
+    assert stats["resolved"] == 1
+    pr.close_issue.assert_awaited_once_with(88)
+    state.clear_skill_prompt_attempts.assert_called_once_with("case_shrink_001")


### PR DESCRIPTION
Batch 6. SkillPromptEvalLoop filed `skill-prompt-drift` issues on a PASS→FAIL case regression but never closed them when the case recovered.

- When a case carrying an open drift dedup key evaluates **PASS** again, close its `Skill prompt drift: {skill} missed {case_id}` issue, clear the dedup key + attempts counter (so a future regression re-files).
- The drift title is now **single-sourced** via `_drift_title(case)`, used by both the file path and the close path — they can't drift apart (the fake-fidelity lesson behind #9351/#9359).
- HITL escalations + `_reconcile_closed_escalations` left untouched (MANAGED).

**Verification:** 1 new recovery test; `make quality` **15896 passed**; `make scenario` + `make scenario-loops` green.

**Progress: 9 loops migrated** (StagingPromotion, CostBudget, Diagram, GateActivator, BranchProtection, Pricing, HealthMonitor×2, SkillPromptEval + `RollupIssueManager`). Remaining: PrinciplesAudit (same FAIL→PASS pattern), ContractRefresh, SecurityPatch, FlakeTracker. StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)