### PR TITLE
fix(wiki): resolve committed conflict markers in 11 term files (#9482)

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-12T22:38:02.490837+00:00",
-  "commit_sha": "f4219dbd098cf3f3bd95253788c962900986284f",
+  "regenerated_at": "2026-06-13T01:57:07.144805+00:00",
+  "commit_sha": "afe655e9bd158229c782d85d7c84009af047572c",
   "artifacts": {
     "loops.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "ports.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "labels.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "modules.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "events.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "adr_xref.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "mockworld.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "changelog.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "coverage_matrix.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "functional_areas.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "ubiquitous-language.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "f4219dbd098cf3f3bd95253788c962900986284f"
+      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,7 +6,8 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
-- `f4219db` — fix(observability): suppress Sentry noise — bugs-only filter + test init guard *(2026-06-12)*
+- `79662e5` — fix(observability): suppress Sentry noise — bugs-only filter + test init guard (#9481) (#9481) *(2026-06-12)*
+- `cadb008` — Fixes #9354: Shadow-drift: exclude non-deterministic corpus samples... (#9445) (#9445) *(2026-06-12)*
 - `e654a48` — feat(dependabot-merge): auto-heal bot PRs stuck on stale arch artifacts (#9475) (#9475) *(2026-06-12)*
 - `8572c35` — fix(pr-unsticker): rebase PRs that went DIRTY after escalation (live merge state) (#9476) (#9476) *(2026-06-12)*
 - `124b2e8` — feat(ul): entry-evidence — 20 new entry links across 11 terms (#9423) (#9423) *(2026-06-12)*

--- a/docs/wiki/terms/adr-council-reviewer.md
+++ b/docs/wiki/terms/adr-council-reviewer.md
@@ -5,21 +5,13 @@ kind: "service"
 bounded_context: "caretaker"
 code_anchor: "src/adr_reviewer.py:ADRCouncilReviewer"
 aliases: ["adr council reviewer", "council reviewer"]
-<<<<<<< HEAD
-related: []
-=======
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}]
->>>>>>> origin/staging
 evidence: []
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-06-12T04:19:40.947529+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:19:40.947533+00:00"
-=======
 updated_at: "2026-06-12T04:21:53.179108+00:00"
->>>>>>> origin/staging
 proposed_by: "TermProposerLoop"
 proposed_at: "2026-06-12T04:19:40.947404+00:00"
 proposal_signals: ["S2"]

--- a/docs/wiki/terms/adr-reviewer-loop.md
+++ b/docs/wiki/terms/adr-reviewer-loop.md
@@ -5,21 +5,13 @@ kind: "loop"
 bounded_context: "caretaker"
 code_anchor: "src/adr_reviewer_loop.py:ADRReviewerLoop"
 aliases: ["ADR reviewer loop", "adr council review loop", "adr review loop"]
-<<<<<<< HEAD
-related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}]
-=======
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "depends_on", "target": "01KTX0X7RK9NPDNYRPZ58BVT9J"}]
->>>>>>> origin/staging
 evidence: []
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T20:00:00.000000+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:17:13.434460+00:00"
-=======
 updated_at: "2026-06-12T04:21:53.179108+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/agent-port.md
+++ b/docs/wiki/terms/agent-port.md
@@ -6,20 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:AgentPort"
 aliases: ["agent port", "agent runner port"]
 related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-<<<<<<< HEAD
 evidence: ["01KQNYZRM4B7DX9MWDQFHF488F"]
-=======
-evidence: []
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-<<<<<<< HEAD
 updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
-updated_at: "2026-06-12T04:17:13.434460+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/base-background-loop.md
+++ b/docs/wiki/terms/base-background-loop.md
@@ -6,20 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/base_background_loop.py:BaseBackgroundLoop"
 aliases: ["base background loop", "loop base class"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}]
-<<<<<<< HEAD
-evidence: ["01KQNYZRM4B7DX9MWDQFHF488H", "01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P"]
-=======
-evidence: ["01KQNYZRM4B7DX9MWDQFHF488H", "01KQP0R43781VJFJ9HZRWQCZPQ", "01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P"]
->>>>>>> origin/staging
+evidence: ["01KQNYZRM4B7DX9MWDQFHF488H", "01KQP0XFBGMB32VFGNPV8GZ268", "01KQP0XFBGMB32VFGNPV8GZ26F", "01KQP0XFBGMB32VFGNPV8GZ26P", "01KQP0R43781VJFJ9HZRWQCZPQ"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668776+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
 updated_at: "2026-06-12T04:22:53.198214+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/dependabot-merge-loop.md
+++ b/docs/wiki/terms/dependabot-merge-loop.md
@@ -6,20 +6,12 @@ bounded_context: "caretaker"
 code_anchor: "src/dependabot_merge_loop.py:DependabotMergeLoop"
 aliases: ["dependabot merge loop", "bot pr merge loop", "auto-merge bot PRs loop"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K4"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K7"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}]
-<<<<<<< HEAD
 evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M5"]
-=======
-evidence: []
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T20:00:00.000000+00:00"
-<<<<<<< HEAD
 updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
-updated_at: "2026-06-12T04:17:13.434460+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/event-bus.md
+++ b/docs/wiki/terms/event-bus.md
@@ -6,20 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/events.py:EventBus"
 aliases: ["pub/sub bus", "hydraflow event bus"]
 related: []
