### PR TITLE
fix(pr-unsticker): rebase PRs that went DIRTY after escalation (live merge state)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-12T18:44:26.737514+00:00",
-  "commit_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff",
+  "regenerated_at": "2026-06-12T19:01:45.553686+00:00",
+  "commit_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803",
   "artifacts": {
     "loops.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "ports.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "labels.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "modules.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "events.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "adr_xref.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "mockworld.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "changelog.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "coverage_matrix.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "functional_areas.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "ubiquitous-language.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "5570ec9e4ca148d9044d38e2633a2444ece2bfff"
+      "source_sha": "124b2e811ba8f9d6258daaf3db2a956e08af0803"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,12 +6,12 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `5570ec9` — Merge remote-tracking branch 'origin/staging' into ul-evidence/f65e78b1 *(2026-06-12)*
+- `124b2e8` — feat(ul): entry-evidence — 20 new entry links across 11 terms (#9423) (#9423) *(2026-06-12)*
+- `076ee8f` — feat(ul): edge-proposer — 107 new edges across 30 terms (#9422) (#9422) *(2026-06-12)*
 - `a293ffc` — feat(ul): term-proposer batch — 1 drafts (#9424) (#9424) *(2026-06-12)*
 - `e201308` — feat(ul): entry-evidence — 2 new entry links across 2 terms (#9428) (#9428) *(2026-06-12)*
 - `d296730` — feat(ul): edge-proposer — 3 new edges across 2 terms (#9427) (#9427) *(2026-06-12)*
 - `39b48b2` — feat(ul): entry-evidence — 3 new entry links across 3 terms (#9425) (#9425) *(2026-06-12)*
-- `f634533` — Merge remote-tracking branch 'origin/staging' into ul-evidence/f65e78b1 *(2026-06-12)*
 - `9ed1b39` — feat(auto-agent): rescue stuck pipeline PRs — diagnose-route + credit-transient (ADR-0084) (#9473) (#9473) *(2026-06-12)*
 - `44d1957` — Fixes #8693: "Recorder-side `gh issue close` support for cassette r... (#9446) (#9446) *(2026-06-12)*
 - `1a7071a` — fix(trust): min-sample guard + repaired semantics + trust-loop scoping for repair_ratio (#9458) (#9470) (#9470) *(2026-06-12)*
@@ -23,7 +23,6 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 - `5ae5f3b` — Fixes #9100: entry_evidence_loop swallows CreditExhaustedError and ... (#9451) (#9451) *(2026-06-12)*
 - `d0f190f` — docs(adr): ADR-0084 — Auto-Agent as a universal root-cause HITL gate (Proposed) (#9435) (#9435) *(2026-06-12)*
 - `0c3c314` — fix(retrospective): route stale review-insights to the factory, not HITL (#9227) (#9431) (#9431) *(2026-06-11)*
-- `a13f2db` — feat(ul): entry-evidence — 20 new entry links across 11 terms *(2026-06-11)*
 - `3f90a67` — fix(adr-drift): symbol-qualify owned citations + pr_manager shared-infra (#9405) (#9405) *(2026-06-11)*
 - `bc00ebe` — fix(mockworld): re-export FakeRouteBackCounter so its marker is actually verified (#8809) (#9408) (#9408) *(2026-06-11)*
 - `9685284` — docs(wiki): correct EpicMonitorLoop entry — it writes, not read-only (#8764) (#9407) (#9407) *(2026-06-11)*

--- a/src/pr_unsticker.py
+++ b/src/pr_unsticker.py
@@ -260,6 +260,31 @@ class PRUnsticker:
 
         return merged
 
+    async def _effective_cause(
+        self, cause: FailureCause, pr_number: int | None
+    ) -> FailureCause:
+        """Override the stored-cause classification with the live merge state.
+
+        A PR that became conflicting *after* its original escalation — e.g. a
+        code-complete PR that went DIRTY when the base branch advanced (the
+        recurring regenerated-artifact conflict) — carries a stale cause string
+        that never mentions a conflict. Routed by that string it would get a
+        no-op code fix and stay DIRTY forever. If GitHub reports the PR as
+        conflicting now, treat it as a ``MERGE_CONFLICT`` so it is rebased
+        first (ADR-0084: rescue stuck PRs).
+        """
+        if cause == FailureCause.MERGE_CONFLICT or not pr_number or pr_number <= 0:
+            return cause
+        if await self._prs.get_pr_mergeable(pr_number) is False:
+            logger.info(
+                "PR #%d is conflicting now — resolving the conflict before the "
+                "stored cause (%s)",
+                pr_number,
+                cause.value,
+            )
+            return FailureCause.MERGE_CONFLICT
+        return cause
+
     async def _process_item(self, item: HITLItem) -> bool:
         """Attempt to resolve issues for a single HITL item.
 
@@ -268,7 +293,7 @@ class PRUnsticker:
         issue_number = item.issue
         branch = self._config.branch_for_issue(issue_number)
         cause_str = self._state.get_hitl_cause(issue_number) or ""
-        cause = _classify_cause(cause_str)
+        cause = await self._effective_cause(_classify_cause(cause_str), item.pr)
 
         # Claim: swap labels
         claim_kwargs: dict[str, int] = {}

--- a/tests/test_pr_unsticker.py
+++ b/tests/test_pr_unsticker.py
@@ -130,6 +130,56 @@ class TestPRUnstickerInternals:
         assert "Falling back to 'general' language classification" in caplog.text
 
 
+class TestEffectiveCauseLiveMergeState:
+    """_effective_cause overrides a stale stored cause with the live merge state
+    so a PR that went DIRTY *after* escalation gets rebased, not a no-op fix."""
+
+    @pytest.mark.asyncio
+    async def test_live_conflict_overrides_non_conflict_cause(
+        self, tmp_path: Path
+    ) -> None:
+        h = _make_unsticker(tmp_path)
+        h.prs.get_pr_mergeable = AsyncMock(return_value=False)  # conflicting now
+        out = await h.unsticker._effective_cause(FailureCause.GENERIC, pr_number=99)
+        assert out == FailureCause.MERGE_CONFLICT
+        h.prs.get_pr_mergeable.assert_awaited_once_with(99)
+
+    @pytest.mark.asyncio
+    async def test_mergeable_pr_keeps_stored_cause(self, tmp_path: Path) -> None:
+        h = _make_unsticker(tmp_path)
+        h.prs.get_pr_mergeable = AsyncMock(return_value=True)
+        out = await h.unsticker._effective_cause(FailureCause.CI_FAILURE, pr_number=99)
+        assert out == FailureCause.CI_FAILURE
+
+    @pytest.mark.asyncio
+    async def test_unknown_mergeable_keeps_stored_cause(self, tmp_path: Path) -> None:
+        # None = unknown; don't override on uncertainty.
+        h = _make_unsticker(tmp_path)
+        h.prs.get_pr_mergeable = AsyncMock(return_value=None)
+        out = await h.unsticker._effective_cause(FailureCause.GENERIC, pr_number=99)
+        assert out == FailureCause.GENERIC
+
+    @pytest.mark.asyncio
+    async def test_already_merge_conflict_skips_live_check(
+        self, tmp_path: Path
+    ) -> None:
+        h = _make_unsticker(tmp_path)
+        h.prs.get_pr_mergeable = AsyncMock(return_value=True)
+        out = await h.unsticker._effective_cause(
+            FailureCause.MERGE_CONFLICT, pr_number=99
+        )
+        assert out == FailureCause.MERGE_CONFLICT
+        h.prs.get_pr_mergeable.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_pr_number_skips_live_check(self, tmp_path: Path) -> None:
+        h = _make_unsticker(tmp_path)
+        h.prs.get_pr_mergeable = AsyncMock(return_value=False)
+        out = await h.unsticker._effective_cause(FailureCause.GENERIC, pr_number=None)
+        assert out == FailureCause.GENERIC
+        h.prs.get_pr_mergeable.assert_not_awaited()
+
+
 class TestCauseClassification:
     """Test _classify_cause() with various cause strings."""
 


### PR DESCRIPTION
Continues the "rescue stuck PRs" work ([ADR-0084](https://github.com/T-rav/hydraflow/pull/9435)). Found by re-examining the current stuck PRs: **#9445** had its review feedback *already applied* ("code-complete") but is still stuck because it went **DIRTY** after escalation.

## Gap

`PRUnsticker` classifies a stuck PR by its **stored** escalation cause, then routes review/CI/generic → a code fix, merge-conflict → a rebase. A PR that became conflicting *after* escalation (the base advanced — the recurring regenerated-artifact conflict, the tax that DIRTYs every factory PR when staging moves) carries a stale cause string that never says "conflict" → it's sent to a code fix that finds nothing to do → **stays DIRTY forever**.

## Fix

`_effective_cause` consults the **live** merge state (`get_pr_mergeable`) before resolving: if GitHub reports the PR conflicting *now*, treat it as `MERGE_CONFLICT` (rebase) regardless of the stale stored cause. Conservative — only overrides on a definite conflict (`False`), never on mergeable/unknown; skips when already a merge conflict or no PR.

## Tests
5 unit tests on `_effective_cause` (live-conflict override, mergeable/unknown keep cause, already-conflict + no-PR skip the check). `src/pr_unsticker.py` pyright-clean · `make quality` ✓ · `scenario-loops` **126**. (The one browser scenario that fails is a pre-existing local Playwright timeout — verified failing on clean staging.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)