### PR TITLE
feat(wiki): /api/wiki/* maintenance surface scopes by repo (Phase 5b)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T05:08:33.667500+00:00",
-  "commit_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13",
+  "regenerated_at": "2026-06-09T05:59:10.990665+00:00",
+  "commit_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583",
   "artifacts": {
     "loops.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "ports.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "labels.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "modules.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "events.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "adr_xref.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "mockworld.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "changelog.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "coverage_matrix.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "functional_areas.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "ubiquitous-language.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "e3413ee1e936f12de4dae3a17ecdbec39ad3ad13"
+      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `af05e0c` — feat(atlas): /api/atlas/* endpoints scope by repo (Phase 5a) (#9377) (#9377) *(2026-06-08)*
 - `1f68711` — feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish) (#9374) (#9374) *(2026-06-08)*
 - `91b6227` — feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4) (#9371) (#9371) *(2026-06-08)*
 - `0be9dbc` — feat(diagnostics): factory-health summary aggregates across repos (Phase 3c-3) (#9369) (#9369) *(2026-06-08)*

--- a/src/dashboard_routes/_wiki_routes.py
+++ b/src/dashboard_routes/_wiki_routes.py
@@ -17,17 +17,20 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
 
+from route_types import REPO_ALL, RepoSlugParam
 from wiki_maint_queue import MaintenanceTask
 
 if TYPE_CHECKING:
     from fastapi import APIRouter
 
+    from config import HydraFlowConfig
     from dashboard_routes._routes import RouteContext
 
 logger = logging.getLogger("hydraflow.dashboard.wiki")
@@ -63,14 +66,16 @@ class RebuildIndexPayload(BaseModel):
     repo: str = Field(min_length=1)
 
 
-def _wiki_loop(ctx: RouteContext):
-    """Return the ``RepoWikiLoop`` from the running orchestrator, or None.
+def _wiki_loop(get_orch: Callable[[], Any]):
+    """Return the ``RepoWikiLoop`` from the resolved orchestrator, or None.
 
-    Services live inside ``ServiceRegistry`` on the orchestrator, which
-    is constructed after the dashboard.  Looking them up lazily keeps
-    the route module decoupled from ``service_registry`` import order.
+    Takes the repo's zero-arg orchestrator getter (``resolve_runtime(repo)``'s
+    4th element) rather than ``ctx`` so each repo's own loop/queue is reached.
+    Services live inside ``ServiceRegistry`` on the orchestrator, which is
+    constructed after the dashboard.  Looking them up lazily keeps the route
+    module decoupled from ``service_registry`` import order.
     """
-    orch = ctx.get_orchestrator()
+    orch = get_orch()
     if orch is None:
         return None
     svc = getattr(orch, "_svc", None)
@@ -79,37 +84,37 @@ def _wiki_loop(ctx: RouteContext):
     return getattr(svc, "repo_wiki_loop", None)
 
 
-def _maintenance_queue(ctx: RouteContext):
+def _maintenance_queue(get_orch: Callable[[], Any]):
     """Return the loop's ``MaintenanceQueue``, or None if loop is down."""
-    loop = _wiki_loop(ctx)
+    loop = _wiki_loop(get_orch)
     if loop is None:
         return None
     return getattr(loop, "_queue", None)
 
 
-def _wiki_root(ctx: RouteContext) -> Path:
-    """Absolute path to the tracked ``repo_wiki/`` directory.
+def _wiki_root(cfg: HydraFlowConfig) -> Path:
+    """Absolute path to a repo's tracked ``repo_wiki/`` directory.
 
     Reads from ``config.repo_root / config.repo_wiki_path`` so the API
     sees what the migration script and phase runners wrote, not the
     legacy ``.hydraflow/repo_wiki/`` layout.
     """
-    return (ctx.config.repo_root / ctx.config.repo_wiki_path).resolve()
+    return (cfg.repo_root / cfg.repo_wiki_path).resolve()
 
 
-def _repo_dir(ctx: RouteContext, owner: str, repo: str) -> Path | None:
+def _repo_dir(cfg: HydraFlowConfig, owner: str, repo: str) -> Path | None:
     """Return the tracked dir for ``{owner}/{repo}`` or None when absent.
 
     Prevents path traversal via ``..`` or absolute paths in owner/repo.
     """
     if "/" in owner or "/" in repo or ".." in owner or ".." in repo:
         return None
-    candidate = _wiki_root(ctx) / owner / repo
+    candidate = _wiki_root(cfg) / owner / repo
     try:
         candidate_resolved = candidate.resolve()
     except OSError:
         return None
-    root = _wiki_root(ctx)
+    root = _wiki_root(cfg)
     if not str(candidate_resolved).startswith(str(root)):
         return None
     if not candidate_resolved.is_dir():
@@ -202,25 +207,44 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
     mutate the wiki directly.
     """
 
+    def _is_all(repo: str | None) -> bool:
+        return repo is not None and repo.strip().lower() == REPO_ALL
+
+    def _resolve(repo: str | None) -> tuple[HydraFlowConfig, Callable[[], Any]]:
+        """``(config, get_orch)`` for the selected repo.
+
+        ``__all__`` and ``None`` resolve the default/host runtime; a specific
+        slug resolves that repo's config + orchestrator (so its own wiki dir
+        and RepoWikiLoop/queue are reached).
+        """
+        cfg, _s, _b, get_orch = ctx.resolve_runtime(None if _is_all(repo) else repo)
+        return cfg, get_orch
+
+    def _reject_all(repo: str | None) -> None:
+        if _is_all(repo):
+            raise HTTPException(
+                status_code=400,
+                detail="repo=__all__ is not valid for wiki admin actions; pass a repo slug",
+            )
+
     @router.get("/api/wiki/metrics")
-    async def get_wiki_metrics() -> dict:
-        """Return current knowledge-system counters as a JSON snapshot."""
+    async def get_wiki_metrics(repo: RepoSlugParam = None) -> dict:
+        """Return current knowledge-system counters as a JSON snapshot.
+
+        ``knowledge_metrics`` is a process-wide singleton — its snapshot already
+        spans every repo's activity, so ``repo`` is accepted for API symmetry
+        but does NOT scope the counters (a per-repo split would need a
+        knowledge_metrics refactor, out of scope for this slice).
+        """
         from knowledge_metrics import metrics as _metrics  # noqa: PLC0415
 
         return _metrics.snapshot()
 
-    @router.get("/api/wiki/health")
-    async def get_wiki_health() -> dict:
-        """Report wiki + tribal store presence and rough sizing.
-
-        Reads the RepoWikiLoop's store and tribal_store attributes so the
-        dashboard can show whether the knowledge system is populated.
-        """
+    def _health_snapshot(get_orch: Callable[[], Any]) -> dict:
         result: dict = {"store": "unconfigured", "tribal": "unconfigured"}
-        loop = _wiki_loop(ctx)
+        loop = _wiki_loop(get_orch)
         if loop is None:
             return result
-
         store = getattr(loop, "_wiki_store", None)
         if store is not None:
             try:
@@ -229,7 +253,6 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 repos = []
             result["store"] = "populated" if repos else "empty"
             result["repos"] = len(repos)
-
         tribal = getattr(loop, "_tribal_store", None)
         if tribal is not None:
             try:
@@ -239,23 +262,60 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             result["tribal"] = "populated" if out else "empty"
         return result
 
+    @router.get("/api/wiki/health")
+    async def get_wiki_health(repo: RepoSlugParam = None) -> dict:
+        """Report wiki + tribal store presence and rough sizing.
+
+        ``repo=__all__`` aggregates across every repo's RepoWikiLoop (summed
+        ``repos`` count; a state is ``populated`` if any repo is); a specific
+        slug (or ``None``) reports that repo's loop.
+        """
+        if _is_all(repo):
+            _precedence = {"populated": 2, "empty": 1, "unconfigured": 0}
+            total = 0
+            store_state = "unconfigured"
+            tribal_state = "unconfigured"
+            for _c, _s, _b, get_orch, _slug in ctx.resolve_runtimes(repo):
+                snap = _health_snapshot(get_orch)
+                total += int(snap.get("repos", 0) or 0)
+                if _precedence[snap["store"]] > _precedence[store_state]:
+                    store_state = snap["store"]
+                if _precedence[snap["tribal"]] > _precedence[tribal_state]:
+                    tribal_state = snap["tribal"]
+            return {"store": store_state, "tribal": tribal_state, "repos": total}
+        return _health_snapshot(_resolve(repo)[1])
+
     @router.get("/api/wiki/repos")
-    def list_wiki_repos() -> list[dict[str, str]]:
-        root = _wiki_root(ctx)
-        if not root.is_dir():
-            return []
-        out: list[dict[str, str]] = []
-        for owner_dir in sorted(root.iterdir()):
-            if not owner_dir.is_dir():
-                continue
-            for repo_dir in sorted(owner_dir.iterdir()):
-                if not repo_dir.is_dir():
+    def list_wiki_repos(repo: RepoSlugParam = None) -> list[dict[str, str]]:
+        def _repos(cfg: HydraFlowConfig) -> list[dict[str, str]]:
+            root = _wiki_root(cfg)
+            if not root.is_dir():
+                return []
+            out: list[dict[str, str]] = []
+            for owner_dir in sorted(root.iterdir()):
+                if not owner_dir.is_dir():
                     continue
-                if (repo_dir / "index.md").exists() or (
-                    repo_dir / "index.json"
-                ).exists():
-                    out.append({"owner": owner_dir.name, "repo": repo_dir.name})
-        return out
+                for repo_dir in sorted(owner_dir.iterdir()):
+                    if not repo_dir.is_dir():
+                        continue
+                    if (repo_dir / "index.md").exists() or (
+                        repo_dir / "index.json"
+                    ).exists():
+                        out.append({"owner": owner_dir.name, "repo": repo_dir.name})
+            return out
+
+        if _is_all(repo):
+            seen: set[tuple[str, str]] = set()
+            out: list[dict[str, str]] = []
+            for cfg, _s, _b, _g, _slug in ctx.resolve_runtimes(repo):
+                for row in _repos(cfg):
+                    key = (row["owner"], row["repo"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    out.append(row)
+            return out
+        return _repos(_resolve(repo)[0])
 
     @router.get("/api/wiki/repos/{owner}/{repo}/entries")
     def list_wiki_entries(
@@ -267,7 +327,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         limit: int = 100,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
-        repo_dir = _repo_dir(ctx, owner, repo)
+        # Entry reads are wiki-subject scoped (owner/repo path). Operated-repo
+        # scoping for ArticlesView is reconciled in 5c (the route's `repo` path
+        # param precludes a `repo` query param), so these read the host wiki.
+        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
         if repo_dir is None:
             return []
         topics: tuple[str, ...] = (topic,) if topic else _TOPICS
@@ -296,7 +359,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
 
     @router.get("/api/wiki/repos/{owner}/{repo}/entries/{entry_id}")
     def get_wiki_entry(owner: str, repo: str, entry_id: str) -> dict[str, Any]:
-        repo_dir = _repo_dir(ctx, owner, repo)
+        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
         if repo_dir is None:
             raise HTTPException(status_code=404, detail="repo not found")
         if not re.fullmatch(r"\d{1,6}", entry_id):
@@ -327,7 +390,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         issue: int | None = None,
         limit: int = 200,
     ) -> list[dict[str, Any]]:
-        repo_dir = _repo_dir(ctx, owner, repo)
+        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
         if repo_dir is None:
             return []
         log_dir = repo_dir / "log"
@@ -355,9 +418,13 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return records[-limit:] if limit else []
 
     @router.get("/api/wiki/maintenance/status")
-    def get_maintenance_status() -> dict[str, Any]:
-        loop = _wiki_loop(ctx)
-        queue = _maintenance_queue(ctx)
+    def get_maintenance_status(repo: RepoSlugParam = None) -> dict[str, Any]:
+        # Maintenance is a single-orchestrator concept (one queue + open PR per
+        # repo); ``__all__``/``None`` report the host/default repo's loop, a
+        # specific slug reports that repo's.
+        cfg, get_orch = _resolve(repo)
+        loop = _wiki_loop(get_orch)
+        queue = _maintenance_queue(get_orch)
         queue_path = (
             queue._path  # noqa: SLF001 — read-only diagnostics
             if queue is not None
@@ -368,17 +435,24 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             "open_pr_branch": getattr(loop, "_open_pr_branch", None) if loop else None,
             "queue_depth": len(queue.peek()) if queue is not None else 0,
             "queue_path": str(queue_path) if queue_path else None,
-            "interval_seconds": ctx.config.repo_wiki_interval,
-            "auto_merge": ctx.config.repo_wiki_maintenance_auto_merge,
-            "coalesce": ctx.config.repo_wiki_maintenance_pr_coalesce,
+            "interval_seconds": cfg.repo_wiki_interval,
+            "auto_merge": cfg.repo_wiki_maintenance_auto_merge,
+            "coalesce": cfg.repo_wiki_maintenance_pr_coalesce,
         }
 
-    @router.post("/api/wiki/admin/force-compile")
-    def admin_force_compile(payload: ForceCompilePayload) -> dict[str, str]:
-        queue = _maintenance_queue(ctx)
+    def _admin_queue(repo: str | None):
+        """The selected repo's maintenance queue; admin actions reject __all__."""
+        _reject_all(repo)
+        queue = _maintenance_queue(_resolve(repo)[1])
         if queue is None:
             raise HTTPException(status_code=503, detail="wiki queue unavailable")
-        queue.enqueue(
+        return queue
+
+    @router.post("/api/wiki/admin/force-compile")
+    def admin_force_compile(
+        payload: ForceCompilePayload, repo: RepoSlugParam = None
+    ) -> dict[str, str]:
+        _admin_queue(repo).enqueue(
             MaintenanceTask(
                 kind="force-compile",
                 repo_slug=f"{payload.owner}/{payload.repo}",
@@ -388,11 +462,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return {"status": "queued"}
 
     @router.post("/api/wiki/admin/mark-stale")
-    def admin_mark_stale(payload: MarkStalePayload) -> dict[str, str]:
-        queue = _maintenance_queue(ctx)
-        if queue is None:
-            raise HTTPException(status_code=503, detail="wiki queue unavailable")
-        queue.enqueue(
+    def admin_mark_stale(
+        payload: MarkStalePayload, repo: RepoSlugParam = None
+    ) -> dict[str, str]:
+        _admin_queue(repo).enqueue(
             MaintenanceTask(
                 kind="mark-stale",
                 repo_slug=f"{payload.owner}/{payload.repo}",
@@ -405,11 +478,10 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return {"status": "queued"}
 
     @router.post("/api/wiki/admin/rebuild-index")
-    def admin_rebuild_index(payload: RebuildIndexPayload) -> dict[str, str]:
-        queue = _maintenance_queue(ctx)
-        if queue is None:
-            raise HTTPException(status_code=503, detail="wiki queue unavailable")
-        queue.enqueue(
+    def admin_rebuild_index(
+        payload: RebuildIndexPayload, repo: RepoSlugParam = None
+    ) -> dict[str, str]:
+        _admin_queue(repo).enqueue(
             MaintenanceTask(
                 kind="rebuild-index",
                 repo_slug=f"{payload.owner}/{payload.repo}",
@@ -419,15 +491,16 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         return {"status": "queued"}
 
     @router.post("/api/wiki/admin/run-now")
-    def admin_run_now() -> dict[str, str]:
+    def admin_run_now(repo: RepoSlugParam = None) -> dict[str, str]:
         """Request that ``RepoWikiLoop`` runs on the next event-loop iteration.
 
         The loop itself decides timing — this endpoint only flips a flag
         the loop observes; it does not bypass the interval directly.
         Phase 5 delivers the queued-for-soon semantics; Phase 6 may add
-        an interrupt path.
+        an interrupt path. ``repo=__all__`` is rejected (admin mutation).
         """
-        loop = _wiki_loop(ctx)
+        _reject_all(repo)
+        loop = _wiki_loop(_resolve(repo)[1])
         if loop is None:
             raise HTTPException(status_code=503, detail="wiki loop unavailable")
         # BaseBackgroundLoop exposes ``trigger_now`` / ``force_tick`` on

--- a/src/ui/src/components/atlas/MaintenanceView.jsx
+++ b/src/ui/src/components/atlas/MaintenanceView.jsx
@@ -1,17 +1,24 @@
 import React, { useCallback, useEffect, useState } from 'react'
 import { theme } from '../../theme'
+import { REPO_ALL } from '../../constants'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 
 export function MaintenanceView() {
+  const { fetchWithRepo, selectedRepoSlug } = useHydraFlow()
+  const isAggregate = selectedRepoSlug === REPO_ALL
   const [status, setStatus] = useState(null)
   const [health, setHealth] = useState(null)
   const [termLoops, setTermLoops] = useState(null)
 
   const refresh = useCallback(() => {
-    fetch('/api/wiki/maintenance/status')
+    // Wiki maintenance/health scope to the selected repo (health aggregates
+    // under "All repos"). Term-loops stays host-scoped here; its repo-aware
+    // threading + per-repo nested shape land with AtlasExplorer (5c).
+    fetchWithRepo('/api/wiki/maintenance/status')
       .then((r) => (r.ok ? r.json() : null))
       .then(setStatus)
       .catch(() => setStatus(null))
-    fetch('/api/wiki/health')
+    fetchWithRepo('/api/wiki/health')
       .then((r) => (r.ok ? r.json() : null))
       .then(setHealth)
       .catch(() => setHealth(null))
@@ -19,7 +26,7 @@ export function MaintenanceView() {
       .then((r) => (r.ok ? r.json() : null))
       .then(setTermLoops)
       .catch(() => setTermLoops(null))
-  }, [])
+  }, [fetchWithRepo])
 
   useEffect(() => {
     refresh()
@@ -28,13 +35,18 @@ export function MaintenanceView() {
   }, [refresh])
 
   const post = async (path, body = {}) => {
-    await fetch(`/api/wiki/admin/${path}`, {
+    // Admin mutations target a single repo — the backend rejects __all__.
+    if (isAggregate) return
+    await fetchWithRepo(`/api/wiki/admin/${path}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     })
     refresh()
   }
+  const adminTip = isAggregate
+    ? 'Select a specific repo to run wiki maintenance actions'
+    : undefined
 
   const styles = {
     root: {
@@ -73,6 +85,7 @@ export function MaintenanceView() {
       cursor: 'pointer',
       fontSize: 12,
     },
+    btnDisabled: { opacity: 0.45, cursor: 'not-allowed' },
     btnRow: { display: 'flex', gap: 8, marginTop: 6, flexWrap: 'wrap' },
     actions: {
       gridColumn: 'span 2',
@@ -118,7 +131,13 @@ export function MaintenanceView() {
           <span>{coalesce}</span>
         </div>
         <div style={styles.btnRow}>
-          <button type="button" style={styles.btn} onClick={() => post('run-now', {})}>
+          <button
+            type="button"
+            style={{ ...styles.btn, ...(isAggregate ? styles.btnDisabled : {}) }}
+            disabled={isAggregate}
+            title={adminTip}
+            onClick={() => post('run-now', {})}
+          >
             Run now
           </button>
         </div>
@@ -203,22 +222,27 @@ export function MaintenanceView() {
         <div style={styles.btnRow}>
           <button
             type="button"
-            style={styles.btn}
+            style={{ ...styles.btn, ...(isAggregate ? styles.btnDisabled : {}) }}
+            disabled={isAggregate}
+            title={adminTip}
             onClick={() => post('rebuild-index', { owner: '', repo: '' })}
           >
             Rebuild index
           </button>
           <button
             type="button"
-            style={styles.btn}
+            style={{ ...styles.btn, ...(isAggregate ? styles.btnDisabled : {}) }}
+            disabled={isAggregate}
+            title={adminTip}
             onClick={() => post('force-compile', { owner: '', repo: '', topic: '' })}
           >
             Force compile
           </button>
         </div>
         <div style={{ color: theme.textMuted, fontSize: 10, marginTop: 6 }}>
-          These actions enqueue a MaintenanceTask onto RepoWikiLoop's queue.
-          Owner/repo fields are placeholders in P1 — wired to a form in a follow-up.
+          These actions enqueue a MaintenanceTask onto the selected repo's
+          RepoWikiLoop queue (disabled under "All repos"). Owner/repo fields are
+          placeholders in P1 — wired to a form in a follow-up.
         </div>
       </div>
     </div>

--- a/src/ui/src/components/atlas/__tests__/AtlasExplorer.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/AtlasExplorer.test.jsx
@@ -1,6 +1,16 @@
 import React from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// MaintenanceView (rendered under the Maintenance sub-tab) reads useHydraFlow.
+// A stable hoisted fetchWithRepo delegates to the per-test global.fetch stub.
+const { fetchWithRepo } = vi.hoisted(() => ({
+  fetchWithRepo: (url, opts) => global.fetch(url, opts),
+}))
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: null, fetchWithRepo }),
+}))
+
 import { AtlasExplorer } from '../AtlasExplorer'
 
 beforeEach(() => {

--- a/src/ui/src/components/atlas/__tests__/MaintenanceView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/MaintenanceView.test.jsx
@@ -1,6 +1,26 @@
 import React from 'react'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// `ctx.selectedRepoSlug` is mutable per-test; `fetchWithRepo` is a STABLE
+// hoisted ref (like the real useCallback-memoized fetcher) so the polling
+// effect that depends on it does not re-render-loop. It mirrors applyRepoParam
+// and delegates to the per-test `global.fetch` stub.
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
+
 import { MaintenanceView } from '../MaintenanceView'
 
 const STATUS = {
@@ -15,6 +35,7 @@ const STATUS = {
 const HEALTH = { store: 'populated', repos: 7, tribal: 'populated' }
 
 beforeEach(() => {
+  ctx.selectedRepoSlug = null
   global.fetch = vi.fn((url, opts) => {
     if (url === '/api/wiki/maintenance/status')
       return Promise.resolve({ ok: true, json: () => Promise.resolve(STATUS) })
@@ -57,5 +78,30 @@ describe('MaintenanceView', () => {
       const calls = global.fetch.mock.calls.map((c) => c[0])
       expect(calls).toContain('/api/wiki/admin/run-now')
     })
+  })
+
+  it('scopes the maintenance fetch to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    render(<MaintenanceView />)
+    await waitFor(() => {
+      const calls = global.fetch.mock.calls.map((c) => c[0])
+      expect(calls).toContain('/api/wiki/maintenance/status?repo=org-x')
+      expect(calls).toContain('/api/wiki/health?repo=org-x')
+    })
+  })
+
+  it('disables admin actions and fires no POST under "All repos"', async () => {
+    ctx.selectedRepoSlug = '__all__'
+    render(<MaintenanceView />)
+    const runNow = await screen.findByRole('button', { name: /run now/i })
+    expect(runNow).toBeDisabled()
+    fireEvent.click(runNow)
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /force compile/i })).toBeDisabled()
+    })
+    const posts = global.fetch.mock.calls.filter(
+      (c) => c[1] && c[1].method === 'POST',
+    )
+    expect(posts).toHaveLength(0)
   })
 })

--- a/tests/test_wiki_routes.py
+++ b/tests/test_wiki_routes.py
@@ -383,6 +383,12 @@ def test_get_wiki_health_reports_unconfigured_when_no_loop():
     router = APIRouter()
     ctx = MagicMock()
     ctx.get_orchestrator = lambda: None
+    ctx.resolve_runtime = lambda repo=None: (
+        MagicMock(),
+        None,
+        None,
+        ctx.get_orchestrator,
+    )
     register(router, ctx)
 
     app = FastAPI()
@@ -440,6 +446,12 @@ def test_get_wiki_health_reports_populated_when_loop_has_stores(tmp_path):
     router = APIRouter()
     ctx = MagicMock()
     ctx.get_orchestrator = lambda: orch
+    ctx.resolve_runtime = lambda repo=None: (
+        MagicMock(),
+        None,
+        None,
+        ctx.get_orchestrator,
+    )
     register(router, ctx)
 
     app = FastAPI()

--- a/tests/test_wiki_routes_multirepo.py
+++ b/tests/test_wiki_routes_multirepo.py
@@ -1,0 +1,131 @@
+"""/api/wiki/* maintenance surface scopes by repo (Phase 5b).
+
+The RepoWikiLoop/queue is per-orchestrator, so ``maintenance``/``health``/admin
+resolve the selected repo's orchestrator: a specific slug reaches that repo's
+loop, ``health`` aggregates across repos for ``__all__``, ``/repos`` unions, and
+admin mutations reject ``__all__``. ``metrics`` stays process-global.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from config import HydraFlowConfig
+from state import StateTracker
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+from wiki_maint_queue import MaintenanceQueue
+
+
+def _fake_orch(n_repos: int, queue: MaintenanceQueue, pr_url: str) -> MagicMock:
+    loop = MagicMock()
+    loop._queue = queue
+    loop._open_pr_url = pr_url
+    loop._open_pr_branch = "wiki-maint"
+    store = MagicMock()
+    store.list_repos.return_value = [f"r{i}" for i in range(n_repos)]
+    loop._wiki_store = store
+    loop._tribal_store = None
+    svc = MagicMock()
+    svc.repo_wiki_loop = loop
+    orch = MagicMock()
+    orch._svc = svc
+    return orch
+
+
+def _seed_wiki_index(cfg: HydraFlowConfig, owner: str, repo: str) -> None:
+    d = cfg.repo_root / cfg.repo_wiki_path / owner / repo
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "index.md").write_text("# index\n", encoding="utf-8")
+
+
+@pytest.fixture
+def setup(tmp_path: Path):
+    cfg_a = HydraFlowConfig(repo_root=tmp_path / "a")
+    cfg_b = HydraFlowConfig(repo_root=tmp_path / "b")
+    (tmp_path / "a").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "b").mkdir(parents=True, exist_ok=True)
+    queue_a = MaintenanceQueue(path=tmp_path / "qa.json")
+    queue_b = MaintenanceQueue(path=tmp_path / "qb.json")
+    orch_a = _fake_orch(2, queue_a, "https://gh/x/pull/1")
+    orch_b = _fake_orch(3, queue_b, "https://gh/x/pull/2")
+    state_a = StateTracker(tmp_path / "sa.json")
+    registry = make_registry(
+        {"slug": "org-a", "config": cfg_a, "state": state_a, "orchestrator": orch_a},
+        {"slug": "org-b", "config": cfg_b, "state": state_a, "orchestrator": orch_b},
+    )
+    router, _ = make_dashboard_router(
+        cfg_a,
+        None,
+        state_a,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+        get_orch=lambda: orch_a,
+    )
+    return router, cfg_a, cfg_b, queue_a, queue_b
+
+
+@pytest.mark.asyncio
+async def test_health_scopes_to_one_repo(setup):
+    router, *_ = setup
+    health = find_endpoint(router, "/api/wiki/health", "GET")
+    assert (await health(repo="org-a"))["repos"] == 2
+    assert (await health(repo="org-b"))["repos"] == 3
+
+
+@pytest.mark.asyncio
+async def test_health_all_aggregates(setup):
+    router, *_ = setup
+    health = find_endpoint(router, "/api/wiki/health", "GET")
+    body = await health(repo="__all__")
+    assert body["repos"] == 5  # 2 + 3 across repos
+    assert body["store"] == "populated"
+
+
+def test_maintenance_status_scopes_to_one_repo(setup):
+    router, *_ = setup
+    status = find_endpoint(router, "/api/wiki/maintenance/status", "GET")
+    assert status(repo="org-a")["open_pr_url"] == "https://gh/x/pull/1"
+    assert status(repo="org-b")["open_pr_url"] == "https://gh/x/pull/2"
+
+
+def test_repos_all_unions_across_repos(setup):
+    router, cfg_a, cfg_b, *_ = setup
+    _seed_wiki_index(cfg_a, "acme", "alpha")
+    _seed_wiki_index(cfg_b, "acme", "beta")
+    repos = find_endpoint(router, "/api/wiki/repos", "GET")
+    rows = repos(repo="__all__")
+    pairs = {(r["owner"], r["repo"]) for r in rows}
+    assert ("acme", "alpha") in pairs
+    assert ("acme", "beta") in pairs
+
+
+def test_admin_force_compile_targets_selected_repo(setup):
+    router, _cfg_a, _cfg_b, queue_a, queue_b = setup
+    force = find_endpoint(router, "/api/wiki/admin/force-compile", "POST")
+    from dashboard_routes._wiki_routes import ForceCompilePayload
+
+    force(
+        payload=ForceCompilePayload(owner="acme", repo="alpha", topic="patterns"),
+        repo="org-b",
+    )
+    # Only org-b's queue receives the task.
+    assert len(queue_b.peek()) == 1
+    assert len(queue_a.peek()) == 0
+
+
+def test_admin_force_compile_rejects_all(setup):
+    router, *_ = setup
+    force = find_endpoint(router, "/api/wiki/admin/force-compile", "POST")
+    from dashboard_routes._wiki_routes import ForceCompilePayload
+
+    with pytest.raises(HTTPException) as exc:
+        force(
+            payload=ForceCompilePayload(owner="acme", repo="alpha", topic="patterns"),
+            repo="__all__",
+        )
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## What

Phase **5b** — make the `/api/wiki/*` maintenance surface repo-aware. The module helpers now take the resolved repo's structures: `_wiki_loop`/`_maintenance_queue` take a zero-arg `get_orch` (so each repo's own RepoWikiLoop/queue is reached) and `_wiki_root`/`_repo_dir` take a `cfg`. `register(router, ctx)` is unchanged; handlers gain `repo: RepoSlugParam = None` resolved via `ctx.resolve_runtime`.

- **health**: the selected repo's loop; `repo=__all__` **aggregates** across every repo (summed `repos`; state precedence populated>empty>unconfigured).
- **`/repos`**: the selected repo's wiki-subject repos; `__all__` **unions + dedups** by `(owner, repo)`.
- **maintenance/status**: the selected repo's loop/queue + that repo's config; `__all__`/None → host (single-orchestrator concept).
- **admin POSTs** (force-compile/mark-stale/rebuild-index) + **run-now**: **reject `__all__` → 400** (mutations need a concrete repo) and target that repo's queue/loop.
- **metrics**: process-wide singleton — accepts `repo` for symmetry but does NOT scope (a per-repo split needs a `knowledge_metrics` refactor; documented).
- **entries/entry/log** keep reading the host wiki — their `{owner}/{repo}` **path** param precludes a `repo` query param, so ArticlesView's operated-repo scoping is reconciled in **5c**.

`repo=None` reproduces the prior host behavior exactly (existing wiki tests pass; two bare-`MagicMock`-ctx health tests gained a `resolve_runtime` stub to match the new ctx contract).

## Frontend

`MaintenanceView` routes maintenance/status + health through `fetchWithRepo` and **disables the admin + run-now actions under "All repos"** (the backend rejects `__all__`); term-loops stays host-scoped pending 5c. The test mocks `useHydraFlow` with a stable hoisted `fetchWithRepo`; `AtlasExplorer`'s test gains the same mock (it renders MaintenanceView).

## Tests

`tests/test_wiki_routes_multirepo.py` (health scope+aggregate, maintenance scope, `/repos` union, admin targets-repo + rejects-`__all__`); MaintenanceView frontend (repo param reaches fetch, admin disabled + no POST under `__all__`).

## Verification

- `make quality` ✅ 15911 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- UI `vitest` ✅ 1115 passed · `npm run build` ✅
- **Adversarial review workflow** (3 parallel dimensions → per-finding verification): **no production bugs**; one minor test-hardening item (the `__all__` admin no-POST is proven via the `disabled` attribute + backend reject; the in-`post()` guard is defense-in-depth) — accepted given the layered coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)