-<<<<<<< HEAD
-evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KRADV2026B0PHASE0003", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
-=======
-evidence: ["01KQP0R43781VJFJ9HZRWQCZPC", "01KQP0XFBGMB32VFGNPV8GZ268", "01KRADV2026B0PHASE0003", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
->>>>>>> origin/staging
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ268", "01KRADV2026B0PHASE0003", "01KRBX2N4QP7VW8FGH3J5YD0M3", "01KQP0R43781VJFJ9HZRWQCZPC"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668765+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
 updated_at: "2026-06-12T04:20:14.221533+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/issue-fetcher-port.md
+++ b/docs/wiki/terms/issue-fetcher-port.md
@@ -6,20 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:IssueFetcherPort"
 aliases: ["issue fetcher port", "github issue fetching port"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}, {"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-<<<<<<< HEAD
 evidence: ["01KQNYZRM4B7DX9MWDQFHF488F", "01KRBX2N4QP7VW8FGH3J5YD0M2", "01KRBX2N4QP7VW8FGH3J5YD0M6"]
-=======
-evidence: []
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-<<<<<<< HEAD
 updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
-updated_at: "2026-06-12T04:17:13.434460+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/report-issue-loop.md
+++ b/docs/wiki/terms/report-issue-loop.md
@@ -6,20 +6,12 @@ bounded_context: "builder"
 code_anchor: "src/report_issue_loop.py:ReportIssueLoop"
 aliases: ["report issue loop", "bug report loop", "dashboard report processor"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K4"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}]
-<<<<<<< HEAD
 evidence: ["01KQP0XFBGMB32VFGNPV8GZ26X"]
-=======
-evidence: []
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T20:00:00.000000+00:00"
-<<<<<<< HEAD
 updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
-updated_at: "2026-06-12T04:17:13.434460+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/review-insight-store-port.md
+++ b/docs/wiki/terms/review-insight-store-port.md
@@ -6,20 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:ReviewInsightStorePort"
 aliases: ["review insight store port", "review insight port"]
 related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-<<<<<<< HEAD
 evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M3"]
-=======
-evidence: []
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-<<<<<<< HEAD
 updated_at: "2026-06-12T04:18:46.416686+00:00"
-=======
-updated_at: "2026-06-12T04:17:13.434460+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/sentry-loop.md
+++ b/docs/wiki/terms/sentry-loop.md
@@ -6,20 +6,12 @@ bounded_context: "caretaker"
 code_anchor: "src/sentry_loop.py:SentryLoop"
 aliases: ["sentry loop", "sentry ingestion loop", "sentry issue poller"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K4"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}]
-<<<<<<< HEAD
-evidence: []
-=======
 evidence: ["01KQP0R43781VJFJ9HZRWQCZPA"]
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T20:00:00.000000+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:17:13.434460+00:00"
-=======
 updated_at: "2026-06-12T04:20:14.221533+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition

--- a/docs/wiki/terms/stale-issue-gc-loop.md
+++ b/docs/wiki/terms/stale-issue-gc-loop.md
@@ -6,20 +6,12 @@ bounded_context: "caretaker"
 code_anchor: "src/stale_issue_gc_loop.py:StaleIssueGCLoop"
 aliases: ["stale issue gc loop", "stale hitl gc loop", "hitl stale closer"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K5"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K7"}, {"kind": "implements", "target": "01KQV37D10M06PGF32CF77W6K5"}]
-<<<<<<< HEAD
-evidence: []
-=======
 evidence: ["01KQP0R43781VJFJ9HZRWQCZPA"]
->>>>>>> origin/staging
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T20:00:00.000000+00:00"
-<<<<<<< HEAD
-updated_at: "2026-06-12T04:17:13.434460+00:00"
-=======
 updated_at: "2026-06-12T04:20:14.221533+00:00"
->>>>>>> origin/staging
 ---
 
 ## Definition


### PR DESCRIPTION
## Problem

`origin/staging` had **raw git conflict markers committed into 11 `docs/wiki/terms/*.md` files** (`<<<<<<< HEAD` / `=======` / `>>>>>>> origin/staging`), introduced by `076ee8f7` (#9422 edge-proposer). They reached staging because **no hook or CI check rejects conflict markers**. Found incidentally during the Sentry-noise cleanup (#9481); see #9482.

## Resolution

The conflicts were in the front-matter `evidence:` / `related:` accumulator arrays and `updated_at`, produced by two wiki-compile runs (~04:17–04:19 vs ~04:20–04:22). **Neither side was a global superset** — some terms had richer `evidence` on the HEAD side (`agent-port`, `issue-fetcher-port`, `report-issue-loop`, …), others on the `origin/staging` side (`adr-*`, `event-bus`, `base-background-loop`, …). Resolved deterministically with a script (not a pick-a-side hand-merge):

- `evidence:` / `related:` → **UNION** of both sides (dedup, order-stable)
- `updated_at:` → **MAX** (latest) timestamp

In every file the newer-timestamp side was a superset of the older, so the union equals the converged compile state. `docs/arch/generated/` regenerated via `make arch-regen`.

## Verification

- `git grep '^<<<<<<< ' / '^>>>>>>> '` → **repo-wide clean** (markers gone everywhere, incl. rendered UL).
- All 11 front-matters parse as valid YAML; `evidence`/`related` are proper unions; `updated_at` is the max.
- `make arch-check` ✓ · `make audit` P7 10/0/0 (the single P10.3 WARN is a pre-existing last-50-PR scan, unrelated; the Principles Audit job is skipped for this docs-only PR).

## Scope

Immediate corruption fix only. The **systemic conflict-marker guard** (pre-commit + CI `git diff --check`) and the edge-proposer root cause remain tracked in **#9482**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)