### PR TITLE
test(dashboard): pipeline-card browser e2e + add_repo pipeline shim (follow-up 2/3)

### DIFF
--- a/tests/scenarios/browser/scenarios/test_multi_repo_pipeline_cards.py
+++ b/tests/scenarios/browser/scenarios/test_multi_repo_pipeline_cards.py
@@ -1,0 +1,103 @@
+"""Tier-3 browser e2e: pipeline CARDS aggregate across repos under repo=__all__.
+
+The lighter `test_multi_repo_aggregation.py` proves the RepoSelector + WS-param
+wiring; this proves the actual board content. Two repos are registered with a
+pipeline-surfacing orchestrator (`add_repo(..., with_pipeline=True)`) and each
+seeded with its own active issue. Picking "All repos" must render BOTH repos'
+flow-dots; picking a single repo must scope the board to that repo only.
+
+Backend aggregation is proven at unit/scenario tiers
+(`test_dashboard_routes_workstream_multirepo.py`,
+`test_multi_repo_aggregate_endpoints.py`); this is the served-board view a user
+sees in a real browser.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from playwright.async_api import expect
+
+from issue_store import STAGE_READY
+
+pytestmark = pytest.mark.scenario_browser
+
+_RUNNING_CONTROL_STATUS = {
+    "status": "running",
+    "credits_paused_until": None,
+    "current_session_id": None,
+    "config": {
+        "app_version": "0.0.0",
+        "latest_version": "",
+        "update_available": False,
+        "repo": "T-rav/hydraflow",
+        "ready_label": ["hydraflow-ready"],
+        "find_label": ["hydraflow-find"],
+        "planner_label": ["hydraflow-plan"],
+        "review_label": ["hydraflow-review"],
+        "hitl_label": ["hydraflow-hitl"],
+        "hitl_active_label": ["hydraflow-hitl-active"],
+        "fixed_label": ["hydraflow-fixed"],
+        "max_triagers": 1,
+        "max_workers": 2,
+        "max_planners": 1,
+        "max_reviewers": 1,
+        "max_hitl_workers": 1,
+        "batch_size": 5,
+        "model": "claude-opus-4-5",
+        "pr_unstick_batch_size": 3,
+        "workspace_base": "/tmp/hydraflow-worktrees",
+    },
+}
+
+
+async def _route_control_status(page) -> None:
+    async def _handle(route) -> None:
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_RUNNING_CONTROL_STATUS),
+        )
+
+    await page.route("**/api/control/status", _handle)
+
+
+async def test_all_repos_renders_both_repos_pipeline_cards(world, page) -> None:
+    """ "All repos" aggregates both repos' cards; a single repo scopes the board."""
+    world.add_repo("owner/alpha", "/tmp/owner-alpha", with_pipeline=True)
+    world.add_repo("owner/beta", "/tmp/owner-beta", with_pipeline=True)
+    # Distinct issue numbers per repo so each flow-dot is unambiguous.
+    world.registry.get("owner-alpha").orchestrator.issue_store.mark_active(
+        1, STAGE_READY
+    )
+    world.registry.get("owner-beta").orchestrator.issue_store.mark_active(
+        101, STAGE_READY
+    )
+
+    url = await world.start_dashboard(with_orchestrator=False)
+    await _route_control_status(page)
+    await page.goto(url)
+    await page.wait_for_selector('body[data-connected="true"]', timeout=10_000)
+
+    # Select "All repos" — the board re-fetches /api/pipeline?repo=__all__.
+    await page.locator('[data-testid="repo-selector-trigger"]').click()
+    dropdown = page.locator('[data-testid="repo-selector-dropdown"]')
+    await expect(dropdown).to_be_visible()
+    await dropdown.get_by_role("option", name="All repos").click()
+
+    # Both repos' cards render under the aggregate view.
+    await expect(page.locator('[data-testid="flow-dot-1"]')).to_be_visible(
+        timeout=10_000
+    )
+    await expect(page.locator('[data-testid="flow-dot-101"]')).to_be_visible(
+        timeout=10_000
+    )
+
+    # Scope to owner-alpha — only its card remains.
+    await page.locator('[data-testid="repo-selector-trigger"]').click()
+    await dropdown.get_by_role("option", name="owner-alpha").click()
+    await expect(page.locator('[data-testid="flow-dot-101"]')).to_have_count(
+        0, timeout=10_000
+    )
+    await expect(page.locator('[data-testid="flow-dot-1"]')).to_be_visible()

