### PR TITLE
fix(trust): right-size FakeCoverageAuditorLoop to cassette-capable adapters

### DIFF
--- a/docs/adr/0047-fake-adapter-contract-testing-cassettes.md
+++ b/docs/adr/0047-fake-adapter-contract-testing-cassettes.md
@@ -55,6 +55,17 @@ Weekly, `ContractRefreshLoop` (spec §4.2) re-records the corpus against the rea
 - A new call shape is added to a fake. The fake code must be backed by a cassette proving the new shape matches the real API.
 - An adapter's cassette directory is empty but the fake is wired into production code paths. Fix by recording a baseline cassette even if the corpus is small.
 
+## Auditor scope (right-sizing, 2026-06-11)
+
+`FakeCoverageAuditorLoop` (spec §4.7) enforces this ADR by flagging un-cassetted fake methods. Its **adapter-surface** audit is scoped to the **cassette-capable** adapters only — those with a real recorder in `src/contract_recording.py` and a YAML cassette corpus: **github, git, docker** (claude is contract-tested via JSONL streams, not the YAML cassette-dir). This is the `_FAKE_TO_CASSETTE_DIR` registry.
+
+Two rules keep the audit honest and noise-free:
+
+1. **No recordable surface → not audited.** Fakes with no real recorder/cassette corpus (`FakeBeads`, `FakeSentry`, `FakeHTTP`, `FakeSubprocessRunner`, `FakeFS`, `FakeLLM`) are *out of scope* for the adapter-surface audit — there is nothing to contract a cassette against. Adding one of these to the cassette system means first adding a recorder + cassette dir (per "When to add a new cassette"), *then* registering it. Auditing them before that infrastructure exists only produces false positives.
+2. **Scaffolding is not adapter surface.** A fake public method with no counterpart on its real production adapter (or that adapter's Port) is in-memory test scaffolding (`add_issue`, `from_seed`, `seed_*`, `set_*`) — there is no real API call to record, so it is excluded via `_FAKE_REAL_SURFACE_SOURCES`.
+
+The genuine remaining github adapter-surface debt (real `PRManager` methods lacking cassettes, e.g. mutating `gh pr create`/`gh pr merge`) is **blocked on an isolated recording sandbox** (issue #9080); see "When to replace this pattern" and the negative consequence above re: live-recording credentials.
+
 ## When to replace this pattern
 
 If a service becomes so dynamic (e.g. non-idempotent responses, per-request IDs that can't be normalized) that cassettes can't faithfully capture it, the fake is no longer a valid test double. Options:

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-09T21:47:53.342399+00:00",
-  "commit_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66",
+  "regenerated_at": "2026-06-11T18:43:33.075064+00:00",
+  "commit_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3",
   "artifacts": {
     "loops.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ports.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "labels.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "modules.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "events.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "adr_xref.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "mockworld.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "changelog.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "coverage_matrix.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "functional_areas.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ubiquitous-language.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "62a66fbdaa556d0f4b5d39c5605d614bf8fe7c66"
+      "source_sha": "bc3049c66729359dc10eeae9353c7d3ebac724f3"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `bc3049c` — feat(dashboard): repo-qualify live worker/PR cards for repo=__all__ (Phase 4-b2) (#9390) (#9390) *(2026-06-09)*
 - `2f1c343` — feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a) (#9387) (#9387) *(2026-06-09)*
 - `b05bc76` — fix(dashboard): scope bare /api/sessions + pipeline-active to default repo (Phase 6) (#9386) (#9386) *(2026-06-09)*
 - `9a46933` — feat(atlas): ArticlesView + wiki entries scope by operated repo (Phase 5c-2) (#9385) (#9385) *(2026-06-09)*

--- a/docs/arch/generated/coverage_matrix.md
+++ b/docs/arch/generated/coverage_matrix.md
@@ -25,7 +25,7 @@ Regenerated from the live source tree. Cell vocabulary: ✅ covered, ⚠️ part
 | `EntryEvidenceLoop` | ✅ [0062, 0078] | ✅ [edge-proposer-loop.md, entry-evidence-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_entry_evidence_loop.py` | ✅ in catalog | ✅ `s24_entry_evidence_no_terms.py` |
 | `EpicMonitorLoop` | ✅ [0064, 0080, 0081] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_epic_monitor_loop.py` | ✅ in catalog | ✅ `s27_epic_monitor_no_epics.py` |
 | `EpicSweeperLoop` | ✅ [0080, 0081] | ✅ [architecture-async-control.md] | ✅ loops.md | ✅ README.md | ✅ `test_epic_sweeper_loop.py` | ✅ in catalog | ✅ `s23_epic_sweeper_no_epics.py` |
-| `FakeCoverageAuditorLoop` | ✅ [0045, 0056, 0057] | ✅ [fake-coverage-auditor-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
+| `FakeCoverageAuditorLoop` | ✅ [0045, 0047, 0056, 0057] | ✅ [fake-coverage-auditor-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_fake_coverage_auditor_loop.py` | ✅ in catalog | ✅ `s29_fake_coverage_auditor_clean.py` |
 | `FlakeTrackerLoop` | ✅ [0045, 0056, 0057, 0065] | ✅ [flake-tracker-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_flake_tracker_loop.py` | ✅ in catalog | ❌ |
 | `GateActivatorLoop` | ✅ [0082] | ❌ | ✅ loops.md | ❌ | ✅ `test_gate_activator_loop.py` | ✅ in catalog | ✅ `s45_gate_activator_no_proposals.py` |
 | `GitHubCacheLoop` | ✅ [0076] | ✅ [github-cache-loop.md] | ✅ loops.md | ✅ README.md | ✅ `test_github_cache_loop.py` | ✅ in catalog | ✅ `s44_github_cache_idle_poll.py` |

--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -2,14 +2,25 @@
 
 Spec: `docs/superpowers/specs/2026-04-22-trust-architecture-hardening-design.md`
 §4.7. Introspects fake classes under `src/mockworld/fakes/` via
-``ast.parse`` and compares two method sets to their coverage sources:
+``ast.parse`` and compares three method sets to their coverage sources:
 
-- ``adapter-surface`` — public non-private methods. Covered by a
-  cassette under ``tests/trust/contracts/cassettes/<adapter>/`` whose
-  ``input.command`` names the method.
-- ``test-helper`` — helpers the scenarios drive (``script_*``,
-  ``fail_service``, ``heal_service``, ``set_state``). Covered by a
-  scenario test under ``tests/scenarios/`` that calls the helper.
+- ``adapter-surface`` — public methods that exist on the fake's real
+  production counterpart (or its Port). Audited **only** for the
+  cassette-capable fakes in ``_FAKE_TO_CASSETTE_DIR`` (github/git/docker,
+  ADR-0047 scope). Covered by a cassette under
+  ``tests/trust/contracts/cassettes/<adapter>/`` whose ``input.command``
+  names the method.
+- ``test-helper`` — helpers the tests drive (``script_*``,
+  ``fail_service``, ``heal_service``, ``set_state``). Covered by any
+  test under ``tests/`` that calls the helper (unit or scenario).
+- ``scaffolding`` — public methods with **no real-adapter counterpart**
+  (in-memory builders/inspectors like ``add_issue``, ``from_seed``,
+  ``seed_*``). Ignored: there is no real API call to record against, so
+  flagging them is noise. Computed via ``_FAKE_REAL_SURFACE_SOURCES``.
+
+Fakes absent from ``_FAKE_TO_CASSETTE_DIR`` have no recordable cassette
+surface and are skipped for the adapter-surface audit entirely (they remain
+eligible for the test-helper audit). See ADR-0047 for the cassette scope.
 
 Files ``find_label`` + ``fake_coverage_gap_label`` + one of
 ``adapter_surface_label`` | ``test_helper_label`` per **rollup** —
@@ -79,8 +90,70 @@ def _is_helper(name: str, class_name: str = "") -> bool:
     return any(name.startswith(p) for p in _HELPER_PREFIXES) or name in _HELPER_NAMES
 
 
-def catalog_fake_methods(fake_dir: Path) -> dict[str, dict[str, list[str]]]:
+# Per-fake real-production-surface sources. A fake public method that is
+# neither a test-helper nor present on its real counterpart (or that
+# counterpart's Port protocol) is in-memory *scaffolding* — it has no
+# recordable real-API call, so the auditor must not treat it as an
+# un-cassetted adapter-surface gap (e.g. ``FakeGitHub.add_issue`` /
+# ``from_seed`` / ``seed_*`` build fake state, not gh calls). Each value is
+# a tuple of ``(module_stem, class_name)`` resolved under ``<repo>/src/``.
+# Only fakes whose surface contains such scaffolding need an entry; FakeGit
+# and FakeDocker surfaces are already clean via the helper carve-outs above.
+_FAKE_REAL_SURFACE_SOURCES: dict[str, tuple[tuple[str, str], ...]] = {
+    "FakeGitHub": (("pr_manager", "PRManager"), ("ports", "PRPort")),
+}
+
+
+def _public_methods_of_class(py_path: Path, class_name: str) -> set[str]:
+    """Return the public (non-underscore) method names of ``class_name`` in
+    ``py_path``. Empty set if the file or class is missing/unparseable."""
+    try:
+        tree = ast.parse(py_path.read_text(), filename=str(py_path))
+    except (OSError, SyntaxError):
+        return set()
+    for node in ast.iter_child_nodes(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return {
+                child.name
+                for child in node.body
+                if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef)
+                and not child.name.startswith("_")
+            }
+    return set()
+
+
+def _real_surface_for_fake(fake: str, repo_root: Path) -> set[str] | None:
+    """Union of public methods across ``fake``'s real-surface sources.
+
+    Returns ``None`` when the fake has no mapping *or* when none of its
+    source files resolve — the latter guard prevents a missing real adapter
+    (e.g. a synthetic test tree) from silently reclassifying the entire fake
+    surface as scaffolding.
+    """
+    sources = _FAKE_REAL_SURFACE_SOURCES.get(fake)
+    if not sources:
+        return None
+    src_dir = repo_root / "src"
+    union: set[str] = set()
+    resolved_any = False
+    for module_stem, class_name in sources:
+        methods = _public_methods_of_class(src_dir / f"{module_stem}.py", class_name)
+        if methods:
+            resolved_any = True
+            union |= methods
+    return union if resolved_any else None
+
+
+def catalog_fake_methods(
+    fake_dir: Path, repo_root: Path | None = None
+) -> dict[str, dict[str, list[str]]]:
     """AST-scan ``fake_dir/*.py`` for classes starting with ``Fake``.
+
+    When ``repo_root`` is given, fakes with a ``_FAKE_REAL_SURFACE_SOURCES``
+    entry have their non-helper publics split against the real production
+    surface: methods absent from it land in ``scaffolding`` (ignored by the
+    auditor) rather than ``adapter-surface``. Without ``repo_root`` (or when
+    the real adapter can't be resolved) the legacy split is preserved.
 
     Returns::
 
@@ -88,6 +161,7 @@ def catalog_fake_methods(fake_dir: Path) -> dict[str, dict[str, list[str]]]:
           "FakeGitHub": {
             "adapter-surface": ["create_issue", "close_issue", ...],
             "test-helper":     ["script_ci", "fail_service", ...],
+            "scaffolding":     ["add_issue", "from_seed", ...],
           },
           ...
         }
@@ -108,8 +182,14 @@ def catalog_fake_methods(fake_dir: Path) -> dict[str, dict[str, list[str]]]:
                 continue
             if not node.name.startswith("Fake"):
                 continue
+            real_surface = (
+                _real_surface_for_fake(node.name, repo_root)
+                if repo_root is not None
+                else None
+            )
             surface: list[str] = []
             helpers: list[str] = []
+            scaffolding: list[str] = []
             for child in node.body:
                 if not isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef):
                     continue
@@ -118,11 +198,14 @@ def catalog_fake_methods(fake_dir: Path) -> dict[str, dict[str, list[str]]]:
                     continue
                 if _is_helper(name, node.name):
                     helpers.append(name)
+                elif real_surface is not None and name not in real_surface:
+                    scaffolding.append(name)
                 else:
                     surface.append(name)
             catalog[node.name] = {
                 "adapter-surface": sorted(surface),
                 "test-helper": sorted(helpers),
+                "scaffolding": sorted(scaffolding),
             }
     return catalog
 
@@ -153,17 +236,21 @@ def catalog_cassette_methods(cassette_dir: Path) -> set[str]:
     return methods
 
 
-# Map from fake class name → cassette sub-directory.
+# Map from fake class name → cassette sub-directory. Scoped to the
+# cassette-*capable* adapters only: those with a real recorder in
+# ``src/contract_recording.py`` and a YAML cassette corpus under
+# ``tests/trust/contracts/cassettes/`` (ADR-0047 scope = github/git/docker;
+# claude is JSONL-stream contract-tested separately, not via this YAML
+# cassette-dir audit). Fakes absent from this map are *not* adapter-surface
+# audited — there is no recordable real-API surface to contract against, so
+# flagging their methods produced pure noise (FakeBeads/FakeSentry/FakeHTTP/
+# FakeSubprocessRunner/FakeFS/FakeLLM). They remain eligible for the
+# scenario-driven *test-helper* audit. See ADR-0047 "When to add a new
+# cassette" and the auditor right-sizing in fix/rightsize-fake-coverage-auditor.
 _FAKE_TO_CASSETTE_DIR: dict[str, str] = {
     "FakeGitHub": "github",
     "FakeDocker": "docker",
     "FakeGit": "git",
-    "FakeBeads": "beads",
-    "FakeSentry": "sentry",
-    "FakeHTTP": "http",
-    "FakeSubprocessRunner": "subprocess",
-    "FakeFS": "fs",
-    "FakeLLM": "llm",
 }
 
 
@@ -205,10 +292,18 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         return self._config.fake_coverage_auditor_interval
 
     async def _grep_scenario_for_helper(self, helper: str) -> bool:
-        """Return True iff ``tests/scenarios/`` contains a call to ``helper``."""
+        """Return True iff any test under ``tests/`` calls ``helper``.
+
+        A fake helper exercised by *any* test (unit or scenario) is part of
+        the working contract and not dead code — restricting the search to
+        ``tests/scenarios/`` produced false positives for helpers that are
+        legitimate unit-test fixtures (e.g. FakeLLM phase scripts driven by
+        ``tests/test_fake_llm_phase_scripts.py``; FakeAgent script helpers by
+        ``tests/test_fake_agent.py``). See the auditor right-sizing notes.
+        """
         repo = self._config.repo_root
-        scenario_dir = repo / "tests" / "scenarios"
-        if not scenario_dir.exists():
+        tests_dir = repo / "tests"
+        if not tests_dir.exists():
             return False
         cmd = [
             "rg",
@@ -216,7 +311,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
             "-l",
             "--fixed-strings",
             f"{helper}(",
-            str(scenario_dir),
+            str(tests_dir),
         ]
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -285,8 +380,8 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         lines = [
             "## Fake coverage gap — test helper",
             "",
-            f"Fake class `{fake}` exposes helpers that no scenario under "
-            f"`tests/scenarios/` invokes (grep-based search).",
+            f"Fake class `{fake}` exposes helpers that no test under "
+            f"`tests/` invokes (grep-based search).",
             "",
             f"**Unexercised helpers ({len(uncovered)}):**",
             "",
@@ -307,7 +402,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         lines.extend(
             [
                 "",
-                "**Repair:** add a scenario that calls each helper so it is "
+                "**Repair:** add a test that calls each helper so it is "
                 "part of the working contract. Spec §4.7; filed by "
                 "`fake_coverage_auditor` (#8986 rollup).",
                 "",
@@ -490,7 +585,7 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         repo = self._config.repo_root
         fake_dir = repo / "src" / "mockworld" / "fakes"
         cassette_root = repo / "tests" / "trust" / "contracts" / "cassettes"
-        catalog = catalog_fake_methods(fake_dir)
+        catalog = catalog_fake_methods(fake_dir, repo_root=repo)
         if not catalog:
             return {"status": "no_fakes", "filed": 0}
 
@@ -507,10 +602,19 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         dedup = self._dedup.get()
         all_known: dict[str, list[str]] = {}
         for fake, sets in catalog.items():
-            surface_methods = sets["adapter-surface"]
             helper_methods = sets["test-helper"]
-            cassette_subdir = cassette_root / _FAKE_TO_CASSETTE_DIR.get(fake, "")
-            cassetted = catalog_cassette_methods(cassette_subdir)
+            # Only cassette-capable fakes (those in the registry) are
+            # adapter-surface audited. Unregistered fakes have no recordable
+            # real-API surface to contract against — skipping them avoids the
+            # cassette-root fallback that previously flagged every method.
+            registered = fake in _FAKE_TO_CASSETTE_DIR
+            if registered:
+                surface_methods = sets["adapter-surface"]
+                cassette_subdir = cassette_root / _FAKE_TO_CASSETTE_DIR[fake]
+                cassetted = catalog_cassette_methods(cassette_subdir)
+            else:
+                surface_methods = []
+                cassetted = set()
 
             covered: list[str] = []
             uncovered_surface: list[str] = []

--- a/tests/scenarios/test_fake_coverage_auditor_scenario.py
+++ b/tests/scenarios/test_fake_coverage_auditor_scenario.py
@@ -122,3 +122,39 @@ class TestFakeCoverageAuditor:
         assert "hydraflow-test-helper" in issue.labels
         assert "hydraflow-fake-coverage-gap" in issue.labels
         assert "hydraflow-find" in issue.labels
+
+    async def test_unregistered_fake_files_no_adapter_gap(self, tmp_path) -> None:
+        """A fake absent from _FAKE_TO_CASSETTE_DIR (no recordable cassette
+        surface) must not produce an adapter-surface gap — no cassette-root
+        fallback flagging every public method (auditor right-sizing)."""
+        world = MockWorld(tmp_path)
+
+        repo = tmp_path / "repo"
+        fake_dir = repo / "src" / "mockworld" / "fakes"
+        fake_dir.mkdir(parents=True)
+        # FakeBeads is not a cassette-capable adapter (no recorder/cassette dir).
+        (fake_dir / "fake_beads.py").write_text(
+            "class FakeBeads:\n"
+            "    async def claim(self, n): ...\n"
+            "    async def close(self, n): ...\n"
+        )
+        # A real github cassette dir exists; pre-fix this is what the root
+        # fallback scanned, flagging FakeBeads.claim/close as "uncovered".
+        (repo / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+            parents=True
+        )
+
+        _seed_ports(
+            world,
+            fake_coverage_reconcile_closed=AsyncMock(return_value=None),
+            fake_coverage_grep=AsyncMock(return_value=True),
+        )
+
+        await world.run_with_loops(["fake_coverage_auditor"], cycles=1)
+
+        assert (
+            await world.github.list_issues_by_label("hydraflow-adapter-surface") == []
+        )
+        assert (
+            await world.github.list_issues_by_label("hydraflow-fake-coverage-gap") == []
+        )

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -14,6 +14,7 @@ from base_background_loop import LoopDeps
 from config import HydraFlowConfig
 from events import EventBus
 from fake_coverage_auditor_loop import (
+    _FAKE_TO_CASSETTE_DIR,
     FakeCoverageAuditorLoop,
     _is_helper,
     catalog_cassette_methods,
@@ -822,3 +823,133 @@ async def test_helper_rollup_same_shape(loop_env, monkeypatch, tmp_path) -> None
     assert "3 methods" in title
     for helper in ("script_a", "script_b", "script_c"):
         assert helper in body
+
+
+# --- Right-sizing (fix/rightsize-fake-coverage-auditor) ----------------------
+# ADR-0047 scopes cassette contract testing to the adapters with a real
+# recorder in src/contract_recording.py (github/git/docker/claude). The
+# auditor must (1) only adapter-surface audit those cassette-capable fakes,
+# and (2) treat in-memory fake scaffolding (methods with no real-adapter
+# counterpart) as neither adapter-surface nor test-helper.
+
+
+def test_registry_contains_only_cassette_capable_adapters() -> None:
+    """Only adapters with a real recorder + YAML cassette dir are audited."""
+    assert set(_FAKE_TO_CASSETTE_DIR) == {"FakeGitHub", "FakeGit", "FakeDocker"}
+
+
+def test_catalog_drops_scaffolding_via_real_adapter(tmp_path: Path) -> None:
+    """A FakeGitHub public method absent from the real PRManager/PRPort surface
+    is scaffolding, not adapter-surface — it has no recordable gh counterpart."""
+    src = tmp_path / "src"
+    fake_dir = src / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (src / "pr_manager.py").write_text(
+        "class PRManager:\n"
+        "    async def create_issue(self, title, body, labels): ...\n"
+        "    async def close_issue(self, n): ...\n"
+        "    async def ensure_labels_exist(self, labels): ...\n"
+    )
+    (src / "ports.py").write_text(
+        "class PRPort:\n    async def create_issue(self, title, body, labels): ...\n"
+    )
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def create_issue(self, title, body, labels): ...\n"
+        "    async def close_issue(self, n): ...\n"
+        "    async def ensure_labels_exist(self, labels): ...\n"
+        "    def add_issue(self, issue): ...\n"
+        "    def from_seed(self, seed): ...\n"
+        "    def script_ci(self, events): ...\n"
+    )
+
+    cat = catalog_fake_methods(fake_dir, repo_root=tmp_path)
+
+    assert set(cat["FakeGitHub"]["adapter-surface"]) == {
+        "create_issue",
+        "close_issue",
+        "ensure_labels_exist",
+    }
+    assert set(cat["FakeGitHub"]["scaffolding"]) == {"add_issue", "from_seed"}
+    assert set(cat["FakeGitHub"]["test-helper"]) == {"script_ci"}
+
+
+def test_catalog_real_adapter_filter_skips_when_adapter_missing(
+    tmp_path: Path,
+) -> None:
+    """If the real adapter module can't be resolved, fall back to legacy
+    classification rather than nuking the whole surface to scaffolding."""
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_github.py").write_text(
+        "class FakeGitHub:\n"
+        "    async def create_issue(self, title): ...\n"
+        "    def add_issue(self, issue): ...\n"
+    )
+    # No src/pr_manager.py or src/ports.py under repo_root → no filtering.
+    cat = catalog_fake_methods(fake_dir, repo_root=tmp_path)
+    assert set(cat["FakeGitHub"]["adapter-surface"]) == {"create_issue", "add_issue"}
+    assert cat["FakeGitHub"]["scaffolding"] == []
+
+
+async def test_do_work_skips_adapter_surface_for_unregistered_fake(
+    loop_env, monkeypatch, tmp_path
+) -> None:
+    """A fake absent from _FAKE_TO_CASSETTE_DIR is not adapter-surface audited
+    (no cassette-root fallback that would flag every public method)."""
+    cfg, state, pr, dedup = loop_env
+    fake_dir = tmp_path / "src" / "mockworld" / "fakes"
+    fake_dir.mkdir(parents=True)
+    (fake_dir / "fake_beads.py").write_text(
+        "class FakeBeads:\n"
+        "    async def claim(self, n): ...\n"
+        "    async def close(self, n): ...\n"
+    )
+    # A real github cassette dir exists, but FakeBeads is unregistered.
+    (tmp_path / "tests" / "trust" / "contracts" / "cassettes" / "github").mkdir(
+        parents=True
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    async def fake_reconcile():
+        return None
+
+    async def fake_grep(_helper):
+        return False
+
+    async def fake_list_titles():
+        return set()
+
+    monkeypatch.setattr(loop, "_reconcile_closed_escalations", fake_reconcile)
+    monkeypatch.setattr(loop, "_grep_scenario_for_helper", fake_grep)
+    monkeypatch.setattr(loop, "_list_open_rollup_titles", fake_list_titles)
+
+    stats = await loop._do_work()
+
+    assert stats["filed"] == 0
+    pr.create_issue.assert_not_called()
+
+
+async def test_helper_coverage_counts_any_test_not_just_scenarios(
+    loop_env, tmp_path
+) -> None:
+    """A helper exercised by a unit test (outside tests/scenarios/) is part of
+    the working contract — the auditor must treat it as covered."""
+    cfg, state, pr, dedup = loop_env
+    # A non-scenario unit test calls the helper; no tests/scenarios/ at all.
+    unit_tests = tmp_path / "tests"
+    unit_tests.mkdir(parents=True)
+    (unit_tests / "test_fake_llm_phase_scripts.py").write_text(
+        "def test_x():\n    fake.script_discover(['a'])\n"
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    assert await loop._grep_scenario_for_helper("script_discover") is True


### PR DESCRIPTION
## Summary

The `FakeCoverageAuditorLoop` (ADR-0047) was filing noisy `fake-coverage-gap` issues for fakes and methods that were never in the cassette system's scope. This right-sizes the auditor so its issues reflect **genuine** debt.

### What "cassette debt" is
Cassettes (ADR-0047) are recorded real-service interactions that prove the MockWorld fakes (`FakeGitHub`/`FakeGit`/`FakeDocker`) match the real `gh`/`git`/`docker` APIs — catching contract drift that mocks miss. The auditor flags fake methods lacking a cassette. The core mechanism is sound and stays; the **issue stream** was over-reaching.

### Three fixes
1. **Scope to cassette-capable adapters.** `_FAKE_TO_CASSETTE_DIR` narrows from 9 fakes → the 3 with a real recorder in `contract_recording.py` + a YAML cassette corpus (github/git/docker). `FakeBeads`/`FakeSentry`/`FakeHTTP`/`FakeSubprocessRunner`/`FakeFS`/`FakeLLM` have **no recorder** — flagging them was pure noise. Unregistered fakes are now skipped for the adapter-surface audit (removes the cassette-root-scan fallback that flagged every public method).
2. **Drop in-memory scaffolding.** A fake public method with no counterpart on its real production adapter (`PRManager`) or Port (`PRPort`) is test scaffolding (`add_issue`, `from_seed`, `seed_*`, `set_*`), not a recordable adapter surface. New `_FAKE_REAL_SURFACE_SOURCES` filters these. FakeGitHub adapter-surface: **63 → 49** genuine.
3. **Count any-test helper coverage.** The test-helper audit only grepped `tests/scenarios/`, false-flagging helpers that are legitimate unit-test fixtures (FakeLLM phase scripts, FakeAgent script helpers). Broadened to all of `tests/`.

### Genuine debt that remains
The 49 real `PRManager` methods still lacking cassettes (mostly mutating `gh` ops like `create_promotion_pr`/`merge_pr`/`push_branch`) are **genuine** debt, tracked on #9183, **blocked on the isolated recording sandbox (#9080)** — they can't be recorded safely today.

### Issues resolved (false positives)
Closing once merged: #9170 #9179 #9187 #9194 #9203 #9205 (adapter-surface noise — no recorder) and #9196 #9168 (test-helper noise — unit-test fixtures). #9183 trimmed to the 49 genuine + blocker note. #9080 / #8693 / #8699 stay open (real infra blockers).

### Verification
- `make quality` (lint + pyright + bandit + 15949 tests) — green after `make arch-regen` (coverage_matrix now links the auditor to ADR-0047; `.meta.json`/`changelog.md` were pre-existing drift, now in sync)
- `make scenario` (189) · `make scenario-loops` (126) · `make audit` (PASS 90 / FAIL 0)
- New tests: unit (scaffolding split, registry gating, any-test helper grep) + scenario (unregistered fake files no gap)
- Design adversarially verified by a multi-agent workflow (one "design-flawed" verdict was a false alarm — agent misread `PRManager ∪ PRPort` as PRPort-only; all 7 flagged methods empirically confirmed kept)

Updates ADR-0047 with the auditor-scope section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Resolves #9170
Resolves #9179
Resolves #9187
Resolves #9194
Resolves #9203
Resolves #9205
Resolves #9196
Resolves #9168

Tracked (NOT resolved here): #9183 (genuine, trimmed to 49, blocked by #9080), #9080, #8693, #8699.
