### PR TITLE
Fixes #9499: PricingRefreshLoop bare-tier alias may lag the newest ...

### DIFF
--- a/docs/arch/.meta.json
+++ b/docs/arch/.meta.json
@@ -1,42 +1,42 @@
 {
-  "regenerated_at": "2026-06-13T01:57:07.144805+00:00",
-  "commit_sha": "afe655e9bd158229c782d85d7c84009af047572c",
+  "regenerated_at": "2026-06-13T09:39:40.759576+00:00",
+  "commit_sha": "722d2d9968053ef160a5f256c21eae65de801418",
   "artifacts": {
     "loops.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "ports.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "labels.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "modules.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "events.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "adr_xref.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "mockworld.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "changelog.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "coverage_matrix.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "functional_areas.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "ubiquitous-language.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     },
     "ubiquitous-language-context-map.md": {
-      "source_sha": "afe655e9bd158229c782d85d7c84009af047572c"
+      "source_sha": "722d2d9968053ef160a5f256c21eae65de801418"
     }
   }
 }

--- a/docs/arch/generated/changelog.md
+++ b/docs/arch/generated/changelog.md
@@ -6,6 +6,7 @@ Commits touching `docs/arch/`, `docs/adr/`, `docs/wiki/`, `src/arch/`, or `mkdoc
 
 ## 2026-W24
 
+- `f0974e5` — fix(wiki): resolve committed conflict markers in 11 term files (#9482) (#9484) (#9484) *(2026-06-12)*
 - `79662e5` — fix(observability): suppress Sentry noise — bugs-only filter + test init guard (#9481) (#9481) *(2026-06-12)*
 - `cadb008` — Fixes #9354: Shadow-drift: exclude non-deterministic corpus samples... (#9445) (#9445) *(2026-06-12)*
 - `e654a48` — feat(dependabot-merge): auto-heal bot PRs stuck on stale arch artifacts (#9475) (#9475) *(2026-06-12)*

--- a/docs/architecture/pricing_tier_alias.likec4
+++ b/docs/architecture/pricing_tier_alias.likec4
@@ -1,0 +1,115 @@
+// Issue #9499 — PricingRefreshLoop bare-tier alias must track the newest model per tier.
+// C4 model of the pricing-refresh subsystem and the data-integrity invariant
+// being added: each bare tier alias ("opus"/"sonnet"/"haiku") owned by the
+// highest-version entry for that tier.
+
+specification {
+  element system
+  element container
+  element component
+  element store
+  element externalSystem
+
+  tag changed       // touched by this issue
+  tag new           // added by this issue
+  tag invariant     // the property being enforced
+}
+
+model {
+  litellm = externalSystem 'LiteLLM upstream' {
+    description 'Raw model_prices_and_context_window.json fetched over https'
+  }
+
+  hydraflow = system 'HydraFlow' {
+
+    pricingRefresh = container 'Pricing-refresh subsystem' {
+
+      loop = component 'PricingRefreshLoop' {
+        #changed
+        description '''
+          Daily caretaker (src/pricing_refresh_loop.py).
+          Fetch upstream -> diff -> bounds-guard -> write file -> open human-reviewed PR.
+          CHANGE: after merging the diff, reconcile bare tier aliases onto the
+          newest entry per tier, then surface the moves in the PR body.
+        '''
+      }
+
+      diffHelpers = component 'pricing_refresh_diff (pure helpers)' {
+        #changed
+        description '''
+          Pure functions, no IO (src/pricing_refresh_diff.py).
+          Existing: normalize_litellm_key, filter_anthropic_entries,
+          map_litellm_to_local_costs, compute_pricing_diff.
+          NEW: tier_of, version_key, newest_per_tier,
+          tier_alias_violations (read-only detector),
+          reconcile_bare_tier_aliases (mutating fixer).
+        '''
+      }
+
+      loader = component 'ModelPricingTable.get_rate' {
+        description '''
+          src/model_pricing.py. Resolves a model id to a ModelRate by
+          exact id -> alias -> fuzzy substring. The bare tier aliases are
+          load-bearing for the fuzzy fallback (issue #9466). Read-only here;
+          benefits because the bare alias now always points at the newest rate.
+        '''
+      }
+
+      pricingAsset = store 'model_pricing.json' {
+        #invariant
+        description '''
+          src/assets/model_pricing.json — committed pricing data.
+          INVARIANT: each bare tier alias is owned by the newest entry for its tier.
+        '''
+      }
+
+      autoPr = component 'auto_pr.open_automated_pr_async' {
+        description 'Opens/updates the pricing-refresh-auto PR (auto_merge=False).'
+      }
+    }
+
+    guardTest = component 'tier-alias data-integrity guard' {
+      #new
+      description '''
+        tests/architecture/test_model_pricing_tier_aliases.py.
+        Loads the live asset and asserts tier_alias_violations(...) == [].
+        Fails CI if any bare tier alias lags the newest entry.
+      '''
+    }
+  }
+
+  // ---- data / control flow ----
+  loop -> litellm 'fetch upstream JSON (urllib, 30s)'
+  loop -> diffHelpers 'filter + compute_pricing_diff'
+  loop -> diffHelpers 'reconcile_bare_tier_aliases(models)' #changed
+  loop -> pricingAsset 'read + write merged file'
+  loop -> autoPr 'open/update human-reviewed PR'
+  loader -> pricingAsset 'read on first get_rate()'
+  guardTest -> pricingAsset 'assert invariant on committed asset' #new
+  guardTest -> diffHelpers 'tier_alias_violations(...)' #new
+}
+
+views {
+  view context {
+    title 'Pricing refresh — context'
+    include hydraflow, litellm
+  }
+
+  view subsystem {
+    title 'Pricing-refresh components (#9499 change area)'
+    include pricingRefresh, pricingRefresh.*, litellm, guardTest
+  }
+
+  // Dynamic view: a tick that ADDS a new newest model (e.g. claude-opus-4-8).
+  dynamic view addNewestModel {
+    title 'Tick adds claude-opus-4-8 -> bare "opus" alias re-points'
+    loop -> litellm 'GET upstream'
+    litellm -> loop 'claude-opus-4-8 present, not local'
+    loop -> diffHelpers 'compute_pricing_diff'
+    diffHelpers -> loop 'diff.added = {claude-opus-4-8: aliases:[]}'
+    loop -> diffHelpers 'reconcile_bare_tier_aliases(models)'
+    diffHelpers -> loop 'move "opus": claude-opus-4-7 -> claude-opus-4-8'
+    loop -> pricingAsset 'write merged + re-pointed file'
+    loop -> autoPr 'open PR (lists added model + alias move)'
+  }
+}


### PR DESCRIPTION
## Summary

Closes #9499.

## Issue

PricingRefreshLoop bare-tier alias may lag the newest model, masking the get_rate warning's value

## Test plan

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual review of changes

---
Generated by HydraFlow