### PR TITLE
test(dashboard): multi-repo aggregation e2e + MockWorld scenarios (Phase 4-c)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T21:47:53.342399+00:00",
-  "commit_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66",
+  "regenerated_at": "2026-06-09T23:24:54.452318+00:00",
+  "commit_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3",
   "artifacts": {
     "loops.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ports.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "labels.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "modules.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "events.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "adr_xref.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "mockworld.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "changelog.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "coverage_matrix.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "functional_areas.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ubiquitous-language.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `bc3049c` — feat(dashboard): repo-qualify live worker/PR cards for repo=__all__ (Phase 4-b2) (#9390) (#9390) *(2026-06-09)*
 - `2f1c343` — feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a) (#9387) (#9387) *(2026-06-09)*
 - `b05bc76` — fix(dashboard): scope bare /api/sessions + pipeline-active to default repo (Phase 6) (#9386) (#9386) *(2026-06-09)*
 - `9a46933` — feat(atlas): ArticlesView + wiki entries scope by operated repo (Phase 5c-2) (#9385) (#9385) *(2026-06-09)*

--- a/tests/scenarios/browser/scenarios/test_multi_repo_aggregation.py
+++ b/tests/scenarios/browser/scenarios/test_multi_repo_aggregation.py
@@ -1,0 +1,116 @@
+"""Tier-3 browser e2e: the multi-repo aggregate (repo=__all__) selection spine.
+
+Proves the wired multi-repo UI a user sees against a real serving dashboard:
+two registered repos surface in the RepoSelector, and picking "All repos"
+reconnects the live WebSocket with ``?repo=__all__`` — the aggregate merged
+stream from Phase 4-a. The backend aggregation + cross-repo dedup are proven at
+the unit / integration tiers (``test_dashboard_ws_merged_multirepo.py`` and the
+reducer vitest); this proves the selection + WS-param threading end to end in a
+real browser.
+
+Boot mirrors ``test_realtime_browser.py``: register repos Python-side via
+``world.add_repo`` (so ``resolve_runtimes`` has >=2 runtimes and /api/repos
+lists them), route /api/control/status to "running" so the board renders, then
+drive the RepoSelector.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from playwright.async_api import expect
+
+pytestmark = pytest.mark.scenario_browser
+
+# Tells React the orchestrator is "running" so panels render live content
+# rather than the idle placeholder (mirrors test_realtime_browser.py).
+_RUNNING_CONTROL_STATUS = {
+    "status": "running",
+    "credits_paused_until": None,
+    "current_session_id": None,
+    "config": {
+        "app_version": "0.0.0",
+        "latest_version": "",
+        "update_available": False,
+        "repo": "T-rav/hydraflow",
+        "ready_label": ["hydraflow-ready"],
+        "find_label": ["hydraflow-find"],
+        "planner_label": ["hydraflow-plan"],
+        "review_label": ["hydraflow-review"],
+        "hitl_label": ["hydraflow-hitl"],
+        "hitl_active_label": ["hydraflow-hitl-active"],
+        "fixed_label": ["hydraflow-fixed"],
+        "max_triagers": 1,
+        "max_workers": 2,
+        "max_planners": 1,
+        "max_reviewers": 1,
+        "max_hitl_workers": 1,
+        "batch_size": 5,
+        "model": "claude-opus-4-5",
+        "pr_unstick_batch_size": 3,
+        "workspace_base": "/tmp/hydraflow-worktrees",
+    },
+}
+
+# Capture the app's /ws socket(s) so the test can read each socket's URL and
+# confirm the aggregate reconnect carries the repo=__all__ query. Runs before
+# any page script. Filtered to /ws so a Vite HMR socket (if any) is ignored.
+_TRACK_WS_INIT_SCRIPT = """
+window.__hfSockets = [];
+class TrackedWS extends WebSocket {
+  constructor(...args) {
+    super(...args);
+    if (String(args[0]).includes('/ws')) window.__hfSockets.push(this);
+  }
+}
+window.WebSocket = TrackedWS;
+"""
+
+
+async def _route_control_status(page) -> None:
+    async def _handle(route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_RUNNING_CONTROL_STATUS),
+        )
+
+    await page.route("**/api/control/status", _handle)
+
+
+async def test_repo_selector_lists_repos_and_all_repos_uses_merged_ws(
+    world, page
+) -> None:
+    """Two repos surface in the selector; "All repos" reconnects WS as __all__."""
+    world.add_repo("owner/alpha", "/tmp/owner-alpha")
+    world.add_repo("owner/beta", "/tmp/owner-beta")
+
+    await page.add_init_script(_TRACK_WS_INIT_SCRIPT)
+    url = await world.start_dashboard(with_orchestrator=False)
+    await _route_control_status(page)
+    await page.goto(url)
+    await page.wait_for_selector('body[data-connected="true"]', timeout=10_000)
+
+    # The RepoSelector renders (multi-repo mode) and lists both registered repos.
+    trigger = page.locator('[data-testid="repo-selector-trigger"]')
+    await expect(trigger).to_be_visible(timeout=10_000)
+    await trigger.click()
+
+    dropdown = page.locator('[data-testid="repo-selector-dropdown"]')
+    await expect(dropdown).to_be_visible()
+    await expect(dropdown).to_contain_text("All repos")
+    await expect(dropdown).to_contain_text("alpha")
+    await expect(dropdown).to_contain_text("beta")
+
+    # Pick "All repos" -> selectedRepoSlug = __all__ -> the WS reconnects with
+    # the aggregate param (the merged fan-in stream).
+    await dropdown.get_by_role("option", name="All repos").click()
+
+    # A /ws socket connects with ?repo=__all__ (polled in-browser over the
+    # captured sockets, so a pass is attributable to the real reconnect).
+    await page.wait_for_function(
+        "() => (window.__hfSockets || [])"
+        ".some(w => String(w.url).includes('repo=__all__'))",
+        timeout=10_000,
+    )

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -774,11 +774,21 @@ class MockWorld:
             # without spinning up a full HydraFlowOrchestrator.
             orchestrator = _HarnessOrchestratorShim(self._harness)
 
+        # Surface registered repos through /api/repos (the supervised-repo list
+        # reads a repo_store, not the registry). Only when a repo was actually
+        # added — single-repo scenarios keep the host-only legacy path (#9359).
+        repo_store = None
+        if len(self._registry) > 0:
+            from repo_store import RepoRegistryStore  # noqa: PLC0415
+
+            repo_store = RepoRegistryStore(self._tmp_path)
+
         dashboard = HydraFlowDashboard(
             config=config,
             event_bus=bus,
             state=state,
             orchestrator=orchestrator,
+            repo_store=repo_store,
             # #9347 began ALWAYS passing this registry to the dashboard, even
             # empty. A non-None-but-empty registry flips the dashboard onto its
             # multi-repo branches for single-repo browser scenarios: POST

--- a/tests/scenarios/test_multi_repo_realtime.py
+++ b/tests/scenarios/test_multi_repo_realtime.py
@@ -1,0 +1,124 @@
+"""Scenario: the Phase 4 realtime REST aggregations union real per-repo runtimes.
+
+Tier-2 MockWorld layer for the merged-feed backend. Unlike the duck-typed unit
+tests (``test_dashboard_ws_merged_multirepo.py`` uses ``make_registry``), these
+drive the actual routes through a MockWorld-seeded registry of real runtimes
+(independent EventBus / StateTracker / config per repo), proving the
+``resolve_runtimes`` fan-in + ``(timestamp, id)`` merge-sort + repo-tagging hold
+end to end against colliding identifiers across repos:
+
+* ``GET /api/events?repo=__all__`` — the reconnect backfill twin of the merged
+  ``/ws`` stream — unions every runtime's event history, sorted and repo-tagged.
+* ``GET /api/prs?repo=__all__`` — unions every runtime's open PRs, each tagged
+  with its slug so the frontend de-collides same-number PRs across repos.
+
+The merged ``/ws`` socket itself is covered at the unit (real EventBus via
+``make_registry``) and browser (served ``/ws?repo=__all__``) tiers.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from events import EventType, HydraFlowEvent
+from mockworld.seed import MockWorldSeed
+from pr_manager import PRManager
+from tests.helpers import find_endpoint, make_dashboard_router
+
+pytestmark = pytest.mark.scenario
+
+
+def _evt(issue: int, ts: str) -> HydraFlowEvent:
+    return HydraFlowEvent(
+        type=EventType.WORKER_UPDATE, data={"issue": issue}, timestamp=ts
+    )
+
+
+@pytest.mark.asyncio
+async def test_events_repo_all_unions_seeded_repo_histories(
+    mock_world, config, event_bus, state, tmp_path
+) -> None:
+    seed = MockWorldSeed(
+        repos=[
+            ("owner/alpha", str(tmp_path / "alpha")),
+            ("owner/beta", str(tmp_path / "beta")),
+        ],
+    )
+    mock_world.apply_seed(seed)
+
+    alpha = mock_world.registry.get("owner-alpha")
+    beta = mock_world.registry.get("owner-beta")
+    # Interleaved timestamps across the two real buses (set_repo tags each).
+    await alpha.event_bus.publish(_evt(1, "2024-01-01T00:00:01+00:00"))
+    await beta.event_bus.publish(_evt(1, "2024-01-01T00:00:02+00:00"))
+    await alpha.event_bus.publish(_evt(2, "2024-01-01T00:00:03+00:00"))
+
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=mock_world.registry,
+        default_repo_slug=config.repo.replace("/", "-"),
+    )
+    endpoint = find_endpoint(router, "/api/events")
+
+    data = json.loads((await endpoint(since=None, repo="__all__")).body)
+
+    # Unioned, repo-tagged, and merge-sorted by (timestamp, id).
+    assert [(e["repo"], e["data"]["issue"]) for e in data] == [
+        ("owner-alpha", 1),
+        ("owner-beta", 1),
+        ("owner-alpha", 2),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_prs_repo_all_unions_and_tags_colliding_pr_numbers(
+    mock_world, config, event_bus, state, tmp_path
+) -> None:
+    seed = MockWorldSeed(
+        repos=[
+            ("owner/alpha", str(tmp_path / "alpha")),
+            ("owner/beta", str(tmp_path / "beta")),
+        ],
+    )
+    mock_world.apply_seed(seed)
+
+    # Both repos expose PR #7 (a cross-repo collision). The seeded runtimes have
+    # no orchestrator, so get_prs reads each repo's PRManager.list_open_prs;
+    # patch it to return the colliding PR for every runtime.
+    async def _fake_list_open_prs(_self, _labels):
+        return [
+            {
+                "pr": 7,
+                "issue": 5,
+                "branch": "agent/issue-5",
+                "url": "https://example/pr/7",
+                "draft": False,
+                "title": "Shared number",
+                "merged": False,
+                "author": "bot",
+            }
+        ]
+
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=mock_world.registry,
+        default_repo_slug=config.repo.replace("/", "-"),
+    )
+    endpoint = find_endpoint(router, "/api/prs")
+
+    with patch.object(PRManager, "list_open_prs", _fake_list_open_prs):
+        data = json.loads((await endpoint(repo="__all__")).body)
+
+    # The colliding PR #7 survives once per repo, each tagged with its slug.
+    assert len(data) == 2
+    assert all(p["pr"] == 7 for p in data)
+    assert {p["repo"] for p in data} == {"owner-alpha", "owner-beta"}


### PR DESCRIPTION
## Phase 4-c — complete the test pyramid for the `repo=__all__` aggregate view

The realtime backend (4-a/b1/b2, all merged) had **unit** + **integration** coverage. This adds the two missing tiers — **browser e2e** (tier-3) and **MockWorld scenarios** (tier-2) — per the test-pyramid standard.

### Browser e2e — `tests/scenarios/browser/scenarios/test_multi_repo_aggregation.py`
Registers two repos, boots the real served dashboard, asserts the **RepoSelector lists both**, and picking **"All repos" reconnects the live WebSocket with `?repo=__all__`** (captured via a TrackedWS init-script). Proves the multi-repo selection + WS-param threading end to end in a real browser. (Verified locally against Chromium; the full 50-test browser suite is green.)

### MockWorld scenarios — `tests/scenarios/test_multi_repo_realtime.py`
Real seeded runtimes (`MockWorldSeed`) — the tier-2 layer the `make_registry` integration tests don't cover under `make scenario`:
- **`/api/events?repo=__all__`** unions + `(timestamp, id)` merge-sorts two repos' real bus histories, repo-tagged (4-a REST backfill).
- **`/api/prs?repo=__all__`** unions a colliding **PR #7** across two repos, each tagged with its slug (4-b2).

### Harness fix — `MockWorld.start_dashboard`
Now wires a `repo_store` when repos are registered, so `/api/repos` surfaces them (the supervised-repo list reads a `repo_store`, not the registry). Single-repo scenarios keep the host-only legacy path (the #9359 guard) — existing browser scenarios unaffected.

### Coverage map
The merged `/ws?repo=__all__` socket is already covered at the **unit** (real `EventBus` via `make_registry`) and **browser** tiers. The `/api/pipeline` · `/api/queue` · `/api/stats` · `/api/hitl` aggregations (Phase 2/3, need orchestrator stubs) are noted as a follow-up.

### Gates
`make quality` + `make scenario` (incl. the 2 new) + `make scenario-loops` + `make audit` + the full browser suite — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)