### PR TITLE
chore(bandit): silence spurious nosec WARNINGs in pre-push gate

### DIFF
--- a/src/docker_runner.py
+++ b/src/docker_runner.py
@@ -90,7 +90,7 @@ def build_container_kwargs(config: HydraFlowConfig) -> dict[str, Any]:
     # caches and config even when the root filesystem is read-only.
     # uid/gid=1000 matches the container's hydraflow user.
     kwargs["tmpfs"] = {
-        "/tmp": f"size={config.docker_tmp_size}",  # nosec B108
+        "/tmp": f"size={config.docker_tmp_size}",  # nosec  # in-container tmpfs path
         _CONTAINER_HOME: f"size={config.docker_tmp_size},uid=1000,gid=1000",
     }
 
@@ -463,7 +463,7 @@ class DockerRunner:
         if env.get("CLAUDE_CONFIG_DIR"):
             env["CLAUDE_CONFIG_DIR"] = _CONTAINER_CLAUDE_HOME
         # Ensure temp dirs use the writable tmpfs, not the readonly root fs.
-        env.setdefault("TMPDIR", "/tmp")  # nosec B108  # noqa: S108
+        env.setdefault("TMPDIR", "/tmp")  # nosec  # noqa: S108  # in-container tmpfs path
         # HOME must point to the writable tmpfs so tools (uv, npm, git) can
         # write caches and config without fighting a read-only root fs.
         env.setdefault("HOME", _CONTAINER_HOME)

--- a/src/flake_tracker_loop.py
+++ b/src/flake_tracker_loop.py
@@ -45,7 +45,7 @@ def parse_junit_xml(xml_bytes: bytes) -> dict[str, str]:
     treated as ``pass`` (skipped tests are not flakes).
     """
     results: dict[str, str] = {}
-    root = ET.fromstring(xml_bytes)  # nosec B314 — JUnit XML from trusted CI artifacts
+    root = ET.fromstring(xml_bytes)  # nosec B314  # JUnit XML from trusted CI artifacts
     for case in root.iter("testcase"):
         cls = case.get("classname") or ""
         name = case.get("name") or ""

--- a/src/rc_budget_loop.py
+++ b/src/rc_budget_loop.py
@@ -310,7 +310,7 @@ class RCBudgetLoop(BaseBackgroundLoop):
             results: list[tuple[str, float]] = []
             for xml_path in Path(td).rglob("*.xml"):
                 try:
-                    root = ET.fromstring(  # nosec B314 — JUnit XML from trusted CI artifacts
+                    root = ET.fromstring(  # nosec B314  # JUnit XML from trusted CI artifacts
                         xml_path.read_bytes()
                     )
                 except ET.ParseError:


### PR DESCRIPTION
## What

Removes the noisy `bandit` WARNINGs that print on every `git push` (via the `pre-push` → `make quality-lite` → bandit step). Nothing was actually failing — these were cosmetic warnings — but they made every push look alarming.

## The two warnings

**1. `nosec encountered (B108), but no failed test on line 93/466`** (`src/docker_runner.py`)

A bandit 1.8.0 quirk: a *targeted* `# nosec B108` on these `/tmp` string literals trips bandit's per-test "did this test fire on this exact line" validation, even though the suppression is correct and the B108 finding is real (removing the nosec surfaces 2 Medium issues). 

- `/tmp` here is the **container-internal tmpfs** path (Docker `tmpfs` mount + in-container `TMPDIR`), **not** a host path — so the literal is intentional and `tempfile.gettempdir()` would be wrong.
- Switched to a bare `# nosec` (keeps the suppression, skips the per-test check) + inline intent comment. These are the only bare `# nosec` in the repo; the divergence from the targeted-ID convention is deliberate and documented because targeted is what triggers the quirk here.

**2. `Test in comment: JUnit/XML/from/trusted/CI/artifacts is not a test name or id`** (`src/flake_tracker_loop.py`, `src/rc_budget_loop.py`)

Bandit parses everything after `# nosec` as a space-separated list of test IDs, so the em-dash prose in `# nosec B314 — JUnit XML from trusted CI artifacts` was read token-by-token. Fixed by terminating the test-ID list with a second `#`: `# nosec B314  # JUnit XML ...`. The legit `B314` suppression is retained.

## Verification

- `bandit -c pyproject.toml -r . --severity-level medium` → **exit 0, zero WARNINGs, 0 Medium/High** (160 pre-existing Low are below the gate)
- `ruff check` + `ruff format --check` → pass
- `pyright` on touched files → 0 errors/warnings
- `pytest` for `test_docker_runner*`, `test_flake_tracker*`, `test_rc_budget*` → 147 passed
- Live `pre-push` hook on this branch → clean, no nosec/comment warnings

Comment-only diff (4 lines); no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)