### PR TITLE
fix(adr-drift): symbol-qualify owned ADR citations + pr_manager shared-infra

### DIFF
--- a/docs/adr/0005-pr-recovery-and-zero-diff-branch-handling.md
+++ b/docs/adr/0005-pr-recovery-and-zero-diff-branch-handling.md
@@ -46,6 +46,9 @@ issues with `hydraflow-review` plus an open PR.
 
 ## Related
 
-- `src/implement_phase.py`
-- `src/pr_manager.py`
+- `src/implement_phase.py:ImplementPhase._resolve_pr` — PR recovery by branch (reuse an already-open PR)
+- `src/implement_phase.py:ImplementPhase._handle_successful_push` — enforce implement→review contract (no review without a valid PR)
+- `src/implement_phase.py:ImplementPhase._handle_no_pr_fallback` — branch diff guard (`ahead_by == 0`)
+- `src/implement_phase.py:ImplementPhase._handle_zero_commits` — zero-diff branch resolution
+- `src/pr_manager.py` — `find_open_pr_for_branch` / `branch_has_diff_from_main` helpers (shared-infra dependency)
 - PR #1294

--- a/docs/adr/0018-screenshot-capture-pipeline.md
+++ b/docs/adr/0018-screenshot-capture-pipeline.md
@@ -138,7 +138,7 @@ inadvertently contains sensitive information.
 - `src/ui/src/components/Header.jsx` — `captureDashboardScreenshot()`, `redactSensitiveElements()`
 - `src/ui/src/components/ReportIssueModal.jsx` — annotation canvas and submission
 - `src/ui/src/constants.js` — `SENSITIVE_SELECTORS`
-- `src/report_issue_loop.py` — `ReportIssueLoop._do_work()`
-- `src/screenshot_scanner.py` — `scan_base64_for_secrets()`
-- `src/pr_manager.py` — `PRManager.upload_screenshot_gist()`
-- `src/config.py` — `screenshot_redaction_enabled`, `screenshot_gist_public`
+- `src/report_issue_loop.py:ReportIssueLoop._do_work` — report-issue intake/orchestration
+- `src/screenshot_scanner.py:scan_base64_for_secrets` — backend secret scan (defense layer 3)
+- `src/pr_manager.py:PRManager.upload_screenshot_gist` — gist visibility control (defense layer 4)
+- `src/config.py:screenshot_redaction_enabled`, `src/config.py:screenshot_gist_public` — redaction + gist-visibility flags

--- a/docs/adr/0032-per-repo-wiki-knowledge-base.md
+++ b/docs/adr/0032-per-repo-wiki-knowledge-base.md
@@ -16,7 +16,7 @@ Andrej Karpathy's "LLM Knowledge Base" pattern proposes an alternative: instead 
 - `src/wiki_compiler.py:WikiCompiler` — LLM synthesis (compile_topic, synthesize_ingest)
 - `src/repo_wiki_loop.py:RepoWikiLoop` — background maintenance loop
 - `src/base_runner.py:_inject_repo_wiki` — prompt injection into all runners
-- `src/hindsight.py` — existing vector-search memory (complementary, not replaced)
+- Hindsight (`src/hindsight*`) — existing vector-search memory (complementary, not replaced; external integration, no first-party module)
 
 ## Decision
 
@@ -36,7 +36,7 @@ Adopt a file-based, per-repo wiki system with three layers:
 
 - **Active self-healing lint**: The background loop marks entries stale when their source issues close (via `StateTracker` outcomes), prunes entries older than 90 days, and rebuilds the index. The wiki degrades gracefully without manual curation.
 
