### PR TITLE
fix(loops): auto-close ContractRefresh fake-drift issues on recovery (#9359)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -72,6 +72,7 @@ from contract_recording import (
 )
 from dedup_store import DedupStore
 from models import WorkCycleResult  # noqa: TCH001
+from rollup_issue_manager import RollupIssueManager
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -165,6 +166,22 @@ class ContractRefreshLoop(BaseBackgroundLoop):
 
     def _get_default_interval(self) -> int:
         return self._config.contract_refresh_interval
+
+    def _fake_drift_rollup(self) -> RollupIssueManager:
+        """One rolling ``fake-drift`` issue, body refreshed each tick and
+        auto-closed once the replay gate passes again (#9359).
+
+        Replaces the per-adapter-set ``Fake drift: ... ({adapters})`` titles,
+        which varied with the drifted-adapter set so they never deduped across
+        ticks and never closed on recovery — resolved fake drifts piled up as
+        open ``hydraflow-find`` issues.
+        """
+        return RollupIssueManager(
+            pr=self._prs,
+            state=self._state,
+            namespace="contract_refresh",
+            labels=["hydraflow-find", "fake-drift"],
+        )
 
     # ------------------------------------------------------------------
     # Recording
@@ -493,13 +510,9 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         pr_url: str | None,
     ) -> int:
         adapters_joined = ", ".join(adapters)
-        labels = ["hydraflow-find", "fake-drift"]
-        for adapter in adapters:
-            labels.append(f"adapter-{adapter}")
-
-        title = (
-            f"Fake drift: replay gate failed after contract refresh ({adapters_joined})"
-        )
+        # Stable title (no variable adapter set) so the rollup dedups across
+        # ticks; the drifted-adapter list lives in the body + `adapter-*` labels.
+        title = "Fake drift: replay gate failed after contract refresh"
         pr_line = f"Refresh PR: {pr_url}" if pr_url else "Refresh PR: (not opened)"
         # Clip replay output so the issue body stays reviewable.
         stdout_tail = (replay_proc.stdout or "").strip()[-2000:]
@@ -519,10 +532,11 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             "### replay gate stderr (tail)\n"
             f"```\n{stderr_tail}\n```\n"
         )
