### PR TITLE
fix(loops): auto-close SecurityPatch issues when the Dependabot alert resolves (#9359)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T05:59:10.990665+00:00",
-  "commit_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583",
+  "regenerated_at": "2026-06-09T06:34:56.843468+00:00",
+  "commit_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8",
   "artifacts": {
     "loops.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "ports.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "labels.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "modules.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "events.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "adr_xref.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "mockworld.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "changelog.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "coverage_matrix.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "functional_areas.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "ubiquitous-language.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "174b51dc80b3c16d80051acece186e6dd4e46ef8"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `99f1f27` — feat(wiki): /api/wiki/* maintenance surface scopes by repo (Phase 5b) (#9379) (#9379) *(2026-06-09)*
 - `af05e0c` — feat(atlas): /api/atlas/* endpoints scope by repo (Phase 5a) (#9377) (#9377) *(2026-06-08)*
 - `1f68711` — feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish) (#9374) (#9374) *(2026-06-08)*
 - `91b6227` — feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4) (#9371) (#9371) *(2026-06-08)*

--- a/docs/arch/generated/modules.md
+++ b/docs/arch/generated/modules.md
@@ -29,7 +29,7 @@ graph LR
     src -- "1" --> src_observability
     src -- "12" --> src_preflight
     src -- "1" --> src_review_phase
-    src -- "49" --> src_state
+    src -- "50" --> src_state
     src -- "7" --> src_telemetry
     src_arch_extractors -- "7" --> src_arch
     src_arch_generators -- "11" --> src_arch

--- a/src/security_patch_loop.py
+++ b/src/security_patch_loop.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 from base_background_loop import BaseBackgroundLoop, LoopDeps
 from config import HydraFlowConfig
-from dedup_store import DedupStore
+from rollup_issue_manager import RollupIssueManager
 
 if TYPE_CHECKING:
     from ports import PRPort
+    from state import StateTracker
 
 logger = logging.getLogger("hydraflow.security_patch_loop")
 
@@ -22,30 +23,54 @@ _SEVERITY_RANK: dict[str, int] = {
     "low": 3,
 }
 
+# Dependabot alert states that mean "no longer an open vulnerability". Querying
+# these explicitly (rather than closing "every tracked issue not in the open
+# set") is what makes recovery safe: ``get_dependabot_alerts`` returns ``[]`` on
+# a transient API error, so an open-set reconcile would mass-close every
+# security issue. A resolved-state query that errors also returns ``[]`` — which
+# closes nothing.
+_RESOLVED_STATES: tuple[str, ...] = ("fixed", "dismissed", "auto_dismissed")
+
 
 class SecurityPatchLoop(BaseBackgroundLoop):
     """Periodically polls Dependabot alerts and files issues for fixable vulnerabilities.
 
     Only processes alerts at or above the configured severity threshold and
-    that have a ``first_patched_version`` available.  Uses :class:`DedupStore`
-    to avoid filing duplicate issues for the same alert number.
+    that have a ``first_patched_version`` available.  One open issue is kept per
+    alert via :class:`RollupIssueManager` (namespace ``security_patch``); when
+    GitHub reports the alert ``fixed``/``dismissed`` the issue is auto-closed
+    (#9359).
     """
 
     def __init__(
         self,
         config: HydraFlowConfig,
         pr_manager: PRPort,
+        state: StateTracker,
         deps: LoopDeps,
     ) -> None:
         super().__init__(worker_name="security_patch", config=config, deps=deps)
         self._pr_manager = pr_manager
-        self._dedup = DedupStore(
-            "security_patch_alerts",
-            config.data_root / "memory" / "security_patch_dedup.json",
-        )
+        self._state = state
 
     def _get_default_interval(self) -> int:
         return self._config.security_patch_interval
+
+    def _rollups(self) -> RollupIssueManager:
+        """One open ``security`` issue per Dependabot alert number.
+
+        ``RollupIssueManager`` subsumes the old local ``DedupStore`` *and* the
+        GitHub-side dedup backstop: ``ensure`` tracks the issue number in
+        ``state.rollup_issues`` and, if that state is lost, ``create_issue``'s
+        exact-title dedup returns the existing number so the issue is re-adopted
+        rather than duplicated.
+        """
+        return RollupIssueManager(
+            pr=self._pr_manager,
+            state=self._state,
+            namespace="security_patch",
+            labels=["security"],
+        )
 
     def _meets_severity(self, severity: str) -> bool:
         """Return True if *severity* meets or exceeds the configured threshold."""
@@ -84,23 +109,17 @@ class SecurityPatchLoop(BaseBackgroundLoop):
         if self._config.dry_run:
             return None
 
+        rollup = self._rollups()
         alerts = await self._pr_manager.get_dependabot_alerts(state="open")
-        seen = self._dedup.get()
 
         filed = 0
         skipped_dedup = 0
-        skipped_existing = 0
         skipped_unfixable = 0
         skipped_severity = 0
 
         for alert in alerts:
             alert_key = str(alert.get("number", ""))
             if not alert_key:
-                continue
-
-            # Skip already-processed alerts
-            if alert_key in seen:
-                skipped_dedup += 1
                 continue
 
             # Skip unfixable alerts
@@ -124,41 +143,62 @@ class SecurityPatchLoop(BaseBackgroundLoop):
                 f"A patched version is available. Please update the dependency.\n"
             )
 
-            # GitHub-side backstop: the local dedup file can lose an entry if a
-            # prior tick crashed between create_issue and dedup.add, which would
-            # otherwise re-file a duplicate security issue. GitHub is the durable
-            # source of truth — if an open issue with this exact title already
-            # exists, skip the create and heal the local dedup. find_existing_issue
-            # returns 0 when none is found (the common path), so creation proceeds.
-            existing = await self._pr_manager.find_existing_issue(title)
-            if existing:
-                self._dedup.add(alert_key)
-                skipped_existing += 1
-                logger.info(
-                    "Security issue for alert #%s already open as #%s; "
-                    "skipping duplicate and healing local dedup",
-                    alert_key,
-                    existing,
-                )
-                continue
-
-            await self._pr_manager.create_issue(title, body, labels=["security"])
-            self._dedup.add(alert_key)
-            filed += 1
-
-            logger.info(
-                "Filed security issue for alert #%s: %s in %s (%s)",
-                alert_key,
-                summary,
-                pkg,
-                severity,
+            # ensure() creates one issue per alert and is a no-op when it is
+            # already tracked (or already open on GitHub by title) — so the old
+            # local-dedup + find_existing_issue backstop are both internal now.
+            already = (
+                self._state.get_rollup_issue(f"security_patch:{alert_key}") is not None
             )
+            await rollup.ensure(alert_key, title=title, body=body)
+            if already:
+                skipped_dedup += 1
+            else:
+                filed += 1
+                logger.info(
+                    "Filed security issue for alert #%s: %s in %s (%s)",
+                    alert_key,
+                    summary,
+                    pkg,
+                    severity,
+                )
+
+        closed = await self._close_resolved(rollup)
 
         return {
             "total_alerts": len(alerts),
             "filed": filed,
+            "closed": closed,
             "skipped_dedup": skipped_dedup,
-            "skipped_existing": skipped_existing,
             "skipped_unfixable": skipped_unfixable,
             "skipped_severity": skipped_severity,
         }
+
+    async def _close_resolved(self, rollup: RollupIssueManager) -> int:
+        """Close security issues for alerts GitHub now reports as resolved (#9359).
+
+        Queries the resolved alert states explicitly (``fixed`` / ``dismissed``
+        / ``auto_dismissed``) and ``resolve``\\ s only the tracked subjects in
+        that set. ``resolve`` is a no-op for an untracked alert, so this never
+        touches an issue we did not file, and a failed (``[]``) query closes
+        nothing — sidestepping the mass-close hazard of an open-set reconcile.
+        """
+        resolved_keys: set[str] = set()
+        for resolved_state in _RESOLVED_STATES:
+            for alert in await self._pr_manager.get_dependabot_alerts(
+                state=resolved_state
+            ):
+                key = str(alert.get("number", ""))
+                if key:
+                    resolved_keys.add(key)
+
+        closed = 0
+        for key in sorted(resolved_keys):
+            if await rollup.resolve(
+                key,
+                comment=(
+                    "Dependabot alert resolved — auto-closing security issue (#9359)."
+                ),
+            ):
+                closed += 1
+                logger.info("Closed security issue for resolved alert #%s", key)
+        return closed

--- a/src/service_registry.py
+++ b/src/service_registry.py
@@ -1025,6 +1025,7 @@ def build_services(
     security_patch_loop = SecurityPatchLoop(  # noqa: F841
         config=config,
         pr_manager=prs,
+        state=state,
         deps=loop_deps,
     )
     repo_wiki_loop = RepoWikiLoop(

--- a/tests/regressions/test_static_config_gates.py
+++ b/tests/regressions/test_static_config_gates.py
@@ -174,9 +174,7 @@ def _epic_monitor_loop(tmp_path: Path):
     from epic_monitor_loop import EpicMonitorLoop
 
     d = _deps(tmp_path, "epic_monitor_loop_enabled")
-    return EpicMonitorLoop(
-        config=d.config, epic_manager=MagicMock(), deps=d.loop_deps
-    )
+    return EpicMonitorLoop(config=d.config, epic_manager=MagicMock(), deps=d.loop_deps)
 
 
 def _epic_sweeper_loop(tmp_path: Path):
@@ -258,9 +256,7 @@ def _merge_state_watcher_loop(tmp_path: Path):
     from merge_state_watcher_loop import MergeStateWatcherLoop
 
     d = _deps(tmp_path, "merge_state_watcher_loop_enabled")
-    return MergeStateWatcherLoop(
-        config=d.config, prs=MagicMock(), deps=d.loop_deps
-    )
+    return MergeStateWatcherLoop(config=d.config, prs=MagicMock(), deps=d.loop_deps)
 
 
 def _pr_unsticker_loop(tmp_path: Path):
@@ -299,9 +295,7 @@ def _repo_wiki_loop(tmp_path: Path):
     from repo_wiki_loop import RepoWikiLoop
 
     d = _deps(tmp_path, "repo_wiki_loop_enabled")
-    return RepoWikiLoop(
-        config=d.config, wiki_store=MagicMock(), deps=d.loop_deps
-    )
+    return RepoWikiLoop(config=d.config, wiki_store=MagicMock(), deps=d.loop_deps)
 
 
 def _report_issue_loop(tmp_path: Path):
@@ -333,9 +327,7 @@ def _runs_gc_loop(tmp_path: Path):
     from runs_gc_loop import RunsGCLoop
 
     d = _deps(tmp_path, "runs_gc_loop_enabled")
-    return RunsGCLoop(
-        config=d.config, run_recorder=MagicMock(), deps=d.loop_deps
-    )
+    return RunsGCLoop(config=d.config, run_recorder=MagicMock(), deps=d.loop_deps)
 
 
 def _security_patch_loop(tmp_path: Path):
@@ -343,7 +335,7 @@ def _security_patch_loop(tmp_path: Path):
 
     d = _deps(tmp_path, "security_patch_loop_enabled")
     return SecurityPatchLoop(
-        config=d.config, pr_manager=MagicMock(), deps=d.loop_deps
+        config=d.config, pr_manager=MagicMock(), state=MagicMock(), deps=d.loop_deps
     )
 
 
@@ -351,9 +343,7 @@ def _sentry_loop(tmp_path: Path):
     from sentry_loop import SentryLoop
 
     d = _deps(tmp_path, "sentry_loop_enabled")
-    return SentryLoop(
-        config=d.config, prs=MagicMock(), deps=d.loop_deps
-    )
+    return SentryLoop(config=d.config, prs=MagicMock(), deps=d.loop_deps)
 
 
 def _skill_prompt_eval_loop(tmp_path: Path):
@@ -373,9 +363,7 @@ def _stale_issue_gc_loop(tmp_path: Path):
     from stale_issue_gc_loop import StaleIssueGCLoop
 
     d = _deps(tmp_path, "stale_issue_gc_loop_enabled")
-    return StaleIssueGCLoop(
-        config=d.config, pr_manager=MagicMock(), deps=d.loop_deps
-    )
+    return StaleIssueGCLoop(config=d.config, pr_manager=MagicMock(), deps=d.loop_deps)
 
 
 def _stale_issue_loop(tmp_path: Path):

--- a/tests/scenarios/catalog/loop_registrations.py
+++ b/tests/scenarios/catalog/loop_registrations.py
@@ -278,7 +278,15 @@ def _build_epic_sweeper(ports: dict[str, Any], config: Any, deps: Any) -> Any:
 def _build_security_patch(ports: dict[str, Any], config: Any, deps: Any) -> Any:
     from security_patch_loop import SecurityPatchLoop  # noqa: PLC0415
 
-    return SecurityPatchLoop(config=config, pr_manager=ports["github"], deps=deps)
+    state = ports.get("security_patch_state")
+    if state is None:
+        state = MagicMock()
+        state.get_rollup_issue.return_value = None
+        state.get_rollup_issue_keys.return_value = []
+        ports["security_patch_state"] = state
+    return SecurityPatchLoop(
+        config=config, pr_manager=ports["github"], state=state, deps=deps
+    )
 
 
 def _build_stale_issue(ports: dict[str, Any], config: Any, deps: Any) -> Any:

--- a/tests/scenarios/test_caretaker_loops.py
+++ b/tests/scenarios/test_caretaker_loops.py
@@ -395,6 +395,7 @@ class TestL13SecurityPatchLoop:
         loop = SecurityPatchLoop(
             config=bg.config,
             pr_manager=world.github,
+            state=MagicMock(),
             deps=loop_deps,
         )
         result = await loop._do_work()

--- a/tests/test_security_patch_loop.py
+++ b/tests/test_security_patch_loop.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
@@ -20,6 +19,37 @@ from tests.helpers import ConfigFactory, make_bg_loop_deps
 # ---------------------------------------------------------------------------
 
 SEVERITY_ORDER = ["critical", "high", "medium", "low"]
+
+
+class _FakeState:
+    """In-memory ``RollupIssueManager`` state surface — mirrors RollupIssueStateMixin."""
+
+    def __init__(self) -> None:
+        self._rollups: dict[str, dict] = {}
+
+    def get_rollup_issue(self, key: str) -> dict | None:
+        entry = self._rollups.get(key)
+        if not entry:
+            return None
+        return {
+            "issue_number": int(entry["issue_number"]),
+            "content_hash": str(entry["content_hash"]),
+        }
+
+    def set_rollup_issue(
+        self, key: str, *, issue_number: int, content_hash: str
+    ) -> None:
+        self._rollups[key] = {
+            "issue_number": int(issue_number),
+            "content_hash": content_hash,
+        }
+
+    def clear_rollup_issue(self, key: str) -> None:
+        self._rollups.pop(key, None)
+
+    def get_rollup_issue_keys(self, namespace: str) -> list[str]:
+        prefix = f"{namespace}:"
+        return [k for k in self._rollups if k.startswith(prefix)]
 
 
 def _make_alert(
@@ -53,10 +83,16 @@ def _make_loop(
     severity_threshold: str = "high",
     security_patch_interval: int = 3600,
     alerts: list[dict] | None = None,
-    existing_dedup: list[str] | None = None,
-    existing_issue_number: int = 0,
+    resolved_alerts: dict[str, list[dict]] | None = None,
+    create_issue_return: int = 42,
 ) -> tuple[SecurityPatchLoop, AsyncMock, asyncio.Event]:
-    """Build a SecurityPatchLoop with test-friendly defaults."""
+    """Build a SecurityPatchLoop with test-friendly defaults.
+
+    ``alerts`` are returned for the ``open`` query; ``resolved_alerts`` maps a
+    resolved state (``fixed`` / ``dismissed`` / ``auto_dismissed``) to the alerts
+    returned for that query, so the recovery path can be exercised without the
+    open query bleeding into the resolved reconcile.
+    """
     deps = make_bg_loop_deps(
         tmp_path,
         enabled=enabled,
@@ -64,24 +100,22 @@ def _make_loop(
         security_patch_interval=security_patch_interval,
         security_patch_severity_threshold=severity_threshold,
     )
-    pr_manager = AsyncMock()
-    pr_manager.get_dependabot_alerts = AsyncMock(return_value=alerts or [])
-    pr_manager.create_issue = AsyncMock(return_value=42)
-    # The GitHub-side backstop: 0 = no existing open issue with that title
-    # (the common case, so create proceeds). A positive number simulates an
-    # issue already filed on GitHub — e.g. the local dedup file lost the entry
-    # to a crash between create_issue and dedup.add on a prior tick.
-    pr_manager.find_existing_issue = AsyncMock(return_value=existing_issue_number)
+    open_alerts = alerts or []
+    resolved = resolved_alerts or {}
 
-    # Seed dedup store file if needed
-    dedup_path = deps.config.data_root / "memory" / "security_patch_dedup.json"
-    if existing_dedup:
-        dedup_path.parent.mkdir(parents=True, exist_ok=True)
-        dedup_path.write_text(json.dumps(existing_dedup))
+    async def _alerts_by_state(state: str = "open") -> list[dict]:
+        if state == "open":
+            return open_alerts
+        return resolved.get(state, [])
+
+    pr_manager = AsyncMock()
+    pr_manager.get_dependabot_alerts = AsyncMock(side_effect=_alerts_by_state)
+    pr_manager.create_issue = AsyncMock(return_value=create_issue_return)
 
     loop = SecurityPatchLoop(
         config=deps.config,
         pr_manager=pr_manager,
+        state=_FakeState(),
         deps=deps.loop_deps,
     )
     return loop, pr_manager, deps.stop_event
@@ -129,9 +163,13 @@ class TestSecurityPatchLoopWork:
         assert result is not None
         assert result["filed"] == 1
         pm.create_issue.assert_called_once()
-        call_args = pm.create_issue.call_args
-        assert "[Security]" in call_args[0][0]
-        assert "lodash" in call_args[0][0]
+        # The rollup files via create_issue(title, body, labels) positionally.
+        title, _body, labels = pm.create_issue.call_args[0]
+        assert "[Security]" in title
+        assert "lodash" in title
+        assert "security" in labels
+        # The issue number is now tracked so a later tick won't re-file.
+        assert loop._state.get_rollup_issue("security_patch:1") is not None
 
     @pytest.mark.asyncio
     async def test_unfixable_alert_skipped(self, tmp_path: Path) -> None:
@@ -146,7 +184,11 @@ class TestSecurityPatchLoopWork:
     @pytest.mark.asyncio
     async def test_duplicate_alert_not_refiled(self, tmp_path: Path) -> None:
         alert = _make_alert(1)
-        loop, pm, _stop = _make_loop(tmp_path, alerts=[alert], existing_dedup=["1"])
+        loop, pm, _stop = _make_loop(tmp_path, alerts=[alert])
+        # Alert #1 already has a tracked open issue (filed on a prior tick).
+        loop._state.set_rollup_issue(
+            "security_patch:1", issue_number=42, content_hash="seed"
+        )
         result = await loop._do_work()
         assert result is not None
         assert result["filed"] == 0
@@ -154,24 +196,20 @@ class TestSecurityPatchLoopWork:
         pm.create_issue.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_backstop_skips_create_when_issue_exists_on_github(
+    async def test_existing_github_issue_adopted_not_duplicated(
         self, tmp_path: Path
     ) -> None:
-        # Regression: the alert is NOT in the local dedup file — simulating a
-        # crash between create_issue and dedup.add on a prior tick, which filed
-        # the issue on GitHub but lost the local dedup entry. Relying solely on
-        # the local file would re-file (duplicate). The GitHub-side backstop
-        # (find_existing_issue) must catch it: no second create_issue, and the
-        # local dedup is healed so later ticks skip it without the gh query.
+        # Local rollup state is empty, but the issue already exists on GitHub —
+        # create_issue's exact-title dedup returns the existing number (99).
+        # ensure() adopts it into state; the next tick must NOT re-file.
         alert = _make_alert(1)
-        loop, pm, _stop = _make_loop(tmp_path, alerts=[alert], existing_issue_number=99)
-        result = await loop._do_work()
-        assert result is not None
-        pm.find_existing_issue.assert_awaited_once()
-        pm.create_issue.assert_not_called()
-        assert result["filed"] == 0
-        assert result["skipped_existing"] == 1
-        assert "1" in loop._dedup.get(), "local dedup must be healed by the backstop"
+        loop, pm, _stop = _make_loop(tmp_path, alerts=[alert], create_issue_return=99)
+        await loop._do_work()
+        await loop._do_work()
+        pm.create_issue.assert_awaited_once()  # adopted, not duplicated
+        tracked = loop._state.get_rollup_issue("security_patch:1")
+        assert tracked is not None
+        assert tracked["issue_number"] == 99
 
     @pytest.mark.asyncio
     async def test_severity_below_threshold_skipped(self, tmp_path: Path) -> None:
@@ -212,3 +250,77 @@ class TestSecurityPatchLoopWork:
         result = await loop._do_work()
         assert result is not None
         assert result["filed"] == 1
+
+
+class TestSecurityPatchLoopRecovery:
+    """#9359: close the security issue when GitHub reports the alert resolved."""
+
+    @pytest.mark.asyncio
+    async def test_fixed_alert_closes_tracked_issue(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(
+            tmp_path,
+            alerts=[],
+            resolved_alerts={"fixed": [_make_alert(1)]},
+        )
+        loop._state.set_rollup_issue(
+            "security_patch:1", issue_number=42, content_hash="seed"
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["closed"] == 1
+        pm.close_issue.assert_awaited_once_with(42)
+        assert loop._state.get_rollup_issue("security_patch:1") is None
+
+    @pytest.mark.asyncio
+    async def test_dismissed_alert_closes_tracked_issue(self, tmp_path: Path) -> None:
+        loop, pm, _stop = _make_loop(
+            tmp_path,
+            alerts=[],
+            resolved_alerts={"dismissed": [_make_alert(7)]},
+        )
+        loop._state.set_rollup_issue(
+            "security_patch:7", issue_number=70, content_hash="seed"
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["closed"] == 1
+        pm.close_issue.assert_awaited_once_with(70)
+
+    @pytest.mark.asyncio
+    async def test_transient_empty_response_does_not_close(
+        self, tmp_path: Path
+    ) -> None:
+        # The mass-close guard: a transient API error makes EVERY alert query
+        # (open + resolved) return []. Nothing must be closed — only an
+        # explicitly-resolved alert closes its issue.
+        loop, pm, _stop = _make_loop(tmp_path, alerts=[], resolved_alerts={})
+        loop._state.set_rollup_issue(
+            "security_patch:1", issue_number=42, content_hash="seed"
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["closed"] == 0
+        pm.close_issue.assert_not_called()
+        assert loop._state.get_rollup_issue("security_patch:1") is not None
+
+    @pytest.mark.asyncio
+    async def test_resolve_closes_only_the_resolved_alert(self, tmp_path: Path) -> None:
+        # Alert #1 is fixed; alert #2 is still open. Only #1's issue closes.
+        still_open = _make_alert(2, package="axios", summary="ReDoS")
+        loop, pm, _stop = _make_loop(
+            tmp_path,
+            alerts=[still_open],
+            resolved_alerts={"fixed": [_make_alert(1)]},
+        )
+        loop._state.set_rollup_issue(
+            "security_patch:1", issue_number=42, content_hash="seed"
+        )
+        loop._state.set_rollup_issue(
+            "security_patch:2", issue_number=43, content_hash="seed"
+        )
+        result = await loop._do_work()
+        assert result is not None
+        assert result["closed"] == 1
+        pm.close_issue.assert_awaited_once_with(42)
+        # Alert #2 stays tracked + open.
+        assert loop._state.get_rollup_issue("security_patch:2") is not None


### PR DESCRIPTION
Batch 9 (loop 12/13). `SecurityPatchLoop` filed a `[Security] ...` issue per fixable Dependabot alert but never closed it when the alert was fixed/dismissed — patched vulnerabilities left their issues open forever.

- Route filing through **`RollupIssueManager`** (namespace `security_patch`, subject = alert number). This subsumes both the old local `DedupStore` and the `find_existing_issue` GitHub-side backstop: `ensure` tracks the issue number in state and re-adopts an existing issue via exact-title dedup if local state is lost.
- **Recovery (`_close_resolved`)** queries the **resolved** alert states explicitly (`fixed`/`dismissed`/`auto_dismissed`) and resolves only those tracked subjects. This is deliberately **not** an "everything not currently open" reconcile: `get_dependabot_alerts` returns `[]` on a transient API error, so an open-set reconcile would **mass-close every security issue**. A resolved-state query that errors also returns `[]` — closing nothing.
- Adds a `state: StateTracker` ctor param (threaded through `service_registry` + the 3 test/scenario construction sites). Drops `skipped_existing` (backstop is internal now); adds `closed`.

**Verification:** rewrote the suite for the rollup model — **17 unit** (incl. fixed/dismissed recovery, the **transient-empty mass-close guard**, existing-issue adoption, resolve-only-the-resolved-alert); wiring + static-gates + caretaker `scenario_loops` green; ruff + pyright (repo config) clean. Merged latest staging (incl. #9381) + regenerated `docs/arch`.

**Progress: 12 loops migrated.** Remaining: FlakeTracker (DedupStore entangled with escalation — last one). StagingBisect stays HITL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)