-- **Drift detection (two layers)**: A deterministic pass (`wiki_drift_detector.detect_drift`) flags entries whose `src/path.py:Symbol` citations point at files or symbols that no longer exist — cheap, side-effect-free, and auto-marks stale. An optional LLM layer (`scan_semantic_drift`, gated by `semantic_drift_enabled`) asks the compilation model whether an entry's CLAIM still matches the current source for entries older than `semantic_drift_min_age_days`, capped at `semantic_drift_max_entries_per_tick` per loop tick. Semantic findings are logged for human review; only the deterministic layer auto-stales.
+- **Drift detection (two layers)**: A deterministic pass (`wiki_drift_detector.detect_drift`) flags entries whose `src/<module>.py:<Symbol>` citations point at files or symbols that no longer exist — cheap, side-effect-free, and auto-marks stale. An optional LLM layer (`scan_semantic_drift`, gated by `semantic_drift_enabled`) asks the compilation model whether an entry's CLAIM still matches the current source for entries older than `semantic_drift_min_age_days`, capped at `semantic_drift_max_entries_per_tick` per loop tick. Semantic findings are logged for human review; only the deterministic layer auto-stales.
 
 - **Depth signals (corroborations + temporal tags)**: every active entry carries a `corroborations` counter in its frontmatter (default 1). `WikiCompiler.dedup_or_corroborate` uses `generalize_pair` to decide whether a newly-ingested entry is a re-discovery of an existing active entry and returns a `CorroborationDecision` carrying the canonical's file path; callers then use `increment_corroboration(path)` to atomically bump the counter instead of writing a sibling duplicate. On the read path, `RepoWikiStore.query_with_tags` returns a `{title: temporal_tag}` map alongside the markdown, and `BaseRunner._inject_repo_wiki` weaves the tags inline as italic lines under each entry — so the planner/reviewer sees `### Always use factories\n*(stable for 6 months (+4))*`. Tag vocabulary: `recently added` (<30d), `stable for N months`, `stable for N year(s)`, `age unknown`; `(+N)` suffix when corroborations > 1. Addresses two depth gaps vs. agentic-memory systems: evidence-weighting and temporal reasoning about when claims settled.
 

--- a/docs/adr/0056-adr-touchpoint-gate-to-caretaker-loop.md
+++ b/docs/adr/0056-adr-touchpoint-gate-to-caretaker-loop.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-05-06
 - **Supersedes:** none (the gate it replaces was a piece of CI tooling, not an ADR-blessed decision)
 - **Superseded by:** none
-- **Related:** [ADR-0029](0029-caretaker-loop-pattern.md) (caretaker-loop pattern), [ADR-0045](0045-trust-architecture-hardening.md) (trust-architecture hardening, which originally floated `Skip-ADR:` as a convention). Code: `src/adr_touchpoint_auditor_loop.py`, `src/adr_drift.py`, `src/state/_adr_audit.py`.
+- **Related:** [ADR-0029](0029-caretaker-loop-pattern.md) (caretaker-loop pattern), [ADR-0045](0045-trust-architecture-hardening.md) (trust-architecture hardening, which originally floated `Skip-ADR:` as a convention). Code: `src/adr_touchpoint_auditor_loop.py:AdrTouchpointAuditorLoop`, `src/adr_drift.py:compute_drift`, `src/state/_adr_audit.py:AdrAuditStateMixin`.
 - **Enforced by:** `tests/test_adr_touchpoint_auditor_loop.py`, `tests/test_adr_drift.py`, `tests/test_loop_wiring_completeness.py` (auto-discovery confirms the loop is wired in all 5 checkpoints).
 
 ## Context

--- a/docs/adr/0056-label-drift-caretaker-loop.md
+++ b/docs/adr/0056-label-drift-caretaker-loop.md
@@ -4,7 +4,7 @@
 - **Date:** 2026-05-07
 - **Supersedes:** none
 - **Superseded by:** none
-- **Related:** [ADR-0002](0002-labels-as-state-machine.md) (label state machine), [ADR-0029](0029-caretaker-loop-pattern.md) (caretaker-loop pattern), [ADR-0049](0049-trust-loop-kill-switch-convention.md) (kill-switch convention). Code: `src/label_drift_watcher_loop.py`, `src/pr_manager.py` (`find_label_drift`), `src/models.py` (`LabelDrift`).
+- **Related:** [ADR-0002](0002-labels-as-state-machine.md) (label state machine), [ADR-0029](0029-caretaker-loop-pattern.md) (caretaker-loop pattern), [ADR-0049](0049-trust-loop-kill-switch-convention.md) (kill-switch convention). Code: `src/label_drift_watcher_loop.py:LabelDriftWatcherLoop`, `src/pr_manager.py` (`find_label_drift`; shared-infra dependency), `src/models.py:LabelDrift`.
 
 ## Context
 

