### PR TITLE
fix(adr-drift): stop recurring false-positive ADR-drift HITL escalations

### DIFF
--- a/docs/adr/0004-agent-cli-as-runtime.md
+++ b/docs/adr/0004-agent-cli-as-runtime.md
@@ -69,7 +69,7 @@ Any tool can be switched to `codex` or `pi` per-stage via environment variables.
 
 ## Related
 
-- `src/agent_cli.py` — command builder
+- `src/agent_cli.py:build_agent_command` — command builder
 - `src/base_runner.py:BaseRunner._execute` — streaming subprocess executor
 - `AGENTS.md` — canonical prompt contracts for each agent role
 - ADR-0002 (GitHub Labels as the Pipeline State Machine) for the output marker protocol that makes tool-agnosticism possible

--- a/docs/adr/0046-meta-observability-bounded-recursion.md
+++ b/docs/adr/0046-meta-observability-bounded-recursion.md
@@ -5,7 +5,7 @@
 - **Supersedes:** none
 - **Superseded by:** none
 - **Related:** [ADR-0045](0045-trust-architecture-hardening.md) (establishes the trust fleet that this ADR supervises)
-- **Enforced by:** `src/trust_fleet_sanity_loop.py` (the meta-observer); `src/health_monitor_loop.py::_check_sanity_loop_staleness` (the dead-man-switch watching the meta-observer); `tests/test_health_monitor_sanity_stall.py` (runtime enforcement test).
+- **Enforced by:** `src/trust_fleet_sanity_loop.py::TrustFleetSanityLoop` (the meta-observer); `src/health_monitor_loop.py::_check_sanity_loop_staleness` (the dead-man-switch watching the meta-observer); `tests/test_health_monitor_sanity_stall.py` (runtime enforcement test).
 
 ## Context
 

--- a/src/adr_drift.py
+++ b/src/adr_drift.py
@@ -57,20 +57,25 @@ def _split_path_symbol(entry: str) -> tuple[str, str | None]:
     return entry, None
 
 