-        return await self._prs.create_issue(
+        return await self._fake_drift_rollup().ensure(
+            "fake_drift",
             title=title,
             body=body,
-            labels=labels,
+            extra_labels=[f"adapter-{adapter}" for adapter in adapters],
         )
 
     # ------------------------------------------------------------------
@@ -636,16 +650,26 @@ class ContractRefreshLoop(BaseBackgroundLoop):
     # Tick — phase helpers
     # ------------------------------------------------------------------
 
-    def _on_clean_tick(self) -> WorkCycleResult:
+    async def _on_clean_tick(self) -> WorkCycleResult:
         """Handle a drift-free tick: clear the fleet dedup and return clean status.
 
         A prior refresh PR has been applied (merged) and the recordings now
         match committed cassettes.  Clearing the fleet dedup allows a *future*
         identical drift (e.g. a reverted PR re-introduces the same diff) to be
         re-filed rather than silently swallowed.  Keeps dedup bounded in size.
+
+        No drift means the fakes match the committed cassettes, so any open
+        fake-drift rollup issue has recovered — close it (#9359). Idempotent.
         """
         if self._dedup.get():
             self._dedup.set_all(set())
+        await self._fake_drift_rollup().resolve(
+            "fake_drift",
+            comment=(
+                "No contract drift this tick — fakes in sync; auto-closing "
+                "fake-drift (#9359)."
+            ),
+        )
         return {
             "status": "clean",
             "adapters_refreshed": 0,
@@ -702,6 +726,16 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             fake_drift_issue = await self._file_fake_drift_issue(
                 adapters_drifted, replay_proc, pr_url
             )
+        else:
+            # Replay gate passed after the refresh — fakes are back in sync, so
+            # close any open fake-drift rollup issue (#9359). Idempotent.
+            await self._fake_drift_rollup().resolve(
+                "fake_drift",
+                comment=(
+                    "Post-refresh replay gate passed — fakes back in sync; "
+                    "auto-closing (#9359)."
+                ),
+            )
         return replay_proc, fake_drift_issue
 
     # ------------------------------------------------------------------
@@ -744,7 +778,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
         self._update_attempt_counters(drifted_adapters)
 
         if not fleet.has_drift:
-            return self._on_clean_tick()
+            return await self._on_clean_tick()
 
         # Task 18 — escalate any adapter that just hit the threshold.
         # Fire before the dedup short-circuit so a stuck adapter whose

--- a/tests/test_contract_refresh_integration.py
+++ b/tests/test_contract_refresh_integration.py
@@ -82,6 +82,7 @@ class _FakeState:
 
     def __init__(self) -> None:
         self._attempts: dict[str, int] = {}
+        self._rollups: dict[str, dict] = {}
 
     def get_contract_refresh_attempts(self, adapter: str) -> int:
         return int(self._attempts.get(adapter, 0))
@@ -92,6 +93,31 @@ class _FakeState:
 
     def clear_contract_refresh_attempts(self, adapter: str) -> None:
         self._attempts.pop(adapter, None)
+
+    # RollupIssueManager surface (#9359) — mirrors RollupIssueStateMixin.
+    def get_rollup_issue(self, key: str) -> dict | None:
+        entry = self._rollups.get(key)
+        if not entry:
+            return None
+        return {
+            "issue_number": int(entry["issue_number"]),
+            "content_hash": str(entry["content_hash"]),
+        }
+
+    def set_rollup_issue(
+        self, key: str, *, issue_number: int, content_hash: str
+    ) -> None:
+        self._rollups[key] = {
+            "issue_number": int(issue_number),
+            "content_hash": content_hash,
+        }
+
+    def clear_rollup_issue(self, key: str) -> None:
+        self._rollups.pop(key, None)
+
+    def get_rollup_issue_keys(self, namespace: str) -> list[str]:
+        prefix = f"{namespace}:"
+        return [k for k in self._rollups if k.startswith(prefix)]
 
 
 def _loop(tmp_path: Path, *, prs: Any | None = None) -> ContractRefreshLoop:
@@ -400,12 +426,12 @@ async def test_end_to_end_replay_gate_fail_files_fake_drift_issue(
     # Companion issue was filed with the factory-routing labels + the
     # replay stderr tail embedded in the body.
     prs.create_issue.assert_awaited_once()
-    issue_kwargs = prs.create_issue.await_args.kwargs
-    labels = issue_kwargs["labels"]
+    # The rollup files via create_issue(title, body, labels) positionally.
+    title, body, labels = prs.create_issue.await_args.args
+    assert title == "Fake drift: replay gate failed after contract refresh"
     assert "hydraflow-find" in labels
     assert "fake-drift" in labels
     assert "adapter-git" in labels
-    body = issue_kwargs["body"]
     assert "replay mismatch" in body
     # The refresh PR URL is threaded into the issue body so the repair
     # implementer can open the PR straight from the companion issue.

--- a/tests/test_contract_refresh_loop.py
+++ b/tests/test_contract_refresh_loop.py
@@ -56,6 +56,7 @@ class _FakeState:
 
     def __init__(self) -> None:
         self._attempts: dict[str, int] = {}
+        self._rollups: dict[str, dict] = {}
 
     def get_contract_refresh_attempts(self, adapter: str) -> int:
         return int(self._attempts.get(adapter, 0))
@@ -66,6 +67,31 @@ class _FakeState:
 
     def clear_contract_refresh_attempts(self, adapter: str) -> None:
         self._attempts.pop(adapter, None)
+
+    # RollupIssueManager surface (#9359) — mirrors RollupIssueStateMixin.
+    def get_rollup_issue(self, key: str) -> dict | None:
+        entry = self._rollups.get(key)
+        if not entry:
+            return None
+        return {
+            "issue_number": int(entry["issue_number"]),
+            "content_hash": str(entry["content_hash"]),
+        }
+
+    def set_rollup_issue(
+        self, key: str, *, issue_number: int, content_hash: str
+    ) -> None:
+        self._rollups[key] = {
+            "issue_number": int(issue_number),
+            "content_hash": content_hash,
+        }
+
+    def clear_rollup_issue(self, key: str) -> None:
+        self._rollups.pop(key, None)
+
+    def get_rollup_issue_keys(self, namespace: str) -> list[str]:
+        prefix = f"{namespace}:"
+        return [k for k in self._rollups if k.startswith(prefix)]
 
 
 def _loop(
@@ -372,12 +398,15 @@ async def test_do_work_replay_gate_fails_files_companion_issue(
     assert calls, "make trust-contracts should have been invoked"
     assert calls[0][:2] == ["make", "trust-contracts"]
 
-    # Companion issue filed with the right labels.
+    # Companion issue filed with the right labels. The rollup files via
+    # create_issue(title, body, labels) positionally.
     prs.create_issue.assert_awaited()
-    kwargs = prs.create_issue.await_args.kwargs
-    assert "hydraflow-find" in kwargs["labels"]
-    assert "fake-drift" in kwargs["labels"]
-    assert "trust-contracts" in kwargs["body"] or "replay" in kwargs["body"].lower()
+    title, body, labels = prs.create_issue.await_args.args
+    assert title == "Fake drift: replay gate failed after contract refresh"
+    assert "hydraflow-find" in labels
+    assert "fake-drift" in labels
+    assert "adapter-git" in labels  # drifted adapter surfaced as a label
+    assert "trust-contracts" in body or "replay" in body.lower()
 
 
 @pytest.mark.asyncio
@@ -407,6 +436,66 @@ async def test_do_work_replay_gate_passes_no_companion_issue(
     await loop._do_work()
 
     prs.create_issue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_clean_tick_closes_open_fake_drift_issue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#9359: a drift-free tick closes a previously-open fake-drift rollup issue."""
+    _stub_recording(monkeypatch)
+    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    _stub_make_trust_contracts_ok(monkeypatch)
+    monkeypatch.setattr(
+        crl_module,
+        "detect_fleet_drift",
+        lambda *_a, **_k: crl_module.FleetDriftReport(reports=[], has_drift=False),
+    )
+
+    state = _FakeState()
+    # A fake-drift issue is already open from a prior failing tick.
+    state.set_rollup_issue(
+        "contract_refresh:fake_drift", issue_number=77, content_hash="x"
+    )
+    prs = AsyncMock()
+    loop = _loop(tmp_path, prs=prs, state=state)
+
+    await loop._do_work()
+
+    prs.close_issue.assert_awaited_once_with(77)
+    assert state.get_rollup_issue("contract_refresh:fake_drift") is None
+
+
+@pytest.mark.asyncio
+async def test_replay_pass_closes_open_fake_drift_issue(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#9359: a passing post-refresh replay gate closes the open fake-drift issue."""
+    _stub_recording(monkeypatch)
+    recorded_git = _seed_recorded_cassette(tmp_path / "rec" / "git", "git", "commit")
+    monkeypatch.setattr(crl_module, "record_git", lambda *_a, **_k: [recorded_git])
+    drifted_report = crl_module.AdapterDriftReport(
+        adapter="git",
+        drifted_cassettes=[recorded_git],
+        new_cassettes=[],
+        deleted_cassettes=[],
+    )
+    fleet = crl_module.FleetDriftReport(reports=[drifted_report], has_drift=True)
+    monkeypatch.setattr(crl_module, "detect_fleet_drift", lambda *_a, **_k: fleet)
+    monkeypatch.setattr(crl_module, "open_automated_pr_async", _FakeAutoPR())
+    _stub_make_trust_contracts_ok(monkeypatch)
+
+    state = _FakeState()
+    state.set_rollup_issue(
+        "contract_refresh:fake_drift", issue_number=88, content_hash="x"
+    )
+    prs = AsyncMock()
+    loop = _loop(tmp_path, prs=prs, state=state)
+
+    await loop._do_work()
+
+    prs.close_issue.assert_awaited_once_with(88)
+    assert state.get_rollup_issue("contract_refresh:fake_drift") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Batch 8 (loop 11/13). `ContractRefreshLoop` filed a `Fake drift: ... ({adapters})` `hydraflow-find` issue when the post-refresh replay gate failed, but the title carried the **drifted-adapter set** — so it never deduped across ticks (overlapping sets produced new titles) and never closed when the fakes came back in sync. Resolved fake drifts accumulated as open issues.

- Route the fake-drift issue through **`RollupIssueManager`** (namespace `contract_refresh`, subject `fake_drift`) with a **stable title**; the drifted adapters move to the body + `adapter-*` labels. The body (replay output, PR link) is content-hash-diffed so redundant ticks no-op.
- **Recovery closes it:** replay gate passes after a refresh → `resolve`; a drift-free tick (`_on_clean_tick`, now async) → `resolve`. Both idempotent.
- The HITL `fake-repair-stuck` escalation is unchanged — it already clears its per-adapter counter + dedup on a clean tick and stays operator-closed.

**Verification:** extended both `_FakeState` stand-ins with the rollup surface; 2 new recovery tests (clean-tick close, replay-pass close); companion-issue assertions updated to positional `create_issue` args. **unit 23 + integration 3 + scenario_loops 2** green; ruff + pyright (repo config) clean.

**Progress: 11 loops migrated.** Remaining: SecurityPatch, FlakeTracker (bespoke). StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)