--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-11T18:58:37.525278+00:00",
-  "commit_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677",
+  "regenerated_at": "2026-06-11T19:55:13.573535+00:00",
+  "commit_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4",
   "artifacts": {
     "loops.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "ports.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "labels.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "modules.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "events.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "adr_xref.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "mockworld.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "changelog.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "coverage_matrix.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "functional_areas.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "ubiquitous-language.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "96310e4b4fa992a67accd6da666aeeddce5c0677"
+      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
     }
   }
 }

--- a/docs/arch/generated/adr_xref.md
+++ b/docs/arch/generated/adr_xref.md
@@ -38,7 +38,7 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | ADR-0029 | — |
 | ADR-0030 | `src.dashboard_routes._routes` |
 | ADR-0031 | `src.config`, `src.discover_phase`, `src.discover_runner`, `src.models`, `src.plan_phase`, `src.review_phase`, `src.shape_phase`, `src.shape_runner`, `src.triage_phase` |
-| ADR-0032 | `src.base_runner`, `src.hindsight`, `src.path`, `src.repo_wiki`, `src.repo_wiki_loop`, `src.wiki_compiler` |
+| ADR-0032 | `src.base_runner`, `src.repo_wiki`, `src.repo_wiki_loop`, `src.wiki_compiler` |
 | ADR-0033 | `src.adr_reviewer`, `src.config` |
 | ADR-0034 | `src.adr_reviewer`, `src.config` |
 | ADR-0035 | `src.config` |
