### PR TITLE
test(dashboard): real-store /api/pipeline aggregation scenario via with_pipeline shim

### DIFF
--- a/tests/scenarios/test_multi_repo_pipeline_shim.py
+++ b/tests/scenarios/test_multi_repo_pipeline_shim.py
@@ -1,0 +1,56 @@
+"""Scenario: /api/pipeline aggregates real per-repo IssueStores under repo=__all__.
+
+Complements ``test_multi_repo_aggregate_endpoints.py`` (which stubs the
+orchestrator with a MagicMock snapshot) by driving the REAL
+``get_pipeline_snapshot`` through the ``add_repo(with_pipeline=True)`` shim's
+per-repo ``IssueStore`` — so the snapshot computation, the backend→frontend
+stage remap, and the per-issue repo-tagging are exercised end to end against
+colliding issue numbers, not mocked. The browser tier
+(``test_multi_repo_pipeline_cards.py``) renders this; here it is asserted at the
+fast API/scenario tier.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from issue_store import STAGE_READY
+from tests.helpers import find_endpoint, make_dashboard_router
+
+pytestmark = pytest.mark.scenario
+
+
+@pytest.mark.asyncio
+async def test_pipeline_repo_all_aggregates_real_per_repo_stores(
+    mock_world, config, event_bus, state, tmp_path
+) -> None:
+    mock_world.add_repo("owner/alpha", str(tmp_path / "alpha"), with_pipeline=True)
+    mock_world.add_repo("owner/beta", str(tmp_path / "beta"), with_pipeline=True)
+    # Issue #5 active in BOTH repos' real IssueStores — must survive as two cards.
+    mock_world.registry.get("owner-alpha").orchestrator.issue_store.mark_active(
+        5, STAGE_READY
+    )
+    mock_world.registry.get("owner-beta").orchestrator.issue_store.mark_active(
+        5, STAGE_READY
+    )
+
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=mock_world.registry,
+        default_repo_slug=config.repo.replace("/", "-"),
+    )
+    endpoint = find_endpoint(router, "/api/pipeline")
+
+    data = json.loads((await endpoint(repo="__all__")).body)
+
+    # backend "ready" maps to frontend "implement"; the colliding #5 survives
+    # once per repo, each repo-tagged (real snapshot computation, not a mock).
+    implement = data["stages"]["implement"]
+    assert len(implement) == 2
+    assert {i["issue_number"] for i in implement} == {5}
+    assert {i["repo"] for i in implement} == {"owner-alpha", "owner-beta"}


### PR DESCRIPTION
## Follow-up — real-store `/api/pipeline` aggregation at the scenario tier

The multi-repo program's `/api/pipeline` aggregation had **mock-based** scenario coverage (`test_multi_repo_aggregate_endpoints.py` stubs the orchestrator with a `MagicMock` snapshot) and a **browser** test (`test_multi_repo_pipeline_cards.py`). This adds the missing middle: a tier-2 MockWorld scenario that drives the **real** `get_pipeline_snapshot` through `add_repo(with_pipeline=True)`'s per-repo `IssueStore`.

Two repos each `mark_active(5, STAGE_READY)` on their real store; `/api/pipeline?repo=__all__` returns the colliding issue #5 **once per repo, repo-tagged**, after the backend→frontend `"ready"→"implement"` stage remap. This exercises the real snapshot computation + the shim wiring (a fake-fidelity upgrade — the MagicMock version bypasses both).

### Also: the worker-grid "denominator" review nit is a verified NON-issue
`_workers_for_runtime` iterates the full `_bg_worker_defs` for **every** runtime, so each repo always has the complete worker set — `activeCount`/total already match, no display fix needed.

**Test-only.** `make scenario` green; ruff/pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)