### PR TITLE
feat(ul): entry-evidence — 8 new entry links across 5 terms

### DIFF
--- a/docs/wiki/terms/agent-runner.md
+++ b/docs/wiki/terms/agent-runner.md
@@ -6,12 +6,12 @@ bounded_context: "builder"
 code_anchor: "src/agent.py:AgentRunner"
 aliases: ["agent runner", "implement runner", "claude agent runner"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K7"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K8"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K2"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K6"}, {"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}, {"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K3"}]
-evidence: []
+evidence: ["01KQP0XFBGMB32VFGNPV8GZ26X"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668798+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-13T05:04:53.216762+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/hydra-flow-config.md
+++ b/docs/wiki/terms/hydra-flow-config.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/config.py:HydraFlowConfig"
 aliases: ["hydraflow config", "config aggregate", "orchestrator config"]
 related: []
-evidence: ["01KQNYW9WM9NY7XJ0DNPVW4GDQ", "01KQNYZRM4B7DX9MWDQFHF488H", "01KQNYZRM4B7DX9MWDQFHF488P", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
+evidence: ["01KQNYW9WM9NY7XJ0DNPVW4GDQ", "01KQNYZRM4B7DX9MWDQFHF488H", "01KQNYZRM4B7DX9MWDQFHF488P", "01KQP0AJ4Z2MY1EXMWW9BTXN99", "01KRBX2N4QP7VW8FGH3J5YD0M3"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668539+00:00"
-updated_at: "2026-06-12T04:18:46.416686+00:00"
+updated_at: "2026-06-13T05:04:53.216762+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/issue-fetcher-port.md
+++ b/docs/wiki/terms/issue-fetcher-port.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:IssueFetcherPort"
 aliases: ["issue fetcher port", "github issue fetching port"]
 related: [{"kind": "depends_on", "target": "01KQV37D10M06PGF32CF77W6K9"}, {"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-evidence: ["01KQNYZRM4B7DX9MWDQFHF488F", "01KRBX2N4QP7VW8FGH3J5YD0M2", "01KRBX2N4QP7VW8FGH3J5YD0M6"]
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-19T00:00:00.000000+00:00"
-updated_at: "2026-06-12T04:18:46.416686+00:00"
+updated_at: "2026-06-13T05:04:53.216762+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/state-tracker.md
+++ b/docs/wiki/terms/state-tracker.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/state/__init__.py:StateTracker"
 aliases: ["state tracker", "state facade", "state mixin facade"]
 related: []
-evidence: ["01KQP0DZNDCVJVV0YHTG430T31"]
+evidence: ["01KQP0AJ4Y4348S0D9AKRTCPP7", "01KQP0AJ4Z2MY1EXMWW9BTXN97", "01KQP0AJ4Z2MY1EXMWW9BTXN99", "01KQP0DZNDCVJVV0YHTG430T31", "01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668771+00:00"
-updated_at: "2026-06-12T04:22:53.198214+00:00"
+updated_at: "2026-06-13T05:04:53.216762+00:00"
 ---
 
 ## Definition

--- a/docs/wiki/terms/workspace-port.md
+++ b/docs/wiki/terms/workspace-port.md
@@ -6,12 +6,12 @@ bounded_context: "shared-kernel"
 code_anchor: "src/ports.py:WorkspacePort"
 aliases: ["workspace port", "worktree port", "git workspace port"]
 related: [{"kind": "depends_on", "target": "01KR1GDECRP5Z9X3HNGX3XFS8B"}]
-evidence: []
+evidence: ["01KRBX2N4QP7VW8FGH3J5YD0M6"]
 superseded_by: null
 superseded_reason: null
 confidence: "accepted"
 created_at: "2026-05-05T03:35:36.668789+00:00"
-updated_at: "2026-05-16T23:48:13.299804+00:00"
+updated_at: "2026-06-13T05:04:53.216762+00:00"
 ---
 
 ## Definition


### PR DESCRIPTION
Auto-generated batch from `EntryEvidenceLoop` (ADR-0062).

Entry → term backlinks added:
- `AgentRunner` ← entry `01KQP0XFBGMB32VFGNPV8GZ26X`
- `HydraFlowConfig` ← entry `01KQP0AJ4Z2MY1EXMWW9BTXN99`
- `IssueFetcherPort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `StateTracker` ← entry `01KQP0AJ4Y4348S0D9AKRTCPP7`
- `StateTracker` ← entry `01KQP0AJ4Z2MY1EXMWW9BTXN97`
- `StateTracker` ← entry `01KQP0AJ4Z2MY1EXMWW9BTXN99`
- `StateTracker` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`
- `WorkspacePort` ← entry `01KRBX2N4QP7VW8FGH3J5YD0M6`

Matches are LLM-validated (one call per uncached entry) against the
live `TermStore`. Idempotent: re-runs skip entries already linked.

Auto-merge on CI green via `DependabotMergeLoop`.

Generated by `EntryEvidenceLoop`