@@ -159,7 +159,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.hf_cli.__main__` | ADR-0036 |
 | `src.hf_cli.supervisor_client` | ADR-0007 |
 | `src.hf_cli.supervisor_service` | ADR-0006, ADR-0007, ADR-0008 |
-| `src.hindsight` | ADR-0032 |
 | `src.implement_phase` | ADR-0005, ADR-0014, ADR-0024, ADR-0063 |
 | `src.issue_cache` | ADR-0041 |
 | `src.issue_fetcher` | ADR-0019, ADR-0067 |
@@ -176,7 +175,6 @@ Bidirectional index between ADRs and the source modules they cite. Powers "Why t
 | `src.mockworld.sandbox_main` | ADR-0052 |
 | `src.models` | ADR-0011, ADR-0012, ADR-0013, ADR-0014, ADR-0015, ADR-0016, ADR-0025, ADR-0031, ADR-0037, ADR-0045, ADR-0050, ADR-0056, ADR-0064 |
 | `src.orchestrator` | ADR-0006, ADR-0009, ADR-0014, ADR-0044, ADR-0045 |
-| `src.path` | ADR-0032 |
 | `src.pending_concerns` | ADR-0064 |
 | `src.plan_council` | ADR-0064 |
 | `src.plan_council_prompts` | ADR-0064 |

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,12 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `96310e4` — fix(trust): right-size FakeCoverageAuditorLoop to cassette-capable adapters *(2026-06-11)*
+- `dc7e09b` — fix(trust): right-size FakeCoverageAuditorLoop to cassette-capable adapters (#9403) (#9403) *(2026-06-11)*
+- `d0ad6db` — fix(dashboard): aggregate /api/timeline* under __all__, repo-tag each item (#9402) (#9402) *(2026-06-11)*
+- `0f9b7fa` — fix(dashboard): aggregate /api/metrics/github under __all__; tag single-repo workers with canonical slug (#9399) (#9399) *(2026-06-10)*
+- `58bf543` — fix(dashboard): route intent + request-changes to the selected/row repo; clear repo-scoped state on switch (#9398) (#9398) *(2026-06-10)*
+- `a0d630c` — test(dashboard): MockWorld scenarios for Phase 2/3 aggregate endpoints (#9392) (#9392) *(2026-06-09)*
+- `56bb8a8` — test(dashboard): multi-repo aggregation e2e + MockWorld scenarios (Phase 4-c) (#9391) (#9391) *(2026-06-09)*
 - `bc3049c` — feat(dashboard): repo-qualify live worker/PR cards for repo=__all__ (Phase 4-b2) (#9390) (#9390) *(2026-06-09)*
 - `2f1c343` — feat(dashboard): merged WebSocket + /api/events backfill for repo=__all__ (Phase 4-a) (#9387) (#9387) *(2026-06-09)*
 - `b05bc76` — fix(dashboard): scope bare /api/sessions + pipeline-active to default repo (Phase 6) (#9386) (#9386) *(2026-06-09)*

--- a/src/adr_drift.py
+++ b/src/adr_drift.py
@@ -57,23 +57,27 @@ def _split_path_symbol(entry: str) -> tuple[str, str | None]:
     return entry, None
 
 
-# Cross-cutting infrastructure modules — bare-cited (file-granular) by ≥5
-# Accepted ADRs as of 2026-06: the config dataclass, shared Pydantic models,
-# the Port protocols, and the post-merge handler. Every feature touches these,
-# so a file-level touch is implementation churn, not a semantic change to any
-# one ADR's decision. They are the dominant source of ADR-drift false positives
-# (e.g. src/config.py absorbed ~20 merged PRs in two weeks, tripping every ADR
-# that lists it as a dependency). #9176 already suppressed the symbol-cited
-# case; this handles the residual *bare-cited* case for these shared modules.
-# An ADR that genuinely owns one of these must cite the specific symbol
-# (``src/config.py:HydraFlowConfig``) to drift — a bare citation is read as a
-# dependency mention and does not drift.
+# Cross-cutting infrastructure modules — bare-cited (file-granular) as a
+# *dependency* by many Accepted ADRs: the config dataclass, shared Pydantic
+# models, the Port protocols, the post-merge handler, and the GitHub PR/issue
+# port wrapper. Every feature touches these, so a file-level touch is
+# implementation churn, not a semantic change to any one ADR's decision. They
+# are the dominant source of ADR-drift false positives (e.g. src/config.py
+# absorbed ~20 merged PRs in two weeks, and src/pr_manager.py is bare-cited by
+# ADR-0005/0018/0045/0056 while changing on nearly every PR that files an issue
+# or PR). #9176 already suppressed the symbol-cited case; #9397 added the first
+# four modules here for the residual *bare-cited* case; pr_manager.py joins them
+# as the next-highest-churn dependency. An ADR that genuinely owns one of these
+# must cite the specific symbol (``src/config.py:HydraFlowConfig``,
+# ``src/pr_manager.py:PRManager.upload_screenshot_gist``) to drift — a bare
+# citation is read as a dependency mention and does not drift.
 _SHARED_INFRA_MODULES = frozenset(
     {
         "src/config.py",
         "src/models.py",
         "src/ports.py",
         "src/post_merge_handler.py",
+        "src/pr_manager.py",
     }
 )
 

--- a/tests/test_adr_drift.py
+++ b/tests/test_adr_drift.py
@@ -153,6 +153,49 @@ def test_bare_citation_of_shared_infra_module_does_not_drift(tmp_path: Path) -> 
     assert findings == []
 
 
+def test_bare_citation_of_pr_manager_does_not_drift(tmp_path: Path) -> None:
+    # src/pr_manager.py is the GitHub PR/issue port wrapper — bare-cited as a
+    # dependency by ADR-0005/0018/0045/0056 and touched by nearly every PR that
+    # files an issue or PR. It is shared-infra: a file-level touch must NOT drift
+    # (the residual false-positive source after #9397; resolves the stuck
+    # ADR-0005/0018/0056 drift escalations). Owning a pr_manager symbol still
+    # requires a :Symbol citation to drift (see test below).
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=53,
+        title="depends on pr_manager",
+        status="Accepted",
+        related_files=["src/pr_manager.py"],
+    )
+    findings = compute_drift(
+        ADRIndex(adr_dir), pr_number=1, changed_files=["src/pr_manager.py"]
+    )
+    assert findings == []
+
+
+def test_symbol_citation_of_pr_manager_still_drifts(tmp_path: Path) -> None:
+    # An ADR that genuinely owns a pr_manager symbol (e.g. ADR-0018 cites
+    # PRManager.upload_screenshot_gist) still drifts when that symbol changes.
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=54,
+        title="owns a pr_manager symbol",
+        status="Accepted",
+        related_files=["src/pr_manager.py:PRManager.upload_screenshot_gist"],
+    )
+    findings = compute_drift(
+        ADRIndex(adr_dir),
+        pr_number=1,
+        changed_files=["src/pr_manager.py:PRManager.upload_screenshot_gist"],
+    )
+    assert len(findings) == 1
+    assert findings[0].adr.number == 54
+
+
 def test_symbol_citation_of_shared_infra_module_still_drifts(tmp_path: Path) -> None:
     # An ADR that genuinely owns a shared-infra symbol cites it at :Symbol
     # granularity and still drifts when that symbol changes.


### PR DESCRIPTION
## Problem

`AdrTouchpointAuditorLoop` (ADR-0056) kept re-filing drift for **ADR-0002/0005/0018/0032/0056**, producing the stuck 3-strike HITL escalations **#9304/#9305/#9307/#9308/#9309** and the trust-loop `issues_per_hour` anomaly **#9222** (29 issues/hr vs threshold 10).

`#9256` (symbol-aware drift) and `#9397` (shared-infra exemption for `config`/`models`/`ports`/`post_merge_handler`) fixed most of the false-positive storm. But five ADRs still **bare-cited real, high-churn modules**, so simply closing the HITL issues would only clear the dedup key (via `_reconcile_closed_escalations`) and let the auditor **re-fire on the next merged PR** touching those files.

