### PR TITLE
feat(atlas): ArticlesView + wiki entries scope by operated repo (Phase 5c-2)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T07:11:48.329240+00:00",
-  "commit_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e",
+  "regenerated_at": "2026-06-09T07:59:41.441788+00:00",
+  "commit_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b",
   "artifacts": {
     "loops.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "ports.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "labels.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "modules.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "events.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "adr_xref.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "mockworld.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "changelog.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "coverage_matrix.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "functional_areas.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "ubiquitous-language.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "82e3fd75961628541886f5c62ebeffa1a928ff7e"
+      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `82e3fd7` — feat(atlas): thread operated repo into the graph cluster + namespaced node ids (Phase 5c-1) *(2026-06-09)*
+- `6aeec86` — feat(atlas): thread operated repo into the graph cluster + namespaced node ids (Phase 5c-1) (#9383) (#9383) *(2026-06-09)*
+- `e6e3269` — fix(loops): auto-close SecurityPatch issues when the alert resolves (#9359) (#9382) (#9382) *(2026-06-09)*
 - `99f1f27` — feat(wiki): /api/wiki/* maintenance surface scopes by repo (Phase 5b) (#9379) (#9379) *(2026-06-09)*
 - `af05e0c` — feat(atlas): /api/atlas/* endpoints scope by repo (Phase 5a) (#9377) (#9377) *(2026-06-08)*
 - `1f68711` — feat(system): aggregate-mode worker affordances + force-clear-credit button (Phase 3b-fe polish) (#9374) (#9374) *(2026-06-08)*

--- a/src/dashboard_routes/_wiki_routes.py
+++ b/src/dashboard_routes/_wiki_routes.py
@@ -317,20 +317,21 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
             return out
         return _repos(_resolve(repo)[0])
 
-    @router.get("/api/wiki/repos/{owner}/{repo}/entries")
+    # The wiki-SUBJECT repo is the `{owner}/{wiki_repo}` path; the OPERATED repo
+    # is the `repo` query (which wiki store to read), resolved via _resolve. The
+    # path placeholder is `wiki_repo` (not `repo`) so the two don't collide.
+    @router.get("/api/wiki/repos/{owner}/{wiki_repo}/entries")
     def list_wiki_entries(
         owner: str,
-        repo: str,
+        wiki_repo: str,
         topic: str | None = None,
         status: str | None = None,
         q: str | None = None,
         limit: int = 100,
         offset: int = 0,
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        # Entry reads are wiki-subject scoped (owner/repo path). Operated-repo
-        # scoping for ArticlesView is reconciled in 5c (the route's `repo` path
-        # param precludes a `repo` query param), so these read the host wiki.
-        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
+        repo_dir = _repo_dir(_resolve(repo)[0], owner, wiki_repo)
         if repo_dir is None:
             return []
         topics: tuple[str, ...] = (topic,) if topic else _TOPICS
@@ -341,7 +342,7 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                 continue
             for entry_path in sorted(topic_dir.glob("*.md")):
                 summary = _entry_summary_from_path(
-                    topic=t, path=entry_path, owner=owner, repo=repo
+                    topic=t, path=entry_path, owner=owner, repo=wiki_repo
                 )
                 if summary is None:
                     continue
@@ -357,9 +358,11 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
         limit = max(limit, 0)
         return out[offset : offset + limit]
 
-    @router.get("/api/wiki/repos/{owner}/{repo}/entries/{entry_id}")
-    def get_wiki_entry(owner: str, repo: str, entry_id: str) -> dict[str, Any]:
-        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
+    @router.get("/api/wiki/repos/{owner}/{wiki_repo}/entries/{entry_id}")
+    def get_wiki_entry(
+        owner: str, wiki_repo: str, entry_id: str, repo: RepoSlugParam = None
+    ) -> dict[str, Any]:
+        repo_dir = _repo_dir(_resolve(repo)[0], owner, wiki_repo)
         if repo_dir is None:
             raise HTTPException(status_code=404, detail="repo not found")
         if not re.fullmatch(r"\d{1,6}", entry_id):
@@ -376,21 +379,22 @@ def register(router: APIRouter, ctx: RouteContext) -> None:
                     "id": entry_id,
                     "topic": topic,
                     "owner": owner,
-                    "repo": repo,
+                    "repo": wiki_repo,
                     "filename": match.name,
                     "frontmatter": frontmatter,
                     "body": body,
                 }
         raise HTTPException(status_code=404, detail="entry not found")
 
-    @router.get("/api/wiki/repos/{owner}/{repo}/log")
+    @router.get("/api/wiki/repos/{owner}/{wiki_repo}/log")
     def get_wiki_log(
         owner: str,
-        repo: str,
+        wiki_repo: str,
         issue: int | None = None,
         limit: int = 200,
+        repo: RepoSlugParam = None,
     ) -> list[dict[str, Any]]:
-        repo_dir = _repo_dir(_resolve(None)[0], owner, repo)
+        repo_dir = _repo_dir(_resolve(repo)[0], owner, wiki_repo)
         if repo_dir is None:
             return []
         log_dir = repo_dir / "log"

--- a/src/ui/src/components/atlas/ArticlesView.jsx
+++ b/src/ui/src/components/atlas/ArticlesView.jsx
@@ -2,9 +2,11 @@ import React, { useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { theme } from '../../theme'
+import { useHydraFlow } from '../../context/HydraFlowContext'
 import { WikiTopBar } from './WikiTopBar'
 
 export function ArticlesView() {
+  const { fetchWithRepo } = useHydraFlow()
   const [typeFilter, setTypeFilter] = useState('all') // all | adrs | wiki
   const [linkFilter, setLinkFilter] = useState('all') // all | linked | discovered
   const [adrs, setAdrs] = useState([])
@@ -18,9 +20,11 @@ export function ArticlesView() {
 
   // Discovered entry IDs (orphans w/ no term evidence). One fetch on mount —
   // stable enough at the cadence the term-proposer + migration script run at.
+  // All Atlas/wiki reads scope to the selected operated repo via fetchWithRepo
+  // (host/default when none is selected; aggregate under "All repos").
   useEffect(() => {
     let cancelled = false
-    fetch('/api/atlas/discovered')
+    fetchWithRepo('/api/atlas/discovered')
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => {
         if (cancelled) return
@@ -33,28 +37,38 @@ export function ArticlesView() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [fetchWithRepo])
 
   // ADRs (always loaded — small set)
   useEffect(() => {
-    fetch('/api/atlas/adrs')
+    fetchWithRepo('/api/atlas/adrs')
       .then((r) => (r.ok ? r.json() : []))
       .then((d) => setAdrs(Array.isArray(d) ? d : []))
       .catch(() => setAdrs([]))
-  }, [])
+  }, [fetchWithRepo])
 
-  // Wiki repos
+  // Wiki-subject repos for the OPERATED repo's wiki store. On an operated-repo
+  // switch (fetchWithRepo changes) the subject list changes — keep the current
+  // pick if it survives, else fall back to the first.
   useEffect(() => {
-    fetch('/api/wiki/repos')
+    fetchWithRepo('/api/wiki/repos')
       .then((r) => (r.ok ? r.json() : []))
       .then((list) => {
         const safe = Array.isArray(list) ? list : []
         setRepos(safe)
-        if (safe.length > 0 && selectedRepo === null) setSelectedRepo(safe[0])
+        setSelectedRepo((prev) =>
+          prev && safe.some((r) => r.owner === prev.owner && r.repo === prev.repo)
+            ? prev
+            : (safe[0] ?? null),
+        )
       })
-      .catch(() => setRepos([]))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+      // On a repos-fetch error during a repo switch, drop the stale subject so
+      // the entries effect doesn't read the old subject under the new scope.
+      .catch(() => {
+        setRepos([])
+        setSelectedRepo(null)
+      })
+  }, [fetchWithRepo])
 
   // Wiki entries
   useEffect(() => {
@@ -62,18 +76,26 @@ export function ArticlesView() {
       setEntries([])
       return
     }
+    let cancelled = false
     const qs = new URLSearchParams()
     if (wikiFilters.topic) qs.set('topic', wikiFilters.topic)
     if (wikiFilters.status) qs.set('status', wikiFilters.status)
     if (wikiFilters.q) qs.set('q', wikiFilters.q)
     qs.set('limit', '200')
-    fetch(
+    fetchWithRepo(
       `/api/wiki/repos/${selectedRepo.owner}/${selectedRepo.repo}/entries?${qs}`,
     )
       .then((r) => (r.ok ? r.json() : []))
-      .then((d) => setEntries(Array.isArray(d) ? d : []))
-      .catch(() => setEntries([]))
-  }, [selectedRepo, wikiFilters.topic, wikiFilters.status, wikiFilters.q])
+      .then((d) => {
+        if (!cancelled) setEntries(Array.isArray(d) ? d : [])
+      })
+      .catch(() => {
+        if (!cancelled) setEntries([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [selectedRepo, wikiFilters.topic, wikiFilters.status, wikiFilters.q, fetchWithRepo])
 
   // Detail body for selected article
   useEffect(() => {
@@ -87,7 +109,7 @@ export function ArticlesView() {
       url = `/api/wiki/repos/${selected.repo.owner}/${selected.repo.repo}/entries/${selected.id}`
     if (!url) return
     let cancelled = false
-    fetch(url)
+    fetchWithRepo(url)
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => {
         if (!cancelled) setBodyDetail(d)
@@ -98,7 +120,7 @@ export function ArticlesView() {
     return () => {
       cancelled = true
     }
-  }, [selected])
+  }, [selected, fetchWithRepo])
 
   const merged = useMemo(() => {
     const rows = []

--- a/src/ui/src/components/atlas/MaintenanceView.jsx
+++ b/src/ui/src/components/atlas/MaintenanceView.jsx
@@ -11,9 +11,8 @@ export function MaintenanceView() {
   const [termLoops, setTermLoops] = useState(null)
 
   const refresh = useCallback(() => {
-    // Wiki maintenance/health scope to the selected repo (health aggregates
-    // under "All repos"). Term-loops stays host-scoped here; its repo-aware
-    // threading + per-repo nested shape land with AtlasExplorer (5c).
+    // Wiki maintenance/health + term-loops scope to the selected repo (health
+    // aggregates and term-loops nests per repo under "All repos").
     fetchWithRepo('/api/wiki/maintenance/status')
       .then((r) => (r.ok ? r.json() : null))
       .then(setStatus)
@@ -22,11 +21,20 @@ export function MaintenanceView() {
       .then((r) => (r.ok ? r.json() : null))
       .then(setHealth)
       .catch(() => setHealth(null))
-    fetch('/api/atlas/term-loops/status')
+    fetchWithRepo('/api/atlas/term-loops/status')
       .then((r) => (r.ok ? r.json() : null))
       .then(setTermLoops)
       .catch(() => setTermLoops(null))
   }, [fetchWithRepo])
+
+  // term-loops/status returns a flat {loop: {...}} for a single repo, or
+  // {repos: [{repo, loops}]} under __all__. Normalize to a list of
+  // {repo, loops} groups so the render handles both.
+  const termLoopGroups = termLoops?.repos
+    ? termLoops.repos
+    : termLoops
+      ? [{ repo: null, loops: termLoops }]
+      : []
 
   useEffect(() => {
     refresh()
@@ -162,55 +170,62 @@ export function MaintenanceView() {
 
       <div style={{ ...styles.card, gridColumn: 'span 2' }}>
         <div style={styles.label}>Term loops</div>
-        <div
-          style={{
-            marginTop: 6,
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr 1fr',
-            gap: 12,
-          }}
-        >
-          {['term_proposer', 'term_pruner', 'edge_proposer'].map((name) => {
-            const loop = termLoops?.[name]
-            const loopStatus = loop?.status ?? 'unknown'
-            const lastRun = loop?.last_run
-            const loopPrUrl = loop?.last_pr_url
-            const count = loop?.last_action_count
-            return (
+        {termLoopGroups.map((group, gi) => (
+          <div key={group.repo ?? gi} style={{ marginTop: 6 }}>
+            {group.repo && (
               <div
-                key={name}
-                style={{
-                  border: `1px solid ${theme.border}`,
-                  borderRadius: 3,
-                  padding: 8,
-                }}
+                style={{ color: theme.textMuted, fontSize: 10, marginBottom: 4 }}
+                data-testid={`term-loops-repo-${group.repo}`}
               >
-                <div style={{ color: theme.textBright }}>{name}</div>
-                <div style={{ color: theme.textMuted, fontSize: 10 }}>
-                  status: {loopStatus}
-                </div>
-                <div style={{ color: theme.textMuted, fontSize: 10 }}>
-                  last run: {lastRun ? lastRun.split('T')[0] : '—'}
-                </div>
-                {loopPrUrl && (
-                  <a
-                    href={loopPrUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    style={{ color: theme.accent, fontSize: 10 }}
-                  >
-                    last PR
-                  </a>
-                )}
-                {typeof count === 'number' && (
-                  <div style={{ color: theme.textMuted, fontSize: 10 }}>
-                    actions: {count}
-                  </div>
-                )}
+                {group.repo}
               </div>
-            )
-          })}
-        </div>
+            )}
+            <div
+              style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12 }}
+            >
+              {['term_proposer', 'term_pruner', 'edge_proposer'].map((name) => {
+                const loop = group.loops?.[name]
+                const loopStatus = loop?.status ?? 'unknown'
+                const lastRun = loop?.last_run
+                const loopPrUrl = loop?.last_pr_url
+                const count = loop?.last_action_count
+                return (
+                  <div
+                    key={name}
+                    style={{
+                      border: `1px solid ${theme.border}`,
+                      borderRadius: 3,
+                      padding: 8,
+                    }}
+                  >
+                    <div style={{ color: theme.textBright }}>{name}</div>
+                    <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                      status: {loopStatus}
+                    </div>
+                    <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                      last run: {lastRun ? lastRun.split('T')[0] : '—'}
+                    </div>
+                    {loopPrUrl && (
+                      <a
+                        href={loopPrUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{ color: theme.accent, fontSize: 10 }}
+                      >
+                        last PR
+                      </a>
+                    )}
+                    {typeof count === 'number' && (
+                      <div style={{ color: theme.textMuted, fontSize: 10 }}>
+                        actions: {count}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        ))}
         <div style={{ color: theme.textMuted, fontSize: 10, marginTop: 6 }}>
           From <code>/api/atlas/term-loops/status</code>. Read-only;
           loops are governed by the System tab toggles.

--- a/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/ArticlesView.test.jsx
@@ -1,6 +1,22 @@
 import React from 'react'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { ctx, fetchWithRepo } = vi.hoisted(() => {
+  const ctx = { selectedRepoSlug: null }
+  const fetchWithRepo = (url, opts) => {
+    const sep = url.includes('?') ? '&' : '?'
+    const scoped = ctx.selectedRepoSlug
+      ? `${url}${sep}repo=${encodeURIComponent(ctx.selectedRepoSlug)}`
+      : url
+    return global.fetch(scoped, opts)
+  }
+  return { ctx, fetchWithRepo }
+})
+vi.mock('../../../context/HydraFlowContext', () => ({
+  useHydraFlow: () => ({ selectedRepoSlug: ctx.selectedRepoSlug, fetchWithRepo }),
+}))
+
 import { ArticlesView } from '../ArticlesView'
 
 const ADRS = [
@@ -45,6 +61,7 @@ const ENTRY_DETAIL = {
 }
 
 beforeEach(() => {
+  ctx.selectedRepoSlug = null
   global.fetch = vi.fn((url) => {
     if (url === '/api/atlas/adrs')
       return Promise.resolve({ ok: true, json: () => Promise.resolve(ADRS) })
@@ -143,5 +160,16 @@ describe('ArticlesView', () => {
     expect(
       screen.queryByLabelText(/linked to term/i),
     ).not.toBeInTheDocument()
+  })
+
+  it('scopes its Atlas + wiki reads to the selected operated repo', async () => {
+    ctx.selectedRepoSlug = 'org-x'
+    render(<ArticlesView />)
+    await waitFor(() => {
+      const urls = global.fetch.mock.calls.map((c) => c[0])
+      expect(urls).toContain('/api/atlas/adrs?repo=org-x')
+      expect(urls).toContain('/api/wiki/repos?repo=org-x')
+      expect(urls).toContain('/api/atlas/discovered?repo=org-x')
+    })
   })
 })

--- a/src/ui/src/components/atlas/__tests__/MaintenanceView.test.jsx
+++ b/src/ui/src/components/atlas/__tests__/MaintenanceView.test.jsx
@@ -87,6 +87,7 @@ describe('MaintenanceView', () => {
       const calls = global.fetch.mock.calls.map((c) => c[0])
       expect(calls).toContain('/api/wiki/maintenance/status?repo=org-x')
       expect(calls).toContain('/api/wiki/health?repo=org-x')
+      expect(calls).toContain('/api/atlas/term-loops/status?repo=org-x')
     })
   })
 
@@ -103,5 +104,25 @@ describe('MaintenanceView', () => {
       (c) => c[1] && c[1].method === 'POST',
     )
     expect(posts).toHaveLength(0)
+  })
+
+  it('renders per-repo term-loop groups for the __all__ nested shape', async () => {
+    ctx.selectedRepoSlug = '__all__'
+    const NESTED = {
+      repos: [
+        { repo: 'org-a', loops: { term_proposer: { status: 'ok' } } },
+        { repo: 'org-b', loops: { term_proposer: { status: 'idle' } } },
+      ],
+    }
+    global.fetch = vi.fn((url) =>
+      url.includes('/api/atlas/term-loops/status')
+        ? Promise.resolve({ ok: true, json: () => Promise.resolve(NESTED) })
+        : Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    )
+    render(<MaintenanceView />)
+    await waitFor(() => {
+      expect(screen.getByTestId('term-loops-repo-org-a')).toBeInTheDocument()
+      expect(screen.getByTestId('term-loops-repo-org-b')).toBeInTheDocument()
+    })
   })
 })

--- a/tests/test_wiki_routes.py
+++ b/tests/test_wiki_routes.py
@@ -135,34 +135,42 @@ class TestReadEndpoints:
         assert result == [{"owner": "acme", "repo": "widget"}]
 
     def test_list_entries_returns_all_by_default(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries", "GET"
+        )
         assert handler is not None
-        entries = handler(owner="acme", repo="widget")
+        entries = handler(owner="acme", wiki_repo="widget")
         assert len(entries) == 2
         topics = {e["topic"] for e in entries}
         assert topics == {"patterns", "gotchas"}
 
     def test_list_entries_filters_by_topic(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
-        entries = handler(owner="acme", repo="widget", topic="patterns")
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries", "GET"
+        )
+        entries = handler(owner="acme", wiki_repo="widget", topic="patterns")
         assert len(entries) == 1
         assert entries[0]["topic"] == "patterns"
 
     def test_list_entries_filters_by_status(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
-        stale = handler(owner="acme", repo="widget", status="stale")
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries", "GET"
+        )
+        stale = handler(owner="acme", wiki_repo="widget", status="stale")
         assert len(stale) == 1
         assert stale[0]["topic"] == "gotchas"
 
     def test_list_entries_rejects_path_traversal_in_owner(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/entries", "GET")
-        assert handler(owner="../evil", repo="widget") == []
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries", "GET"
+        )
+        assert handler(owner="../evil", wiki_repo="widget") == []
 
     def test_get_entry_returns_frontmatter_plus_body(self, router: Any) -> None:
         handler = find_endpoint(
-            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries/{entry_id}", "GET"
         )
-        result = handler(owner="acme", repo="widget", entry_id="0001")
+        result = handler(owner="acme", wiki_repo="widget", entry_id="0001")
         assert result["frontmatter"]["source_phase"] in {"plan", "review"}
         assert "# " in result["body"] or result["body"].strip()
 
@@ -170,31 +178,35 @@ class TestReadEndpoints:
         from fastapi import HTTPException
 
         handler = find_endpoint(
-            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries/{entry_id}", "GET"
         )
         with pytest.raises(HTTPException) as exc:
-            handler(owner="acme", repo="widget", entry_id="9999")
+            handler(owner="acme", wiki_repo="widget", entry_id="9999")
         assert exc.value.status_code == 404
 
     def test_get_entry_400_for_non_numeric_id(self, router: Any) -> None:
         from fastapi import HTTPException
 
         handler = find_endpoint(
-            router, "/api/wiki/repos/{owner}/{repo}/entries/{entry_id}", "GET"
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/entries/{entry_id}", "GET"
         )
         with pytest.raises(HTTPException) as exc:
-            handler(owner="acme", repo="widget", entry_id="../passwd")
+            handler(owner="acme", wiki_repo="widget", entry_id="../passwd")
         assert exc.value.status_code == 400
 
     def test_get_log_filters_by_issue(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/log", "GET")
-        records = handler(owner="acme", repo="widget", issue=10)
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/log", "GET"
+        )
+        records = handler(owner="acme", wiki_repo="widget", issue=10)
         assert len(records) == 1
         assert records[0]["issue_number"] == 10
 
     def test_get_log_empty_for_unknown_repo(self, router: Any) -> None:
-        handler = find_endpoint(router, "/api/wiki/repos/{owner}/{repo}/log", "GET")
-        assert handler(owner="ghost", repo="ghost") == []
+        handler = find_endpoint(
+            router, "/api/wiki/repos/{owner}/{wiki_repo}/log", "GET"
+        )
+        assert handler(owner="ghost", wiki_repo="ghost") == []
 
 
 class TestMaintenanceStatus:

--- a/tests/test_wiki_routes_multirepo.py
+++ b/tests/test_wiki_routes_multirepo.py
@@ -104,6 +104,34 @@ def test_repos_all_unions_across_repos(setup):
     assert ("acme", "beta") in pairs
 
 
+def _seed_entry(cfg, owner, wiki_repo, topic, entry_id, issue):
+    d = cfg.repo_root / cfg.repo_wiki_path / owner / wiki_repo / topic
+    d.mkdir(parents=True, exist_ok=True)
+    (d / f"{entry_id}-issue-{issue}-note.md").write_text(
+        f"---\ntitle: n{issue}\ntopic: {topic}\nstatus: active\nsource_issue: {issue}\n---\nbody {issue}\n",
+        encoding="utf-8",
+    )
+
+
+def test_entries_scope_to_the_operated_repo(setup):
+    router, cfg_a, cfg_b, *_ = setup
+    # Same wiki subject (acme/widgets), a distinct entry in each operated repo.
+    _seed_entry(cfg_a, "acme", "widgets", "patterns", "0001", "10")
+    _seed_entry(cfg_b, "acme", "widgets", "patterns", "0002", "20")
+    entries = find_endpoint(
+        router, "/api/wiki/repos/{owner}/{wiki_repo}/entries", "GET"
+    )
+    a_files = [
+        e["filename"] for e in entries(owner="acme", wiki_repo="widgets", repo="org-a")
+    ]
+    b_files = [
+        e["filename"] for e in entries(owner="acme", wiki_repo="widgets", repo="org-b")
+    ]
+    # Each operated repo's reads stay in its OWN wiki dir.
+    assert a_files == ["0001-issue-10-note.md"]
+    assert b_files == ["0002-issue-20-note.md"]
+
+
 def test_admin_force_compile_targets_selected_repo(setup):
     router, _cfg_a, _cfg_b, queue_a, queue_b = setup
     force = find_endpoint(router, "/api/wiki/admin/force-compile", "POST")


### PR DESCRIPTION
## What

Phase **5c-2** — **completes Phase 5**: the Atlas + wiki vertical is now fully repo-aware.

### Backend

The three wiki entry routes' path placeholder is renamed `{owner}/{repo}` → `{owner}/{wiki_repo}` (the served URL is **unchanged** — placeholder names don't affect matching) so a `repo: RepoSlugParam = None` **query** param is free (previously the wiki-subject path `repo` collided with it). They now read `_repo_dir(_resolve(repo)[0], owner, wiki_repo)`: a specific operated-repo slug reads **that repo's** wiki dir, `None`/`__all__` read the host/default. The response key stays `repo` (= the wiki-subject), so the frontend shape is unchanged.

### Frontend

- **ArticlesView** routes all five reads (discovered, adrs, wiki/repos, entries, detail) through `fetchWithRepo`; the wiki-subject list re-fetches on an operated-repo switch, **preserving** the current subject if it survives the new repo's list else falling back to the first. The entries effect gained a `cancelled` guard (review fix — no stale subject landing after a switch) and the repos error path clears the stale subject (review fix).
- **MaintenanceView** threads term-loops through `fetchWithRepo` and renders the `repo=__all__` nested `{repos:[{repo,loops}]}` shape as **per-repo loop groups** (a flat single-repo response keeps the prior single grid).

`repo=None` reproduces the prior host behavior (existing wiki route tests updated: `{wiki_repo}` placeholders + `wiki_repo=` kwargs, leaving the `ForceCompilePayload(repo=...)` wiki-subject field untouched).

## Tests

`test_wiki_routes_multirepo.py` proves entries scope to each operated repo's own wiki dir (distinct seeded files); ArticlesView asserts `?repo=` reaches every read; MaintenanceView asserts term-loops is scoped + the nested shape renders per-repo groups.

## Verification

- `make quality` ✅ 15926 passed
- `make scenario` ✅ 188 · `make scenario-loops` ✅ 125 · `make audit` ✅ 90/0
- UI `vitest` ✅ 1125+ · `npm run build` ✅
- **Adversarial review** (2 reviewers: backend + frontend): backend clean; 3 frontend findings (entries stale-response guard, repos-error stale-subject, a missing term-loops test assertion) **all fixed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)