### PR TITLE
fix(loops): auto-close PrinciplesAudit drift issues on FAIL→PASS (#9359)

### DIFF
--- a/src/principles_audit_loop.py
+++ b/src/principles_audit_loop.py
@@ -40,6 +40,12 @@ _STUCK_TITLE_RE = re.compile(
     r"^Principles drift stuck:\s*(?P<check_id>[\w\.\-]+)\s+in\s+(?P<slug>[\w\.\-/]+)\s*$"
 )
 
+# Inverse of `_drift_title` — recover the (check_id, slug) pair from an open
+# drift issue's title so a recovered check (FAIL→PASS) can auto-close it (#9359).
+_DRIFT_TITLE_RE = re.compile(
+    r"^Principles drift:\s*(?P<check_id>[\w\.\-]+)\s+regressed in\s+(?P<slug>[\w\.\-/]+)\s*$"
+)
+
 
 def _audit_iso_now() -> str:
     """Return the current UTC time as a second-precision ISO-8601 string."""
@@ -78,6 +84,7 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             "onboarded": 0,
             "audited": 0,
             "regressions_filed": 0,
+            "regressions_closed": 0,
             "escalations_filed": 0,
             "ready_flips": 0,
         }
@@ -111,6 +118,9 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             self._save_snapshot(_HYDRAFLOW_SELF, self_report)
             self_snapshot = self._snapshot_from_report(self_report)
             stats["audited"] += 1
+            stats["regressions_closed"] += await self._close_recovered_issues(
+                _HYDRAFLOW_SELF, self_snapshot
+            )
             self_last = self._state.get_last_green_audit(_HYDRAFLOW_SELF)
             self_regressions = self._diff_regressions(self_last, self_snapshot)
             if self_regressions:
@@ -133,6 +143,9 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             try:
                 snapshot = await self._audit_managed_repo(mr)
                 stats["audited"] += 1
+                stats["regressions_closed"] += await self._close_recovered_issues(
+                    mr.slug, snapshot
+                )
                 report = await self._fetch_last_report(mr)
                 last = self._state.get_last_green_audit(mr.slug)
                 regressions = self._diff_regressions(last, snapshot)
@@ -290,12 +303,60 @@ class PrinciplesAuditLoop(BaseBackgroundLoop):
             if prev == "PASS" and current.get(cid) == "FAIL"
         )
 
+    @staticmethod
+    def _drift_title(slug: str, check_id: str) -> str:
+        """Stable drift-issue title — single source for the file + close paths.
+
+        Used by ``_file_drift_issue`` (producer) and ``_DRIFT_TITLE_RE`` /
+        ``_close_recovered_issues`` (consumer); keeping them in lockstep avoids
+        the fake-fidelity title-drift class behind #9351/#9359.
+        """
+        return f"Principles drift: {check_id} regressed in {slug}"
+
+    async def _close_recovered_issues(self, slug: str, snapshot: dict[str, str]) -> int:
+        """Close drift issues whose check recovered to PASS (#9359 FAIL→PASS).
+
+        Lists open ``principles-drift`` issues, parses ``(check_id, slug)`` from
+        each title, and for every one whose check now reports PASS on ``slug``,
+        closes the informational drift issue and resets its drift-attempt
+        counter so a future regression re-escalates cleanly instead of being
+        suppressed by a stuck counter. The ``hitl-escalation``
+        (``principles-stuck``) issue is intentionally left to the operator-close
+        path (``_reconcile_closed_escalations``) — HITL escalations are not
+        auto-closed.
+        """
+        try:
+            issues = await self._pr.list_issues_by_label("principles-drift")
+        except Exception as exc:  # noqa: BLE001
+            reraise_on_credit_or_bug(exc)
+            logger.debug("recovery-close: skipped for %s", slug, exc_info=True)
+            return 0
+        closed = 0
+        for issue in issues:
+            m = _DRIFT_TITLE_RE.match(str(issue.get("title", "")))
+            if m is None or m.group("slug") != slug:
+                continue
+            check_id = m.group("check_id")
+            if snapshot.get(check_id) != "PASS":
+                continue
+            number = issue.get("number")
+            if number is None:
+                continue
+            await self._pr.post_comment(
+                number,
+                "Principle check recovered to PASS — auto-closing (#9359).",
+            )
+            await self._pr.close_issue(number)
+            self._state.reset_drift_attempts(slug, check_id)
+            closed += 1
+        return closed
+
     async def _file_drift_issue(
         self, slug: str, finding: dict[str, Any], last_status: str
     ) -> int:
         """File a ``hydraflow-find`` + ``principles-drift`` issue for one regression."""
         check_id = finding["check_id"]
