### PR TITLE
fix(trust): fall back to stdlib scan when ripgrep absent (un-red staging after #9403)

### DIFF
--- a/src/fake_coverage_auditor_loop.py
+++ b/src/fake_coverage_auditor_loop.py
@@ -39,6 +39,7 @@ import ast
 import asyncio
 import json
 import logging
+import shutil
 import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING
@@ -305,22 +306,35 @@ class FakeCoverageAuditorLoop(BaseBackgroundLoop):
         tests_dir = repo / "tests"
         if not tests_dir.exists():
             return False
-        cmd = [
-            "rg",
-            "--type=py",
-            "-l",
-            "--fixed-strings",
-            f"{helper}(",
-            str(tests_dir),
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, _ = await proc.communicate()
-        # rg exits 0 on match, 1 on no-match, 2+ on error.
-        return proc.returncode == 0 and bool(stdout.strip())
+        needle = f"{helper}("
+        if shutil.which("rg") is not None:
+            cmd = [
+                "rg",
+                "--type=py",
+                "-l",
+                "--fixed-strings",
+                needle,
+                str(tests_dir),
+            ]
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await proc.communicate()
+            # rg exits 0 on match, 1 on no-match, 2+ on error.
+            return proc.returncode == 0 and bool(stdout.strip())
+
+        # Fallback when ripgrep isn't on PATH (e.g. CI runners, or a deploy
+        # host without it) — a stdlib scan with identical fixed-string
+        # semantics, run off the event loop so the file walk doesn't block it.
+        def _scan() -> bool:
+            return any(
+                needle in path.read_text(encoding="utf-8", errors="ignore")
+                for path in tests_dir.rglob("*.py")
+            )
+
+        return await asyncio.to_thread(_scan)
 
     def _render_surface_body(
         self,

--- a/tests/test_fake_coverage_auditor_loop.py
+++ b/tests/test_fake_coverage_auditor_loop.py
@@ -953,3 +953,28 @@ async def test_helper_coverage_counts_any_test_not_just_scenarios(
     )
 
     assert await loop._grep_scenario_for_helper("script_discover") is True
+
+
+@pytest.mark.asyncio
+async def test_grep_helper_uses_stdlib_fallback_when_ripgrep_absent(
+    loop_env, tmp_path, monkeypatch
+) -> None:
+    """With ripgrep off PATH (CI runners, bare deploy hosts), the helper search
+    falls back to a stdlib scan with the same fixed-string semantics."""
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    cfg, state, pr, dedup = loop_env
+    unit_tests = tmp_path / "tests"
+    unit_tests.mkdir(parents=True)
+    (unit_tests / "test_fake_agent.py").write_text(
+        "def test_x():\n    fake.script_ci(['ok'])\n"
+    )
+
+    stop = asyncio.Event()
+    loop = FakeCoverageAuditorLoop(
+        config=cfg, state=state, pr_manager=pr, dedup=dedup, deps=_deps(stop)
+    )
+
+    # Present in a unit test → found via the fallback; absent → not found.
+    assert await loop._grep_scenario_for_helper("script_ci") is True
+    assert await loop._grep_scenario_for_helper("never_called_helper") is False


### PR DESCRIPTION
## Why

**Staging is currently red.** #9403 (`dc7e09b5`, the staging tip) merged `FakeCoverageAuditorLoop._grep_scenario_for_helper` calling `rg` (ripgrep) unconditionally, plus a test (`test_helper_coverage_counts_any_test_not_just_scenarios`) that exercises the real method. The **CI/Tests** runner has no ripgrep, so the test raised `FileNotFoundError: [Errno 2] No such file or directory: 'rg'` and turned the staging `CI` workflow **failure**.

The gap slipped through because the **Quality** workflow runner *does* have `rg` (so `make quality` stayed green) — only the leaner CI/Tests image lacks it.

## What

- Guard the `rg` fast path behind `shutil.which("rg")` and fall back to a stdlib scan with **identical fixed-string semantics** (`f"{helper}("` substring match over `tests/**/*.py`), run off the event loop via `asyncio.to_thread` so the file walk doesn't block it.
- This also hardens the loop for **production**: a deploy host without ripgrep would have crashed the loop identically, not just CI.

## Tests

- New `test_grep_helper_uses_stdlib_fallback_when_ripgrep_absent` monkeypatches `shutil.which` → `None` and asserts the fallback finds a helper called from a unit test (and returns `False` for an absent helper) — deterministic regardless of whether the host has `rg`.
- Full `tests/test_fake_coverage_auditor_loop.py` green locally (28 passed); ruff + pyright clean.

Follow-up to #9403. Un-reds the staging `CI` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)