### PR TITLE
fix(adr-drift): suppress bare citations of cross-cutting infra modules

### DIFF
--- a/src/adr_drift.py
+++ b/src/adr_drift.py
@@ -57,6 +57,27 @@ def _split_path_symbol(entry: str) -> tuple[str, str | None]:
     return entry, None
 
 
+# Cross-cutting infrastructure modules — bare-cited (file-granular) by ≥5
+# Accepted ADRs as of 2026-06: the config dataclass, shared Pydantic models,
+# the Port protocols, and the post-merge handler. Every feature touches these,
+# so a file-level touch is implementation churn, not a semantic change to any
+# one ADR's decision. They are the dominant source of ADR-drift false positives
+# (e.g. src/config.py absorbed ~20 merged PRs in two weeks, tripping every ADR
+# that lists it as a dependency). #9176 already suppressed the symbol-cited
+# case; this handles the residual *bare-cited* case for these shared modules.
+# An ADR that genuinely owns one of these must cite the specific symbol
+# (``src/config.py:HydraFlowConfig``) to drift — a bare citation is read as a
+# dependency mention and does not drift.
+_SHARED_INFRA_MODULES = frozenset(
+    {
+        "src/config.py",
+        "src/models.py",
+        "src/ports.py",
+        "src/post_merge_handler.py",
+    }
+)
+
+
 def _citation_drifts(adr: ADR, path: str, changed_symbols: frozenset[str]) -> bool:
     """Decide whether *path* drifts *adr* given the symbols changed in it.
 
@@ -64,7 +85,10 @@ def _citation_drifts(adr: ADR, path: str, changed_symbols: frozenset[str]) -> bo
 
     * **Bare-file citation** (empty cited-symbol set) → drifts on *any*
       touch of the file.  This preserves the legacy file-granular
-      behaviour the P2 gate and the existing drift tests rely on.
+      behaviour the P2 gate and the existing drift tests rely on — except
+      for the cross-cutting :data:`_SHARED_INFRA_MODULES`, where a bare
+      citation is treated as a dependency mention and does *not* drift
+      (it must be cited at ``:Symbol`` granularity to drift).
     * **Symbol-qualified citation** (non-empty cited-symbol set) → drifts
       only when a symbol the diff reports as changed for this file
       matches one of the cited symbols.  A file-only diff (no symbol
@@ -74,7 +98,7 @@ def _citation_drifts(adr: ADR, path: str, changed_symbols: frozenset[str]) -> bo
     """
     cited_symbols = adr.source_symbols.get(path, frozenset())
     if not cited_symbols:
-        return True
+        return path not in _SHARED_INFRA_MODULES
     return bool(cited_symbols & changed_symbols)
 
 

--- a/tests/test_adr_drift.py
+++ b/tests/test_adr_drift.py
@@ -132,6 +132,67 @@ def test_superseded_adr_does_not_drift(adr_index: ADRIndex) -> None:
     assert findings == []
 
 
+def test_bare_citation_of_shared_infra_module_does_not_drift(tmp_path: Path) -> None:
+    # Cross-cutting infrastructure modules (config dataclass, shared models,
+    # Port protocols, post-merge handler) are bare-cited by many ADRs as a
+    # dependency. A file-level touch is implementation churn, not a semantic
+    # change to any one ADR's decision — it must NOT drift (the dominant
+    # ADR-drift false-positive source). Require a :Symbol citation to drift.
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=50,
+        title="depends on config",
+        status="Accepted",
+        related_files=["src/config.py"],
+    )
+    findings = compute_drift(
+        ADRIndex(adr_dir), pr_number=1, changed_files=["src/config.py"]
+    )
+    assert findings == []
+
+
+def test_symbol_citation_of_shared_infra_module_still_drifts(tmp_path: Path) -> None:
+    # An ADR that genuinely owns a shared-infra symbol cites it at :Symbol
+    # granularity and still drifts when that symbol changes.
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=51,
+        title="owns config schema",
+        status="Accepted",
+        related_files=["src/config.py:HydraFlowConfig"],
+    )
+    findings = compute_drift(
+        ADRIndex(adr_dir),
+        pr_number=1,
+        changed_files=["src/config.py:HydraFlowConfig"],
+    )
+    assert len(findings) == 1
+    assert findings[0].adr.number == 51
+
+
+def test_bare_citation_of_non_infra_module_still_drifts(tmp_path: Path) -> None:
+    # Regression guard: the shared-infra suppression must not change file-level
+    # drift for ordinary (non-infra) cited modules.
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=52,
+        title="owns widget",
+        status="Accepted",
+        related_files=["src/widget.py"],
+    )
+    findings = compute_drift(
+        ADRIndex(adr_dir), pr_number=1, changed_files=["src/widget.py"]
+    )
+    assert len(findings) == 1
+    assert findings[0].adr.number == 52
+
+
 def test_adr_file_in_diff_helper(adr_index: ADRIndex) -> None:
     adr = next(a for a in adr_index.adrs() if a.number == 1)
     assert _adr_file_in_diff(adr, ["docs/adr/0001-alpha.md"])


### PR DESCRIPTION
## Problem

`ADRTouchpointAuditorLoop` filed ~31 false-positive ADR-drift rollup issues. #9176/#9256 fixed the **symbol-cited** case (a `src/foo.py:Bar` citation no longer drifts on unrelated file churn), but the **bare-cited** case remained: ADRs cite cross-cutting infrastructure modules at file granularity as dependencies, so *any* PR touching them trips drift.

Data across all Accepted/Proposed ADRs — files **bare-cited by the most ADRs** (i.e. cross-cutting infrastructure, not any one ADR's subject):

| Bare-cited by N ADRs | Module |
|---|---|
| 8 | `src/models.py` |
| 7 | `src/config.py` |
| 5 | `src/ports.py` |
| 5 | `src/post_merge_handler.py` |

`src/config.py` alone absorbed ~20 merged PRs in two weeks — every one tripped ADR-0045, ADR-0036, etc. These are the dominant false-positive source (the backlog that was just triaged + closed).

## Fix

`src/adr_drift.py`: a small `_SHARED_INFRA_MODULES` set (the four modules above). In `_citation_drifts`, a **bare** citation of one of these no longer drifts — it's read as a dependency mention. An ADR that genuinely *owns* one of these must cite the specific symbol (`src/config.py:HydraFlowConfig`), which still drifts normally. Non-infra bare citations are unchanged.

This completes the #9176/#9256 line of work for the residual bare-citation case.

### Verified against real ADRs

```
ADRs that drift on a bare src/config.py touch:            []        (was: ADR-0045, 0036, …)
ADRs that drift on a src/adversarial_retry_loop.py touch: [64]      (real drift preserved)
```

## Tests (TDD)

- `test_bare_citation_of_shared_infra_module_does_not_drift` — bare `config.py` citation no longer drifts (the fix)
- `test_symbol_citation_of_shared_infra_module_still_drifts` — `config.py:HydraFlowConfig` still drifts on that symbol
- `test_bare_citation_of_non_infra_module_still_drifts` — regression guard: ordinary bare citations unchanged

`make quality` + `make scenario` green. Existing `adr_drift`/`adr_index` suites pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