## Root cause per ADR (verified against the real `adr_index` parser + `compute_drift`)

| ADR | Before | Why it (re-)drifted |
|---|---|---|
| 0002 | symbol-cited only | already clean (resolved by #9256) — no change needed |
| 0005 | bare `implement_phase.py`, `pr_manager.py` | both real & high-churn → re-drift |
| 0018 | bare `report_issue_loop.py`, `screenshot_scanner.py`, `pr_manager.py` | symbols named in prose but as **separate** backtick spans → parser read them as bare |
| 0032 | bare `src/hindsight.py` (no such module) + `src/path.py:Symbol` doc-example | dead/junk citations leaking into the index |
| 0056 | bare `adr_drift.py`, `adr_touchpoint_auditor_loop.py`, `state/_adr_audit.py`, `label_drift_watcher_loop.py`, `pr_manager.py` | the auditor's own high-churn code |

## Fix (matches the #9397 design intent: *"an ADR that genuinely owns one of these must cite the specific symbol; a bare citation is a dependency mention and does not drift"*)

- **`src/pr_manager.py` → `_SHARED_INFRA_MODULES`.** It's the GitHub PR/issue port wrapper, bare-cited as a *dependency* by ADR-0005/0018/0045/0056 and the highest-churn remaining false-positive source. Symbol-cited ownership (e.g. ADR-0018's `upload_screenshot_gist`) still drifts.
- **Symbol-qualify the genuinely-owned coarse citations** the authors had already named in prose: ADR-0005 implement-phase handlers (`_resolve_pr`/`_handle_successful_push`/`_handle_no_pr_fallback`/`_handle_zero_commits`), ADR-0018 screenshot symbols, ADR-0056 (both files) loop/drift/state symbols.
- **ADR-0032 cleanup:** drop the dead `src/hindsight.py` citation and the `src/path.py:<Symbol>` doc-example.

## Verification

- Real-parser harness: **all five ADRs now report zero file-only drift**; no bare non-infra citations remain in any edited ADR.
- `make quality`: **15986 passed, 0 failed**.
- `scenario_loops` auditor scenario (6) + `tests/regressions/test_issue_9176.py` + 2 new `test_adr_drift.py` unit tests: green.
- `make arch-regen` run; `docs/arch/generated/adr_xref.md` updated (ADR-0032 drops `src.hindsight`/`src.path`).

## Follow-up (filed separately, not in scope here)

Five **duplicate ADR-number collisions** surfaced while parsing: ADR-**0043/0056/0057/0059/0064** are each claimed by two different ADR files, which corrupts the index (`adrs_touching` merges their citations, ambiguous titles). Filed as a `hydraflow-find` for renumbering — it needs cross-reference updates and is riskier than this drift fix.

Addresses the root cause behind #9304 / #9305 / #9307 / #9308 / #9309 / #9222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)