### PR TITLE
fix(retrospective): route stale review-insights to the factory, not HITL (#9227)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-11T19:55:13.573535+00:00",
-  "commit_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4",
+  "regenerated_at": "2026-06-12T04:52:54.868390+00:00",
+  "commit_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68",
   "artifacts": {
     "loops.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "ports.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "labels.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "modules.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "events.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "adr_xref.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "mockworld.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "changelog.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "coverage_matrix.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "functional_areas.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "ubiquitous-language.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "dc7e09b5c3fb53c06d7388d32f69399efe36b5f4"
+      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,9 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `3f90a67` — fix(adr-drift): symbol-qualify owned citations + pr_manager shared-infra (#9405) (#9405) *(2026-06-11)*
+- `bc00ebe` — fix(mockworld): re-export FakeRouteBackCounter so its marker is actually verified (#8809) (#9408) (#9408) *(2026-06-11)*
+- `9685284` — docs(wiki): correct EpicMonitorLoop entry — it writes, not read-only (#8764) (#9407) (#9407) *(2026-06-11)*
 - `dc7e09b` — fix(trust): right-size FakeCoverageAuditorLoop to cassette-capable adapters (#9403) (#9403) *(2026-06-11)*
 - `d0ad6db` — fix(dashboard): aggregate /api/timeline* under __all__, repo-tag each item (#9402) (#9402) *(2026-06-11)*
 - `0f9b7fa` — fix(dashboard): aggregate /api/metrics/github under __all__; tag single-repo workers with canonical slug (#9399) (#9399) *(2026-06-10)*

--- a/src/retrospective_loop.py
+++ b/src/retrospective_loop.py
@@ -26,13 +26,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.retrospective_loop")
 
-# Window (#8988): once a HITL stale-insight issue is filed for a category,
-# do not refile (or recomment) within this window even if the open-issue
-# GitHub lookup races and returns 0.  An hour is much shorter than the
-# 30-minute retrospective_interval default cadence, but long enough to
-# survive back-to-back ticks that hit GitHub before its search index
-# catches up to a freshly-created issue.
-_HITL_DEDUP_WINDOW = timedelta(hours=1)
+# Window (#8988): once a stale-insight escalation is filed for a category,
+# do not refile within this window even if the open-issue GitHub lookup races
+# and returns 0.  An hour is much shorter than the 30-minute
+# retrospective_interval default cadence, but long enough to survive
+# back-to-back ticks that hit GitHub before its search index catches up to a
+# freshly-created issue.
+_INSIGHT_DEDUP_WINDOW = timedelta(hours=1)
 
 
 def _now_utc() -> datetime:
@@ -62,10 +62,10 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         self._insights = insights
         self._queue = queue
         self._prs = prs
-        # Per-category last-filed timestamps for HITL stale-insight dedup
+        # Per-category last-escalated timestamps for stale-insight dedup
         # (#8988).  Lives in-memory; the open-issue GitHub lookup is the
         # cross-restart authority.  This dict is the race-safety net.
-        self._hitl_filed_at: dict[str, datetime] = {}
+        self._insight_escalated_at: dict[str, datetime] = {}
 
     def _get_default_interval(self) -> int:
         return self._config.retrospective_interval
@@ -160,24 +160,34 @@ class RetrospectiveLoop(BaseBackgroundLoop):
         return {"patterns_filed": filed}
 
     async def _handle_verify_proposals(self) -> dict[str, int]:
-        """Verify improvement proposal outcomes and escalate stale ones.
+        """Verify improvement-proposal outcomes and route stale ones to the factory.
+
+        A *stale* proposal means the factory's first pass at a recurring review
+        finding (filed by :meth:`_handle_review_patterns`) did not reduce its
+        frequency after ``_PROPOSAL_STALE_DAYS``. Rather than a ``hydraflow-hitl``
+        dead-end, file an actionable ``find_label`` issue (#9227) so the pipeline
+        (triage → plan → implement → review → merge) takes another, better-informed
+        pass at the root cause. The proposal auto-verifies — and this escalation
+        stops — once the pattern frequency drops >50% (see :func:`verify_proposals`).
 
         Dedup rules (issue #8988):
 
-        - **Open issue exists** for the same category → post a comment
-          carrying the new tick's evidence instead of opening a duplicate.
-        - **Closed issue exists** for the same category → treat the human
-          close as a re-arm signal: clear the in-memory window-tracker so
-          the next stale signal files fresh.  Mirrors
+        - **Open escalation exists** for the category → skip. The factory is
+          already working it; no duplicate, and no comment spam.
+        - **Closed escalation exists** → treat the close (factory merged a fix,
+          or a human dismissed it) as a re-arm signal: clear the in-memory
+          window-tracker so a still-stale proposal files fresh. Mirrors
           ``FakeCoverageAuditorLoop._reconcile_closed_escalations``.
-        - **In-memory window guard** (:data:`_HITL_DEDUP_WINDOW`): if this
-          category was filed within the window, skip entirely.  Catches
+        - **In-memory window guard** (:data:`_INSIGHT_DEDUP_WINDOW`): if this
+          category was escalated within the window, skip entirely. Catches
           races where GitHub's search index has not caught up to a
           freshly-created issue.
         """
         from review_insights import (  # noqa: PLC0415
             _PROPOSAL_STALE_DAYS,
             CATEGORY_DESCRIPTIONS,
+            PERSISTENT_FINDING_PREFIX,
+            build_persistent_finding_body,
             verify_proposals,
         )
 
@@ -188,123 +198,102 @@ class RetrospectiveLoop(BaseBackgroundLoop):
             return {"stale_proposals": 0}
 
         if self._prs is None:
-            logger.warning("Retrospective: cannot file HITL issue — no PRPort")
+            logger.warning(
+                "Retrospective: cannot file review-insight issue — no PRPort"
+            )
             return {"stale_proposals": len(stale)}
 
-        # Re-arm: any closed HITL stale-insight issue clears its category
-        # from the in-memory window-tracker so the next stale tick files
-        # fresh.  Cheap; runs once per verify-proposals tick.
-        await self._reconcile_closed_hitl_issues()
+        # Re-arm: any closed escalation clears its category from the in-memory
+        # window-tracker so the next stale tick files fresh.  Cheap; runs once
+        # per verify-proposals tick.
+        await self._reconcile_closed_insight_escalations()
 
         now = _now_utc()
         for category in stale:
             desc = CATEGORY_DESCRIPTIONS.get(category, category)
-            title = f"[HITL] Stale review insight: {desc}"
+            title = f"{PERSISTENT_FINDING_PREFIX}{desc}"
 
             # 1. Window guard — protects against races where GitHub's
             #    search index has not surfaced our just-filed issue yet.
-            last = self._hitl_filed_at.get(category)
-            if last is not None and (now - last) < _HITL_DEDUP_WINDOW:
+            last = self._insight_escalated_at.get(category)
+            if last is not None and (now - last) < _INSIGHT_DEDUP_WINDOW:
                 logger.debug(
-                    "Retrospective: skipping HITL stale-insight refile for "
+                    "Retrospective: skipping stale-insight refile for "
                     "category=%s — within %s dedup window",
                     category,
-                    _HITL_DEDUP_WINDOW,
+                    _INSIGHT_DEDUP_WINDOW,
                 )
                 continue
 
-            # 2. Open-issue lookup — if one is open, comment instead of
-            #    filing a duplicate.
+            # 2. Open-issue lookup — if the factory is already working a routed
+            #    issue, skip (no duplicate, no comment spam).
             existing = await self._prs.find_existing_issue(title)
             if existing:
-                tick_evidence = self._build_stale_tick_comment(
-                    category, desc, _PROPOSAL_STALE_DAYS
-                )
-                await self._prs.post_comment(existing, tick_evidence)
-                # Touch the window-tracker so we don't immediately re-comment.
-                self._hitl_filed_at[category] = now
+                # Touch the window-tracker so we keep skipping cheaply.
+                self._insight_escalated_at[category] = now
                 continue
 
-            # 3. File a fresh HITL issue. Set the window-tracker BEFORE
-            #    the await so a crash between issue creation and the
-            #    assignment doesn't strand the freshly-filed issue with
-            #    no in-memory guard — protects against the cross-tick
-            #    race where ``find_existing_issue`` may not yet see the
-            #    just-filed issue via GitHub's search index.
-            body = (
-                f"## Stale Improvement Proposal\n\n"
-                f"The improvement proposal for **{category}** ({desc}) "
-                f"was filed over {_PROPOSAL_STALE_DAYS} days ago but the "
-                f"pattern frequency has not decreased. Human intervention is "
-                f"required to resolve this recurring feedback loop.\n\n"
-                f"---\n*Auto-escalated by HydraFlow review insight verification.*"
-            )
-            hitl_labels = list(self._config.hitl_label)
-            self._hitl_filed_at[category] = now
+            # 3. File a fresh actionable find-queue issue. Set the window-tracker
+            #    BEFORE the await so a crash between issue creation and the
+            #    assignment doesn't strand the freshly-filed issue with no
+            #    in-memory guard — protects against the cross-tick race where
+            #    ``find_existing_issue`` may not yet see the just-filed issue via
+            #    GitHub's search index.
+            body = build_persistent_finding_body(category, desc, _PROPOSAL_STALE_DAYS)
+            labels = self._config.find_label[:1]
+            self._insight_escalated_at[category] = now
             try:
-                await self._prs.create_issue(title, body, hitl_labels)
+                await self._prs.create_issue(title, body, labels)
             except Exception:
                 # Filing failed — clear the optimistic guard so the next
                 # tick can retry. Re-raise to preserve normal error flow.
-                self._hitl_filed_at.pop(category, None)
+                self._insight_escalated_at.pop(category, None)
                 raise
 
         return {"stale_proposals": len(stale)}
 
-    @staticmethod
-    def _build_stale_tick_comment(category: str, desc: str, stale_days: int) -> str:
-        """Comment body posted to an existing open HITL stale-insight issue.
-
-        Carries the tick context so a human grooming the issue can see the
-        signal is still recurring rather than letting duplicates pile up.
-        """
-        return (
-            f"Still stale — pattern frequency for **{category}** ({desc}) "
-            f"has not decreased after {stale_days}+ days.  This is a "
-            f"recurring tick from `RetrospectiveLoop`; the underlying "
-            f"escalation remains open.\n\n"
-            f"_Auto-comment by HydraFlow review insight verification._"
-        )
-
-    async def _reconcile_closed_hitl_issues(self) -> None:
-        """Clear the in-memory window-tracker for closed HITL stale-insight issues.
+    async def _reconcile_closed_insight_escalations(self) -> None:
+        """Clear the in-memory window-tracker for closed stale-insight escalations.
 
         Mirrors :meth:`FakeCoverageAuditorLoop._reconcile_closed_escalations`:
-        a human-closed HITL issue is the re-arm signal — the next stale
-        tick should be free to file fresh.
+        a closed escalation (the factory merged a fix, or a human dismissed it)
+        is the re-arm signal — the next stale tick should be free to file fresh.
 
-        Only inspects closed issues carrying the configured ``hitl_label``;
-        matches by title prefix ``[HITL] Stale review insight:`` to scope
-        the clear to this loop's own escalations.
+        Inspects closed issues carrying the configured ``find_label`` and
+        matches by title prefix :data:`PERSISTENT_FINDING_PREFIX` to scope the
+        clear to this loop's own escalations.
         """
         if self._prs is None:
             return
-        if not self._hitl_filed_at:
+        if not self._insight_escalated_at:
             return  # Nothing to re-arm.
 
-        hitl_labels = list(self._config.hitl_label)
-        if not hitl_labels:
+        find_labels = list(self._config.find_label)
+        if not find_labels:
             return
 
         try:
-            closed = await self._prs.list_closed_issues_by_label(hitl_labels[0])
+            closed = await self._prs.list_closed_issues_by_label(find_labels[0])
         except Exception as exc:  # noqa: BLE001
             reraise_on_credit_or_bug(exc)
             # The lookup is best-effort; reraising would block the entire
             # verify-proposals tick on a transient GitHub fault.
             logger.debug(
-                "Retrospective: could not list closed HITL issues for re-arm",
+                "Retrospective: could not list closed find issues for re-arm",
                 exc_info=True,
             )
             return
 
-        from review_insights import CATEGORY_DESCRIPTIONS  # noqa: PLC0415
+        from review_insights import (  # noqa: PLC0415
+            CATEGORY_DESCRIPTIONS,
+            PERSISTENT_FINDING_PREFIX,
+        )
 
-        prefix = "[HITL] Stale review insight: "
+        prefix = PERSISTENT_FINDING_PREFIX
         # Build desc → category reverse lookup once.
         desc_to_category = {
             CATEGORY_DESCRIPTIONS.get(cat, cat): cat
-            for cat in list(self._hitl_filed_at.keys())
+            for cat in list(self._insight_escalated_at.keys())
         }
 
         cleared: list[str] = []
@@ -314,13 +303,13 @@ class RetrospectiveLoop(BaseBackgroundLoop):
                 continue
             desc = title[len(prefix) :]
             category = desc_to_category.get(desc) or desc
-            if category in self._hitl_filed_at:
-                del self._hitl_filed_at[category]
+            if category in self._insight_escalated_at:
+                del self._insight_escalated_at[category]
                 cleared.append(category)
 
         if cleared:
             logger.info(
-                "Retrospective: re-armed HITL stale-insight tracker for %s",
+                "Retrospective: re-armed stale-insight tracker for %s",
                 cleared,
             )
 

--- a/src/review_insights.py
+++ b/src/review_insights.py
@@ -608,3 +608,42 @@ def verify_proposals(
         logger.warning("Error during proposal verification", exc_info=True)
 
     return stale_categories
+
+
+# ---------------------------------------------------------------------------
+# Stale-proposal escalation → factory routing (#9227)
+# ---------------------------------------------------------------------------
+#
+# When the factory's first pass at a recurring review finding hasn't reduced
+# its frequency after ``_PROPOSAL_STALE_DAYS``, the stale proposal is routed
+# back to the factory as an actionable ``find_label`` issue — the pipeline
+# takes another, better-informed pass — instead of a ``hydraflow-hitl``
+# dead-end that only nags a human. The shared title prefix (the dedup key) and
+# body live here so the two writers (``RetrospectiveLoop`` and the
+# ``ReviewPhase`` fallback) can never drift apart.
+PERSISTENT_FINDING_PREFIX = "[Review Insight] Persistent finding: "
+
+
+def build_persistent_finding_body(category: str, desc: str, stale_days: int) -> str:
+    """Body for a stale review-insight routed to the factory find-queue.
+
+    Frames the recurring finding as an actionable task the pipeline can plan
+    and implement, with an acceptance criterion (>50% frequency drop) that
+    ``verify_proposals`` auto-verifies — which stops the escalation.
+    """
+    return (
+        f"## Persistent review finding — factory action requested\n\n"
+        f"Reviews keep flagging **{category}** ({desc}). The improvement "
+        f"proposal was filed over {stale_days} days ago, but the pattern "
+        f"frequency has not decreased — the factory's first pass did not "
+        f"resolve the recurring root cause.\n\n"
+        f"**Task:** investigate the root cause and implement a *structural* "
+        f"fix that reduces this class of review finding — strengthen the "
+        f"relevant gate, check, or agent prompt so it is caught or prevented "
+        f"earlier.\n\n"
+        f"**Acceptance:** the `{category}` review-finding frequency drops by "
+        f">50%; `RetrospectiveLoop` auto-marks the proposal resolved once it "
+        f"does, which stops this escalation.\n\n"
+        f"---\n*Auto-filed by HydraFlow review-insight verification — routed "
+        f"to the factory (previously a HITL escalation, #9227).*"
+    )

--- a/src/review_phase/_phase.py
+++ b/src/review_phase/_phase.py
@@ -113,8 +113,10 @@ from repo_wiki import (
 from review_insights import (
     _PROPOSAL_STALE_DAYS,
     CATEGORY_DESCRIPTIONS,
+    PERSISTENT_FINDING_PREFIX,
     ReviewRecord,
     build_insight_issue_body,
+    build_persistent_finding_body,
     extract_categories,
     verify_proposals,
 )
@@ -138,13 +140,13 @@ from ._common import (
 
 logger = logging.getLogger("hydraflow.review_phase")
 
-# Mirrors ``retrospective_loop._HITL_DEDUP_WINDOW``. Two PR reviews
+# Mirrors ``retrospective_loop._INSIGHT_DEDUP_WINDOW``. Two PR reviews
 # completing back-to-back for the same stale category could otherwise
 # both call ``find_existing_issue`` before either write is indexed by
 # GitHub search, and both file. The window is intentionally identical
 # between sites so behavior is uniform whether the loop or the fallback
 # fires (#8988).
-_HITL_DEDUP_WINDOW = timedelta(hours=1)
+_INSIGHT_DEDUP_WINDOW = timedelta(hours=1)
 
 
 class ReviewPhase:
@@ -192,12 +194,12 @@ class ReviewPhase:
         self._insights: ReviewInsightStorePort = review_insights
         self._active_issues_cb = active_issues_cb
         self._active_issues: set[int] = set()
-        # In-memory window guard for the stale-HITL fallback branch
-        # (mirror of ``RetrospectiveLoop._hitl_filed_at``). Two PR
+        # In-memory window guard for the stale-insight fallback branch
+        # (mirror of ``RetrospectiveLoop._insight_escalated_at``). Two PR
         # reviews completing back-to-back for the same stale category
         # could otherwise both call ``find_existing_issue`` before
         # either write is indexed by GitHub search, and both file.
-        self._hitl_filed_at: dict[str, datetime] = {}
+        self._insight_escalated_at: dict[str, datetime] = {}
         self._active_issues_lock = asyncio.Lock()
         self._conflict_resolver = conflict_resolver
         self._post_merge = post_merge
@@ -3265,51 +3267,38 @@ class ReviewPhase:
 
                 stale = verify_proposals(self._insights, recent)
                 # Dedup mirror of RetrospectiveLoop._handle_verify_proposals
-                # (#8988). This fallback branch fires only when no
-                # retrospective_queue is wired, but it MUST avoid filing a
-                # duplicate `[HITL] Stale review insight: <category>` when
-                # one is already open — same anti-pattern as the loop site.
-                now_hitl = datetime.now(UTC)
+                # (#8988). This fallback fires only when no retrospective_queue
+                # is wired. Like the loop site it routes a stale proposal to the
+                # factory as an actionable `find_label` issue (#9227) — not a
+                # HITL dead-end — and skips (no duplicate, no comment spam) when
+                # one is already open.
+                now_escalated = datetime.now(UTC)
                 for category in stale:
                     desc = CATEGORY_DESCRIPTIONS.get(category, category)
-                    title = f"[HITL] Stale review insight: {desc}"
-                    hitl_labels = list(self._config.hitl_label)
+                    title = f"{PERSISTENT_FINDING_PREFIX}{desc}"
+                    find_labels = self._config.find_label[:1]
                     # Window guard — protects against back-to-back PR
                     # reviews racing the GitHub search index, same shape
                     # as ``RetrospectiveLoop._handle_verify_proposals``.
-                    last = self._hitl_filed_at.get(category)
-                    if last is not None and (now_hitl - last) < _HITL_DEDUP_WINDOW:
+                    last = self._insight_escalated_at.get(category)
+                    if (
+                        last is not None
+                        and (now_escalated - last) < _INSIGHT_DEDUP_WINDOW
+                    ):
                         continue
                     existing = await self._prs.find_existing_issue(title)
                     if existing:
-                        await self._prs.post_comment(
-                            existing,
-                            (
-                                f"Still stale — pattern frequency for "
-                                f"**{category}** ({desc}) has not decreased "
-                                f"after {_PROPOSAL_STALE_DAYS}+ days. "
-                                f"Recurring tick from `ReviewPhase` fallback "
-                                f"(retrospective queue not wired); the "
-                                f"underlying escalation remains open.\n\n"
-                                f"_Auto-comment by HydraFlow review insight "
-                                f"verification._"
-                            ),
-                        )
-                        self._hitl_filed_at[category] = now_hitl
+                        # Factory is already working the routed issue — skip.
+                        self._insight_escalated_at[category] = now_escalated
                         continue
-                    body = (
-                        f"## Stale Improvement Proposal\n\n"
-                        f"The improvement proposal for **{category}** ({desc}) "
-                        f"was filed over {_PROPOSAL_STALE_DAYS} days ago but the "
-                        f"pattern frequency has not decreased. Human intervention is "
-                        f"required to resolve this recurring feedback loop.\n\n"
-                        f"---\n*Auto-escalated by HydraFlow review insight verification.*"
+                    body = build_persistent_finding_body(
+                        category, desc, _PROPOSAL_STALE_DAYS
                     )
-                    self._hitl_filed_at[category] = now_hitl
+                    self._insight_escalated_at[category] = now_escalated
                     try:
-                        await self._transitioner.create_task(title, body, hitl_labels)
+                        await self._transitioner.create_task(title, body, find_labels)
                     except Exception:
-                        self._hitl_filed_at.pop(category, None)
+                        self._insight_escalated_at.pop(category, None)
                         raise
         except (RuntimeError, OSError):
             status = "error"

--- a/tests/regressions/test_credit_exhausted_reraise.py
+++ b/tests/regressions/test_credit_exhausted_reraise.py
@@ -262,7 +262,7 @@ class TestMetricsManagerCreditExhaustedReraise:
 
 # ---------------------------------------------------------------------------
 # RetrospectiveLoop — _do_work catches process-item exceptions, and
-# _reconcile_closed_hitl_issues catches list_closed_issues_by_label
+# _reconcile_closed_insight_escalations catches list_closed_issues_by_label
 # ---------------------------------------------------------------------------
 
 
@@ -316,7 +316,7 @@ class TestRetrospectiveLoopCreditExhaustedReraise:
             await loop._do_work()
 
     @pytest.mark.asyncio
-    async def test_credit_exhausted_propagates_through_reconcile_closed_hitl(
+    async def test_credit_exhausted_propagates_through_reconcile_closed_escalations(
         self, tmp_path: Path
     ) -> None:
         from datetime import UTC, datetime
@@ -328,13 +328,13 @@ class TestRetrospectiveLoopCreditExhaustedReraise:
             )
         )
         # Seed the in-memory window so the early-return on empty doesn't fire.
-        loop._hitl_filed_at["recurring_feedback"] = datetime.now(UTC)
+        loop._insight_escalated_at["recurring_feedback"] = datetime.now(UTC)
 
         with pytest.raises(
             CreditExhaustedError,
             match="credits exhausted in list_closed_issues_by_label",
         ):
-            await loop._reconcile_closed_hitl_issues()
+            await loop._reconcile_closed_insight_escalations()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
+++ b/tests/regressions/test_issue_8988_hitl_stale_insight_dedup.py
@@ -1,16 +1,22 @@
 """Regression for issue #8988 — RetrospectiveLoop must not file duplicate
-``[HITL] Stale review insight: <category>`` issues every tick.
+stale-insight escalations every tick.
 
 Before the fix, ``RetrospectiveLoop._handle_verify_proposals`` filed a fresh
 issue on **every** tick a category was stale, with no open-issue check.  Four
 duplicates were closed manually on 2026-05-19 (``Missing or insufficient test
 coverage`` was filed multiple times for the same recurring pattern).
 
+Since #9227 the escalation is routed to the factory as an actionable
+``[Review Insight] Persistent finding: <category>`` find-queue issue (not a
+HITL dead-end), and subsequent ticks **skip** the open issue silently rather
+than posting follow-up comments.
+
 The contract guarded here:
 
-1. Same category stale across N ticks → 1 ``create_issue`` + N-1 ``post_comment``.
-2. ``[HITL] Stale review insight:`` fallback at
-   ``src/review_phase/_phase.py:3216`` follows the same dedup contract.
+1. Same category stale across N ticks → exactly 1 ``create_issue``, no comment
+   spam (skip while the open one is in the factory pipeline).
+2. The ``ReviewPhase`` fallback at ``src/review_phase/_phase.py`` follows the
+   same dedup + factory-routing contract.
 """
 
 from __future__ import annotations
@@ -64,11 +70,11 @@ def _make_loop_with_prs(
     return loop, insights, queue, prs
 
 
-class TestStaleHITLDedupRegression:
+class TestStaleInsightDedupRegression:
     """Issue #8988 regression — guards the dedup contract end-to-end."""
 
     @pytest.mark.asyncio
-    async def test_five_ticks_one_issue_four_comments(self, tmp_path: Path) -> None:
+    async def test_five_ticks_one_issue_no_comments(self, tmp_path: Path) -> None:
         loop, insights, queue, prs = _make_loop_with_prs(tmp_path)
         insights.load_recent.return_value = []
 
@@ -99,9 +105,8 @@ class TestStaleHITLDedupRegression:
                     await loop._do_work()
 
         assert prs.create_issue.await_count == 1
-        assert prs.post_comment.await_count == 4
-        for call in prs.post_comment.await_args_list:
-            assert call.args[0] == 4242
+        # Routed to the factory; subsequent ticks skip the open issue (no spam).
+        assert prs.post_comment.await_count == 0
 
     @pytest.mark.asyncio
     async def test_closed_then_re_armed(self, tmp_path: Path) -> None:
@@ -136,7 +141,7 @@ class TestStaleHITLDedupRegression:
             prs.list_closed_issues_by_label.return_value = [
                 {
                     "number": 4242,
-                    "title": "[HITL] Stale review insight: Missing test coverage",
+                    "title": "[Review Insight] Persistent finding: Missing test coverage",
                     "body": "",
                     "updated_at": "2026-05-19T01:00:00Z",
                 }
@@ -153,14 +158,14 @@ class TestStaleHITLDedupRegression:
 
 
 class TestReviewPhaseFallbackDedup:
-    """Mirror site — ``src/review_phase/_phase.py:3216`` (fallback branch)
-    must also dedup when a HITL stale-insight issue is already open.
+    """Mirror site — ``src/review_phase/_phase.py`` (fallback branch) must also
+    dedup + route to the factory when a stale-insight issue is already open.
     """
 
     @pytest.mark.asyncio
     async def test_fallback_branch_dedups_via_find_existing_issue(self) -> None:
-        """The fallback path (no retrospective_queue wired) must comment on
-        an existing open HITL issue rather than file a duplicate."""
+        """The fallback path (no retrospective_queue wired) must skip silently
+        when a routed issue is already open rather than file a duplicate."""
         from models import ReviewVerdict
         from tests.conftest import ConfigFactory, ReviewResultFactory
         from tests.helpers import make_review_phase
@@ -196,16 +201,16 @@ class TestReviewPhaseFallbackDedup:
         ):
             await phase._record_review_insight(result)
 
-        # Existing open issue → comment, do NOT create a new task.
-        phase._prs.post_comment.assert_awaited_once()
-        assert phase._prs.post_comment.await_args.args[0] == 7777
+        # Existing open issue → skip silently (no comment spam), and do NOT
+        # create a duplicate task.
+        phase._prs.post_comment.assert_not_awaited()
         phase._prs.create_task.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_fallback_window_guard_skips_back_to_back_filings(self) -> None:
         """Review #8992 S2 fix: two PR reviews completing back-to-back for
         the same stale category must not both file — the in-memory
-        ``_hitl_filed_at`` window guard short-circuits the second call
+        ``_insight_escalated_at`` window guard short-circuits the second call
         before it can race ``find_existing_issue``.
         """
         from models import ReviewVerdict
@@ -252,18 +257,14 @@ class TestReviewPhaseFallbackDedup:
 
 
 class TestRetrospectiveLoopGuardCrashWindow:
-    """Review #8992 S1 fix: the in-memory ``_hitl_filed_at`` guard must
+    """Review #8992 S1 fix: the in-memory ``_insight_escalated_at`` guard must
     be populated BEFORE the ``await create_issue``, not after — otherwise
     a crash between the GitHub write and the assignment leaves the
     just-filed issue with no in-memory guard on restart.
     """
 
     @pytest.mark.asyncio
-    async def test_guard_is_set_before_create_issue_await(
-        self, tmp_path: Path
-    ) -> None:
-        from retrospective_loop import RetrospectiveLoop  # noqa: PLC0415
-
+    async def test_guard_is_set_before_create_issue_await(self, tmp_path: Path) -> None:
         loop, insights, _queue, prs = _make_loop_with_prs(tmp_path)
         prs.find_existing_issue = AsyncMock(return_value=None)
         prs.post_comment = AsyncMock()
@@ -272,9 +273,7 @@ class TestRetrospectiveLoopGuardCrashWindow:
         captured: dict[str, datetime | None] = {"value_at_await": None}
 
         async def capture_create_issue(_title, _body, _labels):
-            captured["value_at_await"] = loop._hitl_filed_at.get(
-                "missing_tests"
-            )
+            captured["value_at_await"] = loop._insight_escalated_at.get("missing_tests")
             return 9999
 
         prs.create_issue = AsyncMock(side_effect=capture_create_issue)

--- a/tests/scenarios/test_caretaker_loops.py
+++ b/tests/scenarios/test_caretaker_loops.py
@@ -136,13 +136,14 @@ class TestL11RetrospectiveLoop:
         fake_queue.acknowledge.assert_called_once_with([item.id])
         fake_retro._load_recent.assert_called_once()
 
-    async def test_stale_hitl_dedup_across_ticks(self, tmp_path) -> None:
-        """Issue #8988: ``RetrospectiveLoop`` must not file duplicate
-        ``[HITL] Stale review insight:`` issues on repeated stale ticks.
+    async def test_stale_insight_dedup_across_ticks(self, tmp_path) -> None:
+        """Issue #8988 / #9227: ``RetrospectiveLoop`` must not file duplicate
+        ``[Review Insight] Persistent finding:`` issues on repeated stale ticks.
 
-        Drives the real loop against FakeGitHub for three ticks of the
-        same stale category and asserts the FakeGitHub issue count caps
-        at 1 with follow-up comments on the existing issue.
+        Drives the real loop against FakeGitHub for three ticks of the same
+        stale category and asserts the FakeGitHub issue count caps at 1 and
+        that subsequent ticks skip silently (no comment spam — the factory is
+        already working the routed find-queue issue).
         """
         from datetime import UTC, datetime, timedelta
         from unittest.mock import patch  # noqa: PLC0415
@@ -165,8 +166,8 @@ class TestL11RetrospectiveLoop:
             insights=fake_insights,
         )
 
-        # Snapshot FakeGitHub HITL title count.
-        hitl_title = "[HITL] Stale review insight: Missing test coverage"
+        # Snapshot FakeGitHub routed-issue title count.
+        insight_title = "[Review Insight] Persistent finding: Missing test coverage"
 
         with (
             patch(
@@ -180,35 +181,35 @@ class TestL11RetrospectiveLoop:
             patch("review_insights._PROPOSAL_STALE_DAYS", 30),
         ):
             base = datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
-            # Tick 1: file
+            # Tick 1: file the routed find-queue issue
             with patch("retrospective_loop._now_utc", return_value=base):
                 await world.run_with_loops(["retrospective"], cycles=1)
-            # Tick 2: comment
+            # Tick 2: skip (issue already open — factory is working it)
             with patch(
                 "retrospective_loop._now_utc",
                 return_value=base + timedelta(hours=2),
             ):
                 await world.run_with_loops(["retrospective"], cycles=1)
-            # Tick 3: comment
+            # Tick 3: skip
             with patch(
                 "retrospective_loop._now_utc",
                 return_value=base + timedelta(hours=4),
             ):
                 await world.run_with_loops(["retrospective"], cycles=1)
 
-        hitl_issues = [
+        insight_issues = [
             issue
             for issue in world._github._issues.values()
-            if issue.title == hitl_title
+            if issue.title == insight_title
         ]
-        assert len(hitl_issues) == 1, (
-            f"expected 1 HITL issue, got {len(hitl_issues)}: "
-            f"{[i.number for i in hitl_issues]}"
+        assert len(insight_issues) == 1, (
+            f"expected 1 routed issue, got {len(insight_issues)}: "
+            f"{[i.number for i in insight_issues]}"
         )
-        # And the loop should have posted 2 follow-up comments on the
-        # one open HITL issue.
-        assert len(hitl_issues[0].comments) == 2, (
-            f"expected 2 follow-up comments, got {len(hitl_issues[0].comments)}"
+        # No comment spam: subsequent ticks skip the open issue silently
+        # (the routed find-queue issue is already in the factory pipeline).
+        assert len(insight_issues[0].comments) == 0, (
+            f"expected 0 follow-up comments, got {len(insight_issues[0].comments)}"
         )
 
 

--- a/tests/test_retrospective_loop.py
+++ b/tests/test_retrospective_loop.py
@@ -226,10 +226,10 @@ class TestReviewPatternIssueFiling:
 
 
 class TestVerifyProposalEscalation:
-    """_handle_verify_proposals escalates stale proposals to HITL."""
+    """_handle_verify_proposals routes stale proposals to the factory (#9227)."""
 
     @pytest.mark.asyncio
-    async def test_files_hitl_issue_for_stale_proposal(self, tmp_path: Path) -> None:
+    async def test_routes_stale_proposal_to_factory(self, tmp_path: Path) -> None:
         from unittest.mock import patch
 
         loop, _, insights, queue, prs = _make_loop(tmp_path, with_prs=True)
@@ -252,9 +252,13 @@ class TestVerifyProposalEscalation:
             await loop._do_work()
 
         prs.create_issue.assert_awaited_once()
-        call_args = prs.create_issue.call_args
-        assert "HITL" in call_args[0][0]
-        assert "missing_tests" in call_args[0][1]
+        title, body, labels = prs.create_issue.call_args[0][:3]
+        # Routed to the factory find-queue as an actionable task, not a HITL
+        # dead-end.
+        assert title.startswith("[Review Insight] Persistent finding:")
+        assert "HITL" not in title
+        assert labels == loop._config.find_label[:1]
+        assert "missing_tests" in body
 
     @pytest.mark.asyncio
     async def test_no_prs_logs_warning_no_crash(self, tmp_path: Path) -> None:
@@ -300,22 +304,21 @@ class TestMultipleItemBatch:
         queue.acknowledge.assert_called_once_with([items[0].id, items[1].id])
 
 
-class TestStaleHITLDedup:
-    """Issue #8988 — dedup [HITL] Stale review insight: <category> filings.
+class TestStaleInsightDedup:
+    """Issue #8988 — dedup [Review Insight] Persistent finding: <category> filings.
 
-    Behaviors guarded:
-      1. Same category stale across N ticks → 1 open issue + N-1 comments.
-      2. Closed-and-re-armed: stale → file → human closes → stale again → new file.
-      3. In-memory `_hitl_filed_at` window guard prevents same-tick double-file
-         even when the open-issue lookup races.
+    Behaviors guarded (post-#9227 — routed to the factory, not HITL):
+      1. Same category stale across N ticks → exactly 1 open issue, no comment
+         spam (skip while the factory works the open one).
+      2. Closed-and-re-armed: stale → file → closed → stale again → new file.
+      3. In-memory `_insight_escalated_at` window guard prevents same-tick
+         double-file even when the open-issue lookup races.
     """
 
     @pytest.mark.asyncio
-    async def test_five_stale_ticks_one_issue_four_comments(
-        self, tmp_path: Path
-    ) -> None:
+    async def test_five_stale_ticks_one_issue_no_comments(self, tmp_path: Path) -> None:
         """5 ticks of the same stale category → create_issue called once,
-        post_comment called 4 times (ticks 2..5 comment on the open one)."""
+        post_comment never called (ticks 2..5 skip the open one — no spam)."""
         from unittest.mock import patch
 
         loop, _, insights, queue, prs = _make_loop(tmp_path, with_prs=True)
@@ -368,16 +371,14 @@ class TestStaleHITLDedup:
         assert prs.create_issue.await_count == 1, (
             f"expected exactly 1 create_issue, got {prs.create_issue.await_count}"
         )
-        assert prs.post_comment.await_count == 4, (
-            f"expected 4 follow-up comments, got {prs.post_comment.await_count}"
+        # No comment spam: the factory works the open issue; ticks 2..5 skip it.
+        assert prs.post_comment.await_count == 0, (
+            f"expected 0 follow-up comments, got {prs.post_comment.await_count}"
         )
-        # The four comments must target the open issue #4242
-        for call in prs.post_comment.await_args_list:
-            assert call.args[0] == 4242
 
     @pytest.mark.asyncio
     async def test_closed_then_re_armed_files_new_issue(self, tmp_path: Path) -> None:
-        """Closed HITL issue → category stale again → 1 NEW issue filed.
+        """Closed escalation → category stale again → 1 NEW issue filed.
 
         Mirrors FakeCoverageAuditorLoop._reconcile_closed_escalations:
         a closed escalation resets dedup so the category re-arms.
@@ -414,7 +415,7 @@ class TestStaleHITLDedup:
             assert prs.create_issue.await_count == 1
             assert prs.post_comment.await_count == 0
 
-            # ---- Tick 2: human has closed #5000 ----
+            # ---- Tick 2: the escalation #5000 has been closed ----
             # find_existing_issue now returns 0 (no OPEN one), but the loop
             # also checks list_closed_issues_by_label to re-arm the in-memory
             # window-tracker.
@@ -423,7 +424,7 @@ class TestStaleHITLDedup:
             prs.list_closed_issues_by_label.return_value = [
                 {
                     "number": 5000,
-                    "title": "[HITL] Stale review insight: Missing test coverage",
+                    "title": "[Review Insight] Persistent finding: Missing test coverage",
                     "body": "",
                     "updated_at": "2026-05-19T01:00:00Z",
                 }


### PR DESCRIPTION
## Problem

`RetrospectiveLoop`'s second-stage escalation fires when a recurring review pattern's frequency hasn't dropped after 30 days (the factory's first-pass `find_label` insight issue didn't move the needle). It filed a **`hydraflow-hitl` dead-end** and posted a *"still stale"* comment **every tick** — a self-improvement signal the factory could never act on.

The poster child is **#9227** ("Missing or insufficient test coverage"), which sat open for a week accumulating **15 identical auto-comments** with no path to resolution.

## Fix — route it to the factory

A stale proposal now files an actionable **`[Review Insight] Persistent finding: <desc>`** issue labelled **`find_label`**, so the pipeline (triage → plan → implement → review → merge) takes another, better-informed pass at the root cause. The proposal **auto-verifies** — and the escalation stops — once `verify_proposals` sees the pattern frequency drop >50%.

- **Open escalation already exists** → skip (no duplicate, **no comment spam** — the factory is already working it).
- **Closed escalation** → re-arm so a still-stale proposal can be re-filed for another pass.

## Two-writers, one set

The escalation was duplicated in two places — `RetrospectiveLoop._handle_verify_proposals` and the `ReviewPhase` fallback (the #8996 mirror site). Both now route to the factory via a **centralised** title prefix + body in `review_insights.py` (`PERSISTENT_FINDING_PREFIX`, `build_persistent_finding_body`) so they can't drift apart again. Renamed the now-misnamed internals (`_hitl_filed_at` → `_insight_escalated_at`, etc.).

## Tests (full pyramid, all green)

- **Unit**: `tests/test_retrospective_loop.py` — routes to `find_label`, actionable title, skip-not-comment.
- **Regression**: `tests/regressions/test_issue_8988_*` — both loop + ReviewPhase-fallback sites updated to the new contract (1 issue, 0 comments; the no-duplicate invariant is preserved/strengthened).
- **Scenario (MockWorld)**: `tests/scenarios/test_caretaker_loops.py::test_stale_insight_dedup_across_ticks` — real loop vs FakeGitHub, caps at 1 routed issue, 0 comments.
- `make quality` **15988 passed** · `make scenario` **198** · `make scenario-loops` **126** · pyright 0 errors.

The existing **#9227** is migrated to the new form (reframed + relabeled `hydraflow-find`) so it now flows through the factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)