### PR TITLE
feat(factory): make factory — run from an isolated workspace (keep dev checkout clean)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ RESET := \033[0m
 DOCKER_IMAGE ?= ghcr.io/t-rav/hydraflow-agent:latest
 DOCKER_BASE_IMAGE ?= ghcr.io/t-rav/hydraflow-agent-base:latest
 
-.PHONY: help run dev dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels ensure-hooks prep scaffold hot docker-build docker-ensure docker-test deps integration soak check-node-ui trust trust-adversarial auto-agent-adversarial
+.PHONY: help run dev factory dry-run clean clean-assets compact coverage cover smoke test test-fast test-cov lint lint-check lint-fix lint-ul typecheck security quality quality-lite install install-plugins setup status ui ui-dev ui-clean ensure-labels ensure-hooks prep scaffold hot docker-build docker-ensure docker-test deps integration soak check-node-ui trust trust-adversarial auto-agent-adversarial
 
 check-node-ui:
 	@cd $(HYDRAFLOW_DIR)src/ui && $(HYDRAFLOW_DIR)scripts/ui-npm.sh --version >/dev/null
@@ -117,6 +117,10 @@ endif
 	wait
 
 dev: run
+
+factory:
+	@echo "$(BLUE)Starting HydraFlow factory in an isolated workspace (dev checkout stays clean)$(RESET)"
+	@$(HYDRAFLOW_DIR)scripts/run-factory-isolated.sh
 
 dry-run:
 	@echo "$(BLUE)HydraFlow dry run (server mode)$(RESET)"

--- a/docs/running-the-factory.md
+++ b/docs/running-the-factory.md
@@ -1,0 +1,42 @@
+# Running the factory without dirtying your checkout
+
+The factory mutates the directory it runs from (`config.repo_root`): the wiki,
+arch, and runtime-cache loops write artifacts into the working tree as they
+operate, and each maintenance PR is built in an *ephemeral* worktree
+(`auto_pr.open_automated_pr_async`) that never cleans the originals. If you run
+`make run` from the same checkout you develop in, that checkout is permanently
+dirty.
+
+## Use a dedicated workspace
+
+```bash
+make factory
+```
+
+This runs `scripts/run-factory-isolated.sh`, which:
+
+1. Clones the repo (once) into a dedicated workspace —
+   `~/.hydraflow/factory-workspace/hydraflow` by default.
+2. Hard-syncs that workspace to the latest base branch (`main` by default) on
+   every launch — the workspace is the factory's scratch space, so its churn is
+   discarded here.
+3. Copies your dev checkout's `.env` into the workspace so credentials/config
+   carry over.
+4. Launches the server (`make run`) from the workspace.
+
+Your dev checkout is never touched. The factory's PRs still land on `origin` as
+usual; pull them into your clean checkout with `git pull`.
+
+### Overrides
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `HYDRAFLOW_FACTORY_WORKSPACE` | `~/.hydraflow/factory-workspace/hydraflow` | Where the dedicated clone lives |
+| `HYDRAFLOW_FACTORY_BRANCH` | `main` | Branch the factory runs |
+
+## Why not just `git restore` after each run?
+
+The runtime caches (`docs/wiki/log.jsonl`, `ingest_dedup.json`, `index.json`)
+are now gitignored, and the maintenance loops will be taught to self-clean after
+their PR merges — but isolating the workspace is the robust catch-all: a fresh
+writer that forgets to clean up can't dirty a checkout it never touches.

--- a/scripts/run-factory-isolated.sh
+++ b/scripts/run-factory-isolated.sh
@@ -17,14 +17,37 @@
 # Usage:  scripts/run-factory-isolated.sh        (or: make factory)
 set -euo pipefail
 
-DEV_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 WORKSPACE="${HYDRAFLOW_FACTORY_WORKSPACE:-$HOME/.hydraflow/factory-workspace/hydraflow}"
 BRANCH="${HYDRAFLOW_FACTORY_BRANCH:-main}"
 
-if [ "$(cd "$DEV_ROOT" && git rev-parse --show-toplevel 2>/dev/null)" = "$WORKSPACE" ]; then
-  echo "[factory] ERROR: workspace ($WORKSPACE) is the current checkout." >&2
-  echo "[factory] Point HYDRAFLOW_FACTORY_WORKSPACE elsewhere, or run from your dev checkout." >&2
+# Canonicalize WORKSPACE to an absolute, symlink-resolved path BEFORE the
+# safety guard — otherwise a relative value ('.', '../hydraflow') would slip
+# past the comparison below and the later `git reset --hard` could wipe the dev
+# checkout. An existing dir is resolved via cd+pwd; a not-yet-created path is
+# made absolute against its (existing) parent. Dangerous aliases of the dev
+# checkout ('.', '..') always already exist, so the cd+pwd branch catches them.
+if [ -d "$WORKSPACE" ]; then
+  WORKSPACE="$(cd "$WORKSPACE" && pwd -P)"
+else
+  _ws_parent="$(dirname "$WORKSPACE")"
+  if [ -d "$_ws_parent" ]; then
+    WORKSPACE="$(cd "$_ws_parent" && pwd -P)/$(basename "$WORKSPACE")"
+  fi
+fi
+
+_abort_in_place() {
+  echo "[factory] ERROR: workspace ($WORKSPACE) is the dev checkout itself." >&2
+  echo "[factory] Set HYDRAFLOW_FACTORY_WORKSPACE to a separate path." >&2
   exit 1
+}
+# Guard 1: resolved paths must differ.
+[ "$WORKSPACE" = "$DEV_ROOT" ] && _abort_in_place
+# Guard 2: even via symlink/nested layout, the workspace must not be the dev
+# repo's git toplevel.
+if [ -e "$WORKSPACE/.git" ]; then
+  _ws_top="$(git -C "$WORKSPACE" rev-parse --show-toplevel 2>/dev/null || true)"
+  [ -n "$_ws_top" ] && [ "$_ws_top" = "$DEV_ROOT" ] && _abort_in_place
 fi
 
 ORIGIN_URL="$(git -C "$DEV_ROOT" remote get-url origin)"

--- a/scripts/run-factory-isolated.sh
+++ b/scripts/run-factory-isolated.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Run HydraFlow's factory from a DEDICATED workspace clone, so your dev checkout
+# stays pristine.
+#
+# Why: the factory's repo_root (the dir it runs from) is mutated as it operates —
+# it writes wiki/arch/runtime artifacts there and builds its PRs in ephemeral
+# worktrees that never clean the originals, leaving the working tree perpetually
+# dirty. Running the factory from its own clone keeps that churn out of the
+# checkout you actually develop in. The dedicated clone's PRs still land on
+# origin exactly as before; you just `git pull` them into your clean dev checkout.
+#
+# Config (env overrides):
+#   HYDRAFLOW_FACTORY_WORKSPACE   dir for the dedicated clone
+#                                 (default: ~/.hydraflow/factory-workspace/hydraflow)
+#   HYDRAFLOW_FACTORY_BRANCH      branch the factory runs (default: main)
+#
+# Usage:  scripts/run-factory-isolated.sh        (or: make factory)
+set -euo pipefail
+
+DEV_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKSPACE="${HYDRAFLOW_FACTORY_WORKSPACE:-$HOME/.hydraflow/factory-workspace/hydraflow}"
+BRANCH="${HYDRAFLOW_FACTORY_BRANCH:-main}"
+
+if [ "$(cd "$DEV_ROOT" && git rev-parse --show-toplevel 2>/dev/null)" = "$WORKSPACE" ]; then
+  echo "[factory] ERROR: workspace ($WORKSPACE) is the current checkout." >&2
+  echo "[factory] Point HYDRAFLOW_FACTORY_WORKSPACE elsewhere, or run from your dev checkout." >&2
+  exit 1
+fi
+
+ORIGIN_URL="$(git -C "$DEV_ROOT" remote get-url origin)"
+
+if [ ! -d "$WORKSPACE/.git" ]; then
+  echo "[factory] cloning $ORIGIN_URL -> $WORKSPACE"
+  mkdir -p "$(dirname "$WORKSPACE")"
+  git clone "$ORIGIN_URL" "$WORKSPACE"
+fi
+
+# Always start the factory on a clean, current base. The dedicated workspace is
+# the factory's scratch space — discarding its working-tree churn here is the
+# whole point (runtime caches are gitignored; real artifacts land via PRs).
+echo "[factory] syncing $WORKSPACE -> origin/$BRANCH"
+git -C "$WORKSPACE" fetch origin --prune
+git -C "$WORKSPACE" checkout "$BRANCH"
+git -C "$WORKSPACE" reset --hard "origin/$BRANCH"
+
+# Reuse the dev checkout's .env (tokens + runtime config) so the factory has the
+# same credentials/settings. Copied each launch so the two stay in sync.
+if [ -f "$DEV_ROOT/.env" ]; then
+  echo "[factory] syncing .env from dev checkout"
+  cp "$DEV_ROOT/.env" "$WORKSPACE/.env"
+else
+  echo "[factory] WARNING: no .env in $DEV_ROOT — the factory may lack credentials" >&2
+fi
+
+echo "[factory] launching from $WORKSPACE (branch: $BRANCH)"
+cd "$WORKSPACE"
+exec make run

--- a/tests/test_isolated_factory_workspace.py
+++ b/tests/test_isolated_factory_workspace.py
@@ -34,11 +34,48 @@ def test_launcher_script_passes_bash_syntax_check() -> None:
     assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
 
 
-def test_launcher_refuses_to_run_in_place() -> None:
-    # The in-place guard (workspace == current checkout) is what stops the
-    # script from dirtying the dev checkout it was meant to protect.
+def _run_launcher(workspace: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run the launcher with a given HYDRAFLOW_FACTORY_WORKSPACE + cwd.
+
+    Only used for cases where the in-place guard must FIRE — those exit before
+    any clone / `make run`, so this never launches a server.
+    """
+    bash = shutil.which("bash")
+    assert bash is not None
+    env = {**os.environ, "HYDRAFLOW_FACTORY_WORKSPACE": workspace}
+    return subprocess.run(
+        [bash, str(SCRIPT)],
+        check=False,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def test_guard_blocks_absolute_dev_root() -> None:
+    # Pointing the workspace at the dev checkout (absolute) must abort before
+    # the destructive `git reset --hard`.
+    result = _run_launcher(str(REPO_ROOT), cwd=REPO_ROOT)
+    assert result.returncode != 0
+    assert "dev checkout" in result.stderr
+
+
+def test_guard_blocks_relative_dot_alias() -> None:
+    # The data-loss bug the adversarial review caught: a RELATIVE workspace
+    # ('.') resolving to the dev checkout must still be refused — the guard
+    # canonicalizes before comparing.
+    result = _run_launcher(".", cwd=REPO_ROOT)
+    assert result.returncode != 0
+    assert "dev checkout" in result.stderr
+
+
+def test_guard_canonicalizes_before_comparing() -> None:
+    # The script must resolve the workspace path before the guard, not compare
+    # a raw (possibly relative) string.
     text = SCRIPT.read_text()
-    assert "is the current checkout" in text
+    assert "pwd -P" in text, "workspace path must be canonicalized before the guard"
 
 
 def test_makefile_wires_the_factory_target() -> None:

--- a/tests/test_isolated_factory_workspace.py
+++ b/tests/test_isolated_factory_workspace.py
@@ -1,0 +1,50 @@
+"""The `make factory` isolated-workspace launcher must stay wired and valid.
+
+Running the factory from a dedicated clone (instead of the dev checkout) is how
+we keep the developer's working tree clean — the factory mutates its repo_root as
+it runs. This guards the launcher script + Makefile wiring so the escape hatch
+can't silently rot.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "run-factory-isolated.sh"
+
+
+def test_launcher_script_exists_and_is_executable() -> None:
+    assert SCRIPT.is_file(), "scripts/run-factory-isolated.sh is missing"
+    assert os.access(SCRIPT, os.X_OK), (
+        "scripts/run-factory-isolated.sh must be executable (chmod +x)"
+    )
+
+
+def test_launcher_script_passes_bash_syntax_check() -> None:
+    bash = shutil.which("bash")
+    if bash is None:
+        return  # no bash on this runner — skip rather than false-fail
+    result = subprocess.run(
+        [bash, "-n", str(SCRIPT)], check=False, capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"bash -n failed:\n{result.stderr}"
+
+
+def test_launcher_refuses_to_run_in_place() -> None:
+    # The in-place guard (workspace == current checkout) is what stops the
+    # script from dirtying the dev checkout it was meant to protect.
+    text = SCRIPT.read_text()
+    assert "is the current checkout" in text
+
+
+def test_makefile_wires_the_factory_target() -> None:
+    makefile = (REPO_ROOT / "Makefile").read_text()
+    assert "\nfactory:" in makefile, "Makefile is missing the `factory` target"
+    assert "run-factory-isolated.sh" in makefile
+    assert ".PHONY: help run dev factory" in makefile, (
+        "`factory` must be declared .PHONY"
+    )


### PR DESCRIPTION
## Problem (factory working-tree hygiene, part 2/3)

The factory mutates the directory it runs from (`config.repo_root`) — wiki/arch/runtime loops write into the working tree and maintenance PRs are built in throwaway worktrees that never clean the originals. Running `make run` from your dev checkout leaves it permanently dirty.

## Fix
`make factory` → `scripts/run-factory-isolated.sh`:
1. Clones the repo (once) into a dedicated workspace (default `~/.hydraflow/factory-workspace/hydraflow`).
2. Hard-syncs it to the base branch (`main` default) every launch — the workspace is the factory's scratch space.
3. Copies the dev checkout's `.env` so credentials/config carry over.
4. Launches `make run` from there.

Your dev checkout is never touched; the factory's PRs still land on `origin`. Overridable via `HYDRAFLOW_FACTORY_WORKSPACE` / `HYDRAFLOW_FACTORY_BRANCH`. An in-place guard refuses to run if the workspace == the current checkout.

This is the **robust catch-all**: a writer that forgets to clean up can't dirty a checkout it never touches.

## Tests
`tests/test_isolated_factory_workspace.py`: script exists + executable + `bash -n` clean, in-place guard present, Makefile target wired (incl. `.PHONY`). Docs in `docs/running-the-factory.md`.

Part of a 3-PR set: (1) untrack runtime caches #9537, (2) this, (3) loop self-clean after maintenance-PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)