### PR TITLE
fix(trace): record loop-trace started_at as work-start, not emit time

### DIFF
--- a/src/trace_collector.py
+++ b/src/trace_collector.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 import time
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from models import (
@@ -443,8 +443,14 @@ def emit_loop_subprocess_trace(
             return
 
         stderr = stderr_excerpt[-_STDERR_TRUNC_CAP:] if stderr_excerpt else None
-        started_at = datetime.now(UTC).isoformat()
-        slug_ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        # The helper is invoked after the subprocess finishes (duration_ms is
+        # already elapsed), so ``emitted`` is ~the work's END. Back-date to the
+        # true start so a consumer's [started_at, started_at + duration_ms]
+        # window brackets the work instead of landing one full duration in the
+        # future. The filename keeps emit-time for uniqueness/ordering.
+        emitted = datetime.now(UTC)
+        started_at = (emitted - timedelta(milliseconds=int(duration_ms))).isoformat()
+        slug_ts = emitted.strftime("%Y%m%dT%H%M%S%fZ")
 
         payload = {
             "kind": "loop",

--- a/tests/test_trace_collector_loop_helper.py
+++ b/tests/test_trace_collector_loop_helper.py
@@ -58,6 +58,31 @@ def test_emit_writes_trace_entry_with_required_shape(data_root: Path) -> None:
     assert "started_at" in payload  # ISO 8601
 
 
+def test_emit_started_at_is_work_start_not_emit_time(data_root: Path) -> None:
+    """started_at marks when the work began, not when the trace was emitted.
+
+    The helper is called after the subprocess completes (it receives the
+    already-elapsed duration_ms), so it back-dates started_at by duration_ms.
+    A consumer computing [started_at, started_at + duration_ms] then brackets
+    the real work interval instead of a window one full duration in the future.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    duration_ms = 60_000
+    before = datetime.now(UTC)
+    emit_loop_subprocess_trace(
+        loop="X", command=["x"], exit_code=0, duration_ms=duration_ms
+    )
+    after = datetime.now(UTC)
+
+    files = list((data_root / "traces" / "_loops" / "x").glob("run-*.json"))
+    payload = json.loads(files[0].read_text(encoding="utf-8"))
+    started = datetime.fromisoformat(payload["started_at"])
+
+    # started_at + duration lands at ~emit time (now), not one duration ahead.
+    assert before <= started + timedelta(milliseconds=duration_ms) <= after
+
+
 def test_emit_truncates_stderr_tail_preserving(data_root: Path) -> None:
     big = "A" * 4096 + "TAIL_MARKER"
     emit_loop_subprocess_trace(


### PR DESCRIPTION
## Problem

`emit_loop_subprocess_trace` wrote a loop trace's `started_at` as `datetime.now()` — but the helper is invoked *after* the subprocess completes (it receives the already-elapsed `duration_ms`). So `started_at` actually recorded the work's **end** time, while every consumer treats it as the **start**. Anything computing `[started_at, started_at + duration_ms]` — notably the waterfall's loop-trace action records — got a window shifted one full duration into the future.

This was the secondary defect called out in #9550's scope note. Per-loop cost no longer depends on it (#9550 moved cost attribution to the inference `source` field), but the waterfall still displayed loop-trace actions at the wrong, shifted time.

## Fix

Back-date `started_at` by `duration_ms` so the field records the true work start (the helper already knows the elapsed duration, so `now() − duration_ms` ≈ the start). The run-file name keeps emit-time for uniqueness/ordering.

## Tests

- New unit test `test_emit_started_at_is_work_start_not_emit_time`: asserts `started_at + duration_ms` lands at ~emit time (now), not one full duration ahead.
- Full `pytest tests/` green (the environment-only `test_mkdocs_strict` deselected locally — mkdocs CLI not installed); ruff / pyright clean.

## Blast radius

Window membership in `iter_loop_traces` / `build_rolling_24h` / `build_by_loop` shifts a trace's `ts` earlier by its duration (sub-second to seconds); only a tick sitting within `duration_ms` of a window boundary could change windows — immaterial for tick counts. The waterfall now displays loop-trace actions at the correct time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