-        title = f"Principles drift: {check_id} regressed in {slug}"
+        title = self._drift_title(slug, check_id)
         body = (
             f"**Principle:** {finding['principle']}\n"
             f"**Severity:** {finding['severity']}\n"

--- a/tests/test_principles_audit_loop.py
+++ b/tests/test_principles_audit_loop.py
@@ -34,6 +34,7 @@ def loop_env(tmp_path: Path):
     state.get_drift_attempts.return_value = 0
     pr_manager = AsyncMock()
     pr_manager.create_issue = AsyncMock(return_value=42)
+    pr_manager.list_issues_by_label = AsyncMock(return_value=[])
     return cfg, state, pr_manager
 
 
@@ -520,6 +521,99 @@ async def test_do_work_managed_repo_regression_files_drift(loop_env, monkeypatch
     assert stats["audited"] == 2  # self + acme/widget
     assert stats["regressions_filed"] == 1
     pr.create_issue.assert_awaited()
+
+
+async def test_recovery_closes_drift_issue_and_resets_attempts(loop_env, monkeypatch):
+    """#9359: a check that recovered FAIL→PASS auto-closes its open drift issue
+    and resets the drift-attempt counter so a future regression re-escalates."""
+    cfg, state, pr = loop_env
+    cfg.managed_repos = []
+    stop = asyncio.Event()
+    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
+
+    # Self audit now reports P1.1 as PASS — it had regressed and is open.
+    async def fake_run_audit(slug, root):
+        return {
+            "summary": {},
+            "findings": [
+                {
+                    "check_id": "P1.1",
+                    "status": "PASS",
+                    "severity": "STRUCTURAL",
+                    "principle": "P1",
+                    "source": "",
+                    "what": "",
+                    "remediation": "",
+                    "message": "",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(loop, "_run_audit", fake_run_audit)
+    pr.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 55,
+                "title": "Principles drift: P1.1 regressed in hydraflow-self",
+                "body": "",
+                "updated_at": "",
+            },
+            {  # a different slug's open drift — must NOT be touched here.
+                "number": 56,
+                "title": "Principles drift: P2.2 regressed in acme/widget",
+                "body": "",
+                "updated_at": "",
+            },
+        ]
+    )
+
+    stats = await loop._do_work()
+
+    assert stats["regressions_closed"] == 1
+    pr.close_issue.assert_awaited_once_with(55)
+    state.reset_drift_attempts.assert_any_call("hydraflow-self", "P1.1")
+
+
+async def test_recovery_skips_check_still_failing(loop_env, monkeypatch):
+    """A drift issue whose check is still FAIL must stay open (no false close)."""
+    cfg, state, pr = loop_env
+    cfg.managed_repos = []
+    stop = asyncio.Event()
+    loop = PrinciplesAuditLoop(config=cfg, state=state, pr_manager=pr, deps=_deps(stop))
+
+    async def fake_run_audit(slug, root):
+        return {
+            "summary": {},
+            "findings": [
+                {
+                    "check_id": "P1.1",
+                    "status": "FAIL",
+                    "severity": "STRUCTURAL",
+                    "principle": "P1",
+                    "source": "",
+                    "what": "",
+                    "remediation": "",
+                    "message": "",
+                },
+            ],
+        }
+
+    monkeypatch.setattr(loop, "_run_audit", fake_run_audit)
+    pr.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 55,
+                "title": "Principles drift: P1.1 regressed in hydraflow-self",
+                "body": "",
+                "updated_at": "",
+            },
+        ]
+    )
+
+    stats = await loop._do_work()
+
+    assert stats["regressions_closed"] == 0
+    pr.close_issue.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Batch 7 (loop 10/13). `PrinciplesAuditLoop` filed `Principles drift: {check_id} regressed in {slug}` issues on a PASS→FAIL regression but never closed them when the check recovered — resolved drifts piled up as open `hydraflow-find` issues.

- Each audited slug (hydraflow-self + every ready managed repo) runs `_close_recovered_issues`: lists open `principles-drift` issues, parses `(check_id, slug)` from the title, and for any whose check now reports **PASS**, closes the informational issue and **resets that check's drift-attempt counter** so a future regression re-escalates cleanly instead of being suppressed by a stuck counter.
- The drift title is **single-sourced** via `_drift_title(slug, check_id)` ↔ inverse `_DRIFT_TITLE_RE` — file and close paths can't drift apart (fake-fidelity lesson behind #9351/#9359).
- The HITL `principles-stuck` escalation is intentionally left to the existing operator-close path (`_reconcile_closed_escalations`) — HITL escalations are not auto-closed (consistent with SkillPromptEval #9378).
- New `regressions_closed` stat.

**Verification:** 2 new tests (recovery closes + resets attempts; still-failing check stays open); targeted suite **22 passed**; ruff + pyright (repo config) clean.

**Progress: 10 loops migrated** (StagingPromotion, CostBudget, Diagram, GateActivator, BranchProtection, Pricing, HealthMonitor×2, SkillPromptEval, PrinciplesAudit + `RollupIssueManager`). Remaining: ContractRefresh, SecurityPatch, FlakeTracker (bespoke). StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)