### PR TITLE
fix(observability): suppress Sentry noise — bugs-only filter + test/scenario init guard

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-12T19:41:23.218564+00:00",
-  "commit_sha": "74bef31ab952b649dd043257df21db96f88de2fd",
+  "regenerated_at": "2026-06-12T22:30:09.913211+00:00",
+  "commit_sha": "e654a480bd45460428494427cca37e0d5398ba1e",
   "artifacts": {
     "loops.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "ports.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "labels.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "modules.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "events.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "adr_xref.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "mockworld.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "changelog.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "coverage_matrix.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "functional_areas.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "ubiquitous-language.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "74bef31ab952b649dd043257df21db96f88de2fd"
+      "source_sha": "e654a480bd45460428494427cca37e0d5398ba1e"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,8 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `74bef31` — Merge remote-tracking branch 'origin/staging' into feat/dependabot-autoheal-stale-arch *(2026-06-12)*
-- `bb21b12` — feat(dependabot-merge): auto-heal bot PRs stuck on stale arch artifacts *(2026-06-12)*
+- `e654a48` — feat(dependabot-merge): auto-heal bot PRs stuck on stale arch artifacts (#9475) (#9475) *(2026-06-12)*
+- `8572c35` — fix(pr-unsticker): rebase PRs that went DIRTY after escalation (live merge state) (#9476) (#9476) *(2026-06-12)*
 - `124b2e8` — feat(ul): entry-evidence — 20 new entry links across 11 terms (#9423) (#9423) *(2026-06-12)*
 - `076ee8f` — feat(ul): edge-proposer — 107 new edges across 30 terms (#9422) (#9422) *(2026-06-12)*
 - `a293ffc` — feat(ul): term-proposer batch — 1 drafts (#9424) (#9424) *(2026-06-12)*

--- a/src/health_monitor_loop.py
+++ b/src/health_monitor_loop.py
@@ -912,11 +912,10 @@ class HealthMonitorLoop(BaseBackgroundLoop):
                         logger.debug(
                             "Failed to write HITL recommendation", exc_info=True
                         )
-                    if self._obs is not None:
-                        self._obs.capture_message(
-                            f"Health monitor filed HITL recommendation: {metric_name}",
-                            level="warning",
-                        )
+                    # NB: filing a HITL recommendation is normal operation — it is
+                    # already persisted to hitl_recommendations.jsonl and logged.
+                    # It is NOT a code bug, so it is deliberately NOT captured to
+                    # Sentry (Sentry's contract is real code bugs only).
                 except Exception:  # noqa: BLE001
                     logger.warning(
                         "Failed to file HITL recommendation for %s",

--- a/src/log_ingestion.py
+++ b/src/log_ingestion.py
@@ -342,9 +342,14 @@ def _escalate_log_pattern(
     pattern: LogPattern,
     known: KnownLogPattern,
     config: HydraFlowConfig,
-    obs: ObservabilityPort | None = None,
 ) -> None:
-    """Write a HITL recommendation for an escalating log pattern."""
+    """Write a HITL recommendation for an escalating log pattern.
+
+    The escalation is persisted to hitl_recommendations.jsonl and logged. It is
+    operational signal, not a code bug, so it is deliberately NOT captured to
+    Sentry (Sentry's contract is real code bugs only) — that previously flooded
+    the project with one event per escalation tick.
+    """
     title = f"[Health Monitor] Log pattern escalating: {pattern.fingerprint[:60]}"
     body = _build_escalation_body(pattern, known)
     try:
@@ -361,12 +366,6 @@ def _escalate_log_pattern(
         logger.warning("HITL recommendation: %s", title)
     except OSError:
         logger.debug("Failed to write HITL recommendation", exc_info=True)
-
-    if obs is not None:
-        obs.capture_message(
-            f"Log pattern escalating: {pattern.fingerprint[:60]}",
-            level="warning",
-        )
 
 
 async def file_log_patterns(
@@ -415,7 +414,7 @@ async def file_log_patterns(
             # Known pattern — check for escalation (3x increase over filed baseline)
             known = known_patterns[key]
             if pattern.count >= known.filed_count * 3:
-                _escalate_log_pattern(pattern, known, config, obs)
+                _escalate_log_pattern(pattern, known, config)
                 escalated += 1
             known.last_count = pattern.count
 

--- a/src/server.py
+++ b/src/server.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import signal
+import sys
 from pathlib import Path
 
 from config import HydraFlowConfig, build_credentials
@@ -15,10 +16,24 @@ from runtime_config import DEFAULT_LOG_FILE, load_runtime_config
 logger = logging.getLogger("hydraflow.server")
 
 
-def _init_sentry() -> None:
-    """Initialize Sentry SDK if SENTRY_DSN is configured."""
+def _init_sentry(*, force: bool = False) -> None:
+    """Initialize Sentry SDK if SENTRY_DSN is configured.
+
+    Skips initialisation entirely under the test suite (``pytest``) or when
+    ``HYDRAFLOW_SENTRY_DISABLED=1``. Tests and MockWorld scenarios run with
+    fixture data (issue #42, PR #101, ``boom`` failure sentinels); without this
+    guard that fixture noise initialises the *real* client and ships straight to
+    production Sentry. ``force=True`` bypasses the guard and is used only by the
+    Sentry integration tests to exercise the init machinery against a mock SDK.
+    """
     dsn = os.environ.get("SENTRY_DSN", "")
     if not dsn:
+        return
+    if not force and (
+        os.environ.get("HYDRAFLOW_SENTRY_DISABLED") == "1"
+        or os.environ.get("PYTEST_CURRENT_TEST")
+        or "pytest" in sys.modules
+    ):
         return
 
     import re  # noqa: PLC0415
@@ -53,28 +68,39 @@ def _init_sentry() -> None:
     )
 
     def _before_send(event, hint):  # type: ignore[no-untyped-def]
-        """Drop transient errors, fingerprint bugs, scrub credentials."""
+        """Keep only real code bugs; drop all operational noise; scrub creds.
+
+        Sentry's contract here is "real code bugs only" (the SentryLoop files a
+        GitHub issue per ingested bug). A real bug is an exception whose type is
+        in ``_BUG_TYPES`` — raised unhandled (caught by FastApiIntegration) or
+        logged with ``exc_info`` / ``logger.exception``. Everything else is
+        dropped:
+
+        * transient / infra exceptions (network, auth, Docker, subprocess);
+        * message-only events — plain ``logger.error(...)`` and direct
+          ``capture_message(...)`` from operational code paths (rate-limit
+          back-offs, gh failures, HITL recommendations, log-pattern escalations).
+
+        This stops operational log lines from flooding Sentry as "errors".
+        """
         exc_info = hint.get("exc_info")
-        if exc_info:
-            exc_type = exc_info[0]
-            if exc_type and not issubclass(exc_type, _BUG_TYPES):
-                return None  # Drop transient errors (network, auth, Docker, etc.)
-            # Fingerprint by exception type + module to collapse duplicates
-            exc_name = exc_type.__name__ if exc_type else "Unknown"
-            module = getattr(exc_info[1], "__module__", "") or ""
-            event["fingerprint"] = [exc_name, module]
+        if not exc_info:
+            # LoggingIntegration events carry the record; an exception may hang
+            # off it (logger.exception / exc_info=True). Plain logger.error has
+            # none, so such events are message-only and get dropped below.
+            log_record = hint.get("log_record")
+            exc_info = getattr(log_record, "exc_info", None) if log_record else None
 
-        # Check log-record events (from LoggingIntegration)
-        log_record = hint.get("log_record")
-        if log_record and not exc_info:
-            record_exc = getattr(log_record, "exc_info", None)
-            if (
-                record_exc
-                and record_exc[0]
-                and not issubclass(record_exc[0], _BUG_TYPES)
-            ):
-                return None  # Drop transient errors logged via logger.exception()
+        if not exc_info:
+            return None  # Message-only event (logger.error / capture_message) — drop.
 
+        exc_type = exc_info[0]
+        if exc_type is None or not issubclass(exc_type, _BUG_TYPES):
+            return None  # Transient / infra exception — not a code bug, drop.
+
+        # Fingerprint by exception type + module to collapse duplicates.
+        module = getattr(exc_info[1], "__module__", "") or ""
+        event["fingerprint"] = [exc_type.__name__, module]
         return _scrub(event)
 
     sentry_sdk.init(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,18 @@ import pytest
 # dedicated `sandbox` job (`scripts/sandbox_scenario.py`).
 collect_ignore_glob = ["sandbox_scenarios/*"]
 
+# The test suite and MockWorld scenarios run with fixture data — issue #42,
+# PR #101, "boom" failure sentinels, AsyncMock collaborators. None of it must
+# ever reach the real Sentry project. A real SENTRY_DSN in the ambient env
+# (e.g. loaded from .env on a developer/CI box) would otherwise let any test
+# that spins up the server or logs an error ship that fixture noise to
+# production Sentry. Neutralise it at import time — before collection — so the
+# guard holds regardless of which test triggers init. `_init_sentry` also
+# honours HYDRAFLOW_SENTRY_DISABLED; the Sentry integration tests opt back in
+# explicitly via `force=True` against a mock SDK.
+os.environ["HYDRAFLOW_SENTRY_DISABLED"] = "1"
+os.environ.pop("SENTRY_DSN", None)
+
 
 def pytest_runtest_teardown(item: pytest.Item, nextitem: pytest.Item | None) -> None:  # noqa: ARG001 — nextitem required by pytest hook signature
     """Fail any test that leaves a ``MagicMock/`` directory in the repo root.

--- a/tests/test_log_ingestion.py
+++ b/tests/test_log_ingestion.py
@@ -692,8 +692,13 @@ class TestFileLogPatterns:
         assert "level" in bc
 
     @pytest.mark.asyncio
-    async def test_sentry_capture_message_called_on_escalation(self) -> None:
-        """ObservabilityPort capture_message is called when a pattern escalates."""
+    async def test_escalation_does_not_capture_sentry_message(self) -> None:
+        """Escalation is operational signal, not a code bug — no Sentry capture.
+
+        The recommendation is persisted to hitl_recommendations.jsonl and logged;
+        capturing it to Sentry previously flooded the project with one ``warning``
+        event per escalation tick. Sentry's contract is real code bugs only.
+        """
         from mockworld.fakes.fake_sentry import FakeSentry
 
         config = _make_config()
@@ -711,12 +716,11 @@ class TestFileLogPatterns:
         }
 
         fake_obs = FakeSentry()
-        await file_log_patterns([pattern], known, config, fake_obs)
+        result = await file_log_patterns([pattern], known, config, fake_obs)
 
+        assert result.escalated == 1
         msg_events = [e for e in fake_obs.events if e["type"] == "message"]
-        assert len(msg_events) >= 1
-        assert "escalating" in msg_events[0]["message"].lower()
-        assert msg_events[0]["level"] == "warning"
+        assert msg_events == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sentry_integration.py
+++ b/tests/test_sentry_integration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,27 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 # Create a mock sentry_sdk module so tests work even when sentry-sdk
 # is not installed in the test environment.
 _mock_sentry = MagicMock()
+
+# A hint that marks a real code bug (the only events _before_send keeps).
+_BUG_HINT = {"exc_info": (ValueError, ValueError("real bug"), None)}
+
+
+def _force_before_send():
+    """Init Sentry (forced, against the mock SDK) and return its before_send.
+
+    ``force=True`` bypasses the pytest / HYDRAFLOW_SENTRY_DISABLED guard so the
+    init machinery runs against the mocked ``sentry_sdk`` and we can capture the
+    ``before_send`` callback it was configured with.
+    """
+    sys.modules.pop("server", None)
+    with patch.dict(
+        "os.environ", {"SENTRY_DSN": "https://key@sentry.io/123"}, clear=False
+    ):
+        from server import _init_sentry
+
+        _mock_sentry.init.reset_mock()
+        _init_sentry(force=True)
+        return _mock_sentry.init.call_args[1]["before_send"]
 
 
 @pytest.fixture(autouse=True)
@@ -46,7 +68,7 @@ class TestSentryInit:
             from server import _init_sentry
 
             _mock_sentry.init.reset_mock()
-            _init_sentry()
+            _init_sentry(force=True)
             _mock_sentry.init.assert_not_called()
 
     def test_initializes_when_dsn_set(self) -> None:
@@ -57,14 +79,19 @@ class TestSentryInit:
             from server import _init_sentry
 
             _mock_sentry.init.reset_mock()
-            _init_sentry()
+            _init_sentry(force=True)
             _mock_sentry.init.assert_called_once()
             call_kwargs = _mock_sentry.init.call_args[1]
             assert call_kwargs["dsn"] == "https://key@sentry.io/123"
 
+    def test_skips_init_under_test_suite_even_with_dsn(self) -> None:
+        """Without force, a configured DSN must NOT init the real client.
 
-class TestScrubSensitiveData:
-    def test_scrubs_github_token(self) -> None:
+        Tests and MockWorld scenarios use fixture data (issue #42, PR #101,
+        "boom"); shipping it to production Sentry was the root cause of the bulk
+        of the noise. The guard trips on pytest being imported and on the
+        HYDRAFLOW_SENTRY_DISABLED kill-switch conftest sets for the whole suite.
+        """
         sys.modules.pop("server", None)
         with patch.dict(
             "os.environ", {"SENTRY_DSN": "https://key@sentry.io/123"}, clear=False
@@ -72,28 +99,80 @@ class TestScrubSensitiveData:
             from server import _init_sentry
 
             _mock_sentry.init.reset_mock()
-            _init_sentry()
-            before_send = _mock_sentry.init.call_args[1]["before_send"]
+            _init_sentry()  # no force → guard should block init
+            _mock_sentry.init.assert_not_called()
 
+    def test_disabled_kill_switch_blocks_init(self) -> None:
+        """HYDRAFLOW_SENTRY_DISABLED=1 is an explicit deploy-time kill-switch."""
+        sys.modules.pop("server", None)
+        with patch.dict(
+            "os.environ",
+            {
+                "SENTRY_DSN": "https://key@sentry.io/123",
+                "HYDRAFLOW_SENTRY_DISABLED": "1",
+            },
+            clear=False,
+        ):
+            from server import _init_sentry
+
+            _mock_sentry.init.reset_mock()
+            _init_sentry()
+            _mock_sentry.init.assert_not_called()
+
+
+class TestScrubSensitiveData:
+    def test_scrubs_github_token(self) -> None:
+        before_send = _force_before_send()
         event = {"message": "Token is ghp_abcdefghijklmnopqrstuvwxyz0123456789"}
-        scrubbed = before_send(event, {})
+        scrubbed = before_send(event, dict(_BUG_HINT))
+        assert scrubbed is not None
         assert "ghp_" not in scrubbed["message"]
         assert "[REDACTED]" in scrubbed["message"]
 
     def test_scrubs_nested_dicts(self) -> None:
-        sys.modules.pop("server", None)
-        with patch.dict(
-            "os.environ", {"SENTRY_DSN": "https://key@sentry.io/123"}, clear=False
-        ):
-            from server import _init_sentry
-
-            _mock_sentry.init.reset_mock()
-            _init_sentry()
-            before_send = _mock_sentry.init.call_args[1]["before_send"]
-
+        before_send = _force_before_send()
         event = {"extra": {"token": "Bearer eyJhbGciOiJSUzI1NiJ9.test"}}
-        scrubbed = before_send(event, {})
+        scrubbed = before_send(event, dict(_BUG_HINT))
+        assert scrubbed is not None
         assert "eyJ" not in str(scrubbed)
+
+
+class TestBeforeSendBugsOnly:
+    """``_before_send`` keeps only real code bugs — the documented contract.
+
+    Operational noise (message-only ``logger.error`` / ``capture_message`` and
+    transient/infra exceptions) is dropped so it never reaches Sentry.
+    """
+
+    def test_drops_message_only_event(self) -> None:
+        before_send = _force_before_send()
+        event = {"message": "GitHub API rate limit hit; backing off"}
+        assert before_send(event, {}) is None
+
+    def test_drops_message_only_log_record(self) -> None:
+        before_send = _force_before_send()
+        record = SimpleNamespace(exc_info=None)
+        event = {"message": "gh issue list failed for label='hydraflow-hitl'"}
+        assert before_send(event, {"log_record": record}) is None
+
+    def test_drops_transient_exception(self) -> None:
+        before_send = _force_before_send()
+        hint = {"exc_info": (RuntimeError, RuntimeError("subprocess boom"), None)}
+        assert before_send({"message": "boom"}, hint) is None
+
+    def test_keeps_bug_exception_and_fingerprints(self) -> None:
+        before_send = _force_before_send()
+        hint = {"exc_info": (TypeError, TypeError("bad type"), None)}
+        kept = before_send({"message": "real bug"}, hint)
+        assert kept is not None
+        assert kept["fingerprint"][0] == "TypeError"
+
+    def test_keeps_bug_logged_with_exc_info(self) -> None:
+        before_send = _force_before_send()
+        record = SimpleNamespace(exc_info=(KeyError, KeyError("missing key"), None))
+        kept = before_send({"message": "logged bug"}, {"log_record": record})
+        assert kept is not None
+        assert kept["fingerprint"][0] == "KeyError"
 
 
 class TestCaptureIfBug:


### PR DESCRIPTION
## Problem

Sentry (`kode-rex/hyrdraflow`) held **88 unresolved issues / ~52,700 events — essentially none of them real code bugs.** All three sources were still live (lastSeen today):

1. **Test/scenario/MockWorld fixtures reaching the *real* client.** `boom`, `Review fix failed for PR #101: boom`, `test-org/test-repo`, `AsyncMock`/`MagicMock`, `No plan found for issue #42` — tagged `environment=production` on `server_name=mac.lan`. `conftest.py` did nothing to suppress Sentry, so any test that spun up the server or logged an error shipped fixture data to production Sentry.
2. **Two operational `capture_message(level="warning")` calls** (`health_monitor_loop.py`, `log_ingestion.py`) firing on *normal* HITL recommendations that are already persisted to `hitl_recommendations.jsonl` and logged — pure duplication (~43 of the 88 issues, incl. the 13.8k-event `Health monitor filed HITL recommendation`).
3. **Operational `logger.error(...)` lines auto-promoted to events.** `_before_send` only dropped transient *exceptions*; message-only logs sailed through (`return _scrub(event)`), contradicting the documented "Sentry captures real code bugs only" contract. This is the single biggest issue: `Could not fetch issue #9466: … gh API rate limit exceeded` at 13.5k events, logged message-only at `issue_fetcher.py:445`.

## Fix

- **`server._init_sentry`** — skip initialisation under `pytest` / `HYDRAFLOW_SENTRY_DISABLED=1`. `force=True` test seam exercises the machinery against a mock SDK.
- **`server._before_send`** — enforce the bugs-only contract: keep only `_BUG_TYPES` exceptions (unhandled, caught by FastApiIntegration, or logged with `exc_info`/`logger.exception`); drop message-only and transient/infra events.
- **Remove the two operational `capture_message` calls**; drop the now-unused `obs` param from `_escalate_log_pattern`.
- **`tests/conftest.py`** — strip `SENTRY_DSN` + set the kill-switch at import, so no test can ever init the real client (belt-and-suspenders with the `_init_sentry` guard).

## Tests

- Flipped `test_log_ingestion` escalation test to assert **no** Sentry capture.
- Added bugs-only filter coverage (drops message-only / transient; keeps `_BUG_TYPE` exceptions + fingerprints) and init-guard coverage to `test_sentry_integration`.

## Verification

| Gate | Result |
|---|---|
| `make quality` | **16117 passed**, 0 fail (11m35s) |
| `make audit` | PASS 91 / WARN 0 / FAIL 0 (P7 observability 10/0/0) |
| `make scenario` | 199 passed |
| `make scenario-loops` | 128 passed |

## Follow-up (after merge)

Bulk-resolve the existing 88 unresolved Sentry issues so any reopen is genuine signal (Sentry auto-reopens on recurrence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)