### PR TITLE
fix(pipeline): break the human-required escalation cycle (ADR-0084 PR-1)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-12T04:52:54.868390+00:00",
-  "commit_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68",
+  "regenerated_at": "2026-06-12T05:51:42.688844+00:00",
+  "commit_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93",
   "artifacts": {
     "loops.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ports.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "labels.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "modules.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "events.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "adr_xref.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "mockworld.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "changelog.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "coverage_matrix.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "functional_areas.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ubiquitous-language.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `0c3c314` — fix(retrospective): route stale review-insights to the factory, not HITL (#9227) (#9431) (#9431) *(2026-06-11)*
 - `3f90a67` — fix(adr-drift): symbol-qualify owned citations + pr_manager shared-infra (#9405) (#9405) *(2026-06-11)*
 - `bc00ebe` — fix(mockworld): re-export FakeRouteBackCounter so its marker is actually verified (#8809) (#9408) (#9408) *(2026-06-11)*
 - `9685284` — docs(wiki): correct EpicMonitorLoop entry — it writes, not read-only (#8764) (#9407) (#9407) *(2026-06-11)*

--- a/src/config.py
+++ b/src/config.py
@@ -3019,6 +3019,11 @@ class HydraFlowConfig(BaseModel):
             self.verify_label,
         ):
             result.extend(labels)
+        # ``human-required`` is orthogonal to the stage machine, but listing it
+        # here ensures ``swap_pipeline_labels`` clears it on a successful HITL
+        # correction — so a corrected issue re-enters the pipeline clean instead
+        # of carrying a stale blocker forever (ADR-0084, pillar C / anti-cycle).
+        result.append("human-required")
         return result
 
     @property

--- a/src/issue_store.py
+++ b/src/issue_store.py
@@ -522,11 +522,20 @@ class IssueStore:
         while q and len(result) < max_count:
             task = q.popleft()
             self._queue_members[stage].discard(task.id)
-            if task.id in self._active or (
-                stage != STAGE_FIND
-                and self._crate_manager is not None
-                and self._crate_manager.active_crate_number is not None
-                and not self._crate_manager.is_in_active_crate(task)
+            if (
+                task.id in self._active
+                # ``human-required`` issues have been escalated out of the
+                # pipeline; core phases must not re-pull them, or they re-fail
+                # and re-escalate forever. The label is cleared on a successful
+                # HITL correction (it is in ``all_pipeline_labels``), after which
+                # the issue re-enters the queue clean (ADR-0084, pillar C).
+                or "human-required" in task.tags
+                or (
+                    stage != STAGE_FIND
+                    and self._crate_manager is not None
+                    and self._crate_manager.active_crate_number is not None
+                    and not self._crate_manager.is_in_active_crate(task)
+                )
             ):
                 skipped.append(task)
             else:

--- a/tests/scenarios/test_anti_cycle_human_required.py
+++ b/tests/scenarios/test_anti_cycle_human_required.py
@@ -1,0 +1,39 @@
+"""Anti-cycle scenario (ADR-0084, pillar C).
+
+An issue that has been escalated out of the pipeline with ``human-required``
+must NOT be re-pulled by a core phase — otherwise it re-fails and re-escalates
+forever. A clean sibling on the same entry label must still flow to done, so
+the guard is specific to the blocker and not a general stall.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.scenarios.builders import IssueBuilder
+
+pytestmark = pytest.mark.scenario
+
+
+class TestHumanRequiredNotRecycled:
+    async def test_human_required_issue_is_not_processed(self, mock_world) -> None:
+        world = mock_world
+        # Clean control + a human-required sibling, same entry label.
+        IssueBuilder().numbered(1).titled("Clean issue").bodied("flows normally").at(
+            world
+        )
+        IssueBuilder().numbered(2).titled("Blocked issue").bodied(
+            "escalated to a human"
+        ).labeled("hydraflow-find", "human-required").at(world)
+
+        result = await world.run_pipeline()
+
+        clean = result.issue(1)
+        assert clean.final_stage == "done"
+        assert clean.merged is True
+
+        blocked = result.issue(2)
+        assert blocked.final_stage != "done", "human-required issue must not complete"
+        assert blocked.merged is False
+        assert blocked.plan_result is None, "no phase should have picked it up"
+        assert "human-required" in blocked.labels, "blocker must remain until cleared"

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1151,6 +1151,16 @@ class TestLabelValidation:
         )
         assert "hydraflow-verify" in cfg.all_pipeline_labels
 
+    def test_human_required_in_all_pipeline_labels(self, tmp_path: Path) -> None:
+        """human-required must be in all_pipeline_labels so swap_pipeline_labels
+        clears it on a successful HITL correction (ADR-0084, pillar C)."""
+        cfg = HydraFlowConfig(
+            repo_root=tmp_path,
+            workspace_base=tmp_path / "wt",
+            state_file=tmp_path / "s.json",
+        )
+        assert "human-required" in cfg.all_pipeline_labels
+
 
 class TestTimeoutConfigFields:
     def test_agent_timeout_default(self) -> None:

--- a/tests/test_issue_store.py
+++ b/tests/test_issue_store.py
@@ -240,6 +240,32 @@ class TestQueueAccessors:
         assert len(result) == 1
         assert result[0].id == 4
 
+    def test_get_plannable_skips_human_required(self) -> None:
+        # An issue escalated out to human-required must not re-enter a core
+        # phase — else it re-fails and re-escalates forever (ADR-0084, C).
+        store = _make_store()
+        store._route_issues(
+            [TaskFactory.create(id=20, tags=["hydraflow-plan", "human-required"])]
+        )
+        assert store.get_plannable(10) == []
+
+    def test_get_reviewable_skips_human_required(self) -> None:
+        store = _make_store()
+        store._route_issues(
+            [TaskFactory.create(id=21, tags=["hydraflow-review", "human-required"])]
+        )
+        assert store.get_reviewable(10) == []
+
+    def test_human_required_skipped_but_clean_sibling_returned(self) -> None:
+        store = _make_store()
+        store._route_issues(
+            [
+                TaskFactory.create(id=22, tags=["hydraflow-plan", "human-required"]),
+                TaskFactory.create(id=23, tags=["hydraflow-plan"]),
+            ]
+        )
+        assert [t.id for t in store.get_plannable(10)] == [23]
+
     def test_get_implementable_excludes_active_issues(self) -> None:
         store = _make_store()
         store._route_issues(


### PR DESCRIPTION
**PR-1 of [ADR-0084](https://github.com/T-rav/hydraflow/pull/9435)** (pillar C — anti-cycle). First of the staged rollout that makes the Auto-Agent a universal root-cause gate so almost nothing reaches a human.

## Problem

An issue escalated out to `human-required` could **cycle forever**: the label was invisible to the core phases AND absent from `config.all_pipeline_labels`, so it survived `swap_pipeline_labels`. An exhausted issue kept its origin stage label → got re-pulled by plan/implement/review → failed → re-escalated. Unbounded.

## Fix (two surgical changes)

- `IssueStore._take_from_queue` skips any task tagged `human-required` → no core phase re-pulls an escalated issue.
- `human-required` added to `all_pipeline_labels` → a successful HITL correction's swap clears it, so the corrected issue re-enters the pipeline clean.

A blocked issue waits for a human; a corrected one flows again; neither loops.

## Scope note

This PR is the **re-entry break** only — which alone eliminates the unbounded autonomous cycle. The **global per-issue escalation cap** moves to **PR-3**, where `BaseEscalationMixin` provides the single chokepoint to count every escalation cleanly (vs bolting it onto ~7 current escalation sites).

## Tests (full pyramid)

- Unit: `test_issue_store.py` (skip human-required, clean sibling still returned), `test_config_validation.py` (human-required in all_pipeline_labels).
- Scenario (MockWorld): `test_anti_cycle_human_required.py` — a human-required issue is not processed while a clean sibling completes.
- `make quality` **16000 passed** · `make scenario` **199 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)