### PR TITLE
fix(control): factory Start brings up the host line only (not every repo)

### DIFF
--- a/src/dashboard_routes/_control_routes.py
+++ b/src/dashboard_routes/_control_routes.py
@@ -451,15 +451,24 @@ def register(router: APIRouter, ctx: RouteContext) -> None:  # noqa: PLR0915
 
     @router.post("/api/control/start")
     async def start_orchestrator() -> JSONResponse:
-        """Start the entire factory — the host orchestrator and every line.
+        """Start the factory — the host line only.
 
-        The factory-level Start starts every registered repo runtime
-        (``registry.start_all``), including the host. Starting a single line
-        is handled by ``POST /api/runtimes/{slug}/start``.
+        The factory-level Start brings up the **host** orchestrator line and
+        nothing else. Registered repos are independent factory lines that the
+        operator turns on individually via ``POST /api/runtimes/{slug}/start``
+        once the factory is running — the factory runs fine with zero repos and
+        must never force them all on. (Previously this called
+        ``registry.start_all`` and booted every registered repo.)
         """
         registry = ctx.registry
         if registry is not None:
-            await registry.start_all()
+            host_rt = registry.get(ctx._default_slug())
+            if host_rt is None:
+                return JSONResponse(
+                    {"error": "No host runtime registered"}, status_code=501
+                )
+            if not host_rt.running:
+                await host_rt.start()
             await ctx.event_bus.publish(
                 HydraFlowEvent(
                     type=EventType.ORCHESTRATOR_STATUS,

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -833,61 +833,71 @@ class HydraFlowOrchestrator:
         """
         self._stop_event.clear()
         self._running = True
-        self._restore_state()
-        await self._publish_status()
-        logger.info(
-            "HydraFlow starting — repo=%s label=%s workers=%d poll=%ds pipeline=%s",
-            self._config.repo,
-            ",".join(self._config.ready_label),
-            self._config.max_workers,
-            self._config.poll_interval,
-            "enabled" if self._pipeline_enabled else "paused",
-        )
-
-        # Only initialize the repo and create a session when the pipeline
-        # is enabled.  When pipeline_enabled=False (dashboard mode), the
-        # orchestrator only runs background workers — no issue fetching,
-        # no repo sanitization, no session.
         try:
-            import sentry_sdk as _sentry  # noqa: PLC0415
-        except ImportError:
-            pass
-        else:
-            try:
-                _sentry.set_tag("hydraflow.repo", self._config.repo or "")
-            except Exception as exc:  # noqa: BLE001
-                logger.debug("sentry_sdk.set_tag failed: %s", exc)
-
-        session_started = False
-        if self._pipeline_enabled:
-            # Concrete-only setup methods — not on Port. See _deferred_pipeline_start.
-            workspaces: WorkspaceManager = cast(
-                "WorkspaceManager", self._svc.workspaces
-            )
-            prs: PRManager = cast("PRManager", self._svc.prs)
-            await workspaces.sanitize_repo()
-            await prs.ensure_labels_exist()
-            await workspaces.enable_rerere()
-            self._warn_if_agents_md_missing()
-            await self._start_session()
-            session_started = True
-
-        try:
-            await self._supervise_loops()
-        finally:
-            if session_started:
-                await self._end_session()
-            self._svc.planners.terminate()
-            self._svc.agents.terminate()
-            self._svc.reviewers.terminate()
-            self._svc.hitl_runner.terminate()
-            with contextlib.suppress(Exception):
-                # Same concrete-only narrowing as the bootstrap above.
-                await cast("WorkspaceManager", self._svc.workspaces).sanitize_repo()
-            await asyncio.sleep(0)
-            self._running = False
+            self._restore_state()
             await self._publish_status()
