### PR TITLE
fix(runner): surface lightweight-agent timeouts instead of masking them as rc=-1

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -196,7 +196,7 @@ _ENV_INT_OVERRIDES: list[tuple[str, str, int]] = [
     ("quality_timeout", "HYDRAFLOW_QUALITY_TIMEOUT", 3600),
     ("git_command_timeout", "HYDRAFLOW_GIT_COMMAND_TIMEOUT", 30),
     ("summarizer_timeout", "HYDRAFLOW_SUMMARIZER_TIMEOUT", 120),
-    ("wiki_compilation_timeout", "HYDRAFLOW_WIKI_COMPILATION_TIMEOUT", 120),
+    ("wiki_compilation_timeout", "HYDRAFLOW_WIKI_COMPILATION_TIMEOUT", 300),
     ("error_output_max_chars", "HYDRAFLOW_ERROR_OUTPUT_MAX_CHARS", 3000),
     (
         "max_troubleshooting_prompt_chars",
@@ -1636,7 +1636,7 @@ class HydraFlowConfig(BaseModel):
         description="CLI backend for wiki compilation",
     )
     wiki_compilation_timeout: int = Field(
-        default=120,
+        default=300,
         ge=30,
         le=600,
         description="Timeout in seconds for wiki compilation LLM calls",

--- a/src/runner_utils.py
+++ b/src/runner_utils.py
@@ -588,7 +588,10 @@ async def run_lightweight_agent(
     lightweight spawn that legitimately needs host plugins/skills.
     """
     from agent_cli import build_lightweight_command  # noqa: PLC0415
-    from exception_classify import reraise_on_credit_or_bug  # noqa: PLC0415
+    from exception_classify import (  # noqa: PLC0415
+        exc_detail,
+        reraise_on_credit_or_bug,
+    )
     from execution import SimpleResult  # noqa: PLC0415
 
     cmd, cmd_input = build_lightweight_command(
@@ -607,15 +610,28 @@ async def run_lightweight_agent(
             result = await runner.run_simple(
                 cmd, env=env, input=cmd_input, timeout=timeout
             )
+        except TimeoutError:
+            # ``asyncio.wait_for`` raises a *bare* TimeoutError whose ``str()``
+            # is "", which would collapse to an undiagnosable "rc=-1: " at the
+            # caller's failure log (the symptom that surfaced the masked wiki
+            # compilation timeouts). Spell out the deadline so the soft failure
+            # is actionable; a timeout is transient, so it is recorded as a
+            # failed inference like any other soft rc=-1.
+            result = SimpleResult(
+                stderr=f"timed out after {timeout:.0f}s", returncode=-1
+            )
+            record_row = True
+            return result
         except Exception as exc:
             # Credit / likely-bug exceptions propagate so the outer loop can
             # pause or surface the bug — and are NOT recorded, matching
             # BaseSubprocessRunner (which reraises before its telemetry write)
             # so a credit-blocked spawn never attributes phantom cost. Transient
             # failures become a soft rc=-1 result the caller treats as an empty
-            # reply, and ARE recorded as a failed inference.
+            # reply, and ARE recorded as a failed inference. ``exc_detail`` keeps
+            # a diagnostic even when ``str(exc)`` is empty (bare OSError, etc.).
             reraise_on_credit_or_bug(exc)
-            result = SimpleResult(stderr=str(exc), returncode=-1)
+            result = SimpleResult(stderr=exc_detail(exc), returncode=-1)
             record_row = True
             return result
         # Credit-out via output text propagates without recording, same as above.

--- a/tests/regressions/test_lightweight_spawn_credit_telemetry.py
+++ b/tests/regressions/test_lightweight_spawn_credit_telemetry.py
@@ -106,6 +106,54 @@ class TestRunLightweightAgentCredit:
         assert result.returncode == -1
 
     @pytest.mark.asyncio
+    async def test_timeout_surfaces_diagnostic_stderr(self, tmp_path) -> None:
+        # Regression: asyncio.wait_for raises a *bare* TimeoutError whose str()
+        # is "". It previously collapsed to rc=-1 with an EMPTY stderr, so the
+        # wiki compiler (and every other lightweight caller) logged an
+        # undiagnosable "model failed (rc=-1): " with no hint it was a timeout.
+        # The timeout — and the deadline that was exceeded — must survive into
+        # stderr so the failure is actionable.
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        runner = _FakeRunner(raise_exc=TimeoutError())
+
+        result = await run_lightweight_agent(
+            runner=runner,
+            config=config,
+            tool="claude",
+            model="sonnet",
+            prompt="x",
+            source="unit_test",
+            timeout=120.0,
+        )
+
+        assert result.returncode == -1
+        assert result.stderr, "timeout must produce a non-empty, diagnosable stderr"
+        assert "timed out" in result.stderr.lower()
+        assert "120" in result.stderr
+
+    @pytest.mark.asyncio
+    async def test_empty_message_transient_exc_keeps_detail(self, tmp_path) -> None:
+        # Regression: an empty-message transient exception (str(exc) == "") must
+        # still yield a non-empty stderr via exc_detail() rather than swallowing
+        # the only diagnostic the caller will log.
+        config = ConfigFactory.create(repo_root=tmp_path / "repo")
+        runner = _FakeRunner(raise_exc=OSError())  # str(OSError()) == ""
+
+        result = await run_lightweight_agent(
+            runner=runner,
+            config=config,
+            tool="claude",
+            model="sonnet",
+            prompt="x",
+            source="unit_test",
+            timeout=5.0,
+        )
+
+        assert result.returncode == -1
+        assert result.stderr, "empty-message exception must still leave a diagnostic"
+        assert "OSError" in result.stderr
+
+    @pytest.mark.asyncio
     async def test_records_telemetry_row_with_source(self, tmp_path) -> None:
         config = ConfigFactory.create(repo_root=tmp_path / "repo")
         runner = _FakeRunner(stdout="ok", returncode=0)

--- a/tests/regressions/test_lightweight_spawn_credit_telemetry.py
+++ b/tests/regressions/test_lightweight_spawn_credit_telemetry.py
@@ -111,8 +111,10 @@ class TestRunLightweightAgentCredit:
         # is "". It previously collapsed to rc=-1 with an EMPTY stderr, so the
         # wiki compiler (and every other lightweight caller) logged an
         # undiagnosable "model failed (rc=-1): " with no hint it was a timeout.
-        # The timeout — and the deadline that was exceeded — must survive into
-        # stderr so the failure is actionable.
+        # The *actual* deadline must survive into stderr (137 — a non-default
+        # value — proves the timeout arg is interpolated, not hardcoded), AND a
+        # timed-out spawn must still record a failed inference so the spend
+        # stays visible to the cost cap (the WS-2.2 invariant of this module).
         config = ConfigFactory.create(repo_root=tmp_path / "repo")
         runner = _FakeRunner(raise_exc=TimeoutError())
 
@@ -122,14 +124,22 @@ class TestRunLightweightAgentCredit:
             tool="claude",
             model="sonnet",
             prompt="x",
-            source="unit_test",
-            timeout=120.0,
+            source="unit_test_timeout",
+            timeout=137.0,
         )
 
         assert result.returncode == -1
         assert result.stderr, "timeout must produce a non-empty, diagnosable stderr"
         assert "timed out" in result.stderr.lower()
-        assert "120" in result.stderr
+        assert "137" in result.stderr, "the actual deadline must be interpolated"
+
+        rows = PromptTelemetry(config).load_inferences()
+        timed_out = [r for r in rows if r.get("source") == "unit_test_timeout"]
+        assert timed_out, "a timed-out lightweight spawn must record a telemetry row"
+        assert timed_out[-1]["status"] == "failed", (
+            "timed-out spend must be recorded as a failed inference so it stays "
+            "visible to the cost cap"
+        )
 
     @pytest.mark.asyncio
     async def test_empty_message_transient_exc_keeps_detail(self, tmp_path) -> None:


### PR DESCRIPTION
## Problem

The wiki compiler emitted a recurring, **undiagnosable** warning — empty after the colon — firing **exactly every ~120s**:

```
Wiki compilation model failed (rc=-1):
```

### Root cause

The configured `claude:sonnet` wiki-compile subprocess exceeds `wiki_compilation_timeout` (120s). `asyncio.wait_for` raises a **bare `TimeoutError` whose `str()` is `""`**. In `runner_utils.run_lightweight_agent`, the generic `except Exception` handler built `SimpleResult(stderr=str(exc), returncode=-1)` → **empty stderr**. `TimeoutError` is not a credit/bug type, so `reraise_on_credit_or_bug` doesn't reraise it.

Result: every lightweight caller (wiki compiler, ADR reviewer, transcript summarizer, PR unsticker) logged `failed (rc=-1): ` with **no hint it was a timeout**, and `_call_model`'s dedicated `except TimeoutError` was **dead code** because the timeout was swallowed upstream. The exactly-120s log spacing is the smoking gun.

## Fix

1. **`runner_utils.py`** — catch `TimeoutError` explicitly (before the generic handler) and return a diagnostic `timed out after {timeout:.0f}s` soft `rc=-1`, still recorded as a failed inference. Use `exc_detail(exc)` instead of `str(exc)` for other empty-message transient exceptions so the caller always has something to log.
2. **`config.py`** — bump `wiki_compilation_timeout` default `120 → 300` in **both** the `_ENV_INT_OVERRIDES` tuple and the pydantic `Field`. These must stay in sync: the env-override loop only applies `HYDRAFLOW_WIKI_COMPILATION_TIMEOUT` when the field still equals the tuple default. 300s is within the existing `le=600` bound and gives sonnet compiles room to finish. Now-diagnostic logs reveal if it's still short.
3. **Regression tests** — pin both behaviors (timeout → diagnostic stderr; empty-message exception → `exc_detail` keeps a diagnostic).

## Verification

- TDD: both regression tests confirmed RED (empty stderr) → GREEN.
- Targeted suites green: `test_lightweight_spawn_credit_telemetry`, `test_config_consistency`, `test_config_env`, `test_wiki_compiler`, `test_compile_topic_tracked`, `test_adr_draft_workflow`.
- Re-verified the env-override path still applies with the dual bump (`default=300`, `HYDRAFLOW_WIKI_COMPILATION_TIMEOUT=240` → `240`).
- Static gates (lint/typecheck/security) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)