-# Cross-cutting infrastructure modules — bare-cited (file-granular) as a
-# *dependency* by many Accepted ADRs: the config dataclass, shared Pydantic
-# models, the Port protocols, the post-merge handler, and the GitHub PR/issue
-# port wrapper. Every feature touches these, so a file-level touch is
-# implementation churn, not a semantic change to any one ADR's decision. They
-# are the dominant source of ADR-drift false positives (e.g. src/config.py
-# absorbed ~20 merged PRs in two weeks, and src/pr_manager.py is bare-cited by
-# ADR-0005/0018/0045/0056 while changing on nearly every PR that files an issue
-# or PR). #9176 already suppressed the symbol-cited case; #9397 added the first
-# four modules here for the residual *bare-cited* case; pr_manager.py joins them
-# as the next-highest-churn dependency. An ADR that genuinely owns one of these
-# must cite the specific symbol (``src/config.py:HydraFlowConfig``,
-# ``src/pr_manager.py:PRManager.upload_screenshot_gist``) to drift — a bare
-# citation is read as a dependency mention and does not drift.
+# High-churn modules bare-cited (file-granular) as a *dependency pointer* by
+# their pattern ADRs — "the implementation lives here", not "this exact decision
+# is this file". A file-level touch is implementation churn, not a semantic
+# change to any one ADR's decision, so a bare citation is read as a dependency
+# mention and does NOT drift. They are the dominant source of ADR-drift false
+# positives. An ADR that genuinely *owns* a symbol in one of these must cite it
+# at ``:Symbol`` granularity (``src/config.py:HydraFlowConfig``,
+# ``src/pr_manager.py:PRManager.upload_screenshot_gist``) to drift.
+#
+# Lineage:
+#   * #9176 suppressed the symbol-cited case.
+#   * #9397 added the first four cross-cutting infra modules (config, models,
+#     ports, post_merge_handler) for the residual bare-cited case.
+#   * pr_manager.py joined as the next-highest-churn dependency.
+#   * 2026-06-13: the dashboard/server/repo_runtime startup surface and the
+#     contract-testing subsystem (contract_recording/diff/refresh_loop, bare-
+#     cited as dependency pointers by ADR-0047/0052) were the remaining recurring
+#     "ADR drift unresolved after 3" HITL escalations — added here so normal
+#     in-scope churn stops re-firing them.
 _SHARED_INFRA_MODULES = frozenset(
     {
         "src/config.py",
@@ -78,6 +83,18 @@ _SHARED_INFRA_MODULES = frozenset(
         "src/ports.py",
         "src/post_merge_handler.py",
         "src/pr_manager.py",
+        # Dashboard / server / multi-repo startup surface — cross-cutting,
+        # bare-cited as a dependency by the dashboard + multi-repo ADRs
+        # (0007/0008/0013/0019/0038/0050/0060/0090).
+        "src/dashboard.py",
+        "src/server.py",
+        "src/repo_runtime.py",
+        # Contract-testing subsystem — bare-cited as dependency pointers by
+        # ADR-0047 (the pattern) and ADR-0052; cassettes/recorders evolve on
+        # normal contract churn that does not change either decision.
+        "src/contract_recording.py",
+        "src/contract_diff.py",
+        "src/contract_refresh_loop.py",
     }
 )
 

--- a/tests/test_adr_drift.py
+++ b/tests/test_adr_drift.py
@@ -236,6 +236,66 @@ def test_bare_citation_of_non_infra_module_still_drifts(tmp_path: Path) -> None:
     assert findings[0].adr.number == 52
 
 
+@pytest.mark.parametrize(
+    "module",
+    [
+        "src/dashboard.py",
+        "src/server.py",
+        "src/repo_runtime.py",
+        "src/contract_recording.py",
+        "src/contract_diff.py",
+        "src/contract_refresh_loop.py",
+    ],
+)
+def test_recurring_fp_module_bare_citation_does_not_drift(
+    tmp_path: Path, module: str
+) -> None:
+    # 2026-06-13: these high-churn modules are bare-cited as dependency pointers
+    # by their pattern ADRs (dashboard/server/repo_runtime by the dashboard +
+    # multi-repo ADRs; contract_* by ADR-0047/0052). A bare file-level touch is
+    # implementation churn and must NOT drift — the recurring source of the
+    # "ADR drift unresolved after 3" HITL escalations. An ADR that genuinely
+    # owns a symbol in one of these still cites it at :Symbol granularity.
+    adr_dir = tmp_path / "adr"
+    adr_dir.mkdir()
+    _write_adr(
+        adr_dir,
+        number=60,
+        title="depends on infra",
+        status="Accepted",
+        related_files=[module],
+    )
+    findings = compute_drift(ADRIndex(adr_dir), pr_number=1, changed_files=[module])
+    assert findings == []
+
+
+def test_real_adrs_do_not_drift_on_dependency_only_touches() -> None:
+    # End-to-end regression for the recurring ADR-drift false positives that
+    # filled the HITL queue (#9526/#9514/#9513/#9488 + the dashboard cluster
+    # #9497/#9507/#9418/#9414). Touching these modules in the production case
+    # (bare paths, no symbol evidence) must NOT drift the Accepted/Proposed ADRs
+    # that merely cite them as dependencies. A new ADR that bare-cites one of
+    # these (instead of a :Symbol) will trip this guard — by design.
+    repo_root = Path(__file__).resolve().parents[1]
+    idx = ADRIndex(repo_root / "docs" / "adr")
+    touches = [
+        "src/agent_cli.py",
+        "src/dashboard.py",
+        "src/server.py",
+        "src/repo_runtime.py",
+        "src/trust_fleet_sanity_loop.py",
+        "src/contract_recording.py",
+        "src/contract_diff.py",
+        "src/contract_refresh_loop.py",
+    ]
+    findings = compute_drift(idx, pr_number=9999, changed_files=touches)
+    drifted = sorted({f.adr.number for f in findings})
+    assert drifted == [], (
+        f"dependency-only touches drifted ADRs {drifted}; the cited module(s) "
+        "must be shared-infra or symbol-qualified in the owning ADR"
+    )
+
+
 def test_adr_file_in_diff_helper(adr_index: ADRIndex) -> None:
     adr = next(a for a in adr_index.adrs() if a.number == 1)
     assert _adr_file_in_diff(adr, ["docs/adr/0001-alpha.md"])


### PR DESCRIPTION
## Problem

The recurring **\"HITL: ADR drift ADR-XXXX unresolved after 3\"** escalations (#9526 ADR-0047, #9514 ADR-0046, #9513 ADR-0038, #9488 ADR-0004) and the dashboard drift-FP cluster (#9497/#9507/#9418/#9414) are **not real drift**. They fire when an Accepted/Proposed ADR bare-cites its own high-churn implementation module and that module changes during normal in-scope work. Because there's nothing to "fix" in the ADR, the auto-resolver loops to HITL forever — pure noise in the human queue.

Root mechanism: `adr_index.parse_adr_file` collapses **any** bare citation of a file onto file-granularity (a bare mention *anywhere* — including prose — overrides a `:Symbol` citation), so a single bare/prose mention makes the ADR drift on every touch of that file.

## Fix — the two documented right-size mechanisms

**1. `_SHARED_INFRA_MODULES`** (bare citation = dependency pointer → does not drift; only `:Symbol` citations drift). Added:
- `src/dashboard.py`, `src/server.py`, `src/repo_runtime.py` — the dashboard/multi-repo startup surface, bare-cited as a dependency by 0007/0008/0013/0019/0038/0050/0060/0090.
- `src/contract_recording.py`, `src/contract_diff.py`, `src/contract_refresh_loop.py` — the contract-testing subsystem, bare-cited as dependency pointers by ADR-0047/0052.

**2. Symbol-qualify owned single-mention citations:**
- ADR-0004: `src/agent_cli.py` → `:build_agent_command` (drops the redundant bare line that was collapsing the existing `:build_agent_command` citation).
- ADR-0046: `src/trust_fleet_sanity_loop.py` → `::TrustFleetSanityLoop`.

## Verification

Before: a dependency-only touch of these modules drifted ADRs `[4, 7, 8, 38, 46, 47, 52]`. After: **zero**.

New tests in `tests/test_adr_drift.py`:
- parametrized guard that each newly-excluded module's bare citation does not drift;
- an end-to-end regression loading the **real** `docs/adr` asserting dependency-only touches drift zero ADRs. A future ADR that bare-cites one of these instead of a `:Symbol` trips the guard — by design.

58 ADR-area tests pass; ruff + pyright + test-sludge + arch-check clean.

## Related cleanup (separate)
The dead `src/dashboard_routes.py` citations in several ADRs (the package was split per ADR-0030) are *harmless* — `adrs_touching` uses exact path matching so they never match a real changed file — so they are not a drift source and are left as a minor doc-hygiene follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)