-            logger.info("HydraFlow stopped")
+            logger.info(
+                "HydraFlow starting — repo=%s label=%s workers=%d poll=%ds pipeline=%s",
+                self._config.repo,
+                ",".join(self._config.ready_label),
+                self._config.max_workers,
+                self._config.poll_interval,
+                "enabled" if self._pipeline_enabled else "paused",
+            )
+
+            # Only initialize the repo and create a session when the pipeline
+            # is enabled.  When pipeline_enabled=False (dashboard mode), the
+            # orchestrator only runs background workers — no issue fetching,
+            # no repo sanitization, no session.
+            try:
+                import sentry_sdk as _sentry  # noqa: PLC0415
+            except ImportError:
+                pass
+            else:
+                try:
+                    _sentry.set_tag("hydraflow.repo", self._config.repo or "")
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("sentry_sdk.set_tag failed: %s", exc)
+
+            session_started = False
+            if self._pipeline_enabled:
+                # Concrete-only setup methods — not on Port. See _deferred_pipeline_start.
+                workspaces: WorkspaceManager = cast(
+                    "WorkspaceManager", self._svc.workspaces
+                )
+                prs: PRManager = cast("PRManager", self._svc.prs)
+                await workspaces.sanitize_repo()
+                await prs.ensure_labels_exist()
+                await workspaces.enable_rerere()
+                self._warn_if_agents_md_missing()
+                await self._start_session()
+                session_started = True
+
+            try:
+                await self._supervise_loops()
+            finally:
+                if session_started:
+                    await self._end_session()
+                self._svc.planners.terminate()
+                self._svc.agents.terminate()
+                self._svc.reviewers.terminate()
+                self._svc.hitl_runner.terminate()
+                with contextlib.suppress(Exception):
+                    # Same concrete-only narrowing as the bootstrap above.
+                    await cast("WorkspaceManager", self._svc.workspaces).sanitize_repo()
+                await asyncio.sleep(0)
+                self._running = False
+                await self._publish_status()
+                logger.info("HydraFlow stopped")
+        finally:
+            # Safety net: if run() is cancelled or raises during the setup
+            # phase above (before the supervise-loops try-block), the inner
+            # finally never executes and the line would stay stuck reporting
+            # running=True forever — a stopped factory line shows green on the
+            # dashboard with last_error=None. Guarantee the flag clears on ANY
+            # exit. Idempotent with the inner finally on the normal shutdown
+            # path. See `rt.start()` -> wait_for cancellation in repo_runtime.
+            self._running = False
 
     def _warn_if_agents_md_missing(self) -> None:
         """Log a warning if AGENTS.md is absent from the repo root.

--- a/tests/regressions/test_factory_start_host_only.py
+++ b/tests/regressions/test_factory_start_host_only.py
@@ -1,0 +1,148 @@
+"""Regression: the factory Start button must bring up the host line ONLY.
+
+Two coupled bugs made it impossible to run the factory with only the host
+(hydraflow) line active:
+
+1. ``POST /api/control/start`` called ``registry.start_all()``, which booted
+   the host AND every registered repo line. A factory must run fine with zero
+   repos; repos are turned on individually via ``/api/runtimes/{slug}/start``
+   once the factory is up.
+
+2. ``orchestrator._running`` was set True *outside* ``run()``'s try/finally.
+   When a line's run-task was cancelled during setup (e.g. by
+   ``RepoRuntime.stop()``'s ``wait_for`` timeout firing before
+   ``_supervise_loops`` was reached), the finally that resets ``_running``
+   never executed — the line stayed stuck reporting ``running=True`` forever
+   (``last_error=None``, since cancellation isn't an exception), so a stopped
+   line showed green on the dashboard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from config import HydraFlowConfig
+from orchestrator import HydraFlowOrchestrator
+from tests.conftest import make_state
+from tests.helpers import (
+    ConfigFactory,
+    find_endpoint,
+    make_dashboard_router,
+    make_registry,
+)
+
+
+def _repo_cfg(tmp_path: Path, name: str) -> HydraFlowConfig:
+    (tmp_path / name).mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / name, repo=f"org/{name}")
+
+
+@pytest.mark.asyncio
+async def test_global_start_starts_only_the_host_line(
+    config: HydraFlowConfig, event_bus, state, tmp_path: Path
+) -> None:
+    """POST /api/control/start starts the default/host line and no other repo."""
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "running": False,
+        },
+        {
+            "slug": "org-b",
+            "config": _repo_cfg(tmp_path, "b"),
+            "state": make_state(tmp_path / "sb"),
+            "event_bus": event_bus,
+            "running": False,
+        },
+    )
+    host = registry.get("org-a")
+    repo = registry.get("org-b")
+    host.start = AsyncMock()
+    repo.start = AsyncMock()
+    registry.start_all = AsyncMock()
+
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    start = find_endpoint(router, "/api/control/start")
+    assert start is not None
+
+    response = await start()
+
+    assert json.loads(response.body)["status"] == "started"
+    host.start.assert_awaited_once()
+    repo.start.assert_not_called()
+    registry.start_all.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_global_start_is_idempotent_when_host_already_running(
+    config: HydraFlowConfig, event_bus, state, tmp_path: Path
+) -> None:
+    """Starting an already-running host line does not re-start it."""
+    registry = make_registry(
+        {
+            "slug": "org-a",
+            "config": _repo_cfg(tmp_path, "a"),
+            "state": make_state(tmp_path / "sa"),
+            "event_bus": event_bus,
+            "running": True,
+        },
+    )
+    host = registry.get("org-a")
+    host.start = AsyncMock()
+
+    router, _ = make_dashboard_router(
+        config,
+        event_bus,
+        state,
+        tmp_path,
+        registry=registry,
+        default_repo_slug="org-a",
+    )
+    start = find_endpoint(router, "/api/control/start")
+    assert start is not None
+
+    response = await start()
+
+    assert json.loads(response.body)["status"] == "started"
+    host.start.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_resets_running_when_cancelled_during_setup(
+    config: HydraFlowConfig,
+) -> None:
+    """A run-task cancelled before _supervise_loops still clears _running."""
+    orch = HydraFlowOrchestrator(config)
+    reached_setup = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_publish_status() -> None:
+        reached_setup.set()
+        await release.wait()
+
+    orch._publish_status = blocking_publish_status  # type: ignore[method-assign]
+
+    task = asyncio.create_task(orch.run())
+    await asyncio.wait_for(reached_setup.wait(), timeout=2)
+    assert orch.running is True
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert orch.running is False

