### PR TITLE
fix(dashboard): aggregate /api/metrics/github under __all__ + canonical worker slug

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-10T03:09:36.452109+00:00",
-  "commit_sha": "56bb8a8be0d00186a84d2092952342362f898073",
+  "regenerated_at": "2026-06-10T05:50:32.411700+00:00",
+  "commit_sha": "9b56261377f7647de7264570e2f732b81ff7d316",
   "artifacts": {
     "loops.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ports.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "labels.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "modules.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "events.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "adr_xref.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "mockworld.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "changelog.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "coverage_matrix.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "functional_areas.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ubiquitous-language.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "56bb8a8be0d00186a84d2092952342362f898073"
+      "source_sha": "9b56261377f7647de7264570e2f732b81ff7d316"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `a0d630c` — test(dashboard): MockWorld scenarios for Phase 2/3 aggregate endpoints (#9392) (#9392) *(2026-06-09)*
 - `56bb8a8` — test(dashboard): multi-repo aggregation e2e + MockWorld scenarios (Phase 4-c) (#9391) (#9391) *(2026-06-09)*
 - `bc3049c` — feat(dashboard): repo-qualify live worker/PR cards for repo=__all__ (Phase 4-b2) (#9390) (#9390) *(2026-06-09)*
 - `2f1c343` — feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a) (#9387) (#9387) *(2026-06-09)*

--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -929,16 +929,14 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     ) -> JSONResponse:
         """Return last known status of each background worker.
 
-        For ``repo=__all__`` every repo's workers are unioned (not merged) and
-        each row is tagged with its repo slug.
+        For ``repo=__all__`` every repo's workers are unioned (not merged); a
+        single repo (or the default) returns just its own. Every row is tagged
+        with its CANONICAL resolved slug — resolve_runtimes uniformly handles
+        all three cases, so the single-repo path no longer tags an empty string.
         """
-        if repo is not None and repo.strip().lower() == REPO_ALL:
-            workers: list[BackgroundWorkerStatus] = []
-            for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
-                workers.extend(_workers_for_runtime(_cfg, _state, _get_orch(), slug))
-            return JSONResponse(BackgroundWorkersResponse(workers=workers).model_dump())
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        workers = _workers_for_runtime(_cfg, _state, _get_orch(), repo or "")
+        workers: list[BackgroundWorkerStatus] = []
+        for _cfg, _state, _bus, _get_orch, slug in ctx.resolve_runtimes(repo):
+            workers.extend(_workers_for_runtime(_cfg, _state, _get_orch(), slug))
         return JSONResponse(BackgroundWorkersResponse(workers=workers).model_dump())
 
     def _resolve_orch_for(repo: str | None) -> tuple[Any, JSONResponse | None]:

--- a/src/dashboard_routes/_metrics_routes.py
+++ b/src/dashboard_routes/_metrics_routes.py
@@ -179,14 +179,31 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
     async def get_github_metrics(
         repo: RepoSlugParam = None,
     ) -> JSONResponse:
-        """Query GitHub for issue/PR counts by label state."""
-        _cfg, _state, _bus, _get_orch = ctx.resolve_runtime(repo)
-        # ``get_label_counts`` is a GitHub-API helper on the concrete
-        # PRManager, not on PRPort. Production always supplies the real
-        # adapter via ``ctx.pr_manager_for``.
-        manager: PRManager = cast("PRManager", ctx.pr_manager_for(_cfg, _bus))
-        counts = await manager.get_label_counts(_cfg)
-        return JSONResponse(counts)
+        """Query GitHub for issue/PR counts by label state.
+
+        For ``repo=__all__`` the counts are summed across every repo (per-label
+        open counts merged, closed/merged totals added). A single repo (or the
+        default) returns its own counts unchanged — resolve_runtimes yields one
+        element there, so the sum is a no-op.
+        """
+        merged: dict[str, Any] = {
+            "open_by_label": {},
+            "total_closed": 0,
+            "total_merged": 0,
+        }
+        for _cfg, _state, _bus, _get_orch, _slug in ctx.resolve_runtimes(repo):
+            # ``get_label_counts`` is a GitHub-API helper on the concrete
+            # PRManager, not on PRPort. Production always supplies the real
+            # adapter via ``ctx.pr_manager_for``.
+            manager: PRManager = cast("PRManager", ctx.pr_manager_for(_cfg, _bus))
+            counts = await manager.get_label_counts(_cfg)
+            for label, count in counts.get("open_by_label", {}).items():
+                merged["open_by_label"][label] = (
+                    merged["open_by_label"].get(label, 0) + count
+                )
+            merged["total_closed"] += counts.get("total_closed", 0)
+            merged["total_merged"] += counts.get("total_merged", 0)
+        return JSONResponse(merged)
 
     @router.get("/api/metrics/history")
     async def get_metrics_history(

--- a/tests/test_bg_worker_status.py
+++ b/tests/test_bg_worker_status.py
@@ -347,6 +347,25 @@ class TestSystemWorkersEndpoint:
         )
 
     @pytest.mark.asyncio
+    async def test_single_repo_workers_carry_canonical_slug_not_empty(
+        self, config, event_bus: EventBus, state, tmp_path: Path
+    ) -> None:
+        """A bare (single-repo) request tags workers with the resolved slug.
+
+        Previously the single-repo path tagged ``repo=""``; now it resolves the
+        canonical dash slug like every other repo-tagged payload.
+        """
+        router = self._make_router(config, event_bus, state, tmp_path)
+        endpoint = self._find_endpoint(router, "/api/system/workers")
+        assert endpoint is not None
+
+        workers = json.loads((await endpoint()).body)["workers"]
+
+        assert workers
+        assert all(w["repo"] for w in workers)
+        assert all(w["repo"] == config.repo.replace("/", "-") for w in workers)
+
+    @pytest.mark.asyncio
     async def test_returns_disabled_when_no_orchestrator(
         self, config, event_bus: EventBus, state, tmp_path: Path
     ) -> None:

--- a/tests/test_dashboard_routes_metrics.py
+++ b/tests/test_dashboard_routes_metrics.py
@@ -164,6 +164,59 @@ class TestGitHubMetricsEndpoint:
         assert data["total_closed"] == 10
         assert data["total_merged"] == 8
 
+    @pytest.mark.asyncio
+    async def test_github_metrics_sums_across_repos_for_all(
+        self, config, event_bus, state, tmp_path
+    ) -> None:
+        import json
+        from unittest.mock import patch
+
+        from pr_manager import PRManager
+        from tests.helpers import ConfigFactory, make_registry
+
+        registry = make_registry(
+            {
+                "slug": "owner-a",
+                "config": ConfigFactory.create(repo="owner/a"),
+                "running": True,
+            },
+            {
+                "slug": "owner-b",
+                "config": ConfigFactory.create(repo="owner/b"),
+                "running": True,
+            },
+        )
+        router, _ = make_dashboard_router(
+            config,
+            event_bus,
+            state,
+            tmp_path,
+            registry=registry,
+            default_repo_slug="owner-host",
+        )
+        get_github_metrics = find_endpoint(router, "/api/metrics/github")
+
+        async def _fake_counts(_self, cfg):
+            if "a" in cfg.repo:
+                return {
+                    "open_by_label": {"hydraflow-plan": 2},
+                    "total_closed": 1,
+                    "total_merged": 3,
+                }
+            return {
+                "open_by_label": {"hydraflow-plan": 1, "hydraflow-ready": 4},
+                "total_closed": 2,
+                "total_merged": 0,
+            }
+
+        with patch.object(PRManager, "get_label_counts", _fake_counts):
+            data = json.loads((await get_github_metrics(repo="__all__")).body)
+
+        # per-label open counts merged; closed/merged totals summed across repos.
+        assert data["open_by_label"] == {"hydraflow-plan": 3, "hydraflow-ready": 4}
+        assert data["total_closed"] == 3
+        assert data["total_merged"] == 3
+
 
 class TestMetricsHistoryEndpoint:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Audit follow-up — read endpoints serving default-as-aggregate

Two integration-audit findings where `repo=__all__` silently returned **default-repo** data:

- **`/api/metrics/github`** now **sums** `LabelCounts` across repos under `__all__` (per-label open counts merged, `total_closed`/`total_merged` added). Unified to a single `resolve_runtimes` loop → a single repo yields one element, so the sum is a no-op (**same response shape** as before).
- **`/api/system/workers`** single-repo path tagged every worker `repo=""` (only the `__all__` branch resolved the slug). Unified to a `resolve_runtimes` loop so all three cases tag the **canonical dash slug**. The Slice-3 worker grid keys single-repo by name, so no frontend change.

### Tests
github `__all__` sum across two seeded repos; single-repo workers carry the canonical slug (not `""`). `make quality` 15959; existing metrics/worker tests unchanged.

### Still deferred (documented in the audit)
`/api/metrics` + `/api/metrics/history` still serve default under `__all__` — a blind 400-reject is unsafe (the frontend `.then(r=>r.json())` without checking `r.ok` would dispatch the error body as data), so proper aggregation is the follow-up. `/api/timeline*` likewise but have no frontend consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)