### PR TITLE
fix(ci): guard against committed git conflict markers (#9482)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -25,6 +25,20 @@ if [ -n "$STAGED_CLAUDE" ]; then
     fi
 fi
 
+# ── Guard: never commit git conflict markers (#9482) ──
+# Runs over ALL staged files BEFORE the short-circuit below — a docs-only commit
+# (e.g. a bot wiki write) must not bypass this. #9422 merged raw markers into 11
+# wiki-term files precisely because no gate inspected a docs-only change.
+STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACM || true)
+if [ -n "$STAGED_ALL" ]; then
+    # shellcheck disable=SC2086 — word-splitting is intended (one arg per path)
+    if ! python3 "$REPO_ROOT/scripts/check_conflict_markers.py" $STAGED_ALL; then
+        echo "pre-commit: BLOCKED — git conflict markers in staged files (above)." >&2
+        echo "  Resolve the conflict (no <<<<<<< / ======= / >>>>>>>), then re-commit." >&2
+        exit 1
+    fi
+fi
+
 # Detect Python changes (existing) AND arch source changes (new).
 STAGED_PY=$(git diff --cached --name-only --diff-filter=ACM -- '*.py' || true)
 STAGED_ARCH=$(git diff --cached --name-only --diff-filter=ACM \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,22 @@ jobs:
               - 'tests/scenarios/browser/**'
               - 'tests/scenarios/fakes/mock_world.py'
 
+  # Universal backstop (#9482): reject leftover git conflict markers on EVERY
+  # PR/push, ungated by `changes` — a docs-only commit (e.g. a bot wiki write)
+  # must not bypass it. #9422 merged raw markers into 11 wiki-term files because
+  # no gate inspected a docs-only change. stdlib-only; no uv sync needed.
+  conflict-markers:
+    name: Conflict Markers
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Scan tracked files for git conflict markers
+        run: python3 scripts/check_conflict_markers.py --tracked
+
   lint:
     name: Lint & Format
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,11 @@ lint-check: deps
 test-sludge-check: deps
 	@cd $(HYDRAFLOW_DIR) && $(UV) python scripts/strip_test_sludge.py --check $(FILES)
 
+# Reject leftover git conflict markers (#9482). stdlib-only — no deps needed.
+# FILES is space-separated; defaults to all tracked files (--tracked).
+conflict-check:
+	@cd $(HYDRAFLOW_DIR) && python3 scripts/check_conflict_markers.py $(if $(FILES),$(FILES),--tracked)
+
 lint-fix: lint
 	@echo "$(GREEN)Auto-repair complete$(RESET)"
 

--- a/scripts/check_conflict_markers.py
+++ b/scripts/check_conflict_markers.py
@@ -1,0 +1,90 @@
+"""Fail if any file contains a leftover git conflict marker.
+
+Conflict markers committed to the repo are a recurring corruption vector: #9422
+merged raw markers into 11 ``docs/wiki/terms/*.md`` files because the (pre-#9475)
+bot-PR auto-heal committed a conflicted merge, and **no check rejected them** —
+they passed every gate and reached ``staging`` (#9482). This guard closes that
+hole universally: it runs in pre-commit (over staged files) and in CI (over the
+whole tracked tree), so a marker can never reach a branch again regardless of
+which path produced it.
+
+Detection is deliberately conservative to avoid false positives. A real conflict
+is identified by an opening (``<`` x7), base (``|`` x7), or closing (``>`` x7)
+marker **at the start of a line**, followed by a space/tab or end-of-line — the
+exact shapes ``git`` writes. The ``=`` x7 separator is intentionally NOT matched
+on its own: it collides with Markdown setext headings and reStructuredText
+underlines, whereas the angle/pipe markers never legitimately begin a line.
+
+Usage:
+    check_conflict_markers.py <file> [<file> ...]   # scan the given paths
+    check_conflict_markers.py --tracked             # scan all git-tracked files
+    check_conflict_markers.py                       # same as --tracked
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Opening / base / closing markers (7 chars) at line start, then space|tab|EOL.
+_MARKER = re.compile(r"^(<{7}|>{7}|\|{7})([ \t]|$)")
+
+
+def _repo_root() -> Path:
+    out = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def _tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files"], cwd=root, capture_output=True, text=True, check=True
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def scan(paths: list[str], root: Path) -> list[tuple[str, int, str]]:
+    """Return (relpath, line_number, snippet) for every conflict marker found."""
+    hits: list[tuple[str, int, str]] = []
+    for rel in paths:
+        path = (root / rel) if not Path(rel).is_absolute() else Path(rel)
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue  # binary or unreadable — not a text conflict
+        for num, line in enumerate(text.splitlines(), start=1):
+            if _MARKER.match(line):
+                hits.append((rel, num, line[:72]))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    root = _repo_root()
+    file_args = [a for a in argv if a != "--tracked"]
+    paths = (
+        _tracked_files(root) if ("--tracked" in argv or not file_args) else file_args
+    )
+
+    hits = scan(paths, root)
+    if hits:
+        print(
+            "git conflict markers found — refusing to proceed "
+            "(resolve them, then re-run):",
+            file=sys.stderr,
+        )
+        for rel, num, snippet in hits:
+            print(f"  {rel}:{num}: {snippet}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_conflict_markers.py
+++ b/tests/test_check_conflict_markers.py
@@ -1,0 +1,83 @@
+"""Unit tests for the conflict-marker guard (scripts/check_conflict_markers.py).
+
+Regression coverage for #9482: raw git conflict markers were committed to 11
+wiki-term files (#9422) and no gate rejected them. Markers below are built at
+runtime (``"<" * 7``) so this test file never contains a line-start marker that
+its own ``--tracked`` scan would flag.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_conflict_markers.py"
+_spec = importlib.util.spec_from_file_location("check_conflict_markers", _SCRIPT)
+assert _spec and _spec.loader
+guard = importlib.util.module_from_spec(_spec)
+sys.modules["check_conflict_markers"] = guard
+_spec.loader.exec_module(guard)
+
+OPEN = "<" * 7
+BASE = "|" * 7
+SEP = "=" * 7
+CLOSE = ">" * 7
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+class TestScan:
+    def test_flags_opening_marker(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path,
+            "f.md",
+            f"line one\n{OPEN} HEAD\nmine\n{SEP}\ntheirs\n{CLOSE} branch\n",
+        )
+        hits = guard.scan(["f.md"], tmp_path)
+        assert [(rel, num) for rel, num, _ in hits] == [("f.md", 2), ("f.md", 6)]
+
+    def test_flags_diff3_base_marker(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path, "f.txt", f"{OPEN} HEAD\na\n{BASE} base\nb\n{SEP}\nc\n{CLOSE} x\n"
+        )
+        rels = {rel for rel, _, _ in guard.scan(["f.txt"], tmp_path)}
+        assert rels == {"f.txt"}
+        # all three angle/pipe markers detected (open, base, close)
+        assert len(guard.scan(["f.txt"], tmp_path)) == 3
+
+    def test_clean_file_passes(self, tmp_path: Path) -> None:
+        _write(tmp_path, "clean.md", "title\nbody text\nmore\n")
+        assert guard.scan(["clean.md"], tmp_path) == []
+
+    def test_bare_equals_separator_not_flagged(self, tmp_path: Path) -> None:
+        # `=======` is a legitimate Markdown setext heading underline.
+        _write(tmp_path, "doc.md", f"My Heading\n{SEP}\n\nbody\n")
+        assert guard.scan(["doc.md"], tmp_path) == []
+
+    def test_marker_not_at_line_start_not_flagged(self, tmp_path: Path) -> None:
+        _write(tmp_path, "code.py", f'    example = "{OPEN} HEAD"  # documented\n')
+        assert guard.scan(["code.py"], tmp_path) == []
+
+    def test_binary_file_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "blob.bin").write_bytes(b"\xff\xfe" + OPEN.encode() + b" \x00\x01")
+        assert guard.scan(["blob.bin"], tmp_path) == []
+
+    def test_missing_path_skipped(self, tmp_path: Path) -> None:
+        assert guard.scan(["does-not-exist.md"], tmp_path) == []
+
+
+class TestMain:
+    def test_returns_1_when_marker_present(self, tmp_path: Path, monkeypatch) -> None:
+        _write(tmp_path, "bad.md", f"{OPEN} HEAD\nx\n{SEP}\ny\n{CLOSE} z\n")
+        monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+        assert guard.main(["bad.md"]) == 1
+
+    def test_returns_0_when_clean(self, tmp_path: Path, monkeypatch) -> None:
+        _write(tmp_path, "ok.md", "all good\n")
+        monkeypatch.setattr(guard, "_repo_root", lambda: tmp_path)
+        assert guard.main(["ok.md"]) == 0


### PR DESCRIPTION
Closes #9482.

## Problem

#9422 merged **raw git conflict markers** (`<<<<<<<` / `=======` / `>>>>>>>`) into 11 `docs/wiki/terms/*.md` files, and they reached `staging` because **no gate inspected the change**: the pre-commit hook short-circuits on docs-only commits, and no CI job scanned for markers. (The corrupted files themselves were cleaned in #9484.)

## Root cause is already closed; this adds the missing backstop

The marker-producing merge came from the **pre-#9475** bot-PR auto-heal: #9422 landed at 12:44, #9475 (`auto-heal ... _is_arch_only_conflict`) at 13:43. The current auto-heal **aborts** on any non-generated conflict (`docs/wiki/terms/` is non-generated) instead of committing a conflicted merge — so that vector is shut. What was still missing is a guard that catches markers *regardless of which path produces them*. That's this PR.

## Change

- **`scripts/check_conflict_markers.py`** — stdlib-only scanner. Flags `<<<<<<<` / `|||||||` / `>>>>>>>` at line start (the exact shapes git writes); **deliberately does not flag a bare `=======`** line, which collides with Markdown setext headings. Scans given paths, or every git-tracked file with `--tracked`. Skips binary/unreadable files.
- **`.githooks/pre-commit`** — runs the scanner over **all staged files before** the Python/arch/test short-circuit, so a docs-only commit can no longer bypass it.
- **`.github/workflows/ci.yml`** — new **Conflict Markers** job, **ungated by `changes`**, runs on every PR/push. This is the reliable backstop for bot-authored docs PRs (the actual #9422 vector).
- `make conflict-check` target; unit + regression test (9 cases).

## Verification

- Unit/regression test green (9 cases): flags open/base/close markers, ignores bare `=======`, ignores mid-line markers, skips binary, handles missing paths.
- `scripts/check_conflict_markers.py --tracked` over the repo → clean (exit 0); planted-marker file → exit 1.
- Pre-commit hook integration-tested: a staged docs-only file with a marker is **BLOCKED** (the exact case that slipped through before).
- `make gen-gates-check` in sync (new job is not a declared gate); ruff + pyright clean; `make quality` green.

## Follow-up

Promotion of **Conflict Markers** to a *required* status check (via `gates.toml`) is intentionally separate — a new required check must already be green on the base branch before being required, or the first PR self-blocks (per the Gates Drift runbook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)