### PR TITLE
feat(atlas): thread operated repo into the graph cluster + namespaced node ids (Phase 5c-1)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T05:59:10.990665+00:00",
-  "commit_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583",
+  "regenerated_at": "2026-06-09T06:46:51.098290+00:00",
+  "commit_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26",
   "artifacts": {
     "loops.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "ports.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "labels.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "modules.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "events.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "adr_xref.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "mockworld.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "changelog.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "coverage_matrix.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "functional_areas.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "ubiquitous-language.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "af05e0cd80fe56a3fe9f3bf43a0851a7dd5f7583"
+      "source_sha": "99f1f27b51193ab8b440c4defd565cd5729c6c26"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `99f1f27` — feat(wiki): /api/wiki/* maintenance surface scopes by repo (Phase 5b) (#9379) (#9379) *(2026-06-09)*
 - `af05e0c` — feat(atlas): /api/atlas/* endpoints scope by repo (Phase 5a) (#9377) (#9377) *(2026-06-08)*
 - `1f68711` — feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish) (#9374) (#9374) *(2026-06-08)*
 - `91b6227` — feat(diagnostics): auto-agent stats scope by repo (Phase 3c-4) (#9371) (#9371) *(2026-06-08)*

--- a/src/ui/src/components/__tests__/App.test.jsx
+++ b/src/ui/src/components/__tests__/App.test.jsx
@@ -11,6 +11,10 @@ const { mockState } = vi.hoisted(() => {
       },
       prs: [],
       events: [],
+      selectedRepoSlug: null,
+      // Atlas/wiki views (rendered under the Atlas tab) read fetchWithRepo.
+      fetchWithRepo: (url, opts) =>
+        (global.fetch ? global.fetch(url, opts) : Promise.resolve({ ok: true, json: async () => ({}) })),
       connected: true,
       orchestratorStatus: 'running',
       sessionPrsCount: 0,

--- a/src/ui/src/components/atlas/AdrDetailPanel.jsx
+++ b/src/ui/src/components/atlas/AdrDetailPanel.jsx
@@ -2,8 +2,11 @@ import React, { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
+import { splitNodeId } from './atlasNodeId'
 
 export function AdrDetailPanel({ selectedNodeId }) {
+  const { fetchWithRepo } = useHydraFlow()
   const [adr, setAdr] = useState(null)
   const [error, setError] = useState(null)
 
@@ -13,8 +16,9 @@ export function AdrDetailPanel({ selectedNodeId }) {
       setError(null)
       return
     }
-    // selectedNodeId for an ADR node is "adr-<number>" (e.g., "adr-59").
-    const m = /^adr-(\d+)$/.exec(selectedNodeId)
+    // The ADR node id is "adr-<n>", namespaced under __all__ ("${slug}/adr-<n>").
+    const { repo, bareId } = splitNodeId(selectedNodeId)
+    const m = /^adr-(\d+)$/.exec(bareId)
     if (!m) {
       setAdr(null)
       setError(new Error('not an adr id'))
@@ -22,7 +26,11 @@ export function AdrDetailPanel({ selectedNodeId }) {
     }
     const number = m[1]
     let cancelled = false
-    fetch(`/api/atlas/adrs/${encodeURIComponent(number)}`)
+    const url = `/api/atlas/adrs/${encodeURIComponent(number)}`
+    const req = repo
+      ? fetch(`${url}?repo=${encodeURIComponent(repo)}`)
+      : fetchWithRepo(url)
+    req
       .then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
@@ -40,7 +48,7 @@ export function AdrDetailPanel({ selectedNodeId }) {
     return () => {
       cancelled = true
     }
-  }, [selectedNodeId])
+  }, [selectedNodeId, fetchWithRepo])
 
   const styles = {
     root: {

--- a/src/ui/src/components/atlas/DetailPanel.jsx
+++ b/src/ui/src/components/atlas/DetailPanel.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { theme } from '../../theme'
 import { TermDetailPanel } from './TermDetailPanel'
 import { AdrDetailPanel } from './AdrDetailPanel'
+import { splitNodeId } from './atlasNodeId'
 
 /**
  * Routes the selected-node detail render to the right panel by id shape:
@@ -25,7 +26,10 @@ export function DetailPanel({ selectedNodeId }) {
       </div>
     )
   }
-  if (/^adr-\d+$/.test(selectedNodeId)) {
+  // Under repo=__all__ the id is namespaced (`${slug}/adr-59`); route on the
+  // bare id so the adr-vs-term shape test still matches.
+  const { bareId } = splitNodeId(selectedNodeId)
+  if (/^adr-\d+$/.test(bareId)) {
     return <AdrDetailPanel selectedNodeId={selectedNodeId} />
   }
   return <TermDetailPanel selectedNodeId={selectedNodeId} />

--- a/src/ui/src/components/atlas/DomainView.jsx
+++ b/src/ui/src/components/atlas/DomainView.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { ReactFlow, Background, Controls, MiniMap } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 import { useGraphLayout } from './useGraphLayout'
 import { computeFocusSet } from './atlasFocus'
 
@@ -64,6 +65,7 @@ export function DomainView({
   filters,
   focusMode,
 }) {
+  const { fetchWithRepo } = useHydraFlow()
   const [graph, setGraph] = useState(null)
   const [discovered, setDiscovered] = useState([])
   const [error, setError] = useState(null)
@@ -71,11 +73,11 @@ export function DomainView({
   useEffect(() => {
     let cancelled = false
     Promise.all([
-      fetch('/api/atlas/graph?include_entries=true').then((r) => {
+      fetchWithRepo('/api/atlas/graph?include_entries=true').then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
       }),
-      fetch('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
+      fetchWithRepo('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
     ])
       .then(([graphData, discoveredData]) => {
         if (cancelled) return
@@ -91,7 +93,7 @@ export function DomainView({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [fetchWithRepo])
 
   const merged = mergeDiscovered(graph, discovered)
   const filtered = applyFilters(merged, filters)

--- a/src/ui/src/components/atlas/GraphView.jsx
+++ b/src/ui/src/components/atlas/GraphView.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { ReactFlow, Background, Controls, MiniMap } from '@xyflow/react'
 import '@xyflow/react/dist/style.css'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 import { useGraphLayout } from './useGraphLayout'
 import { computeFocusSet } from './atlasFocus'
 
@@ -62,6 +63,7 @@ export function GraphView({
   filters,
   focusMode,
 }) {
+  const { fetchWithRepo } = useHydraFlow()
   const [graph, setGraph] = useState(null)
   const [discovered, setDiscovered] = useState([])
   const [error, setError] = useState(null)
@@ -69,11 +71,11 @@ export function GraphView({
   useEffect(() => {
     let cancelled = false
     Promise.all([
-      fetch('/api/atlas/graph?include_entries=true').then((r) => {
+      fetchWithRepo('/api/atlas/graph?include_entries=true').then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
       }),
-      fetch('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
+      fetchWithRepo('/api/atlas/discovered').then((r) => (r.ok ? r.json() : [])),
     ])
       .then(([graphData, discoveredData]) => {
         if (cancelled) return
@@ -89,7 +91,7 @@ export function GraphView({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [fetchWithRepo])
 
   const merged = mergeDiscovered(graph, discovered)
   const filtered = applyFilters(merged, filters)

--- a/src/ui/src/components/atlas/TermDetailPanel.jsx
+++ b/src/ui/src/components/atlas/TermDetailPanel.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
+import { splitNodeId } from './atlasNodeId'
 
 export function TermDetailPanel({ selectedNodeId }) {
+  const { fetchWithRepo } = useHydraFlow()
   const [term, setTerm] = useState(null)
   const [error, setError] = useState(null)
 
@@ -12,7 +15,14 @@ export function TermDetailPanel({ selectedNodeId }) {
       return
     }
     let cancelled = false
-    fetch(`/api/atlas/terms/${encodeURIComponent(selectedNodeId)}`)
+    // Under __all__ the node id carries its repo (`${slug}/${id}`): fetch that
+    // repo's term explicitly; otherwise fetchWithRepo scopes to the selection.
+    const { repo, bareId } = splitNodeId(selectedNodeId)
+    const url = `/api/atlas/terms/${encodeURIComponent(bareId)}`
+    const req = repo
+      ? fetch(`${url}?repo=${encodeURIComponent(repo)}`)
+      : fetchWithRepo(url)
+    req
       .then((r) => {
         if (!r.ok) throw new Error(`status ${r.status}`)
         return r.json()
@@ -30,7 +40,7 @@ export function TermDetailPanel({ selectedNodeId }) {
     return () => {
       cancelled = true
     }
-  }, [selectedNodeId])
+  }, [selectedNodeId, fetchWithRepo])
 
   const styles = {
     root: {

--- a/src/ui/src/components/atlas/__tests__/AdrDetailPanel.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/AdrDetailPanel.test.jsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { fetchWithRepo } = vi.hoisted(() => ({
+  fetchWithRepo: (url, opts) => global.fetch(url, opts),
+}))
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: null, fetchWithRepo }),
+}))
 import { AdrDetailPanel } from '../AdrDetailPanel'
 
 const ADR = {
@@ -41,6 +48,13 @@ describe('AdrDetailPanel', () => {
     render(<AdrDetailPanel selectedNodeId="not-an-adr" />)
     await waitFor(() => {
       expect(screen.getByText(/unable to load adr/i)).toBeInTheDocument()
+    })
+  })
+
+  it('scopes the fetch to the repo encoded in a namespaced node id', async () => {
+    render(<AdrDetailPanel selectedNodeId="org-a/adr-60" />)
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/atlas/adrs/60?repo=org-a')
     })
   })
 })

--- a/src/ui/src/components/atlas/__tests__/DetailPanel.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/DetailPanel.test.jsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { fetchWithRepo } = vi.hoisted(() => ({
+  fetchWithRepo: (url, opts) => global.fetch(url, opts),
+}))
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: null, fetchWithRepo }),
+}))
 import { DetailPanel } from '../DetailPanel'
 
 beforeEach(() => {

--- a/src/ui/src/components/atlas/__tests__/DomainView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/DomainView.test.jsx
@@ -1,6 +1,21 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
 import { DomainView } from '../DomainView'
 
 const SAMPLE_GRAPH = {
@@ -30,6 +45,7 @@ const SAMPLE_GRAPH = {
 }
 
 beforeEach(() => {
+  ctx.selectedRepoSlug = null
   // ResizeObserver is required by React Flow but not present in jsdom
   global.ResizeObserver = class {
     observe() {}
@@ -46,6 +62,17 @@ describe('DomainView', () => {
     render(<DomainView selectedNodeId={null} onSelectNode={() => {}} />)
     await waitFor(() => {
       expect(screen.getByTestId('atlas-domain-view')).toBeInTheDocument()
+    })
+  })
+
+  it('scopes the graph + discovered fetches to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    render(<DomainView selectedNodeId={null} onSelectNode={() => {}} />)
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map((c) => c[0])
+      // The graph URL already has `?` → the repo param appends with `&`.
+      expect(urls).toContain('/api/atlas/graph?include_entries=true&repo=org-x')
+      expect(urls).toContain('/api/atlas/discovered?repo=org-x')
     })
   })
 

--- a/src/ui/src/components/atlas/__tests__/GraphView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/GraphView.test.jsx
@@ -1,6 +1,21 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
 import { GraphView } from '../GraphView'
 
 const SAMPLE_GRAPH = {
@@ -30,12 +45,23 @@ const SAMPLE_GRAPH = {
 }
 
 beforeEach(() => {
+  ctx.selectedRepoSlug = null
   global.fetch = vi.fn(() =>
     Promise.resolve({ ok: true, json: () => Promise.resolve(SAMPLE_GRAPH) }),
   )
 })
 
 describe('GraphView', () => {
+  it('scopes the graph + discovered fetches to the selected repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    render(<GraphView selectedNodeId={null} onSelectNode={() => {}} filters={{}} />)
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map((c) => c[0])
+      expect(urls).toContain('/api/atlas/graph?include_entries=true&repo=org-x')
+      expect(urls).toContain('/api/atlas/discovered?repo=org-x')
+    })
+  })
+
   it('renders the canvas wrapper after fetch', async () => {
     render(<GraphView selectedNodeId={null} onSelectNode={() => {}} filters={{}} />)
     await waitFor(() => {

--- a/src/ui/src/components/atlas/__tests__/TermDetailPanel.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/TermDetailPanel.test.jsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { fetchWithRepo } = vi.hoisted(() => ({
+  fetchWithRepo: (url, opts) => global.fetch(url, opts),
+}))
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: null, fetchWithRepo }),
+}))
 import { TermDetailPanel } from '../TermDetailPanel'
 
 const SAMPLE_TERM = {
@@ -59,6 +66,13 @@ describe('TermDetailPanel', () => {
     render(<TermDetailPanel selectedNodeId="n1" />)
     await waitFor(() => {
       expect(screen.getByText(/unable to load term/i)).toBeInTheDocument()
+    })
+  })
+
+  it('scopes the fetch to the repo encoded in a namespaced node id', async () => {
+    render(<TermDetailPanel selectedNodeId="org-a/01TERM000" />)
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/atlas/terms/01TERM000?repo=org-a')
     })
   })
 })

--- a/src/ui/src/components/atlas/__tests__/atlasNodeId.test.js
+++ b/src/ui/src/components/atlas/__tests__/atlasNodeId.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { splitNodeId } from '../atlasNodeId'
+
+describe('splitNodeId', () => {
+  it('splits a namespaced id into repo + bare id', () => {
+    expect(splitNodeId('org-a/01TERM000')).toEqual({ repo: 'org-a', bareId: '01TERM000' })
+    expect(splitNodeId('org-b/adr-59')).toEqual({ repo: 'org-b', bareId: 'adr-59' })
+  })
+
+  it('returns a null repo for un-prefixed (single-repo) ids', () => {
+    expect(splitNodeId('01TERM000')).toEqual({ repo: null, bareId: '01TERM000' })
+    expect(splitNodeId('adr-59')).toEqual({ repo: null, bareId: 'adr-59' })
+  })
+
+  it('only splits on the first slash and ignores a leading slash', () => {
+    expect(splitNodeId('org-a/entry-acme-widgets-7')).toEqual({
+      repo: 'org-a',
+      bareId: 'entry-acme-widgets-7',
+    })
+    expect(splitNodeId('/x')).toEqual({ repo: null, bareId: '/x' })
+  })
+
+  it('handles empty / non-string input', () => {
+    expect(splitNodeId('')).toEqual({ repo: null, bareId: '' })
+    expect(splitNodeId(null)).toEqual({ repo: null, bareId: null })
+  })
+})

--- a/src/ui/src/components/atlas/atlasNodeId.js
+++ b/src/ui/src/components/atlas/atlasNodeId.js
@@ -1,0 +1,20 @@
+/**
+ * Split an Atlas graph node id into its owning repo slug and bare id.
+ *
+ * Under `repo=__all__` the backend namespaces every node id with `${slug}/`
+ * (so terms/ADRs/entries sharing an id across repos don't collide). A
+ * single-repo graph keeps un-prefixed ids. This recovers the slug + bare id so
+ * a detail fetch can scope to the right repo:
+ *   "org-a/01TERM…"  → { repo: "org-a", bareId: "01TERM…" }
+ *   "org-a/adr-59"   → { repo: "org-a", bareId: "adr-59" }
+ *   "01TERM…"        → { repo: null,    bareId: "01TERM…" }
+ *
+ * Bare ids never contain `/` (slugs do not either — they are dash-normalized),
+ * so the first `/` is unambiguously the namespace separator.
+ */
+export function splitNodeId(nodeId) {
+  if (!nodeId || typeof nodeId !== 'string') return { repo: null, bareId: nodeId }
+  const i = nodeId.indexOf('/')
+  if (i > 0) return { repo: nodeId.slice(0, i), bareId: nodeId.slice(i + 1) }
+  return { repo: null, bareId: nodeId }
+}


### PR DESCRIPTION
## What

Phase **5c-1** — make the Atlas **graph cluster** repo-aware and handle the `repo=__all__` namespaced node ids from 5a. Frontend-only (the `/api/atlas/*` endpoints are already repo-aware).

- **DomainView / GraphView**: fetch `/api/atlas/graph` + `/api/atlas/discovered` through `fetchWithRepo` (scopes to the selected repo; aggregates under "All repos"); effect deps `[fetchWithRepo]`.
- New **`atlasNodeId.splitNodeId(id)`**: under `__all__` the backend namespaces node ids as `${slug}/${bareId}`; this recovers `{repo, bareId}` (first `/` is unambiguously the separator).
- **DetailPanel** routes adr-vs-term by the **bare** id so the shape test still matches a namespaced id.
- **TermDetailPanel / AdrDetailPanel**: split the id; a namespaced id fetches that repo's detail explicitly (`?repo=${slug}`), otherwise `fetchWithRepo` scopes to the selection.

`repo=None` / un-prefixed ids reproduce the prior behavior. **5c-2** (ArticlesView + the entries route-placeholder rename + MaintenanceView term-loops nesting) completes Phase 5.

## Tests

`atlasNodeId.test.js` (split cases); DomainView/GraphView assert the graph + discovered fetches carry `&repo=`/`?repo=` (the `?`→`&` separator edge case); TermDetailPanel + AdrDetailPanel assert the namespaced detail fetch strips the slug + appends `?repo=`.

> The atlas test mocks gained a stable hoisted `fetchWithRepo` mirroring `applyRepoParam`; `App.test`'s `mockState` gained `fetchWithRepo`/`selectedRepoSlug` (it renders the Atlas tab).

## Verification

- `make quality` ✅ 15914 (frontend-only; confirms no Python impact)
- UI `vitest` ✅ 1120+ passed · `npm run build` ✅
- **Adversarial review workflow** (3 dimensions → per-finding verification): no production bugs; the **2 confirmed test-fidelity gaps** (graph repo-threading pinned at null; TermDetailPanel namespaced path untested) are now **fixed** — DomainView/GraphView assert the `?repo=` URL and TermDetailPanel got the namespaced assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)