### PR TITLE
fix(fake-coverage): only surface-audit fakes registered for cassettes

### DIFF
--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -507,10 +507,24 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         dedup = self._dedup.get()
         all_known: dict[str, list[str]] = {}
         for fake, sets in catalog.items():
-            surface_methods = sets["adapter-surface"]
             helper_methods = sets["test-helper"]
-            cassette_subdir = cassette_root / _FAKE_TO_CASSETTE_DIR.get(fake, "")
-            cassetted = catalog_cassette_methods(cassette_subdir)
+            # Adapter-surface (cassette) auditing only applies to fakes
+            # explicitly registered in ``_FAKE_TO_CASSETTE_DIR`` — the fakes of
+            # external adapters whose real I/O can be recorded. Internal-port
+            # fakes (a clock, in-memory stores, span-assertion helpers) have no
+            # recordable counterpart, so no cassette can ever cover them.
+            # Registration is the deliberate opt-in; an unmapped fake is skipped
+            # rather than audited against the cassette ROOT (the old
+            # ``.get(fake, "")`` fallback), which flagged every method as a
+            # false gap. Test-helper (scenario) coverage still applies to all
+            # fakes below.
+            if fake in _FAKE_TO_CASSETTE_DIR:
+                cassette_subdir = cassette_root / _FAKE_TO_CASSETTE_DIR[fake]
+                cassetted = catalog_cassette_methods(cassette_subdir)
+                surface_methods = sets["adapter-surface"]
+            else:
+                cassetted = set()
+                surface_methods = []
 
             covered: list[str] = []
             uncovered_surface: list[str] = []

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -166,6 +166,48 @@ async def test_do_work_files_surface_gap(loop_env, monkeypatch, tmp_path) -> Non
     assert "hydraflow-fake-coverage-gap" in labels
 
 
+async def test_do_work_skips_surface_audit_for_unmapped_fake(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """A fake NOT registered in ``_FAKE_TO_CASSETTE_DIR`` must not file an
+    adapter-surface gap.
+
+    Internal-port fakes (a clock, in-memory stores, assertion helpers) have no
+    recordable external I/O, so no cassette can ever cover them. The empty-string
+    fallback (``_FAKE_TO_CASSETTE_DIR.get(fake, "")``) previously audited such a
+    fake against the cassette *root* — flagging every public method as a false
+    gap (the dominant fake-coverage false positive).
+    """
+    cfg, state, pr, dedup = loop_env
+    state.get_fake_coverage_rollup_issue.return_value = None
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    # FakeClock is not in _FAKE_TO_CASSETTE_DIR; now/monotonic are surface methods.
+    (fake_dir / "fake_clock.py").write_text(
+        "class FakeClock:\n    def now(self): ...\n    def monotonic(self): ...\n"
+    )
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes").mkdir(parents=True)
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    assert stats["filed"] == 0
+    pr.create_issue.assert_not_awaited()
+
+
 async def test_do_work_files_helper_gap(loop_env, monkeypatch, tmp_path) -> None:
     """Un-exercised ``script_*`` helper → one ``test-helper`` rollup issue."""
     cfg, state, pr, dedup = loop_env


### PR DESCRIPTION
## Problem

`FakeCoverageAuditorLoop` filed ~21 fake-coverage-gap issues, most of them false positives. The adapter-surface (cassette) audit used `_FAKE_TO_CASSETTE_DIR.get(fake, "")` — for any fake **not** registered in the map, the empty-string fallback made `cassette_subdir = cassette_root` itself, so the fake's methods were checked against the *union of all cassettes* (docker/git/github) and every method was flagged uncovered.

That mis-flagged 10 **internal-port fakes** that have no recordable external I/O and can never be cassette-covered:

`FakeClock`, `FakeIssueStore`, `FakeReviewInsightStore`, `FakeRouteBackCounter`, `FakeWikiCompiler`, `FakeWorkspace`, `FakeBotPR`, `FakeHoneycomb`, `FakeIssueFetcher`, `FakeAgent`

## Fix

`src/fake_coverage_auditor_loop.py`: adapter-surface auditing now applies **only** to fakes explicitly registered in `_FAKE_TO_CASSETTE_DIR` (the fakes of external adapters whose I/O can be recorded). Registration is the deliberate opt-in; an unmapped fake is skipped rather than audited against the cassette root. **Test-helper (scenario) coverage is unchanged** — it still applies to every fake.

### Verified against the real tree

```
NOW SKIPPED (unmapped, no longer false-flagged):
  FakeAgent, FakeBotPR, FakeClock, FakeHoneycomb, FakeIssueFetcher,
  FakeIssueStore, FakeReviewInsightStore, FakeRouteBackCounter,
  FakeWikiCompiler, FakeWorkspace

STILL FLAGGED (mapped → genuine cassette debt, left open):
  FakeGitHub(63), FakeBeads(12), FakeLLM(8), FakeSentry(7),
  FakeFS(6), FakeSubprocessRunner(3), FakeHTTP(2)
```

The genuine cassette debt for the mapped fakes is preserved — only the category-error false positives are suppressed.

## Tests (TDD)

- `test_do_work_skips_surface_audit_for_unmapped_fake` — an unmapped fake (`FakeClock`) files **no** adapter-surface gap (the fix)
- `test_do_work_files_surface_gap` (existing) — a mapped fake (`FakeGitHub`) with an uncassetted method still files a gap (regression guard)

`make quality` + `make scenario` green.

## Follow-up (not in this PR)

The 7 mapped fakes above are genuine coverage debt (record cassettes). `FakeLLM`'s `pop_*`/`*_count_for` methods are test helpers mis-classified as surface — a candidate for the helper carve-out. Tracked by their existing issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
