### PR TITLE
fix(billing): treat Claude Code session-limit message as a credit pause

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -332,6 +332,13 @@ _CREDIT_PATTERNS = (
     "credit balance is too low",
     "you've hit your limit",
     "hit your usage limit",
+    # Claude Code subscription *session*-cap message
+    # ("You've hit your session limit · resets 5:50am"). The word "session"
+    # sits between "hit your" and "limit", so none of the usage-limit
+    # substrings above match it — both renderings are pinned here.
+    # (2026-06-13 incident; see tests/regressions/test_session_limit_credit_pause.py.)
+    "hit your session limit",
+    "session limit reached",
     # Anthropic API spend-cap rejection (HTTP 400 invalid_request_error).
     # Full phrase — narrower patterns would false-match conversational
     # transcript text like "reached your specified goals" and trigger a
@@ -341,9 +348,11 @@ _CREDIT_PATTERNS = (
 )
 
 # Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",
-# "resets 5am (America/Denver)", "resets at 5am"
+# "resets 5am (America/Denver)", "resets at 5am", "resets 5:50am (America/Denver)".
+# The minutes group is optional so both whole-hour and H:MM renderings parse —
+# Claude Code's session-limit line carries minutes ("resets 5:50am").
 _RESET_TIME_RE = re.compile(
-    r"resets?\s+(?:at\s+)?(\d{1,2})\s*(am|pm)"
+    r"resets?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)"
     r"(?:\s*\(([^)]+)\))?",
     re.IGNORECASE,
 )
@@ -473,11 +482,13 @@ def parse_credit_resume_time(text: str) -> datetime | None:
         return None
 
     hour = int(match.group(1))
-    ampm = match.group(2).lower()
-    tz_name = match.group(3)
+    minute = int(match.group(2)) if match.group(2) else 0
+    ampm = match.group(3).lower()
+    tz_name = match.group(4)
 
-    # Validate 12-hour clock range (1–12)
-    if hour < 1 or hour > 12:
+    # Validate 12-hour clock range (1–12) and minutes (0–59). A bogus minute
+    # ("5:99am") fails to parse rather than rolling over into the next hour.
+    if hour < 1 or hour > 12 or minute > 59:
         return None
 
     # Convert 12-hour to 24-hour
@@ -498,7 +509,7 @@ def parse_credit_resume_time(text: str) -> datetime | None:
             tz = datetime.now().astimezone().tzinfo or UTC
 
     now = datetime.now(tz=tz)
-    reset = now.replace(hour=hour_24, minute=0, second=0, microsecond=0)
+    reset = now.replace(hour=hour_24, minute=minute, second=0, microsecond=0)
 
     # If the reset time is already past, assume it means tomorrow
     if reset <= now:

--- a/tests/regressions/test_session_limit_credit_pause.py
+++ b/tests/regressions/test_session_limit_credit_pause.py
@@ -1,0 +1,67 @@
+"""Regression: a Claude Code *session*-limit message must drive the credit-pause
+path, not be mistaken for an ordinary agent failure.
+
+Incident — 2026-06-13 overnight run. The factory hit its Claude subscription
+session cap. Every in-flight agent (implement / review / auto-agent / diagnostic)
+printed::
+
+    You've hit your session limit · resets 5:50am (America/Denver)
+
+Two latent bugs in ``subprocess_util`` meant this was NOT recognised as a
+billing pause:
+
+1. ``_CREDIT_PATTERNS`` listed ``"you've hit your limit"`` / ``"hit your usage
+   limit"`` — but the word "session" sits between "hit your" and "limit", so no
+   substring matched and :func:`is_credit_exhaustion` returned ``False``.
+2. ``_RESET_TIME_RE`` only accepted whole hours (``5am``); it could not parse the
+   ``H:MM`` form (``5:50am``), so even a detected pause had no resume time.
+
+Consequence: no :class:`CreditExhaustedError` was raised, the orchestrator never
+paused, each agent's attempt was burned as a "failure", ~8 in-flight PRs were
+closed, and their issues were dumped into the HITL queue. This test pins both
+halves of the fix end-to-end through the lightweight runner classifier so a
+future pattern/regex edit cannot silently re-open the gap.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runner_utils import raise_if_credit_exhausted
+from subprocess_util import (
+    CreditExhaustedError,
+    is_credit_exhaustion,
+    parse_credit_resume_time,
+)
+
+# The exact transcript line Claude Code emits when the subscription session cap
+# is reached. Keep verbatim — the bug was a phrasing mismatch.
+SESSION_LIMIT_MSG = "You've hit your session limit · resets 5:50am (America/Denver)"
+
+
+def test_session_limit_is_classified_as_credit_exhaustion() -> None:
+    assert is_credit_exhaustion(SESSION_LIMIT_MSG)
+
+
+def test_session_limit_resume_time_parses_hour_and_minutes() -> None:
+    # 5:50am MDT (June → UTC-6) == 11:50 UTC. Deterministic regardless of "now":
+    # the past-time roll-forward preserves the Denver wall-clock time.
+    resume = parse_credit_resume_time(SESSION_LIMIT_MSG)
+    assert resume is not None
+    assert (resume.hour, resume.minute) == (11, 50)
+
+
+def test_lightweight_runner_raises_credit_error_with_resume_time() -> None:
+    """raise_if_credit_exhausted is the path every run_simple-based runner uses;
+    a session limit on stdout must raise with a populated resume_at so the
+    orchestrator schedules a resume instead of failing the attempt.
+    """
+    with pytest.raises(CreditExhaustedError) as excinfo:
+        raise_if_credit_exhausted(SESSION_LIMIT_MSG, "", tool="claude")
+    assert excinfo.value.resume_at is not None
+    assert excinfo.value.resume_at.minute == 50
+
+
+def test_session_limit_on_stderr_also_raises() -> None:
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted("", SESSION_LIMIT_MSG, tool="claude")

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1228,6 +1228,29 @@ class TestIsCreditExhaustion:
             "You reached your usage limits set in the test config."
         )
 
+    def test_matches_claude_code_session_limit(self) -> None:
+        """Claude Code subscription session-cap message (2026-06-13 incident).
+
+        The overnight 2026-06-13 run hit this exact phrasing on every agent;
+        because 'session' sits between 'hit your' and 'limit', none of the
+        legacy substrings matched and the credit-pause never fired.
+        """
+        assert is_credit_exhaustion(
+            "You've hit your session limit · resets 5:50am (America/Denver)"
+        )
+
+    def test_matches_session_limit_reached_phrasing(self) -> None:
+        """The alternate 'Session limit reached' rendering must also match."""
+        assert is_credit_exhaustion("Session limit reached. Try again later.")
+
+    def test_does_not_false_match_configured_session_count(self) -> None:
+        """A config statement about the session count is NOT an exhaustion
+        signal — CreditExhaustedError is non-retryable, so this must stay False.
+        """
+        assert not is_credit_exhaustion(
+            "The session limit is configured to 10 sessions per repo."
+        )
+
 
 class TestParseCreditResumeTime:
     """parse_credit_resume_time must recognize Anthropic's ISO-style resume format."""
@@ -1256,6 +1279,28 @@ class TestParseCreditResumeTime:
         resume = parse_credit_resume_time("resets at 3pm")
         assert resume is not None
         assert resume.hour in {15, 22, 23, 0, 1, 2, 7, 8}  # tz-dependent
+
+    def test_parses_am_pm_with_minutes_and_tz(self) -> None:
+        """Claude Code prints H:MM ('resets 5:50am'); the old regex only took
+        whole hours and returned None. 5:50am MDT (June, America/Denver UTC-6)
+        is 11:50 UTC — independent of 'now' because the roll-forward to the next
+        day preserves the wall-clock time.
+        """
+        resume = parse_credit_resume_time(
+            "You've hit your session limit · resets 5:50am (America/Denver)"
+        )
+        assert resume is not None
+        assert (resume.hour, resume.minute) == (11, 50)
+
+    def test_parses_am_pm_with_minutes_no_tz(self) -> None:
+        """Minutes must be honoured even without a timezone suffix (local fallback)."""
+        resume = parse_credit_resume_time("resets 5:50am")
+        assert resume is not None
+        assert resume.minute == 50
+
+    def test_rejects_out_of_range_minutes(self) -> None:
+        """A bogus minute value must fail-to-parse, not roll over into the hour."""
+        assert parse_credit_resume_time("resets 5:99am") is None
 
     def test_returns_none_for_non_matching_text(self) -> None:
         assert parse_credit_resume_time("no date here") is None


### PR DESCRIPTION
## Root cause of the 2026-06-13 overnight run ("1 made, tons of HITL")

The factory hit its Claude **subscription session cap** overnight. Every in-flight agent (implement / review / auto-agent / diagnostic) printed:

> You've hit your session limit · resets 5:50am (America/Denver)

Two latent gaps in `src/subprocess_util.py` meant this was **not** recognized as a billing pause:

1. **`_CREDIT_PATTERNS`** listed `"you've hit your limit"` / `"hit your usage limit"`. The word **session** sits between "hit your" and "limit", so no substring matched → `is_credit_exhaustion()` returned `False`.
2. **`_RESET_TIME_RE`** only accepted whole hours (`5am`); it could not parse the `H:MM` form (`5:50am`), so even a detected pause had no resume time.

Because no `CreditExhaustedError` was ever raised, the orchestrator's existing credit-pause + attempt-refund machinery (`auto_agent_preflight_loop` refund, `_pause_for_credits`, resume-after-reset) **never engaged**. Instead each agent's empty/aborted output was scored as a normal failure: attempts were burned, ~8 in-flight `agent/issue-*` PRs were closed (#9519–#9525, #9506, #9511 — each closed with the session-limit comment), and their issues were dumped into the HITL queue.

## Fix

- Add `"hit your session limit"` and `"session limit reached"` to `_CREDIT_PATTERNS`.
- Extend `_RESET_TIME_RE` with an optional minutes group and validate `0–59` (bogus `5:99am` fails-to-parse rather than rolling into the hour).
- Thread the parsed minute through `parse_credit_resume_time`.

Every runner routes credit detection through these two functions, so the pause now fires **fleet-wide** — the next session cap pauses-and-resumes instead of trashing the run.

## Tests
- `tests/test_subprocess_util.py`: new cases in `TestIsCreditExhaustion` (session-limit match + benign "configured to 10 sessions" non-match) and `TestParseCreditResumeTime` (`5:50am` with/without tz, out-of-range minutes).
- `tests/regressions/test_session_limit_credit_pause.py`: pins the full chain through `raise_if_credit_exhausted` (the path every `run_simple`-based runner uses) — detection → `CreditExhaustedError` → populated `resume_at`.

Verified locally: 191 related tests pass; ruff + pyright + test-sludge + arch-check + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)