### PR TITLE
fix(cost): attribute per-loop cost by inference source, not trace overlap

### DIFF
--- a/src/dashboard_routes/_cost_rollups.py
+++ b/src/dashboard_routes/_cost_rollups.py
@@ -410,8 +410,13 @@ _NON_LOOP_COST_SOURCES: frozenset[str] = frozenset(
 # ``worker_name``. Pipeline-runner sources (implementer→implement, …) are
 # folded by ``source_to_phase``; only the genuine bg-loop mismatches live here.
 _COST_SOURCE_TO_WORKER: dict[str, str] = {
-    "unsticker": "pr_unsticker",  # pr_unsticker.py work-item path
+    "unsticker": "pr_unsticker",  # pr_unsticker conflict-transcript label
     "wiki_compilation": "repo_wiki",  # wiki_compiler.py, driven by RepoWikiLoop
+    # DiagnosticLoop's runner emits two source values — "diagnostic" (diagnose
+    # stage) and "diagnostic_fix" (fix stage). Pin BOTH to the loop explicitly
+    # so a future ``source_to_phase`` entry for "diagnostic" can't split the
+    # diagnose-stage spend (the larger of the two) into a separate row.
+    "diagnostic": "diagnostic",  # diagnostic_runner.py diagnose stage
     "diagnostic_fix": "diagnostic",  # diagnostic_runner.py fix stage
 }
 

--- a/src/dashboard_routes/_cost_rollups.py
+++ b/src/dashboard_routes/_cost_rollups.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 from dashboard_routes._waterfall_builder import _phase_for_source
 from model_pricing import ModelPricingTable, load_pricing
 from trace_collector import _slug_for_loop
+from tracing_context import source_to_phase
 
 if TYPE_CHECKING:
     from config import HydraFlowConfig
@@ -396,6 +397,42 @@ def _tally_worker_events(events: list[Any]) -> dict[str, dict[str, Any]]:
     return out
 
 
+# Inference ``source`` values that name no loop: char-estimate token-source
+# markers, the design-time onboarding agent, synchronous post-merge hooks, and
+# empty sources. These never represent a background-worker/pipeline loop, so
+# they are dropped from the per-loop cost view rather than surfacing a spurious
+# row.
+_NON_LOOP_COST_SOURCES: frozenset[str] = frozenset(
+    {"", "estimated", "claude", "post_merge_hook", "threshold_check"}
+)
+
+# Background-loop sources whose telemetry ``source`` differs from the loop's
+# ``worker_name``. Pipeline-runner sources (implementer→implement, …) are
+# folded by ``source_to_phase``; only the genuine bg-loop mismatches live here.
+_COST_SOURCE_TO_WORKER: dict[str, str] = {
+    "unsticker": "pr_unsticker",  # pr_unsticker.py work-item path
+    "wiki_compilation": "repo_wiki",  # wiki_compiler.py, driven by RepoWikiLoop
+    "diagnostic_fix": "diagnostic",  # diagnostic_runner.py fix stage
+}
+
+
+def _worker_for_cost_source(source: str) -> str | None:
+    """Map an inference ``source`` to the loop/worker it should bill to.
+
+    Returns ``None`` for sources that name no loop (telemetry artifacts and
+    synchronous hooks). Background-loop sources whose name differs from the
+    loop's ``worker_name`` are remapped via :data:`_COST_SOURCE_TO_WORKER`;
+    pipeline-runner sources fold to their canonical phase via
+    :func:`source_to_phase`; everything else passes through unchanged.
+    """
+    normalized = (source or "").strip()
+    if normalized in _NON_LOOP_COST_SOURCES:
+        return None
+    if normalized in _COST_SOURCE_TO_WORKER:
+        return _COST_SOURCE_TO_WORKER[normalized]
+    return source_to_phase(normalized)
+
+
 def build_per_loop_cost(
     config: HydraFlowConfig,
     *,
@@ -410,55 +447,60 @@ def build_per_loop_cost(
     issues_filed, issues_closed, escalations, ticks, tick_cost_avg_usd,
     wall_clock_seconds, tick_cost_avg_usd_prev_period, model_breakdown.
 
+    Cost / tokens / llm_calls / model_breakdown are attributed to a loop by the
+    inference ``source`` field (see :func:`_worker_for_cost_source`), **not** by
+    temporal overlap with a loop-trace window: the loops that emit loop traces
+    are LLM-free caretaker loops (gh/git shell-outs), while the LLM-spending
+    background workers emit no loop trace at all — so a trace-window join bills
+    ``$0`` to every loop and, when windows do coincide, mis-attributes pipeline
+    spend to whichever caretaker tick it overlapped. Tick counts and wall-clock
+    still come from loop traces; filed / closed / escalation / errored-tick
+    counters still come from ``BACKGROUND_WORKER_STATUS`` events.
+
     ``model_breakdown`` is a dict keyed by model name (or "unknown" for
     records missing the field), with nested {cost_usd, calls, input_tokens,
     output_tokens, cache_read_tokens, cache_write_tokens}.
     """
     pricing = pricing or load_pricing()
 
-    # Attribution from loop-trace temporal overlap with inference rows.
-    loop_ticks: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    # Tick count + wall-clock from loop traces, keyed by worker_name. (Loops
+    # emit traces under ``self._worker_name``; ``_slug_for_loop`` is a no-op on
+    # an already-snake-case name but normalises any legacy ClassName trace.)
+    per_loop_ticks: dict[str, int] = defaultdict(int)
+    per_loop_wall: dict[str, int] = defaultdict(int)
     for tr in iter_loop_traces(config, since=since, until=until):
-        loop_ticks[str(tr.get("loop", "?"))].append(tr)
+        worker = _slug_for_loop(str(tr.get("loop", "?")))
+        per_loop_ticks[worker] += 1
+        per_loop_wall[worker] += int(tr.get("duration_ms", 0) or 0) // 1000
 
-    inferences = list(
-        iter_priced_inferences(config, since=since, until=until, pricing=pricing)
-    )
-
+    # Cost / tokens / calls / model-breakdown attributed by inference source.
     per_loop_cost: dict[str, float] = defaultdict(float)
     per_loop_tokens_in: dict[str, int] = defaultdict(int)
     per_loop_tokens_out: dict[str, int] = defaultdict(int)
     per_loop_llm_calls: dict[str, int] = defaultdict(int)
-    per_loop_wall: dict[str, int] = defaultdict(int)
     per_loop_model: dict[str, dict[str, dict[str, float | int]]] = defaultdict(
         lambda: defaultdict(_empty_model_bucket)
     )
-
-    for name, ticks in loop_ticks.items():
-        for tick in ticks:
-            per_loop_wall[name] += int(tick.get("duration_ms", 0) or 0) // 1000
-            started = tick["ts"]
-            ended = started + timedelta(
-                milliseconds=int(tick.get("duration_ms", 0) or 0)
-            )
-            for rec in inferences:
-                if started <= rec["ts"] <= ended:
-                    per_loop_cost[name] += rec["cost_usd"]
-                    per_loop_tokens_in[name] += int(rec.get("input_tokens", 0) or 0)
-                    per_loop_tokens_out[name] += int(rec.get("output_tokens", 0) or 0)
-                    per_loop_llm_calls[name] += 1
-                    model_key = str(rec.get("model") or "").strip() or "unknown"
-                    bucket = per_loop_model[name][model_key]
-                    bucket["cost_usd"] += float(rec["cost_usd"])
-                    bucket["calls"] += 1
-                    bucket["input_tokens"] += int(rec.get("input_tokens", 0) or 0)
-                    bucket["output_tokens"] += int(rec.get("output_tokens", 0) or 0)
-                    bucket["cache_read_tokens"] += int(
-                        rec.get("cache_read_input_tokens", 0) or 0
-                    )
-                    bucket["cache_write_tokens"] += int(
-                        rec.get("cache_creation_input_tokens", 0) or 0
-                    )
+    for rec in iter_priced_inferences(
+        config, since=since, until=until, pricing=pricing
+    ):
+        worker = _worker_for_cost_source(str(rec.get("source", "")))
+        if worker is None:
+            continue
+        per_loop_cost[worker] += rec["cost_usd"]
+        per_loop_tokens_in[worker] += int(rec.get("input_tokens", 0) or 0)
+        per_loop_tokens_out[worker] += int(rec.get("output_tokens", 0) or 0)
+        per_loop_llm_calls[worker] += 1
+        model_key = str(rec.get("model") or "").strip() or "unknown"
+        bucket = per_loop_model[worker][model_key]
+        bucket["cost_usd"] += float(rec["cost_usd"])
+        bucket["calls"] += 1
+        bucket["input_tokens"] += int(rec.get("input_tokens", 0) or 0)
+        bucket["output_tokens"] += int(rec.get("output_tokens", 0) or 0)
+        bucket["cache_read_tokens"] += int(rec.get("cache_read_input_tokens", 0) or 0)
+        bucket["cache_write_tokens"] += int(
+            rec.get("cache_creation_input_tokens", 0) or 0
+        )
 
     # Event-based counters (filed / closed / escalations / errored ticks).
     worker_stats: dict[str, dict[str, Any]] = {}
@@ -471,36 +513,17 @@ def build_per_loop_cost(
             events = []
         worker_stats = _tally_worker_events(events or [])
 
-    # Prior-period loop-tick counts (rough signal for > 2× highlight).
-    prev_until = since
-    prev_since = since - (until - since)
-    prev_loop_ticks: dict[str, int] = defaultdict(int)
-    for tr in iter_loop_traces(config, since=prev_since, until=prev_until):
-        prev_loop_ticks[str(tr.get("loop", "?"))] += 1
-    prev_loop_cost: dict[str, float] = defaultdict(float)
-
-    # Combine trace + event names. Trace names are ClassName (e.g.
-    # "RCBudgetLoop"); event names are worker_name (e.g. "rc_budget").
-    # Normalise to worker_name for the final output.
-    name_set: set[str] = set()
-    for name in loop_ticks:
-        name_set.add(_slug_for_loop(name))
-    name_set.update(worker_stats.keys())
+    # Union of every worker seen via traces, inferences, or events. All three
+    # key spaces are worker_name, so they merge into one row per worker.
+    name_set: set[str] = set(per_loop_ticks) | set(per_loop_cost) | set(worker_stats)
 
     rows: list[dict[str, Any]] = []
     for worker in sorted(name_set):
-        class_name = next(
-            (n for n in loop_ticks if _slug_for_loop(n) == worker),
-            worker,
-        )
         stats = worker_stats.get(worker, {})
-        ticks = int(stats.get("ticks", 0) or len(loop_ticks.get(class_name, [])))
-        cost = per_loop_cost.get(class_name, 0.0)
+        ticks = int(stats.get("ticks", 0) or per_loop_ticks.get(worker, 0))
+        cost = per_loop_cost.get(worker, 0.0)
         avg_cost = round(cost / ticks, 6) if ticks else 0.0
-        prev_ticks = prev_loop_ticks.get(class_name, 0)
-        prev_cost = prev_loop_cost.get(class_name, 0.0)
-        prev_avg = round(prev_cost / prev_ticks, 6) if prev_ticks else 0.0
-        breakdown_raw = per_loop_model.get(class_name, {})
+        breakdown_raw = per_loop_model.get(worker, {})
         model_breakdown = {
             model: {
                 "cost_usd": round(float(b["cost_usd"]), 6),
@@ -516,18 +539,21 @@ def build_per_loop_cost(
             {
                 "loop": worker,
                 "cost_usd": round(cost, 6),
-                "tokens_in": per_loop_tokens_in.get(class_name, 0),
-                "tokens_out": per_loop_tokens_out.get(class_name, 0),
-                "llm_calls": per_loop_llm_calls.get(class_name, 0),
+                "tokens_in": per_loop_tokens_in.get(worker, 0),
+                "tokens_out": per_loop_tokens_out.get(worker, 0),
+                "llm_calls": per_loop_llm_calls.get(worker, 0),
                 "issues_filed": int(stats.get("issues_filed", 0) or 0),
                 "issues_closed": int(stats.get("issues_closed", 0) or 0),
                 "escalations": int(stats.get("escalations", 0) or 0),
                 "ticks": ticks,
                 "ticks_errored": int(stats.get("ticks_errored", 0) or 0),
                 "tick_cost_avg_usd": avg_cost,
-                "wall_clock_seconds": per_loop_wall.get(class_name, 0),
+                "wall_clock_seconds": per_loop_wall.get(worker, 0),
                 "last_tick_at": stats.get("last_tick_at", "") or None,
-                "tick_cost_avg_usd_prev_period": prev_avg,
+                # Reserved 0.0 stub: the client-side spike highlight is gated on
+                # ``prev > 0`` (PerLoopCostTable.isSpike), so a future change can
+                # populate this from the prior window without a UI change.
+                "tick_cost_avg_usd_prev_period": 0.0,
                 "model_breakdown": model_breakdown,
             }
         )

--- a/tests/regressions/test_per_loop_cost_source_attribution.py
+++ b/tests/regressions/test_per_loop_cost_source_attribution.py
@@ -1,0 +1,108 @@
+"""Regression: /api/diagnostics/loops/cost bills LLM spend to the right loop.
+
+The per-loop cost table attributed LLM cost by temporal overlap between a
+loop's trace window and inference timestamps. That mechanism billed $0 to
+every background worker, because the loops that emit traces are LLM-free
+caretaker loops while the LLM-spending workers (pr_unsticker, repo_wiki,
+auto_agent_preflight, ...) emit no loop trace at all — and, when windows did
+coincide, it mis-charged pipeline spend to whichever caretaker tick overlapped.
+
+Cost is now attributed by the inference ``source`` field. This locks two
+behaviors end-to-end through the route:
+
+1. a bg worker that records inferences but emits no loop trace still shows
+   non-zero cost;
+2. a caretaker loop whose trace window overlaps an unrelated inference is NOT
+   charged that inference's cost.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from config import HydraFlowConfig
+from dashboard_routes._diagnostics_routes import build_diagnostics_router
+from tests.helpers import ConfigFactory
+
+
+@pytest.fixture
+def config(tmp_path: Path) -> HydraFlowConfig:
+    (tmp_path / "repo").mkdir(parents=True, exist_ok=True)
+    return ConfigFactory.create(repo_root=tmp_path / "repo")
+
+
+@pytest.fixture
+def client(config: HydraFlowConfig, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # The route builds an EventBus from disk; the per-loop cost path under test
+    # needs none, so stub it out to keep the test hermetic.
+    monkeypatch.setattr(
+        "dashboard_routes._diagnostics_routes._event_bus_for_rollup",
+        lambda cfg: None,
+    )
+    app = FastAPI()
+    app.include_router(build_diagnostics_router(config))
+    return TestClient(app)
+
+
+def _write_inference(config: HydraFlowConfig, **fields: object) -> None:
+    config.cost_inferences_path.parent.mkdir(parents=True, exist_ok=True)
+    with config.cost_inferences_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(fields) + "\n")
+
+
+def _write_loop_trace(config: HydraFlowConfig, loop: str, **fields: object) -> None:
+    from trace_collector import _slug_for_loop  # noqa: PLC0415
+
+    d = config.data_root / "traces" / "_loops" / _slug_for_loop(loop)
+    d.mkdir(parents=True, exist_ok=True)
+    payload = {"kind": "loop", "loop": loop, **fields}
+    started = str(fields["started_at"])
+    (d / f"run-{started.replace(':', '')}.json").write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+
+def test_loops_cost_bills_bg_worker_not_overlapping_caretaker_loop(
+    client: TestClient, config: HydraFlowConfig
+) -> None:
+    now = datetime.now(UTC)
+    # A bg worker spends LLM but emits no loop trace. Use the estimated-cost
+    # fallback (zero token counts) so cost is deterministic regardless of the
+    # live pricing table.
+    _write_inference(
+        config,
+        timestamp=(now - timedelta(minutes=30)).isoformat(),
+        source="pr_unsticker",
+        model="claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=0,
+        estimated_cost_usd=0.5,
+    )
+    # An LLM-free caretaker loop ticks across the same window.
+    _write_loop_trace(
+        config,
+        "trust_fleet_sanity",
+        started_at=(now - timedelta(minutes=40)).isoformat(),
+        duration_ms=3_600_000,  # 1h window straddling the inference
+        command=["gh", "issue", "list"],
+        exit_code=0,
+    )
+
+    resp = client.get("/api/diagnostics/loops/cost?range=24h")
+    assert resp.status_code == 200
+    by_loop = {r["loop"]: r for r in resp.json()}
+
+    assert "pr_unsticker" in by_loop
+    assert by_loop["pr_unsticker"]["cost_usd"] == pytest.approx(0.5)
+    assert by_loop["pr_unsticker"]["llm_calls"] == 1
+
+    # The caretaker loop ticked but spent nothing — its window must not absorb
+    # the bg worker's inference.
+    assert by_loop["trust_fleet_sanity"]["cost_usd"] == 0.0
+    assert by_loop["trust_fleet_sanity"]["ticks"] == 1

--- a/tests/test_cost_rollups_helpers.py
+++ b/tests/test_cost_rollups_helpers.py
@@ -735,7 +735,7 @@ def test_per_loop_cost_folds_source_aliases_to_worker(config) -> None:
     """Telemetry sources whose name differs from the loop's worker_name fold
     to the worker (wiki_compilation→repo_wiki, unsticker→pr_unsticker)."""
     now = datetime(2026, 4, 22, 12, tzinfo=UTC)
-    for src in ("wiki_compilation", "unsticker"):
+    for src in ("wiki_compilation", "unsticker", "diagnostic_fix"):
         _write_inference(
             config,
             timestamp=(now - timedelta(minutes=1)).isoformat(),
@@ -754,8 +754,10 @@ def test_per_loop_cost_folds_source_aliases_to_worker(config) -> None:
     loops = {r["loop"] for r in rows}
     assert "repo_wiki" in loops
     assert "pr_unsticker" in loops
+    assert "diagnostic" in loops
     assert "wiki_compilation" not in loops
     assert "unsticker" not in loops
+    assert "diagnostic_fix" not in loops
 
 
 def test_per_loop_cost_folds_pipeline_source_to_phase(config) -> None:

--- a/tests/test_cost_rollups_helpers.py
+++ b/tests/test_cost_rollups_helpers.py
@@ -566,18 +566,13 @@ def test_per_loop_cost_includes_model_breakdown_for_mixed_models(
         cache_read_input_tokens=0,
         cache_creation_input_tokens=0,
     )
-    _write_loop_trace(
-        config,
-        "implementer",
-        started_at=started.isoformat(),
-        duration_ms=60_000,
-    )
 
     rows = build_per_loop_cost(config, since=now - timedelta(hours=1), until=now)
 
     assert len(rows) == 1
     row = rows[0]
-    assert row["loop"] == "implementer"
+    # source "implementer" folds to its canonical phase-loop name "implement".
+    assert row["loop"] == "implement"
     breakdown = row["model_breakdown"]
     assert set(breakdown.keys()) == {"claude-opus-4-7", "claude-sonnet-4-6"}
     opus = breakdown["claude-opus-4-7"]
@@ -611,12 +606,6 @@ def test_per_loop_cost_buckets_missing_model_under_unknown(
         input_tokens=100,
         output_tokens=50,
     )
-    _write_loop_trace(
-        config,
-        "implementer",
-        started_at=started.isoformat(),
-        duration_ms=60_000,
-    )
 
     rows = build_per_loop_cost(config, since=now - timedelta(hours=1), until=now)
 
@@ -640,12 +629,6 @@ def test_per_loop_cost_existing_fields_unchanged(tmp_path) -> None:
         model="claude-opus-4-7",
         input_tokens=1_000,
         output_tokens=200,
-    )
-    _write_loop_trace(
-        config,
-        "implementer",
-        started_at=started.isoformat(),
-        duration_ms=60_000,
     )
 
     rows = build_per_loop_cost(config, since=now - timedelta(hours=1), until=now)
@@ -672,3 +655,154 @@ def test_per_loop_cost_existing_fields_unchanged(tmp_path) -> None:
     assert row["tokens_in"] == 1_000
     assert row["tokens_out"] == 200
     assert row["llm_calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# build_per_loop_cost — source-based cost attribution (issue: bg-worker cost)
+# ---------------------------------------------------------------------------
+#
+# Cost is attributed to a loop by the inference ``source`` field, not by
+# temporal overlap with a loop-trace window. The traced caretaker loops are
+# LLM-free (they shell out to gh/git), while the LLM-spending bg workers emit
+# no loop trace at all — so a trace-window join attributes $0 to everything.
+
+
+def test_per_loop_cost_attributes_bg_worker_by_source(config) -> None:
+    """A bg worker that records inferences but emits no loop trace still gets
+    its LLM cost attributed via the inference ``source`` field."""
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    _write_inference(
+        config,
+        timestamp=(now - timedelta(minutes=1)).isoformat(),
+        source="pr_unsticker",
+        model="claude-sonnet-4-6",
+        input_tokens=1_000,
+        output_tokens=200,
+    )
+    # An unrelated LLM-free caretaker loop emits a trace in the same window.
+    _write_loop_trace(
+        config,
+        "trust_fleet_sanity",
+        started_at=(now - timedelta(minutes=2)).isoformat(),
+        duration_ms=1_000,
+    )
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.05
+
+    rows = build_per_loop_cost(
+        config, since=now - timedelta(hours=1), until=now, pricing=pricing
+    )
+
+    by_loop = {r["loop"]: r for r in rows}
+    assert "pr_unsticker" in by_loop
+    assert by_loop["pr_unsticker"]["cost_usd"] == pytest.approx(0.05)
+    assert by_loop["pr_unsticker"]["llm_calls"] == 1
+
+
+def test_per_loop_cost_does_not_misattribute_overlapping_inference(config) -> None:
+    """A pipeline inference that happens *during* a caretaker loop's trace
+    window must NOT be charged to that caretaker loop — attribution is by
+    source, not by clock overlap."""
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    started = now - timedelta(minutes=5)
+    _write_loop_trace(
+        config,
+        "trust_fleet_sanity",
+        started_at=started.isoformat(),
+        duration_ms=60_000,
+    )
+    _write_inference(
+        config,
+        timestamp=(started + timedelta(seconds=10)).isoformat(),
+        source="implementer",
+        model="claude-sonnet-4-6",
+        input_tokens=1_000,
+        output_tokens=200,
+    )
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.05
+
+    rows = build_per_loop_cost(
+        config, since=now - timedelta(hours=1), until=now, pricing=pricing
+    )
+
+    by_loop = {r["loop"]: r for r in rows}
+    assert by_loop["trust_fleet_sanity"]["cost_usd"] == 0.0
+    assert by_loop["trust_fleet_sanity"]["llm_calls"] == 0
+
+
+def test_per_loop_cost_folds_source_aliases_to_worker(config) -> None:
+    """Telemetry sources whose name differs from the loop's worker_name fold
+    to the worker (wiki_compilation→repo_wiki, unsticker→pr_unsticker)."""
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    for src in ("wiki_compilation", "unsticker"):
+        _write_inference(
+            config,
+            timestamp=(now - timedelta(minutes=1)).isoformat(),
+            source=src,
+            model="claude-sonnet-4-6",
+            input_tokens=1_000,
+            output_tokens=200,
+        )
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.05
+
+    rows = build_per_loop_cost(
+        config, since=now - timedelta(hours=1), until=now, pricing=pricing
+    )
+
+    loops = {r["loop"] for r in rows}
+    assert "repo_wiki" in loops
+    assert "pr_unsticker" in loops
+    assert "wiki_compilation" not in loops
+    assert "unsticker" not in loops
+
+
+def test_per_loop_cost_folds_pipeline_source_to_phase(config) -> None:
+    """Pipeline-runner sources fold to their canonical phase name so the
+    per-loop table matches the loop/worker names used elsewhere."""
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    _write_inference(
+        config,
+        timestamp=(now - timedelta(minutes=1)).isoformat(),
+        source="implementer",
+        model="claude-sonnet-4-6",
+        input_tokens=1_000,
+        output_tokens=200,
+    )
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.05
+
+    rows = build_per_loop_cost(
+        config, since=now - timedelta(hours=1), until=now, pricing=pricing
+    )
+
+    loops = {r["loop"] for r in rows}
+    assert "implement" in loops
+    assert "implementer" not in loops
+
+
+def test_per_loop_cost_excludes_non_loop_sources(config) -> None:
+    """Telemetry artifacts that name no loop (token-source markers, the
+    design-time onboarding agent, empty source) produce no row."""
+    now = datetime(2026, 4, 22, 12, tzinfo=UTC)
+    for src in ("estimated", "claude", ""):
+        _write_inference(
+            config,
+            timestamp=(now - timedelta(minutes=1)).isoformat(),
+            source=src,
+            model="claude-sonnet-4-6",
+            input_tokens=1_000,
+            output_tokens=200,
+        )
+    pricing = MagicMock()
+    pricing.estimate_cost.return_value = 0.05
+
+    rows = build_per_loop_cost(
+        config, since=now - timedelta(hours=1), until=now, pricing=pricing
+    )
+
+    loops = {r["loop"] for r in rows}
+    assert "estimated" not in loops
+    assert "claude" not in loops
+    assert "" not in loops


### PR DESCRIPTION
## Problem

The Factory Cost tab's **Per-Loop Cost** table (`GET /api/diagnostics/loops/cost`) shows **$0 for every background worker** — "cost per loop for bg worker does not seem to be working."

## Root cause

`build_per_loop_cost` attributed LLM cost to a loop by **temporal overlap**: an inference counted toward a loop only if `tick.started_at ≤ inference.timestamp ≤ tick.started_at + duration_ms`. Three compounding defects:

1. **Disjoint key spaces (dominant cause).** The loops that emit loop traces are *LLM-free caretaker loops* — they shell out to `gh`/`git` and call `run_lightweight_agent` zero times — while every dollar of LLM spend comes from workers that emit **no** loop trace at all (`pr_unsticker`, `repo_wiki`, `auto_agent_preflight`, `diagnostic`, plus the pipeline phases). A trace×inference join therefore bills **$0** to every loop, regardless of timing.
2. **Mis-attribution when windows coincide.** On wide ranges the join charges pipeline spend (`implementer`/`triage`/`planner`) to whichever caretaker tick happened to overlap — wrong numbers, not just zeros.
3. **Window shifted into the future.** `emit_loop_subprocess_trace` stamps `started_at = now()` at *emit* time (after the work completes), so the window `[started_at, started_at+duration]` lands a full duration *after* the work and can never contain the inferences it's meant to.

Every inference row already carries a `source` field naming the originating worker, so temporal overlap was reinventing — badly — what the data already encodes.

**Why it shipped:** the unit tests modeled `started_at` as the *true* work-start (production stamps it at completion) and set `source == loop`, so they passed while production returned $0.

## Fix

Attribute `cost_usd` / `tokens_in` / `tokens_out` / `llm_calls` / `model_breakdown` by the inference **`source`** field instead of temporal overlap:

- `source_to_phase` folds pipeline-runner sources to their canonical phase name (`implementer→implement`, …).
- A 3-entry alias map handles bg-loop sources whose telemetry name differs from the loop's `worker_name`: `unsticker→pr_unsticker`, `wiki_compilation→repo_wiki`, `diagnostic_fix→diagnostic`.
- Telemetry artifacts that name no loop (`estimated`, `claude`, `post_merge_hook`, `threshold_check`, empty) are dropped.

`ticks` / `wall_clock_seconds` still come from loop traces; `issues_filed` / `issues_closed` / `escalations` / `ticks_errored` still come from `BACKGROUND_WORKER_STATUS` events. The row schema is unchanged (additive-safe) — `merge_per_loop_cost` and the frontend `PerLoopCostTable` are untouched.

## Verification

Against real `.hydraflow` data, the endpoint goes from **$0 across all loops** to **$404.91 attributed across 12 workers**, with bg workers now showing real cost (`diagnostic` $51.44, `auto_agent_preflight` $1.63, `pr_unsticker` $0.85, …).

## Tests

- 5 new unit tests in `test_cost_rollups_helpers.py` (bg-worker-by-source, no-misattribution, alias fold, pipeline fold, non-loop exclusion).
- New route-level regression `tests/regressions/test_per_loop_cost_source_attribution.py`.
- 3 pre-existing tests corrected from the masking model to the source-based model.
- Full `pytest tests/` green (only the environment-only `test_mkdocs_strict` deselected locally — mkdocs CLI not installed); ruff / pyright / bandit clean; `make arch-check` clean.

## Scope note

`emit_loop_subprocess_trace`'s `started_at`-at-emit mislabel (defect #3) is left as a follow-up: cost no longer depends on it, and it only shifts waterfall *display* timing by a tick. Kept separate to keep this fix focused on the reported symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
