### PR TITLE
feat(dashboard): event-stream dedup for repo=__all__ aggregate view (Phase 4-b1)

### DIFF
--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -68,16 +68,32 @@ function normalizeRepoSlug(value) {
 
 function isDuplicate(state, action) {
   const eventId = action.id ?? -1
-  return eventId !== -1 && eventId <= state.lastSeenId
+  if (eventId === -1) return false
+  // Aggregate (repo=__all__) view: event ids only approximate order across
+  // buses and collide across repos' persisted history, so the monotonic
+  // watermark would wrongly drop a lagging bus's lower id. De-collide on
+  // (repo, id) against the bounded event log instead.
+  if (state.selectedRepoSlug === REPO_ALL) {
+    const repo = action.repo ?? null
+    return state.events.some(e => e.id === eventId && (e.repo ?? null) === repo)
+  }
+  // Single-repo: ids are monotonic, the watermark is the cheap correct dedup.
+  return eventId <= state.lastSeenId
 }
 
 function addEvent(state, action) {
   const eventId = action.id ?? -1
   if (isDuplicate(state, action)) return state
-  const event = { type: action.type, timestamp: action.timestamp, data: action.data, id: eventId }
+  // Carry the event's repo so the aggregate view can badge it and de-collide
+  // cross-repo events that share an issue/pr/id.
+  const event = { type: action.type, timestamp: action.timestamp, data: action.data, id: eventId, repo: action.repo ?? null }
   return {
     ...state,
-    lastSeenId: eventId !== -1 ? eventId : state.lastSeenId,
+    // lastSeenId is the single-repo watermark only. In the aggregate view dedup
+    // is (repo, id)-based, so leave the watermark untouched there — advancing it
+    // would wrongly gate a later single-repo session's lower ids.
+    lastSeenId:
+      eventId !== -1 && state.selectedRepoSlug !== REPO_ALL ? eventId : state.lastSeenId,
     events: [event, ...state.events].slice(0, MAX_EVENTS),
   }
 }
@@ -560,12 +576,14 @@ export function reducer(state, action) {
       return addEvent(state, action)
 
     case 'BACKFILL_EVENTS': {
-      const existingKeys = new Set(
-        state.events.map(e => `${e.type}|${e.timestamp}`)
-      )
+      // Key on repo too so two repos' same-type/same-timestamp frames don't
+      // collide under repo=__all__; preserve id + repo so the merged log can
+      // badge and (repo, id)-dedup live events that re-arrive.
+      const keyOf = e => `${e.type}|${e.timestamp}|${e.repo ?? ''}`
+      const existingKeys = new Set(state.events.map(keyOf))
       const newEvents = action.data
-        .map(e => ({ type: e.type, timestamp: e.timestamp, data: e.data }))
-        .filter(e => !existingKeys.has(`${e.type}|${e.timestamp}`))
+        .map(e => ({ type: e.type, timestamp: e.timestamp, data: e.data, id: e.id ?? -1, repo: e.repo ?? null }))
+        .filter(e => !existingKeys.has(keyOf(e)))
       const merged = [...state.events, ...newEvents]
         .sort((a, b) => b.timestamp.localeCompare(a.timestamp))
         .slice(0, MAX_EVENTS)
@@ -739,6 +757,9 @@ export function reducer(state, action) {
           reviews: [],
           sessionPrsCount: 0,
           events: [],
+          // Reset the dedup watermark — the new scope's events restart from a
+          // fresh id space (else lower ids would be watermark-dropped).
+          lastSeenId: -1,
         }),
       }
     }
@@ -969,6 +990,9 @@ export function HydraFlowProvider({ children }) {
   }, [fetchWithRepo])
 
   const selectRepo = useCallback((slug) => {
+    // Reset the reconnect backfill cursor: the new scope's event timeline is
+    // independent, so the old since= watermark must not gate it.
+    lastEventTsRef.current = null
     dispatch({ type: 'SELECT_REPO', data: { slug } })
   }, [])
 

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -114,6 +114,67 @@ describe('HydraFlowContext reducer', () => {
     expect(next.pipelineIssues.plan[0].repo).toBe('owner-a')
   })
 
