### PR TITLE
fix(loops): auto-close FlakeTracker flaky-test issues on recovery (#9359)

### DIFF
--- a/src/flake_tracker_loop.py
+++ b/src/flake_tracker_loop.py
@@ -179,11 +179,21 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
             if pass_counts.get(test_id, 0) >= 1
         }
 
+    @staticmethod
+    def _flake_title(test_id: str) -> str:
+        """Stable flake-issue title — single source for the file + close paths.
+
+        The flake *rate* lives in the body (it varies tick-to-tick); keeping it
+        out of the title lets the recovery path find-and-close the issue by exact
+        title and avoids the per-rate title-drift class behind #9351/#9359.
+        """
+        return f"Flaky test: {test_id}"
+
     async def _file_flake_issue(
         self, test_id: str, flake_count: int, runs: list[dict[str, Any]]
     ) -> int:
         """File a ``hydraflow-find`` + ``flaky-test`` issue. Returns issue number."""
-        title = f"Flaky test: {test_id} (flake rate: {flake_count}/{_RUN_WINDOW})"
+        title = self._flake_title(test_id)
         run_lines = "\n".join(
             f"- {r.get('url', '?')} ({r.get('createdAt', '?')})" for r in runs[:10]
         )
@@ -212,6 +222,23 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
         return await self._pr.create_issue(
             title, body, ["hitl-escalation", "flaky-test-stuck"]
         )
+
+    async def _resolve_flake_issue(self, test_id: str) -> bool:
+        """Close the open ``flaky-test`` issue for *test_id* on recovery (#9359).
+
+        Returns ``True`` if an issue was found and closed. The stable
+        :meth:`_flake_title` lets us locate it by exact title.
+        """
+        existing = await self._pr.find_existing_issue(self._flake_title(test_id))
+        if not existing:
+            return False
+        await self._pr.post_comment(
+            existing,
+            "Test no longer flaky in the recent RC-promotion window — "
+            "auto-closing (#9359).",
+        )
+        await self._pr.close_issue(existing)
+        return True
 
     async def _reconcile_closed_escalations(self) -> None:
         """Clear dedup keys whose escalation issue has been closed (spec §3.2)."""
@@ -280,9 +307,33 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
         self._state.set_flake_counts(counts)
 
         threshold = self._config.flake_threshold
+        flaky_now = {tid for tid, c in counts.items() if c >= threshold}
+        dedup = set(self._dedup.get())
+        dedup_dirty = False
+
+        # Recovery (#9359): a test with an open flake key that is no longer
+        # flaky this window has recovered — close its `flaky-test` issue and
+        # drop the key so a future regression re-files. Gated on
+        # `attempts < _MAX_ATTEMPTS` so the HITL `flaky-test-stuck` escalation
+        # is left to the operator-close path (`_reconcile_closed_escalations`);
+        # the attempt counter is intentionally NOT cleared here so repeated
+        # flare-ups still accumulate toward escalation.
+        resolved = 0
+        for key in sorted(dedup):
+            if not key.startswith("flake_tracker:"):
+                continue
+            test_id = key.split(":", 1)[1]
+            if test_id in flaky_now:
+                continue
+            if self._state.get_flake_attempts(test_id) >= _MAX_ATTEMPTS:
+                continue
+            if await self._resolve_flake_issue(test_id):
+                dedup.discard(key)
+                dedup_dirty = True
+                resolved += 1
+
         filed = 0
         escalated = 0
-        dedup = set(self._dedup.get())
         for test_id, count in counts.items():
             if count < threshold:
                 continue
@@ -297,6 +348,9 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
                 await self._file_flake_issue(test_id, count, runs)
                 filed += 1
             dedup.add(key)
+            dedup_dirty = True
+
+        if dedup_dirty:
             self._dedup.set_all(dedup)
 
         self._emit_trace(t0, runs_seen=len(runs))
@@ -304,6 +358,7 @@ class FlakeTrackerLoop(BaseBackgroundLoop):
             "status": "ok",
             "filed": filed,
             "escalated": escalated,
+            "resolved": resolved,
             "tests_seen": len(counts),
         }
 

--- a/tests/scenarios/test_flake_tracker_scenario.py
+++ b/tests/scenarios/test_flake_tracker_scenario.py
@@ -71,7 +71,10 @@ class TestFlakeTracker:
         assert len(issues) == 1
         issue = world.github.issue(issues[0]["number"])
         assert "test_flaky" in issue.title
-        assert "flake rate: 4/20" in issue.title
+        # Title is stable (#9359); the flake rate moved to the body so the
+        # recovery path can find-and-close the issue by exact title.
+        assert "flake rate" not in issue.title
+        assert "4 of the last 20" in issue.body
         assert "flaky-test" in issue.labels
         assert "hydraflow-find" in issue.labels
         fake_fetch.assert_awaited_once()

--- a/tests/test_flake_tracker_loop.py
+++ b/tests/test_flake_tracker_loop.py
@@ -211,6 +211,89 @@ async def test_reconcile_closed_escalations_clears_dedup(loop_env, monkeypatch) 
     state.clear_flake_attempts.assert_called_once_with("tests.foo.test_bar")
 
 
