### PR TITLE
feat(auto-agent): converge via retry instead of one-shot needs_human (ADR-0084 PR-2)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-12T04:52:54.868390+00:00",
-  "commit_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68",
+  "regenerated_at": "2026-06-12T06:22:50.672834+00:00",
+  "commit_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93",
   "artifacts": {
     "loops.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ports.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "labels.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "modules.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "events.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "adr_xref.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "mockworld.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "changelog.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "coverage_matrix.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "functional_areas.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ubiquitous-language.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "3f90a673eff0b37b7f5f88768955cd7673af8b68"
+      "source_sha": "97005928cc165b35f5c373c55b53e00d9b2daa93"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `0c3c314` — fix(retrospective): route stale review-insights to the factory, not HITL (#9227) (#9431) (#9431) *(2026-06-11)*
 - `3f90a67` — fix(adr-drift): symbol-qualify owned citations + pr_manager shared-infra (#9405) (#9405) *(2026-06-11)*
 - `bc00ebe` — fix(mockworld): re-export FakeRouteBackCounter so its marker is actually verified (#8809) (#9408) (#9408) *(2026-06-11)*
 - `9685284` — docs(wiki): correct EpicMonitorLoop entry — it writes, not read-only (#8764) (#9407) (#9407) *(2026-06-11)*

--- a/prompts/auto_agent/_envelope.md
+++ b/prompts/auto_agent/_envelope.md
@@ -79,32 +79,63 @@ attempt to work around the restriction.
 
 ## Decision protocol
 
-You MUST terminate by returning ONE of:
+You MUST terminate by returning ONE of three statuses. **Default to fixing.**
+Escalate to a human only when a human is genuinely the only way forward.
 
 1. **`resolved`** — you made the change, ran the tests, pushed the branch, and
-   opened a PR. Provide the PR URL and a brief diagnosis describing what was
-   wrong and how you fixed it.
+   opened a PR. Provide the PR URL and a brief diagnosis of what was wrong and
+   how you fixed it.
 
-2. **`needs_human`** — you investigated but cannot resolve this autonomously.
-   Provide a precise diagnosis: what's wrong, what you tried, what you ruled
-   out, and a specific question or action for the human.
+2. **`retry`** — you could not finish *this* pass, but the blocker is NOT
+   something only a human can fix: a transient fault (worktree/index race, a
+   flaky external call), or you ran out of context/time and another pass with
+   more information would likely succeed. The system retries automatically with
+   broader context — do NOT burn a human on this.
+
+3. **`needs_human`** — a human is genuinely required. Reserve this for blockers
+   only a human can clear: a product/policy DECISION, missing CREDENTIALS, repo
+   PERMISSIONS you cannot obtain, or an UNSAFE/irreversible action. Provide a
+   precise diagnosis: what's wrong, what you ruled out, and the specific
+   decision or action you need.
+
+Always include `<confidence>` (`high`|`medium`|`low`) and, when not `resolved`,
+a `<blocked_reason>`: one of `transient`, `insufficient_context`,
+`needs_human_decision`, `needs_credentials`, `needs_permissions`, `unsafe`, or
+`none`. **`needs_human` is honored only when `<blocked_reason>` is
+`needs_human_decision` / `needs_credentials` / `needs_permissions` / `unsafe`
+at `high` confidence — otherwise the system treats your bail as `retry` and
+tries again.** So be honest: if you're unsure or just out of context, say so.
 
 Format your final response as:
 
 ```
 <status>resolved</status>
 <pr_url>https://...</pr_url>
+<confidence>high</confidence>
 <diagnosis>
-... your diagnosis or fix summary ...
+... what was wrong and how you fixed it ...
 </diagnosis>
 ```
 
-Or:
+Or, when you could not finish but a human is not required:
+
+```
+<status>retry</status>
+<confidence>medium</confidence>
+<blocked_reason>insufficient_context</blocked_reason>
+<diagnosis>
+... what you learned, what to try next pass ...
+</diagnosis>
+```
+
+Or, when a human truly is required:
 
 ```
 <status>needs_human</status>
+<confidence>high</confidence>
+<blocked_reason>needs_human_decision</blocked_reason>
 <diagnosis>
-... your diagnosis ...
+... what's wrong, what you ruled out, the decision or action you need ...
 </diagnosis>
 ```
 

--- a/src/preflight/agent.py
+++ b/src/preflight/agent.py
@@ -42,6 +42,34 @@ class PreflightSpawn:
     prompt_hash: str = ""  # hex prefix; populated by spawn_fn for audit traceability
 
 
+# Blocked reasons that genuinely require a human (ADR-0084 pillar B). Any other
+# bail — transient, insufficient_context, low confidence, or a missing/garbled
+# status — is treated as ``retry`` so the loop attempts again rather than paging
+# a human prematurely (the #9275 failure mode).
+_HUMAN_ONLY_REASONS = frozenset(
+    {"needs_human_decision", "needs_credentials", "needs_permissions", "unsafe"}
+)
+
+
+def _derive_status(
+    raw_status: str, confidence: str, blocked_reason: str, pr_url: str | None
+) -> str:
+    """Map the agent's raw self-reported status into the convergence states.
+
+    - ``resolved`` (with a PR) stays ``resolved``; a claimed resolve with no PR
+      is a ``pr_failed``.
+    - A ``needs_human`` bail is honored only for a genuine human-only
+      ``blocked_reason`` at ``high`` confidence.
+    - Everything else — a transient/insufficient-context bail, low confidence,
+      or a missing/garbled status — becomes ``retry``.
+    """
+    if raw_status == "resolved":
+        return "resolved" if pr_url else "pr_failed"
+    if blocked_reason in _HUMAN_ONLY_REASONS and confidence == "high":
+        return "needs_human"
+    return "retry"
+
+
 async def run_preflight(
     *,
     context: PreflightContext,
@@ -141,14 +169,15 @@ async def run_preflight(
         )
 
     parsed = parse_agent_response(spawn.output_text)
-    raw_status: str = parsed["status"] or "needs_human"
-    status = raw_status if raw_status in {"resolved", "needs_human"} else "needs_human"
+    raw_status = parsed["status"] or ""
+    confidence = parsed["confidence"] or "low"
+    blocked_reason = parsed["blocked_reason"] or "none"
     pr_url = parsed["pr_url"]
-    # Agent claimed "resolved" but produced no PR — that's a PR-creation failure
-    # (spec §2.2: pr_failed status). Demote so the loop applies the right label
-    # set instead of treating the missing PR as a successful resolve.
-    if status == "resolved" and not pr_url:
-        status = "pr_failed"
+    # Convergence (ADR-0084 B): a `needs_human` bail is honored only for a real
+    # human-only blocker at high confidence; everything else — including a
+    # missing/garbled status — becomes `retry` so the loop tries again instead
+    # of paging a human on attempt 1 (the #9275 failure mode).
+    status = _derive_status(raw_status, confidence, blocked_reason, pr_url)
     return PreflightResult(
         status=status,
         pr_url=pr_url,
@@ -157,6 +186,8 @@ async def run_preflight(
         wall_clock_s=wall_s,
         tokens=spawn.tokens,
         prompt_hash=spawn_hash,
+        confidence=confidence,
+        blocked_reason=blocked_reason,
     )
 
 

--- a/src/preflight/decision.py
+++ b/src/preflight/decision.py
@@ -17,13 +17,19 @@ logger = logging.getLogger("hydraflow.preflight.decision")
 
 @dataclass(frozen=True)
 class PreflightResult:
-    status: str  # "resolved" | "needs_human" | "fatal" | "pr_failed" | "cost_exceeded" | "timeout"
+    status: str  # "resolved" | "retry" | "needs_human" | "fatal" | "pr_failed" | "cost_exceeded" | "timeout"
     pr_url: str | None
     diagnosis: str
     cost_usd: float
     wall_clock_s: float
     tokens: int
     prompt_hash: str = ""  # populated from PreflightSpawn for audit traceability
+    # Convergence signals (ADR-0084 pillar B): the agent's self-assessed
+    # confidence and why it stopped. ``needs_human`` is only honored for a
+    # genuine human-only ``blocked_reason`` at high confidence; otherwise the
+    # bail is treated as ``retry`` and the loop tries again next cycle.
+    confidence: str = "high"  # "high" | "medium" | "low"
+    blocked_reason: str = "none"
 
 
 class _PRPort(Protocol):
@@ -46,6 +52,11 @@ class _PRPort(Protocol):
 # doesn't stay in the human queue after a successful auto-fix.
 _LABEL_MAP: dict[str, tuple[list[str], list[str]]] = {
     "resolved": ([], ["hitl-escalation", "human-required"]),
+    # `retry` (ADR-0084 B): a recoverable/low-confidence bail. Add nothing and
+    # remove nothing — the issue keeps `hitl-escalation` (no `human-required`)
+    # so the loop re-attempts next cycle. If the attempt budget is exhausted,
+    # the exhaustion branch below escalates it to a human.
+    "retry": ([], []),
     "needs_human": (["human-required"], []),
     "fatal": (["human-required", "auto-agent-fatal"], []),
     "pr_failed": (["human-required", "auto-agent-pr-failed"], []),
@@ -76,11 +87,17 @@ async def apply_decision(
     if result.status == "resolved" and sub_label and sub_label != "_default":
         remove = list(remove) + [sub_label]
 
-    # Exhaustion check — if this attempt brought us to the cap and it didn't resolve,
-    # flag as exhausted on top of the normal needs_human/fatal label set.
+    # Exhaustion check — if this attempt brought us to the cap and it didn't
+    # resolve, flag as exhausted on top of the normal needs_human/fatal label
+    # set. A `retry` that exhausts its budget must still escalate to a human:
+    # its base label map adds no `human-required`, so add it here.
     exhausted = result.status != "resolved" and current_attempts >= max_attempts
     if exhausted:
-        add = list(add) + ["auto-agent-exhausted"]
+        add = list(add)
+        if "human-required" not in add:
+            add.append("human-required")
+        if "auto-agent-exhausted" not in add:
+            add.append("auto-agent-exhausted")
 
     if add:
         await pr_port.add_labels(issue_number, add)

--- a/src/preflight/runner.py
+++ b/src/preflight/runner.py
@@ -173,10 +173,19 @@ _TAG_RE = re.compile(r"<(\w+)>(.*?)</\1>", re.DOTALL)
 
 
 def parse_agent_response(text: str) -> dict[str, str | None]:
-    """Parse <status>...</status> + <pr_url>...</pr_url> + <diagnosis>...</diagnosis>."""
+    """Parse the agent's response tags.
+
+    Recognises ``<status>``, ``<pr_url>``, ``<confidence>``, ``<blocked_reason>``
+    and ``<diagnosis>``. A missing ``status`` is returned as ``None`` (not
+    ``needs_human``) so the caller can apply convergence-aware fallback — a
+    malformed response is a ``retry``, not an instant human escalation
+    (ADR-0084 pillar B).
+    """
     tags = {m.group(1): m.group(2).strip() for m in _TAG_RE.finditer(text)}
     return {
-        "status": tags.get("status", "needs_human"),
+        "status": tags.get("status") or None,
         "pr_url": tags.get("pr_url") or None,
+        "confidence": (tags.get("confidence") or "").lower() or None,
+        "blocked_reason": (tags.get("blocked_reason") or "").lower() or None,
         "diagnosis": tags.get("diagnosis", text.strip()),
     }

--- a/tests/auto_agent/adversarial/corpus/garbage-output/expected.json
+++ b/tests/auto_agent/adversarial/corpus/garbage-output/expected.json
@@ -1,6 +1,6 @@
 {
-  "status": "needs_human",
-  "labels_added": ["human-required"],
+  "status": "retry",
+  "labels_added": [],
   "labels_removed": [],
   "pr_url": null
 }

--- a/tests/auto_agent/adversarial/corpus/rc-duration-stuck/cassette.json
+++ b/tests/auto_agent/adversarial/corpus/rc-duration-stuck/cassette.json
@@ -1,5 +1,5 @@
 {
-  "output_text": "<status>needs_human</status><diagnosis>Blocking review needed: duration regression spans 6 test modules with no single commit to revert. Requires human to profile and prioritize which modules to optimise first.</diagnosis>",
+  "output_text": "<status>needs_human</status><confidence>high</confidence><blocked_reason>needs_human_decision</blocked_reason><diagnosis>Blocking review needed: duration regression spans 6 test modules with no single commit to revert. Requires human to profile and prioritize which modules to optimise first.</diagnosis>",
   "cost_usd": 0.8,
   "tokens": 6000,
   "crashed": false

--- a/tests/auto_agent/adversarial/corpus/rc-red-bisect-exhausted/cassette.json
+++ b/tests/auto_agent/adversarial/corpus/rc-red-bisect-exhausted/cassette.json
@@ -1,5 +1,5 @@
 {
-  "output_text": "<status>needs_human</status><diagnosis>Bisect ambiguous: both candidate commits touch shared integration layer; cannot isolate blame without runtime profiling. Human review required.</diagnosis>",
+  "output_text": "<status>needs_human</status><confidence>high</confidence><blocked_reason>needs_human_decision</blocked_reason><diagnosis>Bisect ambiguous: both candidate commits touch shared integration layer; cannot isolate blame without runtime profiling. Human review required.</diagnosis>",
   "cost_usd": 0.8,
   "tokens": 6000,
   "crashed": false

--- a/tests/auto_agent/adversarial/corpus/trust-loop-anomaly/cassette.json
+++ b/tests/auto_agent/adversarial/corpus/trust-loop-anomaly/cassette.json
@@ -1,5 +1,5 @@
 {
-  "output_text": "<status>needs_human</status><diagnosis>Anomaly is valid pipeline drift: label sequence confirms a race between caretaker-loop and hitl-controller. Automated fix would mask the underlying state-machine defect; human review required to patch the race.</diagnosis>",
+  "output_text": "<status>needs_human</status><confidence>high</confidence><blocked_reason>needs_human_decision</blocked_reason><diagnosis>Anomaly is valid pipeline drift: label sequence confirms a race between caretaker-loop and hitl-controller. Automated fix would mask the underlying state-machine defect; human review required to patch the race.</diagnosis>",
   "cost_usd": 0.8,
   "tokens": 6000,
   "crashed": false

--- a/tests/scenarios/test_auto_agent_preflight.py
+++ b/tests/scenarios/test_auto_agent_preflight.py
@@ -79,6 +79,37 @@ async def test_flaky_test_resolved(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_low_confidence_bail_retries_without_paging_human(tmp_path: Path) -> None:
+    # A `needs_human` bail with a transient / low-confidence signal must NOT
+    # page a human — the loop converges via `retry`, leaving the issue eligible
+    # for the next cycle (ADR-0084 pillar B; the #9275 failure mode).
+    loop, _state, pr, _audit = _make_loop(tmp_path)
+    pr.list_issues_by_label = AsyncMock(
+        return_value=[
+            {
+                "number": 1,
+                "body": "x",
+                "labels": [
+                    {"name": "hitl-escalation"},
+                    {"name": "flaky-test-stuck"},
+                ],
+            },
+        ]
+    )
+    _stub_spawn(
+        loop,
+        "<status>needs_human</status><confidence>low</confidence>"
+        "<blocked_reason>insufficient_context</blocked_reason>"
+        "<diagnosis>need more context</diagnosis>",
+    )
+    result = await loop._do_work()
+    assert result["result_status"] == "retry"
+    # No human escalation: nothing the loop added may include human-required.
+    for call in pr.add_labels.await_args_list:
+        assert "human-required" not in call.args[1]
+
+
+@pytest.mark.asyncio
 async def test_subprocess_fatal(tmp_path: Path) -> None:
     loop, _state, pr, _audit = _make_loop(tmp_path)
     pr.list_issues_by_label = AsyncMock(

--- a/tests/test_preflight_agent.py
+++ b/tests/test_preflight_agent.py
@@ -9,6 +9,7 @@ import pytest
 from preflight.agent import (
     PreflightAgentDeps,
     PreflightSpawn,
+    _derive_status,
     hash_prompt,
     run_preflight,
 )
@@ -228,7 +229,10 @@ async def test_unspecialised_sublabel_uses_deps_persona() -> None:
 
 
 @pytest.mark.asyncio
-async def test_unparseable_response_falls_back_to_needs_human() -> None:
+async def test_unparseable_response_falls_back_to_retry() -> None:
+    # A garbled/missing status is a recoverable failure, not a human blocker —
+    # the loop retries with broader context rather than paging a human on a
+    # parse glitch (ADR-0084 pillar B, the #9275 failure mode).
     spawn_fn = AsyncMock(
         return_value=PreflightSpawn(
             process=None,
@@ -247,4 +251,37 @@ async def test_unparseable_response_falls_back_to_needs_human() -> None:
     out = await run_preflight(
         context=_ctx(), repo_slug="x/y", worktree_path="/tmp", deps=deps
     )
-    assert out.status == "needs_human"
+    assert out.status == "retry"
+
+
+@pytest.mark.parametrize(
+    ("raw_status", "confidence", "blocked_reason", "pr_url", "expected"),
+    [
+        # Resolved with / without a PR.
+        ("resolved", "high", "none", "https://x/pr/1", "resolved"),
+        ("resolved", "high", "none", None, "pr_failed"),
+        # Genuine human-only blockers at high confidence → needs_human.
+        ("needs_human", "high", "needs_human_decision", None, "needs_human"),
+        ("needs_human", "high", "needs_credentials", None, "needs_human"),
+        ("needs_human", "high", "needs_permissions", None, "needs_human"),
+        ("needs_human", "high", "unsafe", None, "needs_human"),
+        # Same blocker but LOW confidence → retry (don't page a human yet).
+        ("needs_human", "low", "needs_human_decision", None, "retry"),
+        # Recoverable blockers → retry regardless of confidence.
+        ("needs_human", "high", "transient", None, "retry"),
+        ("needs_human", "high", "insufficient_context", None, "retry"),
+        # Missing / garbled status → retry (the #9275 parse-glitch case).
+        ("", "low", "none", None, "retry"),
+        ("needs_human", "high", "none", None, "retry"),
+    ],
+)
+def test_derive_status_matrix(
+    raw_status: str,
+    confidence: str,
+    blocked_reason: str,
+    pr_url: str | None,
+    expected: str,
+) -> None:
+    # ADR-0084 pillar B: needs_human is honored only for a real human-only
+    # blocker at high confidence; everything else converges via retry.
+    assert _derive_status(raw_status, confidence, blocked_reason, pr_url) == expected

--- a/tests/test_preflight_decision.py
+++ b/tests/test_preflight_decision.py
@@ -179,3 +179,46 @@ async def test_timeout_pairs_correctly() -> None:
         max_attempts=3,
     )
     pr.add_labels.assert_awaited_with(42, ["human-required", "timeout"])
+
+
+@pytest.mark.asyncio
+async def test_retry_keeps_issue_eligible_without_human_label() -> None:
+    # A `retry` below the attempt cap adds no labels and removes none — the
+    # issue keeps `hitl-escalation` (no `human-required`) so the loop re-attempts
+    # next cycle (ADR-0084 pillar B).
+    pr = AsyncMock()
+    state = MagicMock()
+    state.get_auto_agent_attempts = MagicMock(return_value=1)
+    out = await apply_decision(
+        issue_number=42,
+        sub_label="flaky-test-stuck",
+        result=_result("retry"),
+        pr_port=pr,
+        state=state,
+        max_attempts=3,
+    )
+    pr.add_labels.assert_not_awaited()
+    pr.remove_label.assert_not_awaited()
+    assert out["exhausted"] is False
+    assert out["status"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_retry_at_cap_escalates_to_human() -> None:
+    # A `retry` that exhausts the attempt budget MUST escalate to a human — its
+    # base label map adds no `human-required`, so the exhaustion branch does.
+    pr = AsyncMock()
+    state = MagicMock()
+    state.get_auto_agent_attempts = MagicMock(return_value=3)
+    out = await apply_decision(
+        issue_number=42,
+        sub_label="flaky-test-stuck",
+        result=_result("retry"),
+        pr_port=pr,
+        state=state,
+        max_attempts=3,
+    )
+    assert out["exhausted"] is True
+    pr.add_labels.assert_awaited_once_with(
+        42, ["human-required", "auto-agent-exhausted"]
+    )

--- a/tests/test_preflight_runner.py
+++ b/tests/test_preflight_runner.py
@@ -160,6 +160,27 @@ def test_parse_agent_response_needs_human() -> None:
     assert out["pr_url"] is None
 
 
+def test_parse_agent_response_parses_confidence_and_blocked_reason() -> None:
+    out = parse_agent_response(
+        "<status>retry</status><confidence>Medium</confidence>"
+        "<blocked_reason>Insufficient_Context</blocked_reason>"
+        "<diagnosis>try again</diagnosis>"
+    )
+    assert out["status"] == "retry"
+    # Normalised to lower-case for the convergence comparison.
+    assert out["confidence"] == "medium"
+    assert out["blocked_reason"] == "insufficient_context"
+
+
+def test_parse_agent_response_missing_status_is_none_not_needs_human() -> None:
+    # A garbled response leaves status None so the caller can retry rather than
+    # defaulting straight to a human escalation (ADR-0084 pillar B).
+    out = parse_agent_response("no tags at all")
+    assert out["status"] is None
+    assert out["confidence"] is None
+    assert out["blocked_reason"] is None
+
+
 def test_prompt_template_with_unknown_field_raises_keyerror(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
**PR-2 of [ADR-0084](https://github.com/T-rav/hydraflow/pull/9435)** (pillar B — convergence). Builds on PR-1 (#9439).

## Problem (#9275, the smoking gun)

The Auto-Agent bailed to `human-required` **on attempt 1** — even for transient faults, low-confidence guesses, or garbled output (`parse_agent_response` *defaulted* to `needs_human`). It fired, said *"all clean, needs_human"*, and paged a human with no fix and no retry.

## Fix — a convergence layer

- **New `retry` outcome** distinct from `needs_human`. The agent emits `<confidence>` and `<blocked_reason>`; **`_derive_status` honours `needs_human` only for a genuine human-only blocker** (`needs_human_decision` / `needs_credentials` / `needs_permissions` / `unsafe`) at high confidence. Everything else → `retry`, and the loop tries again next cycle.
- The attempt cap still bounds it: a `retry` that exhausts the budget escalates to a human (`human-required` + `auto-agent-exhausted`).
- **Parse robustness:** a missing status no longer defaults to `needs_human` — a parse glitch retries instead of paging a human.
- The prompt envelope teaches the agent the three statuses and when each applies.

## Tests (full pyramid)

- Unit: `_derive_status` matrix (11 cases incl. low-confidence-human-blocker→retry, garbled→retry), parse (new tags + missing→None), decision (retry keeps issue eligible; retry-at-cap→human).
- Scenario (MockWorld): a low-confidence bail retries without paging a human.
- **Adversarial corpus** updated to the new contract: 3 genuine human-decision entries (RC-duration prioritization, bisect blame-call, a trust-anomaly the agent *responsibly* declines to auto-fix) upgraded to the new format so they still escalate; the unparseable-output entry now correctly **retries**.
- `make quality` ✓ · `make scenario` **198**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)