+  // --- Phase 4: merged repo=__all__ realtime dedup -------------------------
+
+  it('__all__ keeps two events with the same id but different repo', () => {
+    const state = {
+      ...initialState,
+      selectedRepoSlug: '__all__',
+      events: [{ type: 'log', timestamp: 't1', data: {}, id: 5, repo: 'owner-a' }],
+    }
+    const next = reducer(state, { type: 'log', timestamp: 't2', data: {}, id: 5, repo: 'owner-b' })
+    expect(next.events).toHaveLength(2)
+    expect(next.events.map(e => e.repo).sort()).toEqual(['owner-a', 'owner-b'])
+  })
+
+  it('__all__ drops an exact (repo, id) duplicate', () => {
+    const state = {
+      ...initialState,
+      selectedRepoSlug: '__all__',
+      events: [{ type: 'log', timestamp: 't1', data: {}, id: 5, repo: 'owner-a' }],
+    }
+    const next = reducer(state, { type: 'log', timestamp: 't2', data: {}, id: 5, repo: 'owner-a' })
+    expect(next.events).toHaveLength(1)
+  })
+
+  it('single-repo still drops an event whose id is at/below the watermark', () => {
+    const state = { ...initialState, selectedRepoSlug: null, lastSeenId: 5, events: [] }
+    const next = reducer(state, { type: 'log', timestamp: 't', data: {}, id: 3 })
+    expect(next.events).toHaveLength(0)
+  })
+
+  it('addEvent carries the event repo onto the stored event', () => {
+    const next = reducer(
+      { ...initialState, selectedRepoSlug: '__all__' },
+      { type: 'log', timestamp: 't', data: {}, id: 1, repo: 'owner-z' },
+    )
+    expect(next.events[0].repo).toBe('owner-z')
+  })
+
+  it('BACKFILL keeps cross-repo same type+timestamp frames and preserves repo', () => {
+    const next = reducer(initialState, {
+      type: 'BACKFILL_EVENTS',
+      data: [
+        { type: 'log', timestamp: 'tX', data: {}, id: 1, repo: 'owner-a' },
+        { type: 'log', timestamp: 'tX', data: {}, id: 1, repo: 'owner-b' },
+      ],
+    })
+    expect(next.events).toHaveLength(2)
+    expect(next.events.map(e => e.repo).sort()).toEqual(['owner-a', 'owner-b'])
+  })
+
+  it('__all__ does not advance the single-repo watermark', () => {
+    const state = { ...initialState, selectedRepoSlug: '__all__', lastSeenId: -1 }
+    const next = reducer(state, { type: 'log', timestamp: 't', data: {}, id: 900, repo: 'owner-a' })
+    expect(next.lastSeenId).toBe(-1)
+  })
+
+  it('SELECT_REPO resets the dedup watermark on a scope change', () => {
+    const state = { ...initialState, selectedRepoSlug: 'owner-a', lastSeenId: 50 }
+    const next = reducer(state, { type: 'SELECT_REPO', data: { slug: 'owner-b' } })
+    expect(next.lastSeenId).toBe(-1)
+  })
+
   it('GITHUB_METRICS action sets githubMetrics state', () => {
     const data = {
       open_by_label: { 'hydraflow-plan': 3, 'hydraflow-ready': 1 },


### PR DESCRIPTION
## Phase 4-b1 — correct realtime dedup for the aggregate view

The merged WebSocket (Phase 4-a, merged) now streams every repo's events over one socket. But `event.id` is unique only within the *live* stream and **collides across repos' persisted history** (independent past sessions reuse ids), and cross-bus interleaving means a lagging bus can emit a later-but-lower id. The old monotonic `lastSeenId` watermark would **wrongly drop those events** in the `repo=__all__` view.

This slice fixes the frontend event-stream dedup. **Frontend-only** (`HydraFlowContext` reducer); worker/PR card composite-keying is the next slice (P4-b2).

### Changes (`src/ui/src/context/HydraFlowContext.jsx`)
- **`isDuplicate`**: in the aggregate view (`selectedRepoSlug === REPO_ALL`), de-collide on **`(repo, id)`** against the bounded event log; single-repo keeps the existing **watermark** (ids are monotonic there). `id === -1` is never a duplicate.
- **`addEvent`**: stored events now carry **`repo`** (for badging + `(repo,id)` dedup). `lastSeenId` is now a **single-repo-only** watermark — it no longer advances in the aggregate view (advancing it would gate a later single-repo session's lower ids — *review-caught*).
- **`BACKFILL_EVENTS`**: dedup key includes `repo` (two repos' same `type`+`timestamp` no longer collide) and **preserves `id` + `repo`** on backfilled events.
- **`SELECT_REPO`**: resets `lastSeenId` on a scope change; `selectRepo()` also resets the `lastEventTsRef` reconnect-backfill cursor so the new scope starts on a clean timeline.

### Why `lastSeenId` stays
`lastSeenId` is a tested contract (~12 assertions across `HydraFlowContext.test.jsx` + `useHydraFlowSocket.test.js` — tracks highest id, resets on new-run, not on DISCONNECTED). The single-repo watermark is preserved byte-for-byte; only the aggregate path diverges to `(repo,id)`.

### Tests
7 new reducer tests: `__all__` keeps same-id-different-repo / drops exact `(repo,id)` dup / doesn't advance the watermark; single-repo still drops sub-watermark ids (regression lock); `addEvent` carries repo; `BACKFILL` keeps cross-repo same `type+timestamp`; `SELECT_REPO` resets the watermark. **Full vitest 1131 + 7 = green; `npm run build` green.**

### Review
Focused adversarial pass: single-repo watermark contract preserved, BACKFILL key symmetry (live-added vs backfill-mapped events) confirmed consistent, `selectRepo` is the sole `SELECT_REPO` dispatch site. One latent footgun fixed (`lastSeenId` advancing in `__all__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)