+def _recovery_loop(loop_env, monkeypatch, *, download):
+    """Build a FlakeTrackerLoop with stubbed fetch/download/reconcile for a tick."""
+    cfg, state, pr, dedup = loop_env
+    stop = asyncio.Event()
+    loop = FlakeTrackerLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_fetch():
+        return [{"databaseId": 0, "url": "u"}, {"databaseId": 1, "url": "v"}]
+
+    async def fake_reconcile():
+        return None
+
+    monkeypatch.setattr(loop, "_fetch_recent_runs", fake_fetch)
+    monkeypatch.setattr(loop, "_download_junit", download)
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    return loop
+
+
+async def test_recovery_closes_flake_issue_and_drops_dedup(
+    loop_env, monkeypatch
+) -> None:
+    """#9359: a test no longer flaky closes its flaky-test issue + drops the key,
+    but keeps the attempt counter (so repeat flare-ups still climb to escalation)."""
+    cfg, state, pr, dedup = loop_env
+    dedup.get.return_value = {"flake_tracker:tests.foo.test_bar"}
+    state.get_flake_attempts.return_value = 1  # < _MAX_ATTEMPTS — a flake issue
+    pr.find_existing_issue = AsyncMock(return_value=88)
+
+    async def all_pass(_run):
+        return {"tests.foo.test_bar": "pass", "tests.foo.test_ok": "pass"}
+
+    loop = _recovery_loop(loop_env, monkeypatch, download=all_pass)
+    stats = await loop._do_work()
+
+    assert stats["resolved"] == 1
+    pr.find_existing_issue.assert_awaited_once_with("Flaky test: tests.foo.test_bar")
+    pr.close_issue.assert_awaited_once_with(88)
+    remaining = dedup.set_all.call_args.args[0]
+    assert "flake_tracker:tests.foo.test_bar" not in remaining
+    state.clear_flake_attempts.assert_not_called()  # counter preserved
+
+
+async def test_recovery_skips_escalated_test(loop_env, monkeypatch) -> None:
+    """A test that reached the HITL escalation (attempts >= MAX) is NOT auto-closed."""
+    cfg, state, pr, dedup = loop_env
+    dedup.get.return_value = {"flake_tracker:tests.foo.test_bar"}
+    state.get_flake_attempts.return_value = 3  # >= _MAX_ATTEMPTS — operator's call
+    pr.find_existing_issue = AsyncMock(return_value=88)
+
+    async def all_pass(_run):
+        return {"tests.foo.test_bar": "pass"}
+
+    loop = _recovery_loop(loop_env, monkeypatch, download=all_pass)
+    stats = await loop._do_work()
+
+    assert stats["resolved"] == 0
+    pr.close_issue.assert_not_awaited()
+
+
+async def test_recovery_skips_still_flaky_test(loop_env, monkeypatch) -> None:
+    """A test still flaky this window keeps its issue open (no false close)."""
+    cfg, state, pr, dedup = loop_env
+    cfg.flake_threshold = 1
+    dedup.get.return_value = {"flake_tracker:tests.foo.test_bar"}
+    state.get_flake_attempts.return_value = 1
+    pr.find_existing_issue = AsyncMock(return_value=88)
+
+    call = {"n": 0}
+
+    async def mixed(_run):
+        call["n"] += 1
+        # Mixed pass/fail record → still flaky per spec §4.5.
+        return {"tests.foo.test_bar": "fail" if call["n"] == 1 else "pass"}
+
+    loop = _recovery_loop(loop_env, monkeypatch, download=mixed)
+    stats = await loop._do_work()
+
+    assert stats["resolved"] == 0
+    pr.close_issue.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_kill_switch_short_circuits_do_work(loop_env) -> None:
     """Disabled kill-switch → _do_work returns `disabled` and skips reconcile (ADR-0049)."""


### PR DESCRIPTION
Batch 10 (loop 13/13 — the last). `FlakeTrackerLoop` filed a `Flaky test: {id} (flake rate: N/20)` issue when a test crossed the flake threshold but never closed it once the test stopped flaking. The variable rate in the title also made it un-findable for closing.

- **Stabilize** the title to `Flaky test: {id}` via `_flake_title` (rate → body), so the file + close paths share one source.
- **Recovery** in `_do_work`: for any open `flake_tracker:{id}` dedup key whose test is no longer flaky this window, close its `flaky-test` issue and drop the key so a future regression re-files.
- **Disentangles the shared dedup key**: recovery is gated on `get_flake_attempts(id) < _MAX_ATTEMPTS` so the HITL `flaky-test-stuck` escalation stays operator-closed (`_reconcile_closed_escalations`). The attempt counter is deliberately **not** cleared on recovery, so repeated flare-ups still accumulate toward escalation.
- Adds a `resolved` stat; dedup persisted once per tick (behaviour-equivalent).

**Verification:** 3 new unit tests (recovery closes + drops key + keeps counter; escalated test left alone; still-flaky not falsely closed); scenario assertion updated for the stable title (rate now in body). **unit 18 + scenario 2** green; ruff + pyright clean.

**Progress: 13/13 loops migrated — issue-hygiene rollout complete.** StagingBisect intentionally stays HITL (revert-conflict escalations need human sign-off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)