### PR TITLE
feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T18:18:18.806332+00:00",
-  "commit_sha": "9a46933716c143760948ab2ecf33c03e289828ad",
+  "regenerated_at": "2026-06-09T20:14:09.117080+00:00",
+  "commit_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad",
   "artifacts": {
     "loops.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "ports.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "labels.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "modules.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "events.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "adr_xref.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "mockworld.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "changelog.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "coverage_matrix.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "functional_areas.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "ubiquitous-language.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "9a46933716c143760948ab2ecf33c03e289828ad"
+      "source_sha": "b05bc76d60da2cfbbdcfa9be76c765a00ed059ad"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `b05bc76` — fix(dashboard): scope bare /api/sessions + pipeline-active to default repo (Phase 6) (#9386) (#9386) *(2026-06-09)*
 - `9a46933` — feat(atlas): ArticlesView + wiki entries scope by operated repo (Phase 5c-2) (#9385) (#9385) *(2026-06-09)*
 - `6aeec86` — feat(atlas): thread operated repo into the graph cluster + namespaced node ids (Phase 5c-1) (#9383) (#9383) *(2026-06-09)*
 - `e6e3269` — fix(loops): auto-close SecurityPatch issues when the alert resolves (#9359) (#9382) (#9382) *(2026-06-09)*

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -301,6 +301,132 @@ def _is_likely_disconnect(exc: BaseException) -> bool:
     }
 
 
+# Per-bus subscriber queue depth; the merged ``repo=__all__`` socket sizes its
+# shared fan-in queue at ``N × this`` so a busy line can't starve the others.
+_WS_MERGED_PER_BUS_QUEUE = 500
+
+# A resolve_runtimes 5-tuple: (config, state, event_bus, get_orch, slug).
+_Runtime = tuple[Any, Any, Any, Callable[[], Any], str]
+
+
+def _merge_sorted_history(runtimes: list[_Runtime]) -> list[HydraFlowEvent]:
+    """Merge every runtime's event history into one ``(timestamp, id)``-sorted list.
+
+    Each event is stamped with its bus's repo slug when it isn't already tagged
+    (``set_repo`` tags live events, but legacy/untagged history is normalized
+    here). A bus that fails to yield history (a down/unstarted repo) is skipped —
+    a single bad line must never sink the merged backfill. The id is the tie
+    breaker because the module-global ``_event_counter`` only approximates
+    wall-clock order across buses.
+    """
+    events: list[HydraFlowEvent] = []
+    for _cfg, _state, bus, _get_orch, slug in runtimes:
+        try:
+            history = bus.get_history()
+        except Exception:  # noqa: BLE001 — a down repo must not sink the merge
+            logger.warning("merged WS: skipping history for repo %s", slug)
+            continue
+        for event in history:
+            events.append(
+                event
+                if event.repo is not None
+                else event.model_copy(update={"repo": slug})
+            )
+    events.sort(key=lambda e: (e.timestamp, e.id))
+    return events
+
+
+async def _forward_to_merged(
+    src: asyncio.Queue[HydraFlowEvent],
+    dst: asyncio.Queue[HydraFlowEvent],
+    slug: str,
+) -> None:
+    """Forward live frames from one bus's queue into the shared merged queue.
+
+    Stamps the repo slug when missing and drops the oldest frame on a full
+    shared queue (mirroring ``EventBus.publish``'s slow-subscriber policy) so a
+    single repo can't block the fan-in. Cancelled when the socket closes.
+    """
+    while True:
+        event = await src.get()
+        if event.repo is None:
+            event = event.model_copy(update={"repo": slug})
+        try:
+            dst.put_nowait(event)
+        except asyncio.QueueFull:
+            with contextlib.suppress(asyncio.QueueEmpty):
+                dst.get_nowait()
+            with contextlib.suppress(asyncio.QueueFull):
+                dst.put_nowait(event)
+
+
+async def _serve_merged_ws(ws: WebSocket, runtimes: list[_Runtime]) -> None:
+    """Stream a merged, repo-tagged event feed across every runtime's bus.
+
+    Sends a ``(timestamp, id)``-sorted history backfill, then fans every bus's
+    live subscription into one shared queue. A repo whose subscription fails is
+    skipped (never a 1008 close — that would stop the frontend reconnect for the
+    whole aggregate view). The single-repo fast path is handled by the caller.
+
+    Note on ordering/dedup: ``event.id`` is unique only within a process'
+    *live* stream (one shared counter), but persisted history from independent
+    past sessions can reuse ids across repos. The merged feed therefore streams
+    every frame repo-tagged and lets the client de-collide on ``(repo, id)`` —
+    it never drops a frame here. Timestamps are uniformly UTC ISO-8601, so the
+    lexicographic ``(timestamp, id)`` sort is chronological.
+    """
+    await ws.accept()
+    if not runtimes:
+        # Degenerate empty-aggregate view (no registered runtimes): close
+        # cleanly instead of holding a socket the out-queue can never feed.
+        # In practice the empty-registry guard (#9359) yields the default
+        # runtime, so this only triggers defensively.
+        with contextlib.suppress(Exception):
+            await ws.close(code=1000)
+        return
+    history = _merge_sorted_history(runtimes)
+    out_queue: asyncio.Queue[HydraFlowEvent] = asyncio.Queue(
+        maxsize=max(1, len(runtimes)) * _WS_MERGED_PER_BUS_QUEUE
+    )
+    forwarders: list[asyncio.Task[None]] = []
+    async with contextlib.AsyncExitStack() as stack:
+        for _cfg, _state, bus, _get_orch, slug in runtimes:
+            try:
+                queue = await stack.enter_async_context(bus.subscription())
+            except Exception:  # noqa: BLE001 — skip a down repo, keep the socket
+                logger.warning("merged WS: skipping live feed for repo %s", slug)
+                continue
+            forwarders.append(
+                asyncio.create_task(_forward_to_merged(queue, out_queue, slug))
+            )
+        try:
+            for event in history:
+                await ws.send_text(event.model_dump_json())
+            while True:
+                event = await out_queue.get()
+                await ws.send_text(event.model_dump_json())
+        except WebSocketDisconnect:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            if _is_likely_disconnect(exc):
+                logger.warning(
+                    "WebSocket disconnect during merged streaming: %s",
+                    exc.__class__.__name__,
+                )
+            else:
+                logger.error(
+                    "WebSocket error during merged streaming: %s",
+                    exc.__class__.__name__,
+                    exc_info=True,
+                )
+        finally:
+            for task in forwarders:
+                task.cancel()
+            # Await the cancellations so the buses are unsubscribed (AsyncExitStack
+            # exit) only after their forwarders have actually stopped reading.
+            await asyncio.gather(*forwarders, return_exceptions=True)
+
+
 @dataclass
 class RouteContext:
     """Bundles all dependencies needed by dashboard route handlers.
@@ -1637,24 +1763,36 @@ def create_router(
     ) -> JSONResponse:
         """Return event history, optionally filtered by a since timestamp.
 
-        Resolves the per-repo event bus via ``_resolve_runtime(repo)`` (matching
-        the adjacent operational routes) so the reconnect ``?since=`` backfill
-        returns the requested repo's events in a multi-repo deployment, not the
-        module-level default bus's.
+        Resolves the per-repo event bus via ``_resolve_runtimes(repo)`` so the
+        reconnect ``?since=`` backfill returns the requested repo's events in a
+        multi-repo deployment. For ``repo=__all__`` it unions every runtime's
+        events, repo-tags each, and merge-sorts by ``(timestamp, id)`` — the REST
+        twin of the merged ``/ws`` stream.
         """
-        _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
+        since_dt: datetime | None = None
         if since is not None:
             try:
                 since_dt = datetime.fromisoformat(since)
                 if since_dt.tzinfo is None:
                     since_dt = since_dt.replace(tzinfo=UTC)
-                events = await _bus.load_events_since(since_dt)
-                if events is not None:
-                    return JSONResponse([e.model_dump() for e in events])
             except (ValueError, TypeError):
-                pass  # Fall through to in-memory history
-        history = _bus.get_history()
-        return JSONResponse([e.model_dump() for e in history])
+                since_dt = None  # Fall through to in-memory history
+
+        merged: list[HydraFlowEvent] = []
+        for _cfg, _state, _bus, _get_orch, slug in _resolve_runtimes(repo):
+            events: list[HydraFlowEvent] | None = None
+            if since_dt is not None:
+                events = await _bus.load_events_since(since_dt)
+            if events is None:
+                events = _bus.get_history()
+            for event in events:
+                merged.append(
+                    event
+                    if event.repo is not None
+                    else event.model_copy(update={"repo": slug})
+                )
+        merged.sort(key=lambda e: (e.timestamp, e.id))
+        return JSONResponse([e.model_dump() for e in merged])
 
     @router.get("/api/prs")
     async def get_prs(
@@ -2212,7 +2350,14 @@ def create_router(
         """Stream event history then live events over a WebSocket connection."""
         repo_slug: str | None = ws.query_params.get("repo")
 
-        # Resolve the correct event bus for the requested repo.
+        # Aggregate view: fan every registered repo's bus into one socket. Branch
+        # BEFORE _resolve_runtime — it would treat "__all__" as an unknown slug
+        # and 1008-close, streaming one repo mislabeled as the aggregate.
+        if (repo_slug or "").strip().lower() == REPO_ALL:
+            await _serve_merged_ws(ws, _resolve_runtimes(REPO_ALL))
+            return
+
+        # Single-repo fast path (None / specific slug) — unchanged.
         try:
             _cfg, _state, bus, _get_orch = _resolve_runtime(repo_slug)
         except (ValueError, HTTPException):

--- a/tests/test_dashboard_ws_merged_multirepo.py
+++ b/tests/test_dashboard_ws_merged_multirepo.py
@@ -1,0 +1,298 @@
+"""Phase 4 — merged WebSocket + /api/events backfill for ``repo=__all__``.
+
+The aggregate view fans in every registered repo's event bus over a single
+``/ws`` socket and a single ``/api/events`` backfill. These tests pin:
+
+* the pure merge/forward helpers (sort by ``(timestamp, id)``, repo-tagging,
+  skip-a-down-bus, drop-oldest on a full shared queue), and
+* the end-to-end socket: ``?repo=__all__`` streams a merged, repo-tagged history
+  and does NOT 1008-close when one repo is down (a single down line must not
+  stop the whole aggregate stream / frontend reconnect).
+
+The single-repo fast path (``None`` / specific slug) stays in
+``tests/test_dashboard_websocket.py`` and is unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from events import EventBus, EventType, HydraFlowEvent
+from tests.helpers import find_endpoint, make_dashboard_router, make_registry
+
+if TYPE_CHECKING:
+    from config import HydraFlowConfig
+    from state import StateTracker
+
+pytestmark = pytest.mark.integration
+
+
+def _evt(
+    data: dict,
+    ts: str,
+    *,
+    repo: str | None = None,
+    event_id: int | None = None,
+    event_type: EventType = EventType.WORKER_UPDATE,
+) -> HydraFlowEvent:
+    kwargs: dict = {"type": event_type, "data": data, "timestamp": ts}
+    if repo is not None:
+        kwargs["repo"] = repo
+    if event_id is not None:
+        kwargs["id"] = event_id
+    return HydraFlowEvent(**kwargs)
+
+
+def _runtime(bus: object, slug: str) -> tuple:
+    """A resolve_runtimes 5-tuple (config, state, bus, get_orch, slug)."""
+    return (None, None, bus, lambda: None, slug)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSortedHistory:
+    def test_orders_by_timestamp_then_id_and_tags_repo(self) -> None:
+        from dashboard_routes._routes import _merge_sorted_history
+
+        bus_a = EventBus()
+        bus_b = EventBus()
+        # Untagged history (repo=None) → the merge stamps each with its bus slug.
+        bus_a._history = [_evt({"i": 1}, "2024-01-01T00:00:01+00:00", event_id=1)]
+        bus_b._history = [_evt({"i": 2}, "2024-01-01T00:00:00+00:00", event_id=2)]
+
+        merged = _merge_sorted_history(
+            [_runtime(bus_a, "owner-alpha"), _runtime(bus_b, "owner-beta")]
+        )
+
+        # bus_b's event has the earlier timestamp → first.
+        assert [(e.repo, e.data["i"]) for e in merged] == [
+            ("owner-beta", 2),
+            ("owner-alpha", 1),
+        ]
+
+    def test_id_breaks_timestamp_ties(self) -> None:
+        from dashboard_routes._routes import _merge_sorted_history
+
+        bus_a = EventBus()
+        bus_b = EventBus()
+        same_ts = "2024-01-01T00:00:00+00:00"
+        bus_a._history = [_evt({"i": 10}, same_ts, event_id=10)]
+        bus_b._history = [_evt({"i": 5}, same_ts, event_id=5)]
+
+        merged = _merge_sorted_history(
+            [_runtime(bus_a, "owner-alpha"), _runtime(bus_b, "owner-beta")]
+        )
+
+        assert [e.id for e in merged] == [5, 10]
+
+    def test_preserves_existing_repo_tag(self) -> None:
+        from dashboard_routes._routes import _merge_sorted_history
+
+        bus = EventBus()
+        bus._history = [_evt({"i": 1}, "2024-01-01T00:00:00+00:00", repo="real-repo")]
+
+        merged = _merge_sorted_history([_runtime(bus, "fallback-slug")])
+
+        # An already-tagged event keeps its repo, not the resolved slug.
+        assert merged[0].repo == "real-repo"
+
+    def test_skips_a_down_bus(self) -> None:
+        from dashboard_routes._routes import _merge_sorted_history
+
+        ok = EventBus()
+        ok._history = [_evt({"i": 1}, "2024-01-01T00:00:01+00:00", event_id=1)]
+
+        class _DownBus:
+            def get_history(self) -> list:
+                raise RuntimeError("repo down")
+
+        merged = _merge_sorted_history(
+            [_runtime(ok, "owner-alpha"), _runtime(_DownBus(), "owner-beta")]
+        )
+
+        assert len(merged) == 1
+        assert merged[0].repo == "owner-alpha"
+
+
+class TestForwardToMerged:
+    @pytest.mark.asyncio
+    async def test_tags_repo_and_forwards(self) -> None:
+        from dashboard_routes._routes import _forward_to_merged
+
+        src: asyncio.Queue = asyncio.Queue()
+        dst: asyncio.Queue = asyncio.Queue()
+        src.put_nowait(_evt({"i": 1}, "2024-01-01T00:00:00+00:00"))  # repo=None
+
+        task = asyncio.create_task(_forward_to_merged(src, dst, "owner-alpha"))
+        out = await asyncio.wait_for(dst.get(), timeout=1)
+        task.cancel()
+
+        assert out.repo == "owner-alpha"
+
+    @pytest.mark.asyncio
+    async def test_drops_oldest_when_shared_queue_full(self) -> None:
+        from dashboard_routes._routes import _forward_to_merged
+
+        src: asyncio.Queue = asyncio.Queue()
+        dst: asyncio.Queue = asyncio.Queue(maxsize=1)
+        dst.put_nowait(_evt({"i": 0}, "2024-01-01T00:00:00+00:00", repo="owner-beta"))
+        fresh = _evt({"i": 1}, "2024-01-01T00:00:01+00:00", repo="owner-beta")
+        src.put_nowait(fresh)
+
+        task = asyncio.create_task(_forward_to_merged(src, dst, "owner-beta"))
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        # The full queue dropped the oldest and kept the fresh frame.
+        remaining = dst.get_nowait()
+        assert remaining.data["i"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /ws integration
+# ---------------------------------------------------------------------------
+
+
+def _seed(bus: EventBus, slug: str, events: list[HydraFlowEvent]) -> None:
+    bus.set_repo(slug)
+
+    async def _pub() -> None:
+        for e in events:
+            await bus.publish(e)
+
+    asyncio.run(_pub())
+
+
+class TestMergedWebSocket:
+    def test_repo_all_streams_merged_repo_tagged_history(
+        self, config: HydraFlowConfig, event_bus: EventBus, state: StateTracker
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        from dashboard import HydraFlowDashboard
+
+        bus_a = EventBus()
+        bus_b = EventBus()
+        _seed(bus_a, "owner-alpha", [_evt({"i": 1}, "2024-01-01T00:00:01+00:00")])
+        _seed(bus_b, "owner-beta", [_evt({"i": 2}, "2024-01-01T00:00:02+00:00")])
+
+        registry = make_registry(
+            {"slug": "owner-alpha", "event_bus": bus_a, "running": True},
+            {"slug": "owner-beta", "event_bus": bus_b, "running": True},
+        )
+        dashboard = HydraFlowDashboard(
+            config,
+            event_bus,
+            state,
+            registry=registry,
+            default_repo_slug="owner-alpha",
+        )
+        client = TestClient(dashboard.create_app())
+
+        with client.websocket_connect("/ws?repo=__all__") as ws:
+            m1 = json.loads(ws.receive_text())
+            m2 = json.loads(ws.receive_text())
+
+        assert (m1["repo"], m1["data"]["i"]) == ("owner-alpha", 1)
+        assert (m2["repo"], m2["data"]["i"]) == ("owner-beta", 2)
+
+    @pytest.mark.asyncio
+    async def test_empty_runtimes_closes_cleanly_without_hanging(self) -> None:
+        from unittest.mock import AsyncMock
+
+        from dashboard_routes._routes import _serve_merged_ws
+
+        ws = AsyncMock()
+
+        # An empty aggregate (no runtimes) must close cleanly, not block forever
+        # on an out-queue nothing can feed.
+        await asyncio.wait_for(_serve_merged_ws(ws, []), timeout=2)
+
+        ws.accept.assert_awaited_once()
+        ws.close.assert_awaited_once_with(code=1000)
+
+    def test_repo_all_does_not_1008_when_a_repo_is_down(
+        self, config: HydraFlowConfig, event_bus: EventBus, state: StateTracker
+    ) -> None:
+        from fastapi.testclient import TestClient
+
+        from dashboard import HydraFlowDashboard
+
+        ok = EventBus()
+        _seed(ok, "owner-alpha", [_evt({"i": 1}, "2024-01-01T00:00:01+00:00")])
+
+        class _DownBus:
+            def get_history(self) -> list:
+                return []
+
+            def subscription(self) -> object:
+                raise RuntimeError("repo down")
+
+        registry = make_registry(
+            {"slug": "owner-alpha", "event_bus": ok, "running": True},
+            {"slug": "owner-beta", "event_bus": _DownBus(), "running": True},
+        )
+        dashboard = HydraFlowDashboard(
+            config, event_bus, state, registry=registry, default_repo_slug="owner-alpha"
+        )
+        client = TestClient(dashboard.create_app())
+
+        # If the merged socket 1008-closed on the down repo, receive_text would
+        # raise instead of yielding the healthy repo's history frame.
+        with client.websocket_connect("/ws?repo=__all__") as ws:
+            msg = json.loads(ws.receive_text())
+
+        assert msg["data"]["i"] == 1
+        assert msg["repo"] == "owner-alpha"
+
+
+# ---------------------------------------------------------------------------
+# /api/events backfill merge
+# ---------------------------------------------------------------------------
+
+
+class TestEventsBackfillMerge:
+    @pytest.mark.asyncio
+    async def test_repo_all_merges_and_sorts_tagged(
+        self,
+        config: HydraFlowConfig,
+        event_bus: EventBus,
+        state: StateTracker,
+        tmp_path,
+    ) -> None:
+        bus_a = EventBus()
+        bus_b = EventBus()
+        # Already inside a running loop (async test) — await publishes directly.
+        bus_a.set_repo("owner-alpha")
+        bus_b.set_repo("owner-beta")
+        await bus_a.publish(_evt({"i": 1}, "2024-01-01T00:00:01+00:00"))
+        await bus_b.publish(_evt({"i": 2}, "2024-01-01T00:00:02+00:00"))
+
+        registry = make_registry(
+            {"slug": "owner-alpha", "event_bus": bus_a, "running": True},
+            {"slug": "owner-beta", "event_bus": bus_b, "running": True},
+        )
+        router, _pr = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-alpha",
+        )
+        endpoint = find_endpoint(router, "/api/events")
+
+        resp = await endpoint(since=None, repo="__all__")
+        data = json.loads(resp.body)
+
+        assert [(e["repo"], e["data"]["i"]) for e in data] == [
+            ("owner-alpha", 1),
+            ("owner-beta", 2),
+        ]

--- a/tests/test_error_visibility.py
+++ b/tests/test_error_visibility.py
@@ -252,6 +252,8 @@ class TestWebSocketDisconnectDifferentiation:
         assert endpoint is not None
 
         mock_ws = AsyncMock()
+        # query_params.get is sync (returns str|None) — no repo param here.
+        mock_ws.query_params.get = MagicMock(return_value=None)
         mock_ws.send_text = AsyncMock(side_effect=ConnectionResetError("gone"))
 
         q: asyncio.Queue = asyncio.Queue()
@@ -290,6 +292,8 @@ class TestWebSocketDisconnectDifferentiation:
         assert endpoint is not None
 
         mock_ws = AsyncMock()
+        # query_params.get is sync (returns str|None) — no repo param here.
+        mock_ws.query_params.get = MagicMock(return_value=None)
         mock_ws.send_text = AsyncMock(side_effect=ValueError("unexpected"))
 
         q: asyncio.Queue = asyncio.Queue()
@@ -324,6 +328,8 @@ class TestWebSocketDisconnectDifferentiation:
         from events import HydraFlowEvent
 
         mock_ws = AsyncMock()
+        # query_params.get is sync (returns str|None) — no repo param here.
+        mock_ws.query_params.get = MagicMock(return_value=None)
         event = HydraFlowEvent(type="system_alert", data={"x": 1})
 
         # Put an event in the queue; send_text will raise on the live stream send
@@ -361,6 +367,8 @@ class TestWebSocketDisconnectDifferentiation:
         from events import HydraFlowEvent
 
         mock_ws = AsyncMock()
+        # query_params.get is sync (returns str|None) — no repo param here.
+        mock_ws.query_params.get = MagicMock(return_value=None)
         event = HydraFlowEvent(type="system_alert", data={"x": 1})
 
         q3: asyncio.Queue = asyncio.Queue()


### PR DESCRIPTION
## Phase 4-a — backend merged realtime feed for the aggregate view

The dashboard's **All repos** (`repo=__all__`) view previously **1008-closed** on `/ws` (the single-bus resolver treats `__all__` as an unknown slug), so all-mode had no live event stream — only the 30s REST safety-net poll. This slice gives it a real merged feed. **Backend-only**; the frontend reducer composite-keying is the immediate follow-up (P4-b).

### WS `/ws`
- **Branch on `REPO_ALL` before `_resolve_runtime`** — otherwise it falls back to the default bus and streams one repo *mislabeled* as the aggregate.
- `_serve_merged_ws` fans every registered repo's bus into one socket: an `AsyncExitStack` of per-bus `subscription()` + one forwarder coroutine each into a shared out-queue (sized `N × per-bus`, drop-oldest on full — mirrors `EventBus.publish`'s slow-subscriber policy).
- **`(timestamp, id)`-sorted, repo-tagged history backfill** across all buses.
- **Skip-and-continue on a down repo** — a single unsubscribable line never `1008`-closes the merged socket (which would stop frontend reconnect). The `1008` path stays only for a *specific-slug* request resolving to nothing.
- **Empty-aggregate guard** (review-caught): close cleanly (`1000`) instead of idle-blocking forever.
- **Single-repo fast path (`None`/specific slug) is byte-identical.**

### `/api/events`
`repo=__all__` unions every runtime's `load_events_since`/`get_history`, repo-tags, and merge-sorts by `(timestamp, id)` — the REST twin of the socket. Single-repo behavior preserved.

### Ordering / dedup note (→ P4-b)
`event.id` is unique only within the *live* stream (one shared counter); persisted history from **independent past sessions can reuse ids across repos**. The feed therefore streams every frame **repo-tagged** and never drops one — the client must de-collide on **`(repo, id)`**. That dedup + per-issue/per-pr reducer composite-keying (`worker_update`, `transcript_line`/`agent_activity`/`triage`/`planner`/`review`, `pr_created`/`merge_update`, `HUMAN_INPUT_*`) + `BACKFILL_EVENTS` `(repo,id)` dedup + `lastEventTsRef` reset is **P4-b**.

### Tests
`tests/test_dashboard_ws_merged_multirepo.py` — pure helpers (merge-sort order / id tie-break / repo-tag / skip-a-down-bus; forward tag + drop-oldest) and integration (merged history, **no-1008-when-a-repo-is-down**, **empty-runtimes-no-hang**, `/api/events` merge). Fixed 4 low-fidelity WS mocks: `query_params.get` is a sync `str|None`, not a coroutine.

### Review
3-dimension adversarial workflow (async-correctness / ordering-dedup / regression-backcompat) with per-finding verification. One real defect fixed (empty-runtimes idle-hang guard); the cross-bus id-collision is correctly a P4-b frontend concern (backend loses no frames). CancelledError handling, forwarder cleanup, and single-repo byte-identity all confirmed safe.

### Gates
`make quality` (15945 passed), `make scenario`, `make scenario-loops`, `make audit`, `make arch-regen` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)