--- a/tests/test_dashboard_routes_core.py
+++ b/tests/test_dashboard_routes_core.py
@@ -607,13 +607,16 @@ class TestStopOrchestratorEndpoint:
 
 class TestFactoryStartEndpoint:
     @pytest.mark.asyncio
-    async def test_factory_start_starts_all_lines(
+    async def test_factory_start_starts_host_line_only(
         self, config, event_bus, state, tmp_path
     ) -> None:
         import json
 
+        host_rt = MagicMock()
+        host_rt.running = False
+        host_rt.start = AsyncMock()
         mock_registry = MagicMock()
-        mock_registry.all = []
+        mock_registry.get.return_value = host_rt
         mock_registry.start_all = AsyncMock()
         router, _ = make_dashboard_router(
             config, event_bus, state, tmp_path, registry=mock_registry
@@ -622,7 +625,8 @@ class TestFactoryStartEndpoint:
         response = await endpoint()
         data = json.loads(response.body)
         assert data["status"] == "started"
-        mock_registry.start_all.assert_awaited_once()
+        host_rt.start.assert_awaited_once()
+        mock_registry.start_all.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The factory couldn't run with only the host (hydraflow) line active. Investigating a live instance running 3 repos (hydraflow + amplifier + harvestd, all showing `running`), I found **two coupled bugs**:

1. **Global Start force-starts every repo.** `POST /api/control/start` called `registry.start_all()`, booting the host **and every registered repo**. A factory should run fine with zero repos; lines are turned on individually via `/api/runtimes/{slug}/start` once the factory is up. (This is also the footgun called out in the #9359 regression docstring.)

2. **A stopped line stays stuck reporting `running=True`.** `orchestrator._running` was set `True` *outside* `run()`'s `try/finally`. When a line's run-task is cancelled during **setup** (before `_supervise_loops` — e.g. `RepoRuntime.stop()`'s `wait_for` timeout cancelling it), the `finally` that resets `_running` never executes. The line then reports `running=True` forever with `last_error=None` (cancellation isn't an exception), so a stopped line shows **green** on the dashboard. This is why stopping amplifier/harvestd via the API returned `stopped` in ~15ms yet they kept reporting `running`.

## Fix

- **`/api/control/start`** → start only the default/host line (`ctx._default_slug()`), never `start_all()`. Idempotent when the host is already running.
- **`orchestrator.run()`** → wrap the body so `_running` clears on **any** exit (including setup-phase cancellation). The inner `finally` — and the intentional `run_status="stopping"` transient that relies on `_running` staying True during a normal stop — is unchanged.

Frontend already maps the global Start to `/api/control/start` and per-repo Play to `/api/runtimes/{slug}/start` — no client change needed.

## Tests

`tests/regressions/test_factory_start_host_only.py`:
- global Start starts the host line only (host `.start` awaited; other repo `.start` **not** called; `start_all` **not** awaited)
- Start is idempotent when the host is already running
- a run-task cancelled during setup ends with `running is False`

Updated `test_dashboard_routes_core::TestFactoryStartEndpoint` to the host-only contract.

Verified locally: `test_orchestrator_core`, `test_dashboard_routes_control{,_multirepo}`, `test_repo_runtime`, `test_dashboard_routes_core`, `test_host_runtime_wiring`, `#9359` regression + the new regressions — all green; ruff + format + arch-check clean.

> Note: this changes behavior on **deploy/restart** only. The currently-running instance keeps its stuck `running=True` state for amplifier/harvestd until restarted (per the operator's request not to restart now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)