### PR TITLE
fix(billing): detect the weekly subscription cap as a credit pause (#9529 follow-up)

### DIFF
--- a/src/subprocess_util.py
+++ b/src/subprocess_util.py
@@ -339,6 +339,15 @@ _CREDIT_PATTERNS = (
     # (2026-06-13 incident; see tests/regressions/test_session_limit_credit_pause.py.)
     "hit your session limit",
     "session limit reached",
+    # Claude Code subscription *weekly*-cap message
+    # ("You've hit your weekly limit · resets Jun 18 at 5pm"). Same failure
+    # class as the session cap (2026-06-17 incident): "weekly" sits between
+    # "hit your" and "limit", so it slipped past every substring and the factory
+    # burned its whole attempt budget into HITL. The _LIMIT_HIT_RE regex below
+    # now catches the entire "hit your <period> limit" family so a new cap
+    # wording (daily/monthly/…) cannot recur this.
+    # See tests/regressions/test_weekly_limit_credit_pause.py.
+    "weekly limit reached",
     # Anthropic API spend-cap rejection (HTTP 400 invalid_request_error).
     # Full phrase — narrower patterns would false-match conversational
     # transcript text like "reached your specified goals" and trigger a
@@ -346,6 +355,14 @@ _CREDIT_PATTERNS = (
     "reached your specified api usage limits",
     "reached your specified usage limits",
 )
+
+# Catches the whole "You've hit your <usage|session|weekly|daily|…> limit"
+# family in one shot, so a new subscription-cap wording can't slip past the
+# substring list and burn the attempt budget — the failure mode behind both the
+# 2026-06-13 (session) and 2026-06-17 (weekly) HITL pile-ups. Allows 0–2 words
+# between "your" and "limit"; word-boundary anchored so it does not match prose
+# like "hit your stride, no limit".
+_LIMIT_HIT_RE = re.compile(r"\bhit your(?:\s+\w+){0,2}\s+limit\b", re.IGNORECASE)
 
 # Matches e.g. "reset at 3pm (America/New_York)", "reset at 3am",
 # "resets 5am (America/Denver)", "resets at 5am", "resets 5:50am (America/Denver)".
@@ -356,6 +373,37 @@ _RESET_TIME_RE = re.compile(
     r"(?:\s*\(([^)]+)\))?",
     re.IGNORECASE,
 )
+
+# Weekly-cap resume formats. Claude Code renders the weekly reset as an absolute
+# day, usually WITHOUT a timezone — assume local time (the message is shown in
+# the user's locale). Both forms optionally accept a trailing "(Area/City)".
+#   "resets Jun 18 at 5pm"      → month abbrev + day + time
+#   "resets Wednesday at 5pm"   → weekday name + time (next occurrence)
+_WEEKLY_DATE_RE = re.compile(
+    r"resets?\s+(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec)[a-z]*\s+(\d{1,2})"
+    r"\s+at\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+_WEEKLY_DAY_RE = re.compile(
+    r"resets?\s+(mon|tue|wed|thu|fri|sat|sun)[a-z]*\s+at\s+"
+    r"(\d{1,2})(?::(\d{2}))?\s*(am|pm)(?:\s*\(([^)]+)\))?",
+    re.IGNORECASE,
+)
+_MONTH_ABBR = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
+_WEEKDAY_ABBR = {"mon": 0, "tue": 1, "wed": 2, "thu": 3, "fri": 4, "sat": 5, "sun": 6}
 
 # Matches Anthropic's ISO-style spend-cap resume format:
 # "regain access on 2026-05-01 at 00:00 UTC"
@@ -402,7 +450,103 @@ _DOCKER_ENV_PASSTHROUGH_KEYS = (
 def is_credit_exhaustion(text: str) -> bool:
     """Check if *text* indicates an API credit exhaustion condition."""
     text_lower = text.lower()
-    return any(p in text_lower for p in _CREDIT_PATTERNS)
+    if any(p in text_lower for p in _CREDIT_PATTERNS):
+        return True
+    # Future-proof catch-all for the "hit your <period> limit" family.
+    return _LIMIT_HIT_RE.search(text) is not None
+
+
+def _to_24h(hour: int, minute: int, ampm: str) -> tuple[int, int] | None:
+    """Convert a validated 12-hour clock reading to (hour24, minute), or None.
+
+    Rejects out-of-range hours (1–12) and minutes (0–59) so a bogus value
+    ("5:99am") fails to parse rather than rolling over.
+    """
+    if hour < 1 or hour > 12 or minute > 59:
+        return None
+    if ampm.lower() == "am":
+        hour_24 = 0 if hour == 12 else hour
+    else:
+        hour_24 = hour if hour == 12 else hour + 12
+    return hour_24, minute
+
+
+def _resolve_tz(tz_name: str | None, *, default_utc: bool):
+    """Resolve a parenthesised tz name to a tzinfo.
+
+    ``default_utc`` picks the fallback when no tz is present: the legacy
+    hour-only format defaults to UTC; the weekly formats (rendered in the user's
+    locale without a tz) default to local time.
+    """
+    if tz_name:
+        try:
+            return ZoneInfo(tz_name.strip())
+        except (KeyError, ValueError):
+            logger.warning(
+                "Could not parse timezone %r — falling back to local time", tz_name
+            )
+            return datetime.now().astimezone().tzinfo or UTC
+    if default_utc:
+        return UTC
+    return datetime.now().astimezone().tzinfo or UTC
+
+
+def _parse_weekly_month_day(text: str) -> datetime | None:
+    """Parse ``"resets Jun 18 at 5pm"`` (month abbrev + day) → UTC datetime."""
+    md = _WEEKLY_DATE_RE.search(text)
+    if md is None:
+        return None
+    hm = _to_24h(int(md.group(3)), int(md.group(4) or 0), md.group(5))
+    if hm is None:
+        return None
+    tz = _resolve_tz(md.group(6), default_utc=False)
+    now = datetime.now(tz=tz)
+    try:
+        reset = now.replace(
+            month=_MONTH_ABBR[md.group(1).lower()[:3]],
+            day=int(md.group(2)),
+            hour=hm[0],
+            minute=hm[1],
+            second=0,
+            microsecond=0,
+        )
+    except ValueError:
+        return None  # e.g. "Feb 30"
+    # A weekly reset is always within ~7 days, so a clearly-past month/day is a
+    # stale message — NOT next year. Return None so the caller falls back to its
+    # short default pause and re-evaluates, rather than idling for a year. (1h
+    # slack absorbs clock skew.)
+    if reset < now - timedelta(hours=1):
+        return None
+    return reset.astimezone(UTC)
+
+
+def _parse_weekly_weekday(text: str) -> datetime | None:
+    """Parse ``"resets Wednesday at 5pm"`` (weekday → next occurrence) → UTC."""
+    wd = _WEEKLY_DAY_RE.search(text)
+    if wd is None:
+        return None
+    hm = _to_24h(int(wd.group(2)), int(wd.group(3) or 0), wd.group(4))
+    if hm is None:
+        return None
+    tz = _resolve_tz(wd.group(5), default_utc=False)
+    now = datetime.now(tz=tz)
+    days_ahead = (_WEEKDAY_ABBR[wd.group(1).lower()[:3]] - now.weekday()) % 7
+    reset = (now + timedelta(days=days_ahead)).replace(
+        hour=hm[0], minute=hm[1], second=0, microsecond=0
+    )
+    if reset <= now:
+        reset += timedelta(days=7)
+    return reset.astimezone(UTC)
+
+
+def _parse_weekly_resume_time(text: str) -> datetime | None:
+    """Parse Claude Code's weekly-cap resume formats to a UTC datetime.
+
+    ``"resets Jun 18 at 5pm"`` (month + day) and ``"resets Wednesday at 5pm"``
+    (weekday → next occurrence). Returns None if neither matches.
+    """
+    return _parse_weekly_month_day(text) or _parse_weekly_weekday(text)
 
 
 async def probe_credit_availability() -> bool:
@@ -476,6 +620,13 @@ def parse_credit_resume_time(text: str) -> datetime | None:
             return datetime(year, month, day, hour, minute, tzinfo=UTC)
         except ValueError:
             return None
+
+    # Weekly-cap formats ("resets Jun 18 at 5pm" / "resets Wednesday at 5pm").
+    # Checked before the bare hour format so the "5pm" tail isn't parsed as a
+    # same-day reset (which would resume days early during a weekly pause).
+    weekly = _parse_weekly_resume_time(text)
+    if weekly is not None:
+        return weekly
 
     match = _RESET_TIME_RE.search(text)
     if not match:

--- a/tests/regressions/test_weekly_limit_credit_pause.py
+++ b/tests/regressions/test_weekly_limit_credit_pause.py
@@ -1,0 +1,73 @@
+"""Regression: Claude Code's *weekly*-cap message must drive the credit-pause
+path, not be mistaken for an ordinary agent failure.
+
+Incident — 2026-06-17. The factory hit its Claude subscription WEEKLY limit.
+Agents printed::
+
+    You've hit your weekly limit · resets Jun 18 at 5pm
+
+This is the same failure class as the 2026-06-13 session-limit incident
+(see test_session_limit_credit_pause.py / PR #9529): the word "weekly" sits
+between "hit your" and "limit", so it slipped past every substring in
+``_CREDIT_PATTERNS``. ``is_credit_exhaustion`` returned False, no
+``CreditExhaustedError`` was raised, the orchestrator never paused, and the
+factory burned its whole attempt budget into HITL (one issue accumulated 492
+billing-message comments).
+
+This pins the fix: a future-proof "hit your <period> limit" detector plus
+weekly resume-time parsing, asserted through the lightweight runner classifier
+that every ``run_simple``-based runner uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from runner_utils import raise_if_credit_exhausted
+from subprocess_util import (
+    CreditExhaustedError,
+    is_credit_exhaustion,
+    parse_credit_resume_time,
+)
+
+WEEKLY_MSG = "You've hit your weekly limit · resets Jun 18 at 5pm"
+WEEKLY_WEEKDAY_MSG = "You've hit your weekly limit · resets Wednesday at 5pm"
+
+
+def test_weekly_limit_is_classified_as_credit_exhaustion() -> None:
+    assert is_credit_exhaustion(WEEKLY_MSG)
+    assert is_credit_exhaustion(WEEKLY_WEEKDAY_MSG)
+
+
+def test_lightweight_runner_raises_on_weekly_limit() -> None:
+    """The path every run_simple-based runner uses must raise so the orchestrator
+    pauses + refunds the attempt instead of failing it.
+    """
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted(WEEKLY_MSG, "", tool="claude")
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted("", WEEKLY_WEEKDAY_MSG, tool="claude")
+
+
+def test_weekly_weekday_reset_populates_resume_time() -> None:
+    """The weekday form yields a concrete resume time so the pause lasts the
+    right duration rather than waking every 5h on the default fallback.
+    """
+    with pytest.raises(CreditExhaustedError) as excinfo:
+        raise_if_credit_exhausted(WEEKLY_WEEKDAY_MSG, "", tool="claude")
+    assert excinfo.value.resume_at is not None
+
+
+def test_future_proof_period_family_detected() -> None:
+    """A new single-word cap wording (daily/monthly) must not recur the burn."""
+    for period in ("daily", "monthly", "hourly"):
+        assert is_credit_exhaustion(f"You've hit your {period} limit")
+
+
+def test_weekly_with_unparseable_reset_still_raises() -> None:
+    """Even when the reset clause can't be parsed, detection must fire (the
+    orchestrator falls back to its default pause window).
+    """
+    assert parse_credit_resume_time("You've hit your weekly limit") is None
+    with pytest.raises(CreditExhaustedError):
+        raise_if_credit_exhausted("You've hit your weekly limit", "", tool="claude")

--- a/tests/test_subprocess_util.py
+++ b/tests/test_subprocess_util.py
@@ -1251,6 +1251,53 @@ class TestIsCreditExhaustion:
             "The session limit is configured to 10 sessions per repo."
         )
 
+    def test_matches_claude_code_weekly_limit(self) -> None:
+        """Claude Code subscription *weekly*-cap message (2026-06-17 incident).
+
+        'weekly' sits between 'hit your' and 'limit', so it slipped past every
+        substring and the factory burned its whole attempt budget into HITL.
+        """
+        assert is_credit_exhaustion(
+            "You've hit your weekly limit · resets Jun 18 at 5pm"
+        )
+
+    def test_matches_weekly_limit_reached_phrasing(self) -> None:
+        assert is_credit_exhaustion("Weekly limit reached. Try again later.")
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "You've hit your limit",
+            "You've hit your usage limit",
+            "You've hit your session limit",
+            "You've hit your weekly limit",
+            "You've hit your daily limit",
+            "You've hit your monthly limit",
+            "you have hit your weekly usage limit",
+        ],
+    )
+    def test_limit_hit_regex_covers_the_whole_period_family(self, msg: str) -> None:
+        """Future-proofing: any 'hit your <period> limit' wording must match so a
+        new cap type can't recur the 2026-06-13/2026-06-17 attempt-burn.
+        """
+        assert is_credit_exhaustion(msg)
+
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            "you hit your stride, no limit today",
+            "the rate limit is configured to 100 requests",
+            "we hit your target under the limit",
+            "All tests passed.",
+            "",
+        ],
+    )
+    def test_does_not_false_match_benign_limit_prose(self, msg: str) -> None:
+        """The catch-all regex must not fire on conversational text — a false
+        positive halts all work (non-retryable).
+        """
+        assert not is_credit_exhaustion(msg)
+
 
 class TestParseCreditResumeTime:
     """parse_credit_resume_time must recognize Anthropic's ISO-style resume format."""
@@ -1316,3 +1363,95 @@ class TestParseCreditResumeTime:
         assert (
             parse_credit_resume_time("regain access on 2026-05-01 at 00:00 PST") is None
         )
+
+    # ---- Weekly-cap resume formats (2026-06-17 incident) ----
+
+    def test_parses_weekly_weekday_format(self) -> None:
+        """'resets Wednesday at 5pm' → next Wednesday 17:00 in local time."""
+        from datetime import UTC, datetime, timedelta
+
+        resume = parse_credit_resume_time(
+            "You've hit your weekly limit · resets Wednesday at 5pm"
+        )
+        assert resume is not None
+        now = datetime.now(UTC)
+        assert now < resume <= now + timedelta(days=7)
+        local = datetime.now().astimezone().tzinfo
+        local_reset = resume.astimezone(local)
+        assert local_reset.weekday() == 2  # Wednesday
+        assert (local_reset.hour, local_reset.minute) == (17, 0)
+
+    def test_parses_weekly_weekday_with_minutes(self) -> None:
+        from datetime import datetime
+
+        resume = parse_credit_resume_time("resets Wednesday at 5:30pm")
+        assert resume is not None
+        local = datetime.now().astimezone().tzinfo
+        assert resume.astimezone(local).minute == 30
+
+    def test_parses_weekly_month_day_future(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """'resets Jun 18 at 5pm' with now=Jun 15 → ~3 days out (tz-robust)."""
+        from datetime import UTC, timedelta
+        from datetime import datetime as _dt
+
+        import subprocess_util as su
+
+        frozen = _dt(2026, 6, 15, 12, 0, tzinfo=UTC)
+
+        class _Frozen(_dt):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return (
+                    frozen.astimezone(tz)
+                    if tz is not None
+                    else frozen.replace(tzinfo=None)
+                )
+
+        monkeypatch.setattr(su, "datetime", _Frozen)
+        resume = su.parse_credit_resume_time(
+            "You've hit your weekly limit · resets Jun 18 at 5pm"
+        )
+        assert resume is not None
+        delta = resume - frozen
+        assert timedelta(days=2) < delta < timedelta(days=4)  # ~3d, any tz
+
+    def test_weekly_month_day_in_past_returns_none_not_next_year(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A clearly-past month/day is a stale message — must return None (short
+        default pause), NOT roll a full year and idle the factory.
+        """
+        from datetime import UTC
+        from datetime import datetime as _dt
+
+        import subprocess_util as su
+
+        frozen = _dt(2026, 6, 20, 12, 0, tzinfo=UTC)
+
+        class _Frozen(_dt):
+            @classmethod
+            def now(cls, tz=None):  # type: ignore[override]
+                return (
+                    frozen.astimezone(tz)
+                    if tz is not None
+                    else frozen.replace(tzinfo=None)
+                )
+
+        monkeypatch.setattr(su, "datetime", _Frozen)
+        assert (
+            su.parse_credit_resume_time(
+                "You've hit your weekly limit · resets Jun 18 at 5pm"
+            )
+            is None
+        )
+
+    def test_weekly_invalid_month_day_returns_none(self) -> None:
+        assert parse_credit_resume_time("resets Feb 30 at 5pm") is None
+
+    def test_weekly_detected_but_no_reset_clause_returns_none(self) -> None:
+        """Detection still fires (tested elsewhere); with no parseable reset the
+        caller falls back to its default pause, so parse returns None.
+        """
+        assert parse_credit_resume_time("You've hit your weekly limit") is None


### PR DESCRIPTION
## The real cause of the 2026-06-17 HITL refill

The factory hit its Claude **weekly** limit. Agents printed:
> You've hit your weekly limit · resets Jun 18 at 5pm

Same failure class as the session-limit incident (#9529): "weekly" sits between "hit your" and "limit", so it slipped past every substring in `_CREDIT_PATTERNS`. `is_credit_exhaustion()` returned `False` → no `CreditExhaustedError` → the orchestrator never paused → the factory burned its whole attempt budget escalating ~25 perfectly-auto-resolvable issues into HITL (one issue accumulated **492 billing-message comments**). The triage that flagged "34 in HITL" was 25/34 stuck *only* on this billing gap, not unfixable work.

## Fix (future-proofed)
- **`_LIMIT_HIT_RE`** — one regex catches the whole `hit your <usage|session|weekly|daily|monthly|…> limit` family, word-boundary anchored so it won't fire on prose (`"hit your stride, no limit"`). No more whack-a-mole per cap type.
- `"weekly limit reached"` added to `_CREDIT_PATTERNS`.
- **`parse_credit_resume_time`** now parses the weekly reset formats: `"resets Jun 18 at 5pm"` (month+day) and `"resets Wednesday at 5pm"` (weekday → next occurrence), local-tz default. A clearly-past month/day returns `None` (stale message → short default pause) instead of idling the factory for a year.

Detection is the load-bearing part: it triggers the orchestrator pause **and** the auto-agent attempt-refund, so a weekly cap no longer escalates work to HITL.

## Tests (the "test the shit out of it" part)
- `tests/regressions/test_weekly_limit_credit_pause.py` — full chain through `raise_if_credit_exhausted` (detection → `CreditExhaustedError` → resume_at), period-family future-proofing, unparseable-reset still raises.
- `TestIsCreditExhaustion` — weekly + parametrized period family + parametrized benign-prose non-matches.
- `TestParseCreditResumeTime` — weekday parse, minutes, frozen-clock month/day future, past→None (no year-idle), invalid date.

All credit suites pass; ruff + pyright + lint-check + arch-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)