### PR TITLE
fix(loops): bound hung gh subprocess in TrustFleetSanityLoop + honor contracts_sandbox_repo override (#9410, #9438)

### DIFF
--- a/src/contract_refresh_loop.py
+++ b/src/contract_refresh_loop.py
@@ -83,12 +83,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("hydraflow.contract_refresh_loop")
 
-# The committed sandbox repo the GitHub recorder targets. Centralised here
-# so tests (and the eventual config field in Task 18+) can override in one
-# place. Matches ``docs/superpowers/plans/2026-04-22-fake-contract-tests.md``
-# Task 0.
-_SANDBOX_GITHUB_REPO = "T-rav-Hydra-Ops/hydraflow-contracts-sandbox"
-
 # Hard cap on the replay-gate subprocess — defends the async event loop
 # when a recorder hangs on network I/O or a zombie subprocess.
 _REPLAY_GATE_TIMEOUT_SECONDS = 300
@@ -230,7 +224,7 @@ class ContractRefreshLoop(BaseBackgroundLoop):
             await self._record_with_trace(
                 "contract_recording.record_github",
                 record_github,
-                _SANDBOX_GITHUB_REPO,
+                self._config.contracts_sandbox_repo,
                 tmp_root / "github",
             )
             if external

--- a/src/trust_fleet_sanity_loop.py
+++ b/src/trust_fleet_sanity_loop.py
@@ -121,6 +121,10 @@ Implementation notes for Plan 6b:
 _MAX_ATTEMPTS = 1  # spec §12.1 — the anomaly IS the escalation.
 _HOUR_SECONDS = 3600
 _DAY_SECONDS = 86_400
+# Hard cap on the `gh issue list` reconcile subprocess. Unbounded, a wedged
+# `gh` (auth prompt, network black-hole, hung child) stalls the whole
+# trust_fleet_sanity cycle forever and trips the dead-man-switch (#9410).
+_RECONCILE_GH_TIMEOUT_SECONDS = 30
 _ANOMALY_KINDS: tuple[str, ...] = (
     "issues_per_hour",
     "repair_ratio",
@@ -409,7 +413,21 @@ class TrustFleetSanityLoop(BaseBackgroundLoop):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, _ = await proc.communicate()
+            try:
+                stdout, _ = await asyncio.wait_for(
+                    proc.communicate(), timeout=_RECONCILE_GH_TIMEOUT_SECONDS
+                )
+            except TimeoutError:
+                # Kill the orphaned `gh` and skip this reconcile pass rather
+                # than hang the cycle forever; the next tick retries. A visible
+                # warning (not debug) is deliberate — the original failure was a
+                # *silent* stall that only the dead-man-switch caught (#9410).
+                proc.kill()
+                logger.warning(
+                    "gh issue list timed out after %ss; skipping reconcile pass",
+                    _RECONCILE_GH_TIMEOUT_SECONDS,
+                )
+                return
         except Exception as exc:  # noqa: BLE001
             reraise_on_credit_or_bug(exc)
             logger.debug("gh issue list failed", exc_info=True)

--- a/tests/regressions/test_issue_9410.py
+++ b/tests/regressions/test_issue_9410.py
@@ -1,0 +1,112 @@
+"""Regression for issue #9410 — trust_fleet_sanity silent (dead-man-switch).
+
+Issue #9410 was auto-filed by the `health_monitor` dead-man-switch:
+
+    sanity-loop-stalled: trust_fleet_sanity silent for 520220s (threshold 1800s)
+
+The dead-man-switch itself works (see tests/test_health_monitor_sanity_stall.py)
+— it fired because `TrustFleetSanityLoop` genuinely stopped ticking. This test
+reproduces a concrete code path by which that loop silently stalls *forever*:
+
+`TrustFleetSanityLoop._do_work()` calls `_reconcile_closed_escalations()` as the
+very first awaited step (src/trust_fleet_sanity_loop.py:201). That method shells
+out to `gh issue list` and awaits `proc.communicate()` with **no timeout**
+(src/trust_fleet_sanity_loop.py:401-406). If `gh` blocks — auth prompt, a
+network black-hole, a wedged child — the await never returns, so:
+
+  * the work cycle never reaches `set_trust_fleet_sanity_last_run()` (line 331),
+    so the heartbeat freezes at the moment of the hang ("silent for N seconds");
+  * the orchestrator supervisor wakes only on task *completion*
+    (`asyncio.wait(..., FIRST_COMPLETED)`, src/orchestrator.py), never on a
+    *hung* task, so the dead loop is never restarted — matching the playbook's
+    only remedy, "restart the orchestrator".
+
+Desired behavior: a stuck subprocess must be bounded (e.g. `asyncio.wait_for`)
+so the cycle still finishes and the heartbeat keeps advancing. This test asserts
+that bounded behavior and is RED against current code (it hangs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+import trust_fleet_sanity_loop
+from config import HydraFlowConfig
+from trust_fleet_sanity_loop import TrustFleetSanityLoop
+
+# Generous relative to any sane subprocess timeout, tiny relative to the loop's
+# 600s interval: if the cycle isn't bounded, it never returns and we trip this.
+_CYCLE_BOUND_SECONDS = 3.0
+
+
+class _HangingProcess:
+    """Stand-in for an `asyncio` subprocess whose `gh` child never returns."""
+
+    returncode = 0
+    killed = False
+
+    def kill(self) -> None:
+        # The bounded caller SIGKILLs the wedged child on timeout so it doesn't
+        # leak; the stub just records that it happened.
+        self.killed = True
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        # Model a wedged `gh issue list` — block effectively forever. A bounded
+        # caller (the fix) cancels this via its own timeout; the unbounded
+        # caller (current code) waits here until the heat death of the universe.
+        await asyncio.sleep(1_000_000)
+        return b"[]", b""
+
+
+async def _hanging_create_subprocess_exec(
+    *args: object, **kwargs: object
+) -> _HangingProcess:
+    del args, kwargs
+    return _HangingProcess()
+
+
+def _make_loop(tmp_path: Path) -> TrustFleetSanityLoop:
+    # __new__ bypasses the ctor (which needs a full LoopDeps + collaborators);
+    # `_reconcile_closed_escalations` only reads `_config.repo` before the hang.
+    cfg = HydraFlowConfig(
+        data_root=tmp_path,
+        repo="hydra/hydraflow",
+        trust_fleet_sanity_interval=600,
+    )
+    loop = TrustFleetSanityLoop.__new__(TrustFleetSanityLoop)
+    loop._config = cfg
+    return loop
+
+
+@pytest.mark.asyncio
+async def test_reconcile_does_not_hang_when_gh_subprocess_stalls(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        asyncio,
+        "create_subprocess_exec",
+        _hanging_create_subprocess_exec,
+    )
+    # Shrink the production subprocess cap so the bounded path fires fast — the
+    # fix's real 30s timeout would itself blow the 3s cycle bound below. We are
+    # asserting the call is *bounded*, not the magnitude of the bound.
+    monkeypatch.setattr(trust_fleet_sanity_loop, "_RECONCILE_GH_TIMEOUT_SECONDS", 0.05)
+    loop = _make_loop(tmp_path)
+
+    try:
+        await asyncio.wait_for(
+            loop._reconcile_closed_escalations(),
+            timeout=_CYCLE_BOUND_SECONDS,
+        )
+    except TimeoutError:
+        pytest.fail(
+            "BUG #9410: _reconcile_closed_escalations() never returned — "
+            "`proc.communicate()` has no timeout, so a stuck `gh issue list` "
+            "stalls the whole trust_fleet_sanity cycle indefinitely. The "
+            "heartbeat freezes and the dead-man-switch trips "
+            "('trust_fleet_sanity silent for N seconds')."
+        )

--- a/tests/regressions/test_issue_9438.py
+++ b/tests/regressions/test_issue_9438.py
@@ -1,0 +1,98 @@
+"""Regression for issue #9438.
+
+``ContractRefreshLoop._record_all`` hardcodes the module constant
+``_SANDBOX_GITHUB_REPO`` when invoking the GitHub recorder instead of
+resolving the sandbox slug from ``self._config.contracts_sandbox_repo``.
+
+``config.contracts_sandbox_repo`` documents itself as the override point
+("Override if the sandbox org is renamed"), but the loop ignores it, so
+renaming the sandbox org in config silently has no effect — latent config
+drift. This test overrides ``contracts_sandbox_repo`` to a non-default slug
+and asserts the recorder is invoked with that override. It is RED until the
+loop reads the config field.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import contract_refresh_loop as crl_module
+from base_background_loop import LoopDeps
+from config import HydraFlowConfig
+from contract_refresh_loop import ContractRefreshLoop
+from events import EventBus
+from state import StateTracker
+
+_OVERRIDE_SANDBOX_REPO = "RenamedOrg/renamed-contracts-sandbox"
+
+
+class _FakeState:
+    """Minimal StateTracker stand-in: contract-refresh attempt counters only."""
+
+    def __init__(self) -> None:
+        self._attempts: dict[str, int] = {}
+
+    def get_contract_refresh_attempts(self, adapter: str) -> int:
+        return int(self._attempts.get(adapter, 0))
+
+    def inc_contract_refresh_attempts(self, adapter: str) -> int:
+        self._attempts[adapter] = self._attempts.get(adapter, 0) + 1
+        return self._attempts[adapter]
+
+    def clear_contract_refresh_attempts(self, adapter: str) -> None:
+        self._attempts.pop(adapter, None)
+
+
+def _build_loop(tmp_path: Path) -> ContractRefreshLoop:
+    cfg = HydraFlowConfig(
+        data_root=tmp_path / "data",
+        repo_root=tmp_path / "repo",
+        repo="hydra/hydraflow",
+        contracts_sandbox_repo=_OVERRIDE_SANDBOX_REPO,
+        contract_refresh_external_enabled=True,
+    )
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    deps = LoopDeps(
+        event_bus=EventBus(),
+        stop_event=asyncio.Event(),
+        status_cb=lambda *a, **k: None,
+        enabled_cb=lambda _name: True,
+    )
+    return ContractRefreshLoop(
+        config=cfg,
+        prs=AsyncMock(),
+        state=cast(StateTracker, _FakeState()),
+        deps=deps,
+    )
+
+
+def test_record_all_uses_config_sandbox_repo_override(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    captured_sandbox_repos: list[str] = []
+
+    def _capturing_record_github(sandbox_repo: str, _tmp_dir: Path) -> list[Path]:
+        captured_sandbox_repos.append(sandbox_repo)
+        return []
+
+    monkeypatch.setattr(crl_module, "record_github", _capturing_record_github)
+    monkeypatch.setattr(crl_module, "record_git", lambda *_a, **_k: [])
+    monkeypatch.setattr(crl_module, "record_docker", lambda *_a, **_k: [])
+    monkeypatch.setattr(crl_module, "record_claude_stream", lambda *_a, **_k: [])
+
+    loop = _build_loop(tmp_path)
+    tmp_root = tmp_path / "recordings"
+    tmp_root.mkdir(parents=True, exist_ok=True)
+
+    asyncio.run(loop._record_all(tmp_root))
+
+    assert captured_sandbox_repos == [_OVERRIDE_SANDBOX_REPO], (
+        "record_github was invoked with "
+        f"{captured_sandbox_repos!r}, but the loop should resolve the sandbox "
+        f"slug from config.contracts_sandbox_repo ({_OVERRIDE_SANDBOX_REPO!r}). "
+        "The loop hardcodes _SANDBOX_GITHUB_REPO so the documented config "
+        "override silently has no effect (issue #9438)."
+    )


### PR DESCRIPTION
## Summary

Salvaged two genuinely-local WIP regression tests from the working tree, each of which turned out to guard a **real, still-present loop footgun on staging**. Both fixes are low-risk and behavior-preserving on default config.

### #9410 — `TrustFleetSanityLoop` silently stalls forever on a wedged `gh`
`_reconcile_closed_escalations()` (the **first** awaited step of `_do_work`) shelled out to `gh issue list` and awaited `proc.communicate()` with **no timeout**. If `gh` blocks (auth prompt, network black-hole, hung child), the await never returns:
- the work cycle never reaches `set_trust_fleet_sanity_last_run()`, so the heartbeat freezes ("`trust_fleet_sanity silent for N seconds`");
- the orchestrator supervisor wakes only on task *completion* (`asyncio.wait(FIRST_COMPLETED)`), never on a *hung* task, so the dead loop is never restarted — the playbook's only remedy was "restart the orchestrator".

**Fix:** wrap the call in `asyncio.wait_for(..., timeout=_RECONCILE_GH_TIMEOUT_SECONDS=30)`, kill the orphaned child, and log a **visible warning** (not debug — the whole failure mode was a *silent* stall) before skipping the pass. The next tick retries. Mirrors the existing `_REPLAY_GATE_TIMEOUT_SECONDS` pattern in `contract_refresh_loop.py`.

### #9438 — `ContractRefreshLoop` ignored its documented sandbox-repo override
`_record_all` hardcoded the module constant `_SANDBOX_GITHUB_REPO` when invoking the GitHub recorder, so `config.contracts_sandbox_repo` — which documents itself as "Override if the sandbox org is renamed" — was **dead config** (zero consumers). Renaming the sandbox org silently had no effect.

**Fix:** resolve the slug from `self._config.contracts_sandbox_repo` (default is byte-identical, so no behavior change for default configs) and drop the now-dead constant.

## Tests
- `tests/regressions/test_issue_9410.py` — asserts `_reconcile_closed_escalations()` returns within a bound when the subprocess hangs (monkeypatches the timeout small so it doesn't itself blow the cycle bound). **RED before, GREEN after.**
- `tests/regressions/test_issue_9438.py` — asserts the recorder is invoked with the config override slug. **RED before, GREEN after.**

## Verification
- `make quality` — **16209 passed**, 0 failures
- `make scenario-loops` — **129 passed**
- `make scenario` — **200 passed**
- 57 existing `test_trust_fleet_sanity_loop.py` + `test_contract_refresh_loop.py` tests still green

## Salvage context
These came from 4 WIP regression tests found uncommitted in the working tree. The other two were **dropped after evaluation**: `#9434` (StreamView fork) guarded an aspirational UI behavior never implemented in either component — making it green would be a new feature, not a fix; `#9453` (review category misclassification) guards a real bug, but the token `"test"` is inherently ambiguous (positive "added a test" vs negative "needs a test") so a correct fix is high-risk NLP, out of scope for a salvage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)