--- a/tests/scenarios/fakes/mock_world.py
+++ b/tests/scenarios/fakes/mock_world.py
@@ -366,7 +366,9 @@ class MockWorld:
         self._github.add_issue(number, title, body, labels=labels)
         return self
 
-    def add_repo(self, slug: str, path: str) -> MockWorld:
+    def add_repo(
+        self, slug: str, path: str, *, with_pipeline: bool = False
+    ) -> MockWorld:
         """Seed a RepoRegistryStore entry AND a live runtime in the registry.
 
         Scenarios that exercise multi-repo controls (register / remove) start
@@ -374,6 +376,15 @@ class MockWorld:
         is a duck-typed namespace (the proven test pattern) with its own
         EventBus tagged via set_repo, so >=2 calls yield genuinely independent
         runtimes that resolve_runtimes can aggregate.
+
+        When ``with_pipeline`` is True the runtime also gets a pipeline-surfacing
+        orchestrator (the host ``_HarnessOrchestratorShim`` over a fresh per-repo
+        ``IssueStore``) and ``running=True``, so ``/api/pipeline`` (and the other
+        active-gated routes) serve this repo's seeded issues — used by the
+        aggregate browser e2e to render two repos' pipeline cards. Seed via
+        ``registry.get(slug).orchestrator.issue_store.mark_active(n, stage)``.
+        Default ``False`` keeps the legacy orchestrator-less runtime so existing
+        callers are unaffected.
         """
         from types import SimpleNamespace  # noqa: PLC0415
 
@@ -395,13 +406,25 @@ class MockWorld:
         bus = EventBus()
         bus.set_repo(dash)
         st = StateTracker(repo_root / "state.json")
+
+        orchestrator: Any = None
+        running = False
+        if with_pipeline:
+            from unittest.mock import AsyncMock  # noqa: PLC0415
+
+            from issue_store import IssueStore  # noqa: PLC0415
+
+            issue_store = IssueStore(cfg, AsyncMock(), bus)
+            orchestrator = _HarnessOrchestratorShim(SimpleNamespace(store=issue_store))
+            running = True
+
         self._registry._runtimes[dash] = SimpleNamespace(
             slug=dash,
             config=cfg,
             state=st,
             event_bus=bus,
-            orchestrator=None,
-            running=False,
+            orchestrator=orchestrator,
+            running=running,
             last_error=None,
         )
         return self


### PR DESCRIPTION
## Follow-up 2/3 — pipeline CARDS aggregate in a real browser

The lighter `test_multi_repo_aggregation.py` proved the RepoSelector + WS-param wiring; this proves the **board content**: two repos' pipeline cards render under `repo=__all__`, and scoping to one repo drops the other's.

### `MockWorld.add_repo(..., with_pipeline=False)` — opt-in
When `True`, the runtime gets a pipeline-surfacing orchestrator (the existing `_HarnessOrchestratorShim` over a fresh per-repo `IssueStore`) + `running=True`, so `/api/pipeline` (and the other active-gated routes) serve that repo's seeded issues. **Default `False` keeps the legacy orchestrator-less runtime — every existing `add_repo` caller is byte-identical (zero blast radius).**

### Browser scenario `test_multi_repo_pipeline_cards.py`
Two repos seeded with distinct active issues via `registry.get(slug).orchestrator.issue_store.mark_active(n, STAGE_READY)`. Picking **"All repos" renders BOTH repos' flow-dots**; scoping to one repo drops the other's.

**Test-infra only.** Full **51-test browser suite green** (verified against local Chromium) + `make quality` green (covers the `add_repo`-using #9359 regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)