### PR TITLE
fix(dashboard): route intent + request-changes to selected/row repo; clear repo-scoped state on switch

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-10T03:09:36.452109+00:00",
-  "commit_sha": "56bb8a8be0d00186a84d2092952342362f898073",
+  "regenerated_at": "2026-06-10T05:33:29.476775+00:00",
+  "commit_sha": "9b56261377f7647de7264570e2f732b81ff7d316",
   "artifacts": {
     "loops.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ports.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "labels.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "modules.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "events.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "adr_xref.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "mockworld.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "changelog.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "coverage_matrix.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "functional_areas.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ubiquitous-language.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `a0d630c` — test(dashboard): MockWorld scenarios for Phase 2/3 aggregate endpoints (#9392) (#9392) *(2026-06-09)*
 - `56bb8a8` — test(dashboard): multi-repo aggregation e2e + MockWorld scenarios (Phase 4-c) (#9391) (#9391) *(2026-06-09)*
 - `bc3049c` — feat(dashboard): repo-qualify live worker/PR cards for repo=__all__ (Phase 4-b2) (#9390) (#9390) *(2026-06-09)*
 - `2f1c343` — feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a) (#9387) (#9387) *(2026-06-09)*

--- a/src/dashboard_routes/_routes.py
+++ b/src/dashboard_routes/_routes.py
@@ -2270,7 +2270,16 @@ def create_router(
 
         Repo-scoped: the issue is created in the SELECTED repo (and its URL
         points there), not the default repo, in a multi-repo deployment.
+        ``repo=__all__`` is rejected — issue creation needs a specific repo.
         """
+        if repo is not None and repo.strip().lower() == REPO_ALL:
+            return JSONResponse(
+                {
+                    "status": "error",
+                    "detail": "issue creation requires a specific repo",
+                },
+                status_code=400,
+            )
         _cfg, _state, _bus, _get_orch = _resolve_runtime(repo)
         title = request.text[:120]
         body = request.text

--- a/src/ui/src/components/StreamCard.jsx
+++ b/src/ui/src/components/StreamCard.jsx
@@ -101,7 +101,7 @@ export function StreamCard({ issue, intent, defaultExpanded, onRequestChanges, t
     if (!feedbackText.trim() || submitting) return
     setSubmitting(true)
     setSubmitError(null)
-    const ok = await onRequestChanges(issue.issueNumber, feedbackText.trim(), issue.currentStage)
+    const ok = await onRequestChanges(issue.issueNumber, feedbackText.trim(), issue.currentStage, issue.repo)
     setSubmitting(false)
     if (ok) {
       setShowFeedback(false)
@@ -109,7 +109,7 @@ export function StreamCard({ issue, intent, defaultExpanded, onRequestChanges, t
     } else {
       setSubmitError('Failed to submit. Please try again.')
     }
-  }, [feedbackText, submitting, onRequestChanges, issue.issueNumber, issue.currentStage])
+  }, [feedbackText, submitting, onRequestChanges, issue.issueNumber, issue.currentStage, issue.repo])
 
   const meta = STAGE_META[issue.currentStage]
   const isActive = issue.overallStatus === 'active'

--- a/src/ui/src/components/__tests__/StreamCard.test.jsx
+++ b/src/ui/src/components/__tests__/StreamCard.test.jsx
@@ -310,7 +310,9 @@ describe('StreamCard request changes feedback flow', () => {
     fireEvent.click(submitBtn)
 
     await waitFor(() => {
-      expect(onRequestChanges).toHaveBeenCalledWith(42, 'Fix the tests please', 'review')
+      // The row's repo is threaded so the escalation lands on the right line
+      // under repo=__all__.
+      expect(onRequestChanges).toHaveBeenCalledWith(42, 'Fix the tests please', 'review', issue.repo)
     })
   })
 

--- a/src/ui/src/context/HydraFlowContext.jsx
+++ b/src/ui/src/context/HydraFlowContext.jsx
@@ -804,6 +804,12 @@ export function reducer(state, action) {
           // repo tagging (single-repo uses "") and would otherwise be filtered
           // out of the aggregate grid until the next REST poll repopulates them.
           backgroundWorkers: [],
+          // These are repo-scoped too — clear them so the prior repo's prompts /
+          // pending intents / escalation context don't flash in the new scope
+          // until their next poll refetches.
+          humanInputRequests: {},
+          intents: [],
+          hitlEscalation: null,
           // Reset the dedup watermark — the new scope's events restart from a
           // fresh id space (else lower ids would be watermark-dropped).
           lastSeenId: -1,
@@ -1307,7 +1313,9 @@ export function HydraFlowProvider({ children }) {
   const submitIntent = useCallback(async (text) => {
     dispatch({ type: 'INTENT_SUBMITTED', data: { text } })
     try {
-      const res = await fetch('/api/intent', {
+      // Create the issue in the SELECTED repo. Under repo=__all__ the backend
+      // rejects (an issue needs a specific repo) and the optimistic entry fails.
+      const res = await fetchWithRepo('/api/intent', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
@@ -1323,7 +1331,7 @@ export function HydraFlowProvider({ children }) {
       dispatch({ type: 'INTENT_FAILED', data: { text } })
       return null
     }
-  }, [])
+  }, [fetchWithRepo])
 
   const submitReport = useCallback(async ({ description, screenshot_base64 }) => {
     const pi = state.pipelineIssues || {}
@@ -1420,9 +1428,14 @@ export function HydraFlowProvider({ children }) {
     } catch { /* ignore — local state already updated */ }
   }, [applyRepoParam, state.selectedRepoSlug])
 
-  const requestChanges = useCallback(async (issueNumber, feedback, stage) => {
+  const requestChanges = useCallback(async (issueNumber, feedback, stage, repo) => {
     try {
-      const resp = await fetch('/api/request-changes', {
+      // Escalate against the ROW's repo (not the aggregate selection) so the
+      // label swap + HITL cause land on the right line under repo=__all__.
+      const url = repo
+        ? `/api/request-changes?repo=${encodeURIComponent(repo)}`
+        : '/api/request-changes'
+      const resp = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ issue_number: issueNumber, feedback, stage }),

--- a/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
+++ b/src/ui/src/context/__tests__/HydraFlowContext.test.jsx
@@ -185,6 +185,20 @@ describe('HydraFlowContext reducer', () => {
     expect(next.backgroundWorkers).toEqual([])
   })
 
+  it('SELECT_REPO clears repo-scoped human-input / intents / escalation on a change', () => {
+    const state = {
+      ...initialState,
+      selectedRepoSlug: 'owner-a',
+      humanInputRequests: { 42: { issue: 42 } },
+      intents: [{ text: 'do a thing', status: 'pending' }],
+      hitlEscalation: { issue: 42 },
+    }
+    const next = reducer(state, { type: 'SELECT_REPO', data: { slug: 'owner-b' } })
+    expect(next.humanInputRequests).toEqual({})
+    expect(next.intents).toEqual([])
+    expect(next.hitlEscalation).toBeNull()
+  })
+
   // --- Phase 4-b2: worker/PR card composite-keying ------------------------
 
   it('worker_update keys by repo so same-issue cards across repos coexist (__all__)', () => {

--- a/tests/test_intent_endpoint.py
+++ b/tests/test_intent_endpoint.py
@@ -99,6 +99,25 @@ class TestIntentEndpoint:
         assert data["status"] == "created"
 
     @pytest.mark.asyncio
+    async def test_intent_rejects_repo_all(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        """repo=__all__ is rejected — issue creation needs a specific repo."""
+        from models import IntentRequest
+
+        router, pr_mgr = _make_router(config, event_bus, state, tmp_path)
+        pr_mgr.create_issue = AsyncMock(return_value=7)
+
+        endpoint = _find_endpoint(router, "/api/intent")
+        assert endpoint is not None
+
+        response = await endpoint(IntentRequest(text="add a thing"), repo="__all__")
+
+        assert response.status_code == 400
+        assert "specific repo" in json.loads(response.body)["detail"]
+        pr_mgr.create_issue.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_intent_returns_500_on_create_failure(
         self, config, event_bus: EventBus, state, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Audit-found data-integrity fixes (multi-repo)

A cross-phase **integration audit** surfaced dashboard **mutations + state resets that ignored the multi-repo scope** — silently misdirecting writes to the *default* repo and leaking prior-repo state across switches. These are the highest-impact findings (silent data corruption in multi-repo deployments).

### Frontend — `HydraFlowContext`
- **`submitIntent`** → `fetchWithRepo` so the issue is created in the **selected** repo (was: always the default). Under `repo=__all__` the backend now rejects (issue creation needs a specific repo).
- **`requestChanges`** takes the **row's** repo and sends `?repo=<row-repo>` so a HITL escalation lands on the right line under `repo=__all__` (was: default repo). `StreamCard` threads `issue.repo`.
- **`SELECT_REPO`** now also clears `humanInputRequests` / `intents` / `hitlEscalation` (all repo-scoped) so the prior repo's prompts / pending intents / escalation don't flash in the new scope until the next poll.

### Backend — `_routes.py`
`POST /api/intent` rejects `repo=__all__` with **400** (mirrors `/api/request-changes`) — it was silently creating the issue in the default repo.

### Tests / gates
vitest (`SELECT_REPO` clears the three; `StreamCard` threads the row repo) + `test_intent_endpoint` (`__all__` → 400, `create_issue` not called). **`make quality` 15958 + full vitest 1144 + build** green.

### Follow-up (documented, not in this PR)
The audit also found read-only `__all__` gaps: `/api/metrics{,/github,/history}` silently serve default-repo data, and `/api/timeline*` likewise (no frontend consumer). `/api/metrics/github` aggregation + `/api/system/workers` slug are a separate small PR; proper `/api/metrics{,/history}` aggregation is deferred (the frontend dispatches error bodies without checking `r.ok`, so a blind reject isn't safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)