### PR TITLE
fix(dashboard): None=default for /api/sessions + pipeline-active (Phase 6 closing)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T07:59:41.441788+00:00",
-  "commit_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b",
+  "regenerated_at": "2026-06-09T18:18:18.806332+00:00",
+  "commit_sha": "9a46933716c143760948ab2ecf33c03e289828ad",
   "artifacts": {
     "loops.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "ports.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "labels.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "modules.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "events.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "adr_xref.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "mockworld.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "changelog.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "coverage_matrix.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "functional_areas.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "ubiquitous-language.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "6aeec866fcd6ae3fdd9a803e42c86f13f5bbdc0b"
+      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `9a46933` — feat(atlas): ArticlesView + wiki entries scope by operated repo (Phase 5c-2) (#9385) (#9385) *(2026-06-09)*
 - `6aeec86` — feat(atlas): thread operated repo into the graph cluster + namespaced node ids (Phase 5c-1) (#9383) (#9383) *(2026-06-09)*
 - `e6e3269` — fix(loops): auto-close SecurityPatch issues when the alert resolves (#9359) (#9382) (#9382) *(2026-06-09)*
 - `99f1f27` — feat(wiki): /api/wiki/* maintenance surface scopes by repo (Phase 5b) (#9379) (#9379) *(2026-06-09)*

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -379,17 +379,34 @@ class RouteContext:
             return False
         return orch.pipeline_enabled
 
+    def _default_slug(self) -> str:
+        """Canonical dash slug for the default (host) repo.
+
+        Prefers the explicitly-wired ``default_repo_slug``, else derives it from
+        the host config (``owner/repo`` → ``owner-repo``, or the repo-root name).
+        """
+        return self.default_repo_slug or (
+            self.config.repo.replace("/", "-")
+            if self.config.repo
+            else self.config.repo_root.name
+        )
+
     def is_repo_pipeline_active(self, slug: str | None) -> bool:
         """Return whether the resolved repo's pipeline is actively processing.
 
         The host repo is a registered runtime like any other, so this resolves
-        purely through the registry. When *slug* is ``None`` or the ``REPO_ALL``
-        sentinel (All repos view), returns True if ANY line is running.
+        purely through the registry. Per the ``None``=default invariant, a
+        ``None`` *slug* scopes to the **default** repo; only the ``REPO_ALL``
+        sentinel (All repos view) returns True if ANY line is running.
         """
         if self.registry is not None:
-            if slug is None or slug.strip().lower() == REPO_ALL:
+            if slug is not None and slug.strip().lower() == REPO_ALL:
                 return any(getattr(rt, "running", False) for rt in self.registry.all)
-            rt = self.registry.get(slug)
+            # None ⇒ the default repo; a slug ⇒ that line. The host repo is a
+            # registered runtime, so the default resolves through the registry
+            # like any other (absent ⇒ not running).
+            resolved = slug if slug is not None else self._default_slug()
+            rt = self.registry.get(resolved)
             return getattr(rt, "running", False) if rt is not None else False
         # No registry (single-repo/test wiring): fall back to the host orch.
         return self._host_pipeline_active()
@@ -461,11 +478,7 @@ class RouteContext:
         ``None`` while registry runtimes yield their live orchestrator —
         consumers must handle ``None``.
         """
-        default_slug = self.default_repo_slug or (
-            self.config.repo.replace("/", "-")
-            if self.config.repo
-            else self.config.repo_root.name
-        )
+        default_slug = self._default_slug()
 
         if slug is not None and slug.strip().lower() == REPO_ALL:
             if self.registry is not None:
@@ -793,9 +806,9 @@ def create_router(
     def _is_pipeline_active(slug: str | None) -> bool:
         """Check if the selected repo's pipeline is running.
 
-        When no repo is selected (All repos view), checks the default
-        repo's pipeline state — data only shows when something is
-        actually running.
+        A bare ``None`` slug checks the default repo's pipeline state; only the
+        ``__all__`` sentinel (All repos view) returns True if any line is
+        running. Data only shows when something is actually running.
         """
         return ctx.is_repo_pipeline_active(slug)
 
@@ -2156,13 +2169,19 @@ def create_router(
         for _cfg, _state, _bus, _get_orch, _slug in _resolve_runtimes(repo):
             sessions.extend(_state.load_sessions())
         repo_filter = (repo or "").strip()
-        if repo_filter and repo_filter.lower() != REPO_ALL and registry is None:
-            # Legacy no-registry wiring: load_sessions returns ALL; filter by tag.
-            normalized = repo_filter.lower()
+        if repo_filter.lower() != REPO_ALL and registry is None:
+            # Legacy no-registry wiring: the single state holds sessions for
+            # every repo. Scope to the requested repo — and per the None=default
+            # invariant, a bare request scopes to the DEFAULT repo, not the
+            # whole set. Normalize slash/dash so a dash-form query slug
+            # ("owner-x") matches a slash-form SessionLog.repo ("owner/x").
+            target = (
+                (repo_filter or _resolve_runtimes(None)[0][4]).replace("/", "-").lower()
+            )
             sessions = [
                 session
                 for session in sessions
-                if (session.repo or "").lower() == normalized
+                if (session.repo or "").replace("/", "-").lower() == target
             ]
         return JSONResponse([s.model_dump() for s in sessions])
 

--- a/tests/scenarios/test_multi_repo_sessions.py
+++ b/tests/scenarios/test_multi_repo_sessions.py
@@ -1,0 +1,73 @@
+"""Scenario: /api/sessions honours the None=default vs __all__=union invariant.
+
+Drives the real route through a MockWorld-seeded registry of two isolated
+``RepoRuntime`` objects (separate config / state / event bus per repo). Unlike
+the duck-typed unit tests — which exercise the legacy no-registry single-state
+filter — this proves the registry-present path end to end:
+
+* ``repo=__all__`` unions every registered line's sessions, and
+* a bare ``repo=None`` scopes to the *default* repo only (here the host repo is
+  itself a registered runtime, as in a real deployment), rather than leaking the
+  whole multi-repo set.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mockworld.seed import MockWorldSeed
+from models import SessionLog
+from tests.helpers import find_endpoint, make_dashboard_router
+
+pytestmark = pytest.mark.scenario
+
+
+def _session(repo: str, session_id: str) -> SessionLog:
+    return SessionLog(
+        id=session_id,
+        repo=repo,
+        started_at="2024-01-01T00:00:00Z",
+        ended_at="2024-01-01T01:00:00Z",
+        issues_processed=[1],
+        issues_succeeded=1,
+        issues_failed=0,
+        status="completed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_sessions_all_unions_and_none_scopes_to_default(
+    mock_world, tmp_path
+) -> None:
+    seed = MockWorldSeed(
+        repos=[
+            ("owner/alpha", str(tmp_path / "alpha")),
+            ("owner/beta", str(tmp_path / "beta")),
+        ],
+    )
+    mock_world.apply_seed(seed)
+
+    alpha = mock_world.registry.get("owner-alpha")
+    beta = mock_world.registry.get("owner-beta")
+    alpha.state.save_session(_session("owner/alpha", "alpha-1"))
+    beta.state.save_session(_session("owner/beta", "beta-1"))
+
+    # Wire the host/default line to the alpha runtime, so the default repo is a
+    # registered member of the registry (matching real multi-repo deployments).
+    router, _ = make_dashboard_router(
+        alpha.config,
+        alpha.event_bus,
+        alpha.state,
+        tmp_path,
+        registry=mock_world.registry,
+        default_repo_slug="owner-alpha",
+    )
+    endpoint = find_endpoint(router, "/api/sessions")
+
+    all_data = json.loads((await endpoint(repo="__all__")).body)
+    assert {s["repo"] for s in all_data} == {"owner/alpha", "owner/beta"}
+
+    none_data = json.loads((await endpoint(repo=None)).body)
+    assert {s["repo"] for s in none_data} == {"owner/alpha"}

--- a/tests/test_route_context.py
+++ b/tests/test_route_context.py
@@ -11,7 +11,7 @@ from config import Credentials, HydraFlowConfig
 from dashboard_routes import RouteContext
 from events import EventBus
 from state import StateTracker
-from tests.helpers import make_dashboard_router
+from tests.helpers import make_dashboard_router, make_registry
 
 
 def _make_ctx(
@@ -192,6 +192,106 @@ class TestRouteContextResolveRuntime:
         assert cfg is config
         assert st is state
         assert bus is event_bus
+
+
+class TestRouteContextIsRepoPipelineActive:
+    """The ``None``=default invariant for the pipeline-active indicator (D7).
+
+    ``None`` scopes to the *default* repo (matching the caller's contract);
+    only the ``__all__`` sentinel means "any line running". Previously ``None``
+    aliased ``__all__`` and returned True whenever *any* repo was active.
+    """
+
+    def test_none_scopes_to_default_repo_not_any(
+        self,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+        tmp_path: Path,
+    ) -> None:
+        registry = make_registry(
+            {"slug": "owner-default", "running": False},
+            {"slug": "owner-other", "running": True},
+        )
+        ctx = _make_ctx(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-default",
+        )
+
+        # None resolves the default line (idle) — NOT "any line running".
+        assert ctx.is_repo_pipeline_active(None) is False
+
+    def test_all_sentinel_is_true_when_any_line_running(
+        self,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+        tmp_path: Path,
+    ) -> None:
+        registry = make_registry(
+            {"slug": "owner-default", "running": False},
+            {"slug": "owner-other", "running": True},
+        )
+        ctx = _make_ctx(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-default",
+        )
+
+        assert ctx.is_repo_pipeline_active("__all__") is True
+
+    def test_specific_slug_resolves_that_line(
+        self,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+        tmp_path: Path,
+    ) -> None:
+        registry = make_registry(
+            {"slug": "owner-default", "running": False},
+            {"slug": "owner-other", "running": True},
+        )
+        ctx = _make_ctx(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-default",
+        )
+
+        assert ctx.is_repo_pipeline_active("owner-other") is True
+        assert ctx.is_repo_pipeline_active("owner-default") is False
+
+    def test_none_returns_false_when_default_not_registered(
+        self,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+        tmp_path: Path,
+    ) -> None:
+        # Default slug is absent from the registry — None resolves the default
+        # line, finds nothing, and returns False rather than aliasing "any line
+        # running". (In practice the host is always a registered runtime.)
+        registry = make_registry({"slug": "owner-other", "running": True})
+        ctx = _make_ctx(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-default",
+        )
+
+        assert ctx.is_repo_pipeline_active(None) is False
+        assert ctx.is_repo_pipeline_active("__all__") is True
 
 
 class TestRouteContextPrManagerFor:

--- a/tests/test_ui_repo_parity.py
+++ b/tests/test_ui_repo_parity.py
@@ -68,19 +68,64 @@ class TestSessionAPIRepoFiltering:
         assert data_beta[0]["repo"] == "owner/beta"
 
     @pytest.mark.asyncio
-    async def test_sessions_no_repo_returns_all(
+    async def test_sessions_no_repo_returns_default(
         self, config, event_bus, state, tmp_path: Path
     ) -> None:
-        """GET /api/sessions with no repo param returns all sessions."""
+        """A bare GET /api/sessions scopes to the DEFAULT repo, not all repos.
+
+        Per the ``None``=default invariant (multi-repo scoping spec, D7), an
+        unscoped request is the *default repo's* view — only ``__all__`` unions
+        every line. The legacy single-state path holds sessions for every repo,
+        so it must filter down to the default rather than leak the whole set.
+        """
+        state.save_session(_make_session("owner/alpha", "alpha-1"))
+        state.save_session(_make_session("owner/beta", "beta-1"))
+
+        router, _pr = make_dashboard_router(
+            config, event_bus, state, tmp_path, default_repo_slug="owner-alpha"
+        )
+        endpoint = find_endpoint(router, "/api/sessions")
+
+        resp = await endpoint(repo=None)
+        data = json.loads(resp.body)
+        assert [s["repo"] for s in data] == ["owner/alpha"]
+
+    @pytest.mark.asyncio
+    async def test_sessions_all_returns_union(
+        self, config, event_bus, state, tmp_path: Path
+    ) -> None:
+        """GET /api/sessions?repo=__all__ unions every repo's sessions."""
+        state.save_session(_make_session("owner/alpha", "alpha-1"))
+        state.save_session(_make_session("owner/beta", "beta-1"))
+
+        router, _pr = make_dashboard_router(
+            config, event_bus, state, tmp_path, default_repo_slug="owner-alpha"
+        )
+        endpoint = find_endpoint(router, "/api/sessions")
+
+        resp = await endpoint(repo="__all__")
+        data = json.loads(resp.body)
+        assert {s["repo"] for s in data} == {"owner/alpha", "owner/beta"}
+
+    @pytest.mark.asyncio
+    async def test_sessions_dash_slug_matches_slash_tag(
+        self, config, event_bus, state, tmp_path: Path
+    ) -> None:
+        """A dash-form query slug matches slash-form ``SessionLog.repo`` tags.
+
+        The frontend sends the canonical dash slug (``owner-alpha``) while
+        sessions are tagged with the slash repo (``owner/alpha``). The filter
+        normalizes both sides so the scope still resolves.
+        """
         state.save_session(_make_session("owner/alpha", "alpha-1"))
         state.save_session(_make_session("owner/beta", "beta-1"))
 
         router, _pr = make_dashboard_router(config, event_bus, state, tmp_path)
         endpoint = find_endpoint(router, "/api/sessions")
 
-        resp = await endpoint(repo=None)
+        resp = await endpoint(repo="owner-alpha")
         data = json.loads(resp.body)
-        assert len(data) == 2
+        assert [s["repo"] for s in data] == ["owner/alpha"]
 
     @pytest.mark.asyncio
     async def test_sessions_unknown_repo_returns_empty(


### PR DESCRIPTION
## Phase 6 (closing) — the `None`=default invariant (multi-repo scoping spec, D7)

Closes the last semantic inconsistency in the multi-repo dashboard program: a **bare** (`None`) `repo` param must mean **the default (host) repo**, not "all repos". Only the `__all__` sentinel aggregates. Two endpoints still aliased `None`→all; both are flipped here.

### Behavior changes
| Endpoint / method | Before | After |
|---|---|---|
| `GET /api/sessions` (legacy no-registry path) | `None` → **all** repos' sessions | `None` → **default** repo only; `__all__` → union |
| `RouteContext.is_repo_pipeline_active` | `None` aliased `__all__` → True if **any** line running | `None` → **default** line; only `__all__` → any |

Plus a **latent bug fix** in the sessions filter: it compared the raw query slug to `SessionLog.repo`, but the frontend sends the **dash** slug (`owner-x`) while sessions are tagged with the **slash** repo (`owner/x`). Both sides are now normalized, so a dash-form scope actually resolves.

### Refactor
- Extracted `RouteContext._default_slug()` and reused it in `resolve_runtimes` (DRY).
- Corrected the now-backward `_is_pipeline_active` docstring (review-caught).

### Inventory (complete)
The only `None`-means-all deviations were these two. Atlas/epic/control/diagnostics routes already gate on `repo is not None and == REPO_ALL`, so `None`≠all there. The sole frontend `/api/sessions` consumer uses `fetchWithRepo`, so no raw call relied on `None`=all.

### Tests
- Migrated `test_sessions_no_repo_returns_all` → `…returns_default`; added `…all_returns_union` + `…dash_slug_matches_slash_tag`.
- New `TestRouteContextIsRepoPipelineActive` (4 cases: None→default, `__all__`→any, specific slug, default-not-registered).
- New MockWorld 2-repo scenario `tests/scenarios/test_multi_repo_sessions.py` — covers the **registry-present** path (`__all__`→union, `None`→default) the unit tests don't reach.
- `#9359` empty-registry regression still passes.

### Gates
`make quality` (15934 passed), `make scenario`, `make scenario-loops`, `make audit`, `make arch-regen` — all green. Adversarial review: no correctness defects (only the docstring, fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)