### PR TITLE
fix(agents): isolate strict-JSON contract agents from host plugin SessionStart hook

### DIFF
--- a/src/acceptance_criteria.py
+++ b/src/acceptance_criteria.py
@@ -126,6 +126,7 @@ class AcceptanceCriteriaGenerator:
             tool=self._config.ac_tool,
             model=self._config.ac_model,
             disallowed_tools="Write,Edit,NotebookEdit",
+            isolate_user_settings=True,
         )
 
     def _build_prompt(

--- a/src/adversarial_agent_runner.py
+++ b/src/adversarial_agent_runner.py
@@ -111,7 +111,13 @@ class SubprocessAgentRunner:
         """
         prompt = self._compose_prompt(system_prompt, user_message)
         cmd, cmd_input = build_lightweight_command(
-            tool=self.tool, model=self.model, prompt=prompt
+            tool=self.tool,
+            model=self.model,
+            prompt=prompt,
+            # Adversarial judges (SpecJudge, PlanCouncil, …) emit strict JSON.
+            # Isolate from host user plugins/hooks (e.g. a superpowers
+            # SessionStart hook) that would derail the JSON contract.
+            isolate_user_settings=True,
         )
         gh_token = self.credentials.gh_token if self.credentials is not None else ""
         env = make_clean_env(gh_token)

--- a/src/agent_cli.py
+++ b/src/agent_cli.py
@@ -31,6 +31,26 @@ def _plugin_dir_flags() -> list[str]:
     return flags
 
 
+# Setting-source scope for isolated (contract-agent) claude spawns. Restricting
+# the Claude CLI to the ``project`` scope drops user-level plugins and hooks —
+# notably a host-installed superpowers ``SessionStart`` hook that injects
+# "invoke a skill BEFORE any response, explore first" guidance into every
+# headless ``claude -p`` session. That guidance derails strict-JSON contract
+# agents (triage, judges, councils) off their output contract — they explore
+# the repo instead of emitting the verdict — so the verdict parser finds
+# nothing. ``--setting-sources project`` leaves OAuth/keychain auth intact
+# (unlike ``--bare``, which forces ANTHROPIC_API_KEY). Callers that isolate also
+# skip ``_plugin_dir_flags`` so a pre-cloned superpowers ``--plugin-dir`` can't
+# re-introduce the hook inside the Docker image (an explicit ``--plugin-dir``
+# load bypasses ``--setting-sources``).
+_CONTRACT_SETTING_SOURCES = "project"
+
+
+def _claude_isolation_flags() -> list[str]:
+    """Return flags restricting an isolated claude spawn to project settings."""
+    return ["--setting-sources", _CONTRACT_SETTING_SOURCES]
+
+
 # Tools the issue-derived implementer / auto-agent legitimately needs in
 # restricted mode. WebFetch and WebSearch are deliberately EXCLUDED here and
 # additionally placed on the disallow list — they are the agent's built-in
@@ -61,6 +81,7 @@ def build_agent_command(
     max_turns: int | None = None,
     effort: str | None = None,
     restricted: bool = False,
+    isolate_user_settings: bool = False,
 ) -> list[str]:
     """Build a non-interactive command for an agent stage.
 
@@ -72,6 +93,12 @@ def build_agent_command(
     by ``acceptEdits`` + an explicit tool allowlist, and the network-egress
     tools (WebFetch/WebSearch) are disallowed. Codex switches to its
     network-blocked ``workspace-write`` sandbox.
+
+    *isolate_user_settings* (claude only) restricts the spawn to ``project``
+    settings and skips the pre-cloned ``--plugin-dir`` flags. Strict-JSON
+    contract agents (triage, judges, councils) set this so a host/user-level
+    plugin's ``SessionStart`` hook can't inject skill-invocation guidance that
+    breaks the JSON contract — see :data:`_CONTRACT_SETTING_SOURCES`.
     """
     if tool == "codex":
         return _build_codex_command(model=model, restricted=restricted)
@@ -99,7 +126,10 @@ def build_agent_command(
         disallowed_tools = _merge_disallowed(disallowed_tools, _NETWORK_EGRESS_TOOLS)
     else:
         cmd.extend(["--permission-mode", "bypassPermissions"])
-    cmd.extend(_plugin_dir_flags())
+    if isolate_user_settings:
+        cmd.extend(_claude_isolation_flags())
+    else:
+        cmd.extend(_plugin_dir_flags())
     if disallowed_tools:
         cmd.extend(["--disallowedTools", disallowed_tools])
     if max_turns is not None:
@@ -156,6 +186,7 @@ def build_lightweight_command(
     tool: AgentTool,
     model: str,
     prompt: str,
+    isolate_user_settings: bool = False,
 ) -> tuple[list[str], bytes | None]:
     """Build a simple CLI command for lightweight (non-streaming) callers.
 
@@ -170,6 +201,11 @@ def build_lightweight_command(
 
     Large prompts are passed via stdin to avoid hitting the OS
     ``ARG_MAX`` limit (typically ~130 KB on macOS/Linux).
+
+    *isolate_user_settings* (claude only) restricts the spawn to ``project``
+    settings and skips the pre-cloned ``--plugin-dir`` flags, shielding the
+    contract worker from a host/user ``SessionStart`` hook — see
+    :data:`_CONTRACT_SETTING_SOURCES`.
     """
     if tool == "codex":
         cmd = _build_codex_command(model=model)
@@ -208,7 +244,10 @@ def build_lightweight_command(
         input_bytes = None
 
     if tool == "claude":
-        cmd.extend(_plugin_dir_flags())
+        if isolate_user_settings:
+            cmd.extend(_claude_isolation_flags())
+        else:
+            cmd.extend(_plugin_dir_flags())
     return cmd, input_bytes
 
 

--- a/src/expert_council.py
+++ b/src/expert_council.py
@@ -418,6 +418,7 @@ The experts will read this before revoting.
             model=self._config.triage_model,  # Use fast model for voting
             disallowed_tools="Write,Edit,NotebookEdit",
             max_turns=1,
+            isolate_user_settings=True,
         )
 
     @staticmethod

--- a/src/implement_spec_reviewer.py
+++ b/src/implement_spec_reviewer.py
@@ -356,6 +356,7 @@ class AgentSubagentRunnerAdapter:
             tool=self._config.review_tool,
             model=model,
             disallowed_tools="Write,Edit,NotebookEdit",
+            isolate_user_settings=True,
         )
         # Use the executor's public AgentPort entry point (forwards to
         # _execute under the hood). cwd is repo_root so the reviewer can

--- a/src/plan_reviewer.py
+++ b/src/plan_reviewer.py
@@ -267,6 +267,7 @@ class PlanReviewer(BaseRunner):
             tool=self._config.planner_tool,
             model=self._config.planner_model,
             disallowed_tools="Write,Edit,NotebookEdit",
+            isolate_user_settings=True,
         )
 
     # ------------------------------------------------------------------

--- a/src/research_runner.py
+++ b/src/research_runner.py
@@ -104,6 +104,7 @@ class ResearchRunner(BaseRunner):
             tool=self._config.planner_tool,
             model=self._config.planner_model,
             disallowed_tools="Write,Edit,NotebookEdit",
+            isolate_user_settings=True,
         )
 
     async def _build_prompt(self, task: Task) -> str:

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -330,6 +330,7 @@ class ReviewPhase:
                     tool=parent._config.review_tool,
                     model=model,
                     disallowed_tools="Write,Edit,NotebookEdit",
+                    isolate_user_settings=True,
                 )
                 return await reviewers._execute(
                     cmd,
@@ -1824,6 +1825,7 @@ class ReviewPhase:
                 tool=self._config.review_tool,
                 model=self._config.review_model,
                 disallowed_tools="Write,Edit,NotebookEdit",
+                isolate_user_settings=True,
             )
             transcript = await self._reviewers._execute(
                 cmd,

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -557,6 +557,7 @@ async def run_lightweight_agent(
     issue_number: int | None = None,
     pr_number: int | None = None,
     session_id: str | None = None,
+    isolate_user_settings: bool = True,
 ) -> SimpleResult:
     """One-shot lightweight LLM CLI call with credit detection + telemetry.
 
@@ -578,12 +579,24 @@ async def run_lightweight_agent(
     Returns the ``SimpleResult``; callers inspect ``returncode``/``stdout`` as
     before. Lightweight LLM spawns MUST route through this helper rather than
     calling ``run_simple`` on a ``build_lightweight_command`` directly.
+
+    *isolate_user_settings* defaults to ``True``: every current lightweight
+    caller (wiki compiler, ADR reviewer, transcript summarizer, PR unsticker,
+    …) is a strict-output contract worker, so the spawn is restricted to
+    ``project`` settings to keep a host user-level ``SessionStart`` hook from
+    leaking skill-invocation guidance into the reply. Pass ``False`` for a
+    lightweight spawn that legitimately needs host plugins/skills.
     """
     from agent_cli import build_lightweight_command  # noqa: PLC0415
     from exception_classify import reraise_on_credit_or_bug  # noqa: PLC0415
     from execution import SimpleResult  # noqa: PLC0415
 
-    cmd, cmd_input = build_lightweight_command(tool=tool, model=model, prompt=prompt)
+    cmd, cmd_input = build_lightweight_command(
+        tool=tool,
+        model=model,
+        prompt=prompt,
+        isolate_user_settings=isolate_user_settings,
+    )
     env = make_clean_env(gh_token)
     start = time.monotonic()
     success = False

--- a/src/term_proposer_runtime.py
+++ b/src/term_proposer_runtime.py
@@ -63,7 +63,10 @@ class ClaudeCLIClient:
         from runner_utils import raise_if_credit_exhausted  # noqa: PLC0415
 
         cmd, cmd_input = build_lightweight_command(
-            tool=self._tool, model=self._model, prompt=prompt
+            tool=self._tool,
+            model=self._model,
+            prompt=prompt,
+            isolate_user_settings=True,
         )
         result = await self._runner.run_simple(
             cmd, input=cmd_input, timeout=self._timeout

--- a/src/triage.py
+++ b/src/triage.py
@@ -198,6 +198,12 @@ class TriageRunner(BaseRunner):
             tool=self._config.triage_tool,
             model=self._config.triage_model,
             max_turns=self._config.triage_max_turns,
+            # Triage is a fast JSON-verdict classifier. A host user-level
+            # superpowers SessionStart hook injects "invoke a skill BEFORE any
+            # response, explore first" guidance, derailing triage into repo
+            # exploration so it never emits the {"ready": ...} verdict and the
+            # parser falls back to ready=True. Restrict to project settings.
+            isolate_user_settings=True,
         )
 
     def _build_prompt_with_stats(

--- a/src/verification_judge.py
+++ b/src/verification_judge.py
@@ -347,6 +347,7 @@ REFINED_INSTRUCTIONS_END
             tool=self._config.verification_judge_tool,
             model=self._config.review_model,
             disallowed_tools="Write,Edit,NotebookEdit",
+            isolate_user_settings=True,
         )
 
     def _build_precheck_prompt(

--- a/tests/test_adversarial_agent_runner.py
+++ b/tests/test_adversarial_agent_runner.py
@@ -95,6 +95,23 @@ class TestSubprocessAgentRunnerBasic:
         assert cmd[0] == "claude"
         assert "claude-haiku-4-5-test" in cmd
 
+    @pytest.mark.asyncio
+    async def test_claude_spawn_isolates_user_settings(self) -> None:
+        # Regression: adversarial judges (SpecJudge, PlanCouncil, …) emit
+        # strict JSON. A host user-level superpowers SessionStart hook injects
+        # "invoke a skill before responding" guidance that derails the JSON
+        # contract (the judge explores the repo instead of voting), so the
+        # downstream parser fails with "Expecting value: line 1 column 1".
+        # The spawn must restrict settings to the project scope.
+        runner = FakeRunner(returncode=0, stdout='{"verdict": "PASS"}')
+        agent = SubprocessAgentRunner(runner=runner, tool="claude")
+
+        await agent.run("sys", "usr")
+
+        cmd = runner.calls[0]["cmd"]
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "project"
+
 
 class TestSubprocessAgentRunnerErrorHandling:
     @pytest.mark.asyncio

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -432,3 +432,84 @@ class TestPluginDirFlags:
         from agent_cli import _PRE_CLONED_PLUGIN_ROOT
 
         assert Path("/opt/plugins") == _PRE_CLONED_PLUGIN_ROOT
+
+
+class TestContractAgentIsolation:
+    """``isolate_user_settings`` shields strict-JSON contract agents (triage,
+    judges, councils) from host user-level plugins/hooks.
+
+    A user-installed superpowers plugin registers a ``SessionStart`` hook that
+    injects "invoke a skill BEFORE any response, explore first" guidance into
+    every headless ``claude -p`` spawn. That guidance derails a contract agent
+    off its JSON output contract (it explores the repo instead of emitting the
+    verdict), so the verdict parser finds nothing. Restricting settings to the
+    ``project`` scope drops the user-level plugin/hook while leaving OAuth /
+    keychain auth intact (unlike ``--bare``), and the pre-cloned ``--plugin-dir``
+    flags are skipped so the same leak can't happen inside the Docker image.
+    """
+
+    def test_streaming_claude_isolation_restricts_setting_sources_to_project(
+        self,
+    ) -> None:
+        cmd = build_agent_command(
+            tool="claude", model="sonnet", isolate_user_settings=True
+        )
+
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "project"
+
+    def test_streaming_claude_isolation_skips_pre_cloned_plugin_dirs(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        import agent_cli
+
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "superpowers").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
+            cmd = build_agent_command(
+                tool="claude", model="sonnet", isolate_user_settings=True
+            )
+
+        assert "--plugin-dir" not in cmd
+
+    def test_streaming_claude_default_omits_setting_sources(self) -> None:
+        cmd = build_agent_command(tool="claude", model="sonnet")
+
+        assert "--setting-sources" not in cmd
+
+    def test_streaming_non_claude_ignores_isolation(self) -> None:
+        cmd = build_agent_command(tool="codex", model="gpt", isolate_user_settings=True)
+
+        assert "--setting-sources" not in cmd
+
+    def test_lightweight_claude_isolation_sets_project_and_drops_plugins(
+        self, tmp_path: Path
+    ) -> None:
+        from unittest.mock import patch
+
+        import agent_cli
+
+        root = tmp_path / "plugins"
+        root.mkdir()
+        (root / "superpowers").mkdir()
+
+        with patch.object(agent_cli, "_PRE_CLONED_PLUGIN_ROOT", root):
+            cmd, _ = build_lightweight_command(
+                tool="claude",
+                model="sonnet",
+                prompt="test",
+                isolate_user_settings=True,
+            )
+
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "project"
+        assert "--plugin-dir" not in cmd
+
+    def test_lightweight_claude_default_omits_setting_sources(self) -> None:
+        cmd, _ = build_lightweight_command(tool="claude", model="sonnet", prompt="test")
+
+        assert "--setting-sources" not in cmd

--- a/tests/test_triage.py
+++ b/tests/test_triage.py
@@ -534,6 +534,17 @@ class TestBuildCommand:
         perm_idx = cmd.index("--permission-mode")
         assert cmd[perm_idx + 1] == "bypassPermissions"
 
+    def test_claude_command_isolates_user_settings(self, event_bus: EventBus) -> None:
+        # Regression: the headless triage spawn must not inherit a host
+        # user-level superpowers SessionStart hook, which injects
+        # skill-invocation guidance that derails triage off its JSON verdict
+        # (it explores the repo instead) → parse fails → silent ready=True.
+        config = ConfigFactory.create(triage_tool="claude")
+        runner = TriageRunner(config, event_bus)
+        cmd = runner._build_command()
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "project"
+
     def test_command_supports_codex_backend(self, event_bus: EventBus) -> None:
         config = ConfigFactory.create(
             triage_tool="codex",


### PR DESCRIPTION
## Problem

Headless `claude -p` **contract agents** (triage, the SpecJudge + adversarial councils, verification/plan/spec reviewers, expert council, AC generator, term proposer, and the lightweight one-shot workers) inherit the host's user-level plugins via default `~/.claude/plugins/cache/` discovery. The **superpowers** plugin registers a `SessionStart:startup` hook that injects *"invoke a skill BEFORE any response, explore first"* guidance into **every** session.

For a strict-JSON contract agent that derails it off its output contract. The saved triage transcript for amplifier issue #43 shows the agent obeying the injected skill — grepping the repo (`grep -r trust_fleet_sanity`, `find .hydraflow`) — instead of emitting its `{"ready": ...}` verdict, burning its turn (even hitting a rate-limit event). The parser then finds no verdict and falls back:

- **triage** → silent `ready=True` (the triage gate is effectively off — every issue passes)
- **SpecJudge** → `FAIL` + a synthetic `HIGH` concern force-carried into implementation (`SPEC-JUDGE-001|HIGH … Expecting value: line 1 column 1 (char 0)` — fresh in production logs)

Root cause confirmed from the live `server.log`, the saved transcript, and the superpowers hook script (no opt-out env var). Affects every repo (host-config-driven).

## Fix

Add `isolate_user_settings` to `build_agent_command` / `build_lightweight_command`. For the **claude** backend it appends `--setting-sources project` (drops user-level plugins/hooks) **and** skips the pre-cloned `--plugin-dir` flags (so the same hook can't re-enter via the Docker image's `/opt/plugins/superpowers`). OAuth/keychain auth is unaffected — unlike `--bare`, which forces `ANTHROPIC_API_KEY`.

Threaded through the **contract agents only** (per the scope decision):

| Isolated (contract / JSON-verdict) | Left on plugins (intentional `phase_skills`) |
|---|---|
| triage, verification_judge, plan_reviewer, expert_council, acceptance_criteria, implement_spec_reviewer, research_runner, review_phase (spec-check + self-review), term_proposer, adversarial_agent_runner (**SpecJudge + councils**), `run_lightweight_agent` (wiki compiler, ADR reviewer, transcript summarizer, PR unsticker) | implementer (`agent.py`), planner, reviewer, discover, shape, bug_reproducer, diagnostic_runner |

The coding/exploratory phases that are deliberately wired to plugin skills via `config.phase_skills` keep their plugins (`pyright-lsp`, TDD/simplify/code-review skills).

### Empirical verification

| Spawn | SessionStart/hook lines | superpowers injection | auth errors |
|---|---|---|---|
| Baseline (current flags) | 4 | yes | 0 |
| `--setting-sources project` | **0** | **none** | **0** (OAuth intact) |

## Tests

- `tests/test_agent_cli.py::TestContractAgentIsolation` — `isolate_user_settings` adds `--setting-sources project` and drops `--plugin-dir` (streaming + lightweight); default omits it; non-claude tools ignore it.
- `tests/test_adversarial_agent_runner.py::…::test_claude_spawn_isolates_user_settings` — regression on the confirmed SpecJudge path.
- `tests/test_triage.py::TestBuildCommand::test_claude_command_isolates_user_settings` — regression on the confirmed triage path.

`make quality` green.

## Note / follow-up

`triage` carries `phase_skills['triage'] = ['superpowers:systematic-debugging']`. Isolating its spawn makes that skill non-loadable (the prompt still lists it — prompt-building is untouched, so `test_phase_skill_injection` stays green). A debugging skill is dubious for a ready/not-ready classifier; consider pruning `phase_skills['triage']` as a follow-up. The other configured phases (discover/shape/reviewer/planner/agent) were intentionally left on plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
